### PR TITLE
Improve shutdown sequence of Aspire service and fix race condition

### DIFF
--- a/src/Dotnet.Watch/.editorconfig
+++ b/src/Dotnet.Watch/.editorconfig
@@ -14,12 +14,14 @@ dotnet_diagnostic.CA2008.severity = none # Do not create tasks without passing a
 
 # CS - C# compiler warnings/errors
 dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
-dotnet_diagnostic.CS1573.severity = none # Parameter 'sourceFile' has no matching param tag in the XML comment
+dotnet_diagnostic.CS1573.severity = none # Parameter has no matching param tag in the XML comment
+dotnet_diagnostic.CS1572.severity = warning # XML comment has a param tag for '...', but there is no parameter by that name
 
 # IDE - IDE/Style warnings
 dotnet_diagnostic.IDE0005.severity = none # Using directive is unnecessary
 dotnet_diagnostic.IDE0011.severity = none # Add braces
 dotnet_diagnostic.IDE0036.severity = none # Order modifiers
+dotnet_diagnostic.IDE0044.severity = none # Make field readonly
 dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter
 dotnet_diagnostic.IDE0073.severity = none # File header does not match required text
 dotnet_diagnostic.IDE0161.severity = none # Convert to file-scoped namespace

--- a/src/Dotnet.Watch/AspireService/AspireServerService.cs
+++ b/src/Dotnet.Watch/AspireService/AspireServerService.cs
@@ -42,7 +42,12 @@ internal partial class AspireServerService : IAsyncDisposable
     private readonly string _currentSecret;
     private readonly string _displayName;
 
-    private readonly CancellationTokenSource _shutdownCancellationTokenSource = new();
+    /// <summary>
+    /// Triggered when the shutdown process has been initiated.
+    /// During this time all requests respond with <see cref="HttpStatusCode.ServiceUnavailable"/>.
+    /// </summary>
+    private readonly CancellationTokenSource _shutdownCancellationSource = new();
+
     private readonly int _port;
     private readonly X509Certificate2 _certificate;
     private readonly string _certificateEncodedBytes;
@@ -91,12 +96,20 @@ internal partial class AspireServerService : IAsyncDisposable
         _requestListener = StartListeningAsync();
     }
 
+    public void InitiateShutdown()
+    {
+        Log("Server shutdown initiated.");
+        _shutdownCancellationSource.Cancel();
+
+        // TODO: send message to DCP
+        // https://github.com/dotnet/aspire/issues/14987
+    }
+
     public async ValueTask DisposeAsync()
     {
-        // Shutdown the service:
-        _shutdownCancellationTokenSource.Cancel();
+        Log("Disposing server ...");
 
-        Log("Waiting for server to shutdown ...");
+        _shutdownCancellationSource.Cancel();
 
         try
         {
@@ -111,7 +124,7 @@ internal partial class AspireServerService : IAsyncDisposable
 
         _socketConnectionManager.Dispose();
         _certificate.Dispose();
-        _shutdownCancellationTokenSource.Dispose();
+        _shutdownCancellationSource.Dispose();
     }
 
     /// <inheritdoc/>
@@ -214,14 +227,14 @@ internal partial class AspireServerService : IAsyncDisposable
         var app = builder.Build();
 
         app.MapGet("/", () => _displayName);
-        app.MapGet(InfoResponse.Url, GetInfoAsync);
+        app.MapGet(InfoResponse.Url, HandleInfoRequestAsync);
 
         // Set up the run session endpoints
         var runSessionApi = app.MapGroup(RunSessionRequest.Url);
 
-        runSessionApi.MapPut("/", RunSessionPutAsync);
-        runSessionApi.MapDelete("/{sessionId}", RunSessionDeleteAsync);
-        runSessionApi.Map(SessionNotification.Url, RunSessionNotifyAsync);
+        runSessionApi.MapPut("/", HandleStartSessionRequestAsync);
+        runSessionApi.MapDelete("/{sessionId}", HandleStopSessionRequestAsync);
+        runSessionApi.Map(SessionNotification.Url, HandleSessionNotifyRequestAsync);
 
         app.UseWebSockets(new WebSocketOptions
         {
@@ -229,62 +242,48 @@ internal partial class AspireServerService : IAsyncDisposable
         });
 
         // Run the application async. It will shutdown when the cancel token is signaled
-        return app.RunAsync(_shutdownCancellationTokenSource.Token);
+        return app.RunAsync(_shutdownCancellationSource.Token);
     }
 
-    private async Task RunSessionPutAsync(HttpContext context)
+    private bool TryAcceptRequest(HttpContext context)
     {
+        if (_shutdownCancellationSource.IsCancellationRequested)
+        {
+            Log("Service unavailable -- shutdown in progress.");
+            context.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
+            return false;
+        }
+
         // Check the authentication header
         if (!IsValidAuthentication(context))
         {
             Log("Authorization failure");
             context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+            return false;
         }
-        else
-        {
-            await HandleStartSessionRequestAsync(context);
-        }
+
+        return true;
     }
 
-    private async Task RunSessionDeleteAsync(HttpContext context, string sessionId)
+    private async Task HandleInfoRequestAsync(HttpContext context)
     {
-        // Check the authentication header
-        if (!IsValidAuthentication(context))
+        if (!TryAcceptRequest(context))
         {
-            Log("Authorization failure");
-            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-        }
-        else
-        {
-            await HandleStopSessionRequestAsync(context, sessionId);
-        }
-    }
-
-    private async Task GetInfoAsync(HttpContext context)
-    {
-        // Check the authentication header
-        if (!IsValidAuthentication(context))
-        {
-            Log("Authorization failure");
-            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-        }
-        else
-        {
-            context.Response.StatusCode = (int)HttpStatusCode.OK;
-            await context.Response.WriteAsJsonAsync(InfoResponse.Instance, JsonSerializerOptions, _shutdownCancellationTokenSource.Token);
-        }
-    }
-
-    private async Task RunSessionNotifyAsync(HttpContext context)
-    {
-        // Check the authentication header
-        if (!IsValidAuthentication(context))
-        {
-            Log("Authorization failure");
-            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
             return;
         }
-        else if (!context.WebSockets.IsWebSocketRequest)
+
+        context.Response.StatusCode = (int)HttpStatusCode.OK;
+        await context.Response.WriteAsJsonAsync(InfoResponse.Instance, JsonSerializerOptions, _shutdownCancellationSource.Token);
+    }
+
+    private async Task HandleSessionNotifyRequestAsync(HttpContext context)
+    {
+        if (!TryAcceptRequest(context))
+        {
+            return;
+        }
+
+        if (!context.WebSockets.IsWebSocketRequest)
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
             return;
@@ -323,6 +322,11 @@ internal partial class AspireServerService : IAsyncDisposable
 
     private async Task HandleStartSessionRequestAsync(HttpContext context)
     {
+        if (!TryAcceptRequest(context))
+        {
+            return;
+        }
+
         string? projectPath = null;
 
         try
@@ -333,7 +337,7 @@ internal partial class AspireServerService : IAsyncDisposable
             }
 
             // Get the project launch request data
-            var projectLaunchRequest = await context.GetProjectLaunchInformationAsync(_shutdownCancellationTokenSource.Token);
+            var projectLaunchRequest = await context.GetProjectLaunchInformationAsync(_shutdownCancellationSource.Token);
             if (projectLaunchRequest == null)
             {
                 // Unknown or unsupported version
@@ -343,7 +347,7 @@ internal partial class AspireServerService : IAsyncDisposable
 
             projectPath = projectLaunchRequest.ProjectPath;
 
-            var sessionId = await _aspireServerEvents.StartProjectAsync(context.GetDcpId(), projectLaunchRequest, _shutdownCancellationTokenSource.Token);
+            var sessionId = await _aspireServerEvents.StartProjectAsync(context.GetDcpId(), projectLaunchRequest, _shutdownCancellationSource.Token);
 
             context.Response.StatusCode = (int)HttpStatusCode.Created;
             context.Response.Headers.Location = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}/{sessionId}";
@@ -370,14 +374,14 @@ internal partial class AspireServerService : IAsyncDisposable
                 Error = new ErrorDetail { ErrorCode = errorCode, Message = ex.GetMessageFromException() }
             };
 
