### PR TITLE
Added --framework arg to "dotnet format" to set TFM 

### DIFF
--- a/src/BuiltInTools/dotnet-format/CodeFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/CodeFormatter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             using var workspace = formatOptions.WorkspaceType == WorkspaceType.Folder
                 ? OpenFolderWorkspace(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
-                : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false);
+                : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken, formatOptions.TargetFramework).ConfigureAwait(false);
 
             if (workspace is null)
             {
@@ -126,16 +126,17 @@ namespace Microsoft.CodeAnalysis.Tools
             string? binaryLogPath,
             bool logWorkspaceWarnings,
             ILogger logger,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            string? targetFramework = null)
         {
             if (requiresSemantics &&
                 !noRestore &&
-                await DotNetHelper.PerformRestoreAsync(solutionOrProjectPath, logger) != 0)
+                await DotNetHelper.PerformRestoreAsync(solutionOrProjectPath, logger, targetFramework) != 0)
             {
                 throw new Exception("Restore operation failed.");
             }
 
-            return await MSBuildWorkspaceLoader.LoadAsync(solutionOrProjectPath, workspaceType, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken);
+            return await MSBuildWorkspaceLoader.LoadAsync(solutionOrProjectPath, workspaceType, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken, targetFramework);
         }
 
         private static async Task<Solution> RunCodeFormattersAsync(

--- a/src/BuiltInTools/dotnet-format/CodeFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/CodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Tools
         {
             if (requiresSemantics &&
                 !noRestore &&
-                await DotNetHelper.PerformRestoreAsync(solutionOrProjectPath, logger, targetFramework) != 0)
+                await DotNetHelper.PerformRestoreAsync(solutionOrProjectPath, logger) != 0)
             {
                 throw new Exception("Restore operation failed.");
             }

--- a/src/BuiltInTools/dotnet-format/CodeFormatter.cs
+++ b/src/BuiltInTools/dotnet-format/CodeFormatter.cs
@@ -25,8 +25,7 @@ namespace Microsoft.CodeAnalysis.Tools
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(
             FormatOptions formatOptions,
             ILogger logger,
-            CancellationToken cancellationToken,
-            string? binaryLogPath = null)
+            CancellationToken cancellationToken)
         {
             var logWorkspaceWarnings = formatOptions.LogLevel == LogLevel.Trace;
 
@@ -38,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             using var workspace = formatOptions.WorkspaceType == WorkspaceType.Folder
                 ? OpenFolderWorkspace(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
-                : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken, formatOptions.TargetFramework).ConfigureAwait(false);
+                : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, formatOptions.NoRestore, formatOptions.FixCategory != FixCategory.Whitespace, formatOptions.BinaryLogPath, logWorkspaceWarnings, logger, formatOptions.TargetFramework, cancellationToken).ConfigureAwait(false);
 
             if (workspace is null)
             {
@@ -126,8 +125,8 @@ namespace Microsoft.CodeAnalysis.Tools
             string? binaryLogPath,
             bool logWorkspaceWarnings,
             ILogger logger,
-            CancellationToken cancellationToken,
-            string? targetFramework = null)
+            string? targetFramework,
+            CancellationToken cancellationToken)
         {
             if (requiresSemantics &&
                 !noRestore &&
@@ -136,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 throw new Exception("Restore operation failed.");
             }
 
-            return await MSBuildWorkspaceLoader.LoadAsync(solutionOrProjectPath, workspaceType, binaryLogPath, logWorkspaceWarnings, logger, cancellationToken, targetFramework);
+            return await MSBuildWorkspaceLoader.LoadAsync(solutionOrProjectPath, workspaceType, binaryLogPath, logWorkspaceWarnings, logger, targetFramework, cancellationToken);
         }
 
         private static async Task<Solution> RunCodeFormattersAsync(

--- a/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
+++ b/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
@@ -34,6 +34,11 @@ namespace Microsoft.CodeAnalysis.Tools
         {
             Description = Resources.Doesnt_execute_an_implicit_restore_before_formatting,
         };
+        internal static readonly Option<string> FrameworkOption = new Option<string>("--framework", "-f")
+        {
+            HelpName = "framework",
+            Description = Resources.The_target_framework_to_use_when_loading_the_workspace,
+        };
         internal static readonly Option<bool> VerifyNoChanges = new("--verify-no-changes")
         {
             Description = Resources.Verify_no_formatting_changes_would_be_performed_Terminates_with_a_non_zero_exit_code_if_any_files_would_have_been_formatted,
@@ -115,6 +120,7 @@ namespace Microsoft.CodeAnalysis.Tools
         {
             command.Arguments.Add(SlnOrProjectArgument);
             command.Options.Add(NoRestoreOption);
+            command.Options.Add(FrameworkOption);
             command.Options.Add(VerifyNoChanges);
             command.Options.Add(IncludeOption);
             command.Options.Add(ExcludeOption);
@@ -209,6 +215,12 @@ namespace Microsoft.CodeAnalysis.Tools
                         ? (formatOptions with { BinaryLogPath = Path.ChangeExtension(binaryLogPath, ".binlog") })
                         : (formatOptions with { BinaryLogPath = binaryLogPath });
                 }
+            }
+
+            if (parseResult.GetResult(FrameworkOption) is not null &&
+                parseResult.GetValue(FrameworkOption) is string { Length: > 0 } framework)
+            {
+                formatOptions = formatOptions with { TargetFramework = framework };
             }
 
             return formatOptions;

--- a/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
+++ b/src/BuiltInTools/dotnet-format/Commands/FormatCommandCommon.cs
@@ -111,8 +111,7 @@ namespace Microsoft.CodeAnalysis.Tools
             var formatResult = await CodeFormatter.FormatWorkspaceAsync(
                 formatOptions,
                 logger,
-                cancellationToken,
-                binaryLogPath: formatOptions.BinaryLogPath).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
             return formatResult.GetExitCode(formatOptions.ChangesAreErrors);
         }
 

