### PR TITLE
[dotnet run] `$(Device)` global property missing during `DeployToDevice` target

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -259,6 +259,7 @@ public class RunCommand
         {
             globalProperties["Device"] = Device;
             var properties = new Dictionary<string, string> { { "Device", Device } };
+            selector.InvalidateGlobalProperties(properties);
             var additionalProperties = new ReadOnlyDictionary<string, string>(properties);
             MSBuildArgs = MSBuildArgs.CloneWithAdditionalProperties(additionalProperties);
         }
@@ -319,6 +320,8 @@ public class RunCommand
                     _restoreDoneForDeviceSelection = false;
                 }
 
+                // Update the selector's global properties so DeployToDevice and other targets see the Device
+                selector.InvalidateGlobalProperties(properties);
                 var additionalProperties = new ReadOnlyDictionary<string, string>(properties);
                 MSBuildArgs = MSBuildArgs.CloneWithAdditionalProperties(additionalProperties);
             }


### PR DESCRIPTION
When the `DeployToDevice` target runs, and you selected a device from the `dotnet run` device selection prompt, `$(Device)` is blank!

This was because evaluation already occurred, so we have to invalidate the project, so it will occur in subsequent steps.

I could reproduce this in a test, so this verifies it will remain fixed for the future.