### PR TITLE
Enable and fix WASM tests

### DIFF
--- a/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj
+++ b/src/BuiltInTools/HotReloadAgent.WebAssembly.Browser/Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\WasmSdk\Sdk\TargetFrameworks.props" />
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(WasmAgentTargetFrameworkV10)</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <LangVersion>preview</LangVersion>

--- a/src/BuiltInTools/HotReloadClient/Web/StaticWebAssetsManifest.cs
+++ b/src/BuiltInTools/HotReloadClient/Web/StaticWebAssetsManifest.cs
@@ -90,6 +90,11 @@ internal sealed class StaticWebAssetsManifest(ImmutableDictionary<string, string
         {
             stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         }
+        catch (FileNotFoundException)
+        {
+            logger.LogDebug("File '{FilePath}' does not exist.", path);
+            return null;
+        }
         catch (Exception e)
         {
             logger.LogError("Failed to read '{FilePath}': {Message}", path, e.Message);

--- a/src/BuiltInTools/Watch/Build/EvaluationResult.cs
+++ b/src/BuiltInTools/Watch/Build/EvaluationResult.cs
@@ -130,7 +130,9 @@ internal sealed class EvaluationResult(ProjectGraph projectGraph, IReadOnlyDicti
             }
 
             // command line args items should be available:
-            Debug.Assert(Path.GetExtension(projectInstance.FullPath) != ".csproj" || projectInstance.GetItems("CscCommandLineArgs").Any());
+            Debug.Assert(
+                !Path.GetExtension(projectInstance.FullPath).Equals(".csproj", PathUtilities.OSSpecificPathComparison) ||
+                projectInstance.GetItems("CscCommandLineArgs").Any());
 
             var projectPath = projectInstance.FullPath;
             var projectDirectory = Path.GetDirectoryName(projectPath)!;

--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -14,6 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- For wasi-wasm, we don't want to import StaticWebAssets SDK. -->
   <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' != 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNETSdkStaticWebAssets)' == 'true'" />
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm' and '$(_WasmSdkImportsMicrosoftNetSdk)' == 'true'" />
+  <Import Project="TargetFrameworks.props" />
 
   <PropertyGroup>
     <_WasmEnableHotReload>$(WasmEnableHotReload)</_WasmEnableHotReload>
@@ -22,14 +23,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   <Target Name="_WasmImplicitlyReferenceHotReload" BeforeTargets="ResolveProjectStaticWebAssets" AfterTargets="ResolveStaticWebAssetsConfiguration" Condition="'$(_WasmEnableHotReload)' == 'true'">
     <PropertyGroup>
-      <_WasmHotReloadTfm Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">net10.0</_WasmHotReloadTfm>
+      <_WasmHotReloadTfm Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">$(WasmAgentTargetFrameworkV10)</_WasmHotReloadTfm>
       <_WasmHotReloadPath Condition="'$(_WasmHotReloadTfm)' != ''">$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'hotreload', $(_WasmHotReloadTfm)))</_WasmHotReloadPath>
       <_WasmHotReloadIntermediatePath>$(IntermediateOutputPath)hotreload\</_WasmHotReloadIntermediatePath>
     </PropertyGroup>
 
     <!-- Copy the JS module to intermediate folder to avoid duplicate identity when multiple projects reference the same SDK file -->
     <Copy
-      SourceFiles="$(_WasmHotReloadPath)wwwroot\Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js"
+      SourceFiles="$(_WasmHotReloadPath)Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js"
       DestinationFolder="$(_WasmHotReloadIntermediatePath)"
       SkipUnchangedFiles="true"
       Condition="'$(_WasmHotReloadPath)' != ''" />

--- a/src/WasmSdk/Sdk/TargetFrameworks.props
+++ b/src/WasmSdk/Sdk/TargetFrameworks.props
@@ -1,0 +1,9 @@
+<Project>
+  <!--
+    !!! Intentionally fixed versions. Do not update to the latest. !!!
+  -->
+  <PropertyGroup>
+    <!-- Used for assemblies injected to WASM apps targeting .NET 10.0+ -->
+    <WasmAgentTargetFrameworkV10>net10.0</WasmAgentTargetFrameworkV10>
+  </PropertyGroup>
+</Project>

