### PR TITLE
Rename ms.docs to ms-docs in mcp.json

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,6 +1,6 @@
 {
 	"servers": {
-		"ms.docs": {
+		"ms-docs": {
 			"url": "https://learn.microsoft.com/api/mcp",
 			"type": "http"
 		}


### PR DESCRIPTION
Fixes this error I'm getting in copilot CLI:

<p><samp>
Error: MCP server 'ms.docs' in C:/sdk-2\.vscode/mcp.json contains invalid characters: '.'. Only alphanumeric characters, underscores, and hyphens are allowed. Consider renaming to 'ms-docs'.
</samp></p>