### PR TITLE
Fix dotnet host detection using GetFileNameWithoutExtension

### DIFF
--- a/src/BuiltInTools/Watch/Context/EnvironmentOptions.cs
+++ b/src/BuiltInTools/Watch/Context/EnvironmentOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Watch
 
         private static string ValidateMuxerPath(string path)
         {
-            Debug.Assert(Path.GetFileName(path).Equals("dotnet" + PathUtilities.ExecutableExtension, StringComparison.OrdinalIgnoreCase));
+            Debug.Assert(Path.GetFileName(path) == $"dotnet{PathUtilities.ExecutableExtension}");
             return path;
         }
 

--- a/src/BuiltInTools/Watch/Context/EnvironmentOptions.cs
+++ b/src/BuiltInTools/Watch/Context/EnvironmentOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Watch
 
         private static string ValidateMuxerPath(string path)
         {
-            Debug.Assert(Path.GetFileNameWithoutExtension(path) == "dotnet");
+            Debug.Assert(Path.GetFileName(path).Equals("dotnet" + PathUtilities.ExecutableExtension, StringComparison.OrdinalIgnoreCase));
             return path;
         }
 

--- a/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
+++ b/src/RazorSdk/Tool/ServerProtocol/ServerConnection.cs
@@ -290,14 +290,15 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             expectedPath = Process.GetCurrentProcess().MainModule.FileName;
 #endif
 
-            if ("dotnet".Equals(Path.GetFileNameWithoutExtension(expectedPath), StringComparison.Ordinal))
+            // Use GetFileName (not GetFileNameWithoutExtension) to avoid false matches with dotnet-prefixed names like "dotnet.Tests".
+            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+            if (exeName.Equals(Path.GetFileName(expectedPath), StringComparison.Ordinal))
             {
                 return expectedPath;
             }
 
             // We were probably running from Visual Studio or Build Tools and found MSBuild instead of dotnet. Use the PATH...
             var paths = Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator);
-            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
             foreach (string path in paths)
             {
                 var dotnetPath = Path.Combine(path, exeName);

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -234,9 +234,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                         minimumVSDefinedSDKVersion);
                 }
 
-                string? fullPathToMuxer =
-                    TryResolveMuxerFromSdkResolution(dotnetSdkDir)
-                    ?? Path.Combine(dotnetRoot, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Constants.DotNetExe : Constants.DotNet);
+                string? fullPathToMuxer = TryResolveMuxerFromSdkResolution(dotnetSdkDir) ?? Path.Combine(dotnetRoot, Constants.DotNetFileName);
                 if (File.Exists(fullPathToMuxer))
                 {
                     // keeping this in until this component no longer needs to handle 17.14.
@@ -349,10 +347,9 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         /// </remarks>
         private static string? TryResolveMuxerFromSdkResolution(string resolvedSdkDirectory)
         {
-            var expectedFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Constants.DotNetExe : Constants.DotNet;
             var currentDir = resolvedSdkDirectory;
             var expectedDotnetRoot = Path.GetDirectoryName(Path.GetDirectoryName(currentDir));
-            var expectedMuxerPath = Path.Combine(expectedDotnetRoot, expectedFileName);
+            var expectedMuxerPath = Path.Combine(expectedDotnetRoot, Constants.DotNetFileName);
             if (File.Exists(expectedMuxerPath))
             {
                 return expectedMuxerPath;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Constants.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Constants.cs
@@ -10,11 +10,10 @@ namespace Microsoft.DotNet.NativeWrapper
         public const string PATH = "PATH";
         public const string DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR";
 
-        public static readonly string DotNetFileName = DotNet + ExeSuffix;
-
         public static readonly string ExeSuffix =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
 
+        public static readonly string DotNetFileName = DotNet + ExeSuffix;
         public static class RuntimeProperty
         {
             public const string HostFxrPath = "HOSTFXR_PATH";

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Constants.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Constants.cs
@@ -7,9 +7,10 @@ namespace Microsoft.DotNet.NativeWrapper
     {
         public const string HostFxr = "hostfxr";
         public const string DotNet = "dotnet";
-        public const string DotNetExe = "dotnet.exe";
         public const string PATH = "PATH";
         public const string DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR";
+
+        public static readonly string DotNetFileName = DotNet + ExeSuffix;
 
         public static readonly string ExeSuffix =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/EnvironmentProvider.cs
@@ -64,8 +64,8 @@ namespace Microsoft.DotNet.NativeWrapper
             // the current process path on .NET Framework. We are expected to find dotnet on PATH.
             dotnetExe = _getCurrentProcessPath();
 
-            if (string.IsNullOrEmpty(dotnetExe) || !Path.GetFileNameWithoutExtension(dotnetExe)
-                    .Equals(Constants.DotNet, StringComparison.InvariantCultureIgnoreCase))
+            if (string.IsNullOrEmpty(dotnetExe) || !Path.GetFileName(dotnetExe)
+                    .Equals(Constants.DotNetFileName, StringComparison.InvariantCultureIgnoreCase))
 #endif
             {
                 string? dotnetExeFromPath = GetCommandPath(Constants.DotNet);


### PR DESCRIPTION
## Summary

Multiple locations in the codebase use Path.GetFileNameWithoutExtension to check whether the current process is the dotnet host. This is incorrect because GetFileNameWithoutExtension treats any dot-separated suffix as a file extension — for example, GetFileNameWithoutExtension("dotnet.Tests") returns "dotnet", which is a false positive match.

This was discovered during the xUnit v3 migration (#52930), where tests run as standalone executables named dotnet.Tests. The test GivenAProjectToolsCommandResolver.ItWritesADepsJsonFileNextToTheLockfile was failing because Muxer incorrectly treated the dotnet.Tests process as the dotnet host, causing ProjectToolsCommandResolver.GenerateDepsJsonFile to invoke dotnet.Tests exec MSBuild.dll ... instead of the real dotnet host, resulting in:

    GracefulException: Unable to generate deps.json, it may have been already generated.

## Fix

All affected locations now use Path.GetFileName and compare against the full executable name (dotnet on Linux, dotnet.exe on Windows), matching the pattern already established in EnvironmentProvider.GetDotnetExeDirectory. Duplicate inline computations of the dotnet filename were unified into shared fields (Constants.DotNetFileName, Muxer.muxerFileName).

## Testing

Added ItDoesNotMistakeDotnetPrefixedProcessForDotnetHost test that verifies GetDotnetExeDirectory falls through to PATH-based lookup when the process path is a dotnet-prefixed name like dotnet.Tests.