--- a/src/BuiltInTools/dotnet-format/Commands/FormatWhitespaceCommand.cs
+++ b/src/BuiltInTools/dotnet-format/Commands/FormatWhitespaceCommand.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             command.AddCommonOptions();
             command.Validators.Add(EnsureFolderNotSpecifiedWithNoRestore);
             command.Validators.Add(EnsureFolderNotSpecifiedWhenLoggingBinlog);
+            command.Validators.Add(EnsureFolderNotSpecifiedWithFramework);
             command.Action = s_formattingHandler;
             return command;
         }
@@ -43,6 +44,16 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             if (folder && binarylog is not null && !binarylog.Implicit)
             {
                 symbolResult.AddError(Resources.Cannot_specify_the_folder_option_when_writing_a_binary_log);
+            }
+        }
+
+        internal static void EnsureFolderNotSpecifiedWithFramework(CommandResult symbolResult)
+        {
+            var folder = symbolResult.GetValue(FolderOption);
+            var framework = symbolResult.GetResult(FrameworkOption);
+            if (folder && framework is not null && !framework.Implicit)
+            {
+                symbolResult.AddError(Resources.Cannot_specify_the_folder_option_with_framework);
             }
         }
 

--- a/src/BuiltInTools/dotnet-format/FormatOptions.cs
+++ b/src/BuiltInTools/dotnet-format/FormatOptions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.Tools
             SourceFileMatcher FileMatcher,
             string? ReportPath,
             string? BinaryLogPath,
-            bool IncludeGeneratedFiles)
+            bool IncludeGeneratedFiles,
+            string? TargetFramework)
     {
         public static FormatOptions Instance = new(
             WorkspaceFilePath: null!, // must be supplied
@@ -39,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Tools
             FileMatcher: SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>()),
             ReportPath: null,
             BinaryLogPath: null,
-            IncludeGeneratedFiles: false);
+            IncludeGeneratedFiles: false,
+            TargetFramework: null);
     }
 }

--- a/src/BuiltInTools/dotnet-format/Resources.resx
+++ b/src/BuiltInTools/dotnet-format/Resources.resx
@@ -330,6 +330,12 @@
   <data name="Cannot_specify_the_folder_option_when_writing_a_binary_log" xml:space="preserve">
     <value>Cannot specify the '--folder' option when writing a binary log.</value>
   </data>
