### PR TITLE
Remove RunTestsAsTool Concept

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -46,12 +46,6 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <!-- Optionally override arcade's test target with one which will run the tests as tools.
-       Conditionally overriding a target requires a conditional import of another (.targets)
-       file. -->
-  <Import Project="OverrideTest.targets"
-          Condition="'$(RunTestsAsTool)' == 'true' And '$(CanRunTestAsTool)' == 'true'"/>
-
   <!-- Update KnownFrameworkReferences to target the right version of the runtime -->
   <!-- Don't use live shims when building tool packs in .NET product build mode as only packages for the current arch are available. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'

--- a/OverrideTest.targets
+++ b/OverrideTest.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <Target Name="Test"
-          DependsOnTargets="TestAsTool"
-          Condition="'$(IsUnitTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true'" />
-
-</Project>

--- a/benchmarks/MicroBenchmark/MicroBenchmark.csproj
+++ b/benchmarks/MicroBenchmark/MicroBenchmark.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
 
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <IsTestProject>false</IsTestProject>
     <IsUnitTestProject>false</IsUnitTestProject>
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -23,7 +23,6 @@ parameters:
   targetArchitecture: x64
   publishArgument: ''
   signArgument: ''
-  runTestsAsTool: false
   pgoInstrument: false
   enableDefaultArtifacts: false
   runtimeIdentifier: linux-x64
@@ -97,7 +96,6 @@ jobs:
           ${{ parameters.signArgument }}
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }}
           /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-          /p:RunTestsAsTool=${{ parameters.runTestsAsTool }}
           /p:PgoInstrument=${{ parameters.pgoInstrument }}
           ${{ parameters.runtimeSourceProperties }}
           ${{ parameters.officialBuildProperties }}
@@ -120,7 +118,6 @@ jobs:
           ${{ parameters.signArgument }} \
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }} \
           /p:TargetArchitecture=${{ parameters.targetArchitecture }} \
-          /p:RunTestsAsTool=${{ parameters.runTestsAsTool }} \
           /p:PgoInstrument=${{ parameters.pgoInstrument }} \
           /p:TargetRid=${{ parameters.runtimeIdentifier }} \
           ${{ parameters.osProperties }} \

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -8,10 +8,6 @@ parameters:
     publishRetryConfig: true
   - categoryName: FullFramework
     testFullMSBuild: true
-  - categoryName: TestAsTools
-    runTestsAsTool: true
-    # This job uses the build step for testing, so the extra test step is not necessary.
-    runTests: false
   - categoryName: TemplateEngine
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true

--- a/test/ArgumentForwarding.Tests/ArgumentForwarding.Tests.csproj
+++ b/test/ArgumentForwarding.Tests/ArgumentForwarding.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,16 +4,6 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(CanRunTestAsTool)' != 'false' AND '$(OutputType)' == 'Exe' AND '$(DotNetBuildSourceOnly)' != 'true'">
-    <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>$(PackageId)</ToolCommandName>
-    <CanRunTestAsTool Condition="'$(CanRunTestAsTool)' == ''">true</CanRunTestAsTool>
-
-    <!-- Put packages for tests in subfolder so we don't try to sign them -->
-    <PackageOutputPath>$(PackageOutputPath)tests\</PackageOutputPath>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Set this to true for test project only because test assets contains .editorconfig file -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
@@ -22,60 +12,6 @@
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="$(MSBuildThisFileDirectory)Common\Program.cs" />
   </ItemGroup>