-            await response.WriteAsJsonAsync(error, JsonSerializerOptions, _shutdownCancellationTokenSource.Token);
+            await response.WriteAsJsonAsync(error, JsonSerializerOptions, _shutdownCancellationSource.Token);
         }
         else
         {
             errorResponse = Encoding.UTF8.GetBytes(ex.GetMessageFromException());
             response.ContentType = "text/plain";
             response.ContentLength = errorResponse.Length;
-            await response.WriteAsync(ex.GetMessageFromException(), _shutdownCancellationTokenSource.Token);
+            await response.WriteAsync(ex.GetMessageFromException(), _shutdownCancellationSource.Token);
         }
     }
 
@@ -394,7 +398,7 @@ internal partial class AspireServerService : IAsyncDisposable
         try
         {
             using var cancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken, _shutdownCancellationTokenSource.Token, connection.HttpRequestAborted);
+                cancellationToken, _shutdownCancellationSource.Token, connection.HttpRequestAborted);
 
             await _webSocketAccess.WaitAsync(cancelTokenSource.Token);
             await connection.Socket.SendAsync(new ArraySegment<byte>(messageBytes), WebSocketMessageType.Text, endOfMessage: true, cancelTokenSource.Token);
@@ -415,8 +419,13 @@ internal partial class AspireServerService : IAsyncDisposable
         return success;
     }
 
-    private async ValueTask HandleStopSessionRequestAsync(HttpContext context, string sessionId)
+    private async Task HandleStopSessionRequestAsync(HttpContext context, string sessionId)
     {
+        if (!TryAcceptRequest(context))
+        {
+            return;
+        }
+
         try
         {
             if (_isDisposed)
@@ -424,7 +433,7 @@ internal partial class AspireServerService : IAsyncDisposable
                 throw new ObjectDisposedException(nameof(AspireServerService), "Received 'DELETE /run_session' request after the service has been disposed.");
             }
 
-            var sessionExists = await _aspireServerEvents.StopSessionAsync(context.GetDcpId(), sessionId, _shutdownCancellationTokenSource.Token);
+            var sessionExists = await _aspireServerEvents.StopSessionAsync(context.GetDcpId(), sessionId, _shutdownCancellationSource.Token);
             context.Response.StatusCode = (int)(sessionExists ? HttpStatusCode.OK : HttpStatusCode.NoContent);
         }
         catch (Exception e) when (e is not OperationCanceledException)

--- a/src/Dotnet.Watch/HotReloadClient/ClientTransport.cs
+++ b/src/Dotnet.Watch/HotReloadClient/ClientTransport.cs
@@ -44,5 +44,10 @@ internal abstract class ClientTransport : IDisposable
     /// </summary>
     public abstract ValueTask<ClientTransportResponse?> ReadAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// True if <paramref name="exception"/> and <paramref name="cancellationToken"/> indicate an expected connection termination signal.
+    /// </summary>
+    public abstract bool IsExpectedConnectionTermination(Exception exception, CancellationToken cancellationToken);
+
     public abstract void Dispose();
 }

