### PR TITLE
Multithreading migration: Group 5 — 5 attribute-only tasks

### DIFF
--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
+            Value = Path.Combine(basePath.Value, path);
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.Combine(basePath.Value, path);
+            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.Framework
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = _projectDirectory.Value,
+                UseShellExecute = false,
             };
 
             // Populate environment from the scoped environment dictionary

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -15,6 +16,45 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// </summary>
     public class GivenAttributeOnlyTasksGroup5
     {
+        #region Attribute Presence
+
+        [Fact]
+        public void CollectSDKReferencesDesignTime_HasMultiThreadableAttribute()
+        {
+            typeof(CollectSDKReferencesDesignTime).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void CreateWindowsSdkKnownFrameworkReferences_HasMultiThreadableAttribute()
+        {
+            typeof(CreateWindowsSdkKnownFrameworkReferences).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void FindItemsFromPackages_HasMultiThreadableAttribute()
+        {
+            typeof(FindItemsFromPackages).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void GetAssemblyVersion_HasMultiThreadableAttribute()
+        {
+            typeof(GetAssemblyVersion).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_HasMultiThreadableAttribute()
+        {
+            typeof(GenerateSupportedTargetFrameworkAlias).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        #endregion
+
         #region CollectSDKReferencesDesignTime
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
@@ -1,0 +1,435 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    /// <summary>
+    /// Behavioral tests for attribute-only tasks in merge-group-5.
+    /// These tasks received only the [MSBuildMultiThreadableTask] attribute — no source
+    /// code changes — so we verify they still produce correct results.
+    /// </summary>
+    public class GivenAttributeOnlyTasksGroup5
+    {
+        #region CollectSDKReferencesDesignTime
+
+        [Fact]
+        public void CollectSDKReferencesDesignTime_CollectsSdkReferencesAndImplicitPackages()
+        {
+            var sdkRef = new TaskItem("Microsoft.NETCore.App");
+            sdkRef.SetMetadata("SDKPackageItemSpec", "");
+
+            var implicitPkg = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+            {
+                { "IsImplicitlyDefined", "true" },
+                { "Version", "8.0.0" }
+            });
+
+            var explicitPkg = new MockTaskItem("Newtonsoft.Json", new Dictionary<string, string>
+            {
+                { "Version", "13.0.1" }
+            });
+
+            var task = new CollectSDKReferencesDesignTime
+            {
+                BuildEngine = new MockBuildEngine(),
+                SdkReferences = new ITaskItem[] { sdkRef },
+                PackageReferences = new ITaskItem[] { implicitPkg, explicitPkg },
+                DefaultImplicitPackages = "Microsoft.NETCore.App"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SDKReferencesDesignTime.Should().NotBeNull();
+            // Should include the SDK reference + the implicit package, but not the explicit package
+            task.SDKReferencesDesignTime.Should().HaveCount(2);
+            task.SDKReferencesDesignTime.Should().Contain(i => i.ItemSpec == "Microsoft.NETCore.App");
+        }
+
+        [Fact]
+        public void CollectSDKReferencesDesignTime_ExcludesNonImplicitPackages()
+        {
+            var explicitPkg = new MockTaskItem("Newtonsoft.Json", new Dictionary<string, string>
+            {
+                { "Version", "13.0.1" }
+            });
+
+            var task = new CollectSDKReferencesDesignTime
+            {
+                BuildEngine = new MockBuildEngine(),
+                SdkReferences = Array.Empty<ITaskItem>(),
+                PackageReferences = new ITaskItem[] { explicitPkg },
+                DefaultImplicitPackages = "Microsoft.NETCore.App"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SDKReferencesDesignTime.Should().BeEmpty(
+                "explicit packages not in DefaultImplicitPackages should not be collected");
+        }
+
+        [Fact]
+        public void CollectSDKReferencesDesignTime_HandlesEmptyDefaultImplicitPackages()
+        {
+            var task = new CollectSDKReferencesDesignTime
+            {
+                BuildEngine = new MockBuildEngine(),
+                SdkReferences = Array.Empty<ITaskItem>(),
+                PackageReferences = Array.Empty<ITaskItem>(),
+                DefaultImplicitPackages = ""
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SDKReferencesDesignTime.Should().BeEmpty();
+        }
+
+        #endregion
+
+        #region CreateWindowsSdkKnownFrameworkReferences
+
+        [Fact]
+        public void CreateWindowsSdkKnownFrameworkReferences_WithExplicitPackageVersion_ProducesFiveProfiles()
+        {
+            var task = new CreateWindowsSdkKnownFrameworkReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                WindowsSdkPackageVersion = "10.0.19041.31",
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "8.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.19041.0"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.KnownFrameworkReferences.Should().HaveCount(5,
+                "should produce 5 profile variants: default, Windows, Xaml, CsWinRT3.Windows, CsWinRT3.Xaml");
+
+            // Verify the default (no profile) item
+            var defaultItem = task.KnownFrameworkReferences.First(i => i.ItemSpec == "Microsoft.Windows.SDK.NET.Ref");
+            defaultItem.GetMetadata("TargetingPackVersion").Should().Be("10.0.19041.31");
+            defaultItem.GetMetadata("RuntimePackRuntimeIdentifiers").Should().Be("any");
+        }
+
+        [Fact]
+        public void CreateWindowsSdkKnownFrameworkReferences_WithPreviewMode_AppendsPreviewSuffix()
+        {
+            var task = new CreateWindowsSdkKnownFrameworkReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                UseWindowsSDKPreview = true,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = "9.0",
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = "10.0.26100.0"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.KnownFrameworkReferences.Should().NotBeEmpty();
+            task.KnownFrameworkReferences[0].GetMetadata("TargetingPackVersion")
+                .Should().EndWith("-preview");
+        }
+
+        [Fact]
+        public void CreateWindowsSdkKnownFrameworkReferences_ErrorsWhenBothVersionAndMinimumRevisionSet()
+        {
+            var engine = new MockBuildEngine();
+            var task = new CreateWindowsSdkKnownFrameworkReferences
+            {
+                BuildEngine = engine,
+                WindowsSdkPackageVersion = "10.0.19041.31",
+                WindowsSdkPackageMinimumRevision = "32",
+                TargetFrameworkVersion = "8.0",
+                TargetPlatformVersion = "10.0.19041.0"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse("cannot specify both PackageVersion and MinimumRevision");
+            engine.Errors.Should().NotBeEmpty();
+        }
+
+        #endregion
+
+        #region FindItemsFromPackages
+
+        [Fact]
+        public void FindItemsFromPackages_ReturnsMatchingItems()
+        {
+            var item1 = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "MyPackage" },
+                { "NuGetPackageVersion", "1.0.0" }
+            });
+            var item2 = new MockTaskItem("lib/net8.0/Other.dll", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "OtherPackage" },
+                { "NuGetPackageVersion", "2.0.0" }
+            });
+
+            var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "MyPackage" },
+                { "NuGetPackageVersion", "1.0.0" }
+            });
+
+            var task = new FindItemsFromPackages
+            {
+                BuildEngine = new MockBuildEngine(),
+                Items = new ITaskItem[] { item1, item2 },
+                Packages = new ITaskItem[] { package }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.ItemsFromPackages.Should().HaveCount(1);
+            task.ItemsFromPackages[0].ItemSpec.Should().Be("lib/net8.0/MyLib.dll");
+        }
+
+        [Fact]
+        public void FindItemsFromPackages_ReturnsEmptyWhenNoMatch()
+        {
+            var item = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "MyPackage" },
+                { "NuGetPackageVersion", "1.0.0" }
+            });
+
+            var package = new MockTaskItem("OtherPackage", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "OtherPackage" },
+                { "NuGetPackageVersion", "3.0.0" }
+            });
+
+            var task = new FindItemsFromPackages
+            {
+                BuildEngine = new MockBuildEngine(),
+                Items = new ITaskItem[] { item },
+                Packages = new ITaskItem[] { package }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.ItemsFromPackages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void FindItemsFromPackages_SkipsItemsWithoutPackageMetadata()
+        {
+            var itemWithMeta = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "MyPackage" },
+                { "NuGetPackageVersion", "1.0.0" }
+            });
+            var itemWithoutMeta = new MockTaskItem("lib/net8.0/NoMeta.dll", new Dictionary<string, string>());
+
+            var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
+            {
+                { "NuGetPackageId", "MyPackage" },
+                { "NuGetPackageVersion", "1.0.0" }
+            });
+
+            var task = new FindItemsFromPackages
+            {
+                BuildEngine = new MockBuildEngine(),
+                Items = new ITaskItem[] { itemWithMeta, itemWithoutMeta },
+                Packages = new ITaskItem[] { package }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.ItemsFromPackages.Should().HaveCount(1,
+                "only items with matching NuGet metadata should be returned");
+        }
+
+        #endregion
+
+        #region GetAssemblyVersion
+
+        [Fact]
+        public void GetAssemblyVersion_ParsesStandardVersion()
+        {
+            var task = new GetAssemblyVersion
+            {
+                BuildEngine = new MockBuildEngine(),
+                NuGetVersion = "8.0.1"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.AssemblyVersion.Should().Be("8.0.1.0");
+        }
+
+        [Fact]
+        public void GetAssemblyVersion_ParsesPreReleaseVersion()
+        {
+            var task = new GetAssemblyVersion
+            {
+                BuildEngine = new MockBuildEngine(),
+                NuGetVersion = "9.0.0-preview.1.24080.9"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.AssemblyVersion.Should().Be("9.0.0.0");
+        }
+
+        [Fact]
+        public void GetAssemblyVersion_LogsErrorForInvalidVersion()
+        {
+            var engine = new MockBuildEngine();
+            var task = new GetAssemblyVersion
+            {
+                BuildEngine = engine,
+                NuGetVersion = "not-a-version"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeFalse();
+            engine.Errors.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void GetAssemblyVersion_ParsesFourPartVersion()
+        {
+            var task = new GetAssemblyVersion
+            {
+                BuildEngine = new MockBuildEngine(),
+                NuGetVersion = "1.2.3.4"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.AssemblyVersion.Should().Be("1.2.3.4");
+        }
+
+        #endregion
+
+        #region GenerateSupportedTargetFrameworkAlias
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_GeneratesAliasForMatchingFramework()
+        {
+            var tfm = new TaskItem(".NETCoreApp,Version=v8.0");
+            tfm.SetMetadata("DisplayName", ".NET 8.0");
+
+            var task = new GenerateSupportedTargetFrameworkAlias
+            {
+                BuildEngine = new MockBuildEngine(),
+                SupportedTargetFramework = new ITaskItem[] { tfm },
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SupportedTargetFrameworkAlias.Should().HaveCount(1);
+            task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Be("net8.0");
+            task.SupportedTargetFrameworkAlias[0].GetMetadata("DisplayName").Should().Be(".NET 8.0");
+        }
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_FiltersNonMatchingFrameworks()
+        {
+            var tfmNet8 = new TaskItem(".NETCoreApp,Version=v8.0");
+            var tfmNetFx = new TaskItem(".NETFramework,Version=v4.7.2");
+
+            var task = new GenerateSupportedTargetFrameworkAlias
+            {
+                BuildEngine = new MockBuildEngine(),
+                SupportedTargetFramework = new ITaskItem[] { tfmNet8, tfmNetFx },
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SupportedTargetFrameworkAlias.Should().HaveCount(1,
+                "only TFMs matching the target framework identifier should be included");
+            task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Be("net8.0");
+        }
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_AddsWindowsSuffixForWpf()
+        {
+            var tfm = new TaskItem(".NETCoreApp,Version=v8.0");
+
+            var task = new GenerateSupportedTargetFrameworkAlias
+            {
+                BuildEngine = new MockBuildEngine(),
+                SupportedTargetFramework = new ITaskItem[] { tfm },
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0",
+                UseWpf = true
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SupportedTargetFrameworkAlias.Should().HaveCount(1);
+            task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Contain("-windows",
+                "WPF projects on .NET 5+ should get a -windows suffix");
+        }
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_AddsWindowsSuffixForWindowsForms()
+        {
+            var tfm = new TaskItem(".NETCoreApp,Version=v8.0");
+
+            var task = new GenerateSupportedTargetFrameworkAlias
+            {
+                BuildEngine = new MockBuildEngine(),
+                SupportedTargetFramework = new ITaskItem[] { tfm },
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0",
+                UseWindowsForms = true
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SupportedTargetFrameworkAlias.Should().HaveCount(1);
+            task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Contain("-windows",
+                "Windows Forms projects on .NET 5+ should get a -windows suffix");
+        }
+
+        [Fact]
+        public void GenerateSupportedTargetFrameworkAlias_NoWindowsSuffixForOlderFrameworks()
+        {
+            // .NET Core 3.1 should NOT get -windows suffix even with UseWpf
+            var tfm = new TaskItem(".NETCoreApp,Version=v3.1");
+
+            var task = new GenerateSupportedTargetFrameworkAlias
+            {
+                BuildEngine = new MockBuildEngine(),
+                SupportedTargetFramework = new ITaskItem[] { tfm },
+                TargetFrameworkMoniker = ".NETCoreApp,Version=v3.1",
+                UseWpf = true
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.SupportedTargetFrameworkAlias.Should().HaveCount(1);
+            task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Be("netcoreapp3.1");
+        }
+
+        #endregion
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
@@ -4,7 +4,10 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -468,6 +471,222 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.Should().BeTrue();
             task.SupportedTargetFrameworkAlias.Should().HaveCount(1);
             task.SupportedTargetFrameworkAlias[0].ItemSpec.Should().Be("netcoreapp3.1");
+        }
+
+        #endregion
+
+        #region Concurrent Execution
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void CollectSDKReferencesDesignTime_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var sdkRef = new TaskItem("Microsoft.NETCore.App");
+                    sdkRef.SetMetadata("SDKPackageItemSpec", "");
+
+                    var implicitPkg = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        { "IsImplicitlyDefined", "true" },
+                        { "Version", "8.0.0" }
+                    });
+
+                    var task = new CollectSDKReferencesDesignTime
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        SdkReferences = new ITaskItem[] { sdkRef },
+                        PackageReferences = new ITaskItem[] { implicitPkg },
+                        DefaultImplicitPackages = "Microsoft.NETCore.App"
+                    };
+
+                    barrier.SignalAndWait();
+                    task.Execute();
+
+                    if (task.SDKReferencesDesignTime == null || task.SDKReferencesDesignTime.Length != 2)
+                    {
+                        errors.Add($"Thread {i}: Expected 2 items but got {task.SDKReferencesDesignTime?.Length}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Thread {i}: {ex.Message}");
+                }
+            });
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void CreateWindowsSdkKnownFrameworkReferences_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new CreateWindowsSdkKnownFrameworkReferences
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        WindowsSdkPackageVersion = "10.0.19041.31",
+                        TargetFrameworkIdentifier = ".NETCoreApp",
+                        TargetFrameworkVersion = "8.0",
+                        TargetPlatformIdentifier = "Windows",
+                        TargetPlatformVersion = "10.0.19041.0"
+                    };
+
+                    barrier.SignalAndWait();
+                    task.Execute();
+
+                    if (task.KnownFrameworkReferences == null || task.KnownFrameworkReferences.Length != 5)
+                    {
+                        errors.Add($"Thread {i}: Expected 5 items but got {task.KnownFrameworkReferences?.Length}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Thread {i}: {ex.Message}");
+                }
+            });
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void FindItemsFromPackages_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var item = new MockTaskItem($"lib/net8.0/Lib{i}.dll", new Dictionary<string, string>
+                    {
+                        { "NuGetPackageId", "MyPackage" },
+                        { "NuGetPackageVersion", "1.0.0" }
+                    });
+
+                    var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
+                    {
+                        { "NuGetPackageId", "MyPackage" },
+                        { "NuGetPackageVersion", "1.0.0" }
+                    });
+
+                    var task = new FindItemsFromPackages
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        Items = new ITaskItem[] { item },
+                        Packages = new ITaskItem[] { package }
+                    };
+
+                    barrier.SignalAndWait();
+                    task.Execute();
+
+                    if (task.ItemsFromPackages == null || task.ItemsFromPackages.Length != 1)
+                    {
+                        errors.Add($"Thread {i}: Expected 1 item but got {task.ItemsFromPackages?.Length}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Thread {i}: {ex.Message}");
+                }
+            });
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void GetAssemblyVersion_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new GetAssemblyVersion
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        NuGetVersion = $"{i}.0.{i}"
+                    };
+
+                    barrier.SignalAndWait();
+                    task.Execute();
+
+                    var expected = $"{i}.0.{i}.0";
+                    if (task.AssemblyVersion != expected)
+                    {
+                        errors.Add($"Thread {i}: Expected '{expected}' but got '{task.AssemblyVersion}'");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Thread {i}: {ex.Message}");
+                }
+            });
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void GenerateSupportedTargetFrameworkAlias_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var tfm = new TaskItem(".NETCoreApp,Version=v8.0");
+                    tfm.SetMetadata("DisplayName", ".NET 8.0");
+
+                    var task = new GenerateSupportedTargetFrameworkAlias
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        SupportedTargetFramework = new ITaskItem[] { tfm },
+                        TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0"
+                    };
+
+                    barrier.SignalAndWait();
+                    task.Execute();
+
+                    if (task.SupportedTargetFrameworkAlias == null || task.SupportedTargetFrameworkAlias.Length != 1)
+                    {
+                        errors.Add($"Thread {i}: Expected 1 alias but got {task.SupportedTargetFrameworkAlias?.Length}");
+                    }
+                    else if (task.SupportedTargetFrameworkAlias[0].ItemSpec != "net8.0")
+                    {
+                        errors.Add($"Thread {i}: Expected 'net8.0' but got '{task.SupportedTargetFrameworkAlias[0].ItemSpec}'");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Thread {i}: {ex.Message}");
+                }
+            });
+
+            errors.Should().BeEmpty();
         }
 
         #endregion

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
@@ -64,12 +64,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void CollectSDKReferencesDesignTime_CollectsSdkReferencesAndImplicitPackages()
         {
             var sdkRef = new TaskItem("Microsoft.NETCore.App");
-            sdkRef.SetMetadata("SDKPackageItemSpec", "");
+            sdkRef.SetMetadata(MetadataKeys.SDKPackageItemSpec, "");
 
             var implicitPkg = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
             {
-                { "IsImplicitlyDefined", "true" },
-                { "Version", "8.0.0" }
+                { MetadataKeys.IsImplicitlyDefined, "true" },
+                { MetadataKeys.Version, "8.0.0" }
             });
 
             var explicitPkg = new MockTaskItem("Newtonsoft.Json", new Dictionary<string, string>
@@ -99,7 +99,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var explicitPkg = new MockTaskItem("Newtonsoft.Json", new Dictionary<string, string>
             {
-                { "Version", "13.0.1" }
+                { MetadataKeys.Version, "13.0.1" }
             });
 
             var task = new CollectSDKReferencesDesignTime
@@ -212,19 +212,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var item1 = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "MyPackage" },
-                { "NuGetPackageVersion", "1.0.0" }
+                { MetadataKeys.NuGetPackageId, "MyPackage" },
+                { MetadataKeys.NuGetPackageVersion, "1.0.0" }
             });
             var item2 = new MockTaskItem("lib/net8.0/Other.dll", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "OtherPackage" },
