### PR TITLE
Fix NRE when running sln remove

### DIFF
--- a/src/Cli/dotnet/Commands/Solution/Remove/SolutionRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Solution/Remove/SolutionRemoveCommand.cs
@@ -76,7 +76,7 @@ internal class SolutionRemoveCommand : CommandBase
             // If the project is not found, try to find it by name without extension
             if (project is null && !Path.HasExtension(projectPath))
             {
-                var projectsMatchByName = solution.SolutionProjects.Where(p => Path.GetFileNameWithoutExtension(p.DisplayName).Equals(projectPath));
+                var projectsMatchByName = solution.SolutionProjects.Where(p => p.ActualDisplayName.Equals(projectPath));
                 project = projectsMatchByName.Count() == 1 ? projectsMatchByName.First() : null;
             }
             // If project is still not found, print error

--- a/test/dotnet.Tests/CommandTests/Solution/Remove/GivenDotnetSlnRemove.cs
+++ b/test/dotnet.Tests/CommandTests/Solution/Remove/GivenDotnetSlnRemove.cs
@@ -155,6 +155,26 @@ Options:
         }
 
         [Theory]
+        [InlineData("sln", ".sln")]
+        [InlineData("solution", ".sln")]
+        [InlineData("sln", ".slnx")]
+        [InlineData("solution", ".slnx")]
+        public void WhenProjectWithoutExtensionIsPassedAndDoesntExistItPrintsError(string solutionCommand, string solutionExtension)
+        {
+            var projectDirectory = _testAssetsManager
+                .CopyTestAsset("TestAppWithSlnAndCsprojFiles", identifier: $"{solutionCommand}GivenDotnetSlnRemove")
+                .WithSource()
+                .Path;
+
+            var cmd = new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(solutionCommand, $"App{solutionExtension}", "remove", "InexistingProjectNameWithoutExtension");
+
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Be(string.Format(CliStrings.ProjectNotFoundInTheSolution, "InexistingProjectNameWithoutExtension"));
+        }
+
+        [Theory]
         [InlineData("sln")]
         [InlineData("solution")]
         public void WhenNoSolutionExistsInTheDirectoryRemovePrintsErrorAndUsage(string solutionCommand)


### PR DESCRIPTION
Hi 👋 , this PR fixes an NRE when running dotnet sln remove with a project name that doesn't exist (without extension) in the solution.

The property DisplayName is null, causing `Path.GetExtensionWithoutFileName` to return null leading to an NRE. So the command outputs the following:

"Object reference not set to an instance of an object."

Changing it to use `ActualDisplayName` fixes this and we get:

"Project 'foo' could not be found in the solution."