### PR TITLE
Revert "Disable macOS AMD64 TemplateEngine test leg"

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -37,12 +37,10 @@ parameters:
   macOSJobParameterSets:
   - categoryName: TestBuild
     runtimeIdentifier: osx-x64
-  # Disabled due to high failure rate. See: https://github.com/dotnet/sdk/issues/51574
   - categoryName: TemplateEngine
     testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
     publishXunitResults: true
     runtimeIdentifier: osx-x64
-    disableJob: true
   - categoryName: AoT
     runAoTTests: true
     runtimeIdentifier: osx-x64


### PR DESCRIPTION
Reverts dotnet/sdk#52752

The original issue appears to have gone away so let's try reenabling. If it comes back, let's have copilot run in a loop trying things.