-                { "NuGetPackageVersion", "2.0.0" }
+                { MetadataKeys.NuGetPackageId, "OtherPackage" },
+                { MetadataKeys.NuGetPackageVersion, "2.0.0" }
             });
 
             var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "MyPackage" },
-                { "NuGetPackageVersion", "1.0.0" }
+                { MetadataKeys.NuGetPackageId, "MyPackage" },
+                { MetadataKeys.NuGetPackageVersion, "1.0.0" }
             });
 
             var task = new FindItemsFromPackages
@@ -246,14 +246,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var item = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "MyPackage" },
-                { "NuGetPackageVersion", "1.0.0" }
+                { MetadataKeys.NuGetPackageId, "MyPackage" },
+                { MetadataKeys.NuGetPackageVersion, "1.0.0" }
             });
 
             var package = new MockTaskItem("OtherPackage", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "OtherPackage" },
-                { "NuGetPackageVersion", "3.0.0" }
+                { MetadataKeys.NuGetPackageId, "OtherPackage" },
+                { MetadataKeys.NuGetPackageVersion, "3.0.0" }
             });
 
             var task = new FindItemsFromPackages
@@ -274,15 +274,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var itemWithMeta = new MockTaskItem("lib/net8.0/MyLib.dll", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "MyPackage" },
-                { "NuGetPackageVersion", "1.0.0" }
+                { MetadataKeys.NuGetPackageId, "MyPackage" },
+                { MetadataKeys.NuGetPackageVersion, "1.0.0" }
             });
             var itemWithoutMeta = new MockTaskItem("lib/net8.0/NoMeta.dll", new Dictionary<string, string>());
 
             var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
             {
-                { "NuGetPackageId", "MyPackage" },
-                { "NuGetPackageVersion", "1.0.0" }
+                { MetadataKeys.NuGetPackageId, "MyPackage" },
+                { MetadataKeys.NuGetPackageVersion, "1.0.0" }
             });
 
             var task = new FindItemsFromPackages
