### PR TITLE
Remove failing assert from file-level directive parser

### DIFF
--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -89,8 +89,6 @@ internal static class FileLevelDirectiveHelpers
         ErrorReporter reportError,
         ImmutableArray<CSharpDirective>.Builder? builder)
     {
-        Debug.Assert(triviaList.Span.Start == 0);
-
         var deduplicated = new Dictionary<CSharpDirective.Named, CSharpDirective.Named>(NamedDirectiveComparer.Instance);
         TextSpan previousWhiteSpaceSpan = default;
 


### PR DESCRIPTION
This assert is failing in test `FileBasedAppSourceEditorTests.Comment_Documentation` (only in Debug builds, so not in CI which interestingly runs only Release binaries in the SDK repo).

It's failing because a doc comment doesn't need to start at column 0 even if it's the first trivia (since it's structured trivia and hence can have its own nested leading trivia).