### PR TITLE
Multithreading migration: Group 9 — 4 Package/Asset tasks (Pattern B)

### DIFF
--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
+            Value = Path.Combine(basePath.Value, path);
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.Combine(basePath.Value, path);
+            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.Framework
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = _projectDirectory.Value,
+                UseShellExecute = false,
             };
 
             // Populate environment from the scoped environment dictionary

--- a/src/Tasks/Common/TaskEnvironmentDefaults.cs
+++ b/src/Tasks/Common/TaskEnvironmentDefaults.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Provides a default TaskEnvironment for single-threaded MSBuild execution.
+// When MSBuild supports IMultiThreadableTask, it sets TaskEnvironment directly.
+// This fallback ensures tasks work with older MSBuild versions that do not set it.
+
+#if NETFRAMEWORK
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    internal static class TaskEnvironmentDefaults
+    {
+        /// <summary>
+        /// Creates a default TaskEnvironment backed by the current process environment.
+        /// Uses Environment.CurrentDirectory as the project directory, which in single-threaded
+        /// MSBuild is set to the project directory before task execution.
+        /// </summary>
+        internal static TaskEnvironment Create() =>
+            new TaskEnvironment(new ProcessTaskEnvironmentDriver(Environment.CurrentDirectory));
+    }
+}
+
+#endif

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 var teProp = task.GetType().GetProperty("TaskEnvironment");
                 teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