+  <data name="The_target_framework_to_use_when_loading_the_workspace" xml:space="preserve">
+    <value>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</value>
+  </data>
+  <data name="Cannot_specify_the_folder_option_with_framework" xml:space="preserve">
+    <value>Cannot specify the '--folder' option with '--framework'.</value>
+  </data>
   <data name="SolutionOrProjectArgumentName" xml:space="preserve">
     <value>PROJECT | SOLUTION</value>
   </data>

--- a/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
+++ b/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
@@ -7,15 +7,14 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
     internal static class DotNetHelper
     {
-        internal static string BuildRestoreArguments(string workspaceFilePath, string? targetFramework)
+        internal static string BuildRestoreArguments(string workspaceFilePath)
         {
-            var frameworkArg = targetFramework is not null ? $" -p:TargetFramework={targetFramework}" : string.Empty;
-            return $"restore \"{workspaceFilePath}\"{frameworkArg}";
+            return $"restore \"{workspaceFilePath}\"";
         }
 
-        public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger, string? targetFramework = null)
+        public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger)
         {
-            var processInfo = ProcessRunner.CreateProcess("dotnet", BuildRestoreArguments(workspaceFilePath, targetFramework), captureOutput: true, displayWindow: false);
+            var processInfo = ProcessRunner.CreateProcess("dotnet", BuildRestoreArguments(workspaceFilePath), captureOutput: true, displayWindow: false);
             var restoreResult = await processInfo.Result;
 
             logger.LogDebug(string.Join(Environment.NewLine, restoreResult.OutputLines));

--- a/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
+++ b/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
@@ -7,14 +7,10 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
     internal static class DotNetHelper
     {
-        internal static string BuildRestoreArguments(string workspaceFilePath)
-        {
-            return $"restore \"{workspaceFilePath}\"";
-        }
 
         public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger)
         {
-            var processInfo = ProcessRunner.CreateProcess("dotnet", BuildRestoreArguments(workspaceFilePath), captureOutput: true, displayWindow: false);
+            var processInfo = ProcessRunner.CreateProcess("dotnet", $"restore \"{workspaceFilePath}\"", captureOutput: true, displayWindow: false);
             var restoreResult = await processInfo.Result;
 
             logger.LogDebug(string.Join(Environment.NewLine, restoreResult.OutputLines));

--- a/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
+++ b/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
@@ -7,9 +7,15 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
     internal static class DotNetHelper
     {
-        public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger)
+        internal static string BuildRestoreArguments(string workspaceFilePath, string? targetFramework)
         {
-            var processInfo = ProcessRunner.CreateProcess("dotnet", $"restore \"{workspaceFilePath}\"", captureOutput: true, displayWindow: false);
+            var frameworkArg = targetFramework is not null ? $" -p:TargetFramework={targetFramework}" : string.Empty;
+            return $"restore \"{workspaceFilePath}\"{frameworkArg}";
+        }
+
+        public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger, string? targetFramework = null)
+        {
+            var processInfo = ProcessRunner.CreateProcess("dotnet", BuildRestoreArguments(workspaceFilePath, targetFramework), captureOutput: true, displayWindow: false);
             var restoreResult = await processInfo.Result;
 
             logger.LogDebug(string.Join(Environment.NewLine, restoreResult.OutputLines));

--- a/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
+++ b/src/BuiltInTools/dotnet-format/Utilities/DotNetHelper.cs
@@ -7,7 +7,6 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
     internal static class DotNetHelper
     {
-
         public static async Task<int> PerformRestoreAsync(string workspaceFilePath, ILogger logger)
         {
             var processInfo = ProcessRunner.CreateProcess("dotnet", $"restore \"{workspaceFilePath}\"", captureOutput: true, displayWindow: false);

--- a/src/BuiltInTools/dotnet-format/Workspaces/MSBuildWorkspaceLoader.cs
+++ b/src/BuiltInTools/dotnet-format/Workspaces/MSBuildWorkspaceLoader.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             string? binaryLogPath,
             bool logWorkspaceWarnings,
             ILogger logger,
-            CancellationToken cancellationToken,
-            string? targetFramework = null)
+            string? targetFramework,
+            CancellationToken cancellationToken)
         {
             var properties = new Dictionary<string, string>(StringComparer.Ordinal)
             {

--- a/src/BuiltInTools/dotnet-format/Workspaces/MSBuildWorkspaceLoader.cs
+++ b/src/BuiltInTools/dotnet-format/Workspaces/MSBuildWorkspaceLoader.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             string? binaryLogPath,
             bool logWorkspaceWarnings,
             ILogger logger,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            string? targetFramework = null)
         {
             var properties = new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -27,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
                 // AppDomains will likely not work due to https://github.com/Microsoft/MSBuildLocator/issues/16.
                 { "AlwaysCompileMarkupFilesInSeparateDomain", bool.FalseString },
             };
+
+            if (targetFramework is not null)
+            {
+                properties["TargetFramework"] = targetFramework;
+            }
 
             var workspace = MSBuildWorkspace.Create(properties);
 

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Při spouštění analyzátorů není možné zadat možnost --folder.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Není možné zadat možnost --folder s parametrem --framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Není možné zadat možnost --folder s parametrem --no-restore.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Naformátoval se soubor kódu {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Cílová architektura (TFM), která se má použít při načítání pracovního prostoru. Omezuje obnovení a analýzu pouze na zadanou architekturu.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.cs.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Není možné zadat možnost --folder s parametrem --framework.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Cílová architektura (TFM), která se má použít při načítání pracovního prostoru. Omezuje obnovení a analýzu pouze na zadanou architekturu.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Die Option „--folder" kann nicht mit „--framework" angegeben werden.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Das Zielframework (TFM), das beim Laden des Arbeitsbereichs verwendet werden soll. Beschränkt Wiederherstellung und Analyse nur auf das angegebene Framework.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Die Option „--Ordner“ kann beim Ausführen von Analysetools nicht angegeben werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Die Option „--folder" kann nicht mit „--framework" angegeben werden.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Die Option „--Ordner“ kann nicht mit „--keine-Wiederherstellung“ angegeben werden.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Codedatei "{0}" wurde formatiert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Das Zielframework (TFM), das beim Laden des Arbeitsbereichs verwendet werden soll. Beschränkt Wiederherstellung und Analyse nur auf das angegebene Framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">No se puede especificar la opción "--folder" al ejecutar analizadores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">No se puede especificar la opción '--folder' con '--framework'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">No se puede especificar la opción "--folder" con "--no-restore".</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Archivo de código "{0}" con formato aplicado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">El marco de destino (TFM) que se utilizará al cargar el área de trabajo. Restringe la restauración y el análisis solo al marco especificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.es.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">No se puede especificar la opción '--folder' con '--framework'.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">El marco de destino (TFM) que se utilizará al cargar el área de trabajo. Restringe la restauración y el análisis solo al marco especificado.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Impossible de spécifier l’option « --folder » lors de l’exécution des analyseurs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Impossible de spécifier l'option « --folder » avec « --framework ».</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Impossible de spécifier l’option « --folder » avec « --no-restore ».</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Fichier de code '{0}' mis en forme.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Le framework cible (TFM) à utiliser lors du chargement de l'espace de travail. Restreint la restauration et l'analyse au framework spécifié uniquement.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.fr.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Impossible de spécifier l'option « --folder » avec « --framework ».</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Le framework cible (TFM) à utiliser lors du chargement de l'espace de travail. Restreint la restauration et l'analyse au framework spécifié uniquement.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Non è possibile specificare l'opzione '--folder' con '--framework'.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Il framework di destinazione (TFM) da usare durante il caricamento dell'area di lavoro. Limita il ripristino e l'analisi solo al framework specificato.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Impossibile specificare l'opzione '--folder' durante l'esecuzione degli analizzatori.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Non è possibile specificare l'opzione '--folder' con '--framework'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Non è possibile specificare l'opzione '--folder' con '--no-restore'.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Il file di codice '{0}' è stato formattato.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Il framework di destinazione (TFM) da usare durante il caricamento dell'area di lavoro. Limita il ripristino e l'analisi solo al framework specificato.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">'--framework' では '--folder' オプションを指定できません。</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">ワークスペースの読み込み時に使用するターゲット フレームワーク (TFM)。復元と分析を指定されたフレームワークのみに制限します。</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">アナライザーの実行時に '--folder' オプションを指定することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">'--framework' では '--folder' オプションを指定できません。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">'--folder' オプションを '--no-restore' と共に指定することはできません。</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">コード ファイル '{0}' がフォーマットされました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">ワークスペースの読み込み時に使用するターゲット フレームワーク (TFM)。復元と分析を指定されたフレームワークのみに制限します。</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">분석기를 실행할 때는 '--folder' 옵션을 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">'--framework'와 함께 '--folder' 옵션을 지정할 수 없습니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">'--no-restore'와 함께 '--folder' 옵션을 지정할 수 없습니다.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">코드 파일 '{0}'의 서식을 지정했습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">작업 영역을 로드할 때 사용할 대상 프레임워크(TFM)입니다. 복원 및 분석을 지정된 프레임워크로만 제한합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ko.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">'--framework'와 함께 '--folder' 옵션을 지정할 수 없습니다.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">작업 영역을 로드할 때 사용할 대상 프레임워크(TFM)입니다. 복원 및 분석을 지정된 프레임워크로만 제한합니다.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Nie można określić opcji „--folder" razem z parametrem „--framework".</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Docelowa platforma (TFM) do użycia podczas ładowania obszaru roboczego. Ogranicza przywracanie i analizę tylko do określonej platformy.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Nie można określić opcji „--folder” podczas uruchamiania analizatorów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Nie można określić opcji „--folder" razem z parametrem „--framework".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Nie można określić opcji „--folder” z parametrem „--no-restore”.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Sformatowano plik kodu „{0}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Docelowa platforma (TFM) do użycia podczas ładowania obszaru roboczego. Ogranicza przywracanie i analizę tylko do określonej platformy.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Não é possível especificar a opção '--folder' ao executar analisadores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Não é possível especificar a opção '--folder' com '--framework'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Não é possível especificar a opção '--folder' com '--no-restore'.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Arquivo de código '{0}' formatado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">A estrutura de destino (TFM) a ser usada ao carregar o espaço de trabalho. Restringe a restauração e a análise somente à estrutura especificada.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.pt-BR.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Não é possível especificar a opção '--folder' com '--framework'.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">A estrutura de destino (TFM) a ser usada ao carregar o espaço de trabalho. Restringe a restauração e a análise somente à estrutura especificada.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">Невозможно указать параметр "--folder" с "--framework".</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Целевая платформа (TFM), используемая при загрузке рабочей области. Ограничивает восстановление и анализ только указанной платформой.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Невозможно указать параметр "--folder" при запуске анализаторов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">Невозможно указать параметр "--folder" с "--framework".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">Невозможно указать параметр "--folder" с "--no-restore".</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">Отформатированный файл кода "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Целевая платформа (TFM), используемая при загрузке рабочей области. Ограничивает восстановление и анализ только указанной платформой.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Çözümleyiciler çalıştırılırken '--folder' seçeneği belirtilemiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">'--framework' seçeneği ile '--folder' seçeneği belirtilemiyor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">'--no-restore' seçeneği ile '--folder' seçeneği belirtilemiyor.</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">'{0}' kod dosyası biçimlendirildi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">Çalışma alanı yüklenirken kullanılacak hedef çerçeve (TFM). Geri yükleme ve analizi yalnızca belirtilen çerçeveyle sınırlandırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.tr.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">'--framework' seçeneği ile '--folder' seçeneği belirtilemiyor.</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">Çalışma alanı yüklenirken kullanılacak hedef çerçeve (TFM). Geri yükleme ve analizi yalnızca belirtilen çerçeveyle sınırlandırır.</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">无法使用 '--framework' 指定 '--folder' 选项。</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">加载工作区时要使用的目标框架 (TFM)。将还原和分析限制为仅指定的框架。</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">运行分析器时无法指定 '--folder' 选项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">无法使用 '--framework' 指定 '--folder' 选项。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">无法使用 '--no-restore' 指定 '--folder' 选项。</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">已将代码文件“{0}”格式化。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">加载工作区时要使用的目标框架 (TFM)。将还原和分析限制为仅指定的框架。</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
@@ -64,7 +64,7 @@
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_framework">
         <source>Cannot specify the '--folder' option with '--framework'.</source>
-        <target state="translated">無法指定 '--folder' 選項搭配 '--framework'。</target>
+        <target state="new">Cannot specify the '--folder' option with '--framework'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
         <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
-        <target state="translated">載入工作區時使用的目標架構 (TFM)。將還原和分析限制為僅指定的架構。</target>
+        <target state="new">The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
+++ b/src/BuiltInTools/dotnet-format/xlf/Resources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">執行分析器時無法指定 '--folder' 選項。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_the_folder_option_with_framework">
+        <source>Cannot specify the '--folder' option with '--framework'.</source>
+        <target state="translated">無法指定 '--folder' 選項搭配 '--framework'。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_the_folder_option_with_no_restore">
         <source>Cannot specify the '--folder' option with '--no-restore'.</source>
         <target state="translated">無法指定 '--folder' 選項搭配 '--no-restore'。</target>
@@ -350,6 +355,11 @@
       <trans-unit id="Formatted_code_file_0">
         <source>Formatted code file '{0}'.</source>
         <target state="translated">正在將程式碼檔案 '{0}' 格式化。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_target_framework_to_use_when_loading_the_workspace">
+        <source>The target framework (TFM) to use when loading the workspace. Restricts restore and analysis to the specified framework only.</source>
+        <target state="translated">載入工作區時使用的目標架構 (TFM)。將還原和分析限制為僅指定的架構。</target>
         <note />
       </trans-unit>
       <trans-unit id="Unable_to_fix_0_Code_fix_1_didnt_return_a_Fix_All_action">

--- a/test/dotnet-format.UnitTests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
 
                 // Load the analyzer_project into a MSBuildWorkspace.
                 var workspacePath = Path.Combine(TestProjectsPathHelper.GetProjectsDirectory(), s_analyzerProjectFilePath);
-                var analyzerWorkspace = await MSBuildWorkspaceLoader.LoadAsync(workspacePath, WorkspaceType.Project, binaryLogPath: null, logWorkspaceWarnings: true, logger, CancellationToken.None);
+                var analyzerWorkspace = await MSBuildWorkspaceLoader.LoadAsync(workspacePath, WorkspaceType.Project, binaryLogPath: null, logWorkspaceWarnings: true, logger, null, CancellationToken.None);
 
                 TestOutputHelper.WriteLine(logger.GetLog());
 

--- a/test/dotnet-format.UnitTests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
 
                 // Load the analyzer_project into a MSBuildWorkspace.
                 var workspacePath = Path.Combine(TestProjectsPathHelper.GetProjectsDirectory(), s_analyzerProjectFilePath);
-                var analyzerWorkspace = await MSBuildWorkspaceLoader.LoadAsync(workspacePath, WorkspaceType.Project, binaryLogPath: null, logWorkspaceWarnings: true, logger, null, CancellationToken.None);
+                var analyzerWorkspace = await MSBuildWorkspaceLoader.LoadAsync(workspacePath, WorkspaceType.Project, binaryLogPath: null, logWorkspaceWarnings: true, logger, targetFramework: null, CancellationToken.None);
 
                 TestOutputHelper.WriteLine(logger.GetLog());
 

--- a/test/dotnet-format.UnitTests/CodeFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/CodeFormatterTests.cs
@@ -696,7 +696,8 @@ Greeter.Greeter() -> void";
                 fileMatcher,
                 ReportPath: string.Empty,
                 IncludeGeneratedFiles: includeGenerated,
-                BinaryLogPath: null);
+                BinaryLogPath: null,
+                TargetFramework: null);
             var formatResult = await CodeFormatter.FormatWorkspaceAsync(formatOptions, logger, CancellationToken.None);
             Environment.CurrentDirectory = currentDirectory;
 

--- a/test/dotnet-format.UnitTests/Formatters/AbstractFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/Formatters/AbstractFormatterTests.cs
@@ -230,7 +230,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 fileMatcher,
                 ReportPath: string.Empty,
                 IncludeGeneratedFiles: false,
-                BinaryLogPath: null);
+                BinaryLogPath: null,
+                TargetFramework: null);
 
             var pathsToFormat = GetOnlyFileToFormat(solution);
 

