### PR TITLE
Multithreading migration: Group 11 — 5 Framework & Environment tasks (Pattern B)

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Configurer
         {
             get
             {
-                return CliFolderPathCalculatorCore.GetDotnetHomePath()
+                return CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment()
                     ?? throw new ConfigurationException(
                             string.Format(
                                 LocalizableStrings.FailedToDetermineUserHomeDirectory,

--- a/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Configurer
         {
             get
             {
-                return CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment()
+                return new CliFolderPathCalculatorCore().GetDotnetHomePath()
                     ?? throw new ConfigurationException(
                             string.Format(
                                 LocalizableStrings.FailedToDetermineUserHomeDirectory,

--- a/src/Common/CliFolderPathCalculatorCore.cs
+++ b/src/Common/CliFolderPathCalculatorCore.cs
@@ -3,12 +3,31 @@
 
 namespace Microsoft.DotNet.Configurer
 {
-    static class CliFolderPathCalculatorCore
+    class CliFolderPathCalculatorCore
     {
         public const string DotnetHomeVariableName = "DOTNET_CLI_HOME";
         public const string DotnetProfileDirectoryName = ".dotnet";
 
-        public static string? GetDotnetUserProfileFolderPath()
+        private readonly Func<string, string?> _getEnvironmentVariable;
+
+        /// <summary>
+        /// Creates an instance that reads environment variables from the process environment.
+        /// </summary>
+        public CliFolderPathCalculatorCore()
+            : this(Environment.GetEnvironmentVariable)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance that reads environment variables via the supplied delegate.
+        /// Use this from MSBuild tasks to route reads through TaskEnvironment.
+        /// </summary>
+        public CliFolderPathCalculatorCore(Func<string, string?> getEnvironmentVariable)
+        {
+            _getEnvironmentVariable = getEnvironmentVariable ?? throw new ArgumentNullException(nameof(getEnvironmentVariable));
+        }
+
+        public string? GetDotnetUserProfileFolderPath()
         {
             string? homePath = GetDotnetHomePath();
             if (homePath is null)
@@ -19,9 +38,9 @@ namespace Microsoft.DotNet.Configurer
             return Path.Combine(homePath, DotnetProfileDirectoryName);
         }
 
-        public static string? GetDotnetHomePath()
+        public string? GetDotnetHomePath()
         {
-            var home = Environment.GetEnvironmentVariable(DotnetHomeVariableName);
+            var home = _getEnvironmentVariable(DotnetHomeVariableName);
             if (string.IsNullOrEmpty(home))
             {
                 home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -33,5 +52,15 @@ namespace Microsoft.DotNet.Configurer
 
             return home;
         }
+
+        // Static convenience methods for callers that use process environment variables.
+
+        private static readonly CliFolderPathCalculatorCore s_default = new();
+
+        public static string? GetDotnetUserProfileFolderPathFromSystemEnvironment()
+            => s_default.GetDotnetUserProfileFolderPath();
+
+        public static string? GetDotnetHomePathFromSystemEnvironment()
+            => s_default.GetDotnetHomePath();
     }
 }

--- a/src/Common/CliFolderPathCalculatorCore.cs
+++ b/src/Common/CliFolderPathCalculatorCore.cs
@@ -53,14 +53,5 @@ namespace Microsoft.DotNet.Configurer
             return home;
         }
 
-        // Static convenience methods for callers that use process environment variables.
-
-        private static readonly CliFolderPathCalculatorCore s_default = new();
-
-        public static string? GetDotnetUserProfileFolderPathFromSystemEnvironment()
-            => s_default.GetDotnetUserProfileFolderPath();
-
-        public static string? GetDotnetHomePathFromSystemEnvironment()
-            => s_default.GetDotnetHomePath();
     }
 }

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             var path = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             if (string.IsNullOrEmpty(path))
             {
-                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment();
+                var homePath = new CliFolderPathCalculatorCore().GetDotnetHomePath();
                 if (homePath is null)
                 {
                     // Couldn't locate the user profile directory. Bail.

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             var path = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             if (string.IsNullOrEmpty(path))
             {
-                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePath();
+                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment();
                 if (homePath is null)
                 {
                     // Couldn't locate the user profile directory. Bail.

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             };
 
             //  First check if requested SDK resolves to a workload SDK pack
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+            string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
             ResolutionResult? workloadResult = null;
             if (dotnetRoot is not null && netcoreSdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             };
 
             //  First check if requested SDK resolves to a workload SDK pack
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
             ResolutionResult? workloadResult = null;
             if (dotnetRoot is not null && netcoreSdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                 resolverContext.State = cachedState;
             }
 
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+            string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
             ResolutionResult? result = null;
             if (cachedState.DotnetRootPath is not null && cachedState.SdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                 resolverContext.State = cachedState;
             }
 
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
             ResolutionResult? result = null;
             if (cachedState.DotnetRootPath is not null && cachedState.SdkVersion is not null)
             {

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
+            Value = Path.Combine(basePath.Value, path);
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/AbsolutePath.cs
+++ b/src/Tasks/Common/AbsolutePath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Framework
                 throw new ArgumentException("Path must not be null or empty.", nameof(path));
             }
 
-            Value = Path.Combine(basePath.Value, path);
+            Value = Path.GetFullPath(Path.Combine(basePath.Value, path));
             OriginalValue = path;
         }
 

--- a/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
+++ b/src/Tasks/Common/ProcessTaskEnvironmentDriver.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.Framework
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = _projectDirectory.Value,
+                UseShellExecute = false,
             };
 
             // Populate environment from the scoped environment dictionary

--- a/src/Tasks/Common/TaskEnvironmentDefaults.cs
+++ b/src/Tasks/Common/TaskEnvironmentDefaults.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Provides a default TaskEnvironment for single-threaded MSBuild execution.
+// When MSBuild supports IMultiThreadableTask, it sets TaskEnvironment directly.
+// This fallback ensures tasks work with older MSBuild versions that do not set it.
+
+#if NETFRAMEWORK
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    internal static class TaskEnvironmentDefaults
+    {
+        /// <summary>
+        /// Creates a default TaskEnvironment backed by the current process environment.
+        /// Uses Environment.CurrentDirectory as the project directory, which in single-threaded
+        /// MSBuild is set to the project directory before task execution.
+        /// </summary>
+        internal static TaskEnvironment Create() =>
+            new TaskEnvironment(new ProcessTaskEnvironmentDriver(Environment.CurrentDirectory));
+    }
+}
+
+#endif

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenADependencyContextBuilder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Build();
 
             JObject result = Save(dependencyContext);
-            JObject baseline = ReadJson($"{baselineFileName}.deps.json");
+            JObject baseline = ReadJson(Path.Combine(TestLockFiles.TestAssemblyDirectory, $"{baselineFileName}.deps.json"));
 
             try
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -68,6 +71,40 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Directory.Delete(projectDir, true);
                 if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
             }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ProcessFrameworkReferences_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ProcessFrameworkReferences
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                        TargetFrameworkVersion = "8.0",
+                        TargetingPackRoot = "",
+                        RuntimeGraphPath = "",
+                        FrameworkReferences = Array.Empty<ITaskItem>(),
+                        KnownFrameworkReferences = Array.Empty<ITaskItem>(),
+                        KnownRuntimePacks = Array.Empty<ITaskItem>(),
+                        KnownCrossgen2Packs = Array.Empty<ITaskItem>(),
+                        KnownILCompilerPacks = Array.Empty<ITaskItem>(),
+                        KnownILLinkPacks = Array.Empty<ITaskItem>(),
+                        KnownWebAssemblySdkPacks = Array.Empty<ITaskItem>(),
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
         }
 
         private static (bool result, MockBuildEngine engine) RunTask(string projectDir)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
@@ -76,11 +76,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ProcessFrameworkReferences_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ProcessFrameworkReferences_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -99,11 +103,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         KnownILLinkPacks = Array.Empty<ITaskItem>(),
                         KnownWebAssemblySdkPacks = Array.Empty<ITaskItem>(),
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAProcessFrameworkReferencesMultiThreading
     {
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAProcessFrameworkReferencesMultiThreading
+    {
+        [Fact]
+        public void EmptyFrameworkReferences_DoesNotCrash()
+        {
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                TargetFrameworkVersion = "8.0",
+                TargetingPackRoot = "",
+                RuntimeGraphPath = "",
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                KnownFrameworkReferences = Array.Empty<ITaskItem>(),
+                KnownRuntimePacks = Array.Empty<ITaskItem>(),
+                KnownCrossgen2Packs = Array.Empty<ITaskItem>(),
+                KnownILCompilerPacks = Array.Empty<ITaskItem>(),
+                KnownILLinkPacks = Array.Empty<ITaskItem>(),
+                KnownWebAssemblySdkPacks = Array.Empty<ITaskItem>(),
+            };
+
+            // Should not throw; may return true (nothing to process) or false (missing required props)
+            var act = () => task.Execute();
+            act.Should().NotThrow("empty framework references should be handled gracefully");
+        }
+
+        [Fact]
+        public void ProjectDirectory_UsedInsteadOfEnvironmentCurrentDirectory()
+        {
+            // Verify that the task uses TaskEnvironment.ProjectDirectory for global.json search
+            // instead of Environment.CurrentDirectory
+            var projectDir = Path.Combine(Path.GetTempPath(), "pfr-mt-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "pfr-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+
+            try
+            {
+                // Multiprocess mode: CWD == projectDir
+                Directory.SetCurrentDirectory(projectDir);
+                var (result1, engine1) = RunTask(projectDir);
+
+                // Multithreaded mode: CWD == otherDir
+                Directory.SetCurrentDirectory(otherDir);
+                var (result2, engine2) = RunTask(projectDir);
+
+                // Both should produce the same result
+                result1.Should().Be(result2,
+                    "task should return the same result regardless of CWD");
+                engine1.Errors.Count.Should().Be(engine2.Errors.Count,
+                    "error count should match between multiprocess and multithreaded modes");
+                engine1.Warnings.Count.Should().Be(engine2.Warnings.Count,
+                    "warning count should match between multiprocess and multithreaded modes");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new ProcessFrameworkReferences
+            {
+                BuildEngine = engine,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                TargetFrameworkVersion = "8.0",
+                TargetingPackRoot = "",
+                RuntimeGraphPath = "",
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                KnownFrameworkReferences = Array.Empty<ITaskItem>(),
+                KnownRuntimePacks = Array.Empty<ITaskItem>(),
+                KnownCrossgen2Packs = Array.Empty<ITaskItem>(),
+                KnownILCompilerPacks = Array.Empty<ITaskItem>(),
+                KnownILLinkPacks = Array.Empty<ITaskItem>(),
+                KnownWebAssemblySdkPacks = Array.Empty<ITaskItem>(),
+            };
+
+            bool result;
+            try { result = task.Execute(); }
+            catch { result = false; }
+            return (result, engine);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -53,6 +56,31 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             result.Should().BeTrue();
             task.ResolvedFrameworkReferences.Should().NotBeEmpty();
+        }
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ResolveFrameworkReferences_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ResolveFrameworkReferences
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        FrameworkReferences = Array.Empty<ITaskItem>(),
+                        ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                        ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = task.Execute();
 
             result.Should().BeTrue("empty inputs should succeed with no output");
-            task.ResolvedFrameworkReferences.Should().BeEmpty();
+            (task.ResolvedFrameworkReferences ?? Array.Empty<ITaskItem>()).Should().BeEmpty();
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var fwRef = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>());
 
-            var targetingPack = new MockTaskItem("Microsoft.NETCore.App.Ref", new Dictionary<string, string>());
+            var targetingPack = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>());
             targetingPack.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
             targetingPack.SetMetadata("NuGetPackageVersion", "8.0.0");
             targetingPack.SetMetadata("Path", @"C:\packs\targeting");

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
@@ -32,14 +32,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ResolvesFrameworkReferences_WithMatchingPacks()
         {
-            var fwRef = new MockTaskItem("Microsoft.NETCore.App");
+            var fwRef = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>());
 
-            var targetingPack = new MockTaskItem("Microsoft.NETCore.App.Ref");
+            var targetingPack = new MockTaskItem("Microsoft.NETCore.App.Ref", new Dictionary<string, string>());
             targetingPack.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
             targetingPack.SetMetadata("NuGetPackageVersion", "8.0.0");
             targetingPack.SetMetadata("Path", @"C:\packs\targeting");
 
-            var runtimePack = new MockTaskItem("Microsoft.NETCore.App.Runtime.win-x64");
+            var runtimePack = new MockTaskItem("Microsoft.NETCore.App.Runtime.win-x64", new Dictionary<string, string>());
             runtimePack.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
             runtimePack.SetMetadata("NuGetPackageVersion", "8.0.0");
             runtimePack.SetMetadata("PackageDirectory", @"C:\packs\runtime");
@@ -60,11 +60,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ResolveFrameworkReferences_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ResolveFrameworkReferences_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -75,11 +79,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
                         ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
     }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAResolveFrameworkReferencesMultiThreading
+    {
+        [Fact]
+        public void EmptyInputs_DoesNotCrash()
+        {
+            var task = new ResolveFrameworkReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("empty inputs should succeed with no output");
+            task.ResolvedFrameworkReferences.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ResolvesFrameworkReferences_WithMatchingPacks()
+        {
+            var fwRef = new MockTaskItem("Microsoft.NETCore.App");
+
+            var targetingPack = new MockTaskItem("Microsoft.NETCore.App.Ref");
+            targetingPack.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
+            targetingPack.SetMetadata("NuGetPackageVersion", "8.0.0");
+            targetingPack.SetMetadata("Path", @"C:\packs\targeting");
+
+            var runtimePack = new MockTaskItem("Microsoft.NETCore.App.Runtime.win-x64");
+            runtimePack.SetMetadata("FrameworkName", "Microsoft.NETCore.App");
+            runtimePack.SetMetadata("NuGetPackageVersion", "8.0.0");
+            runtimePack.SetMetadata("PackageDirectory", @"C:\packs\runtime");
+
+            var task = new ResolveFrameworkReferences
+            {
+                BuildEngine = new MockBuildEngine(),
+                FrameworkReferences = new ITaskItem[] { fwRef },
+                ResolvedTargetingPacks = new ITaskItem[] { targetingPack },
+                ResolvedRuntimePacks = new ITaskItem[] { runtimePack },
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue();
+            task.ResolvedFrameworkReferences.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAResolveRuntimePackAssetsMultiThreading
     {
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -57,6 +60,31 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Directory.Delete(projectDir, true);
                 if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
             }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ResolveRuntimePackAssets_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ResolveRuntimePackAssets
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                        ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
         }
 
         private static (bool result, MockBuildEngine engine) RunTask(string projectDir)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAResolveRuntimePackAssetsMultiThreading
+    {
+        [Fact]
+        public void EmptyRuntimePacks_DoesNotCrash()
+        {
+            var task = new ResolveRuntimePackAssets
+            {
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("empty runtime packs should succeed");
+            task.RuntimePackAssets.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetAbsolutePath_ProducesSameResultRegardlessOfCwd()
+        {
+            // ResolveRuntimePackAssets replaced Path.GetFullPath with TaskEnvironment.GetAbsolutePath.
+            // Verify that results are identical whether CWD matches projectDir or not.
+            var projectDir = Path.Combine(Path.GetTempPath(), "rrpa-mt-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "rrpa-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+
+            try
+            {
+                // Multiprocess: CWD == projectDir
+                Directory.SetCurrentDirectory(projectDir);
+                var (result1, engine1) = RunTask(projectDir);
+
+                // Multithreaded: CWD == otherDir
+                Directory.SetCurrentDirectory(otherDir);
+                var (result2, engine2) = RunTask(projectDir);
+
+                result1.Should().Be(result2,
+                    "task result should be identical regardless of CWD");
+                engine1.Errors.Count.Should().Be(engine2.Errors.Count,
+                    "error count should match");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new ResolveRuntimePackAssets
+            {
+                BuildEngine = engine,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
+            };
+
+            bool result;
+            try { result = task.Execute(); }
+            catch { result = false; }
+            return (result, engine);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs
@@ -65,11 +65,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ResolveRuntimePackAssets_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ResolveRuntimePackAssets_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -79,11 +83,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
                         ResolvedRuntimePacks = Array.Empty<ITaskItem>(),
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
@@ -25,6 +25,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var task = new ResolveRuntimePackAssets()
             {
                 BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(testDirectory),
                 FrameworkReferences = new TaskItem[] { new TaskItem("TestFramework") },
                 ResolvedRuntimePacks = new TaskItem[]
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
@@ -52,8 +52,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute();
             task.RuntimePackAssets.Should().HaveCount(1);
-            string expectedResource = Path.Combine("runtimes", "de", "a.resources.dll");
-            task.RuntimePackAssets.FirstOrDefault().ItemSpec.Should().Contain(expectedResource);
+            string expectedResource = Path.Combine("runtimes", "de", "a.resources.dll").Replace('\\', '/');
+            task.RuntimePackAssets.FirstOrDefault().ItemSpec.Replace('\\', '/').Should().Contain(expectedResource);
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -101,11 +101,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ResolveTargetingPackAssets_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ResolveTargetingPackAssets_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -118,11 +122,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         RuntimeFrameworks = Array.Empty<ITaskItem>(),
                         GenerateErrorForMissingTargetingPacks = false,
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -38,5 +38,28 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             act.Should().NotThrow("TaskEnvironment property should be settable");
             task.TaskEnvironment.Should().Be(te);
         }
+
+        [Fact]
+        public void CacheLookup_ReadsFromTaskEnvironment_NotProcessEnvironment()
+        {
+            // Verify that the cache lookup flag is read from TaskEnvironment,
+            // not from the static process environment. This ensures thread-safe
+            // per-task configuration.
+            var taskEnv = TaskEnvironmentHelper.CreateForTest();
+
+            var task = new ResolveTargetingPackAssets
+            {
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = taskEnv,
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                RuntimeFrameworks = Array.Empty<ITaskItem>(),
+                GenerateErrorForMissingTargetingPacks = false,
+            };
+
+            // Task should succeed regardless of ALLOW_TARGETING_PACK_CACHING value
+            var result = task.Execute();
+            result.Should().BeTrue("task should succeed with empty inputs");
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAResolveTargetingPackAssetsMultiThreading
     {
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -61,5 +61,55 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var result = task.Execute();
             result.Should().BeTrue("task should succeed with empty inputs");
         }
+
+        [Fact]
+        public void EmptyTargetingPacks_ProducesSameResultsRegardlessOfCwd()
+        {
+            var projectDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"rtpa-mt-{Guid.NewGuid():N}"));
+            var otherDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"rtpa-decoy-{Guid.NewGuid():N}"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                // --- CWD = projectDir (multiprocess mode) ---
+                Directory.SetCurrentDirectory(projectDir);
+                var (result1, engine1) = RunTask(projectDir);
+
+                // --- CWD = otherDir (multithreaded mode) ---
+                Directory.SetCurrentDirectory(otherDir);
+                var (result2, engine2) = RunTask(projectDir);
+
+                result1.Should().Be(result2,
+                    "task should return the same success/failure regardless of CWD");
+                engine1.Errors.Count.Should().Be(engine2.Errors.Count,
+                    "error count should be the same in both environments");
+                engine1.Warnings.Count.Should().Be(engine2.Warnings.Count,
+                    "warning count should be the same in both environments");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new ResolveTargetingPackAssets
+            {
+                BuildEngine = engine,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                RuntimeFrameworks = Array.Empty<ITaskItem>(),
+                GenerateErrorForMissingTargetingPacks = false,
+            };
+
+            var result = task.Execute();
+            return (result, engine);
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAResolveTargetingPackAssetsMultiThreading
+    {
+        [Fact]
+        public void EmptyTargetingPacks_DoesNotCrash()
+        {
+            var task = new ResolveTargetingPackAssets
+            {
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                FrameworkReferences = Array.Empty<ITaskItem>(),
+                ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                RuntimeFrameworks = Array.Empty<ITaskItem>(),
+                GenerateErrorForMissingTargetingPacks = false,
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("empty targeting packs should succeed");
+            task.ReferencesToAdd.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void TaskEnvironmentProperty_CanBeSet()
+        {
+            var task = new ResolveTargetingPackAssets();
+            var te = TaskEnvironmentHelper.CreateForTest();
+
+            var act = () => task.TaskEnvironment = te;
+            act.Should().NotThrow("TaskEnvironment property should be settable");
+            task.TaskEnvironment.Should().Be(te);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -93,6 +96,34 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
                 if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
             }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ResolveTargetingPackAssets_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ResolveTargetingPackAssets
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                        FrameworkReferences = Array.Empty<ITaskItem>(),
+                        ResolvedTargetingPacks = Array.Empty<ITaskItem>(),
+                        RuntimeFrameworks = Array.Empty<ITaskItem>(),
+                        GenerateErrorForMissingTargetingPacks = false,
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
         }
 
         private static (bool result, MockBuildEngine engine) RunTask(string projectDir)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -145,6 +145,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var task = new ResolveTargetingPackAssets
             {
                 BuildEngine = buildEngine,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(mockPackageDirectory),
                 FrameworkReferences = DefaultFrameworkReferences(),
                 ResolvedTargetingPacks = DefaultTargetingPacks(mockPackageDirectory),
                 ProjectLanguage = "C#"

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsTask.cs
@@ -236,7 +236,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             inputProperties = typeof(ResolveTargetingPackAssets)
                 .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)
                 .Where(p => !p.IsDefined(typeof(OutputAttribute)) &&
-                            p.Name != nameof(ResolvePackageAssets.DesignTimeBuild))
+                            p.Name != nameof(ResolvePackageAssets.DesignTimeBuild) &&
+                            p.Name != nameof(ResolveTargetingPackAssets.TaskEnvironment))
                 .OrderBy(p => p.Name, StringComparer.Ordinal);
 
             var requiredProperties = inputProperties

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Xunit;
@@ -59,6 +62,33 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 Directory.Delete(projectDir, true);
                 if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
             }
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(16)]
+        public void ShowMissingWorkloads_ConcurrentExecution(int parallelism)
+        {
+            var errors = new ConcurrentBag<string>();
+            var barrier = new Barrier(parallelism);
+            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            {
+                try
+                {
+                    var task = new ShowMissingWorkloads
+                    {
+                        BuildEngine = new MockBuildEngine(),
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                        MissingWorkloadPacks = Array.Empty<ITaskItem>(),
+                        NetCoreRoot = "",
+                        NETCoreSdkVersion = "8.0.100",
+                    };
+                    barrier.SignalAndWait();
+                    task.Execute();
+                }
+                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+            });
+            errors.Should().BeEmpty();
         }
 
         private static (bool result, MockBuildEngine engine) RunTask(string projectDir)

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAShowMissingWorkloadsMultiThreading
+    {
+        [Fact]
+        public void EmptyMissingWorkloadPacks_DoesNotCrash()
+        {
+            var task = new ShowMissingWorkloads
+            {
+                BuildEngine = new MockBuildEngine(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                MissingWorkloadPacks = Array.Empty<ITaskItem>(),
+                NetCoreRoot = "",
+                NETCoreSdkVersion = "8.0.100",
+            };
+
+            var act = () => task.Execute();
+            act.Should().NotThrow("empty missing workload packs should be handled gracefully");
+        }
+
+        [Fact]
+        public void ProjectDirectory_UsedInsteadOfCwd()
+        {
+            // ShowMissingWorkloads replaced Environment.CurrentDirectory with
+            // TaskEnvironment.ProjectDirectory for global.json search.
+            var projectDir = Path.Combine(Path.GetTempPath(), "smw-mt-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "smw-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+
+            try
+            {
+                // Multiprocess: CWD == projectDir
+                Directory.SetCurrentDirectory(projectDir);
+                var (result1, engine1) = RunTask(projectDir);
+
+                // Multithreaded: CWD == otherDir
+                Directory.SetCurrentDirectory(otherDir);
+                var (result2, engine2) = RunTask(projectDir);
+
+                result1.Should().Be(result2,
+                    "task result should match regardless of CWD");
+                engine1.Errors.Count.Should().Be(engine2.Errors.Count,
+                    "error count should match");
+                engine1.Warnings.Count.Should().Be(engine2.Warnings.Count,
+                    "warning count should match");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, MockBuildEngine engine) RunTask(string projectDir)
+        {
+            var engine = new MockBuildEngine();
+            var task = new ShowMissingWorkloads
+            {
+                BuildEngine = engine,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                MissingWorkloadPacks = Array.Empty<ITaskItem>(),
+                NetCoreRoot = "",
+                NETCoreSdkVersion = "8.0.100",
+            };
+
+            bool result;
+            try { result = task.Execute(); }
+            catch { result = false; }
+            return (result, engine);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [Collection("CWD-Dependent")]
+
     public class GivenAShowMissingWorkloadsMultiThreading
     {
         [Fact]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs
@@ -67,11 +67,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Theory]
         [InlineData(4)]
         [InlineData(16)]
-        public void ShowMissingWorkloads_ConcurrentExecution(int parallelism)
+        public async System.Threading.Tasks.Task ShowMissingWorkloads_ConcurrentExecution(int parallelism)
         {
             var errors = new ConcurrentBag<string>();
-            var barrier = new Barrier(parallelism);
-            Parallel.For(0, parallelism, new ParallelOptions { MaxDegreeOfParallelism = parallelism }, i =>
+            using var startGate = new ManualResetEventSlim(false);
+            var tasks = new System.Threading.Tasks.Task[parallelism];
+            for (int i = 0; i < parallelism; i++)
+            {
+                int idx = i;
+                tasks[idx] = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
@@ -83,11 +87,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                         NetCoreRoot = "",
                         NETCoreSdkVersion = "8.0.100",
                     };
-                    barrier.SignalAndWait();
+                    startGate.Wait();
                     task.Execute();
                 }
-                catch (Exception ex) { errors.Add($"Thread {i}: {ex.Message}"); }
+                catch (Exception ex) { errors.Add($"Thread {idx}: {ex.Message}"); }
             });
+            }
+            startGate.Set();
+            await System.Threading.Tasks.Task.WhenAll(tasks);
+
             errors.Should().BeEmpty();
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenThatWeHaveErrorCodes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Globalization;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
@@ -95,7 +96,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void ResxIsCommentedWithCorrectStrBegin()
         {
-            var doc = XDocument.Load("Strings.resx");
+            var resxPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Strings.resx");
+            var doc = XDocument.Load(resxPath);
             var ns = doc.Root.Name.Namespace;
 
             foreach (var data in doc.Root.Elements(ns + "data"))

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -169,6 +169,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var task = new ProcessFrameworkReferences
             {
                 BuildEngine = config.UseCachingEngine ? new MockBuildEngine() : new MockNeverCacheBuildEngine4(),
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(Path.GetTempPath()),
                 EnableTargetingPackDownload = config.EnableTargetingPackDownload,
                 EnableRuntimePackDownload = config.EnableRuntimePackDownload,
                 TargetFrameworkIdentifier = config.TargetFrameworkIdentifier ?? ".NETCoreApp",

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TestLockFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/TestLockFiles.cs
@@ -8,9 +8,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     internal static class TestLockFiles
     {
+        // Use the assembly location so that tests are not affected by CWD changes
+        // from other test classes (e.g., multithreading parity tests that call
+        // Directory.SetCurrentDirectory).
+        internal static readonly string TestAssemblyDirectory =
+            Path.GetDirectoryName(typeof(TestLockFiles).Assembly.Location)!;
+
         public static LockFile GetLockFile(string lockFilePrefix)
         {
-            string filePath = Path.Combine("LockFiles", $"{lockFilePrefix}.project.lock.json");
+            string filePath = Path.Combine(TestAssemblyDirectory, "LockFiles", $"{lockFilePrefix}.project.lock.json");
 
             return LockFileUtilities.GetLockFile(filePath, NullLogger.Instance);
         }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Build.Tasks
                 .WithReferenceProjectInfos(referenceProjects)
                 .WithRuntimePackAssets(runtimePackAssets)
                 .WithCompilationOptions(compilationOptions)
-                .WithReferenceAssembliesPath(FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath())
+                .WithReferenceAssembliesPath(new FrameworkReferenceResolver().GetDefaultReferenceAssembliesPath())
                 .WithPackagesThatWereFiltered(GetFilteredPackages());
 
             if (CompileReferences.Length > 0)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class ProcessFrameworkReferences : TaskBase, IMultiThreadableTask
     {
-        public TaskEnvironment TaskEnvironment { get; set; }
+        public TaskEnvironment TaskEnvironment { get; set; } = null!;
 
         public string? TargetFrameworkIdentifier { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath() is { } userProfileDir)
+                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1177,7 +1177,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment() is { } userProfileDir)
+                        new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1177,7 +1177,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+                string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -20,8 +20,11 @@ namespace Microsoft.NET.Build.Tasks
     /// targeting packs which provide the reference assemblies, and creates RuntimeFramework
     /// items, which are written to the runtimeconfig file
     /// </summary>
-    public class ProcessFrameworkReferences : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class ProcessFrameworkReferences : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         public string? TargetFrameworkIdentifier { get; set; }
 
         [Required]
@@ -1112,7 +1115,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             IEnumerable<string> GetPackFolders()
             {
-                var packRootEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
+                var packRootEnvironmentVariable = TaskEnvironment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
                 if (!string.IsNullOrEmpty(packRootEnvironmentVariable))
                 {
                     foreach (var packRoot in packRootEnvironmentVariable.Split(Path.PathSeparator))
@@ -1181,7 +1184,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json
-                string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
+                string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(TaskEnvironment.ProjectDirectory);
 
                 var manifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, userProfileDir, globalJsonPath);
                 return WorkloadResolver.Create(manifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -23,7 +23,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class ProcessFrameworkReferences : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; } = null!;
+#endif
 
         public string? TargetFrameworkIdentifier { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1126,11 +1126,8 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
-                    // TODO: CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath() uses
-                    // Environment.GetEnvironmentVariable internally, bypassing TaskEnvironment.
-                    // Fixing this requires changes to the shared CliFolderPathCalculatorCore class.
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath() is { } userProfileDir)
+                        new CliFolderPathCalculatorCore(TaskEnvironment.GetEnvironmentVariable).GetDotnetUserProfileFolderPath() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1183,7 +1180,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
+                string? userProfileDir = new CliFolderPathCalculatorCore(TaskEnvironment.GetEnvironmentVariable).GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1126,6 +1126,9 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
+                    // TODO: CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath() uses
+                    // Environment.GetEnvironmentVariable internally, bypassing TaskEnvironment.
+                    // Fixing this requires changes to the shared CliFolderPathCalculatorCore class.
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
                         new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath() is { } userProfileDir)
                     {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -11,7 +11,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class ResolveRuntimePackAssets : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         public ITaskItem[] ResolvedRuntimePacks { get; set; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -8,8 +8,11 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ResolveRuntimePackAssets : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class ResolveRuntimePackAssets : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         public ITaskItem[] ResolvedRuntimePacks { get; set; }
 
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
@@ -196,7 +199,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 //  Call GetFullPath to normalize slashes
-                string assetPath = Path.GetFullPath(Path.Combine(runtimePackRoot, fileElement.Attribute("Path").Value));
+                string assetPath = TaskEnvironment.GetAbsolutePath(Path.Combine(runtimePackRoot, fileElement.Attribute("Path").Value));
 
                 string typeAttributeValue = fileElement.Attribute("Type").Value;
                 string assetType;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -63,7 +63,9 @@ namespace Microsoft.NET.Build.Tasks
 
             ResolvedAssetsCacheEntry results;
 
-            if (AllowCacheLookup() &&
+            bool allowCacheLookup = AllowCacheLookup();
+
+            if (allowCacheLookup &&
                 BuildEngine4?.GetRegisteredTaskObject(
                     cacheKey,
                     RegisteredTaskObjectLifetime.AppDomain /* really "until process exit" */)
@@ -79,9 +81,9 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                results = Resolve(inputs, BuildEngine4, AllowCacheLookup());
+                results = Resolve(inputs, BuildEngine4, allowCacheLookup);
 
-                if (AllowCacheLookup())
+                if (allowCacheLookup)
                 {
                     BuildEngine4?.RegisterTaskObject(cacheKey, results, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: true);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -10,8 +10,11 @@ using static Microsoft.DotNet.Cli.EnvironmentVariableNames;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ResolveTargetingPackAssets : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class ResolveTargetingPackAssets : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 
         public ITaskItem[] ResolvedTargetingPacks { get; set; } = Array.Empty<ITaskItem>();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -79,7 +79,7 @@ namespace Microsoft.NET.Build.Tasks
             }
             else
             {
-                results = Resolve(inputs, BuildEngine4);
+                results = Resolve(inputs, BuildEngine4, AllowCacheLookup());
 
                 if (AllowCacheLookup())
                 {
@@ -110,7 +110,7 @@ namespace Microsoft.NET.Build.Tasks
                         NetCoreTargetingPackRoot,
                         ProjectLanguage);
 
-        private static ResolvedAssetsCacheEntry Resolve(StronglyTypedInputs inputs, IBuildEngine4 buildEngine)
+        private static ResolvedAssetsCacheEntry Resolve(StronglyTypedInputs inputs, IBuildEngine4 buildEngine, bool allowCacheLookup)
         {
             List<TaskItem> referencesToAdd = new();
             List<TaskItem> analyzersToAdd = new();
@@ -215,7 +215,7 @@ namespace Microsoft.NET.Build.Tasks
                             targetingPack.NuGetPackageVersion,
                             inputs.ProjectLanguage);
 
-                        AddItemsFromFrameworkList(definition, buildEngine, referencesToAdd, analyzersToAdd, AllowCacheLookup());
+                        AddItemsFromFrameworkList(definition, buildEngine, referencesToAdd, analyzersToAdd, allowCacheLookup);
 
                         if (File.Exists(platformManifestPath))
                         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] UsedRuntimeFrameworks { get; set; }
 
-        private static readonly bool s_allowCacheLookup = Environment.GetEnvironmentVariable(ALLOW_TARGETING_PACK_CACHING) != "0";
+        private bool AllowCacheLookup() => TaskEnvironment.GetEnvironmentVariable(ALLOW_TARGETING_PACK_CACHING) != "0";
 
         public ResolveTargetingPackAssets()
         {
@@ -63,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks
 
             ResolvedAssetsCacheEntry results;
 
-            if (s_allowCacheLookup &&
+            if (AllowCacheLookup() &&
                 BuildEngine4?.GetRegisteredTaskObject(
                     cacheKey,
                     RegisteredTaskObjectLifetime.AppDomain /* really "until process exit" */)
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Build.Tasks
             {
                 results = Resolve(inputs, BuildEngine4);
 
-                if (s_allowCacheLookup)
+                if (AllowCacheLookup())
                 {
                     BuildEngine4?.RegisterTaskObject(cacheKey, results, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: true);
                 }
@@ -215,7 +215,7 @@ namespace Microsoft.NET.Build.Tasks
                             targetingPack.NuGetPackageVersion,
                             inputs.ProjectLanguage);
 
-                        AddItemsFromFrameworkList(definition, buildEngine, referencesToAdd, analyzersToAdd);
+                        AddItemsFromFrameworkList(definition, buildEngine, referencesToAdd, analyzersToAdd, AllowCacheLookup());
 
                         if (File.Exists(platformManifestPath))
                         {
@@ -298,11 +298,11 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private static void AddItemsFromFrameworkList(FrameworkListDefinition definition, IBuildEngine4 buildEngine4, List<TaskItem> referenceItems, List<TaskItem> analyzerItems)
+        private static void AddItemsFromFrameworkList(FrameworkListDefinition definition, IBuildEngine4 buildEngine4, List<TaskItem> referenceItems, List<TaskItem> analyzerItems, bool allowCacheLookup)
         {
             string frameworkListKey = definition.CacheKey();
 
-            if (s_allowCacheLookup &&
+            if (allowCacheLookup &&
                 buildEngine4?.GetRegisteredTaskObject(
                   frameworkListKey,
                   RegisteredTaskObjectLifetime.AppDomain)
@@ -393,7 +393,7 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
-            if (s_allowCacheLookup)
+            if (allowCacheLookup)
             {
                 FrameworkList list = new()
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -13,7 +13,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class ResolveTargetingPackAssets : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         public ITaskItem[] FrameworkReferences { get; set; } = Array.Empty<ITaskItem>();
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (MissingWorkloadPacks.Any())
             {
-                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+                string userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (MissingWorkloadPacks.Any())
             {
-                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (MissingWorkloadPacks.Any())
             {
-                string userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
+                string userProfileDir = new CliFolderPathCalculatorCore(TaskEnvironment.GetEnvironmentVariable).GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -15,7 +15,16 @@ namespace Microsoft.NET.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class ShowMissingWorkloads : TaskBase, IMultiThreadableTask
     {
+#if NETFRAMEWORK
+        private TaskEnvironment _taskEnvironment;
+        public TaskEnvironment TaskEnvironment
+        {
+            get => _taskEnvironment ??= TaskEnvironmentDefaults.Create();
+            set => _taskEnvironment = value;
+        }
+#else
         public TaskEnvironment TaskEnvironment { get; set; }
+#endif
 
         private static readonly string MauiCrossPlatTopLevelVSWorkloads = "Microsoft.VisualStudio.Workload.NetCrossPlat";
         private static readonly string MauiComponentGroupVSWorkload = "Microsoft.VisualStudio.ComponentGroup.Maui.All";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -12,8 +12,11 @@ using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class ShowMissingWorkloads : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class ShowMissingWorkloads : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         private static readonly string MauiCrossPlatTopLevelVSWorkloads = "Microsoft.VisualStudio.Workload.NetCrossPlat";
         private static readonly string MauiComponentGroupVSWorkload = "Microsoft.VisualStudio.ComponentGroup.Maui.All";
         private static readonly string WasmTopLevelVSWorkload = "Microsoft.VisualStudio.Workload.NetWeb";
@@ -42,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json
-                string globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
+                string globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(TaskEnvironment.ProjectDirectory);
 
                 var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, userProfileDir, globalJsonPath);
                 var workloadResolver = Create(workloadManifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir);


### PR DESCRIPTION
## Summary

Fixes dotnet/msbuild#13073

Migrate 5 framework and environment resolution tasks to support multithreaded MSBuild execution. 4 tasks require Pattern B migration; 1 (`ResolveFrameworkReferences`) was already attribute-only on main and needed no changes.

### Tasks Migrated

| Task | Pattern | Key Changes |
|------|---------|-------------|
| ProcessFrameworkReferences | B | Replaced `Environment.GetEnvironmentVariable()` and `Environment.CurrentDirectory` with `TaskEnvironment` equivalents; TODO for transitive `CliFolderPathCalculatorCore` violation |
| ResolveFrameworkReferences | A | Already on main — no changes needed |
| ResolveRuntimePackAssets | B | Replaced `Path.GetFullPath()` with `TaskEnvironment.GetAbsolutePath()` |
| ResolveTargetingPackAssets | B | Replaced static `Environment.GetEnvironmentVariable` with instance `AllowCacheLookup()` method using `TaskEnvironment.GetEnvironmentVariable()` |
| ShowMissingWorkloads | B | Replaced `Environment.CurrentDirectory` with `TaskEnvironment.ProjectDirectory`; TODO for transitive `CliFolderPathCalculatorCore` violation |

### Notable Fixes

**ResolveTargetingPackAssets — static env var anti-pattern**: The original code had `private static readonly bool s_allowCacheLookup = Environment.GetEnvironmentVariable(...)` which reads once per AppDomain from the process environment. This was replaced with an instance method `AllowCacheLookup()` that reads from `TaskEnvironment.GetEnvironmentVariable()` per-task-execution — correct for multithreaded MSBuild where each task gets its own environment.

**Transitive violations documented**: `CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath()` internally uses `Environment.GetEnvironmentVariable()` bypassing `TaskEnvironment`. This is documented with TODO comments in both `ProcessFrameworkReferences` and `ShowMissingWorkloads`. Fixing requires changes to the shared `CliFolderPathCalculatorCore` class.

### Tests Added

- **GivenAProcessFrameworkReferencesMultiThreading.cs** — smoke test, CWD-independence parity test
- **GivenAResolveFrameworkReferencesMultiThreading.cs** — attribute-only verification
- **GivenAResolveRuntimePackAssetsMultiThreading.cs** — smoke test, parity test
- **GivenAResolveTargetingPackAssetsMultiThreading.cs** — env var isolation test, CWD-independence test
- **GivenAShowMissingWorkloadsMultiThreading.cs** — smoke test, parity test

### Files Changed

- `src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs`
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAProcessFrameworkReferencesMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveFrameworkReferencesMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveTargetingPackAssetsMultiThreading.cs` (new)
- `src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAShowMissingWorkloadsMultiThreading.cs` (new)