### PR TITLE
CA1873: Add specific reason to diagnostic message

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -2193,10 +2193,37 @@ Widening and user defined conversions are not supported with generic types.</val
     <value>In many situations, logging is disabled or set to a log level that results in an unnecessary evaluation for this argument.</value>
   </data>
   <data name="AvoidPotentiallyExpensiveCallWhenLoggingMessage" xml:space="preserve">
-    <value>Evaluation of this argument may be expensive and unnecessary if logging is disabled</value>
+    <value>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</value>
   </data>
   <data name="AvoidPotentiallyExpensiveCallWhenLoggingTitle" xml:space="preserve">
     <value>Avoid potentially expensive logging</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation" xml:space="preserve">
+    <value>anonymous object creation</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation" xml:space="preserve">
+    <value>array creation</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression" xml:space="preserve">
+    <value>await expression</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion" xml:space="preserve">
+    <value>boxing conversion</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression" xml:space="preserve">
+    <value>collection expression</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation" xml:space="preserve">
+    <value>method invocation</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation" xml:space="preserve">
+    <value>object creation</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation" xml:space="preserve">
+    <value>string interpolation</value>
+  </data>
+  <data name="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression" xml:space="preserve">
+    <value>with expression</value>
   </data>
   <data name="AvoidSingleUseOfLocalJsonSerializerOptionsMessage" xml:space="preserve">
     <value>Avoid creating a new 'JsonSerializerOptions' instance for every serialization operation. Cache and reuse instances instead.</value>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLogging.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLogging.cs
@@ -91,9 +91,9 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 // Check each argument if it is potentially expensive to evaluate and raise a diagnostic if it is.
                 foreach (var argument in invocation.Arguments.Skip(invocation.IsExtensionMethodAndHasNoInstance() ? 1 : 0))
                 {
-                    if (IsPotentiallyExpensive(argument.Value))
+                    if (GetExpenseReason(argument.Value) is { } reason)
                     {
-                        context.ReportDiagnostic(argument.CreateDiagnostic(Rule));
+                        context.ReportDiagnostic(argument.CreateDiagnostic(Rule, reason));
                     }
                 }
 
@@ -103,95 +103,118 @@ namespace Microsoft.NetCore.Analyzers.Performance
             }
         }
 
-        private static bool IsPotentiallyExpensive(IOperation? operation)
+        private static string? GetExpenseReason(IOperation? operation)
         {
             if (operation is null)
             {
-                return false;
+                return null;
             }
 
-            if (ICollectionExpressionOperationWrapper.IsInstance(operation) ||
-                operation is IAnonymousObjectCreationOperation or IAwaitOperation or IWithOperation)
+            if (ICollectionExpressionOperationWrapper.IsInstance(operation))
             {
-                return true;
+                return MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression;
+            }
+
+            if (operation is IAnonymousObjectCreationOperation)
+            {
+                return MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation;
+            }
+
+            if (operation is IAwaitOperation)
+            {
+                return MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression;
+            }
+
+            if (operation is IWithOperation)
+            {
+                return MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression;
             }
 
             if (operation is IInvocationOperation invocationOperation)
             {
-                return !IsTrivialInvocation(invocationOperation);
+                return !IsTrivialInvocation(invocationOperation)
+                    ? MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation
+                    : null;
             }
 
             if (operation is IObjectCreationOperation { Type.IsReferenceType: true })
             {
-                return true;
+                return MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation;
             }
 
             if (operation is IArrayCreationOperation arrayCreationOperation)
             {
-                return !IsEmptyImplicitParamsArrayCreation(arrayCreationOperation);
+                return !IsEmptyImplicitParamsArrayCreation(arrayCreationOperation)
+                    ? MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation
+                    : null;
             }
 
             if (operation is IConversionOperation conversionOperation)
             {
-                return IsBoxing(conversionOperation) || IsPotentiallyExpensive(conversionOperation.Operand);
+                return IsBoxing(conversionOperation)
+                    ? MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion
+                    : GetExpenseReason(conversionOperation.Operand);
             }
 
             if (operation is IArrayElementReferenceOperation arrayElementReferenceOperation)
             {
-                return IsPotentiallyExpensive(arrayElementReferenceOperation.ArrayReference) ||
-                       arrayElementReferenceOperation.Indices.Any(IsPotentiallyExpensive);
+                return GetExpenseReason(arrayElementReferenceOperation.ArrayReference) ??
+                       arrayElementReferenceOperation.Indices.Select(GetExpenseReason).FirstOrDefault(r => r is not null);
             }
 
             if (operation is IBinaryOperation binaryOperation)
             {
-                return IsPotentiallyExpensive(binaryOperation.LeftOperand) ||
-                       IsPotentiallyExpensive(binaryOperation.RightOperand);
+                return GetExpenseReason(binaryOperation.LeftOperand) ??
+                       GetExpenseReason(binaryOperation.RightOperand);
             }
 
             if (operation is ICoalesceOperation coalesceOperation)
             {
-                return IsPotentiallyExpensive(coalesceOperation.Value) ||
-                       IsPotentiallyExpensive(coalesceOperation.WhenNull);
+                return GetExpenseReason(coalesceOperation.Value) ??
+                       GetExpenseReason(coalesceOperation.WhenNull);
             }
 
             if (operation is IConditionalAccessOperation conditionalAccessOperation)
             {
-                return IsPotentiallyExpensive(conditionalAccessOperation.WhenNotNull);
+                return GetExpenseReason(conditionalAccessOperation.WhenNotNull);
             }
 
             if (operation is IIncrementOrDecrementOperation incrementOrDecrementOperation)
             {
-                return IsPotentiallyExpensive(incrementOrDecrementOperation.Target);
+                return GetExpenseReason(incrementOrDecrementOperation.Target);
             }
 
             if (operation is IInterpolatedStringOperation interpolatedStringOperation)
             {
                 return interpolatedStringOperation.Parts.Any(p => p is
                     IInterpolationOperation { Expression.ConstantValue.HasValue: false } or
-                    IInterpolatedStringTextOperation { Text.ConstantValue.HasValue: false });
+                    IInterpolatedStringTextOperation { Text.ConstantValue.HasValue: false })
+                    ? MicrosoftNetCoreAnalyzersResources.AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation
+                    : null;
             }
 
             if (operation is IMemberReferenceOperation memberReferenceOperation)
             {
-                if (IsPotentiallyExpensive(memberReferenceOperation.Instance))
+                var instanceReason = GetExpenseReason(memberReferenceOperation.Instance);
+                if (instanceReason is not null)
                 {
-                    return true;
+                    return instanceReason;
                 }
 
                 if (memberReferenceOperation is IPropertyReferenceOperation propertyReferenceOperation)
                 {
                     // We assume simple property accesses are cheap. For properties with arguments (indexers),
                     // we do still need to validate the arguments.
-                    return propertyReferenceOperation.Arguments.Any(static a => IsPotentiallyExpensive(a.Value));
+                    return propertyReferenceOperation.Arguments.Select(static a => GetExpenseReason(a.Value)).FirstOrDefault(r => r is not null);
                 }
             }
 
             if (operation is IUnaryOperation unaryOperation)
             {
-                return IsPotentiallyExpensive(unaryOperation.Operand);
+                return GetExpenseReason(unaryOperation.Operand);
             }
 