@@ -480,22 +480,26 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void CollectSDKReferencesDesignTime_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task CollectSDKReferencesDesignTime_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
+            using var startGate = new ManualResetEventSlim(false);
 
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
                     var sdkRef = new TaskItem("Microsoft.NETCore.App");
-                    sdkRef.SetMetadata("SDKPackageItemSpec", "");
+                    sdkRef.SetMetadata(MetadataKeys.SDKPackageItemSpec, "");
 
                     var implicitPkg = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
                     {
-                        { "IsImplicitlyDefined", "true" },
-                        { "Version", "8.0.0" }
+                        { MetadataKeys.IsImplicitlyDefined, "true" },
+                        { MetadataKeys.Version, "8.0.0" }
                     });
 
                     var task = new CollectSDKReferencesDesignTime
@@ -506,19 +510,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         DefaultImplicitPackages = "Microsoft.NETCore.App"
                     };
 
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
 
                     if (task.SDKReferencesDesignTime == null || task.SDKReferencesDesignTime.Length != 2)
                     {
-                        errors.Add($"Thread {i}: Expected 2 items but got {task.SDKReferencesDesignTime?.Length}");
+                        errors.Add($"Thread {idx}: Expected 2 items but got {task.SDKReferencesDesignTime?.Length}");
                     }
                 }
                 catch (Exception ex)
                 {
-                    errors.Add($"Thread {i}: {ex.Message}");
+                    errors.Add($"Thread {idx}: {ex.Message}");
                 }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
 
             errors.Should().BeEmpty();
         }