--- a/test/dotnet-format.UnitTests/Formatters/FormattedFilesTests.cs
+++ b/test/dotnet-format.UnitTests/Formatters/FormattedFilesTests.cs
@@ -72,7 +72,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 fileMatcher,
                 ReportPath: string.Empty,
                 IncludeGeneratedFiles: false,
-                BinaryLogPath: null);
+                BinaryLogPath: null,
+                TargetFramework: null);
 
             var pathsToFormat = GetOnlyFileToFormat(solution);
 

--- a/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceLoaderTests.cs
+++ b/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceLoaderTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.MSBuild
         {
             var binaryLogPath = Path.ChangeExtension(projectFilePath, ".binlog");
 
-            using var workspace = (MSBuildWorkspace)await MSBuildWorkspaceLoader.LoadAsync(projectFilePath, WorkspaceType.Project, binaryLogPath, logWorkspaceWarnings: true, logger, CancellationToken.None);
+            using var workspace = (MSBuildWorkspace)await MSBuildWorkspaceLoader.LoadAsync(projectFilePath, WorkspaceType.Project, binaryLogPath, logWorkspaceWarnings: true, logger, null, CancellationToken.None);
 
             Assert.Empty(workspace.Diagnostics);
 

--- a/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceLoaderTests.cs
+++ b/test/dotnet-format.UnitTests/MSBuild/MSBuildWorkspaceLoaderTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.MSBuild
         {
             var binaryLogPath = Path.ChangeExtension(projectFilePath, ".binlog");
 
-            using var workspace = (MSBuildWorkspace)await MSBuildWorkspaceLoader.LoadAsync(projectFilePath, WorkspaceType.Project, binaryLogPath, logWorkspaceWarnings: true, logger, null, CancellationToken.None);
+            using var workspace = (MSBuildWorkspace)await MSBuildWorkspaceLoader.LoadAsync(projectFilePath, WorkspaceType.Project, binaryLogPath, logWorkspaceWarnings: true, logger, targetFramework: null, CancellationToken.None);
 
             Assert.Empty(workspace.Diagnostics);
 

--- a/test/dotnet-format.UnitTests/ProgramTests.cs
+++ b/test/dotnet-format.UnitTests/ProgramTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -321,27 +321,19 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         }
 
         [Fact]
-        public void DotNetHelper_BuildRestoreArguments_WithoutFramework_OmitsProperty()
+        public void DotNetHelper_BuildRestoreArguments_ProducesRestoreCommand()
         {
-            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: null);
+            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj");
 
             Assert.Equal("restore \"my.csproj\"", args);
         }
 
         [Fact]
