### PR TITLE
Add Static Web Assets agent instructions and validation skill

### DIFF
--- a/.claude/skills/validate-static-web-asset-change/SKILL.md
+++ b/.claude/skills/validate-static-web-asset-change/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: validate-static-web-asset-change
+description: Use this skill when you are implementing a change on src\StaticWebAssetsSdk and want to test the behavior locally to validate it works as expected.
+---
+# Validating Static Web Asset SDK Changes
+
+This document describes how to build, test, and validate changes to the Static Web Assets SDK tasks locally.
+
+## 1. Building the SDK Tasks
+
+To build only the Static Web Assets tasks (fast iteration):
+
+```powershell
+cd src/StaticWebAssetsSdk/Tasks
+dotnet build
+```
+
+The output DLL lands under:
+```
+artifacts/bin/*/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/*/
+```
+
+Use a glob search to find the exact path if needed.
+
+## 2. Determine What Needs to Be Patched
+
+Run `git diff --name-only` (or `git diff --name-only HEAD` for uncommitted changes) and look at which files under `src/StaticWebAssetsSdk/` have changed:
+
+- **`Tasks/**/*.cs`** — The tasks DLL needs to be patched. Build the tasks project first (`dotnet build` in `src/StaticWebAssetsSdk/Tasks`), then copy the resulting `Microsoft.NET.Sdk.StaticWebAssets.Tasks.dll` to the target SDK's matching location under `Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/{tfm}/`.
+- **`Targets/**/*.targets` or `Targets/**/*.props`** — These files also need to be copied. Copy each changed `.targets` or `.props` file to the matching path under `Sdks/Microsoft.NET.Sdk.StaticWebAssets/targets/` in the target SDK.
+- **`Sdk/**/*.props` or `Sdk/**/*.targets`** — Copy to the matching path under `Sdks/Microsoft.NET.Sdk.StaticWebAssets/Sdk/` in the target SDK.
+
+The target SDK location is:
+```
+{dotnet-root}/sdk/{version}/Sdks/Microsoft.NET.Sdk.StaticWebAssets/
+```
+
+## 3. Setting Up a Test SDK
+
+You need an SDK to test your changes against. Do **not** modify your system-installed SDK.
+
+### Option A: Use the Repo Redist SDK (Recommended)
+
+For most projects, use the repo's built-in redist SDK. Build it once from the repo root:
+
+```powershell
+.\build.cmd   # Windows
+./build.sh    # Linux/macOS
+```
+
+This produces a full SDK at `artifacts/bin/redist/{Configuration}/dotnet/`. Set `DOTNET_ROOT` and `PATH` to point to it:
+
+```
+DOTNET_ROOT={repo}\artifacts\bin\redist\{Configuration}\dotnet
+PATH={repo}\artifacts\bin\redist\{Configuration}\dotnet;{rest-of-PATH}
+```
+
+After patching the files there (see Section 2), any `dotnet build` / `dotnet publish` in that shell will use your changes.
+
+### Option B: Download an SDK (Required for Blazor WASM)
+
+The redist SDK does not include workload packs, so **Blazor WebAssembly projects will not work with it**. For WASM scenarios, install a fresh SDK into `artifacts/test-sdk` using the official `dotnet-install` script:
+
+```powershell
+# Windows (PowerShell)
+& ([scriptblock]::Create((Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1'))) -InstallDir artifacts/test-sdk -Channel 10.0.1xx
+```
+
+```bash
+# Linux/macOS
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir artifacts/test-sdk --channel 10.0.1xx
+```
+
+Adjust `--channel` to match the major version you are working on (e.g., `11.0.1xx`). Then patch and point to it:
+
+```
+DOTNET_ROOT={repo}\artifacts\test-sdk
+PATH={repo}\artifacts\test-sdk;{rest-of-PATH}
+```
+
+## 4. Creating an Isolated Test Project
+
+Sample projects created inside or near the repo must be **isolated** from the repo's MSBuild configuration. Without isolation, the project inherits the repo's Arcade SDK, central package management, custom `global.json` SDK resolution, and internal NuGet feeds — all of which will cause build failures.
+
+Create a folder for your test project and add these sentinel files **before** creating the project itself:
+
+### `Directory.Build.props` (required)
+
+```xml
+<Project>
+  <!-- Stop MSBuild from walking up to the repo's Directory.Build.props -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>
+```
+
+MSBuild walks up the directory tree looking for this file. Placing it here stops the walk so the repo root's version (which imports Arcade SDK, enables central package management, etc.) is never found. `ManagePackageVersionsCentrally` must be explicitly set to `false` because the repo enables it globally.
+
+### `Directory.Build.targets` (required)
+
+```xml
+<Project>
+  <!-- Stop MSBuild from walking up to the repo's Directory.Build.targets -->
+</Project>
+```
+
+Same traversal-stopping purpose for `.targets`. The repo root's version adds signing, analyzers, and other infrastructure.
+
+### `NuGet.config` (required)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+The repo's `NuGet.config` references internal Azure DevOps feeds that require authentication. The `<clear />` directive ensures no parent config bleeds through.
+
+### Then create the project
+
+After placing the sentinel files, create your test project in the same folder:
+
+```powershell
+dotnet new blazor     # or webapp, classlib, etc.
+```
+
+The sentinel files apply to all projects in that folder and its subfolders.
+
+## 5. Testing Your Changes
+
+1. Create or use a sample project that exercises the scenario you changed (e.g., a Blazor app with scoped CSS, a library with static assets, etc.).
+2. Build and/or publish the project using the patched SDK:
+   ```powershell
+   {patched-dotnet} build MyProject.csproj
+   {patched-dotnet} publish MyProject.csproj -c Release -o publish
+   ```
+3. Capture a binary log if you need to debug the build:
+   ```powershell
+   {patched-dotnet} build MyProject.csproj -bl:build.binlog
+   {patched-dotnet} publish MyProject.csproj -bl:publish.binlog
+   ```
+   If you have an MSBuild binary log MCP server available, use that to inspect the log.
+
+## 6. Quick Validation Checklist
+
+After making a change, verify:
+
+1. **Build the tasks** — `dotnet build` in `src/StaticWebAssetsSdk/Tasks` succeeds
+2. **Patch and test locally** — Copy the changed files into a test SDK and build/publish a sample project
+3. **Check manifests** — Inspect the generated `.staticwebassets.runtime.json` and `.staticwebassets.endpoints.json` in the output
+4. **Check assets** — Verify that the correct assets are included with expected properties (source, content root, relative path, etc.)
+5. **Check endpoints** — Verify that routes, response headers, selectors, and endpoint properties are correct