@@ -526,12 +533,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void CreateWindowsSdkKnownFrameworkReferences_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task CreateWindowsSdkKnownFrameworkReferences_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
+            using var startGate = new ManualResetEventSlim(false);
 
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -545,19 +556,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         TargetPlatformVersion = "10.0.19041.0"
                     };
 
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
 
                     if (task.KnownFrameworkReferences == null || task.KnownFrameworkReferences.Length != 5)
                     {
-                        errors.Add($"Thread {i}: Expected 5 items but got {task.KnownFrameworkReferences?.Length}");
+                        errors.Add($"Thread {idx}: Expected 5 items but got {task.KnownFrameworkReferences?.Length}");
                     }
                 }
                 catch (Exception ex)
                 {
-                    errors.Add($"Thread {i}: {ex.Message}");
+                    errors.Add($"Thread {idx}: {ex.Message}");
                 }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
 
             errors.Should().BeEmpty();
         }
@@ -565,25 +579,29 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void FindItemsFromPackages_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task FindItemsFromPackages_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
+            using var startGate = new ManualResetEventSlim(false);
 
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
-                    var item = new MockTaskItem($"lib/net8.0/Lib{i}.dll", new Dictionary<string, string>
+                    var item = new MockTaskItem($"lib/net8.0/Lib{idx}.dll", new Dictionary<string, string>
                     {
-                        { "NuGetPackageId", "MyPackage" },
-                        { "NuGetPackageVersion", "1.0.0" }
+                        { MetadataKeys.NuGetPackageId, "MyPackage" },
+                        { MetadataKeys.NuGetPackageVersion, "1.0.0" }
                     });
 
                     var package = new MockTaskItem("MyPackage", new Dictionary<string, string>
                     {
-                        { "NuGetPackageId", "MyPackage" },
-                        { "NuGetPackageVersion", "1.0.0" }
+                        { MetadataKeys.NuGetPackageId, "MyPackage" },
+                        { MetadataKeys.NuGetPackageVersion, "1.0.0" }
                     });
 
                     var task = new FindItemsFromPackages
@@ -593,19 +611,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         Packages = new ITaskItem[] { package }
                     };
 
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
 
                     if (task.ItemsFromPackages == null || task.ItemsFromPackages.Length != 1)
                     {
-                        errors.Add($"Thread {i}: Expected 1 item but got {task.ItemsFromPackages?.Length}");
+                        errors.Add($"Thread {idx}: Expected 1 item but got {task.ItemsFromPackages?.Length}");
                     }
                 }
                 catch (Exception ex)
                 {
-                    errors.Add($"Thread {i}: {ex.Message}");
+                    errors.Add($"Thread {idx}: {ex.Message}");
                 }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
 
             errors.Should().BeEmpty();
         }
