### PR TITLE
Multithreading migration: Group 7 — 4 attribute-only + 2 Pattern B tasks

### DIFF
--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
+            Value = Path.Combine(basePath.Value, path);
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.Combine(basePath.Value, path);
+            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.Framework
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = _projectDirectory.Value,
+                UseShellExecute = false,
             };
 
             // Populate environment from the scoped environment dictionary

--- a/src/Tasks/Common/TaskEnvironmentDefaults.cs
+++ b/src/Tasks/Common/TaskEnvironmentDefaults.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Provides a default TaskEnvironment for single-threaded MSBuild execution.
+// When MSBuild supports IMultiThreadableTask, it sets TaskEnvironment directly.
+// This fallback ensures tasks work with older MSBuild versions that do not set it.
+
+#if NETFRAMEWORK
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    internal static class TaskEnvironmentDefaults
+    {
+        /// <summary>
+        /// Creates a default TaskEnvironment backed by the current process environment.
+        /// Uses Environment.CurrentDirectory as the project directory, which in single-threaded
+        /// MSBuild is set to the project directory before task execution.
+        /// </summary>
+        internal static TaskEnvironment Create() =>
+            new TaskEnvironment(new ProcessTaskEnvironmentDriver(Environment.CurrentDirectory));
+    }
+}
+
+#endif

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
@@ -3,12 +3,34 @@
 
 using FluentAssertions;
 using Microsoft.Build.Framework;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAFilterResolvedFilesMultiThreading
     {
+        private const string AssetsJson = """
+            {
+              "version": 3,
+              "targets": { ".NETCoreApp,Version=v8.0": {} },
+              "libraries": {},
+              "packageFolders": {},
+              "projectFileDependencyGroups": { ".NETCoreApp,Version=v8.0": [] },
+              "project": {
+                "version": "1.0.0",
+                "frameworks": { "net8.0": {} }
+              }
+            }
+            """;
+
+        [Fact]
+        public void FilterResolvedFiles_HasMultiThreadableAttribute()
+        {
+            typeof(FilterResolvedFiles).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
         [Fact]
         public void AssetsFilePath_IsResolvedRelativeToProjectDirectory()
         {
@@ -16,22 +38,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Directory.CreateDirectory(projectDir);
             try
             {
-                // Create a minimal lock file at a relative path
                 var assetsDir = Path.Combine(projectDir, "obj");
                 Directory.CreateDirectory(assetsDir);
-                File.WriteAllText(Path.Combine(assetsDir, "project.assets.json"),
-                    """
-                    {
-                      "version": 3,
-                      "targets": { ".NETCoreApp,Version=v8.0": {} },
-                      "libraries": {},
-                      "projectFileDependencyGroups": { ".NETCoreApp,Version=v8.0": [] },
-                      "project": {
-                        "version": "1.0.0",
-                        "frameworks": { "net8.0": {} }
-                      }
-                    }
-                    """);
+                File.WriteAllText(Path.Combine(assetsDir, "project.assets.json"), AssetsJson);
 
                 var task = new FilterResolvedFiles
                 {
@@ -40,12 +49,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     ResolvedFiles = Array.Empty<ITaskItem>(),
                     PackagesToPrune = Array.Empty<ITaskItem>(),
                     TargetFramework = ".NETCoreApp,Version=v8.0",
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
                 };
-
-                // Set TaskEnvironment via reflection
-                var teProp = task.GetType().GetProperty("TaskEnvironment");
-                teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
-                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
 
                 var result = task.Execute();
                 result.Should().BeTrue("task should succeed when assets file is found via TaskEnvironment");
@@ -53,6 +58,63 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             finally
             {
                 Directory.Delete(projectDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(
+            string assetsRelPath, string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new FilterResolvedFiles
+            {
+                BuildEngine = engine,
+                AssetsFilePath = assetsRelPath,
+                ResolvedFiles = Array.Empty<ITaskItem>(),
+                PackagesToPrune = Array.Empty<ITaskItem>(),
+                TargetFramework = ".NETCoreApp,Version=v8.0",
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+
+            var result = task.Execute();
+            return (result, engine);
+        }
+
+        [Fact]
+        public void ItProducesSameResultsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var objDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(objDir);
+                File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
+
+                var assetsRelPath = Path.Combine("obj", "project.assets.json");
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine) = RunTask(assetsRelPath, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine) = RunTask(assetsRelPath, projectDir);
+
+                mpResult.Should().Be(mtResult,
+                    "task should return the same success/failure in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                mpEngine.Warnings.Count.Should().Be(mtEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 var task = new FilterResolvedFiles
                 {
                     BuildEngine = new MockBuildEngine(),
-                    AssetsFilePath = "obj\\project.assets.json",
+                    AssetsFilePath = Path.Combine("obj", "project.assets.json"),
                     ResolvedFiles = Array.Empty<ITaskItem>(),
                     PackagesToPrune = Array.Empty<ITaskItem>(),
                     TargetFramework = ".NETCoreApp,Version=v8.0",
@@ -124,7 +124,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void FilterResolvedFiles_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task FilterResolvedFiles_ConcurrentExecution(int parallelism)
         {
             var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-concurrent-{Guid.NewGuid():N}"));
             Directory.CreateDirectory(projectDir);
@@ -135,25 +135,34 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
 
                 var errors = new ConcurrentBag<string>();
-                var barrier = new Barrier(parallelism);
-                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                using var startGate = new ManualResetEventSlim(false);
+                var tasks = new System.Threading.Tasks.Task[parallelism];
+                for (int i = 0; i < parallelism; i++)
                 {
-                    try
+                    int idx = i;
+                    tasks[idx] = System.Threading.Tasks.Task.Run(() =>
                     {
-                        var task = new FilterResolvedFiles
+                        try
                         {
-                            BuildEngine = new MockBuildEngine(),
-                            AssetsFilePath = Path.Combine("obj", "project.assets.json"),
-                            ResolvedFiles = Array.Empty<ITaskItem>(),
-                            PackagesToPrune = Array.Empty<ITaskItem>(),
-                            TargetFramework = ".NETCoreApp,Version=v8.0",
-                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
-                        };
-                        barrier.SignalAndWait();
-                        task.Execute();
-                    }
-                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
-                });
+                            var task = new FilterResolvedFiles
+                            {
+                                BuildEngine = new MockBuildEngine(),
+                                AssetsFilePath = Path.Combine("obj", "project.assets.json"),
+                                ResolvedFiles = Array.Empty<ITaskItem>(),
+                                PackagesToPrune = Array.Empty<ITaskItem>(),
+                                TargetFramework = ".NETCoreApp,Version=v8.0",
+                                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                            };
+                            startGate.Wait();
+                            var result = task.Execute();
+                            if (!result) errors.Add($"Thread {idx}: Execute returned false");
+                        }
+                        catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
+                    });
+                }
+                startGate.Set();
+                await System.Threading.Tasks.Task.WhenAll(tasks);
+
                 errors.Should().BeEmpty();
             }
             finally

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAFilterResolvedFilesMultiThreading
     {
         private const string AssetsJson = """

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
@@ -3,7 +3,10 @@
 
 using FluentAssertions;
 using Microsoft.Build.Framework;
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -115,6 +118,47 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Directory.SetCurrentDirectory(savedCwd);
                 Directory.Delete(projectDir, true);
                 if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void FilterResolvedFiles_ConcurrentExecution(int parallelism)
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-concurrent-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var objDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(objDir);
+                File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
+
+                var errors = new ConcurrentBag<string>();
+                var barrier = new Barrier(parallelism);
+                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                {
+                    try
+                    {
+                        var task = new FilterResolvedFiles
+                        {
+                            BuildEngine = new MockBuildEngine(),
+                            AssetsFilePath = Path.Combine("obj", "project.assets.json"),
+                            ResolvedFiles = Array.Empty<ITaskItem>(),
+                            PackagesToPrune = Array.Empty<ITaskItem>(),
+                            TargetFramework = ".NETCoreApp,Version=v8.0",
+                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                        };
+                        barrier.SignalAndWait();
+                        task.Execute();
+                    }
+                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                });
+                errors.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
             }
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAFilterResolvedFilesMultiThreading
+    {
+        [Fact]
+        public void AssetsFilePath_IsResolvedRelativeToProjectDirectory()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-mt-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                // Create a minimal lock file at a relative path
+                var assetsDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(assetsDir);
+                File.WriteAllText(Path.Combine(assetsDir, "project.assets.json"),
+                    """
+                    {
+                      "version": 3,
+                      "targets": { ".NETCoreApp,Version=v8.0": {} },
+                      "libraries": {},
+                      "projectFileDependencyGroups": { ".NETCoreApp,Version=v8.0": [] },
+                      "project": {
+                        "version": "1.0.0",
+                        "frameworks": { "net8.0": {} }
+                      }
+                    }
+                    """);
+
+                var task = new FilterResolvedFiles
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    AssetsFilePath = "obj\\project.assets.json",
+                    ResolvedFiles = Array.Empty<ITaskItem>(),
+                    PackagesToPrune = Array.Empty<ITaskItem>(),
+                    TargetFramework = ".NETCoreApp,Version=v8.0",
+                };
+
+                // Set TaskEnvironment via reflection
+                var teProp = task.GetType().GetProperty("TaskEnvironment");
+                teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
+                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+
+                var result = task.Execute();
+                result.Should().BeTrue("task should succeed when assets file is found via TaskEnvironment");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenASelectRuntimeIdentifierSpecificItems.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenASelectRuntimeIdentifierSpecificItems.cs
@@ -28,7 +28,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetRuntimeIdentifier = "ubuntu.18.04-x64",
                 Items = items,
                 RuntimeIdentifierGraphPath = testRuntimeGraphPath,
-                BuildEngine = new MockBuildEngine()
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest()
             };
 
             // Act
@@ -59,7 +60,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetRuntimeIdentifier = "win-x64",
                 Items = items,
                 RuntimeIdentifierGraphPath = testRuntimeGraphPath,
-                BuildEngine = new MockBuildEngine()
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest()
             };
 
             // Act
@@ -88,7 +90,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetRuntimeIdentifier = "linux-x64",
                 Items = items,
                 RuntimeIdentifierGraphPath = testRuntimeGraphPath,
-                BuildEngine = new MockBuildEngine()
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest()
             };
 
             // Act
@@ -114,7 +117,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Items = new[] { item },
                 RuntimeIdentifierItemMetadata = "CustomRID",
                 RuntimeIdentifierGraphPath = testRuntimeGraphPath,
-                BuildEngine = new MockBuildEngine()
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest()
             };
 
             // Act
@@ -137,7 +141,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetRuntimeIdentifier = "linux-x64",
                 Items = new ITaskItem[0],
                 RuntimeIdentifierGraphPath = testRuntimeGraphPath,
-                BuildEngine = new MockBuildEngine()
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest()
             };
 
             // Act

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -85,11 +85,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 // --- Run with CWD = projectDir ---
                 Directory.SetCurrentDirectory(projectDir);
-                var (cwdResult, cwdSelected) = RunSelectRidTask("linux-x64", items, graphPath);
+                var (cwdResult, cwdSelected) = RunSelectRidTask("linux-x64", items, graphPath, projectDir);
 
                 // --- Run with CWD = otherDir ---
                 Directory.SetCurrentDirectory(otherDir);
-                var (otherResult, otherSelected) = RunSelectRidTask("linux-x64", items, graphPath);
+                var (otherResult, otherSelected) = RunSelectRidTask("linux-x64", items, graphPath, projectDir);
 
                 cwdResult.Should().Be(otherResult, "task should return same result regardless of CWD");
                 cwdSelected.Length.Should().Be(otherSelected.Length, "same number of items should be selected");
@@ -108,11 +108,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         private static (bool result, ITaskItem[] selected) RunSelectRidTask(
-            string targetRid, ITaskItem[] items, string graphPath)
+            string targetRid, ITaskItem[] items, string graphPath, string projectDir)
         {
             var task = new SelectRuntimeIdentifierSpecificItems
             {
                 BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
                 TargetRuntimeIdentifier = targetRid,
                 Items = items,
                 RuntimeIdentifierGraphPath = graphPath
@@ -366,6 +367,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     var task = new SelectRuntimeIdentifierSpecificItems
                     {
                         BuildEngine = new MockBuildEngine(),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(Path.GetTempPath()),
                         TargetRuntimeIdentifier = "linux-x64",
                         Items = new ITaskItem[]
                         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -356,66 +356,98 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void SelectRuntimeIdentifierSpecificItems_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task SelectRuntimeIdentifierSpecificItems_ConcurrentExecution(int parallelism)
         {
+            var projectDir = Path.Combine(Path.GetTempPath(), $"select-rid-concurrent-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(projectDir);
+            var runtimeGraphPath = Path.Combine(projectDir, "runtime.json");
+            File.WriteAllText(runtimeGraphPath, @"{ ""runtimes"": { ""linux-x64"": { ""#import"": [""linux"", ""unix""] } } }");
+            try
+            {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
                     var task = new SelectRuntimeIdentifierSpecificItems
                     {
                         BuildEngine = new MockBuildEngine(),
-                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(Path.GetTempPath()),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
                         TargetRuntimeIdentifier = "linux-x64",
                         Items = new ITaskItem[]
                         {
-                            CreateItemWithRid($"Item{i}", "linux-x64")
+                            CreateItemWithRid($"Item{idx}", "linux-x64")
                         },
-                        RuntimeIdentifierGraphPath = ""
+                        RuntimeIdentifierGraphPath = "runtime.json"
                     };
-                    barrier.SignalAndWait();
-                    task.Execute();
+                    startGate.Wait();
+                    var result = task.Execute();
+                    if (!result) errors.Add($"Thread {idx}: Execute returned false");
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
         }
 
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void SetGeneratedAppConfigMetadata_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task SetGeneratedAppConfigMetadata_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
                     var task = new SetGeneratedAppConfigMetadata
                     {
                         BuildEngine = new MockBuildEngine(),
-                        GeneratedAppConfigFile = $"obj/app{i}.exe.config",
-                        TargetName = $"app{i}.exe.config"
+                        GeneratedAppConfigFile = $"obj/app{idx}.exe.config",
+                        TargetName = $"app{idx}.exe.config"
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ValidateExecutableReferences_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ValidateExecutableReferences_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -426,22 +458,30 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         SelfContained = false,
                         ReferencedProjects = Array.Empty<ITaskItem>()
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void RemoveDuplicatePackageReferences_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task RemoveDuplicatePackageReferences_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -450,14 +490,18 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         BuildEngine = new MockBuildEngine(),
                         InputPackageReferences = new ITaskItem[]
                         {
-                            new MockTaskItem($"Package{i}", new Dictionary<string, string> { { "Version", "1.0.0" } })
+                            new MockTaskItem($"Package{idx}", new Dictionary<string, string> { { "Version", "1.0.0" } })
                         }
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -4,7 +4,10 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -346,5 +349,116 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         // FilterResolvedFiles parity test removed — it belongs in GivenAFilterResolvedFilesMultiThreading.cs
         // (FilterResolvedFiles is Pattern B, not attribute-only). The duplicate here also had a bug:
         // it created FilterResolvedFiles without setting TaskEnvironment, causing NullReferenceException.
+
+        #region Concurrent Execution
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void SelectRuntimeIdentifierSpecificItems_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new SelectRuntimeIdentifierSpecificItems
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        TargetRuntimeIdentifier = "linux-x64",
+                        Items = new ITaskItem[]
+                        {
+                            CreateItemWithRid($"Item{i}", "linux-x64")
+                        },
+                        RuntimeIdentifierGraphPath = ""
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void SetGeneratedAppConfigMetadata_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new SetGeneratedAppConfigMetadata
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        GeneratedAppConfigFile = $"obj/app{i}.exe.config",
+                        TargetName = $"app{i}.exe.config"
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ValidateExecutableReferences_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ValidateExecutableReferences
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        IsExecutable = false,
+                        SelfContained = false,
+                        ReferencedProjects = Array.Empty<ITaskItem>()
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void RemoveDuplicatePackageReferences_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new RemoveDuplicatePackageReferences
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        InputPackageReferences = new ITaskItem[]
+                        {
+                            new MockTaskItem($"Package{i}", new Dictionary<string, string> { { "Version", "1.0.0" } })
+                        }
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
+        }
+
+        #endregion
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -343,76 +343,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         #endregion
 
-        #region FilterResolvedFiles (dual-mode parity test)
-
-        [Fact]
-        public void FilterResolvedFiles_ProducesSameResultsRegardlessOfCwd()
-        {
-            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-parity-{Guid.NewGuid():N}"));
-            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-decoy-{Guid.NewGuid():N}"));
-            Directory.CreateDirectory(projectDir);
-            Directory.CreateDirectory(otherDir);
-            var savedCwd = Directory.GetCurrentDirectory();
-            try
-            {
-                var assetsContent = @"{
-                    ""version"": 3,
-                    ""targets"": { "".NETCoreApp,Version=v8.0"": {} },
-                    ""libraries"": {},
-                    ""packageFolders"": {},
-                    ""projectFileDependencyGroups"": { "".NETCoreApp,Version=v8.0"": [] },
-                    ""project"": { ""version"": ""1.0.0"", ""frameworks"": { ""net8.0"": {} } }
-                }";
-                var assetsPath = Path.Combine(projectDir, "project.assets.json");
-                File.WriteAllText(assetsPath, assetsContent);
-
-                var resolvedFiles = new ITaskItem[]
-                {
-                    new MockTaskItem("MyLib.dll", new Dictionary<string, string>
-                    {
-                        { "NuGetPackageId", "MyPackage" },
-                        { "NuGetPackageVersion", "1.0.0" }
-                    })
-                };
-                var packagesToPrune = Array.Empty<ITaskItem>();
-
-                // --- CWD = projectDir ---
-                Directory.SetCurrentDirectory(projectDir);
-                var (cwdResult, cwdEngine) = RunFilterTask(assetsPath, resolvedFiles, packagesToPrune);
-
-                // --- CWD = otherDir ---
-                Directory.SetCurrentDirectory(otherDir);
-                var (otherResult, otherEngine) = RunFilterTask(assetsPath, resolvedFiles, packagesToPrune);
-
-                cwdResult.Should().Be(otherResult,
-                    "FilterResolvedFiles should return same success/failure in both environments");
-                cwdEngine.Errors.Count.Should().Be(otherEngine.Errors.Count,
-                    "error count should be the same in both environments");
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(savedCwd);
-                Directory.Delete(projectDir, true);
-                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
-            }
-        }
-
-        private static (bool result, MockBuildEngine engine) RunFilterTask(
-            string assetsPath, ITaskItem[] resolvedFiles, ITaskItem[] packagesToPrune)
-        {
-            var engine = new MockBuildEngine();
-            var task = new FilterResolvedFiles
-            {
-                BuildEngine = engine,
-                AssetsFilePath = assetsPath,
-                ResolvedFiles = resolvedFiles,
-                PackagesToPrune = packagesToPrune,
-                TargetFramework = ".NETCoreApp,Version=v8.0"
-            };
-            var result = task.Execute();
-            return (result, engine);
-        }
-
-        #endregion
+        // FilterResolvedFiles parity test removed — it belongs in GivenAFilterResolvedFilesMultiThreading.cs
+        // (FilterResolvedFiles is Pattern B, not attribute-only). The duplicate here also had a bug:
+        // it created FilterResolvedFiles without setting TaskEnvironment, causing NullReferenceException.
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -1,0 +1,385 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    /// <summary>
+    /// Behavioral tests for attribute-only tasks in merge-group-7.
+    /// These tasks received only the [MSBuildMultiThreadableTask] attribute — no source
+    /// code changes — so we verify they still produce correct results.
+    /// </summary>
+    public class GivenAttributeOnlyTasksGroup7
+    {
+        #region SelectRuntimeIdentifierSpecificItems (parity test)
+
+        [Fact]
+        public void SelectRuntimeIdentifierSpecificItems_ProducesSameResultsRegardlessOfCwd()
+        {
+            // This parity test verifies the task behaves identically
+            // when CWD is projectDir vs a different directory.
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"select-rid-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"select-rid-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var runtimeGraphJson = @"{
+                    ""runtimes"": {
+                        ""linux"": {},
+                        ""linux-x64"": { ""#import"": [""linux""] },
+                        ""win"": {},
+                        ""win-x64"": { ""#import"": [""win""] }
+                    }
+                }";
+                var graphPath = Path.Combine(projectDir, "runtime.json");
+                File.WriteAllText(graphPath, runtimeGraphJson);
+
+                var items = new[]
+                {
+                    CreateItemWithRid("Item1", "linux-x64"),
+                    CreateItemWithRid("Item2", "win-x64"),
+                    CreateItemWithRid("Item3", "linux")
+                };
+
+                // --- Run with CWD = projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (cwdResult, cwdSelected) = RunSelectRidTask("linux-x64", items, graphPath);
+
+                // --- Run with CWD = otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (otherResult, otherSelected) = RunSelectRidTask("linux-x64", items, graphPath);
+
+                cwdResult.Should().Be(otherResult, "task should return same result regardless of CWD");
+                cwdSelected.Length.Should().Be(otherSelected.Length, "same number of items should be selected");
+
+                // Both should select linux-x64 and linux, but NOT win-x64
+                cwdSelected.Should().HaveCount(2);
+                cwdSelected.Should().Contain(i => i.ItemSpec == "Item1"); // linux-x64
+                cwdSelected.Should().Contain(i => i.ItemSpec == "Item3"); // linux
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, ITaskItem[] selected) RunSelectRidTask(
+            string targetRid, ITaskItem[] items, string graphPath)
+        {
+            var task = new SelectRuntimeIdentifierSpecificItems
+            {
+                BuildEngine = new MockBuildEngine(),
+                TargetRuntimeIdentifier = targetRid,
+                Items = items,
+                RuntimeIdentifierGraphPath = graphPath
+            };
+            var result = task.Execute();
+            return (result, task.SelectedItems ?? Array.Empty<ITaskItem>());
+        }
+
+        private static TaskItem CreateItemWithRid(string itemSpec, string rid)
+        {
+            var item = new TaskItem(itemSpec);
+            item.SetMetadata("RuntimeIdentifier", rid);
+            return item;
+        }
+
+        #endregion
+
+        #region SetGeneratedAppConfigMetadata
+
+        [Fact]
+        public void SetGeneratedAppConfigMetadata_WithNoSourceAppConfig_SetsTargetPath()
+        {
+            var task = new SetGeneratedAppConfigMetadata
+            {
+                BuildEngine = new MockBuildEngine(),
+                GeneratedAppConfigFile = "obj/myapp.exe.config",
+                TargetName = "myapp.exe.config"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.OutputAppConfigFileWithMetadata.Should().NotBeNull();
+            task.OutputAppConfigFileWithMetadata.ItemSpec.Should().Be("obj/myapp.exe.config");
+            task.OutputAppConfigFileWithMetadata.GetMetadata("TargetPath").Should().Be("myapp.exe.config");
+        }
+
+        [Fact]
+        public void SetGeneratedAppConfigMetadata_WithSourceAppConfig_CopiesMetadata()
+        {
+            var sourceConfig = new MockTaskItem("app.config", new Dictionary<string, string>
+            {
+                { "Link", "linked/app.config" },
+                { "TargetPath", "myapp.exe.config" }
+            });
+
+            var task = new SetGeneratedAppConfigMetadata
+            {
+                BuildEngine = new MockBuildEngine(),
+                AppConfigFile = sourceConfig,
+                GeneratedAppConfigFile = "obj/myapp.exe.config",
+                TargetName = "myapp.exe.config"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.OutputAppConfigFileWithMetadata.Should().NotBeNull();
+            task.OutputAppConfigFileWithMetadata.ItemSpec.Should().Be("obj/myapp.exe.config");
+            // Source metadata should be copied to the output
+            task.OutputAppConfigFileWithMetadata.GetMetadata("TargetPath").Should().Be("myapp.exe.config");
+        }
+
+        [Fact]
+        public void SetGeneratedAppConfigMetadata_OutputItemSpecIsGeneratedPath()
+        {
+            var task = new SetGeneratedAppConfigMetadata
+            {
+                BuildEngine = new MockBuildEngine(),
+                GeneratedAppConfigFile = "generated/config.xml",
+                TargetName = "output.exe.config"
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.OutputAppConfigFileWithMetadata.ItemSpec.Should().Be("generated/config.xml",
+                "the output item should use the generated file path as its ItemSpec");
+        }
+
+        #endregion
+
+        #region ValidateExecutableReferences
+
+        [Fact]
+        public void ValidateExecutableReferences_NonExecutableProject_SkipsValidation()
+        {
+            var task = new ValidateExecutableReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                IsExecutable = false,
+                SelfContained = true,
+                ReferencedProjects = new ITaskItem[]
+                {
+                    new TaskItem("SomeProject.csproj")
+                }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("non-executable projects should skip validation entirely");
+        }
+
+        [Fact]
+        public void ValidateExecutableReferences_NoReferencedProjects_Succeeds()
+        {
+            var task = new ValidateExecutableReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                IsExecutable = true,
+                SelfContained = false,
+                ReferencedProjects = Array.Empty<ITaskItem>()
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("no references means nothing to validate");
+        }
+
+        [Fact]
+        public void ValidateExecutableReferences_ProjectWithoutNearestTfm_SkipsProject()
+        {
+            // Projects without NearestTargetFramework metadata (e.g., C++ projects)
+            // should be silently skipped
+            var project = new MockTaskItem("NativeProject.vcxproj", new Dictionary<string, string>());
+
+            var task = new ValidateExecutableReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                IsExecutable = true,
+                SelfContained = false,
+                ReferencedProjects = new ITaskItem[] { project }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("projects without NearestTargetFramework should be skipped");
+        }
+
+        #endregion
+
+        #region RemoveDuplicatePackageReferences
+
+        [Fact]
+        public void RemoveDuplicatePackageReferences_RemovesDuplicates()
+        {
+            var packages = new ITaskItem[]
+            {
+                new MockTaskItem("MyPackage", new Dictionary<string, string> { { "Version", "1.0.0" } }),
+                new MockTaskItem("MyPackage", new Dictionary<string, string> { { "Version", "1.0.0" } }),
+                new MockTaskItem("OtherPackage", new Dictionary<string, string> { { "Version", "2.0.0" } })
+            };
+
+            var task = new RemoveDuplicatePackageReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                InputPackageReferences = packages
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.UniquePackageReferences.Should().HaveCount(2);
+            task.UniquePackageReferences.Should().Contain(i => i.ItemSpec == "MyPackage");
+            task.UniquePackageReferences.Should().Contain(i => i.ItemSpec == "OtherPackage");
+        }
+
+        [Fact]
+        public void RemoveDuplicatePackageReferences_PreservesVersionMetadata()
+        {
+            var packages = new ITaskItem[]
+            {
+                new MockTaskItem("MyPackage", new Dictionary<string, string> { { "Version", "3.5.1" } })
+            };
+
+            var task = new RemoveDuplicatePackageReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                InputPackageReferences = packages
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.UniquePackageReferences.Should().HaveCount(1);
+            task.UniquePackageReferences[0].GetMetadata("Version").Should().Be("3.5.1");
+        }
+
+        [Fact]
+        public void RemoveDuplicatePackageReferences_DifferentVersionsAreNotDuplicates()
+        {
+            var packages = new ITaskItem[]
+            {
+                new MockTaskItem("MyPackage", new Dictionary<string, string> { { "Version", "1.0.0" } }),
+                new MockTaskItem("MyPackage", new Dictionary<string, string> { { "Version", "2.0.0" } })
+            };
+
+            var task = new RemoveDuplicatePackageReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                InputPackageReferences = packages
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.UniquePackageReferences.Should().HaveCount(2,
+                "same package with different versions are distinct identities");
+        }
+
+        [Fact]
+        public void RemoveDuplicatePackageReferences_SinglePackage_PassesThrough()
+        {
+            var packages = new ITaskItem[]
+            {
+                new MockTaskItem("SinglePackage", new Dictionary<string, string> { { "Version", "1.0.0" } })
+            };
+
+            var task = new RemoveDuplicatePackageReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                InputPackageReferences = packages
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.UniquePackageReferences.Should().HaveCount(1);
+            task.UniquePackageReferences[0].ItemSpec.Should().Be("SinglePackage");
+        }
+
+        #endregion
+
+        #region FilterResolvedFiles (dual-mode parity test)
+
+        [Fact]
+        public void FilterResolvedFiles_ProducesSameResultsRegardlessOfCwd()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"filter-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var assetsContent = @"{
+                    ""version"": 3,
+                    ""targets"": { "".NETCoreApp,Version=v8.0"": {} },
+                    ""libraries"": {},
+                    ""packageFolders"": {},
+                    ""projectFileDependencyGroups"": { "".NETCoreApp,Version=v8.0"": [] },
+                    ""project"": { ""version"": ""1.0.0"", ""frameworks"": { ""net8.0"": {} } }
+                }";
+                var assetsPath = Path.Combine(projectDir, "project.assets.json");
+                File.WriteAllText(assetsPath, assetsContent);
+
+                var resolvedFiles = new ITaskItem[]
+                {
+                    new MockTaskItem("MyLib.dll", new Dictionary<string, string>
+                    {
+                        { "NuGetPackageId", "MyPackage" },
+                        { "NuGetPackageVersion", "1.0.0" }
+                    })
+                };
+                var packagesToPrune = Array.Empty<ITaskItem>();
+
+                // --- CWD = projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (cwdResult, cwdEngine) = RunFilterTask(assetsPath, resolvedFiles, packagesToPrune);
+
+                // --- CWD = otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (otherResult, otherEngine) = RunFilterTask(assetsPath, resolvedFiles, packagesToPrune);
+
+                cwdResult.Should().Be(otherResult,
+                    "FilterResolvedFiles should return same success/failure in both environments");
+                cwdEngine.Errors.Count.Should().Be(otherEngine.Errors.Count,
+                    "error count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunFilterTask(
+            string assetsPath, ITaskItem[] resolvedFiles, ITaskItem[] packagesToPrune)
+        {
+            var engine = new MockBuildEngine();
+            var task = new FilterResolvedFiles
+            {
+                BuildEngine = engine,
+                AssetsFilePath = assetsPath,
+                ResolvedFiles = resolvedFiles,
+                PackagesToPrune = packagesToPrune,
+                TargetFramework = ".NETCoreApp,Version=v8.0"
+            };
+            var result = task.Execute();
+            return (result, engine);
+        }
+
+        #endregion
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -15,6 +16,38 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// </summary>
     public class GivenAttributeOnlyTasksGroup7
     {
+        #region Attribute Presence
+
+        [Fact]
+        public void SelectRuntimeIdentifierSpecificItems_HasMultiThreadableAttribute()
+        {
+            typeof(SelectRuntimeIdentifierSpecificItems).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void SetGeneratedAppConfigMetadata_HasMultiThreadableAttribute()
+        {
+            typeof(SetGeneratedAppConfigMetadata).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void ValidateExecutableReferences_HasMultiThreadableAttribute()
+        {
+            typeof(ValidateExecutableReferences).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        [Fact]
+        public void RemoveDuplicatePackageReferences_HasMultiThreadableAttribute()
+        {
+            typeof(RemoveDuplicatePackageReferences).GetCustomAttribute<MSBuildMultiThreadableTaskAttribute>()
+                .Should().NotBeNull("task must be decorated with [MSBuildMultiThreadableTask]");
+        }
+
+        #endregion
+
         #region SelectRuntimeIdentifierSpecificItems (parity test)
 
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs
@@ -17,6 +17,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// These tasks received only the [MSBuildMultiThreadableTask] attribute — no source
     /// code changes — so we verify they still produce correct results.
     /// </summary>
+    [Collection("CWD-Dependent")]
+
     public class GivenAttributeOnlyTasksGroup7
     {
         #region Attribute Presence

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Globalization;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
@@ -95,7 +96,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ResxIsCommentedWithCorrectStrBegin()
         {
-            var doc = XDocument.Load("Strings.resx");
+            var resxPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Strings.resx");
+            var doc = XDocument.Load(resxPath);
             var ns = doc.Root.Name.Namespace;
 
             foreach (var data in doc.Root.Elements(ns + "data"))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -13,10 +13,13 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Filters out the assemblies from the list based on a given package closure.
     /// </summary>
-    public class FilterResolvedFiles : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class FilterResolvedFiles : TaskBase, IMultiThreadableTask
     {
         private readonly List<ITaskItem> _assembliesToPublish = new();
         private readonly List<ITaskItem> _packagesResolved = new();
+
+        public TaskEnvironment TaskEnvironment { get; set; }
 
         public string AssetsFilePath { get; set; }
 
@@ -52,7 +55,7 @@ namespace Microsoft.NET.Build.Tasks
         protected override void ExecuteCore()
         {
             var lockFileCache = new LockFileCache(this);
-            LockFile lockFile = lockFileCache.GetLockFile(AssetsFilePath);
+            LockFile lockFile = lockFileCache.GetLockFile(TaskEnvironment.GetAbsolutePath(AssetsFilePath));
 
             ProjectContext projectContext = lockFile.CreateProjectContext(
                 TargetFramework,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs
@@ -19,7 +19,16 @@ namespace Microsoft.NET.Build.Tasks
         private readonly List<ITaskItem> _assembliesToPublish = new();
         private readonly List<ITaskItem> _packagesResolved = new();
 
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         public string AssetsFilePath { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
@@ -11,6 +11,7 @@ namespace Microsoft.NET.Build.Tasks;
 /// This task filters an Item list by those items that contain a specific Metadata that is
 /// compatible with a specified Runtime Identifier, according to a given RuntimeIdentifierGraph file.
 /// </summary>
+[MSBuildMultiThreadableTask]
 public class SelectRuntimeIdentifierSpecificItems : TaskBase
 {
     /// <summary>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
@@ -14,7 +14,16 @@ namespace Microsoft.NET.Build.Tasks;
 [MSBuildMultiThreadableTask]
 public class SelectRuntimeIdentifierSpecificItems : TaskBase, IMultiThreadableTask
 {
+#if NETFRAMEWORK
+    private TaskEnvironment _taskEnvironment;
+    public TaskEnvironment TaskEnvironment
+    {
+        get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+        set => _taskEnvironment = value;
+    }
+#else
     public TaskEnvironment TaskEnvironment { get; set; } = null!;
+#endif
 
     /// <summary>
     /// The target runtime identifier to check compatibility against.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs
@@ -12,8 +12,10 @@ namespace Microsoft.NET.Build.Tasks;
 /// compatible with a specified Runtime Identifier, according to a given RuntimeIdentifierGraph file.
 /// </summary>
 [MSBuildMultiThreadableTask]
-public class SelectRuntimeIdentifierSpecificItems : TaskBase
+public class SelectRuntimeIdentifierSpecificItems : TaskBase, IMultiThreadableTask
 {
+    public TaskEnvironment TaskEnvironment { get; set; } = null!;
+
     /// <summary>
     /// The target runtime identifier to check compatibility against.
     /// </summary>
@@ -53,7 +55,7 @@ public class SelectRuntimeIdentifierSpecificItems : TaskBase
 
         string ridMetadata = RuntimeIdentifierItemMetadata ?? "RuntimeIdentifier";
 
-        RuntimeGraph runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeIdentifierGraphPath);
+        RuntimeGraph runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(TaskEnvironment.GetAbsolutePath(RuntimeIdentifierGraphPath));
 
         var selectedItems = new List<ITaskItem>();
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/SetGeneratedAppConfigMetadata.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/SetGeneratedAppConfigMetadata.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public sealed class SetGeneratedAppConfigMetadata : TaskBase
     {
         /// <summary>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.Cli;
 
 namespace Microsoft.NET.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public class ValidateExecutableReferences : TaskBase
     {
         public bool SelfContained { get; set; }


### PR DESCRIPTION
## Summary

Migrate 5 tasks to support multithreaded MSBuild execution. Three tasks are attribute-only (Pattern A), two require interface-based migration (Pattern B).

### Tasks Migrated

| Task | Pattern | Key Changes |
|------|---------|-------------|
| SetGeneratedAppConfigMetadata | A | Attribute added; behavioral tests |
| ValidateExecutableReferences | A | Attribute added; behavioral tests |
| RemoveDuplicatePackageReferences | A | Attribute already on main; tests added |
| SelectRuntimeIdentifierSpecificItems | B | Added `IMultiThreadableTask`, `TaskEnvironment`; absolutized `RuntimeIdentifierGraphPath` |
| FilterResolvedFiles | B | Added `IMultiThreadableTask`, `TaskEnvironment`; absolutized `AssetsFilePath` |

### Pattern B Details

**SelectRuntimeIdentifierSpecificItems**: Calls `RuntimeGraphCache.GetRuntimeGraph(RuntimeIdentifierGraphPath)` which enforces `Path.IsPathRooted()` and performs file I/O via `JsonRuntimeFormat.ReadRuntimeGraph()`. `RuntimeIdentifierGraphPath` is absolutized via `TaskEnvironment.GetAbsolutePath()` before the call.

**FilterResolvedFiles**: Calls `LockFileCache.GetLockFile(AssetsFilePath)` which requires rooted paths. `AssetsFilePath` is absolutized before the call.

### Tests Added

- **GivenAttributeOnlyTasksGroup7.cs** — attribute-presence tests, behavioral tests, parity tests, concurrent execution tests
- **GivenAFilterResolvedFilesMultiThreading.cs** — CWD-independence parity test, path resolution test

### Files Changed

- `src/Tasks/Microsoft.NET.Build.Tasks/SelectRuntimeIdentifierSpecificItems.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/SetGeneratedAppConfigMetadata.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/ValidateExecutableReferences.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/FilterResolvedFiles.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAttributeOnlyTasksGroup7.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAFilterResolvedFilesMultiThreading.cs` (new)