### PR TITLE
Add binlog workspace support to dotnet-format

### DIFF
--- a/src/BuiltInTools/dotnet-format/CodeFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/CodeFormatter.cs
@@ -37,7 +37,9 @@ namespace Microsoft.CodeAnalysis.Tools
 
             using var workspace = formatOptions.WorkspaceType == WorkspaceType.Folder
                 ? OpenFolderWorkspace(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
-                : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false);
+                : formatOptions.WorkspaceType == WorkspaceType.Binlog
+                    ? await BinlogWorkspaceLoader.LoadAsync(formatOptions.WorkspaceFilePath, logger, cancellationToken).ConfigureAwait(false)
+                    : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false);
 
             if (workspace is null)
             {
@@ -180,13 +182,18 @@ namespace Microsoft.CodeAnalysis.Tools
 
             foreach (var project in solution.Projects)
             {
-                if (project?.FilePath is null)
+                if (project is null)
+                {
+                    continue;
+                }
+
+                if (project.FilePath is null && formatOptions.WorkspaceType != WorkspaceType.Binlog)
                 {
                     continue;
                 }
 
                 // If a project is used as a workspace, then ignore other referenced projects.
-                if (!string.IsNullOrEmpty(projectPath) && !project.FilePath.Equals(projectPath, StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(projectPath) && !projectPath.Equals(project.FilePath, StringComparison.OrdinalIgnoreCase))
                 {
                     logger.LogDebug(Resources.Skipping_referenced_project_0, project.Name);
                     continue;
@@ -195,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 // Ignore unsupported project types.
                 if (project.Language != LanguageNames.CSharp && project.Language != LanguageNames.VisualBasic)
                 {
-                    logger.LogWarning(Resources.Could_not_format_0_Format_currently_supports_only_CSharp_and_Visual_Basic_projects, project.FilePath);
+                    logger.LogWarning(Resources.Could_not_format_0_Format_currently_supports_only_CSharp_and_Visual_Basic_projects, project.FilePath ?? project.Name);
                     continue;
                 }
 
@@ -213,6 +220,7 @@ namespace Microsoft.CodeAnalysis.Tools
                     addedFilePaths.Add(document.FilePath);
 
                     var isFileIncluded = formatOptions.WorkspaceType == WorkspaceType.Folder ||
+                        formatOptions.WorkspaceType == WorkspaceType.Binlog ||
                         (formatOptions.FileMatcher.HasMatches(document.FilePath) && File.Exists(document.FilePath));
                     if (!isFileIncluded || !document.SupportsSyntaxTree)
                     {

--- a/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
+++ b/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
         internal static async Task<int> FormatAsync(FormatOptions formatOptions, ILogger<Program> logger, CancellationToken cancellationToken)
         {
-            if (formatOptions.WorkspaceType != WorkspaceType.Folder)
+            if (formatOptions.WorkspaceType != WorkspaceType.Folder && formatOptions.WorkspaceType != WorkspaceType.Binlog)
             {
                 var runtimeVersion = GetRuntimeVersion();
                 logger.LogDebug(Resources.The_dotnet_runtime_version_is_0, runtimeVersion);
@@ -305,6 +305,14 @@ namespace Microsoft.CodeAnalysis.Tools
                 {
                     formatOptions = formatOptions with { WorkspaceFilePath = slnOrProject };
                     formatOptions = formatOptions with { WorkspaceType = WorkspaceType.Folder };
+                    return formatOptions;
+                }
+
+                if (slnOrProject.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase))
+                {
+                    var binlogPath = Path.GetFullPath(slnOrProject, currentDirectory);
+                    formatOptions = formatOptions with { WorkspaceFilePath = binlogPath };
+                    formatOptions = formatOptions with { WorkspaceType = WorkspaceType.Binlog };
                     return formatOptions;
                 }
 

--- a/src/BuiltInTools/dotnet-format/Resources.resx
+++ b/src/BuiltInTools/dotnet-format/Resources.resx
@@ -360,4 +360,22 @@
   <data name="A_space_separated_list_of_diagnostic_ids_to_ignore_when_fixing_code_style_or_3rd_party_issues" xml:space="preserve">
     <value>A space separated list of diagnostic ids to ignore when fixing code style or 3rd party issues.</value>
   </data>
+  <data name="Failed_to_read_binary_log_0_1" xml:space="preserve">
+    <value>Failed to read binary log '{0}': {1}</value>
+  </data>
+  <data name="No_C_compiler_invocations_found_in_binary_log_0" xml:space="preserve">
+    <value>No C# compiler invocations found in binary log '{0}'.</value>
+  </data>
+  <data name="Found_0_C_compiler_invocations_in_binary_log" xml:space="preserve">
+    <value>Found {0} C# compiler invocation(s) in binary log.</value>
+  </data>
+  <data name="Warning_Command_line_parse_errors_for_project_0" xml:space="preserve">
+    <value>Warning: Command line parse errors for project '{0}'.</value>
+  </data>
+  <data name="Warning_Reference_not_found_0" xml:space="preserve">
+    <value>Warning: Reference not found: {0}</value>
+  </data>
+  <data name="Warning_Source_file_not_found_0" xml:space="preserve">
+    <value>Warning: Source file not found: {0}</value>
+  </data>
 </root>

--- a/src/BuiltInTools/dotnet-format/WorkspaceType.cs
+++ b/src/BuiltInTools/dotnet-format/WorkspaceType.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Tools
     {
         Folder,
         Project,
-        Solution
+        Solution,
+        Binlog
     }
 }

--- a/src/BuiltInTools/dotnet-format/Workspaces/BinlogParser.cs
+++ b/src/BuiltInTools/dotnet-format/Workspaces/BinlogParser.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.Build.Logging.StructuredLogger;
+using MSBuildProject = Microsoft.Build.Logging.StructuredLogger.Project;
+using MSBuildTask = Microsoft.Build.Logging.StructuredLogger.Task;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal record CscInvocation(string ProjectName, string ProjectDirectory, string[] CommandLineArgs);
+
+    internal static class BinlogParser
+    {
+        public static List<CscInvocation> ExtractCscInvocations(string binlogPath)
+        {
+            var results = new List<CscInvocation>();
+            var build = BinaryLog.ReadBuild(binlogPath);
+
+            build.VisitAllChildren<MSBuildTask>(task =>
+            {
+                if (task.Name == "Csc")
+                {
+                    var project = task.GetNearestParent<MSBuildProject>();
+                    var projectName = project?.Name ?? "Unknown";
+                    var projectDirectory = project?.ProjectDirectory ?? Environment.CurrentDirectory;
+
+                    var commandLine = GetCscCommandLine(task);
+                    if (commandLine.Length > 0)
+                    {
+                        results.Add(new CscInvocation(projectName, projectDirectory, commandLine));
+                    }
+                }
+            });
+
+            return results;
+        }
+
+        private static string[] GetCscCommandLine(MSBuildTask cscTask)
+        {
+            // Look for CommandLineArguments property which contains the full csc command line
+            foreach (var child in cscTask.Children)
+            {
+                if (child is Property prop && prop.Name == "CommandLineArguments")
+                {
+                    var cmdLine = prop.Value;
+                    // Strip the compiler executable path (everything before the first space)
+                    var firstSpace = cmdLine.IndexOf(' ');
+                    if (firstSpace > 0)
+                    {
+                        cmdLine = cmdLine.Substring(firstSpace + 1);
+                    }
+                    return CscCommandLineParser.Parse(cmdLine);
+                }
+            }
+
+            // Fallback: build from Parameters folder
+            var args = new List<string>();
+            foreach (var child in cscTask.Children)
+            {
+                if (child is Folder folder && folder.Name == "Parameters")
+                {
+                    foreach (var param in folder.Children.OfType<Property>())
+                    {
+                        if (param.Name == "Sources" || param.Name == "Analyzers")
+                            continue;
+                        args.Add($"/{param.Name}:{param.Value}");
+                    }
+
+                    foreach (var param in folder.Children.OfType<Parameter>())
+                    {
+                        if (param.Name == "Sources")
+                        {
+                            foreach (var item in param.Children.OfType<Item>())
+                            {
+                                args.Add(item.Name);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return args.ToArray();
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-format/Workspaces/BinlogWorkspaceLoader.cs
+++ b/src/BuiltInTools/dotnet-format/Workspaces/BinlogWorkspaceLoader.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal static class BinlogWorkspaceLoader
+    {
+        public static async Task<Workspace?> LoadAsync(
+            string binlogPath,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            List<CscInvocation> invocations;
+            try
+            {
+                invocations = BinlogParser.ExtractCscInvocations(binlogPath);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(Resources.Failed_to_read_binary_log_0_1, binlogPath, ex.Message);
+                return null;
+            }
+
+            if (invocations.Count == 0)
+            {
+                logger.LogError(Resources.No_C_compiler_invocations_found_in_binary_log_0, binlogPath);
+                return null;
+            }
+
+            logger.LogDebug(Resources.Found_0_C_compiler_invocations_in_binary_log, invocations.Count);
+
+            var workspace = new AdhocWorkspace();
+
+            foreach (var invocation in invocations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var parsedArgs = CSharpCommandLineParser.Default.Parse(
+                    invocation.CommandLineArgs,
+                    invocation.ProjectDirectory,
+                    sdkDirectory: null);
+
+                if (parsedArgs.Errors.Any())
+                {
+                    logger.LogWarning(Resources.Warning_Command_line_parse_errors_for_project_0, invocation.ProjectName);
+                    foreach (var error in parsedArgs.Errors)
+                    {
+                        logger.LogDebug("  {0}", error.GetMessage());
+                    }
+                }
+
+                var projectId = ProjectId.CreateNewId(invocation.ProjectName);
+
+                var metadataReferences = new List<MetadataReference>();
+                foreach (var reference in parsedArgs.MetadataReferences)
+                {
+                    if (File.Exists(reference.Reference))
+                    {
+                        metadataReferences.Add(MetadataReference.CreateFromFile(reference.Reference));
+                    }
+                    else
+                    {
+                        logger.LogDebug(Resources.Warning_Reference_not_found_0, reference.Reference);
+                    }
+                }
+
+                var projectInfo = ProjectInfo.Create(
+                    projectId,
+                    VersionStamp.Default,
+                    invocation.ProjectName,
+                    invocation.ProjectName,
+                    LanguageNames.CSharp,
+                    compilationOptions: parsedArgs.CompilationOptions,
+                    parseOptions: parsedArgs.ParseOptions,
+                    metadataReferences: metadataReferences);
+
+                var solution = workspace.CurrentSolution.AddProject(projectInfo);
+
+                // Add analyzer config files (.editorconfig, globalconfig)
+                foreach (var configPath in parsedArgs.AnalyzerConfigPaths)
+                {
+                    if (File.Exists(configPath))
+                    {
+                        var docId = DocumentId.CreateNewId(projectId, configPath);
+                        solution = solution.AddAnalyzerConfigDocument(
+                            docId,
+                            Path.GetFileName(configPath),
+                            SourceText.From(await File.ReadAllTextAsync(configPath, cancellationToken).ConfigureAwait(false)),
+                            filePath: configPath);
+                    }
+                }
+
+                // Add source files
+                foreach (var sourceFile in parsedArgs.SourceFiles)
+                {
+                    var filePath = sourceFile.Path;
+                    if (!File.Exists(filePath))
+                    {
+                        logger.LogDebug(Resources.Warning_Source_file_not_found_0, filePath);
+                        continue;
+                    }
+
+                    var text = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
+                    var documentId = DocumentId.CreateNewId(projectId, filePath);
+                    solution = solution.AddDocument(
+                        documentId,
+                        Path.GetFileName(filePath),
+                        SourceText.From(text),
+                        filePath: filePath);
+                }
+
+                workspace.TryApplyChanges(solution);
+            }
+
+            return workspace;
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-format/Workspaces/CscCommandLineParser.cs
+++ b/src/BuiltInTools/dotnet-format/Workspaces/CscCommandLineParser.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal static class CscCommandLineParser
+    {
+        /// <summary>
+        /// Parses a raw csc command line string into individual arguments,
+        /// handling quoted paths that contain spaces.
+        /// </summary>
+        public static string[] Parse(string commandLine)
+        {
+            var args = new List<string>();
+            var current = new StringBuilder();
+            var inQuotes = false;
+
+            foreach (var c in commandLine)
+            {
+                if (c == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if (c == ' ' && !inQuotes)
+                {
+                    if (current.Length > 0)
+                    {
+                        args.Add(current.ToString());
+                        current.Clear();
+                    }
+                }
+                else
+                {
+                    current.Append(c);
+                }
+            }
+
+            if (current.Length > 0)
+            {
+                args.Add(current.ToString());
+            }
+
+            return args.ToArray();
+        }
+    }
+}

--- a/src/BuiltInTools/dotnet-format/dotnet-format.csproj
+++ b/src/BuiltInTools/dotnet-format/dotnet-format.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Features" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" />
 
+    <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
 

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Nepovedlo se použít opravu kódu {0} pro {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Nepodařilo se uložit změny formátování.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Formátují se soubory kódu v pracovním prostoru {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Zahrňte do operací formátování vygenerované soubory kódu.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">{0} obsahuje více souborů řešení MSBuild. Určete, který soubor chcete použít, pomocí argumentu &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Ověřte, že se neprovedou žádné změny formátování. Ukončí se s nenulovým ukončovacím kódem, pokud by byly nějaké soubory naformátovány.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Fehler beim Anwenden der Codekorrektur "{0}" für "{1}": {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Fehler beim Speichern von Formatierungsänderungen.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Codedateien im Arbeitsbereich "{0}" werden formatiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Hiermit werden generierte Codedateien in Formatierungsvorgänge einbezogen.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">In "{0}" wurden mehrere MSBuild-Projektmappendateien gefunden. Geben Sie die zu verwendende Datei mit dem &lt;workspace&gt;-Argument an.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Vergewissern Sie sich, dass keine Formatierungsänderungen vorgenommen würden. Wird mit einem Exitcode ungleich 0 beendet, wenn Dateien formatiert worden wären.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
@@ -117,6 +117,11 @@
         <target state="translated">No se pudo aplicar la corrección de código {0} para {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Error al guardar cambios de formato.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Aplicar formato a archivos de código en espacio de trabajo "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Incluya los archivos de código generados en las operaciones de formato.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Se encontraron varios archivos de solución MSBuild en "{0}". Especifique cuál debe usarse con el argumento &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Compruebe que no se vayan a realizar cambios de formato. Termina con un código de salida distinto de cero si se hubiera formateado algún archivo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Échec de l'application du correctif de code {0} pour {1} : {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">L'enregistrement des changements de mise en forme a échoué.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Mise en forme des fichiers de code dans l'espace de travail '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Ajoutez des fichiers de code générés dans les opérations de mise en forme.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Plusieurs fichiers solution MSBuild trouvés dans '{0}'. Spécifiez celui qui doit être utilisé avec l'argument &lt;espace de travail&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Vérifiez qu’il n’y a aucune modification de mise en forme effectuée. Se termine par un code de sortie différent de zéro si des fichiers auraient été mis en forme.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Non è stato possibile applicare la correzione del codice {0} per {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Non è stato possibile salvare le modifiche di formattazione.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Formattazione del file di codice nell'area di lavoro '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Includere i file del codice generato nelle operazioni di formattazione.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">In '{0}' sono stati trovati più file di soluzione MSBuild. Per specificare quello desiderato, usare l'argomento &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Verificare che non siano state eseguite modifiche di formattazione. Termina con un codice di uscita diverso da zero se sono stati formattati file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
@@ -117,6 +117,11 @@
         <target state="translated">{1} のコード修正プログラム {0} を適用できませんでした: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">書式変更を保存できませんでした。</target>
@@ -187,6 +192,11 @@
         <target state="translated">ワークスペース '{0}' でコード ファイルを書式設定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">生成されたコード ファイルを書式設定操作に含めます。</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">複数の MSBuild ソリューション ファイルが '{0}' で見つかりました。使用するものを &lt;workspace&gt; 引数で指定してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">書式設定の変更が実行されないことを確認します。いずれかのファイルが書式設定された場合は、0 以外の終了コードで終了します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
@@ -117,6 +117,11 @@
         <target state="translated">{1}에 대한 코드 수정 사항 {0}을(를) 적용하지 못했습니다. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">서식 변경 내용을 저장하지 못했습니다.</target>
@@ -187,6 +192,11 @@
         <target state="translated">'{0}' 작업 영역에서 코드 파일의 서식을 지정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">서식 지정 작업에서 생성된 코드 파일을 포함합니다.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">'{0}'에 여러 MSBuild 솔루션 파일이 있습니다. &lt;workspace&gt; 인수를 사용하여 사용할 파일을 지정하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">서식 변경이 수행되지 않았는지 확인합니다. 서식이 지정된 파일이 있는 경우 0이 아닌 종료 코드로 끝납니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Nie można zastosować poprawki kodu {0} dla elementu {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Nie można zapisać zmian formatowania.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Formatowanie plików kodu w obszarze roboczym „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Uwzględnij wygenerowane pliki kodu w operacjach formatowania.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">W elemencie „{0}” znaleziono wiele plików rozwiązań MSBuild. Określ plik do użycia za pomocą argumentu &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Sprawdź, czy nie zostaną wprowadzone żadne zmiany formatowania. Kończy się kodem zakończenia innym niż zero, jeśli jakiekolwiek pliki zostałyby sformatowane.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Falha ao aplicar a correção de código {0} para {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Falha ao salvar alterações de formatação.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Formatação de arquivos de código no espaço de trabalho '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Incluir arquivos de código gerados em operações de formatação.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Foram encontrados vários arquivos de solução do MSBuild em '{0}'. Especifique qual será usado com o argumento &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Verifique se nenhuma alteração de formatação será executada. Termina com um código de saída diferente de zero se algum arquivo tiver sido formatado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Не удалось применить исправление кода {0} для {1}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Не удалось сохранить изменения форматирования.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Форматирование кода файлов в рабочей области "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Включить созданные файлы кода в операции форматирования.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">В "{0}" обнаружено несколько файлов решения MSBuild. Укажите используемый файл с помощью аргумента &lt;workspace&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Убедитесь, что изменения форматирования не будут выполнены. Завершается ненулевым кодом завершения, если какие-либо файлы были отформатированы.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">{1} için {0} kod düzeltmesi uygulanamadı: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Biçimlendirme değişiklikleri kaydedilemedi.</target>
@@ -187,6 +192,11 @@
         <target state="translated">Çalışma alanı '{0}' kod dosyalarında biçimlendirme.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">Biçimlendirme işlemlerinde oluşturulan kod dosyalarını ekleyin.</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">'{0}' içinde birden fazla MSBuild çözüm dosyası bulundu. Hangisinin &lt;workspace&gt; bağımsız değişkeni ile kullanılacağını belirtin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">Biçimlendirme değişikliği yapılmadığını doğrulayın. Biçimlendirilmiş dosyalar sıfır olmayan bir çıkış koduyla biter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
@@ -117,6 +117,11 @@
         <target state="translated">未能对 {1} 应用代码修复 {0}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">未能保存格式更改。</target>
@@ -187,6 +192,11 @@
         <target state="translated">正在设置工作区“{0}”中代码文件的格式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">在格式化操作中包含所生成的代码文件。</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">在“{0}”中找到多个 MSBuild 解决方案文件。请指定要用于 &lt;workspace&gt; 参数的文件。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">验证不会执行任何格式更改。如果任何文件已格式化，则以非零退出代码终止。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
@@ -117,6 +117,11 @@
         <target state="translated">無法為 {1} 套用程式碼修正 {0}: {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_binary_log_0_1">
+        <source>Failed to read binary log '{0}': {1}</source>
+        <target state="new">Failed to read binary log '{0}': {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">無法儲存格式化變更。</target>
@@ -187,6 +192,11 @@
         <target state="translated">正在將工作區 '{0}' 中的程式碼檔案格式化。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_C_compiler_invocations_in_binary_log">
+        <source>Found {0} C# compiler invocation(s) in binary log.</source>
+        <target state="new">Found {0} C# compiler invocation(s) in binary log.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Include_generated_code_files_in_formatting_operations">
         <source>Include generated code files in formatting operations.</source>
         <target state="translated">在格式化作業中包含產生的程式碼檔案。</target>
@@ -215,6 +225,11 @@
       <trans-unit id="Multiple_MSBuild_solution_files_found_in_0_Specify_which_to_use_with_the_workspace_argument">
         <source>Multiple MSBuild solution files found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">在 '{0}' 中找到多個 MSBuild 解決方案檔。請指定要用於 &lt;workspace&gt; 引數的檔案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="No_C_compiler_invocations_found_in_binary_log_0">
+        <source>No C# compiler invocations found in binary log '{0}'.</source>
+        <target state="new">No C# compiler invocations found in binary log '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Project_0_is_using_configuration_from_1">
@@ -390,6 +405,21 @@
       <trans-unit id="Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted">
         <source>Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.</source>
         <target state="translated">確認不會執行任何格式化變更。如果有任何檔案已格式化，請以非零的結束代碼終止。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Command_line_parse_errors_for_project_0">
+        <source>Warning: Command line parse errors for project '{0}'.</source>
+        <target state="new">Warning: Command line parse errors for project '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Reference_not_found_0">
+        <source>Warning: Reference not found: {0}</source>
+        <target state="new">Warning: Reference not found: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Warning_Source_file_not_found_0">
+        <source>Warning: Source file not found: {0}</source>
+        <target state="new">Warning: Source file not found: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">

--- a/test/dotnet-format.UnitTests/ProgramTests.cs
+++ b/test/dotnet-format.UnitTests/ProgramTests.cs
@@ -245,5 +245,34 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             // Assert
             Assert.Empty(result.Errors);
         }
+        [Fact]
+        public void CommandLine_BinlogArgument_DetectedCorrectly()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+
+            // Act
+            var result = sut.Parse(new[] { "build.binlog" });
+
+            // Assert
+            Assert.Empty(result.Errors);
+            Assert.Equal("build.binlog", result.GetValue(FormatCommandCommon.SlnOrProjectArgument));
+        }
+
+        [Fact]
+        public void CommandLine_BinlogArgument_WithOptions()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+
+            // Act
+            var result = sut.Parse(new[] { "build.binlog", "--verbosity", "detailed", "--verify-no-changes" });
+
+            // Assert
+            Assert.Empty(result.Errors);
+            Assert.Equal("build.binlog", result.GetValue(FormatCommandCommon.SlnOrProjectArgument));
+            Assert.Equal("detailed", result.GetValue(FormatCommandCommon.VerbosityOption));
+            Assert.True(result.GetValue(FormatCommandCommon.VerifyNoChanges));
+        }
     }
 }

--- a/test/dotnet-format.UnitTests/Workspaces/BinlogParserTests.cs
+++ b/test/dotnet-format.UnitTests/Workspaces/BinlogParserTests.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Tools.Workspaces;
+
+namespace Microsoft.CodeAnalysis.Tools.Tests.Workspaces
+{
+    public class BinlogParserTests
+    {
+        [Fact]
+        public void ExtractCscInvocations_WithNonExistentFile_Throws()
+        {
+            Assert.ThrowsAny<Exception>(() =>
+                BinlogParser.ExtractCscInvocations("/nonexistent/path/build.binlog"));
+        }
+    }
+}

--- a/test/dotnet-format.UnitTests/Workspaces/BinlogWorkspaceLoaderTests.cs
+++ b/test/dotnet-format.UnitTests/Workspaces/BinlogWorkspaceLoaderTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Tools.Workspaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Tools.Tests.Workspaces
+{
+    public class BinlogWorkspaceLoaderTests
+    {
+        [Fact]
+        public async Task LoadAsync_WithNonExistentFile_ReturnsNull()
+        {
+            var logger = NullLogger<Program>.Instance;
+
+            var workspace = await BinlogWorkspaceLoader.LoadAsync(
+                "/nonexistent/path/build.binlog",
+                logger,
+                CancellationToken.None);
+
+            Assert.Null(workspace);
+        }
+
+        [Fact]
+        public void ParseCommandLine_ExtractsSourceFiles()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), $"dotnet-format-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(testDir);
+
+            try
+            {
+                var file1 = Path.Combine(testDir, "Program.cs");
+                var file2 = Path.Combine(testDir, "Helper.cs");
+                File.WriteAllText(file1, "class Program { }");
+                File.WriteAllText(file2, "class Helper { }");
+
+                var args = new[]
+                {
+                    "/target:exe",
+                    "/langversion:latest",
+                    "/nullable:enable",
+                    file1,
+                    file2
+                };
+
+                var parsedArgs = CSharpCommandLineParser.Default.Parse(args, testDir, sdkDirectory: null);
+
+                Assert.Equal(2, parsedArgs.SourceFiles.Length);
+                Assert.Contains(parsedArgs.SourceFiles, f => f.Path == file1);
+                Assert.Contains(parsedArgs.SourceFiles, f => f.Path == file2);
+            }
+            finally
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ParseCommandLine_ExtractsCompilationOptions()
+        {
+            var args = new[]
+            {
+                "/target:library",
+                "/langversion:12",
+                "/nullable:enable",
+                "/define:DEBUG;TRACE",
+                "dummy.cs"
+            };
+
+            var parsedArgs = CSharpCommandLineParser.Default.Parse(args, "/tmp", sdkDirectory: null);
+
+            Assert.Equal(OutputKind.DynamicallyLinkedLibrary, parsedArgs.CompilationOptions.OutputKind);
+            Assert.Equal(NullableContextOptions.Enable, parsedArgs.CompilationOptions.NullableContextOptions);
+            Assert.Equal(LanguageVersion.CSharp12, parsedArgs.ParseOptions.LanguageVersion);
+        }
+
+        [Fact]
+        public async Task CreateWorkspace_WithSourceFiles_AddsDocuments()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), $"dotnet-format-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(testDir);
+
+            try
+            {
+                var file1 = Path.Combine(testDir, "Program.cs");
+                var file2 = Path.Combine(testDir, "Helper.cs");
+                File.WriteAllText(file1, "class Program { static void Main() { } }");
+                File.WriteAllText(file2, "class Helper { }");
+
+                using var workspace = new AdhocWorkspace();
+                var projectId = ProjectId.CreateNewId("TestProject");
+
+                var projectInfo = ProjectInfo.Create(
+                    projectId,
+                    VersionStamp.Default,
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp);
+
+                var solution = workspace.CurrentSolution.AddProject(projectInfo);
+
+                foreach (var file in new[] { file1, file2 })
+                {
+                    var text = await File.ReadAllTextAsync(file);
+                    var docId = DocumentId.CreateNewId(projectId, file);
+                    solution = solution.AddDocument(docId, Path.GetFileName(file),
+                        SourceText.From(text), filePath: file);
+                }
+
+                workspace.TryApplyChanges(solution);
+
+                var project = workspace.CurrentSolution.GetProject(projectId)!;
+                Assert.Equal(2, project.Documents.Count());
+                Assert.Contains(project.Documents, d => d.FilePath == file1);
+                Assert.Contains(project.Documents, d => d.FilePath == file2);
+            }
+            finally
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task CreateWorkspace_CanGetCompilation()
+        {
+            var testDir = Path.Combine(Path.GetTempPath(), $"dotnet-format-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(testDir);
+
+            try
+            {
+                var file = Path.Combine(testDir, "Test.cs");
+                File.WriteAllText(file, "class Test { public int Value { get; set; } }");
+
+                using var workspace = new AdhocWorkspace();
+                var projectId = ProjectId.CreateNewId("TestProject");
+
+                var projectInfo = ProjectInfo.Create(
+                    projectId,
+                    VersionStamp.Default,
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+                var solution = workspace.CurrentSolution.AddProject(projectInfo);
+
+                var text = await File.ReadAllTextAsync(file);
+                var docId = DocumentId.CreateNewId(projectId, file);
+                solution = solution.AddDocument(docId, "Test.cs", SourceText.From(text), filePath: file);
+
+                workspace.TryApplyChanges(solution);
+
+                var project = workspace.CurrentSolution.GetProject(projectId)!;
+                var compilation = await project.GetCompilationAsync();
+
+                Assert.NotNull(compilation);
+                Assert.Contains(compilation!.SyntaxTrees, t => t.FilePath == file);
+            }
+            finally
+            {
+                Directory.Delete(testDir, recursive: true);
+            }
+        }
+    }
+}

--- a/test/dotnet-format.UnitTests/Workspaces/CscCommandLineParserTests.cs
+++ b/test/dotnet-format.UnitTests/Workspaces/CscCommandLineParserTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Tools.Workspaces;
+
+namespace Microsoft.CodeAnalysis.Tools.Tests.Workspaces
+{
+    public class CscCommandLineParserTests
+    {
+        [Fact]
+        public void Parse_SimpleArgs_SplitsCorrectly()
+        {
+            var result = CscCommandLineParser.Parse("/noconfig /unsafe- /checked-");
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal("/noconfig", result[0]);
+            Assert.Equal("/unsafe-", result[1]);
+            Assert.Equal("/checked-", result[2]);
+        }
+
+        [Fact]
+        public void Parse_QuotedPath_PreservesSpaces()
+        {
+            var result = CscCommandLineParser.Parse("/out:\"C:\\Program Files\\output.dll\" /target:exe");
+
+            Assert.Equal(2, result.Length);
+            Assert.Equal("/out:C:\\Program Files\\output.dll", result[0]);
+            Assert.Equal("/target:exe", result[1]);
+        }
+
+        [Fact]
+        public void Parse_EmptyString_ReturnsEmpty()
+        {
+            var result = CscCommandLineParser.Parse("");
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Parse_MultipleSpaces_HandlesCorrectly()
+        {
+            var result = CscCommandLineParser.Parse("/a   /b    /c");
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal("/a", result[0]);
+            Assert.Equal("/b", result[1]);
+            Assert.Equal("/c", result[2]);
+        }
+
+        [Fact]
+        public void Parse_SourceFiles_IncludesFilePaths()
+        {
+            var result = CscCommandLineParser.Parse("/target:exe Program.cs Helpers.cs");
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal("/target:exe", result[0]);
+            Assert.Equal("Program.cs", result[1]);
+            Assert.Equal("Helpers.cs", result[2]);
+        }
+
+        [Fact]
+        public void Parse_DefineConstants_HandlesLongValue()
+        {
+            var result = CscCommandLineParser.Parse("/define:TRACE;DEBUG;NET;NET10_0");
+
+            Assert.Single(result);
+            Assert.Equal("/define:TRACE;DEBUG;NET;NET10_0", result[0]);
+        }
+    }
+}


### PR DESCRIPTION
Enable dotnet-format to operate directly on MSBuild binary log files (.binlog), allowing formatting when a normal workspace cannot be loaded.

Usage: dotnet format build.binlog [options]

When the workspace argument ends with .binlog, dotnet-format now:
- Parses Csc task invocations from the binlog using StructuredLogger
- Constructs an AdhocWorkspace with proper compilation options, metadata references, analyzer configs, and source files
- Runs all existing formatters (whitespace, style, analyzers)

New files:
- BinlogParser: Extracts CscInvocation records from binlog files
- BinlogWorkspaceLoader: Creates Roslyn workspace from invocations
- CscCommandLineParser: Tokenizes quoted csc command lines