-        public void DotNetHelper_BuildRestoreArguments_WithFramework_UsesMSBuildProperty()
+        public void DotNetHelper_BuildRestoreArguments_DoesNotPassFrameworkToRestore()
         {
-            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: "net8.0");
+            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj");
 
-            Assert.Equal("restore \"my.csproj\" -p:TargetFramework=net8.0", args);
-        }
-
-        [Fact]
-        public void DotNetHelper_BuildRestoreArguments_WithFramework_DoesNotUseDashDashFramework()
-        {
-            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: "net8.0");
-
-            Assert.DoesNotContain("--framework", args);
+            Assert.DoesNotContain("framework", args, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/test/dotnet-format.UnitTests/ProgramTests.cs
+++ b/test/dotnet-format.UnitTests/ProgramTests.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using Microsoft.CodeAnalysis.Tools.Commands;
+using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
+using ProductionDotNetHelper = Microsoft.CodeAnalysis.Tools.Utilities.DotNetHelper;
 
 namespace Microsoft.CodeAnalysis.Tools.Tests
 {
@@ -245,6 +247,101 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
             // Assert
             Assert.Empty(result.Errors);
+        }
+
+        [Fact]
+        public void CommandLine_FrameworkOption_IsParsedCorrectly()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+
+            // Act
+            var result = sut.Parse(new[] { "--framework", "net8.0" });
+
+            // Assert
+            Assert.Empty(result.Errors);
+            Assert.Equal("net8.0", result.GetValue(FormatCommandCommon.FrameworkOption));
+        }
+
+        [Fact]
+        public void CommandLine_FrameworkOption_ShortAlias_IsParsedCorrectly()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+
+            // Act
+            var result = sut.Parse(new[] { "-f", "net8.0" });
+
+            // Assert
+            Assert.Empty(result.Errors);
+            Assert.Equal("net8.0", result.GetValue(FormatCommandCommon.FrameworkOption));
+        }
+
+        [Fact]
+        public void CommandLine_FolderValidation_FailsIfFrameworkSpecified()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+
+            // Act
+            var result = sut.Parse(new[] { "whitespace", "--folder", "--framework", "net8.0" });
+
+            // Assert
+            Assert.Single(result.Errors);
+        }
+
+        [Fact]
+        public void ParseCommonOptions_FrameworkOption_SetsTargetFramework()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+            var result = sut.Parse(new[] { "--framework", "net8.0" });
+            var logger = new TestLogger();
+
+            // Act
+            var formatOptions = result.ParseCommonOptions(FormatOptions.Instance, logger);
+
+            // Assert
+            Assert.Equal("net8.0", formatOptions.TargetFramework);
+        }
+
+        [Fact]
+        public void ParseCommonOptions_NoFrameworkOption_LeavesTargetFrameworkNull()
+        {
+            // Arrange
+            var sut = RootFormatCommand.GetCommand();
+            var result = sut.Parse(Array.Empty<string>());
+            var logger = new TestLogger();
+
+            // Act
+            var formatOptions = result.ParseCommonOptions(FormatOptions.Instance, logger);
+
+            // Assert
+            Assert.Null(formatOptions.TargetFramework);
+        }
+
+        [Fact]
+        public void DotNetHelper_BuildRestoreArguments_WithoutFramework_OmitsProperty()
+        {
+            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: null);
+
+            Assert.Equal("restore \"my.csproj\"", args);
+        }
+
+        [Fact]
+        public void DotNetHelper_BuildRestoreArguments_WithFramework_UsesMSBuildProperty()
+        {
+            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: "net8.0");
+
+            Assert.Equal("restore \"my.csproj\" -p:TargetFramework=net8.0", args);
+        }
+
+        [Fact]
+        public void DotNetHelper_BuildRestoreArguments_WithFramework_DoesNotUseDashDashFramework()
+        {
+            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj", targetFramework: "net8.0");
+
+            Assert.DoesNotContain("--framework", args);
         }
     }
 }

