### PR TITLE
Desync CodeOwners for `dnup` merge flow

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -47,7 +47,7 @@
         "main":{
             "MergeToBranch": "release/dnup",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*;CODEOWNERS"
         },
         // Automate opening PRs to merge sdk repos from dnup to release/dnup
         "dnup":{


### PR DESCRIPTION
The intent of this is that codeowners in release/dnup does not notify others about code changes, such that the code flow from `main` to `release/dnup` doesn't trigger the pings. The codeowners file is meant to inform others about  the SDK, but dnup is a separate product that others don't need to be notified about - the code change would've already made it to main in the SDK, so they've already been notified

This assumes that the codeowners file in the branch is respected by github over the one defined by `main`, which is what the docs suggest: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners