### PR TITLE
Remove unused package references

### DIFF
--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -80,9 +80,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.CommandLine.XPlat" />
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Build" />
@@ -92,7 +90,8 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- Lift dependency of NETStandard.Library.NETFramework to version produced in SBRP. -->


### PR DESCRIPTION
There are a couple of packages that don't seem to be directly utilized.

`Microsoft.Extensions.FileSystemGlobbing`
`NewtonSoft.Json`

NewtonSoft comes in indirectly through the template engine and nuget I believe.

The following appear to be good for AOT:

- [Microsoft.VisualStudio.SolutionPersistence](https://github.com/microsoft/vs-solutionpersistence)
- [Microsoft.NET.HostModel](https://github.com/dotnet/runtime/blob/main/src/installer/managed/Microsoft.NET.HostModel/README.md)
- [Spectre.Console](https://github.com/spectreconsole/spectre.console)
- [Microsoft.Deployment.DotNet.Releases](https://github.com/dotnet/deployment-tools/tree/main/src/Microsoft.Deployment.DotNet.Releases)
- [System.ServiceProcess.ServiceController](https://github.com/dotnet/runtime/tree/main/src/libraries/System.ServiceProcess.ServiceController)
- [Microsoft.Windows.CsWin32](https://github.com/microsoft/CsWin32)

Not AOT friendly or presumed so:

- Microsoft.ApplicationInsights
- Microsoft.Build
- NuGet.CommandLine.XPlat