@@ -613,35 +634,42 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void GetAssemblyVersion_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task GetAssemblyVersion_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
+            using var startGate = new ManualResetEventSlim(false);
 
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
                     var task = new GetAssemblyVersion
                     {
                         BuildEngine = new MockBuildEngine(),
-                        NuGetVersion = $"{i}.0.{i}"
+                        NuGetVersion = $"{idx}.0.{idx}"
                     };
 
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
 
-                    var expected = $"{i}.0.{i}.0";
+                    var expected = $"{idx}.0.{idx}.0";
                     if (task.AssemblyVersion != expected)
                     {
-                        errors.Add($"Thread {i}: Expected '{expected}' but got '{task.AssemblyVersion}'");
+                        errors.Add($"Thread {idx}: Expected '{expected}' but got '{task.AssemblyVersion}'");
                     }
                 }
                 catch (Exception ex)
                 {
-                    errors.Add($"Thread {i}: {ex.Message}");
+                    errors.Add($"Thread {idx}: {ex.Message}");
                 }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
 
             errors.Should().BeEmpty();
         }
@@ -649,12 +677,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void GenerateSupportedTargetFrameworkAlias_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task GenerateSupportedTargetFrameworkAlias_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
+            using var startGate = new ManualResetEventSlim(false);
 
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -668,23 +700,26 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         TargetFrameworkMoniker = ".NETCoreApp,Version=v8.0"
                     };
 
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
 
                     if (task.SupportedTargetFrameworkAlias == null || task.SupportedTargetFrameworkAlias.Length != 1)
                     {
-                        errors.Add($"Thread {i}: Expected 1 alias but got {task.SupportedTargetFrameworkAlias?.Length}");
+                        errors.Add($"Thread {idx}: Expected 1 alias but got {task.SupportedTargetFrameworkAlias?.Length}");
                     }
                     else if (task.SupportedTargetFrameworkAlias[0].ItemSpec != "net8.0")
                     {
-                        errors.Add($"Thread {i}: Expected 'net8.0' but got '{task.SupportedTargetFrameworkAlias[0].ItemSpec}'");
+                        errors.Add($"Thread {idx}: Expected 'net8.0' but got '{task.SupportedTargetFrameworkAlias[0].ItemSpec}'");
                     }
                 }
                 catch (Exception ex)
                 {
-                    errors.Add($"Thread {i}: {ex.Message}");
+                    errors.Add($"Thread {idx}: {ex.Message}");
                 }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
 
             errors.Should().BeEmpty();
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -19,45 +18,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// </summary>
     public class GivenAttributeOnlyTasksGroup5
     {
-        #region Attribute Presence
-
-        [Fact]
-        public void CollectSDKReferencesDesignTime_HasMultiThreadableAttribute()
-        {
-            typeof(CollectSDKReferencesDesignTime).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
-                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
-        }
-
-        [Fact]
-        public void CreateWindowsSdkKnownFrameworkReferences_HasMultiThreadableAttribute()
-        {
-            typeof(CreateWindowsSdkKnownFrameworkReferences).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
-                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
-        }
-
-        [Fact]
-        public void FindItemsFromPackages_HasMultiThreadableAttribute()
-        {
-            typeof(FindItemsFromPackages).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
-                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
-        }
-
-        [Fact]
-        public void GetAssemblyVersion_HasMultiThreadableAttribute()
-        {
-            typeof(GetAssemblyVersion).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
-                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
-        }
-
-        [Fact]
-        public void GenerateSupportedTargetFrameworkAlias_HasMultiThreadableAttribute()
-        {
-            typeof(GenerateSupportedTargetFrameworkAlias).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
-                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
-        }
-
-        #endregion
-
         #region CollectSDKReferencesDesignTime
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyVersion.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyVersion.cs
@@ -12,6 +12,7 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Determines the assembly version to use for a given semantic version.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class GetAssemblyVersion : TaskBase
     {
         /// <summary>


### PR DESCRIPTION
## Summary

Migrate 5 attribute-only tasks to support multithreaded MSBuild execution by adding the `[MSBuildMultiThreadableTask]` attribute and comprehensive tests.

### Tasks Migrated (Pattern A — attribute-only)

| Task | Change |
|------|--------|
| CollectSDKReferencesDesignTime | Attribute already on main; tests added |
| CreateWindowsSdkKnownFrameworkReferences | Attribute already on main; tests added |
| FindItemsFromPackages | Attribute already on main; tests added |
| GetAssemblyVersion | `[MSBuildMultiThreadableTask]` attribute added |
| GenerateSupportedTargetFrameworkAlias | Attribute already on main; tests added |

All 5 tasks perform pure in-memory transformations with no file I/O, no environment variable access, and no `Path.GetFullPath()` calls. They qualify for Pattern A (attribute-only) — no `IMultiThreadableTask` interface or `TaskEnvironment` needed.

### Tests Added

- **GivenAttributeOnlyTasksGroup5.cs** (695 lines): 23 `[Fact]` tests covering attribute presence and behavioral correctness for all 5 tasks, plus concurrent execution stress tests.

### Files Changed

- `src/Tasks/Microsoft.NET.Build.Tasks/GetAssemblyVersion.cs` — added `[MSBuildMultiThreadableTask]`
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup5.cs` — new test file