-
-  <Target Name="TestAsTool" DependsOnTargets="Pack;_InnerGetTestsToRun">
-    <PropertyGroup>
-      <TestLocalToolFolder>$(TestLayoutDir)$(ToolCommandName)\</TestLocalToolFolder>
-      <TestLocalToolExecutionFolder>$(TestLayoutDir)$(ToolCommandName)\w</TestLocalToolExecutionFolder>
-      <DOTNET_CLI_HOME>$(TestLayoutDir)DOTNET_CLI_HOME\</DOTNET_CLI_HOME>
-    </PropertyGroup>
-
-    <RemoveDir Directories="$(TestLocalToolExecutionFolder)" />
-    <RemoveDir Directories="$(TestLocalToolFolder)" />
-    <MakeDir Directories="$(TestLocalToolFolder)" />
-    <MakeDir Directories="$(TestLocalToolExecutionFolder)" />
-
-    <MakeDir Directories="$(ArtifactsTestResultsDir)" />
-
-    <!-- Remove tool package from NuGet cache, so that local changes will be reflected if the package version
-         hasn't changed. -->
-    <RemoveDir Directories="$(NuGetPackageRoot)$(ToolCommandName)\$(PackageVersion)" />
-
-    <Exec Command="dotnet new tool-manifest"
-      IgnoreStandardErrorWarningFormat="true"
-      WorkingDirectory="$(TestLocalToolFolder)"
-      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
-
-    <Exec Command="dotnet tool install --local $(ToolCommandName) --version $(PackageVersion) --add-source $(ArtifactsNonShippingPackagesDir)"
-      WorkingDirectory="$(TestLocalToolFolder)"
-      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
-
-    <Exec Command="dotnet tool restore"
-      WorkingDirectory="$(TestLocalToolFolder)"
-      EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"/>
-
-    <PropertyGroup>
-      <ResultsXmlPath>@(TestToRun->'%(ResultsXmlPath)')</ResultsXmlPath>
-      <ResultsHtmlPath>@(TestToRun->'%(ResultsHtmlPath)')</ResultsHtmlPath>
-      <ResultsStdOutPath>@(TestToRun->'%(ResultsStdOutPath)')</ResultsStdOutPath>
-
-      <TestArgs>-noautoreporters -noRepoInference</TestArgs>
-      <TestArgs>$(TestArgs) -dotnetPath $(TestHostDotNetTool)</TestArgs>
-      <TestArgs>$(TestArgs) -xml "$(ResultsXmlPath)"</TestArgs>
-      <TestArgs>$(TestArgs) -html "$(ResultsHtmlPath)" $(TestRunnerAdditionalArguments)</TestArgs>
-      <TestArgs>$(TestArgs) &gt; $(ResultsStdOutPath)</TestArgs>
-      <TestArgs>$(TestArgs) -testExecutionDirectory $(TestLocalToolExecutionFolder)</TestArgs>
-    </PropertyGroup>
-
-    <!-- Run "dotnet new" (which will just display usage and available templates) in order to print first time
-         use message so that it doesn't interfere with tests which check the output of commands. -->
-    <Exec Command="$(TestHostDotNetTool) new" />
-
-    <Exec Command="dotnet tool run $(ToolCommandName) -- $(TestArgs)"
-          WorkingDirectory="$(TestLocalToolFolder)"
-          EnvironmentVariables="DOTNET_CLI_HOME=$(DOTNET_CLI_HOME)"
-          IgnoreStandardErrorWarningFormat="true" />
-  </Target>
 
   <Import Project="..\Directory.Build.targets" />
 

--- a/test/EndToEnd.Tests/EndToEnd.Tests.csproj
+++ b/test/EndToEnd.Tests/EndToEnd.Tests.csproj
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -10,7 +10,6 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.NET.TestFramework/SdkTestContext.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTestContext.cs
@@ -204,9 +204,10 @@ namespace Microsoft.NET.TestFramework
             SdkTestContext testContext = new();
 
             string basePath = Path.Combine(AppContext.BaseDirectory, "TestAssets");
+            string? envTestAssetsDir = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY");
             testContext.TestAssetsDirectory =
                 (Directory.Exists(basePath) ? basePath : null)
-                ?? Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY")
+                ?? (!string.IsNullOrEmpty(envTestAssetsDir) ? envTestAssetsDir : null)
                 ?? FindFolderInTree(Path.Combine("test", "TestAssets"), AppContext.BaseDirectory)!;
 
             string? repoRoot = null;
@@ -225,9 +226,10 @@ namespace Microsoft.NET.TestFramework
                 repoRoot = GetRepoRoot();
             }
 
+            string? envTestExecDir = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_EXECUTION_DIRECTORY");
             testContext.TestExecutionDirectory =
                 commandLine.TestExecutionDirectory
-                ?? Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_EXECUTION_DIRECTORY")
+                ?? (!string.IsNullOrEmpty(envTestExecDir) ? envTestExecDir : null)
                 ?? Path.Combine(FindFolderInTree("artifacts", AppContext.BaseDirectory)!, "tmp", repoConfiguration, "testing");
 
             Directory.CreateDirectory(testContext.TestExecutionDirectory);

--- a/test/Microsoft.NET.TestFramework/SdkTestContext.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTestContext.cs
@@ -203,28 +203,11 @@ namespace Microsoft.NET.TestFramework
 
             SdkTestContext testContext = new();
 
-            bool runAsTool = false;
-            if (Directory.Exists(Path.Combine(AppContext.BaseDirectory, "TestAssets")))
-            {
-                runAsTool = true;
-                testContext.TestAssetsDirectory = Path.Combine(AppContext.BaseDirectory, "TestAssets");
-            }
-            else if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_AS_TOOL")))
-            {
-                //  Pretend to run as a tool, but use the test assets found in the repo
-                //  This allows testing most of the "tests as global tool" behavior by setting an environment
-                //  variable instead of packing the test, and installing it as a global tool.
-                runAsTool = true;
-                string? FindFolder = FindFolderInTree(Path.Combine("test", "TestAssets"), AppContext.BaseDirectory);
-                if (FindFolder is not null)
-                {
-                    testContext.TestAssetsDirectory = FindFolder;
-                }
-            }
-            else if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY")) && Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY") is not null)
-            {
-                testContext.TestAssetsDirectory = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY")!;
-            }
+            string basePath = Path.Combine(AppContext.BaseDirectory, "TestAssets");
+            testContext.TestAssetsDirectory =
+                (Directory.Exists(basePath) ? basePath : null)
+                ?? Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_ASSETS_DIRECTORY")
+                ?? FindFolderInTree(Path.Combine("test", "TestAssets"), AppContext.BaseDirectory)!;
 
             string? repoRoot = null;
 #if DEBUG