--- a/src/WasmSdk/Tasks/Microsoft.NET.Sdk.WebAssembly.Tasks.csproj
+++ b/src/WasmSdk/Tasks/Microsoft.NET.Sdk.WebAssembly.Tasks.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="..\Sdk\TargetFrameworks.props" />
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -43,6 +44,9 @@
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
+      <OutputItemType>AdditionalContent</OutputItemType>
+      <PackagePath>hotreload\$(WasmAgentTargetFrameworkV10)</PackagePath>
+      <Targets>Build;ContentFilesProjectOutputGroup</Targets>
     </ProjectReference>
     <AdditionalContent Include="$(WasmSdkRoot)targets\**\*.*">
       <Pack>true</Pack>
@@ -51,10 +55,6 @@
     <AdditionalContent Include="$(WasmSdkRoot)Sdk\**\*.*">
       <Pack>true</Pack>
       <PackagePath>Sdk</PackagePath>
-    </AdditionalContent>
-    <AdditionalContent Include="$(ArtifactsBinDir)\Microsoft.DotNet.HotReload.WebAssembly.Browser\$(Configuration)\**\*.*">
-      <Pack>true</Pack>
-      <PackagePath>hotreload</PackagePath>
     </AdditionalContent>
   </ItemGroup>
 
@@ -67,11 +67,11 @@
   </Target>
 
   <Target Name="CopyAdditionalFilesToLayout"
-          Condition="'$(TargetFramework)' == ''"
+          Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'"
           DependsOnTargets="PrepareAdditionalFilesToLayout"
           AfterTargets="Build" Inputs="@(LayoutFile)"
-          Outputs="@(LayoutFile-&gt;'$(PackageLayoutOutputPath)%(TargetPath)')">
-    <Copy SourceFiles="@(LayoutFile)" DestinationFiles="@(LayoutFile-&gt;'$(PackageLayoutOutputPath)%(TargetPath)')">
+          Outputs="@(LayoutFile->'$(PackageLayoutOutputPath)%(TargetPath)')">
+    <Copy SourceFiles="@(LayoutFile)" DestinationFiles="@(LayoutFile->'$(PackageLayoutOutputPath)%(TargetPath)')">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
   </Target>

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -25,7 +25,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         App.AssertOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage("https://localhost:5001", ""));
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+    [Fact]
     public async Task BrowserDiagnostics()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -25,11 +25,11 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         App.AssertOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage("https://localhost:5001", ""));
     }
 
-    [Fact]
+    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
     public async Task BrowserDiagnostics()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")
-                .WithSource();
+            .WithSource();
 
         App.UseTestBrowser();
 

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -26,7 +26,17 @@ namespace Microsoft.DotNet.Watch.UnitTests
             using var watcher = DirectoryWatcher.Create(dir, watchedFileNames ?? [], usePolling, includeSubdirectories: watchSubdirectories);
             if (watcher is EventBasedDirectoryWatcher dotnetWatcher)
             {
-                dotnetWatcher.Logger = m => output.WriteLine(m);
+                dotnetWatcher.Logger = m =>
+                {
+                    try
+                    {
+                        output.WriteLine(m);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // the test output might have been closed already
+                    }
+                };
             }
 
             var operationCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -853,10 +853,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains("exited with exit code 0.");
         }
 
-        [PlatformSpecificTheory(TestPlatforms.Windows, Skip = "https://github.com/dotnet/sdk/issues/49928")] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Theory]
         [CombinatorialData]
         public async Task BlazorWasm(bool projectSpecifiesCapabilities)
         {
+            var tfm = ToolsetInfo.CurrentTargetFramework;
+
             var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasm", identifier: projectSpecifiesCapabilities.ToString())
                 .WithSource();
 
@@ -875,13 +877,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var port = TestOptions.GetTestPort();
             App.Start(testAsset, ["--urls", "http://localhost:" + port], testFlags: TestFlags.MockBrowser);
 
-            await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
-
             await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToUseBrowserRefresh);
             await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
 
-            // Browser is launched based on blazor-devserver output "Now listening on: ...".
-            await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}", ""));
+            // env variable passed when launching the server:
+            await App.WaitUntilOutputContains($"HOTRELOAD_DELTA_CLIENT_LOG_MESSAGES=dotnet watch 🕵️ [blazorwasm ({tfm})]");
+            App.Process.ClearOutput();
 
             // Middleware should have been loaded to blazor-devserver before the browser is launched:
             await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]");
@@ -894,26 +895,25 @@ namespace Microsoft.DotNet.Watch.UnitTests
             // shouldn't see any agent messages (agent is not loaded into blazor-devserver):
             App.AssertOutputDoesNotContain("🕵️");
 