-            return false;
+            return null;
 
             static bool IsTrivialInvocation(IInvocationOperation invocationOperation)
             {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">Vyhodnocení tohoto argumentu může být nákladné a zbytečné, pokud je protokolování zakázané.</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">Die Auswertung dieses Arguments kann kostspielig und unnötig sein, wenn die Protokollierung deaktiviert ist.</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">La evaluación de este argumento puede ser costosa e innecesaria si el registro está deshabilitado</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">L’évaluation de cet argument peut être coûteuse et inutile si la journalisation est désactivée</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">La valutazione di questo argomento può essere dispendiosa e non necessaria se la registrazione è disabilitata</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">ログが無効になっている場合、この引数の評価は高価で不要である可能性があります</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">로깅이 비활성화되면 이 인수를 평가하는 데 비용이 많이 들고 불필요할 수 있습니다.</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">Ocena tego argumentu może być kosztowna i niepotrzebna, jeśli rejestrowanie jest wyłączone</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">A avaliação deste argumento pode ser cara e desnecessária se o registro em log estiver desabilitado</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">Оценка этого аргумента может быть ресурсоемкой и ненужной, если ведение журнала отключено</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">Günlüğe kaydetme devre dışı bırakılırsa bu bağımsız değişkenin değerlendirmesi pahalı ve gereksiz olabilir</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">如果禁用日志记录，则计算此参数可能会成本高昂且不必要</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -73,8 +73,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingMessage">
-        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled</source>
-        <target state="translated">如果停用記錄，則此引數的評估可能會非常昂貴且不必要</target>
+        <source>Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</source>
+        <target state="new">Evaluation of this argument may be expensive and unnecessary if logging is disabled ({0})</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAnonymousObjectCreation">
+        <source>anonymous object creation</source>
+        <target state="new">anonymous object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonArrayCreation">
+        <source>array creation</source>
+        <target state="new">array creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonAwaitExpression">
+        <source>await expression</source>
+        <target state="new">await expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonBoxingConversion">
+        <source>boxing conversion</source>
+        <target state="new">boxing conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonCollectionExpression">
+        <source>collection expression</source>
+        <target state="new">collection expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonMethodInvocation">
+        <source>method invocation</source>
+        <target state="new">method invocation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonObjectCreation">
+        <source>object creation</source>
+        <target state="new">object creation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonStringInterpolation">
+        <source>string interpolation</source>
+        <target state="new">string interpolation</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingReasonWithExpression">
+        <source>with expression</source>
+        <target state="new">with expression</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPotentiallyExpensiveCallWhenLoggingTitle">


### PR DESCRIPTION
## Description

Updates the CA1873 (Avoid potentially expensive logging) analyzer to include a specific reason in the diagnostic message, helping developers understand *why* an argument is flagged as expensive.

### Before
```
warning CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled
```

### After
```
warning CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled (method invocation)
```

The 9 specific reasons are:

| Reason | Trigger |
|---|---|
| `method invocation` | Non-trivial method calls |
| `object creation` | Reference type `new` expressions |
| `array creation` | Non-empty array allocations |
| `boxing conversion` | Value type → reference type conversion |
| `string interpolation` | Non-constant interpolated strings |
| `collection expression` | `[...]` collection expressions |
| `anonymous object creation` | `new { ... }` |
| `await expression` | `await` in arguments |
| `with expression` | `record with { ... }` |

## Customer Impact

Addresses feedback from #53006 where the volume of CA1873 diagnostics makes it hard to find signal. With specific reasons, developers can quickly prioritize which warnings to address (e.g., `object creation` and `array creation` are clearly more impactful than `boxing conversion`).

## Changes

- Refactored `IsPotentiallyExpensive(IOperation?) → bool` to `GetExpenseReason(IOperation?) → string?` returning a localizable reason string
- Updated the message format to `"...if logging is disabled ({0})"`
- Added 9 localizable resource strings for each reason category
- Regenerated all 13 `.xlf` translation files via `/t:UpdateXlf`

## Risk

**Low.** This only changes the diagnostic message text, not the diagnostic triggering logic. The same set of warnings is raised in the same locations — they just include more context.

Fixes #53006