### PR TITLE
Cloak the obfuscated files

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -104,7 +104,11 @@
         },
         {
             "name": "roslyn",
-            "defaultRemote": "https://github.com/dotnet/roslyn"
+            "defaultRemote": "https://github.com/dotnet/roslyn",
+            "exclude": [
+                // Obfuscated files are blocking the source tarball signing
+                "src/Compilers/Test/Resources/Core/MetadataTests/Invalid/Obfuscated*.dll"
+            ]
         },
         {
             "name": "roslyn-analyzers",


### PR DESCRIPTION
These files are blocking the Esrp signing of source-build tarball. Esrp scans all tarball binaries before signing the container.