### PR TITLE
Fix test templates for Central Package Management (CPM)

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/.template.config/template.json
@@ -220,6 +220,32 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "condition": "(CoverageTool == \"coverlet\")",
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "condition": "(!UseMSTestSdk)",
+      "description": "Add package reference: MSTest",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to MSTest to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest",
+        "version": "4.0.2",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -11,12 +11,6 @@
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
-<!--#if (CoverageTool == "coverlet")-->
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-  </ItemGroup>
-<!--#endif-->
 <!--#else-->
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
@@ -38,13 +32,6 @@
     <OutputType>Exe</OutputType>
 <!--#endif-->
   </PropertyGroup>
-
-  <ItemGroup>
-<!--#if (CoverageTool == "coverlet")-->
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/.template.config/template.json
@@ -220,6 +220,32 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "condition": "(CoverageTool == \"coverlet\")",
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "condition": "(!UseMSTestSdk)",
+      "description": "Add package reference: MSTest",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to MSTest to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest",
+        "version": "4.0.2",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -11,12 +11,6 @@
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
-<!--#if (CoverageTool == "coverlet")-->
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-  </ItemGroup>
-<!--#endif-->
 <!--#else-->
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
@@ -43,13 +37,6 @@
     <OutputType>Exe</OutputType>
 <!--#endif-->
   </PropertyGroup>
-
-  <ItemGroup>
-<!--#if (CoverageTool == "coverlet")-->
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/.template.config/template.json
@@ -220,6 +220,32 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "condition": "(CoverageTool == \"coverlet\")",
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "condition": "(!UseMSTestSdk)",
+      "description": "Add package reference: MSTest",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to MSTest to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest",
+        "version": "4.0.2",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -11,12 +11,6 @@
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
-<!--#if (CoverageTool == "coverlet")-->
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-  </ItemGroup>
-<!--#endif-->
 <!--#else-->
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
@@ -38,13 +32,6 @@
     <OutputType>Exe</OutputType>
 <!--#endif-->
   </PropertyGroup>
-
-  <ItemGroup>
-<!--#if (CoverageTool == "coverlet")-->
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/template.json
@@ -79,6 +79,66 @@
   ],
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit",
+        "version": "4.3.2",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit.Analyzers",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit.Analyzers to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit.Analyzers",
+        "version": "4.7.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit3TestAdapter",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit3TestAdapter to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit3TestAdapter",
+        "version": "5.0.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -12,14 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/template.json
@@ -75,6 +75,66 @@
   ],
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.0",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit",
+        "version": "4.3.2",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit.Analyzers",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit.Analyzers to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit.Analyzers",
+        "version": "4.7.0",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit3TestAdapter",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit3TestAdapter to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit3TestAdapter",
+        "version": "5.0.0",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -15,12 +15,5 @@
     <Compile Include="Program.fs"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-  </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -75,6 +75,66 @@
   ],
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.0",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit",
+        "version": "4.3.2",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit.Analyzers",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit.Analyzers to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit.Analyzers",
+        "version": "4.7.0",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit3TestAdapter",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit3TestAdapter to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit3TestAdapter",
+        "version": "5.0.0",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -9,12 +9,5 @@
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-  </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/.template.config/template.json
@@ -240,6 +240,45 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "condition": "(CoverageTool == \"coverlet\")",
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "condition": "(!UseMSTestSdk)",
+      "description": "Add package reference: Microsoft.Playwright.MSTest.v4",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.Playwright.MSTest.v4 to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Playwright.MSTest.v4",
+        "version": "1.55.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "condition": "(!UseMSTestSdk)",
+      "description": "Add package reference: MSTest",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to MSTest to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "MSTest",
+        "version": "4.0.2",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -12,12 +12,6 @@
 <!--#if (TestRunner == "VSTest")-->
     <UseVSTest>true</UseVSTest>
   </PropertyGroup>
-<!--#if (CoverageTool == "coverlet")-->
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-  </ItemGroup>
-<!--#endif-->
 <!--#else-->
     <TestingExtensionsProfile Condition=" '$(ExtensionsProfile)' != 'Default' ">$(ExtensionsProfile)</TestingExtensionsProfile>
   </PropertyGroup>
@@ -39,14 +33,6 @@
     <OutputType>Exe</OutputType>
 <!--#endif-->
   </PropertyGroup>
