### PR TITLE
Refactor CliFolderPathCalculatorCore to support environment variable injection

### DIFF
--- a/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Configurer
         {
             get
             {
-                return CliFolderPathCalculatorCore.GetDotnetHomePath()
+                return CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment()
                     ?? throw new ConfigurationException(
                             string.Format(
                                 LocalizableStrings.FailedToDetermineUserHomeDirectory,

--- a/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
+++ b/src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Configurer
         {
             get
             {
-                return CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment()
+                return new CliFolderPathCalculatorCore().GetDotnetHomePath()
                     ?? throw new ConfigurationException(
                             string.Format(
                                 LocalizableStrings.FailedToDetermineUserHomeDirectory,

--- a/src/Common/CliFolderPathCalculatorCore.cs
+++ b/src/Common/CliFolderPathCalculatorCore.cs
@@ -3,12 +3,31 @@
 
 namespace Microsoft.DotNet.Configurer
 {
-    static class CliFolderPathCalculatorCore
+    class CliFolderPathCalculatorCore
     {
         public const string DotnetHomeVariableName = "DOTNET_CLI_HOME";
         public const string DotnetProfileDirectoryName = ".dotnet";
 
-        public static string? GetDotnetUserProfileFolderPath()
+        private readonly Func<string, string?> _getEnvironmentVariable;
+
+        /// <summary>
+        /// Creates an instance that reads environment variables from the process environment.
+        /// </summary>
+        public CliFolderPathCalculatorCore()
+            : this(Environment.GetEnvironmentVariable)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance that reads environment variables via the supplied delegate.
+        /// Use this from MSBuild tasks to route reads through TaskEnvironment.
+        /// </summary>
+        public CliFolderPathCalculatorCore(Func<string, string?> getEnvironmentVariable)
+        {
+            _getEnvironmentVariable = getEnvironmentVariable ?? throw new ArgumentNullException(nameof(getEnvironmentVariable));
+        }
+
+        public string? GetDotnetUserProfileFolderPath()
         {
             string? homePath = GetDotnetHomePath();
             if (homePath is null)
@@ -19,9 +38,9 @@ namespace Microsoft.DotNet.Configurer
             return Path.Combine(homePath, DotnetProfileDirectoryName);
         }
 
-        public static string? GetDotnetHomePath()
+        public string? GetDotnetHomePath()
         {
-            var home = Environment.GetEnvironmentVariable(DotnetHomeVariableName);
+            var home = _getEnvironmentVariable(DotnetHomeVariableName);
             if (string.IsNullOrEmpty(home))
             {
                 home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -33,5 +52,15 @@ namespace Microsoft.DotNet.Configurer
 
             return home;
         }
+
+        // Static convenience methods for callers that use process environment variables.
+
+        private static readonly CliFolderPathCalculatorCore s_default = new();
+
+        public static string? GetDotnetUserProfileFolderPathFromSystemEnvironment()
+            => s_default.GetDotnetUserProfileFolderPath();
+
+        public static string? GetDotnetHomePathFromSystemEnvironment()
+            => s_default.GetDotnetHomePath();
     }
 }

--- a/src/Common/CliFolderPathCalculatorCore.cs
+++ b/src/Common/CliFolderPathCalculatorCore.cs
@@ -53,14 +53,5 @@ namespace Microsoft.DotNet.Configurer
             return home;
         }
 
-        // Static convenience methods for callers that use process environment variables.
-
-        private static readonly CliFolderPathCalculatorCore s_default = new();
-
-        public static string? GetDotnetUserProfileFolderPathFromSystemEnvironment()
-            => s_default.GetDotnetUserProfileFolderPath();
-
-        public static string? GetDotnetHomePathFromSystemEnvironment()
-            => s_default.GetDotnetHomePath();
     }
 }

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             var path = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             if (string.IsNullOrEmpty(path))
             {
-                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment();
+                var homePath = new CliFolderPathCalculatorCore().GetDotnetHomePath();
                 if (homePath is null)
                 {
                     // Couldn't locate the user profile directory. Bail.

--- a/src/RazorSdk/Tool/ServerCommand.cs
+++ b/src/RazorSdk/Tool/ServerCommand.cs
@@ -169,7 +169,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             var path = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             if (string.IsNullOrEmpty(path))
             {
-                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePath();
+                var homePath = CliFolderPathCalculatorCore.GetDotnetHomePathFromSystemEnvironment();
                 if (homePath is null)
                 {
                     // Couldn't locate the user profile directory. Bail.

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             };
 
             //  First check if requested SDK resolves to a workload SDK pack
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+            string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
             ResolutionResult? workloadResult = null;
             if (dotnetRoot is not null && netcoreSdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             };
 
             //  First check if requested SDK resolves to a workload SDK pack
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
             ResolutionResult? workloadResult = null;
             if (dotnetRoot is not null && netcoreSdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                 resolverContext.State = cachedState;
             }
 
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+            string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
             ResolutionResult? result = null;
             if (cachedState.DotnetRootPath is not null && cachedState.SdkVersion is not null)
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                 resolverContext.State = cachedState;
             }
 
-            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+            string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
             ResolutionResult? result = null;
             if (cachedState.DotnetRootPath is not null && cachedState.SdkVersion is not null)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateDepsFile.cs
@@ -244,7 +244,7 @@ namespace Microsoft.NET.Build.Tasks
                 .WithReferenceProjectInfos(referenceProjects)
                 .WithRuntimePackAssets(runtimePackAssets)
                 .WithCompilationOptions(compilationOptions)
-                .WithReferenceAssembliesPath(FrameworkReferenceResolver.GetDefaultReferenceAssembliesPath())
+                .WithReferenceAssembliesPath(new FrameworkReferenceResolver().GetDefaultReferenceAssembliesPath())
                 .WithPackagesThatWereFiltered(GetFilteredPackages());
 
             if (CompileReferences.Length > 0)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath() is { } userProfileDir)
+                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1177,7 +1177,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment() is { } userProfileDir)
+                        new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1177,7 +1177,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+                string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (MissingWorkloadPacks.Any())
             {
-                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
+                string userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             if (MissingWorkloadPacks.Any())
             {
-                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPath();
+                string userProfileDir = CliFolderPathCalculatorCore.GetDotnetUserProfileFolderPathFromSystemEnvironment();
 
                 //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
                 //  starting point to search for global.json


### PR DESCRIPTION
## Summary

Make \CliFolderPathCalculatorCore\ non-static with a \Func<string, string?>\ constructor parameter for environment variable reads. This enables MSBuild tasks to route env var reads through \TaskEnvironment\ instead of using process-global \Environment.GetEnvironmentVariable\.

## Motivation

The MSBuild multithreading migration (merge-groups 1–11) requires all MSBuild tasks to avoid process-wide state like \Environment.GetEnvironmentVariable\. \CliFolderPathCalculatorCore\ is a shared type used by both CLI code and MSBuild tasks, and currently reads \DOTNET_CLI_HOME\ via the static \Environment.GetEnvironmentVariable\.

This refactor separates the concern so that:
- CLI/resolver callers continue to use process environment variables (via static convenience methods — **zero behavior change**)
- MSBuild task callers can inject \TaskEnvironment.GetEnvironmentVariable\ via the instance constructor

## Changes

### \src/Common/CliFolderPathCalculatorCore.cs\
- Made **non-static** with \Func<string, string?>\ constructor injection
- Default constructor uses \Environment.GetEnvironmentVariable\ (backward compatible)
- Injection constructor accepts custom env var reader delegate
- Added static convenience methods: \GetDotnetUserProfileFolderPathFromSystemEnvironment()\, \GetDotnetHomePathFromSystemEnvironment()\

### Callsite updates (all use static convenience methods — no behavior change)
- \src/Cli/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs\ — \GetDotnetHomePath()\ → \GetDotnetHomePathFromSystemEnvironment()\
- \src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs\ — \GetDotnetUserProfileFolderPath()\ → \GetDotnetUserProfileFolderPathFromSystemEnvironment()\
- \src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs\ — same
- \src/RazorSdk/Tool/ServerCommand.cs\ — \GetDotnetHomePath()\ → \GetDotnetHomePathFromSystemEnvironment()\
- \src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs\ (2 sites) — \GetDotnetUserProfileFolderPath()\ → \GetDotnetUserProfileFolderPathFromSystemEnvironment()\
- \src/Tasks/Microsoft.NET.Build.Tasks/ShowMissingWorkloads.cs\ — same

## Follow-up

The \merge-group-11\ PR will rebase onto this and replace the static convenience calls in \ProcessFrameworkReferences\ and \ShowMissingWorkloads\ with:
\\\csharp
new CliFolderPathCalculatorCore(TaskEnvironment.GetEnvironmentVariable).GetDotnetUserProfileFolderPath()
\\\

## Testing

- Tasks project builds cleanly ✅
- Tasks unit tests pass (no regressions from this change) ✅
- Other projects (CLI, Resolvers, RazorSdk) share the file via \<Compile Include>\ and will pick up the change automatically
