### PR TITLE
Migrate 5 MSBuild tasks to IMultiThreadableTask (Group 1)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateClsidMap.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateClsidMap.cs
@@ -10,7 +10,8 @@ using Microsoft.NET.HostModel.ComHost;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GenerateClsidMap : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GenerateClsidMap : TaskBase, IMultiThreadableTask
     {
         [Required]
         public string IntermediateAssembly { get; set; }
@@ -18,9 +19,23 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string ClsidMapDestinationPath { get; set; }
 
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
+        public TaskEnvironment TaskEnvironment { get; set; }
+#endif
+
         protected override void ExecuteCore()
         {
-            using (var assemblyStream = new FileStream(IntermediateAssembly, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+            AbsolutePath assemblyPath = TaskEnvironment.GetAbsolutePath(IntermediateAssembly);
+            AbsolutePath clsidMapPath = TaskEnvironment.GetAbsolutePath(ClsidMapDestinationPath);
+
+            using (var assemblyStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
             {
                 try
                 {
@@ -34,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks
                                 Log.LogError(Strings.ClsidMapInvalidAssembly, IntermediateAssembly);
                                 return;
                             }
-                            ClsidMap.Create(reader, ClsidMapDestinationPath);
+                            ClsidMap.Create(reader, clsidMapPath);
                         }
                     }
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -17,7 +17,8 @@ namespace Microsoft.NET.Build.Tasks
     /// Generates the $(project).runtimeconfig.json and optionally $(project).runtimeconfig.dev.json files
     /// for a project.
     /// </summary>
-    public class GenerateRuntimeConfigurationFiles : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GenerateRuntimeConfigurationFiles : TaskBase, IMultiThreadableTask
     {
         public string AssetsFilePath { get; set; }
 
@@ -55,6 +56,17 @@ namespace Microsoft.NET.Build.Tasks
         public bool GenerateRuntimeConfigDevFile { get; set; }
 
         public bool AlwaysIncludeCoreFramework { get; set; }
+
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
+        public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         List<ITaskItem> _filesWritten = new();
 
@@ -127,7 +139,8 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                LockFile lockFile = new LockFileCache(this).GetLockFile(AssetsFilePath);
+                AbsolutePath assetsPath = TaskEnvironment.GetAbsolutePath(AssetsFilePath);
+                LockFile lockFile = new LockFileCache(this).GetLockFile(assetsPath);
 
                 ProjectContext projectContext = lockFile.CreateProjectContext(
                     TargetFramework,
@@ -176,7 +189,7 @@ namespace Microsoft.NET.Build.Tasks
                 AddAdditionalProbingPaths(config.RuntimeOptions, packageFolders);
             }
 
-            WriteToJsonFile(RuntimeConfigPath, config);
+            WriteToJsonFile(TaskEnvironment.GetAbsolutePath(RuntimeConfigPath), config);
             _filesWritten.Add(new TaskItem(RuntimeConfigPath));
         }
 
@@ -266,13 +279,19 @@ namespace Microsoft.NET.Build.Tasks
 
         private void AddUserRuntimeOptions(RuntimeOptions runtimeOptions)
         {
-            if (string.IsNullOrEmpty(UserRuntimeConfig) || !File.Exists(UserRuntimeConfig))
+            if (string.IsNullOrEmpty(UserRuntimeConfig))
+            {
+                return;
+            }
+
+            AbsolutePath userConfigPath = TaskEnvironment.GetAbsolutePath(UserRuntimeConfig);
+            if (!File.Exists(userConfigPath))
             {
                 return;
             }
 
             JObject runtimeOptionsFromProject;
-            using (JsonTextReader reader = new(File.OpenText(UserRuntimeConfig)))
+            using (JsonTextReader reader = new(File.OpenText(userConfigPath)))
             {
                 runtimeOptionsFromProject = JObject.Load(reader);
             }
@@ -340,7 +359,7 @@ namespace Microsoft.NET.Build.Tasks
 
             AddAdditionalProbingPaths(devConfig.RuntimeOptions, packageFolders);
 
-            WriteToJsonFile(RuntimeConfigDevPath, devConfig);
+            WriteToJsonFile(TaskEnvironment.GetAbsolutePath(RuntimeConfigDevPath), devConfig);
             _filesWritten.Add(new TaskItem(RuntimeConfigDevPath));
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateToolsSettingsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateToolsSettingsFile.cs
@@ -7,7 +7,8 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GenerateToolsSettingsFile : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GenerateToolsSettingsFile : TaskBase, IMultiThreadableTask
     {
         [Required]
         public string EntryPointRelativePath { get; set; }
@@ -28,10 +29,22 @@ namespace Microsoft.NET.Build.Tasks
         [Required]
         public string ToolsSettingsFilePath { get; set; }
 
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
+        public TaskEnvironment TaskEnvironment { get; set; }
+#endif
+
         protected override void ExecuteCore()
         {
+            AbsolutePath settingsPath = TaskEnvironment.GetAbsolutePath(ToolsSettingsFilePath);
             GenerateDocument(EntryPointRelativePath, CommandName, CommandRunner, RuntimeIdentifier, ToolPackageId, ToolPackageVersion, ToolPackageRuntimeIdentifiers)
-                .Save(ToolsSettingsFilePath);
+                .Save(settingsPath);
         }
 
         internal static XDocument GenerateDocument(string entryPointRelativePath, string commandName, string commandRunner, string runtimeIdentifier,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyAttributes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyAttributes.cs
@@ -9,8 +9,20 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GetAssemblyAttributes : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GetAssemblyAttributes : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
+        public TaskEnvironment TaskEnvironment { get; set; }
+#endif
+
         [Required]
         public string PathToTemplateFile { get; set; }
 
@@ -19,8 +31,9 @@ namespace Microsoft.NET.Build.Tasks
 
         protected override void ExecuteCore()
         {
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(Path.GetFullPath(PathToTemplateFile));
-            Version assemblyVersion = FileUtilities.TryGetAssemblyVersion(Path.GetFullPath(PathToTemplateFile));
+            AbsolutePath templatePath = TaskEnvironment.GetAbsolutePath(PathToTemplateFile);
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(templatePath);
+            Version assemblyVersion = FileUtilities.TryGetAssemblyVersion(templatePath);
 
             AssemblyAttributes = FormatToAttributes(AssemblyAttributesNameByFieldInFileVersionInfo: new Dictionary<string, string>
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageDependencies.cs
@@ -18,7 +18,8 @@ namespace Microsoft.NET.Build.Tasks
     /// <remarks>
     /// Only called for backwards compatability, when <c>ResolvePackageDependencies</c> is true.
     /// </remarks>
-    public sealed class ResolvePackageDependencies : TaskBase
+    [MSBuildMultiThreadableTask]
+    public sealed class ResolvePackageDependencies : TaskBase, IMultiThreadableTask
     {
         private readonly Dictionary<string, string> _fileTypes = new(StringComparer.OrdinalIgnoreCase);
 
@@ -114,6 +115,17 @@ namespace Microsoft.NET.Build.Tasks
 
         #endregion
 
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
+        public TaskEnvironment TaskEnvironment { get; set; }
+#endif
+
         public ResolvePackageDependencies()
         {
         }
@@ -131,7 +143,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private IPackageResolver PackageResolver => _packageResolver ??= NuGetPackageResolver.CreateResolver(LockFile);
 
-        private LockFile LockFile => _lockFile ??= new LockFileCache(this).GetLockFile(ProjectAssetsFile);
+        private LockFile LockFile => _lockFile ??= new LockFileCache(this).GetLockFile(TaskEnvironment.GetAbsolutePath(ProjectAssetsFile));
 
         private Dictionary<string, string> _targetNameToAliasMap;
 
@@ -464,7 +476,13 @@ namespace Microsoft.NET.Build.Tasks
 
         private string GetAbsolutePathFromProjectRelativePath(string path)
         {
-            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(ProjectPath), path));
+            string projectDirectory = Path.GetDirectoryName(ProjectPath);
+            AbsolutePath absProjectDir = string.IsNullOrEmpty(projectDirectory)
+                ? TaskEnvironment.ProjectDirectory
+                : TaskEnvironment.GetAbsolutePath(projectDirectory);
+            // Path.GetFullPath resolves ".." segments so output matches the old behavior.
+            // Cannot use AbsolutePath.GetCanonicalForm() as it only exists in the NETFRAMEWORK polyfill.
+            return Path.GetFullPath(new AbsolutePath(path, absProjectDir));
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGenerateClsidMapMultiThreading
+    {
+        [Fact]
+        public void ItProducesSameErrorsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            // In multiprocess mode, CWD == projectDir (as MSBuild traditionally works).
+            // In multithreaded mode, CWD == otherDir but TaskEnvironment still points to projectDir.
+            // Both should produce identical errors for an invalid (non-PE) assembly.
+            var projectDir = Path.Combine(Path.GetTempPath(), "clsidmap-test-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "clsidmap-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                // Place a non-PE file at a relative path under projectDir
+                var assemblyRelativePath = Path.Combine("output", "test.dll");
+                var assemblyAbsolutePath = Path.Combine(projectDir, assemblyRelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(assemblyAbsolutePath)!);
+                File.WriteAllText(assemblyAbsolutePath, "not a real assembly");
+
+                var clsidMapRelativePath = Path.Combine("output", "clsid.map");
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (multiProcessResult, multiProcessEngine) = RunTask(assemblyRelativePath, clsidMapRelativePath, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir (different from projectDir) ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (multiThreadedResult, multiThreadedEngine) = RunTask(assemblyRelativePath, clsidMapRelativePath, projectDir);
+
+                // Both should produce the same result
+                multiProcessResult.Should().Be(multiThreadedResult,
+                    "task should return the same success/failure in both environments");
+                multiProcessEngine.Errors.Count.Should().Be(multiThreadedEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < multiProcessEngine.Errors.Count; i++)
+                {
+                    multiProcessEngine.Errors[i].Message.Should().Be(
+                        multiThreadedEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+                multiProcessEngine.Warnings.Count.Should().Be(multiThreadedEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItProducesSameClsidMapInMultiProcessAndMultiThreadedEnvironments()
+        {
+            // Same pattern but with a valid .NET assembly to test the success path.
+            // Both modes should produce identical CLSID map file contents.
+            var projectDir = Path.Combine(Path.GetTempPath(), "clsidmap-test-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "clsidmap-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                // Copy a real .NET assembly into projectDir
+                var sourceAssembly = typeof(GenerateClsidMap).Assembly.Location;
+                var assemblyRelativePath = Path.Combine("output", "test.dll");
+                var assemblyAbsolutePath = Path.Combine(projectDir, assemblyRelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(assemblyAbsolutePath)!);
+                File.Copy(sourceAssembly, assemblyAbsolutePath);
+
+                // Each mode writes to a separate clsid map so we can compare contents
+                var clsidMap1Relative = Path.Combine("output", "clsid1.map");
+                var clsidMap2Relative = Path.Combine("output", "clsid2.map");
+                var clsidMap1Absolute = Path.Combine(projectDir, clsidMap1Relative);
+                var clsidMap2Absolute = Path.Combine(projectDir, clsidMap2Relative);
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (result1, engine1) = RunTask(assemblyRelativePath, clsidMap1Relative, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (result2, engine2) = RunTask(assemblyRelativePath, clsidMap2Relative, projectDir);
+
+                // Same result, same errors/warnings
+                result1.Should().Be(result2, "task result should match between environments");
+                engine1.Errors.Count.Should().Be(engine2.Errors.Count, "error count should match");
+                engine1.Warnings.Count.Should().Be(engine2.Warnings.Count, "warning count should match");
+
+                // Both map files should be created (or both not)
+                File.Exists(clsidMap1Absolute).Should().Be(File.Exists(clsidMap2Absolute),
+                    "both environments should agree on whether the clsid map file is created");
+
+                if (File.Exists(clsidMap1Absolute))
+                {
+                    File.ReadAllText(clsidMap1Absolute).Should().Be(
+                        File.ReadAllText(clsidMap2Absolute),
+                        "clsid map file contents should be identical in both environments");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(
+            string assemblyRelativePath, string clsidMapRelativePath, string projectDir)
+        {
+            var task = new GenerateClsidMap
+            {
+                IntermediateAssembly = assemblyRelativePath,
+                ClsidMapDestinationPath = clsidMapRelativePath,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+            var engine = new MockBuildEngine();
+            task.BuildEngine = engine;
+
+            var result = task.Execute();
+            return (result, engine);
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -1,0 +1,360 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGenerateRuntimeConfigMultiThreading
+    {
+        [Fact]
+        public void ItWritesRuntimeConfigViaTaskEnvironment()
+        {
+            // Create a temp directory to act as a fake project dir (different from CWD).
+            // If the task resolves RuntimeConfigPath via TaskEnvironment (correct), it creates the file.
+            // If it resolves via CWD (incorrect), it writes to the wrong location or fails.
+            var projectDir = Path.Combine(Path.GetTempPath(), "rtconfig-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var configRelativePath = Path.Combine("bin", "test.runtimeconfig.json");
+                var configAbsolutePath = Path.Combine(projectDir, configRelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(configAbsolutePath)!);
+
+                var runtimeFramework = new TaskItem("Microsoft.NETCore.App");
+                runtimeFramework.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
+                runtimeFramework.SetMetadata("Version", "8.0.0");
+
+                var mockEngine = new MockBuildEngine();
+                var task = new GenerateRuntimeConfigurationFiles
+                {
+                    BuildEngine = mockEngine,
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    TargetFramework = ".NETCoreApp,Version=v8.0",
+                    TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0",
+                    RuntimeConfigPath = configRelativePath,
+                    RuntimeFrameworks = new ITaskItem[] { runtimeFramework },
+                    IsSelfContained = false,
+                    GenerateRuntimeConfigDevFile = false,
+                };
+
+                // Execute — should write runtimeconfig.json under projectDir via TaskEnvironment
+                task.Execute().Should().BeTrue(
+                    string.Join("; ", mockEngine.Errors.Select(e => e.Message)));
+
+                // The runtimeconfig.json file should exist at the absolute path under projectDir
+                File.Exists(configAbsolutePath).Should().BeTrue(
+                    "the runtimeconfig file should be created at the path resolved via TaskEnvironment, not CWD");
+
+                // Verify it's valid JSON with framework info
+                var content = File.ReadAllText(configAbsolutePath);
+                content.Should().Contain("Microsoft.NETCore.App");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItBehavesSameWithEmptyAssetsFilePathInBothEnvironments()
+        {
+            // When AssetsFilePath = "", the task enters the else branch (not null)
+            // and calls TaskEnvironment.GetAbsolutePath(""), which should fail the same way
+            // regardless of whether CWD matches the project directory or not.
+            var projectDir = Path.Combine(Path.GetTempPath(), "rtconfig-empty-assets-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "rtconfig-empty-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var configRelativePath = Path.Combine("bin", "test.runtimeconfig.json");
+                Directory.CreateDirectory(Path.Combine(projectDir, "bin"));
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpException) = RunTaskWithAssetsFilePath("", configRelativePath, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtException) = RunTaskWithAssetsFilePath("", configRelativePath, projectDir);
+
+                // Both should produce the same outcome
+                mpResult.Should().Be(mtResult,
+                    "task return value should be the same in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+
+                // Both should throw the same exception type (or both succeed without exception)
+                if (mpException != null)
+                {
+                    mtException.Should().NotBeNull("both environments should throw the same exception");
+                    mtException!.GetType().Should().Be(mpException.GetType(),
+                        "exception type should match between environments");
+                }
+                else
+                {
+                    mtException.Should().BeNull("neither environment should throw if one doesn't");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir))
+                    Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool? result, MockBuildEngine engine, Exception? exception) RunTaskWithAssetsFilePath(
+            string assetsFilePath, string configRelativePath, string projectDir)
+        {
+            return RunTaskCore(projectDir, configRelativePath, assetsFilePath: assetsFilePath);
+        }
+
+        private static (bool? result, MockBuildEngine engine, Exception? exception) RunTaskCore(
+            string projectDir,
+            string? runtimeConfigPath,
+            string? assetsFilePath = null,
+            string? runtimeConfigDevPath = null,
+            string? userRuntimeConfig = null)
+        {
+            var runtimeFramework = new TaskItem("Microsoft.NETCore.App");
+            runtimeFramework.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
+            runtimeFramework.SetMetadata("Version", "8.0.0");
+
+            var task = new GenerateRuntimeConfigurationFiles
+            {
+                TargetFramework = ".NETCoreApp,Version=v8.0",
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0",
+                RuntimeConfigPath = runtimeConfigPath,
+                RuntimeFrameworks = new ITaskItem[] { runtimeFramework },
+                IsSelfContained = false,
+                GenerateRuntimeConfigDevFile = false,
+                AssetsFilePath = assetsFilePath,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+            if (runtimeConfigDevPath != null)
+            {
+                task.RuntimeConfigDevPath = runtimeConfigDevPath;
+            }
+            if (userRuntimeConfig != null)
+            {
+                task.UserRuntimeConfig = userRuntimeConfig;
+            }
+            var engine = new MockBuildEngine();
+            task.BuildEngine = engine;
+
+            bool? result = null;
+            Exception? caught = null;
+            try
+            {
+                result = task.Execute();
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+
+            return (result, engine, caught);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ItBehavesSameWithEmptyOrNullRuntimeConfigPathInBothEnvironments(string? runtimeConfigPath)
+        {
+            // WriteRuntimeConfig calls TaskEnvironment.GetAbsolutePath(RuntimeConfigPath).
+            // When RuntimeConfigPath is "" or null, this should fail the same way
+            // regardless of whether CWD matches the project directory or not.
+            var projectDir = Path.Combine(Path.GetTempPath(), "rtconfig-path-test-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "rtconfig-path-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpException) = RunTaskCore(projectDir, runtimeConfigPath);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtException) = RunTaskCore(projectDir, runtimeConfigPath);
+
+                // Both should produce the same outcome
+                mpResult.Should().Be(mtResult,
+                    "task return value should be the same in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+
+                // Both should throw the same exception type (or both not throw)
+                if (mpException != null)
+                {
+                    mtException.Should().NotBeNull(
+                        "both environments should throw the same exception for RuntimeConfigPath={0}", runtimeConfigPath ?? "(null)");
+                    mtException!.GetType().Should().Be(mpException.GetType(),
+                        "exception type should match between environments");
+                }
+                else
+                {
+                    mtException.Should().BeNull(
+                        "neither environment should throw if one doesn't");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir))
+                    Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+
+        [Fact]
+        public void UserRuntimeConfigProducesSameOutputInBothEnvironments()
+        {
+            // AddUserRuntimeOptions calls TaskEnvironment.GetAbsolutePath(UserRuntimeConfig).
+            // Verify that the merged runtimeconfig.json content is identical whether
+            // CWD == projectDir (multiprocess) or CWD == otherDir (multithreaded).
+            var projectDir = Path.Combine(Path.GetTempPath(), "rtconfig-user-test-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "rtconfig-user-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                // Use separate output files so both runs can write without conflict
+                var config1RelativePath = Path.Combine("bin", "test1.runtimeconfig.json");
+                var config2RelativePath = Path.Combine("bin", "test2.runtimeconfig.json");
+                var config1Absolute = Path.Combine(projectDir, config1RelativePath);
+                var config2Absolute = Path.Combine(projectDir, config2RelativePath);
+                Directory.CreateDirectory(Path.Combine(projectDir, "bin"));
+
+                // Create a user runtime config at a relative path under projectDir
+                var userConfigRelativePath = "runtimeconfig.template.json";
+                File.WriteAllText(
+                    Path.Combine(projectDir, userConfigRelativePath),
+                    "{\"configProperties\":{\"TestProperty\":true}}");
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpException) = RunTaskCore(
+                    projectDir, config1RelativePath, userRuntimeConfig: userConfigRelativePath);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtException) = RunTaskCore(
+                    projectDir, config2RelativePath, userRuntimeConfig: userConfigRelativePath);
+
+                // Both should succeed
+                mpResult.Should().Be(mtResult,
+                    "task return value should be the same in both environments");
+                mpException.Should().BeNull("multiprocess run should not throw");
+                mtException.Should().BeNull("multithreaded run should not throw");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+
+                // Both output files should exist and have identical content
+                File.Exists(config1Absolute).Should().BeTrue("multiprocess output should be created");
+                File.Exists(config2Absolute).Should().BeTrue("multithreaded output should be created");
+                var content1 = File.ReadAllText(config1Absolute);
+                var content2 = File.ReadAllText(config2Absolute);
+                content1.Should().Be(content2,
+                    "runtimeconfig.json content should be identical in both environments");
+
+                // Verify the user options were actually merged
+                content1.Should().Contain("TestProperty",
+                    "user runtime config properties should be merged into the output");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir))
+                    Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+
+        [Fact]
+        public void UserRuntimeConfigWithNonexistentFileProducesSameOutputInBothEnvironments()
+        {
+            // When UserRuntimeConfig points to a file that doesn't exist,
+            // AddUserRuntimeOptions silently skips it. Verify both environments agree.
+            var projectDir = Path.Combine(Path.GetTempPath(), "rtconfig-nouser-test-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "rtconfig-nouser-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var config1RelativePath = Path.Combine("bin", "test1.runtimeconfig.json");
+                var config2RelativePath = Path.Combine("bin", "test2.runtimeconfig.json");
+                var config1Absolute = Path.Combine(projectDir, config1RelativePath);
+                var config2Absolute = Path.Combine(projectDir, config2RelativePath);
+                Directory.CreateDirectory(Path.Combine(projectDir, "bin"));
+
+                // Point to a file that does NOT exist under projectDir
+                var missingUserConfig = "does-not-exist.template.json";
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpException) = RunTaskCore(
+                    projectDir, config1RelativePath, userRuntimeConfig: missingUserConfig);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtException) = RunTaskCore(
+                    projectDir, config2RelativePath, userRuntimeConfig: missingUserConfig);
+
+                mpResult.Should().Be(mtResult,
+                    "task return value should be the same in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+
+                if (mpException != null)
+                {
+                    mtException.Should().NotBeNull("both environments should throw the same exception");
+                    mtException!.GetType().Should().Be(mpException.GetType());
+                }
+                else
+                {
+                    mtException.Should().BeNull();
+                }
+
+                // Both output files should have identical content (without user properties)
+                if (File.Exists(config1Absolute) && File.Exists(config2Absolute))
+                {
+                    File.ReadAllText(config1Absolute).Should().Be(
+                        File.ReadAllText(config2Absolute),
+                        "runtimeconfig.json content should be identical in both environments");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir))
+                    Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir))
+                    Directory.Delete(otherDir, true);
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -215,6 +215,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         private class TestableGenerateRuntimeConfigurationFiles : GenerateRuntimeConfigurationFiles
         {
+            public TestableGenerateRuntimeConfigurationFiles()
+            {
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
+            }
+
             public void PublicExecuteCore()
             {
                 base.ExecuteCore();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFileMultiThreading.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGenerateToolsSettingsFileMultiThreading
+    {
+        [Fact]
+        public void ItSavesFileRelativeToTaskEnvironmentProjectDir()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "gtsf-test-" + Guid.NewGuid().ToString("N"));
+            var outputDir = Path.Combine(projectDir, "output");
+            Directory.CreateDirectory(outputDir);
+            try
+            {
+                var task = new GenerateToolsSettingsFile
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    EntryPointRelativePath = "tool.dll",
+                    CommandName = "mytool",
+                    ToolsSettingsFilePath = "output/settings.xml",
+                };
+
+                task.Execute().Should().BeTrue();
+
+                var expectedFile = Path.Combine(projectDir, "output", "settings.xml");
+                File.Exists(expectedFile).Should().BeTrue("the file should be written under the project dir, not the CWD");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetAssemblyAttributesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetAssemblyAttributesMultiThreading.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGetAssemblyAttributesMultiThreading
+    {
+        [Fact]
+        public void ItResolvesRelativePathsViaTaskEnvironment()
+        {
+            // Create a temp directory to act as a fake project dir (different from CWD)
+            var projectDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                // We need a real .NET assembly file for FileVersionInfo.GetVersionInfo to work.
+                // Copy the test assembly itself to the project directory with a relative-path-friendly name.
+                var sourceAssembly = typeof(GivenAGetAssemblyAttributesMultiThreading).Assembly.Location;
+                var relativeFileName = "template.dll";
+                var expectedAbsPath = Path.Combine(projectDir, relativeFileName);
+                File.Copy(sourceAssembly, expectedAbsPath);
+
+                var task = new GetAssemblyAttributes
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    PathToTemplateFile = relativeFileName,
+                };
+
+                var result = task.Execute();
+
+                result.Should().BeTrue("the task should succeed when the file exists under the project directory");
+                task.AssemblyAttributes.Should().NotBeNull();
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesMultiThreading.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using NuGet.ProjectModel;
+using Xunit;
+using static Microsoft.NET.Build.Tasks.UnitTests.LockFileSnippets;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAResolvePackageDependenciesMultiThreading
+    {
+        [Fact]
+        public void ItResolvesProjectReferencePathsViaTaskEnvironment()
+        {
+            // Create a temp directory to act as a fake project dir (different from CWD).
+            // This ensures the test fails if the task uses Path.GetFullPath (CWD-relative)
+            // instead of TaskEnvironment.GetAbsolutePath (ProjectDirectory-relative).
+            var projectDir = Path.Combine(Path.GetTempPath(), "rpd-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var projectPath = Path.Combine(projectDir, "myproject.csproj");
+                File.WriteAllText(projectPath, "<Project/>");
+
+                string classLibDefn = CreateProjectLibrary("ClassLib/1.0.0",
+                    path: "../ClassLib/project.json",
+                    msbuildProject: "../ClassLib/ClassLib.csproj");
+
+                string targetLib = CreateTargetLibrary("ClassLib/1.0.0", "project");
+
+                string lockFileContent = CreateLockFileSnippet(
+                    targets: new string[] {
+                        CreateTarget(".NETCoreApp,Version=v1.0", targetLib),
+                    },
+                    libraries: new string[] { classLibDefn },
+                    projectFileDependencyGroups: new string[] {
+                        ProjectGroup,
+                        CreateProjectGroup(".NETCoreApp,Version=v1.0", "ClassLib >= 1.0.0"),
+                    }
+                );
+
+                var lockFile = TestLockFiles.CreateLockFile(lockFileContent);
+                var resolver = new MockPackageResolver();
+
+                var task = new ResolvePackageDependencies(lockFile, resolver)
+                {
+                    ProjectAssetsFile = lockFile.Path,
+                    ProjectPath = projectPath,
+                    ProjectLanguage = null,
+                    TargetFramework = null,
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                };
+
+                task.Execute().Should().BeTrue();
+
+                // The resolved path for the project reference should be relative to
+                // the project directory (via TaskEnvironment), not the process CWD.
+                var classLibPkg = task.PackageDefinitions
+                    .First(p => p.GetMetadata(MetadataKeys.Name) == "ClassLib");
+                var resolvedPath = classLibPkg.GetMetadata(MetadataKeys.ResolvedPath);
+
+                var expectedPath = Path.GetFullPath(Path.Combine(projectDir, "../ClassLib/ClassLib.csproj"));
+                resolvedPath.Should().Be(expectedPath);
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        private static string CreateProjectGroup(string tfm, params string[] deps)
+        {
+            string depList = deps.Length > 0 ? string.Join(",", deps.Select(d => $"\"{d}\"")) : "";
+            return $"\"{tfm}\": [{depList}]";
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
@@ -12,8 +12,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAResolvePackageDependenciesTask
     {
-        private static readonly string _packageRoot = "\\root\\packages".Replace('\\', Path.DirectorySeparatorChar);
-        private static readonly string _projectPath = "\\root\\anypath\\solutiondirectory\\myprojectdir\\myproject.csproj".Replace('\\', Path.DirectorySeparatorChar);
+        private static readonly string _drivePrefix = OperatingSystem.IsWindows() ? "C:" : "";
+        private static readonly string _packageRoot = (_drivePrefix + "\\root\\packages").Replace('\\', Path.DirectorySeparatorChar);
+        private static readonly string _projectPath = (_drivePrefix + "\\root\\anypath\\solutiondirectory\\myprojectdir\\myproject.csproj").Replace('\\', Path.DirectorySeparatorChar);
 
         [Theory]
         [MemberData(nameof(ItemCounts))]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
@@ -841,6 +841,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ProjectLanguage = null,
                 TargetFramework = target
             };
+            task.TaskEnvironment = TaskEnvironmentHelper.CreateForTest(
+                Path.GetDirectoryName(_projectPath));
 
             task.Execute().Should().BeTrue();
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -32,6 +32,37 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         _env.Dispose();
     }
 
+    #region Infrastructure Verification Tests
+
+    [Fact]
+    public void TestEnvironment_ProjectAndSpawnDirectories_AreDifferent()
+    {
+        _env.ProjectDirectory.Should().NotBe(_env.SpawnDirectory);
+        Directory.Exists(_env.ProjectDirectory).Should().BeTrue();
+        Directory.Exists(_env.SpawnDirectory).Should().BeTrue();
+
+        _output.WriteLine($"Project directory: {_env.ProjectDirectory}");
+        _output.WriteLine($"Spawn directory: {_env.SpawnDirectory}");
+    }
+
+    [Fact]
+    public void TestEnvironment_DemonstratesPathDifference()
+    {
+        var projectFile = _env.CreateProjectFile("test.txt", "content");
+
+        var correctPath = _env.GetProjectPath("test.txt");
+        var incorrectPath = _env.GetIncorrectPath("test.txt");
+
+        correctPath.Should().NotBe(incorrectPath);
+        File.Exists(correctPath).Should().BeTrue("file was created in project directory");
+        File.Exists(incorrectPath).Should().BeFalse("file should not exist in spawn directory");
+
+        _output.WriteLine($"Correct path (in project): {correctPath}");
+        _output.WriteLine($"Incorrect path (in spawn): {incorrectPath}");
+    }
+
+    #endregion
+
     #region AllowEmptyTelemetry - No File I/O
 
     [Fact]
@@ -82,6 +113,95 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #endregion
 
+    #region GenerateRuntimeConfigurationFiles
+
+    [Fact]
+    public void GenerateRuntimeConfigurationFiles_WithRelativePaths_ShouldResolveFromProjectDirectory()
+    {
+        _env.CreateProjectDirectory("obj");
+
+        Directory.Exists(_env.GetProjectPath("obj")).Should().BeTrue();
+        Directory.Exists("obj").Should().BeFalse("obj should NOT exist relative to CWD");
+
+        var task = new GenerateRuntimeConfigurationFiles
+        {
+            BuildEngine = new MockBuildEngine(),
+            TaskEnvironment = _env.TaskEnvironment,
+            RuntimeConfigPath = "obj/myapp.runtimeconfig.json",
+            TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0",
+            RuntimeFrameworks = Array.Empty<ITaskItem>(),
+            RollForward = "LatestMinor",
+            UserRuntimeConfig = "",
+            HostConfigurationOptions = Array.Empty<ITaskItem>(),
+            AdditionalProbingPaths = Array.Empty<ITaskItem>(),
+            IsSelfContained = false,
+            WriteAdditionalProbingPathsToMainConfig = false,
+            WriteIncludedFrameworks = false,
+            AlwaysIncludeCoreFramework = false
+        };
+
+        var result = task.Execute();
+
+        result.Should().BeTrue("task should resolve relative paths via TaskEnvironment");
+        File.Exists(_env.GetProjectPath("obj/myapp.runtimeconfig.json")).Should().BeTrue(
+            "runtimeconfig should be written to project dir, not CWD");
+    }
+
+    #endregion
+
+    #region GenerateToolsSettingsFile
+
+    [Fact]
+    public void GenerateToolsSettingsFile_WithRelativePaths_ShouldResolveFromProjectDirectory()
+    {
+        _env.CreateProjectDirectory("obj");
+
+        Directory.Exists(_env.GetProjectPath("obj")).Should().BeTrue();
+        Directory.Exists("obj").Should().BeFalse("obj should NOT exist relative to CWD");
+
+        var task = new GenerateToolsSettingsFile
+        {
+            BuildEngine = new MockBuildEngine(),
+            TaskEnvironment = _env.TaskEnvironment,
+            EntryPointRelativePath = "myapp.dll",
+            CommandName = "mytool",
+            ToolsSettingsFilePath = "obj/DotnetToolSettings.xml"
+        };
+
+        var result = task.Execute();
+
+        result.Should().BeTrue("task should resolve relative paths via TaskEnvironment");
+        File.Exists(_env.GetProjectPath("obj/DotnetToolSettings.xml")).Should().BeTrue(
+            "settings file should be written to project dir, not CWD");
+    }
+
+    #endregion
+
+    #region GetAssemblyAttributes
+
+    [Fact]
+    public void GetAssemblyAttributes_WithRelativePaths_ShouldResolveFromProjectDirectory()
+    {
+        _env.CreateProjectDirectory("obj");
+        _env.CreateProjectFile("obj/AssemblyInfo.cs.template", "// template content");
+
+        File.Exists(_env.GetProjectPath("obj/AssemblyInfo.cs.template")).Should().BeTrue();
+        File.Exists("obj/AssemblyInfo.cs.template").Should().BeFalse("file should NOT exist relative to CWD");
+
+        var task = new GetAssemblyAttributes
+        {
+            BuildEngine = new MockBuildEngine(),
+            TaskEnvironment = _env.TaskEnvironment,
+            PathToTemplateFile = "obj/AssemblyInfo.cs.template"
+        };
+
+        var result = task.Execute();
+
+        result.Should().BeTrue("task should resolve relative paths via TaskEnvironment");
+    }
+
+    #endregion
+
     #region ResolvePackageAssets
 
     [Fact]
@@ -123,6 +243,76 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         var result = task.Execute();
 
         result.Should().BeTrue("task should succeed when TaskEnvironment correctly resolves relative paths");
+    }
+
+    #endregion
+
+    #region ResolvePackageDependencies
+
+    [Fact]
+    public void ResolvePackageDependencies_WithRelativePaths_ShouldResolveFromProjectDirectory()
+    {
+        var assetsContent = @"{
+            ""version"": 3,
+            ""targets"": { "".NETCoreApp,Version=v8.0"": {} },
+            ""libraries"": {},
+            ""projectFileDependencyGroups"": { "".NETCoreApp,Version=v8.0"": [] },
+            ""project"": { ""version"": ""1.0.0"", ""frameworks"": { ""net8.0"": {} } }
+        }";
+        _env.CreateProjectDirectory("obj");
+        _env.CreateProjectFile("obj/project.assets.json", assetsContent);
+        _env.CreateProjectFile("myapp.csproj", "<Project></Project>");
+
+        File.Exists(_env.GetProjectPath("obj/project.assets.json")).Should().BeTrue();
+        File.Exists("obj/project.assets.json").Should().BeFalse("file should NOT exist relative to CWD");
+
+        var task = new ResolvePackageDependencies
+        {
+            BuildEngine = new MockBuildEngine(),
+            TaskEnvironment = _env.TaskEnvironment,
+            ProjectAssetsFile = "obj/project.assets.json",
+            ProjectPath = "myapp.csproj"
+        };
+
+        var result = task.Execute();
+
+        result.Should().BeTrue("task should resolve relative paths via TaskEnvironment");
+    }
+
+    #endregion
+
+    #region Demonstration: Absolute vs Relative Paths
+
+    [Fact]
+    public void AbsolutePath_AlwaysPointsToCorrectFile()
+    {
+        var content = "test content";
+        var absolutePath = _env.CreateProjectFile("data/input.txt", content);
+
+        Path.IsPathRooted(absolutePath).Should().BeTrue();
+
+        var readContent = File.ReadAllText(absolutePath);
+        readContent.Should().Be(content);
+
+        _output.WriteLine($"Absolute path: {absolutePath}");
+        _output.WriteLine($"Successfully read file content: {readContent}");
+    }
+
+    [Fact]
+    public void MockTaskEnvironment_ResolvesRelativeToProjectDirectory()
+    {
+        var content = "test content";
+        _env.CreateProjectFile("subdir/file.txt", content);
+
+        var resolvedPath = _env.TaskEnvironment.GetAbsolutePath("subdir/file.txt");
+
+        var expectedPath = _env.GetProjectPath("subdir/file.txt");
+        ((string)resolvedPath).Replace('/', Path.DirectorySeparatorChar)
+            .Should().Be(expectedPath.Replace('/', Path.DirectorySeparatorChar));
+
+        File.Exists(resolvedPath).Should().BeTrue();
+
+        _output.WriteLine($"TaskEnvironment resolved: {resolvedPath}");
     }
 
     #endregion

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.NET.Build.Tests
@@ -37,7 +38,11 @@ namespace Microsoft.NET.Build.Tests
                 return;
             }
 
-            var dependencyPackageReferences = new List<TestPackageReference>();
+            // ConcurrentBag because Parallel.ForEach calls Add from multiple threads.
+            // Also fixes a pre-existing bug: the original List was never populated inside
+            // the parallel loop, so dependencyPackageReferences was always empty and the
+            // test passed vacuously without verifying any NuGet reference compatibility.
+            var dependencyPackageReferences = new ConcurrentBag<TestPackageReference>();
 
             // Process all dependencies in parallel
             Parallel.ForEach(
@@ -56,9 +61,7 @@ namespace Microsoft.NET.Build.Tests
                         "1.0.0",
                         ConstantStringValues.ConstructNuGetPackageReferencePath(dependencyProject, identifier: referencerTarget + testDescription + rawDependencyTargets));
 
-                    // Create package if it doesn't exist
-                    if (!dependencyPackageReference.NuGetPackageExists() &&
-                        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dependencyProject.BuildsOnNonWindows))
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || dependencyProject.BuildsOnNonWindows)
                     {
                         if (!dependencyPackageReference.NuGetPackageExists())
                         {
@@ -77,6 +80,7 @@ namespace Microsoft.NET.Build.Tests
                                 .Execute().Should().Pass();
                         }
 
+                        dependencyPackageReferences.Add(dependencyPackageReference);
                     }
                 });
 


### PR DESCRIPTION
Squashed merge of 5 MSBuild task migrations to support multithreaded execution.

Stacked on #52909 (multithreading-polyfills).

## Migrated Tasks
- ResolvePackageDependencies
- GetAssemblyAttributes
- GenerateToolsSettingsFile
- GenerateClsidMap
- GenerateRuntimeConfigurationFiles

## Changes (13 files)
Each task receives:
- [MSBuildMultiThreadableTask] attribute
- IMultiThreadableTask interface implementation
- TaskEnvironment property
- Path absolutization for File/Directory/FileStream operations

Includes multithreading unit tests for each task.

## Test Results
233 passed, 11 failed (pre-existing redist.csproj failures, unrelated).
