### PR TITLE
Add flow from main to release/dnup

### DIFF
--- a/.github/workflows/inter-branch-merge-flow.yml
+++ b/.github/workflows/inter-branch-merge-flow.yml
@@ -2,6 +2,7 @@ name: Inter-branch merge workflow
 on:
   push:
     branches:
+      - main
       - release/**
 
 permissions:

--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -43,6 +43,12 @@
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
+        // Automate opening PRs to merge sdk repos from main to release/dnup
+        "main":{
+            "MergeToBranch": "release/dnup",
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+        },
         // Automate opening PRs to merge sdk repos from dnup to release/dnup
         "dnup":{
             "MergeToBranch": "release/dnup",


### PR DESCRIPTION
This is so we keep up to date with fixes from the SDK repo. Example: LLM telemetry changes will be picked up by the SDK repo. Having a bot make these PRs rather than having it manual is ideal.

This will create a large number of PRs as main changes frequently - we can review them on a need to / weekly basis.