--- a/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.HotReload
                 {
                     // Don't report a warning when cancelled. The process has terminated or the host is shutting down in that case.
                     // Best effort: There is an inherent race condition due to time between the process exiting and the cancellation token triggering.
-                    if (!cancellationToken.IsCancellationRequested)
+                    if (!transport.IsExpectedConnectionTermination(e, cancellationToken))
                     {
                         Logger.LogError("Failed to read capabilities: {Message}", e.Message);
                     }
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.HotReload
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
-                if (!cancellationToken.IsCancellationRequested)
+                if (!transport.IsExpectedConnectionTermination(e, cancellationToken))
                 {
                     Logger.LogError("Failed to read response: {Exception}", e.ToString());
                 }

--- a/src/Dotnet.Watch/HotReloadClient/NamedPipeClientTransport.cs
+++ b/src/Dotnet.Watch/HotReloadClient/NamedPipeClientTransport.cs
@@ -50,30 +50,14 @@ internal sealed class NamedPipeClientTransport : ClientTransport
     public override async Task WaitForConnectionAsync(CancellationToken cancellationToken)
     {
         _logger.LogDebug("Waiting for application to connect to pipe '{NamedPipeName}'.", _namedPipeName);
-
-        try
-        {
-            await _pipe.WaitForConnectionAsync(cancellationToken);
-        }
-        catch (Exception e) when (e is not OperationCanceledException)
-        {
-            // The process may die while we're waiting for the connection and the pipe may be disposed.
-            // Log and let subsequent ReadAsync return null gracefully.
-            if (IsExpectedPipeException(e, cancellationToken))
-            {
-                _logger.LogDebug("Pipe connection ended: {Message}", e.Message);
-                return;
-            }
-
-            throw;
-        }
+        await _pipe.WaitForConnectionAsync(cancellationToken);
     }
 
     /// <summary>
     /// Returns true if the exception is expected when the pipe is disposed or the process has terminated.
     /// On Unix named pipes can also throw SocketException with ErrorCode 125 (Operation canceled) when disposed.
     /// </summary>
-    private static bool IsExpectedPipeException(Exception e, CancellationToken cancellationToken)
+    public override bool IsExpectedConnectionTermination(Exception e, CancellationToken cancellationToken)
     {
         return e is ObjectDisposedException or EndOfStreamException or SocketException { ErrorCode: 125 }
             || cancellationToken.IsCancellationRequested;
@@ -93,16 +77,8 @@ internal sealed class NamedPipeClientTransport : ClientTransport
 
     public override async ValueTask<ClientTransportResponse?> ReadAsync(CancellationToken cancellationToken)
     {
-        try
-        {
-            var type = (ResponseType)await _pipe.ReadByteAsync(cancellationToken);
-            return new ClientTransportResponse(type, _pipe, disposeStream: false);
-        }
-        catch (Exception e) when (e is not OperationCanceledException && IsExpectedPipeException(e, cancellationToken))
-        {
-            // Pipe has been disposed or the process has terminated.
-            return null;
-        }
+        var type = (ResponseType)await _pipe.ReadByteAsync(cancellationToken);
+        return new ClientTransportResponse(type, _pipe, disposeStream: false);
     }
 
     public override void Dispose()

--- a/src/Dotnet.Watch/HotReloadClient/Web/KestrelWebSocketServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/KestrelWebSocketServer.cs
@@ -39,10 +39,6 @@ internal sealed class KestrelWebSocketServer(IHost host, ImmutableArray<string> 
     /// <summary>
     /// Starts the Kestrel WebSocket server.
     /// </summary>
-    /// <param name="hostName">Host name to bind to</param>
-    /// <param name="port">HTTP port to bind to (0 for auto-assign)</param>
-    /// <param name="securePort">HTTPS port to bind to in addition to HTTP port. Null to skip HTTPS.</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     public static async ValueTask<KestrelWebSocketServer> StartServerAsync(WebSocketConfig config, RequestDelegate requestHandler, CancellationToken cancellationToken)
     {
         var host = new HostBuilder()

--- a/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
+++ b/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
@@ -43,6 +43,9 @@ internal sealed class WebSocketClientTransport : ClientTransport
         _handler.Dispose();
     }
 
+    public override bool IsExpectedConnectionTermination(Exception exception, CancellationToken cancellationToken)
+        => cancellationToken.IsCancellationRequested;
+
     /// <summary>
     /// Creates and starts a new <see cref="WebSocketClientTransport"/> instance.
     /// </summary>

--- a/src/Dotnet.Watch/Watch.Aspire/Server/AspireServerLauncher.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/AspireServerLauncher.cs
@@ -3,12 +3,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.Threading.Channels;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
-using Microsoft.DotNet.HotReload;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Microsoft.DotNet.Watch;
 

--- a/src/Dotnet.Watch/Watch.Aspire/Server/AspireWatcherLauncher.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/AspireWatcherLauncher.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch;

--- a/src/Dotnet.Watch/Watch.Aspire/Server/ProcessLauncherFactory.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/ProcessLauncherFactory.cs
@@ -7,7 +7,6 @@ using System.IO.Pipes;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Channels;
-using Aspire.Tools.Service;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;

--- a/src/Dotnet.Watch/Watch.Aspire/Server/StatusReportingLoggerFactory.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/StatusReportingLoggerFactory.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DotNet.Watch;
 
 /// <summary>
 /// Intercepts select log messages reported by watch and forwards them to <see cref="WatchStatusWriter"/> to be sent to an external listener.
+/// Does not own (dispose) <paramref name="writer"/> and <paramref name="underlyingFactory"/>.
 /// </summary>
 internal sealed class StatusReportingLoggerFactory(WatchStatusWriter writer, LoggerFactory underlyingFactory) : ILoggerFactory
 {

--- a/src/Dotnet.Watch/Watch.Aspire/Server/WatchControlReader.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/WatchControlReader.cs
@@ -46,6 +46,8 @@ internal sealed class WatchControlReader : IAsyncDisposable
         {
             // Pipe may already be broken if the server disconnected
         }
+
+        _disposalCancellationSource.Dispose();
     }
 
     private async Task ListenAsync(CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/Watch.Aspire/Server/WatchStatusWriter.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/WatchStatusWriter.cs
@@ -1,12 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.IO.Pipes;
-using System.Reflection.Metadata;
 using System.Text.Json;
 using System.Threading.Channels;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch;

--- a/src/Dotnet.Watch/Watch.Aspire/Utilities/AspireEnvironmentVariables.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Utilities/AspireEnvironmentVariables.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.DotNet.Watch;
 
 internal static class AspireEnvironmentVariables

--- a/src/Dotnet.Watch/Watch/Aspire/AspireServiceFactory.cs
+++ b/src/Dotnet.Watch/Watch/Aspire/AspireServiceFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Channels;
@@ -46,7 +47,7 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
         private volatile bool _isDisposed;
 
         // The number of sessions whose initialization is in progress.
-        private int _pendingSessionInitializationCount;
+        private volatile int _pendingSessionInitializationCount;
 
         // Blocks disposal until no session initialization is in progress.
         private readonly SemaphoreSlim _postDisposalSessionInitializationCompleted = new(initialCount: 0, maxCount: 1);
@@ -69,14 +70,16 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
 
             _logger.LogDebug("Disposing service factory ...");
 
-            // stop accepting requests - triggers cancellation token for in-flight operations:
-            await _service.DisposeAsync();
-
-            // should not receive any more requests at this point:
             _isDisposed = true;
 
+            // should not receive any more requests at this point, triggeres cancellation of any in-flight operations:
+            _service.InitiateShutdown();
+
             // wait for all in-flight process initialization to complete:
-            await _postDisposalSessionInitializationCompleted.WaitAsync(CancellationToken.None);
+            if (_pendingSessionInitializationCount > 0)
+            {
+                await _postDisposalSessionInitializationCompleted.WaitAsync(CancellationToken.None);
+            }
 
             // terminate all active sessions:
             ImmutableArray<Session> sessions;
@@ -91,6 +94,9 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
 
             _postDisposalSessionInitializationCompleted.Dispose();
 
+            // terminate the web server:
+            await _service.DisposeAsync();
+
             _logger.LogDebug("Service factory disposed");
         }
 
@@ -102,8 +108,6 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
         /// </summary>
         async ValueTask<string> IAspireServerEvents.StartProjectAsync(string dcpId, ProjectLaunchRequest projectLaunchInfo, CancellationToken cancellationToken)
         {
-            ObjectDisposedException.ThrowIf(_isDisposed, this);
-
             var projectOptions = GetProjectOptions(projectLaunchInfo);
             var sessionId = Interlocked.Increment(ref _sessionIdDispenser).ToString(CultureInfo.InvariantCulture);
             await StartProjectAsync(dcpId, sessionId, projectOptions, isRestart: false, cancellationToken);
@@ -112,18 +116,18 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
 
         public async ValueTask StartProjectAsync(string dcpId, string sessionId, ProjectOptions projectOptions, bool isRestart, CancellationToken cancellationToken)
         {
-            // Neither request from DCP nor restart should happen once the disposal has started.
-            ObjectDisposedException.ThrowIf(_isDisposed, this);
-
-            _logger.LogDebug("[#{SessionId}] Starting: '{Path}'", sessionId, projectOptions.Representation.ProjectOrEntryPointFilePath);
-
-            RunningProject? runningProject = null;
-            var outputChannel = Channel.CreateUnbounded<OutputLine>(s_outputChannelOptions);
-
             Interlocked.Increment(ref _pendingSessionInitializationCount);
-
             try
             {
+                // Abort before launching if cancellation has been requested.
+                // This is important after shutdown has been initiated to avoid creating orphaned processes.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _logger.LogDebug("[#{SessionId}] Starting: '{Path}'", sessionId, projectOptions.Representation.ProjectOrEntryPointFilePath);
+
+                RunningProject? runningProject = null;
+                var outputChannel = Channel.CreateUnbounded<OutputLine>(s_outputChannelOptions);
+
                 runningProject = await _projectLauncher.TryLaunchProcessAsync(
                     projectOptions,
                     onOutput: line =>
@@ -169,32 +173,32 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
 
                     _sessions[sessionId] = new Session(dcpId, sessionId, runningProject, outputReader);
                 }
+
+                _logger.LogDebug("[#{SessionId}] Session started", sessionId);
+
+                async Task StartChannelReader(CancellationToken cancellationToken)
+                {
+                    try
+                    {
+                        await foreach (var line in outputChannel.Reader.ReadAllAsync(cancellationToken))
+                        {
+                            await _service.NotifyLogMessageAsync(dcpId, sessionId, isStdErr: line.IsError, data: line.Content, cancellationToken);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            _logger.LogError("Unexpected error reading output of session '{SessionId}': {Exception}", sessionId, e);
+                        }
+                    }
+                }
             }
             finally
             {
                 if (Interlocked.Decrement(ref _pendingSessionInitializationCount) == 0 && _isDisposed)
                 {
                     _postDisposalSessionInitializationCompleted.Release();
-                }
-            }
-
-            _logger.LogDebug("[#{SessionId}] Session started", sessionId);
-
-            async Task StartChannelReader(CancellationToken cancellationToken)
-            {
-                try
-                {
-                    await foreach (var line in outputChannel.Reader.ReadAllAsync(cancellationToken))
-                    {
-                        await _service.NotifyLogMessageAsync(dcpId, sessionId, isStdErr: line.IsError, data: line.Content, cancellationToken);
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        _logger.LogError("Unexpected error reading output of session '{SessionId}': {Exception}", sessionId, e);
-                    }
                 }
             }
         }

--- a/src/Dotnet.Watch/Watch/Aspire/AspireServiceFactory.cs
+++ b/src/Dotnet.Watch/Watch/Aspire/AspireServiceFactory.cs
@@ -72,7 +72,7 @@ internal class AspireServiceFactory(ProjectOptions hostProjectOptions) : IRuntim
 
             _isDisposed = true;
 
-            // should not receive any more requests at this point, triggeres cancellation of any in-flight operations:
+            // should not receive any more requests at this point, triggers cancellation of any in-flight operations:
             _service.InitiateShutdown();
 
             // wait for all in-flight process initialization to complete:

--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
@@ -140,11 +140,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 disposalCompletionSource.Token,
                 timeoutCancellation.Token);
 
-            if (!Debugger.IsAttached)
-            {
-                outputReadCancellation.CancelAfter(s_timeout);
-            }
-
             try
             {
                 while (!outputReadCancellation.IsCancellationRequested)

--- a/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/AspireHostLauncherTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/AspireHostLauncherTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.CommandLine;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;

--- a/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/AspireLauncherTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/AspireLauncherTests.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.IO.Pipes;
-using System.Reflection.Metadata;
 using System.Text.Json;
-using Elfie.Serialization;
-using Xunit.Runners;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 

--- a/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/Utilities/PipeUtilities.cs
+++ b/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/Utilities/PipeUtilities.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel.DataAnnotations;
 using System.IO.Pipes;
 using System.Text.Json;
 

--- a/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains($"[WatchAspire.Web ({tfm})] Exited");
             await App.WaitUntilOutputContains($"[WatchAspire.AppHost ({tfm})] Exited");
 
-            await App.WaitUntilOutputContains("dotnet watch ⭐ Waiting for server to shutdown ...");
+            await App.WaitUntilOutputContains("dotnet watch ⭐ Disposing server ...");
 
             // TODO: these are not reliably reported: https://github.com/dotnet/sdk/issues/53308
             //await App.WaitUntilOutputContains("dotnet watch ⭐ [#1] Stop session");


### PR DESCRIPTION
Fixes intermittent test failure observed in https://github.com/dotnet/sdk/pull/53424

Also fixes error reporting when expected exception is thrown after pipe disposal. This is a regression introduced by refactoring of named pipe transport
