### PR TITLE
Fix CA1873 false positives for simple params logging args

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLoggingTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLoggingTests.cs
@@ -3103,6 +3103,24 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             await VerifyCSharpDiagnosticAsync(source);
         }
 
+        [Fact]
+        public async Task ImplicitReferenceTypeParamsArrayCreation_NoDiagnostic_CS()
+        {
+            string source = """
+                using Microsoft.Extensions.Logging;
+
+                class C
+                {
+                    void M(ILogger logger, string value)
+                    {
+                        logger.LogInformation("Test: {Value}", value);
+                    }
+                }
+                """;
+
+            await VerifyCSharpDiagnosticAsync(source);
+        }
+
         // VB tests
 
         [Fact]
@@ -5693,6 +5711,22 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 Class C
                     Sub M(logger As ILogger)
                         [|logger.LogInformation("Test: {Number1} and {Number2}", 1, 2)|]
+                    End Sub
+                End Class
+                """;
+
+            await VerifyBasicDiagnosticAsync(source);
+        }
+
+        [Fact]
+        public async Task ImplicitReferenceTypeParamsArrayCreation_NoDiagnostic_VB()
+        {
+            string source = """
+                Imports Microsoft.Extensions.Logging
+
+                Class C
+                    Sub M(logger As ILogger, value As String)
+                        logger.LogInformation("Test: {Value}", value)
                     End Sub
                 End Class
                 """;


### PR DESCRIPTION
## Summary
Fixes a CA1873 regression where simple string-reference logging arguments started producing warnings in 10.0.103.

Fixes #53006.

## Problem
After #51839, `IsPotentiallyExpensive` treated compiler-generated implicit `params` wrappers (array/collection) as expensive based on wrapper shape alone. This caused false positives for calls like:

```csharp
logger.LogInformation("Value: {Value}", value);
```

when `value` is a simple string reference.

## Fix
- In `AvoidPotentiallyExpensiveCallWhenLoggingAnalyzer.IsPotentiallyExpensive`:
  - Handle implicit `IArrayCreationOperation` (params wrapper) by inspecting elements and only flagging when any contained element is actually expensive.
  - Handle implicit collection-expression wrappers similarly.
  - Preserve previous behavior for explicit array/collection arguments (still treated as expensive).
- Added regression tests:
  - `ImplicitReferenceTypeParamsArrayCreation_NoDiagnostic_CS`
  - `ImplicitReferenceTypeParamsArrayCreation_NoDiagnostic_VB`

## Testing
- Reproduced issue with a minimal project:
  - SDK `10.0.103`: CA1873 appears for `logger.LogInformation("...", value)` with string `value`.
  - SDK `10.0.101`: same code does not produce CA1873.
- Added analyzer unit tests above to lock in behavior.
