### PR TITLE
Add RoslynAnalyzers with opt-in properties

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Features" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="$(MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(MicrosoftCodeAnalysisResxSourceGeneratorVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="$(MicrosoftCodeAnalysisRazorToolingInternalVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftCodeAnalysisPackageVersion)" />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -43,9 +43,9 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisPublicApiAnalyzersPackageVersion>
-    <MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
-    <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>
-    <MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>
+    <MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>
     <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>10.0.0-preview.26152.106</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -43,6 +43,9 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisPublicApiAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>5.5.0-2.26152.106</MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion>
     <MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>10.0.0-preview.26152.106</MicrosoftCodeAnalysisRazorToolingInternalPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.6.0-2.26152.106</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
@@ -186,6 +189,9 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisExternalAccessHotReloadVersion>$(MicrosoftCodeAnalysisExternalAccessHotReloadPackageVersion)</MicrosoftCodeAnalysisExternalAccessHotReloadVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>$(MicrosoftCodeAnalysisPublicApiAnalyzersPackageVersion)</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>$(MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersPackageVersion)</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>
+    <MicrosoftCodeAnalysisResxSourceGeneratorVersion>$(MicrosoftCodeAnalysisResxSourceGeneratorPackageVersion)</MicrosoftCodeAnalysisResxSourceGeneratorVersion>
     <MicrosoftCodeAnalysisRazorToolingInternalVersion>$(MicrosoftCodeAnalysisRazorToolingInternalPackageVersion)</MicrosoftCodeAnalysisRazorToolingInternalVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonVersion>$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)</MicrosoftCodeAnalysisWorkspacesCommonVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildVersion>$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)</MicrosoftCodeAnalysisWorkspacesMSBuildVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -387,6 +387,18 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.5.0-2.26152.106">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="5.5.0-2.26152.106">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.5.0-2.26152.106">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
+    </Dependency>
     <Dependency Name="System.CommandLine" Version="3.0.0-preview.3.26152.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -387,15 +387,15 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.5.0-2.26152.106">
+    <Dependency Name="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0-2.26152.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="5.5.0-2.26152.106">
+    <Dependency Name="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="5.6.0-2.26152.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.5.0-2.26152.106">
+    <Dependency Name="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.6.0-2.26152.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>5507d7a2f05bb6c073a055ead6ce1c4bbe396cda</Sha>
     </Dependency>

--- a/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
+++ b/src/Layout/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers/VS.Redist.Common.Net.Core.SDK.RuntimeAnalyzers.proj
@@ -29,6 +29,7 @@
       <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)packs\Microsoft.AspNetCore.App.Ref\*\analyzers\**\*.*" DeploymentSubpath="AspNetCoreAnalyzers" />
       <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk\analyzers\**\*.*" DeploymentSubpath="SDKAnalyzers" />
       <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk.Web\analyzers\**\*.*" DeploymentSubpath="WebSDKAnalyzers" />
+      <RedistRuntimeAnalyzersContent Include="$(RedistInstallerLayoutPath)sdk\*\Sdks\Microsoft.NET.Sdk\roslynanalyzers\**\*.*" DeploymentSubpath="RoslynAnalyzers" />
     </ItemGroup>
 
     <Error Condition="'@(RedistRuntimeAnalyzersContent)' == ''" Text="The 'RedistRuntimeAnalyzersContent' items are empty. This shouldn't happen!" />
@@ -36,7 +37,7 @@
     <!-- The custom task cannot access %(RecursiveDir) without this. -->
     <ItemGroup>
       <RedistRuntimeAnalyzersContent Update="@(RedistRuntimeAnalyzersContent)">
-        <CustomRecursiveDir>%(RecursiveDir)</CustomRecursiveDir>      
+        <CustomRecursiveDir>%(RecursiveDir)</CustomRecursiveDir>
       </RedistRuntimeAnalyzersContent>
     </ItemGroup>
 

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" ExcludeAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.FSharp.Compiler" ExcludeAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" GeneratePathProperty="true" />
     <PackageDownload Include="Microsoft.Net.Compilers.Toolset" Version="[$(MicrosoftNetCompilersToolsetVersion)]" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -65,7 +65,7 @@
                    AppBinaryName="%(_RoslynAppHost.Filename)%(_RoslynAppHost.Extension)"
                    IntermediateAssembly="%(_RoslynAppHost.FullPath)"
                    EnableMacOSCodeSign="$(SharedFrameworkRid.StartsWith('osx'))" />
