### PR TITLE
Disambiguate Helix test runs in AzDO

### DIFF
--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -8,6 +8,8 @@
 
     <EnableAzurePipelinesReporter Condition="'$(BUILD_BUILDNUMBER)' != ''">true</EnableAzurePipelinesReporter>
 
+    <TestRunNamePrefix Condition="'$(AGENT_JOBNAME)' != ''">$(AGENT_JOBNAME) run on </TestRunNamePrefix>
+    <TestRunNameSuffix Condition="'$(SYSTEM_JOBATTEMPT)' != ''"> (attempt $(SYSTEM_JOBATTEMPT))</TestRunNameSuffix>
     <XUnitWorkItemTimeout>02:00:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -8,6 +8,7 @@
 
     <EnableAzurePipelinesReporter Condition="'$(BUILD_BUILDNUMBER)' != ''">true</EnableAzurePipelinesReporter>
 
+    <!-- Helix SDK specifies the default run name to be: $(TestRunNamePrefix)$(_CurrentTargetQueue)$(TestRunNameSuffix) -->
     <TestRunNamePrefix Condition="'$(AGENT_JOBNAME)' != ''">$(AGENT_JOBNAME) run on </TestRunNamePrefix>
     <TestRunNameSuffix Condition="'$(SYSTEM_JOBATTEMPT)' != ''"> (attempt $(SYSTEM_JOBATTEMPT))</TestRunNameSuffix>
     <XUnitWorkItemTimeout>02:00:00</XUnitWorkItemTimeout>


### PR DESCRIPTION
The rest runs reported in AzDO are ambiguous as shown below:

<img width="759" height="857" alt="image" src="https://github.com/user-attachments/assets/d1546eb5-3716-455d-a913-91c297fe8d08" />

These changes make it easier to understand what jobs the test runs are associated with by adding the agent name and attempt #.

<img width="1186" height="639" alt="image" src="https://github.com/user-attachments/assets/dfd6bb29-91cf-42bd-ba58-d3bc6f8a11e7" />

