### PR TITLE
Update `RunCommand` to write launch settings messages to stderr for MCP

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -466,7 +466,7 @@ public class RunCommand
 
         if (!RunCommandVerbosity.IsQuiet())
         {
-            Reporter.Output.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, LaunchProfile);


### PR DESCRIPTION
### Reasoning behind the [issue](https://github.com/dotnet/sdk/issues/45640)
* MCP guides often redirect logs to **stderr** so stdout stays “clean” for the protocol messages.
* The `dotnet run` command outputs `launchSettings.json` usage messages to **stdout**, which the MCP server reads as incoming messages.
* Unfortunately, the current `RunCommand.cs` prints `Reporter.Output.WriteLine` unconditionally to stdout; the user can’t easily redirect this via `dotnet run` without code changes.

The `TryGetLaunchProfileSettingsIfNeeded` method prints a message like:

```text
Using launch settings from C:\path\to\Properties\launchSettings.json
```

directly via:

```csharp
// RunCommand.cs, line 469
Reporter.Output.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
```

If the project logs are being sent to **stdout**, VS Code (or any LSP client) can interpret that as a protocol message. MCP servers expect **JSON-RPC messages on stdout**, so any other output (like this “Using launch settings from …”) is considered a **malformed message**, triggering:

```
Failed to parse message: "Using launch settings from ...\Properties\launchSettings.json..."
```

This is only a **warning** — the server still works, but the message pollutes the LSP/JSON-RPC stream.

---

