### PR TITLE
[release/8.0.1xx] Update branding to 8.0.126

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -101,7 +101,7 @@ stages:
             demands: ImageOverride -equals 1es-windows-2022-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>8.0.125</VersionPrefix>
+    <VersionPrefix>8.0.126</VersionPrefix>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -33,7 +33,7 @@ jobs:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals 1es-ubuntu-2204
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
+          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: Ubuntu.2204.Amd64
         strategy:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -28,10 +28,10 @@ jobs:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2204-open
+            demands: ImageOverride -equals build.ubuntu.2204.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2204
+            demands: ImageOverride -equals build.ubuntu.2204.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -24,18 +24,18 @@ jobs:
 
     - template: /eng/build-pr.yml
       parameters:
-        agentOs: Ubuntu_20_04_TemplateEngine
+        agentOs: Ubuntu_22_04_TemplateEngine
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2004-open
+            demands: ImageOverride -equals 1es-ubuntu-2204-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals 1es-ubuntu-2004
+            demands: ImageOverride -equals 1es-ubuntu-2204
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'ubuntu.2004.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
+          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Ubuntu.2004.Amd64
+          helixTargetQueue: Ubuntu.2204.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -6,10 +6,10 @@ jobs:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.1xx`.

**Changes:**
- Repository: sdk
  - PatchVersion: `25` → `26`

**Files Modified:**
- eng/Versions.props (+1 -1)