-                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+                task.TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir);
 
                 var result = task.Execute();
                 result.Should().BeTrue("task should succeed when assets file is found via TaskEnvironment");

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGetPackageDirectoryMultiThreading
+    {
+        private const string AssetsJson = """
+            {
+              "version": 3,
+              "targets": { ".NETCoreApp,Version=v8.0": {} },
+              "libraries": {},
+              "packageFolders": {},
+              "projectFileDependencyGroups": { ".NETCoreApp,Version=v8.0": [] },
+              "project": {
+                "version": "1.0.0",
+                "frameworks": { "net8.0": {} }
+              }
+            }
+            """;
+
+        private static (bool result, MockBuildEngine engine) RunTask(
+            string assetsRelPath, string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new GetPackageDirectory
+            {
+                BuildEngine = engine,
+                AssetsFileWithAdditionalPackageFolders = assetsRelPath,
+                Items = Array.Empty<ITaskItem>(),
+                PackageFolders = Array.Empty<string>(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+
+            var result = task.Execute();
+            return (result, engine);
+        }
+
+        [Fact]
+        public void AssetsFile_IsResolvedRelativeToProjectDirectory()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pkgdir-mt-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var objDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(objDir);
+                File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
+
+                var task = new GetPackageDirectory
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    AssetsFileWithAdditionalPackageFolders = "obj\\project.assets.json",
+                    Items = Array.Empty<ITaskItem>(),
+                    PackageFolders = Array.Empty<string>(),
+                };
+
+                var teProp = task.GetType().GetProperty("TaskEnvironment");
+                teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
+                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+
+                var result = task.Execute();
+                result.Should().BeTrue("task should succeed when assets file is found via TaskEnvironment");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItProducesSameResultsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pkgdir-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pkgdir-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var objDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(objDir);
+                File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
+
+                var assetsRelPath = Path.Combine("obj", "project.assets.json");
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine) = RunTask(assetsRelPath, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine) = RunTask(assetsRelPath, projectDir);
+
+                mpResult.Should().Be(mtResult,
+                    "task should return the same success/failure in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(
+                        mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+                mpEngine.Warnings.Count.Should().Be(mtEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -65,6 +68,46 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 var result = task.Execute();
                 result.Should().BeTrue("task should succeed when assets file is found via TaskEnvironment");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void GetPackageDirectory_ConcurrentExecution(int parallelism)
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pkgdir-conc-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var objDir = Path.Combine(projectDir, "obj");
+                Directory.CreateDirectory(objDir);
+                File.WriteAllText(Path.Combine(objDir, "project.assets.json"), AssetsJson);
+
+                var errors = new ConcurrentBag<string>();
+                var barrier = new Barrier(parallelism);
+                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                {
+                    try
+                    {
+                        var task = new GetPackageDirectory
+                        {
+                            BuildEngine = new MockBuildEngine(),
+                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                            AssetsFileWithAdditionalPackageFolders = Path.Combine("obj", "project.assets.json"),
+                            Items = Array.Empty<ITaskItem>(),
+                            PackageFolders = Array.Empty<string>(),
+                        };
+                        barrier.SignalAndWait();
+                        task.Execute();
+                    }
+                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                });
+                errors.Should().BeEmpty();
             }
             finally
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAGetPackageDirectoryMultiThreading
     {
         private const string AssetsJson = """

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAGetPackagesToPruneMultiThreading
     {
         private const string Tfm = "10.0";

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -116,6 +119,58 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 var result = task.Execute();
                 result.Should().BeTrue("task should succeed when AllowMissingPrunePackageData is true");
                 engine.Errors.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void GetPackagesToPrune_ConcurrentExecution(int parallelism)
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-conc-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var pruneRelPath = "PruneData";
+                WritePruneData(Path.Combine(projectDir, pruneRelPath));
+
+                var errors = new ConcurrentBag<string>();
+                var barrier = new Barrier(parallelism);
+                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                {
+                    try
+                    {
+                        var task = new GetPackagesToPrune
+                        {
+                            BuildEngine = new MockBuildEngine(),
+                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                            TargetFrameworkIdentifier = ".NETCoreApp",
+                            TargetFrameworkVersion = Tfm,
+                            FrameworkReferences = new ITaskItem[]
+                            {
+                                new MockTaskItem(FrameworkRef, new Dictionary<string, string>())
+                            },
+                            TargetingPacks = new ITaskItem[]
+                            {
+                                new MockTaskItem(FrameworkRef, new Dictionary<string, string>
+                                {
+                                    ["RuntimeFrameworkName"] = FrameworkRef
+                                })
+                            },
+                            TargetingPackRoots = Array.Empty<string>(),
+                            PrunePackageDataRoot = pruneRelPath,
+                            AllowMissingPrunePackageData = false,
+                        };
+                        barrier.SignalAndWait();
+                        task.Execute();
+                    }
+                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                });
+                errors.Should().BeEmpty();
             }
             finally
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGetPackagesToPruneMultiThreading
+    {
+        private const string Tfm = "10.0";
+        private const string FrameworkRef = "Microsoft.NETCore.App";
+
+        /// <summary>
+        /// Creates the PrunePackageData directory structure with a PackageOverrides.txt file.
+        /// Layout: {pruneRoot}/{tfm}/{frameworkRef}/PackageOverrides.txt
+        /// </summary>
+        private static void WritePruneData(string pruneRoot)
+        {
+            var dir = Path.Combine(pruneRoot, Tfm, FrameworkRef);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "PackageOverrides.txt"),
+                "System.Text.Json|10.0.0\nSystem.Memory|10.0.0\n");
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(
+            string pruneDataRelPath, string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new GetPackagesToPrune
+            {
+                BuildEngine = engine,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = Tfm,
+                FrameworkReferences = new ITaskItem[]
+                {
+                    new MockTaskItem(FrameworkRef, new Dictionary<string, string>())
+                },
+                TargetingPacks = new ITaskItem[]
+                {
+                    new MockTaskItem(FrameworkRef, new Dictionary<string, string>
+                    {
+                        ["RuntimeFrameworkName"] = FrameworkRef
+                    })
+                },
+                TargetingPackRoots = Array.Empty<string>(),
+                PrunePackageDataRoot = pruneDataRelPath,
+                AllowMissingPrunePackageData = false,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+
+            var result = task.Execute();
+            return (result, engine);
+        }
+
+        [Fact]
+        public void PrunePackageDataRoot_IsResolvedRelativeToProjectDirectory()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-mt-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var pruneRelPath = "PruneData";
+                WritePruneData(Path.Combine(projectDir, pruneRelPath));
+
+                // CWD != projectDir - path must resolve via TaskEnvironment
+                Directory.SetCurrentDirectory(otherDir);
+
+                var (result, engine) = RunTask(pruneRelPath, projectDir);
+
+                result.Should().BeTrue("task should succeed when prune data is found via TaskEnvironment");
+                engine.Errors.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        [Fact]
+        public void MissingPruneData_WithAllowMissing_ProducesNoError()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-null-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var engine = new MockBuildEngine();
+                var task = new GetPackagesToPrune
+                {
+                    BuildEngine = engine,
+                    TargetFrameworkIdentifier = ".NETCoreApp",
+                    TargetFrameworkVersion = Tfm,
+                    FrameworkReferences = new ITaskItem[]
+                    {
+                        new MockTaskItem(FrameworkRef, new Dictionary<string, string>())
+                    },
+                    TargetingPacks = new ITaskItem[]
+                    {
+                        new MockTaskItem(FrameworkRef, new Dictionary<string, string>
+                        {
+                            ["RuntimeFrameworkName"] = FrameworkRef
+                        })
+                    },
+                    TargetingPackRoots = Array.Empty<string>(),
+                    PrunePackageDataRoot = "nonexistent",
+                    AllowMissingPrunePackageData = true,
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                };
+
+                var result = task.Execute();
+                result.Should().BeTrue("task should succeed when AllowMissingPrunePackageData is true");
+                engine.Errors.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItProducesSameResultsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"prune-parity-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var pruneRelPath = "PruneData";
+                WritePruneData(Path.Combine(projectDir, pruneRelPath));
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine) = RunTask(pruneRelPath, projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine) = RunTask(pruneRelPath, projectDir);
+
+                mpResult.Should().Be(mtResult,
+                    "task should return the same success/failure in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(
+                        mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+                mpEngine.Warnings.Count.Should().Be(mtEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAParseTargetManifestsMultiThreading
+    {
+        private const string ArtifactXml = """
+            <StoreArtifacts>
+              <Package Id="TestPackage" Version="1.0.0" />
+            </StoreArtifacts>
+            """;
+
+        private static (bool result, MockBuildEngine engine, ITaskItem[]? packages) RunTask(
+            string manifestRelPath, string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new ParseTargetManifests
+            {
+                BuildEngine = engine,
+                TargetManifestFiles = manifestRelPath,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+
+            var result = task.Execute();
+            return (result, engine, task.RuntimeStorePackages);
+        }
+
+        [Fact]
+        public void ManifestFile_IsResolvedRelativeToProjectDirectory()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"manifest-mt-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "artifact.xml"), ArtifactXml);
+
+                var task = new ParseTargetManifests
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TargetManifestFiles = "artifact.xml",
+                };
+
+                var teProp = task.GetType().GetProperty("TaskEnvironment");
+                teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
+                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+
+                var result = task.Execute();
+                result.Should().BeTrue("task should succeed when manifest is found via TaskEnvironment");
+                task.RuntimeStorePackages.Should().HaveCount(1);
+                task.RuntimeStorePackages[0].GetMetadata("NuGetPackageId").Should().Be("TestPackage");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItProducesSameResultsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"manifest-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"manifest-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "artifact.xml"), ArtifactXml);
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpPackages) = RunTask("artifact.xml", projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtPackages) = RunTask("artifact.xml", projectDir);
+
+                mpResult.Should().Be(mtResult,
+                    "task should return the same success/failure in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(
+                        mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+                mpEngine.Warnings.Count.Should().Be(mtEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+
+                // Both should produce the same packages
+                (mpPackages?.Length ?? 0).Should().Be(mtPackages?.Length ?? 0,
+                    "package count should be the same in both environments");
+                if (mpPackages != null && mtPackages != null)
+                {
+                    for (int i = 0; i < mpPackages.Length; i++)
+                    {
+                        mpPackages[i].GetMetadata("NuGetPackageId").Should().Be(
+                            mtPackages[i].GetMetadata("NuGetPackageId"),
+                            $"package [{i}] NuGetPackageId should be identical");
+                    }
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 var teProp = task.GetType().GetProperty("TaskEnvironment");
                 teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
-                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+                task.TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir);
 
                 var result = task.Execute();
                 result.Should().BeTrue("task should succeed when manifest is found via TaskEnvironment");

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAParseTargetManifestsMultiThreading
     {
         private const string ArtifactXml = """

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -53,6 +56,42 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 result.Should().BeTrue("task should succeed when manifest is found via TaskEnvironment");
                 task.RuntimeStorePackages.Should().HaveCount(1);
                 task.RuntimeStorePackages[0].GetMetadata("NuGetPackageId").Should().Be("TestPackage");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ParseTargetManifests_ConcurrentExecution(int parallelism)
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"manifest-conc-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "artifact.xml"), ArtifactXml);
+
+                var errors = new ConcurrentBag<string>();
+                var barrier = new Barrier(parallelism);
+                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                {
+                    try
+                    {
+                        var task = new ParseTargetManifests
+                        {
+                            BuildEngine = new MockBuildEngine(),
+                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                            TargetManifestFiles = "artifact.xml",
+                        };
+                        barrier.SignalAndWait();
+                        task.Execute();
+                    }
+                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                });
+                errors.Should().BeEmpty();
             }
             finally
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphJson =

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAPickBestRidMultiThreading
+    {
+        private const string RuntimeGraphJson =
+            """{"runtimes":{"win-x64":{"#import":["win","any"]},"win":{"#import":["any"]},"any":{}}}""";
+
+        private static (bool result, MockBuildEngine engine, string? matchingRid) RunTask(
+            string runtimeGraphRelPath, string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new PickBestRid
+            {
+                BuildEngine = engine,
+                RuntimeGraphPath = runtimeGraphRelPath,
+                TargetRid = "win-x64",
+                SupportedRids = new[] { "win-x64", "linux-x64" },
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+            };
+
+            var result = task.Execute();
+            return (result, engine, task.MatchingRid);
+        }
+
+        [Fact]
+        public void RuntimeGraphPath_IsResolvedRelativeToProjectDirectory()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pickrid-mt-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "runtime.json"), RuntimeGraphJson);
+
+                var task = new PickBestRid
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    RuntimeGraphPath = "runtime.json",
+                    TargetRid = "win-x64",
+                    SupportedRids = new[] { "win-x64", "linux-x64" },
+                };
+
+                var teProp = task.GetType().GetProperty("TaskEnvironment");
+                teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
+                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+
+                var result = task.Execute();
+                result.Should().BeTrue();
+                task.MatchingRid.Should().Be("win-x64");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Fact]
+        public void ItProducesSameResultsInMultiProcessAndMultiThreadedEnvironments()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pickrid-parity-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pickrid-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "runtime.json"), RuntimeGraphJson);
+
+                // --- Multiprocess mode: CWD == projectDir ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpEngine, mpRid) = RunTask("runtime.json", projectDir);
+
+                // --- Multithreaded mode: CWD == otherDir ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtEngine, mtRid) = RunTask("runtime.json", projectDir);
+
+                mpResult.Should().Be(mtResult,
+                    "task should return the same success/failure in both environments");
+                mpEngine.Errors.Count.Should().Be(mtEngine.Errors.Count,
+                    "error count should be the same in both environments");
+                for (int i = 0; i < mpEngine.Errors.Count; i++)
+                {
+                    mpEngine.Errors[i].Message.Should().Be(
+                        mtEngine.Errors[i].Message,
+                        $"error message [{i}] should be identical in both environments");
+                }
+                mpEngine.Warnings.Count.Should().Be(mtEngine.Warnings.Count,
+                    "warning count should be the same in both environments");
+                mpRid.Should().Be(mtRid,
+                    "matching RID should be identical in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
@@ -51,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
                 var teProp = task.GetType().GetProperty("TaskEnvironment");
                 teProp.Should().NotBeNull("task must have a TaskEnvironment property after migration");
-                teProp!.SetValue(task, TaskEnvironmentHelper.CreateForTest(projectDir));
+                task.TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir);
 
                 var result = task.Execute();
                 result.Should().BeTrue();

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -53,6 +56,44 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 var result = task.Execute();
                 result.Should().BeTrue();
                 task.MatchingRid.Should().Be("win-x64");