+            // Browser is launched based on blazor-devserver output "Now listening on: ...".
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}", ""));
+
+            await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
+            App.Process.ClearOutput();
+
             var newSource = """
                 @page "/"
                 <h1>Updated</h1>
                 """;
 
             UpdateSourceFile(Path.Combine(testAsset.Path, "Pages", "Index.razor"), newSource);
-            await App.WaitUntilOutputContains(MessageDescriptor.ManagedCodeChangesApplied);
 
-            // check project specified capapabilities:
-            if (projectSpecifiesCapabilities)
-            {
-                await App.WaitUntilOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddMethodToExistingType Baseline.");
-            }
-            else
-            {
-                await App.WaitUntilOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddFieldRva AddInstanceFieldToExistingType AddMethodToExistingType AddStaticFieldToExistingType Baseline ChangeCustomAttributes GenericAddFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod NewTypeDefinition UpdateParameters.");
-            }
+            // WebAssemblyHotReloadCapabilities set by project is overwritten in WASM SDK targets:
+            await App.WaitUntilOutputContains("dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddInstanceFieldToExistingType AddMethodToExistingType AddStaticFieldToExistingType Baseline ChangeCustomAttributes GenericAddFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod NewTypeDefinition UpdateParameters.");
+            await App.WaitUntilOutputContains(MessageDescriptor.ManagedCodeChangesApplied);
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Fact]
         public async Task BlazorWasm_MSBuildWarning()
         {
             var testAsset = TestAssets
@@ -935,7 +935,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Fact]
         public async Task BlazorWasm_Restart()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasm")
@@ -958,31 +958,21 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.ReloadingBrowser);
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows, Skip = "https://github.com/dotnet/sdk/issues/49928")] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Fact]
         public async Task BlazorWasmHosted()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasmHosted")
                 .WithSource();
 
-            var tfm = ToolsetInfo.CurrentTargetFramework;
-
             var port = TestOptions.GetTestPort();
             App.Start(testAsset, ["--urls", "http://localhost:" + port], "blazorhosted", testFlags: TestFlags.MockBrowser);
-
-            await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
             await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToUseBrowserRefresh);
             await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
             await App.WaitUntilOutputContains(MessageDescriptor.ApplicationKind_BlazorHosted);
-
-            // client capabilities:
-            await App.WaitUntilOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Project specifies capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod UpdateParameters GenericAddFieldToExistingType AddExplicitInterfaceImplementation.");
-
-            // server capabilities:
-            await App.WaitUntilOutputContains($"dotnet watch ⌚ [blazorhosted ({tfm})] Capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType AddFieldRva AddExplicitInterfaceImplementation.");
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Fact]
         public async Task Razor_Component_ScopedCssAndStaticAssets()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")
@@ -1221,7 +1211,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains("> NewSubdir");
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+        [Fact]
         public async Task Aspire_BuildError_ManualRestart()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;
@@ -1250,7 +1240,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             // MigrationService terminated:
             await App.WaitUntilOutputContains("dotnet watch ⭐ [#1] Sending 'sessionTerminated'");
 
-            // working directory of the service should be it's project directory:
+            // working directory of the service should be its project directory:
             await App.WaitUntilOutputContains($"ApiService working directory: '{Path.GetDirectoryName(serviceProjectPath)}'");
 
             // Service -- valid code change:
@@ -1321,7 +1311,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains("dotnet watch ⭐ [#3] Sending 'sessionTerminated'");
         }
 
-        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/aspnetcore/issues/63759
+        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53058
         public async Task Aspire_NoEffect_AutoRestart()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -1211,7 +1211,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains("> NewSubdir");
         }
 
-        [Fact]
+        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53058
         public async Task Aspire_BuildError_ManualRestart()
         {
             var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ApplyDeltaTests.cs
@@ -958,7 +958,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.ReloadingBrowser);
         }
 
-        [Fact]
+        [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53064
         public async Task BlazorWasmHosted()
         {
             var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasmHosted")


### PR DESCRIPTION
Fixes Microsoft.DotNet.HotReload.WebAssembly.Browser asset layout. The test were failing to build WASM projects because `Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js` and `Microsoft.DotNet.HotReload.WebAssembly.Browser.dll` were not copied to the right directories.

Reenables WASM Hot Reload tests in dotnet-watch test suite.