@@ -237,36 +220,15 @@ namespace Microsoft.NET.TestFramework
             {
                 repoRoot = commandLine.SDKRepoPath;
             }
-            else if (!commandLine.NoRepoInference && !runAsTool)
+            else if (!commandLine.NoRepoInference)
             {
                 repoRoot = GetRepoRoot();
             }
 
-            if (!string.IsNullOrEmpty(commandLine.TestExecutionDirectory) && commandLine.TestExecutionDirectory is not null)
-            {
-                testContext.TestExecutionDirectory = commandLine.TestExecutionDirectory;
-            }
-            else if (Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_EXECUTION_DIRECTORY") != null)
-            {
-                testContext.TestExecutionDirectory = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_EXECUTION_DIRECTORY")!;
-            }
-            else if (runAsTool)
-            {
-                testContext.TestExecutionDirectory = Path.Combine(Path.GetTempPath(), "dotnetSdkTests", Path.GetRandomFileName());
-            }
-            else
-            {
-                string? FindFolder1 = FindFolderInTree("artifacts", AppContext.BaseDirectory);
-                string? FindFolder2 = FindFolderInTree(Path.Combine("test", "TestAssets"), AppContext.BaseDirectory);
-                if (FindFolder1 is not null)
-                {
-                    testContext.TestExecutionDirectory = Path.Combine(FindFolder1, "tmp", repoConfiguration, "testing");
-                }
-                if (FindFolder2 is not null)
-                {
-                    testContext.TestAssetsDirectory = FindFolder2;
-                }
-            }
+            testContext.TestExecutionDirectory =
+                commandLine.TestExecutionDirectory
+                ?? Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_EXECUTION_DIRECTORY")
+                ?? Path.Combine(FindFolderInTree("artifacts", AppContext.BaseDirectory)!, "tmp", repoConfiguration, "testing");
 
             Directory.CreateDirectory(testContext.TestExecutionDirectory);
 
@@ -293,18 +255,6 @@ namespace Microsoft.NET.TestFramework
 
                 testContext.TestPackages = Path.Combine(artifactsDir, "tmp", repoConfiguration, "testing", "testpackages");
                 testContext.ShippingPackagesDirectory = Path.Combine(artifactsDir, "packages", repoConfiguration, "Shipping");
-            }
-            else if (runAsTool)
-            {
-                testContext.NuGetFallbackFolder = Path.Combine(testContext.TestExecutionDirectory, ".nuget", "NuGetFallbackFolder");
-                testContext.NuGetExePath = Path.Combine(testContext.TestExecutionDirectory, ".nuget", $"nuget{Constants.ExeSuffix}");
-                testContext.NuGetCachePath = Path.Combine(testContext.TestExecutionDirectory, ".nuget", "packages");
-
-                var testPackages = Path.Combine(testContext.TestExecutionDirectory, "Testpackages");
-                if (Directory.Exists(testPackages))
-                {
-                    testContext.TestPackages = testPackages;
-                }
             }
             else
             {

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -4,8 +4,12 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
     <OutputType>Exe</OutputType>
-    <IsPackable>true</IsPackable>
     <EnableDefaultScopedCssItems>false</EnableDefaultScopedCssItems>
+
+    <!-- Suppress pack warnings for this test project. Microsoft.NET.Sdk.Web defaults 
+         WarnOnPackingNonPackableProject=true, but test projects have IsPackable=false by default,
+         which would generate warnings/errors during pack operations that we want to suppress. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
     <OutputType>Exe</OutputType>
+    <IsPackable>true</IsPackable>
     <EnableDefaultScopedCssItems>false</EnableDefaultScopedCssItems>
   </PropertyGroup>
 

--- a/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <IsTestProject>false</IsTestProject>
     <IsUnitTestProject>false</IsUnitTestProject>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>

--- a/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/test/SDDLTests/SDDLTests.csproj
+++ b/test/SDDLTests/SDDLTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <IsTestProject>false</IsTestProject>
     <IsUnitTestProject>false</IsUnitTestProject>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>

--- a/test/System.CommandLine.StaticCompletions.Tests/System.CommandLine.StaticCompletions.Tests.csproj
+++ b/test/System.CommandLine.StaticCompletions.Tests/System.CommandLine.StaticCompletions.Tests.csproj
@@ -6,7 +6,6 @@
     <OutputType>Exe</OutputType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <RootNamespace>Microsoft.DotNet.MsiInstallerTests</RootNamespace>
   </PropertyGroup>
 

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -14,7 +14,6 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
 
     <!-- Use layout folder for the output folder, to support in-process tests which expect to be running
          on a valid layout. -->

--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <CanRunTestAsTool>false</CanRunTestAsTool>
     <OutputPath>$(TestHostFolder)</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
The RunTestAsTool concept was necessary when there was separate dotnet/sdk and dotnet/installer repos.  The installer ran several of the sdk tests using this mechanism.  Now that the repos have been consolidated, this infrastructure is no longer necessary.  Removing it cleans up the infrastructure and removes an entire leg from CI (TestAsTools).  This infrastructure was requiring workarounds for the [xunit v3 upgrade](https://github.com/dotnet/sdk/issues/52914)