--- a/test/dotnet-format.UnitTests/ProgramTests.cs
+++ b/test/dotnet-format.UnitTests/ProgramTests.cs
@@ -319,21 +319,5 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             // Assert
             Assert.Null(formatOptions.TargetFramework);
         }
-
-        [Fact]
-        public void DotNetHelper_BuildRestoreArguments_ProducesRestoreCommand()
-        {
-            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj");
-
-            Assert.Equal("restore \"my.csproj\"", args);
-        }
-
-        [Fact]
-        public void DotNetHelper_BuildRestoreArguments_DoesNotPassFrameworkToRestore()
-        {
-            var args = ProductionDotNetHelper.BuildRestoreArguments("my.csproj");
-
-            Assert.DoesNotContain("framework", args, StringComparison.OrdinalIgnoreCase);
-        }
     }
 }


### PR DESCRIPTION
I was really annoyed by #41899 which describes a problem with "dotnet format" when projects have multiple target frameworks, so I added support for a --framework argument to it to specify a single TFM. 

### Implemented Solution:
New argument "--framework" with alias "-f"  which takes a TFM and restricts restore and analysis to the specified framework only.
Unit tests similar to existing dotnet format tests.

### Remarks
- The translations in 'src\BuiltInTools\dotnet-format\xlf' were done with AI(Claude Sonett 4.6) and are not further confirmed.
- This does not work with the --folder argument. 