-
-  <ItemGroup>
-<!--#if (CoverageTool == "coverlet")-->
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
-    <PackageReference Include="Microsoft.Playwright.MSTest.v4" Version="1.55.0" />
-    <PackageReference Include="MSTest" Version="4.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Microsoft.Playwright.MSTest" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/.template.config/template.json
@@ -79,6 +79,78 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.Playwright.NUnit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.Playwright.NUnit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.Playwright.NUnit",
+        "version": "1.52.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit",
+        "version": "4.3.2",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit.Analyzers",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit.Analyzers to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit.Analyzers",
+        "version": "4.7.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: NUnit3TestAdapter",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to NUnit3TestAdapter to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "NUnit3TestAdapter",
+        "version": "5.0.0",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [ { "text": "Run 'dotnet restore'" } ],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/Company.TestProject1.csproj
@@ -12,15 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.52.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Using Include="Microsoft.Playwright.NUnit" />
     <Using Include="NUnit.Framework" />
     <Using Include="System.Text.RegularExpressions" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/.template.config/template.json
@@ -71,6 +71,54 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.1",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit",
+        "version": "2.9.3",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit.runner.visualstudio",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit.runner.visualstudio to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit.runner.visualstudio",
+        "version": "3.1.4",
+        "projectFileExtensions": ".csproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -11,13 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/.template.config/template.json
@@ -67,6 +67,54 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.1",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit",
+        "version": "2.9.3",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit.runner.visualstudio",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit.runner.visualstudio to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit.runner.visualstudio",
+        "version": "3.1.4",
+        "projectFileExtensions": ".fsproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -12,11 +12,5 @@
     <Compile Include="Tests.fs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
-  </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/.template.config/template.json
@@ -67,6 +67,54 @@
   "defaultName": "TestProject1",
   "postActions": [
     {
+      "description": "Add package reference: coverlet.collector",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to coverlet.collector to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "coverlet.collector",
+        "version": "6.0.4",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: Microsoft.NET.Test.Sdk",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to Microsoft.NET.Test.Sdk to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "Microsoft.NET.Test.Sdk",
+        "version": "17.14.1",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit",
+        "version": "2.9.3",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
+      "description": "Add package reference: xunit.runner.visualstudio",
+      "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+      "continueOnError": true,
+      "manualInstructions": [{ "text": "Manually add a reference to xunit.runner.visualstudio to your project file." }],
+      "args": {
+        "referenceType": "package",
+        "reference": "xunit.runner.visualstudio",
+        "version": "3.1.4",
+        "projectFileExtensions": ".vbproj"
+      }
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -8,11 +8,5 @@
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

This PR fixes test project templates to work correctly in solutions that use **Central Package Management (CPM)** via Directory.Packages.props.

**Fixes #48903**

## Problem

When a user creates a test project (mstest, nunit, xunit) in a solution with CPM enabled, the generated project file contains hardcoded Version attributes on PackageReference items. This causes **NU1008** errors because CPM requires versions to be managed centrally in Directory.Packages.props, not in individual project files.

## Solution

Replace hardcoded PackageReference elements (with Version attributes) in template .csproj/.fsproj/.vbproj files with **addPackageReference post-actions** (action ID B17581D1-C5C9-4489-8F0A-004BE667B814).

This post-action uses the dotnet add package command internally, which is **CPM-aware**:

- **Without CPM**: Adds PackageReference with Version to the project file (same behavior as before)
- **With CPM**: Adds PackageReference without Version to the project file AND adds PackageVersion to Directory.Packages.props

This approach was recommended by @baronfel in the [issue discussion](https://github.com/dotnet/sdk/issues/48903#issuecomment-2872199804).

## Templates Updated

| Template | Language | Packages Moved to Post-Actions |
|----------|----------|-------------------------------|
| MSTest | C#, F#, VB | coverlet.collector (conditional), MSTest (non-SDK mode only) |
| NUnit | C#, F#, VB | coverlet.collector, Microsoft.NET.Test.Sdk, NUnit, NUnit.Analyzers, NUnit3TestAdapter |
| xUnit | C#, F#, VB | coverlet.collector, Microsoft.NET.Test.Sdk, xunit, xunit.runner.visualstudio |
| Playwright-MSTest | C# | coverlet.collector (conditional), Microsoft.Playwright.MSTest.v4, MSTest (non-SDK mode) |
| Playwright-NUnit | C# | coverlet.collector, Microsoft.NET.Test.Sdk, Microsoft.Playwright.NUnit, NUnit, NUnit.Analyzers, NUnit3TestAdapter |

## Behavior Notes

- **MSTest SDK mode** (UseMSTestSdk=true): Packages are pulled via the SDK itself. Only coverlet.collector is affected (conditional on CoverageTool=coverlet).
- **MSTest non-SDK mode**: Both coverlet (conditional) and MSTest are now added via post-actions.
- **Conditional packages**: coverlet.collector post-action has condition (CoverageTool == coverlet) matching existing template logic. MSTest post-action has condition (!UseMSTestSdk).
- **Non-test templates** (console, classlib): Not affected by this change.

## Testing

The post-action approach uses the same addPackageReference mechanism already tested in the SDK codebase (see test assets at test/TestAssets/TestPackages/dotnet-new/test_templates/PostActions/AddPackageReference/).
