### PR TITLE
Enable R2R crossgen for DotnetTools .NET Core assemblies

### DIFF
--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -88,8 +88,8 @@
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(InstallerOutputDirectory)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
 
-      <!-- Don't CrossGen bundled DotnetTools -->
-      <RemainingFiles Remove="$(InstallerOutputDirectory)DotnetTools\**\*" />
+      <!-- Don't CrossGen .NET Framework components of DotnetTools -->
+      <RemainingFiles Remove="$(InstallerOutputDirectory)DotnetTools\**\BuildHost-net472\**\*" />
 
       <!-- Don't crossgen satellite assemblies -->
       <RoslynFiles Remove="$(InstallerOutputDirectory)Roslyn\bincore\**\*.resources.dll" />


### PR DESCRIPTION
DotnetTools (dotnet-format, dotnet-watch, dotnet-user-jwts, etc.) were blanket-excluded from crossgen, causing their .NET Core assemblies to ship as pure IL. This prevented deduplication with the R2R copies of the same assemblies elsewhere in the SDK layout, resulting in ~20 MB of unnecessary duplicate content.

Narrow the exclusion to only the BuildHost-net472 subdirectories, which contain .NET Framework assemblies that cannot be crossgenned. The .NET Core assemblies in DotnetTools will now be R2R compiled, matching the rest of the SDK and enabling deduplication via hardlinks/symlinks.

Related to https://github.com/dotnet/sdk/issues/52182