--- a/src/StaticWebAssetsSdk/AGENTS.md
+++ b/src/StaticWebAssetsSdk/AGENTS.md
@@ -1,0 +1,375 @@
+# Agent Instructions for Working on the .NET SDK
+
+This document provides comprehensive instructions for AI agents working on the dotnet/sdk repository, particularly for Static Web Assets related changes.
+
+## Repository Structure
+
+The SDK repository contains multiple components. Key paths for Static Web Assets:
+
+```
+src/StaticWebAssetsSdk/
+├── Tasks/                          # MSBuild task implementations
+│   ├── Data/                       # Data structures (StaticWebAsset, StaticWebAssetEndpoint, etc.)
+│   ├── Utils/                      # Utilities (PathTokenizer, OSPath, etc.)
+│   └── *.cs                        # Task implementations
+├── Targets/                        # MSBuild targets (.targets files)
+└── Sdk/                            # SDK props and targets
+
+test/Microsoft.NET.Sdk.StaticWebAssets.Tests/
+├── StaticWebAssets/                # Unit tests for tasks
+└── *.cs                            # Integration tests
+```
+
+## Static Web Assets Build and Publish Flow
+
+### Build Flow
+```
+StaticWebAssetsPrepareForRun
+├── ResolveBuildStaticWebAssets
+│   ├── ResolveCoreStaticWebAssets
+│   │   ├── UpdateExistingPackageStaticWebAssets
+│   │   ├── ResolveProjectStaticWebAssets
+│   │   ├── ResolveEmbeddedProjectsStaticWebAssets
+│   │   └── ResolveReferencedProjectsStaticWebAssets
+│   │       └── ResolveReferencedProjectsStaticWebAssetsConfiguration
+│   ├── ResolveStaticWebAssetsInputs
+│   │   ├── ResolveCoreStaticWebAssets (already run)
+│   │   ├── GenerateComputedBuildStaticWebAssets
+│   │   │   └── BundleScopedCssFiles (if ScopedCss enabled)
+│   │   └── ResolveScopedCssAssets (if ScopedCss enabled)
+│   │   └── ResolveJSModuleManifestBuildStaticWebAssets (if JSModules enabled)
+│   └── ResolveBuildRelatedStaticWebAssets
+│       └── ResolveBuildCompressedStaticWebAssets (if Compression enabled)
+├── GenerateStaticWebAssetsManifest
+└── CopyStaticWebAssetsToOutputDirectory
+    └── LoadStaticWebAssetsBuildManifest
+```
+
+### Publish Flow
+```
+StaticWebAssetsPrepareForPublish
+├── ResolveStaticWebAssetsConfiguration
+├── GenerateStaticWebAssetsPublishManifest
+│   └── ResolveAllPublishStaticWebAssets
+│       ├── ResolveCorePublishStaticWebAssets
+│       │   ├── LoadStaticWebAssetsBuildManifest
+│       │   ├── ComputeReferencedProjectsEmbeddedPublishAssets
+│       │   └── ComputeReferencedProjectsPublishAssets
+│       ├── ResolvePublishStaticWebAssets
+│       │   ├── ResolveCorePublishStaticWebAssets (already run)
+│       │   └── GenerateComputedPublishStaticWebAssets
+│       └── ResolvePublishRelatedStaticWebAssets
+│           └── ResolvePublishCompressedStaticWebAssets
+└── CopyStaticWebAssetsToPublishDirectory
+    ├── StaticWebAssetsPrepareForPublish (already run)
+    └── LoadStaticWebAssetsPublishManifest
+```
+
+## Static Web Assets Targets
+
+### Main Targets (Microsoft.NET.Sdk.StaticWebAssets.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `StaticWebAssetsPrepareForRun` | Entry point - orchestrates build-time asset processing |
+| `ResolveBuildStaticWebAssets` | Master orchestration for 3-stage asset resolution |
+| `ResolveCoreStaticWebAssets` | Stage 1: Discover existing assets from disk |
+| `ResolveStaticWebAssetsInputs` | Stage 2: Generate computed assets |
+| `ResolveBuildRelatedStaticWebAssets` | Stage 3: Create derived assets (compression) |
+| `ResolveProjectStaticWebAssets` | Discover current project's wwwroot files |
+| `UpdateExistingPackageStaticWebAssets` | Update NuGet package assets |
+| `GenerateStaticWebAssetsManifest` | Generate all manifest files |
+| `GenerateComputedBuildStaticWebAssets` | Generate computed assets (hook) |
+| `CopyStaticWebAssetsToOutputDirectory` | Copy assets to output |
+| `ResolveStaticWebAssetsConfiguration` | Set up paths and properties |
+| `AddStaticWebAssetsManifest` | Add manifest to output |
+| `AddStaticWebAssetEndpointsBuildManifest` | Add endpoints manifest to output |
+| `LoadStaticWebAssetsBuildManifest` | Load manifest for publish |
+| `WriteStaticWebAssetsUpToDateCheck` | IDE up-to-date check support |
+
+### Reference Targets (Microsoft.NET.Sdk.StaticWebAssets.References.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `ResolveReferencedProjectsStaticWebAssetsConfiguration` | Get configuration from project references |
+| `GetStaticWebAssetsProjectConfiguration` | Return this project's SWA config |
+| `ResolveReferencedProjectsStaticWebAssets` | Get assets from project references |
+| `GetCurrentProjectBuildStaticWebAssetItems` | Expose assets to referencing projects |
+| `GetCurrentProjectPublishStaticWebAssetItems` | Expose publish assets to references |
+
+### Publish Targets (Microsoft.NET.Sdk.StaticWebAssets.Publish.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `StaticWebAssetsPrepareForPublish` | Entry point for publish |
+| `GenerateComputedPublishStaticWebAssets` | Generate publish-time computed assets |
+| `GenerateStaticWebAssetsPublishManifest` | Generate publish manifest |
+| `ResolveCorePublishStaticWebAssets` | Resolve core publish assets |
+| `ResolvePublishStaticWebAssets` | Resolve all publish assets |
+| `ResolveAllPublishStaticWebAssets` | Master orchestration for publish |
+| `ComputeReferencedProjectsPublishAssets` | Get publish assets from references |
+| `ComputeReferencedStaticWebAssetsPublishManifest` | Compute referenced manifests |
+| `CopyStaticWebAssetsToPublishDirectory` | Copy assets to publish output |
+| `CopyStaticWebAssetsEndpointsManifest` | Copy endpoints manifest |
+| `LoadStaticWebAssetsPublishManifest` | Load publish manifest |
+
+### Compression Targets (Microsoft.NET.Sdk.StaticWebAssets.Compression.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `ResolveBuildCompressedStaticWebAssets` | Create compressed variants (build) |
+| `GenerateBuildCompressedStaticWebAssets` | Generate compressed files (build) |
+| `ResolveBuildCompressedStaticWebAssetsConfiguration` | Configure build compression |
+| `ResolvePublishCompressedStaticWebAssets` | Create compressed variants (publish) |
+| `GeneratePublishCompressedStaticWebAssets` | Generate compressed files (publish) |
+| `ResolvePublishCompressedStaticWebAssetsConfiguration` | Configure publish compression |
+
+### Scoped CSS Targets (Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `ResolveScopedCssAssets` | Main scoped CSS processing |
+| `GenerateScopedCssFiles` | Generate scoped CSS |
+| `ResolveScopedCssInputs` | Discover scoped CSS inputs |
+| `ComputeCssScope` | Compute CSS scope identifiers |
+| `ResolveScopedCssOutputs` | Set output paths |
+| `BundleScopedCssFiles` | Create CSS bundle |
+| `ResolveBundledCssAssets` | Resolve bundled CSS |
+| `UpdateLegacyPackageScopedCssBundles` | Back-compat for legacy bundles |
+
+### JS Modules Targets (Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `ResolveJsInitializerModuleStaticWebAssets` | Resolve JS initializer modules |
+| `ResolveJSModuleManifestBuildConfiguration` | Configure build JS manifest |
+| `GenerateJSModuleManifestBuildStaticWebAssets` | Generate build JS manifest |
+| `ResolveJSModuleManifestBuildStaticWebAssets` | Resolve build JS manifest |
+| `ResolveJSModuleManifestPublishConfiguration` | Configure publish JS manifest |
+| `GenerateJSModuleManifestPublishStaticWebAssets` | Generate publish JS manifest |
+| `ResolveJSModuleManifestPublishStaticWebAssets` | Resolve publish JS manifest |
+| `ResolveJSModuleStaticWebAssets` | Resolve component JS modules |
+
+### Embedded Assets Targets (Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets)
+
+| Target | Purpose |
+|--------|---------|
+| `GetStaticWebAssetsCrosstargetingProjectConfiguration` | Get embedded project config |
+| `ResolveStaticWebAssetsCrossTargetingConfiguration` | Resolve cross-targeting config |
+| `ResolveStaticWebAssetsEmbeddingRules` | Resolve embedding rules |
+| `ResolveEmbeddedProjectsStaticWebAssets` | Resolve embedded project assets |
+| `ResolveEmbeddedConfigurationsPackageAssets` | Resolve embedded package assets |
+| `GetEmbeddedReferencedPackageAssets` | Get embedded package assets |
+| `ComputeReferencedProjectsEmbeddedPublishAssets` | Compute embedded publish assets |
+| `GetCurrentProjectEmbeddedBuildStaticWebAssetItems` | Expose embedded build assets |
+| `GetCurrentProjectEmbeddedPublishStaticWebAssetItems` | Expose embedded publish assets |
+
+## Static Web Assets Tasks
+
+| Task | File | Purpose |
+|------|------|---------|
+| `DefineStaticWebAssets` | DefineStaticWebAssets.cs | Create asset definitions from candidates |
+| `DefineStaticWebAssetEndpoints` | DefineStaticWebAssetEndpoints.cs | Create endpoint definitions |
+| `UpdateExternallyDefinedStaticWebAssets` | UpdateExternallyDefinedStaticWebAssets.cs | Update imported assets |
+| `UpdateStaticWebAssetEndpoints` | UpdateStaticWebAssetEndpoints.cs | Update endpoint properties |
+| `UpdatePackageStaticWebAssets` | UpdatePackageStaticWebAssets.cs | Update package assets |
+| `FilterStaticWebAssetEndpoints` | FilterStaticWebAssetEndpoints.cs | Filter endpoints by criteria |
+| `ComputeReferenceStaticWebAssetItems` | ComputeReferenceStaticWebAssetItems.cs | Compute reference assets |
+| `ComputeEndpointsForReferenceStaticWebAssets` | ComputeEndpointsForReferenceStaticWebAssets.cs | Transform endpoint routes |
+| `ComputeStaticWebAssetsForCurrentProject` | ComputeStaticWebAssetsForCurrentProject.cs | Filter to current project |
+| `ComputeStaticWebAssetsTargetPaths` | ComputeStaticWebAssetsTargetPaths.cs | Compute target paths |
+| `CollectStaticWebAssetsToCopy` | CollectStaticWebAssetsToCopy.cs | Collect assets for copying |
+| `MergeStaticWebAssets` | MergeStaticWebAssets.cs | Merge assets from multiple TFMs |
+| `MergeConfigurationProperties` | MergeConfigurationProperties.cs | Merge project configurations |
+| `GenerateStaticWebAssetsManifest` | GenerateStaticWebAssetsManifest.cs | Generate main manifest |
+| `GenerateStaticWebAssetEndpointsManifest` | GenerateStaticWebAssetEndpointsManifest.cs | Generate endpoints manifest |
+| `GenerateStaticWebAssetsDevelopmentManifest` | GenerateStaticWebAssetsDevelopmentManifest.cs | Generate development manifest |
+| `ReadStaticWebAssetsManifestFile` | ReadStaticWebAssetsManifestFile.cs | Read manifest file |
+| `ResolveStaticWebAssetEndpointRoutes` | ResolveStaticWebAssetEndpointRoutes.cs | Resolve endpoint routes |
+| `ResolveFingerprintedStaticWebAssetEndpointsForAssets` | ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs | Resolve fingerprinted endpoints |
+| `ResolveStaticWebAssetsEmbeddedProjectConfiguration` | ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs | Resolve embedded config |
+| `ApplyCompressionNegotiation` | ApplyCompressionNegotiation.cs | Apply content negotiation |
+| `BrotliCompress` | Compression/ | Brotli compression |
+| `GZipCompress` | Compression/ | Gzip compression |
+| `DiscoverPrecompressedAssets` | Compression/ | Find pre-compressed assets |
+| `ResolveCompressedAssets` | Compression/ | Resolve compression candidates |
+| `DiscoverDefaultScopedCssItems` | DiscoverDefaultScopedCssItems.cs | Discover scoped CSS |
+| `ResolveAllScopedCssAssets` | ScopedCss/ | Resolve all scoped CSS |
+| `ApplyCssScopes` | ScopedCss/ | Apply CSS scopes |
+| `ComputeCssScope` | ScopedCss/ | Compute scope identifiers |
+| `RewriteCss` | ScopedCss/ | Rewrite CSS with scopes |
+| `ConcatenateCssFiles` | ScopedCss/ | Bundle CSS files |
+| `GenerateJsModuleManifest` | JSModules/ | Generate JS module manifest |
+| `ApplyJsModules` | JSModules/ | Apply JS modules to components |
+
+## Core Data Model
+
+The Static Web Assets system is built around two primary data structures: `StaticWebAsset` and `StaticWebAssetEndpoint`. Understanding their properties and relationships is essential for working with the codebase.
+
+### StaticWebAsset
+
+Defined in `Tasks/Data/StaticWebAsset.cs`. Represents a single static file (CSS, JS, image, etc.) that is tracked through the build and publish pipeline. Each asset carries metadata describing where it came from, how it should be served, and how it relates to other assets.
+
+#### Identity and Source Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Identity` | `string` | Full path to the file on disk. Used as the unique identifier for the asset. Defaults to the `FullPath` metadata of the original MSBuild item. |
+| `SourceId` | `string` | Identifier of the project or package that owns this asset (e.g., project name or NuGet package ID). Used to group assets by origin and detect conflicts between sources. |
+| `SourceType` | `string` | How the asset was discovered. One of: `Discovered` (found on disk in wwwroot), `Computed` (generated during build, e.g., scoped CSS bundles), `Project` (from a referenced project), `Package` (from a NuGet package). |
+| `ContentRoot` | `string` | Absolute path to the root directory containing the asset (always ends with a directory separator). For wwwroot assets this is the wwwroot folder; for package assets it is the package's staticwebassets folder. |
+| `OriginalItemSpec` | `string` | The original MSBuild item spec before normalization. Used as a fallback when resolving the file on disk. |
+
+#### Path and Routing Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `BasePath` | `string` | URL prefix under which the asset is served (e.g., `_content/MyLib`). For `Discovered` and `Computed` assets this is ignored when computing the target path since they are relative to the project root. Normalized to forward slashes with no leading/trailing slashes. |
+| `RelativePath` | `string` | Path relative to the content root. May contain **token expressions** like `#[.{fingerprint}]?` for fingerprinted file names. Normalized to forward slashes. |
+
+**Path Token Syntax:** The `RelativePath` can embed token expressions using the format `#[.{tokenName}]`. The `#` prefix ensures tokens are never confused with valid file paths. `[]` delimit the expression, `{}` delimit variables, `?` marks the expression as optional (non-fingerprinted on disk), and `!` marks it as optional but preferred (fingerprinted on disk). For example, `app#[.{fingerprint}]!.js` means the file on disk is named `app.<hash>.js` but can also be addressed as `app.js`. Currently the only supported token is `fingerprint` (a base-36 SHA-256 hash).
+
+#### Asset Classification Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AssetKind` | `string` | When the asset is relevant. `Build` = build only, `Publish` = publish only, `All` = both build and publish. Defaults to `All` unless `CopyToPublishDirectory` is `Never`, in which case defaults to `Build`. |
+| `AssetMode` | `string` | Visibility scope. `All` = visible to current project and references, `CurrentProject` = only the owning project, `Reference` = only referencing projects. |
+| `AssetRole` | `string` | Relationship to other assets. `Primary` = standalone asset, `Related` = associated with a primary asset (e.g., `.map` file), `Alternative` = variant of a primary asset (e.g., compressed version). |
+| `RelatedAsset` | `string` | Full path to the primary asset this asset is related to. Required when `AssetRole` is `Related` or `Alternative`. |
+| `AssetTraitName` | `string` | Name of the trait that distinguishes an alternative asset (e.g., `Content-Encoding`). Required for `Alternative` assets. |
+| `AssetTraitValue` | `string` | Value of the distinguishing trait (e.g., `gzip`, `br`). Required for `Alternative` assets. |
+
+#### Merge Behavior Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AssetMergeBehavior` | `string` | Controls conflict resolution when merging assets from multiple TFMs or embedded projects. Values: `None` (default), `PreferTarget`, `PreferSource`, `Exclude`. |
+| `AssetMergeSource` | `string` | Identifies the source of the asset during merge operations, used alongside `AssetMergeBehavior`. |
+
+#### Copy Behavior Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `CopyToOutputDirectory` | `string` | Whether to copy to the build output directory. Values: `Never` (default), `PreserveNewest`, `Always`. |
+| `CopyToPublishDirectory` | `string` | Whether to copy to the publish output directory. Values: `Never`, `PreserveNewest` (default), `Always`. |
+
+#### Integrity and File Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Fingerprint` | `string` | Base-36 encoded SHA-256 hash of the file. Used for cache-busting in URL paths via token expressions. |
+| `Integrity` | `string` | Base-64 encoded SHA-256 hash of the file. Used for Sub-Resource Integrity (SRI) in HTML tags and HTTP headers. |
+| `FileLength` | `long` | Size of the file in bytes. Used for `Content-Length` headers and up-to-date checks. |
+| `LastWriteTime` | `DateTimeOffset` | Last modification time of the file. Used for `Last-Modified` headers and incremental build checks. |
+
+### StaticWebAssetEndpoint
+
+Defined in `Tasks/Data/StaticWebAssetEndpoint.cs`. Represents a URL route through which a static web asset can be served at runtime. A single asset can have multiple endpoints (e.g., a fingerprinted URL and a non-fingerprinted URL). Endpoints carry the response headers, content-negotiation selectors, and metadata properties needed by the runtime to serve the asset correctly.
+
+#### Core Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Route` | `string` | URL path as it should be registered in the routing table (used as the MSBuild item identity). For example, `_content/MyLib/app.js` or `_content/MyLib/app.abc123.js` for a fingerprinted variant. |
+| `AssetFile` | `string` | Path to the physical file on disk, matching the `StaticWebAsset.Identity`. Links the endpoint back to its underlying asset. |
+
+#### Selectors (Content Negotiation)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Selectors` | `StaticWebAssetEndpointSelector[]` | JSON-serialized array of request conditions that must match for this endpoint to be selected. Used for content negotiation (e.g., selecting a gzip-compressed variant when the client sends `Accept-Encoding: gzip`). |
+
+Each `StaticWebAssetEndpointSelector` has:
+- **`Name`** – The request header or attribute to match (e.g., `Content-Encoding`).
+- **`Value`** – The expected value (e.g., `gzip`).
+- **`Quality`** – Preference weight used when multiple selectors match.
+
+#### Response Headers
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ResponseHeaders` | `StaticWebAssetEndpointResponseHeader[]` | JSON-serialized array of HTTP response headers to include when serving this endpoint. Typical headers include `Content-Type`, `Cache-Control`, `ETag`, and `Content-Length`. |
+
+Each `StaticWebAssetEndpointResponseHeader` has:
+- **`Name`** – Header name (e.g., `Content-Type`).
+- **`Value`** – Header value (e.g., `text/css`).
+
+#### Endpoint Properties (Metadata)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `EndpointProperties` | `StaticWebAssetEndpointProperty[]` | JSON-serialized array of key-value metadata pairs associated with the endpoint. Used to carry build-time information (e.g., `fingerprint`, `integrity`, `label`) that the runtime or other tasks can consume. |
+
+Each `StaticWebAssetEndpointProperty` has:
+- **`Name`** – Property name (e.g., `integrity`, `fingerprint`, `label`).
+- **`Value`** – Property value.
+
+### Relationship Between Assets and Endpoints
+
+```
+StaticWebAsset (file on disk)
+├── Identity: D:\project\wwwroot\css\app.css
+├── RelativePath: css/app#[.{fingerprint}]!.css
+├── Fingerprint: abc123
+│
+├── Endpoint 1 (fingerprinted, preferred)
+│   ├── Route: css/app.abc123.css
+│   ├── AssetFile: D:\project\wwwroot\css\app.css
+│   ├── ResponseHeaders: [Content-Type=text/css, Cache-Control=max-age=31536000,immutable]
+│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-..., label=css/app.css]
+│
+├── Endpoint 2 (non-fingerprinted)
+│   ├── Route: css/app.css
+│   ├── AssetFile: D:\project\wwwroot\css\app.css
+│   ├── ResponseHeaders: [Content-Type=text/css, ETag="abc123"]
+│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-...]
+│
+└── Alternative Asset (gzip compressed)
+    ├── Identity: D:\project\obj\compressed\css\app.css.gz
+    ├── AssetRole: Alternative
+    ├── RelatedAsset: D:\project\wwwroot\css\app.css
+    ├── AssetTraitName: Content-Encoding
+    ├── AssetTraitValue: gzip
+    │
+    └── Endpoint 3 (compressed variant of Endpoint 1)
+        ├── Route: css/app.abc123.css
+        ├── AssetFile: D:\project\obj\compressed\css\app.css.gz
+        ├── Selectors: [Content-Encoding=gzip]
+        └── ResponseHeaders: [Content-Type=text/css, Content-Encoding=gzip, Vary=Content-Encoding]
+```
+
+## Development Workflow
+
+For detailed instructions on building, patching, and validating changes, see the [validate-static-web-asset-change skill](../../.claude/skills/validate-static-web-asset-change/SKILL.md).
+
+Do an initial build of the entire repo at the beginning following the instructions on the README.md.
+
+### Inner Loop: Make → Patch → Validate
+
+The primary development workflow is an iterative loop focused on fast feedback with a real project:
+
+1. **Make changes** — Edit task code in `src/StaticWebAssetsSdk/Tasks/` (or targets/props files)
+2. **Build the tasks** — `dotnet build` in `src/StaticWebAssetsSdk/Tasks`
+3. **Patch the SDK** — Copy the built DLL (and any changed `.targets`/`.props` files) into the redist SDK at `artifacts/bin/redist/{Configuration}/dotnet/sdk/{version}/Sdks/Microsoft.NET.Sdk.StaticWebAssets/`
+4. **Test with a real project** — Use the redist `dotnet` to `dotnet build` / `dotnet publish` a sample project and verify the behavior
+5. **Inspect results** — Check output assets, manifests (`.staticwebassets.runtime.json`, `.staticwebassets.endpoints.json`), and endpoints. Use binary logs (`-bl`) if needed.
+6. **Repeat** — Go back to step 1 until the behavior is correct
+
+**Do not write or run tests during the inner loop.** Focus on getting the behavior right first.
+
+### After Validation: Unit Tests
+
+Once the change is validated against a real project, write **unit tests** for the affected tasks. Unit tests live in `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/` and are plain test classes — they do **not** extend `AspNetSdkBaselineTest` or any SDK test base class. They test individual task logic in isolation by constructing task inputs and asserting outputs directly.
+
+```powershell
+dotnet test test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj --filter "FullyQualifiedName~YourTestClassName"
+```
+
+Never run all the tests — that takes a very long time. Always use `--filter` to run only the relevant test class.
+
+### Last: Integration Tests
+
+Integration tests extend `AspNetSdkBaselineTest` (or `IsolatedNuGetPackageFolderAspNetSdkBaselineTest`) and run full MSBuild builds against test project assets. They are slow and should **not** be part of the inner development loop. Write or update integration tests only after the change is validated and unit-tested. Leave running the full integration test suite to CI.
+
+**Never modify the system dotnet SDK.** Always use the repo-local redist SDK at `artifacts/bin/redist/{Configuration}/dotnet/` or a freshly downloaded copy for Blazor WASM scenarios.

--- a/src/StaticWebAssetsSdk/AGENTS.md
+++ b/src/StaticWebAssetsSdk/AGENTS.md
@@ -36,7 +36,7 @@ StaticWebAssetsPrepareForRun
 │   │   ├── ResolveCoreStaticWebAssets (already run)
 │   │   ├── GenerateComputedBuildStaticWebAssets
 │   │   │   └── BundleScopedCssFiles (if ScopedCss enabled)
-│   │   └── ResolveScopedCssAssets (if ScopedCss enabled)
+│   │   ├── ResolveScopedCssAssets (if ScopedCss enabled)
 │   │   └── ResolveJSModuleManifestBuildStaticWebAssets (if JSModules enabled)
 │   └── ResolveBuildRelatedStaticWebAssets
 │       └── ResolveBuildCompressedStaticWebAssets (if Compression enabled)
@@ -189,18 +189,18 @@ StaticWebAssetsPrepareForPublish
 | `ResolveFingerprintedStaticWebAssetEndpointsForAssets` | ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs | Resolve fingerprinted endpoints |
 | `ResolveStaticWebAssetsEmbeddedProjectConfiguration` | ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs | Resolve embedded config |
 | `ApplyCompressionNegotiation` | ApplyCompressionNegotiation.cs | Apply content negotiation |
-| `BrotliCompress` | Compression/ | Brotli compression |
-| `GZipCompress` | Compression/ | Gzip compression |
-| `DiscoverPrecompressedAssets` | Compression/ | Find pre-compressed assets |
-| `ResolveCompressedAssets` | Compression/ | Resolve compression candidates |
+| `BrotliCompress` | Compression/BrotliCompress.cs | Brotli compression |
+| `GZipCompress` | Compression/GZipCompress.cs | Gzip compression |
+| `DiscoverPrecompressedAssets` | Compression/DiscoverPrecompressedAssets.cs | Find pre-compressed assets |
+| `ResolveCompressedAssets` | Compression/ResolveCompressedAssets.cs | Resolve compression candidates |
 | `DiscoverDefaultScopedCssItems` | DiscoverDefaultScopedCssItems.cs | Discover scoped CSS |
-| `ResolveAllScopedCssAssets` | ScopedCss/ | Resolve all scoped CSS |
-| `ApplyCssScopes` | ScopedCss/ | Apply CSS scopes |
-| `ComputeCssScope` | ScopedCss/ | Compute scope identifiers |
-| `RewriteCss` | ScopedCss/ | Rewrite CSS with scopes |
-| `ConcatenateCssFiles` | ScopedCss/ | Bundle CSS files |
-| `GenerateJsModuleManifest` | JSModules/ | Generate JS module manifest |
-| `ApplyJsModules` | JSModules/ | Apply JS modules to components |
+| `ResolveAllScopedCssAssets` | ScopedCss/ResolveAllScopedCssAssets.cs | Resolve all scoped CSS |
+| `ApplyCssScopes` | ScopedCss/ApplyCssScopes.cs | Apply CSS scopes |
+| `ComputeCssScope` | ScopedCss/ComputeCssScope.cs | Compute scope identifiers |
+| `RewriteCss` | ScopedCss/RewriteCss.cs | Rewrite CSS with scopes |
+| `ConcatenateCssFiles` | ScopedCss/ConcatenateCssFiles.cs | Bundle CSS files |
+| `GenerateJsModuleManifest` | JSModules/GenerateJsModuleManifest.cs | Generate JS module manifest |
+| `ApplyJsModules` | JSModules/ApplyJsModules.cs | Apply JS modules to components |
 
 ## Core Data Model
 

--- a/src/StaticWebAssetsSdk/AGENTS.md
+++ b/src/StaticWebAssetsSdk/AGENTS.md
@@ -356,7 +356,7 @@ The primary development workflow is an iterative loop focused on fast feedback w
 5. **Inspect results** — Check output assets, manifests (`.staticwebassets.runtime.json`, `.staticwebassets.endpoints.json`), and endpoints. Use binary logs (`-bl`) if needed.
 6. **Repeat** — Go back to step 1 until the behavior is correct
 
-**Do not write or run tests during the inner loop.** Focus on getting the behavior right first.
+**Do not write or run integration tests during the inner loop.** Scoped unit tests (run with `--filter "FullyQualifiedName~YourTestClassName"`) are fine for quick validation of task logic.
 
 ### After Validation: Unit Tests
 
@@ -370,6 +370,8 @@ Never run all the tests — that takes a very long time. Always use `--filter` t
 
 ### Last: Integration Tests
 
-Integration tests extend `AspNetSdkBaselineTest` (or `IsolatedNuGetPackageFolderAspNetSdkBaselineTest`) and run full MSBuild builds against test project assets. They are slow and should **not** be part of the inner development loop. Write or update integration tests only after the change is validated and unit-tested. Leave running the full integration test suite to CI.
+Integration tests extend `AspNetSdkBaselineTest` (or `IsolatedNuGetPackageFolderAspNetSdkBaselineTest`) and run full MSBuild builds against test project assets. They are slow and should **not** be part of the inner development loop. Write or update integration tests only after the change is validated and unit-tested.
+
+When running integration tests locally, only run the specific tests you wrote or modified — at most the tests from the same class using `--filter "FullyQualifiedName~YourIntegrationTestClassName"`. Leave running the full integration test suite to CI.
 
 **Never modify the system dotnet SDK.** Always use the repo-local redist SDK at `artifacts/bin/redist/{Configuration}/dotnet/` or a freshly downloaded copy for Blazor WASM scenarios.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for AI agents working on the Static Web Assets SDK area of the dotnet/sdk repository.

## Changes

### `src/StaticWebAssetsSdk/AGENTS.md` (new)

Agent instructions file covering:
- **Repository structure** for Static Web Assets
- **Build and publish flow diagrams** showing target dependency trees
- **Targets reference** — all MSBuild targets organized by file (Main, Reference, Publish, Compression, Scoped CSS, JS Modules, Embedded Assets)
- **Tasks reference** — all MSBuild tasks with source file locations and purpose
- **Core data model** — detailed property documentation for `StaticWebAsset` and `StaticWebAssetEndpoint`, including path token syntax, asset classification, and the relationship between assets and endpoints
- **Development workflow** summary with links to the validation skill

### `.claude/skills/validate-static-web-asset-change/SKILL.md` (new)

Validation skill for testing SDK changes locally:
- Building the SDK tasks
- Determining what files need patching (tasks DLL, targets/props files)
- Setting up a test SDK (repo redist SDK for most cases, downloaded SDK for Blazor WASM)
- Creating isolated test projects within the repo (Directory.Build.props/targets, NuGet.config sentinel files)
- Testing workflow and validation checklist

## No code changes

This PR contains only documentation files — no source code, tests, or build infrastructure changes.