-    
+
     <Exec Command="codesign --sign - --force --entitlements '$(MSBuildProjectDirectory)/roslyn-entitlements.plist' %(_RoslynAppHost.RootDir)%(_RoslynAppHost.Directory)%(_RoslynAppHost.Filename)$(ExeExtension)"
           Condition="$(SharedFrameworkRid.StartsWith('osx'))" />
   </Target>
@@ -133,6 +133,85 @@
 
     <Error Condition="'@(CodeStyleVisualBasicConfig)' == ''" Text="Something moved around in Code style packeges, could not find globalconfig files. Adjust code here accordingly. TFM change?" />
     <Copy SourceFiles="@(CodeStyleVisualBasicConfig)" DestinationFiles="@(CodeStyleVisualBasicConfig->'$(CodeStyleVisualBasicConfigDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <!-- Microsoft.CodeAnalysis.BannedApiAnalyzers -->
+    <PropertyGroup>
+      <BannedApiCSharpDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\bannedapi\cs</BannedApiCSharpDirectory>
+      <BannedApiVisualBasicDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\bannedapi\vb</BannedApiVisualBasicDirectory>
+      <BannedApiTargetsDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\bannedapi\build</BannedApiTargetsDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <BannedApiCSharpAssemblies Include="$(PkgMicrosoft_CodeAnalysis_BannedApiAnalyzers)/analyzers/dotnet/cs/**/*.dll" />
+      <BannedApiVisualBasicAssemblies Include="$(PkgMicrosoft_CodeAnalysis_BannedApiAnalyzers)/analyzers/dotnet/vb/**/*.dll" />
+      <BannedApiBuildFiles Include="$(PkgMicrosoft_CodeAnalysis_BannedApiAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.BannedApiAnalyzers.props;
+                                    $(PkgMicrosoft_CodeAnalysis_BannedApiAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.BannedApiAnalyzers.targets" />
+    </ItemGroup>
+
+    <Error Condition="'@(BannedApiCSharpAssemblies)' == ''" Text="Something moved around in BannedApiAnalyzers package, could not find C# assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(BannedApiCSharpAssemblies)" DestinationFiles="@(BannedApiCSharpAssemblies->'$(BannedApiCSharpDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <Error Condition="'@(BannedApiVisualBasicAssemblies)' == ''" Text="Something moved around in BannedApiAnalyzers package, could not find VB assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(BannedApiVisualBasicAssemblies)" DestinationFiles="@(BannedApiVisualBasicAssemblies->'$(BannedApiVisualBasicDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <Error Condition="'@(BannedApiBuildFiles)' == ''" Text="Something moved around in BannedApiAnalyzers package, could not find build targets/props. Adjust code here accordingly." />
+    <Copy SourceFiles="@(BannedApiBuildFiles)" DestinationFiles="@(BannedApiBuildFiles->'$(BannedApiTargetsDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <!-- Microsoft.CodeAnalysis.PublicApiAnalyzers -->
+    <PropertyGroup>
+      <PublicApiAssembliesDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\publicapi</PublicApiAssembliesDirectory>
+      <PublicApiTargetsDirectory>$(PublicApiAssembliesDirectory)\build</PublicApiTargetsDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- PublicApiAnalyzers DLLs are language-neutral (at analyzers/dotnet/ level, not under cs/ or vb/) -->
+      <PublicApiAssemblies Include="$(PkgMicrosoft_CodeAnalysis_PublicApiAnalyzers)/analyzers/dotnet/*.dll" />
+      <PublicApiBuildFiles Include="$(PkgMicrosoft_CodeAnalysis_PublicApiAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.PublicApiAnalyzers.props;
+                                    $(PkgMicrosoft_CodeAnalysis_PublicApiAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.PublicApiAnalyzers.targets" />
+    </ItemGroup>
+
+    <Error Condition="'@(PublicApiAssemblies)' == ''" Text="Something moved around in PublicApiAnalyzers package, could not find assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(PublicApiAssemblies)" DestinationFiles="@(PublicApiAssemblies->'$(PublicApiAssembliesDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <Error Condition="'@(PublicApiBuildFiles)' == ''" Text="Something moved around in PublicApiAnalyzers package, could not find build targets/props. Adjust code here accordingly." />
+    <Copy SourceFiles="@(PublicApiBuildFiles)" DestinationFiles="@(PublicApiBuildFiles->'$(PublicApiTargetsDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <!-- Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers -->
+    <PropertyGroup>
+      <PerfSensitiveCSharpDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\performancesensitive\cs</PerfSensitiveCSharpDirectory>
+      <PerfSensitiveTargetsDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\performancesensitive\build</PerfSensitiveTargetsDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PerfSensitiveCSharpAssemblies Include="$(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/analyzers/dotnet/cs/**/*.dll" />
+      <PerfSensitiveBuildFiles Include="$(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.props;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/PerformanceSensitiveAttribute.cs;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/PerformanceSensitiveAttribute.vb" />
+    </ItemGroup>
+
+    <Error Condition="'@(PerfSensitiveCSharpAssemblies)' == ''" Text="Something moved around in PerformanceSensitiveAnalyzers package, could not find assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(PerfSensitiveCSharpAssemblies)" DestinationFiles="@(PerfSensitiveCSharpAssemblies->'$(PerfSensitiveCSharpDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <Error Condition="'@(PerfSensitiveBuildFiles)' == ''" Text="Something moved around in PerformanceSensitiveAnalyzers package, could not find build files. Adjust code here accordingly." />
+    <Copy SourceFiles="@(PerfSensitiveBuildFiles)" DestinationFiles="@(PerfSensitiveBuildFiles->'$(PerfSensitiveTargetsDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <!-- Microsoft.CodeAnalysis.ResxSourceGenerator -->
+    <PropertyGroup>
+      <ResxSourceGenCSharpDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\resxsourcegen\cs</ResxSourceGenCSharpDirectory>
+      <ResxSourceGenVisualBasicDirectory>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk\roslynanalyzers\resxsourcegen\vb</ResxSourceGenVisualBasicDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ResxSourceGenCSharpAssemblies Include="$(PkgMicrosoft_CodeAnalysis_ResxSourceGenerator)/analyzers/dotnet/cs/**/*.dll" />
+      <ResxSourceGenVisualBasicAssemblies Include="$(PkgMicrosoft_CodeAnalysis_ResxSourceGenerator)/analyzers/dotnet/vb/**/*.dll" />
+    </ItemGroup>
+
+    <Error Condition="'@(ResxSourceGenCSharpAssemblies)' == ''" Text="Something moved around in ResxSourceGenerator package, could not find C# assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(ResxSourceGenCSharpAssemblies)" DestinationFiles="@(ResxSourceGenCSharpAssemblies->'$(ResxSourceGenCSharpDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+
+    <Error Condition="'@(ResxSourceGenVisualBasicAssemblies)' == ''" Text="Something moved around in ResxSourceGenerator package, could not find VB assemblies. Adjust code here accordingly." />
+    <Copy SourceFiles="@(ResxSourceGenVisualBasicAssemblies)" DestinationFiles="@(ResxSourceGenVisualBasicAssemblies->'$(ResxSourceGenVisualBasicDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
 
   <Target Name="PublishDotnetFormat">

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -184,10 +184,10 @@
 
     <ItemGroup>
       <PerfSensitiveCSharpAssemblies Include="$(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/analyzers/dotnet/cs/**/*.dll" />
-      <PerfSensitiveBuildFiles Include="$(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.props;
-                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets;
-                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/PerformanceSensitiveAttribute.cs;
-                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/build/PerformanceSensitiveAttribute.vb" />
+      <PerfSensitiveBuildFiles Include="$(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.props;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/buildTransitive/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/buildTransitive/PerformanceSensitiveAttribute.cs;
+                                        $(PkgMicrosoft_CodeAnalysis_PerformanceSensitiveAnalyzers)/buildTransitive/PerformanceSensitiveAttribute.vb" />
     </ItemGroup>
 
     <Error Condition="'@(PerfSensitiveCSharpAssemblies)' == ''" Text="Something moved around in PerformanceSensitiveAnalyzers package, could not find assemblies. Adjust code here accordingly." />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -112,6 +112,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
     <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>
+    <EnableBannedApiAnalysis Condition="'$(EnableBannedApiAnalysis)' == ''">false</EnableBannedApiAnalysis>
+    <EnablePublicApiAnalysis Condition="'$(EnablePublicApiAnalysis)' == ''">false</EnablePublicApiAnalysis>
+    <EnableResxSourceGeneration Condition="'$(EnableResxSourceGeneration)' == ''">false</EnableResxSourceGeneration>
+    <EnablePerformanceSensitiveAnalysis Condition="'$(EnablePerformanceSensitiveAnalysis)' == ''">false</EnablePerformanceSensitiveAnalysis>
   </PropertyGroup>
 
   <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for all C# and VB projects for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -99,10 +99,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
 
     <!-- Opt-in Roslyn analyzer properties. These are always opt-in regardless of AnalysisLevel. -->
-    <EnableBannedApiAnalysis Condition="'$(EnableBannedApiAnalysis)' == ''">false</EnableBannedApiAnalysis>
-    <EnablePublicApiAnalysis Condition="'$(EnablePublicApiAnalysis)' == ''">false</EnablePublicApiAnalysis>
-    <EnableResxSourceGeneration Condition="'$(EnableResxSourceGeneration)' == ''">false</EnableResxSourceGeneration>
-    <EnablePerformanceSensitiveAnalysis Condition="'$(EnablePerformanceSensitiveAnalysis)' == ''">false</EnablePerformanceSensitiveAnalysis>
+    <EnableBannedApiAnalyzer Condition="'$(EnableBannedApiAnalyzer)' == ''">false</EnableBannedApiAnalyzer>
+    <EnablePublicApiAnalyzer Condition="'$(EnablePublicApiAnalyzer)' == ''">false</EnablePublicApiAnalyzer>
+    <EnableResxSourceGenerator Condition="'$(EnableResxSourceGenerator)' == ''">false</EnableResxSourceGenerator>
+    <EnablePerformanceSensitiveAnalyzer Condition="'$(EnablePerformanceSensitiveAnalyzer)' == ''">false</EnablePerformanceSensitiveAnalyzer>
   </PropertyGroup>
 
   <!-- Establish good defaults for scenarios where no EffectiveAnalysisLevel was set (e.g. .NETFramework) -->
@@ -112,10 +112,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
     <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>
-    <EnableBannedApiAnalysis Condition="'$(EnableBannedApiAnalysis)' == ''">false</EnableBannedApiAnalysis>
-    <EnablePublicApiAnalysis Condition="'$(EnablePublicApiAnalysis)' == ''">false</EnablePublicApiAnalysis>
-    <EnableResxSourceGeneration Condition="'$(EnableResxSourceGeneration)' == ''">false</EnableResxSourceGeneration>
-    <EnablePerformanceSensitiveAnalysis Condition="'$(EnablePerformanceSensitiveAnalysis)' == ''">false</EnablePerformanceSensitiveAnalysis>
+    <EnableBannedApiAnalyzer Condition="'$(EnableBannedApiAnalyzer)' == ''">false</EnableBannedApiAnalyzer>
+    <EnablePublicApiAnalyzer Condition="'$(EnablePublicApiAnalyzer)' == ''">false</EnablePublicApiAnalyzer>
+    <EnableResxSourceGenerator Condition="'$(EnableResxSourceGenerator)' == ''">false</EnableResxSourceGenerator>
+    <EnablePerformanceSensitiveAnalyzer Condition="'$(EnablePerformanceSensitiveAnalyzer)' == ''">false</EnablePerformanceSensitiveAnalyzer>
   </PropertyGroup>
 
   <!-- Unconditionally import 'Microsoft.CodeAnalysis.NetAnalyzers.props' for all C# and VB projects for supporting https://github.com/dotnet/roslyn-analyzers/issues/3977 -->
@@ -131,21 +131,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- BannedApiAnalyzers build targets -->
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props"
-          Condition="$(EnableBannedApiAnalysis)" />
+          Condition="$(EnableBannedApiAnalyzer)" />
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets"
-          Condition="$(EnableBannedApiAnalysis)" />
+          Condition="$(EnableBannedApiAnalyzer)" />
 
   <!-- PublicApiAnalyzers build targets -->
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\build\Microsoft.CodeAnalysis.PublicApiAnalyzers.props"
-          Condition="$(EnablePublicApiAnalysis)" />
+          Condition="$(EnablePublicApiAnalyzer)" />
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\build\Microsoft.CodeAnalysis.PublicApiAnalyzers.targets"
-          Condition="$(EnablePublicApiAnalysis)" />
+          Condition="$(EnablePublicApiAnalyzer)" />
 
   <!-- PerformanceSensitiveAnalyzers build targets -->
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\build\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.props"
-          Condition="$(EnablePerformanceSensitiveAnalysis)" />
+          Condition="$(EnablePerformanceSensitiveAnalyzer)" />
   <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\build\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets"
-          Condition="$(EnablePerformanceSensitiveAnalysis)" />
+          Condition="$(EnablePerformanceSensitiveAnalyzer)" />
 
   <!-- .NET Analyzers -->
   <ItemGroup Condition="$(EnableNETAnalyzers)">
@@ -208,7 +208,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- BannedApi Analyzers -->
-  <ItemGroup Condition="$(EnableBannedApiAnalysis)">
+  <ItemGroup Condition="$(EnableBannedApiAnalyzer)">
     <Analyzer
       Condition="'$(Language)' == 'C#'"
       Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll"
@@ -228,7 +228,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- PublicApi Analyzers (language-neutral) -->
-  <ItemGroup Condition="$(EnablePublicApiAnalysis)">
+  <ItemGroup Condition="$(EnablePublicApiAnalyzer)">
     <Analyzer
       Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\Microsoft.CodeAnalysis.PublicApiAnalyzers.dll"
       IsImplicitlyDefined="true" />
@@ -238,7 +238,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- PerformanceSensitive Analyzers (C# only) -->
-  <ItemGroup Condition="$(EnablePerformanceSensitiveAnalysis) And '$(Language)' == 'C#'">
+  <ItemGroup Condition="$(EnablePerformanceSensitiveAnalyzer) And '$(Language)' == 'C#'">
     <Analyzer
       Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\cs\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.dll"
       IsImplicitlyDefined="true" />
@@ -251,7 +251,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!-- ResxSourceGenerator -->
-  <ItemGroup Condition="$(EnableResxSourceGeneration)">
+  <ItemGroup Condition="$(EnableResxSourceGenerator)">
     <Analyzer
       Condition="'$(Language)' == 'C#'"
       Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\resxsourcegen\cs\Microsoft.CodeAnalysis.ResxSourceGenerator.dll"
@@ -277,8 +277,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="_ResolveSdkAnalyzerConflicts"
           AfterTargets="ResolveLockFileAnalyzers"
-          Condition="$(EnableBannedApiAnalysis) Or $(EnablePublicApiAnalysis) Or
-                     $(EnablePerformanceSensitiveAnalysis) Or $(EnableResxSourceGeneration)">
+          Condition="$(EnableBannedApiAnalyzer) Or $(EnablePublicApiAnalyzer) Or
+                     $(EnablePerformanceSensitiveAnalyzer) Or $(EnableResxSourceGenerator)">
 
     <ItemGroup>
       <!-- Remove SDK-bundled BannedApiAnalyzers when the NuGet package is also referenced -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Analyzers.targets
@@ -97,6 +97,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- EnforceCodeStyleInBuild Allows code style analyzers to be disabled in bulk via msbuild if the user wants to -->
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">false</EnforceCodeStyleInBuild>
+
+    <!-- Opt-in Roslyn analyzer properties. These are always opt-in regardless of AnalysisLevel. -->
+    <EnableBannedApiAnalysis Condition="'$(EnableBannedApiAnalysis)' == ''">false</EnableBannedApiAnalysis>
+    <EnablePublicApiAnalysis Condition="'$(EnablePublicApiAnalysis)' == ''">false</EnablePublicApiAnalysis>
+    <EnableResxSourceGeneration Condition="'$(EnableResxSourceGeneration)' == ''">false</EnableResxSourceGeneration>
+    <EnablePerformanceSensitiveAnalysis Condition="'$(EnablePerformanceSensitiveAnalysis)' == ''">false</EnablePerformanceSensitiveAnalysis>
   </PropertyGroup>
 
   <!-- Establish good defaults for scenarios where no EffectiveAnalysisLevel was set (e.g. .NETFramework) -->
@@ -118,6 +124,24 @@ Copyright (c) .NET Foundation. All rights reserved.
           Condition="'$(Language)' == 'C#'" />
   <Import Project="$(MSBuildThisFileDirectory)..\codestyle\vb\build\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.targets"
           Condition="'$(Language)' == 'VB'" />
+
+  <!-- BannedApiAnalyzers build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props"
+          Condition="$(EnableBannedApiAnalysis)" />
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets"
+          Condition="$(EnableBannedApiAnalysis)" />
+
+  <!-- PublicApiAnalyzers build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\build\Microsoft.CodeAnalysis.PublicApiAnalyzers.props"
+          Condition="$(EnablePublicApiAnalysis)" />
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\build\Microsoft.CodeAnalysis.PublicApiAnalyzers.targets"
+          Condition="$(EnablePublicApiAnalysis)" />
+
+  <!-- PerformanceSensitiveAnalyzers build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\build\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.props"
+          Condition="$(EnablePerformanceSensitiveAnalysis)" />
+  <Import Project="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\build\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets"
+          Condition="$(EnablePerformanceSensitiveAnalysis)" />
 
   <!-- .NET Analyzers -->
   <ItemGroup Condition="$(EnableNETAnalyzers)">
@@ -178,5 +202,133 @@ Copyright (c) .NET Foundation. All rights reserved.
       Include="$(MSBuildThisFileDirectory)..\codestyle\vb\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.dll"
       IsImplicitlyDefined="true" />
   </ItemGroup>
+
+  <!-- BannedApi Analyzers -->
+  <ItemGroup Condition="$(EnableBannedApiAnalysis)">
+    <Analyzer
+      Condition="'$(Language)' == 'C#'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'C#'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'VB'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\vb\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'VB'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\bannedapi\vb\Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!-- PublicApi Analyzers (language-neutral) -->
+  <ItemGroup Condition="$(EnablePublicApiAnalysis)">
+    <Analyzer
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\Microsoft.CodeAnalysis.PublicApiAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\publicapi\Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.dll"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!-- PerformanceSensitive Analyzers (C# only) -->
+  <ItemGroup Condition="$(EnablePerformanceSensitiveAnalysis) And '$(Language)' == 'C#'">
+    <Analyzer
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\cs\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\cs\Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\performancesensitive\cs\Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes.dll"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!-- ResxSourceGenerator -->
+  <ItemGroup Condition="$(EnableResxSourceGeneration)">
+    <Analyzer
+      Condition="'$(Language)' == 'C#'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\resxsourcegen\cs\Microsoft.CodeAnalysis.ResxSourceGenerator.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'C#'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\resxsourcegen\cs\Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'VB'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\resxsourcegen\vb\Microsoft.CodeAnalysis.ResxSourceGenerator.dll"
+      IsImplicitlyDefined="true" />
+    <Analyzer
+      Condition="'$(Language)' == 'VB'"
+      Include="$(MSBuildThisFileDirectory)..\roslynanalyzers\resxsourcegen\vb\Microsoft.CodeAnalysis.ResxSourceGenerator.VisualBasic.dll"
+      IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!--
+    When a user also references these analyzer packages directly via NuGet, remove the SDK-bundled copies
+    to avoid duplicate analyzer diagnostics. NuGet-resolved analyzers carry NuGetPackageId metadata, so we
+    detect them after ResolvePackageAssets and remove our IsImplicitlyDefined copies.
+  -->
+  <Target Name="_ResolveSdkAnalyzerConflicts"
+          AfterTargets="ResolveLockFileAnalyzers"
+          Condition="$(EnableBannedApiAnalysis) Or $(EnablePublicApiAnalysis) Or
+                     $(EnablePerformanceSensitiveAnalysis) Or $(EnableResxSourceGeneration)">
+
+    <ItemGroup>
+      <!-- Remove SDK-bundled BannedApiAnalyzers when the NuGet package is also referenced -->
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.BannedApiAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.BannedApiAnalyzers'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.BannedApiAnalyzers'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.BannedApiAnalyzers'))" />
+
+      <!-- Remove SDK-bundled PublicApiAnalyzers when the NuGet package is also referenced -->
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.PublicApiAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.PublicApiAnalyzers'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.PublicApiAnalyzers'))" />
+
+      <!-- Remove SDK-bundled PerformanceSensitiveAnalyzers when the NuGet package is also referenced -->
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers'))" />
+
+      <!-- Remove SDK-bundled ResxSourceGenerator when the NuGet package is also referenced -->
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.ResxSourceGenerator' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.ResxSourceGenerator'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.ResxSourceGenerator'))" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.IsImplicitlyDefined)' == 'true' And
+                           '%(Filename)' == 'Microsoft.CodeAnalysis.ResxSourceGenerator.VisualBasic' And
+                           @(Analyzer->AnyHaveMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.ResxSourceGenerator'))" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
+++ b/src/Tasks/sdk-tasks/GenerateRuntimeAnalyzersSWR.cs
@@ -49,6 +49,10 @@ namespace Microsoft.DotNet.Cli.Build
                       "WebSDKAnalyzers",
                       @$"{installDir}\WebSDKAnalyzers");
 
+            AddFolder(sb,
+                      "RoslynAnalyzers",
+                      @$"{installDir}\RoslynAnalyzers");
+
             File.WriteAllText(OutputFile, sb.ToString());
 
             return true;


### PR DESCRIPTION
## Ship Roslyn analyzers (BannedApi, PublicApi, PerformanceSensitive, ResxSourceGenerator) in the SDK

This change bundles four additional Roslyn analyzer packages into the SDK layout, following the same pattern used for CodeStyle and NetAnalyzers today:

- **Microsoft.CodeAnalysis.BannedApiAnalyzers**
- **Microsoft.CodeAnalysis.PublicApiAnalyzers**
- **Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers**
- **Microsoft.CodeAnalysis.ResxSourceGenerator**

### Opt-in properties

All four are **opt-in** (default `false`). Users enable them by setting the corresponding MSBuild property:

| Property | Analyzer |
|----------|----------|
| `EnableBannedApiAnalysis` | BannedApiAnalyzers |
| `EnablePublicApiAnalysis` | PublicApiAnalyzers |
| `EnablePerformanceSensitiveAnalysis` | PerformanceSensitiveAnalyzers |
| `EnableResxSourceGeneration` | ResxSourceGenerator |

### NuGet package dedup

When a project also references one of these packages directly via NuGet, the SDK-bundled copy is automatically removed to avoid duplicate diagnostics. This is handled entirely on the SDK side (via the `_ResolveSdkAnalyzerConflicts` target) so that it works correctly even against older NuGet package versions that have no awareness of the SDK-bundled analyzers.

### What changed

- **`redist.csproj`** — Added `PackageReference` entries (with `ExcludeAssets="All" GeneratePathProperty="true"`) so the packages are downloaded for layout extraction.
- **`GenerateLayout.targets`** — Extended `PublishNETAnalyzers` to copy analyzer DLLs and build assets into `roslynanalyzers/` subdirectories of the SDK layout.
- **`Microsoft.NET.Sdk.Analyzers.targets`** — Added Enable\* property defaults, `<Import>` of each package's `.props`/`.targets`, `<Analyzer>` item groups gated on the Enable\* properties, and the `_ResolveSdkAnalyzerConflicts` dedup target.
- **`Version.Details.xml` / `Version.Details.props` / `Directory.Packages.props`** — Added version entries for the three new packages (PublicApiAnalyzers already existed).