### PR TITLE
Cleans up test package references and global usings

### DIFF
--- a/test/ArgumentsReflector/ArgumentsReflector.csproj
+++ b/test/ArgumentsReflector/ArgumentsReflector.csproj
@@ -5,17 +5,4 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="AwesomeAssertions" />
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-    <Using Remove="Xunit" />
-    <Using Remove="Xunit.Abstractions" />
-  </ItemGroup>
-
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -24,21 +24,4 @@
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" />
-  </ItemGroup>
-
-  <!-- Global usings -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Include="FluentAssertions" />
-    <Using Include="Microsoft.NET.TestFramework" />
-    <Using Include="Microsoft.NET.TestFramework.Assertions" />
-    <Using Include="Microsoft.NET.TestFramework.Commands" />
-    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Include="Microsoft.NET.TestFramework.Utilities" />
-    <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
-  </ItemGroup>
-
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -20,6 +20,17 @@
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <Using Include="FluentAssertions" />
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(OutputType)' == 'Exe' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="$(MSBuildThisFileDirectory)Common\Program.cs" />
   </ItemGroup>

--- a/test/HelixTasks/HelixTasks.csproj
+++ b/test/HelixTasks/HelixTasks.csproj
@@ -20,17 +20,4 @@
     <PackageReference Include="System.Reflection.Metadata" VersionOverride="$(SystemReflectionMetadataToolsetPackageVersion)" />
   </ItemGroup>
 
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="AwesomeAssertions" />
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-    <Using Remove="Xunit" />
-    <Using Remove="Xunit.Abstractions" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/AssertEx.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/AssertEx.cs
@@ -7,6 +7,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Xunit;
 using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Watch.UnitTests

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
@@ -5,6 +5,8 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks.Dataflow;
+using Microsoft.NET.TestFramework.Utilities;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests
 {

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/DebugTestOutputLogger.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/DebugTestOutputLogger.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/TestAssetExtensions.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/TestAssetExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.NET.TestFramework;
+
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal static class TestAssetExtensions

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/TestLogger.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/TestLogger.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageDownloaderMock.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.TestFramework.Utilities;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Versioning;

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -51,7 +51,17 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.IO.Hashing" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.assert" />
+    <PackageReference Include="AwesomeAssertions" />
+
+    <Using Include="FluentAssertions" />
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <!-- Packages that are in-box for .NET Core, so we only need to reference them for .NET Framework -->

--- a/test/SDDLTests/Program.cs
+++ b/test/SDDLTests/Program.cs
@@ -96,6 +96,15 @@ namespace SDDLTests
             Console.ResetColor();
         }
 
+        private static void Assert(bool condition, string message)
+        {
+            if (!condition)
+            {
+                WriteError(message);
+                Environment.Exit(-1);
+            }
+        }
+
         /// <summary>
         /// Extracts the owner, group and DACL (individual ACES) of the security descriptor.
         /// </summary>
@@ -185,13 +194,13 @@ namespace SDDLTests
             Console.WriteLine($"Verifying descriptor: {sddlDescriptor}");
             (string owner, string group, IEnumerable<string> ACEs) d = GetDescriptorParts(sddlDescriptor);
 
-            Assert.True(expectedOwnerSID == d.owner, $"Expected owner SID to be {expectedOwnerSID}. Actual value: {d.owner}");
-            Assert.True(expectedGroupSID == d.group, $"Expected group SID to be {expectedGroupSID}. Actual value: {d.group}");
-            Assert.True(d.ACEs.Count() == expectedNumberOfACEsInDACL, $"Expected {expectedNumberOfACEsInDACL}. Actual: {d.ACEs.Count()}");
+            Assert(expectedOwnerSID == d.owner, $"Expected owner SID to be {expectedOwnerSID}. Actual value: {d.owner}");
+            Assert(expectedGroupSID == d.group, $"Expected group SID to be {expectedGroupSID}. Actual value: {d.group}");
+            Assert(d.ACEs.Count() == expectedNumberOfACEsInDACL, $"Expected {expectedNumberOfACEsInDACL}. Actual: {d.ACEs.Count()}");
 
             foreach (string ace in expectedACEs)
             {
-                Assert.True(d.ACEs.Contains(ace), $"Expected DACL to contain {ace}, but it did not.");
+                Assert(d.ACEs.Contains(ace), $"Expected DACL to contain {ace}, but it did not.");
             }
         }
 

--- a/test/SDDLTests/SDDLTests.csproj
+++ b/test/SDDLTests/SDDLTests.csproj
@@ -16,19 +16,4 @@
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="xunit" />
-  </ItemGroup>
-
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="FluentAssertions" />
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-  </ItemGroup>
-
 </Project>

--- a/test/TelemetryStdOutLogger/TelemetryStdOutLogger.csproj
+++ b/test/TelemetryStdOutLogger/TelemetryStdOutLogger.csproj
@@ -14,19 +14,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="FluentAssertions" />
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-    <Using Remove="Xunit" />
-    <Using Remove="Xunit.Abstractions" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   
 </Project>

--- a/test/dotnet-watch-test-browser/dotnet-watch-test-browser.csproj
+++ b/test/dotnet-watch-test-browser/dotnet-watch-test-browser.csproj
@@ -8,7 +8,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup>
-    <Using Remove="@(Using)"/>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Only include test global usings in test projects.
Only include AwesomeAssertions package reference in test projects.

Fixes test project loading in VS Code. See https://github.com/microsoft/vscode-dotnettools/issues/2784