+            }
+            finally
+            {
+                Directory.Delete(projectDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void PickBestRid_ConcurrentExecution(int parallelism)
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"pickrid-conc-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                File.WriteAllText(Path.Combine(projectDir, "runtime.json"), RuntimeGraphJson);
+
+                var errors = new ConcurrentBag<string>();
+                var barrier = new Barrier(parallelism);
+                Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+                {
+                    try
+                    {
+                        var task = new PickBestRid
+                        {
+                            BuildEngine = new MockBuildEngine(),
+                            TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                            RuntimeGraphPath = "runtime.json",
+                            TargetRid = "win-x64",
+                            SupportedRids = new[] { "win-x64", "linux-x64" },
+                        };
+                        barrier.SignalAndWait();
+                        task.Execute();
+                    }
+                    catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                });
+                errors.Should().BeEmpty();
             }
             finally
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Globalization;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
@@ -95,7 +96,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ResxIsCommentedWithCorrectStrBegin()
         {
-            var doc = XDocument.Load("Strings.resx");
+            var resxPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Strings.resx");
+            var doc = XDocument.Load(resxPath);
             var ns = doc.Root.Name.Namespace;
 
             foreach (var data in doc.Root.Elements(ns + "data"))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -11,8 +11,11 @@ namespace Microsoft.NET.Build.Tasks
 {
     //  Locates the root NuGet package directory for each of the input items that has PackageName and PackageVersion,
     //  but not PackageDirectory metadata specified
-    public class GetPackageDirectory : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GetPackageDirectory : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         public ITaskItem[] Items { get; set; } = Array.Empty<ITaskItem>();
 
         public string[] PackageFolders { get; set; } = Array.Empty<string>();
@@ -33,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks
             if (!string.IsNullOrEmpty(AssetsFileWithAdditionalPackageFolders))
             {
                 var lockFileCache = new LockFileCache(this);
-                var lockFile = lockFileCache.GetLockFile(AssetsFileWithAdditionalPackageFolders);
+                var lockFile = lockFileCache.GetLockFile(TaskEnvironment.GetAbsolutePath(AssetsFileWithAdditionalPackageFolders));
                 PackageFolders = PackageFolders.Concat(lockFile.PackageFolders.Select(p => p.Path)).ToArray();
             }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -14,7 +14,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class GetPackageDirectory : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         public ITaskItem[] Items { get; set; } = Array.Empty<ITaskItem>();
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -12,8 +12,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GetPackagesToPrune : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GetPackagesToPrune : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
         // Minimum .NET Core version that supports package pruning
         private const int FrameworkReferenceMinVersion = 3;
         
@@ -134,7 +136,10 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
-            PackagesToPrune = LoadPackagesToPrune(key, TargetingPackRoots, PrunePackageDataRoot, Log, AllowMissingPrunePackageData);
+            PackagesToPrune = LoadPackagesToPrune(key,
+                TargetingPackRoots.Select(r => TaskEnvironment.GetAbsolutePath(r).Value).ToArray(),
+                TaskEnvironment.GetAbsolutePath(PrunePackageDataRoot).Value,
+                Log, AllowMissingPrunePackageData);
 
             BuildEngine4.RegisterTaskObject(key, PackagesToPrune, RegisteredTaskObjectLifetime.Build, true);
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -15,7 +15,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class GetPackagesToPrune : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
         // Minimum .NET Core version that supports package pruning
         private const int FrameworkReferenceMinVersion = 3;
         

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -12,9 +12,12 @@ namespace Microsoft.NET.Build.Tasks
     /// <summary>
     /// Parses the target manifest files into MSBuild Items.
     /// </summary>
-    public sealed class ParseTargetManifests : TaskBase
+    [MSBuildMultiThreadableTask]
+    public sealed class ParseTargetManifests : TaskBase, IMultiThreadableTask
     {
-        public string TargetManifestFiles { get; set; }
+        public TaskEnvironment TaskEnvironment { get; set; }
+
+        public string TargetManifestFiles{ get; set; }
 
         [Output]
         public ITaskItem[] RuntimeStorePackages { get; private set; }
@@ -28,7 +31,7 @@ namespace Microsoft.NET.Build.Tasks
                 var runtimeStorePackages = new Dictionary<PackageIdentity, StringBuilder>();
                 foreach (var manifestFile in targetManifestFileList)
                 {
-                    var packagesSpecified = StoreArtifactParser.Parse(manifestFile);
+                    var packagesSpecified = StoreArtifactParser.Parse(TaskEnvironment.GetAbsolutePath(manifestFile));
                     var targetManifestFileName = Path.GetFileName(manifestFile);
 
                     foreach (var pkg in packagesSpecified)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -15,7 +15,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public sealed class ParseTargetManifests : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         public string TargetManifestFiles { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks
     {
         public TaskEnvironment TaskEnvironment { get; set; }
 
-        public string TargetManifestFiles{ get; set; }
+        public string TargetManifestFiles { get; set; }
 
         [Output]
         public ITaskItem[] RuntimeStorePackages { get; private set; }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -9,8 +9,10 @@ namespace Microsoft.NET.Build.Tasks;
 /// <summary>
 /// This task uses the given RID graph in a given SDK to pick the best match from among a set of supported RIDs for the current RID
 /// </summary>
-public sealed class PickBestRid : TaskBase
+[MSBuildMultiThreadableTask]
+public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 {
+    public TaskEnvironment TaskEnvironment { get; set; } = null!;
     /// <summary>
     /// The path to the RID graph to read
     /// </summary>
@@ -37,13 +39,14 @@ public sealed class PickBestRid : TaskBase
 
     protected override void ExecuteCore()
     {
-        if (!File.Exists(RuntimeGraphPath))
+        var absoluteRuntimeGraphPath = (string)TaskEnvironment.GetAbsolutePath(RuntimeGraphPath);
+        if (!File.Exists(absoluteRuntimeGraphPath))
         {
             Log.LogError(Strings.RuntimeGraphFileDoesNotExist, RuntimeGraphPath);
             return;
         }
 
-        RuntimeGraph graph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+        RuntimeGraph graph = new RuntimeGraphCache(this).GetRuntimeGraph(absoluteRuntimeGraphPath);
         var bestRidForPlatform = NuGetUtils.GetBestMatchingRid(graph, TargetRid, SupportedRids, out bool wasInGraph);
 
         if (!wasInGraph || bestRidForPlatform == null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Build.Tasks;
 [MSBuildMultiThreadableTask]
 public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 {
-    public TaskEnvironment TaskEnvironment { get; set; }
+    public TaskEnvironment TaskEnvironment { get; set; } = null!;
     /// <summary>
     /// The path to the RID graph to read
     /// </summary>
@@ -39,7 +39,7 @@ public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 
     protected override void ExecuteCore()
     {
-        var absoluteRuntimeGraphPath = (string)TaskEnvironment.GetAbsolutePath(RuntimeGraphPath);
+        var absoluteRuntimeGraphPath = TaskEnvironment.GetAbsolutePath(RuntimeGraphPath);
         if (!File.Exists(absoluteRuntimeGraphPath))
         {
             Log.LogError(Strings.RuntimeGraphFileDoesNotExist, RuntimeGraphPath);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NET.Build.Tasks;
 [MSBuildMultiThreadableTask]
 public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 {
-    public TaskEnvironment TaskEnvironment { get; set; } = null!;
+    public TaskEnvironment TaskEnvironment { get; set; }
     /// <summary>
     /// The path to the RID graph to read
     /// </summary>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -12,7 +12,16 @@ namespace Microsoft.NET.Build.Tasks;
 [MSBuildMultiThreadableTask]
 public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 {
+#if NETFRAMEWORK
+    private TaskEnvironment _taskEnvironment;
+    public TaskEnvironment TaskEnvironment
+    {
+        get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+        set => _taskEnvironment = value;
+    }
+#else
     public TaskEnvironment TaskEnvironment { get; set; } = null!;
+#endif
     /// <summary>
     /// The path to the RID graph to read
     /// </summary>


### PR DESCRIPTION
## Summary

Migrate 4 package and asset resolution tasks to support multithreaded MSBuild execution. All 4 tasks perform file I/O and require full Pattern B migration (`IMultiThreadableTask` + `TaskEnvironment`).

### Tasks Migrated

| Task | Key Changes |
|------|-------------|
| GetPackageDirectory | Absolutized `AssetsFileWithAdditionalPackageFolders` before `LockFileCache.GetLockFile()` |
| GetPackagesToPrune | Absolutized `TargetingPackRoots` elements and `PrunePackageDataRoot` before file access |
| ParseTargetManifests | Absolutized manifest file paths before `StoreArtifactParser.Parse()` (which calls `XDocument.Load()`) |
| PickBestRid | Absolutized `RuntimeGraphPath` before `File.Exists()` and `RuntimeGraphCache.GetRuntimeGraph()` |

### Migration Details

Each task absolutizes all input paths via `TaskEnvironment.GetAbsolutePath()` before they flow into file I/O operations. `LockFileCache.GetLockFile()` enforces `Path.IsPathRooted()` and `RuntimeGraphCache.GetRuntimeGraph()` does the same — callers must provide absolute paths.

### Tests Added

- **GivenAGetPackageDirectoryMultiThreading.cs** — path resolution test, CWD-independence parity test
- **GivenAGetPackagesToPruneMultiThreading.cs** — path resolution test, missing-data boundary test, parity test
- **GivenAParseTargetManifestsMultiThreading.cs** — manifest resolution test, parity test
- **GivenAPickBestRidMultiThreading.cs** — graph path resolution test, parity test

All tests use `TaskEnvironmentHelper.CreateForTest(projectDir)` with direct property assignment.

### Files Changed

- `src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/ParseTargetManifests.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackageDirectoryMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAGetPackagesToPruneMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAParseTargetManifestsMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAPickBestRidMultiThreading.cs` (new)