### PR TITLE
Implement #:ref directive for file-based apps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,7 @@ Testing:
   - Create a dogfood environment: `source eng/dogfood.sh` 
   - Test commands in the dogfood shell (e.g., `dnx --help`, `dotnet tool install --help`)
   - The dogfood script sets up PATH and environment to use the newly built SDK
+- For fast incremental iteration on specific projects (e.g., `dotnet`, `Microsoft.DotNet.ProjectTools`), use `eng/deploy-dogfood.ps1` instead of a full `build.cmd`. It builds only the specified projects and copies DLLs into the redist layout (~30s vs ~5min). Usage: `.\eng\deploy-dogfood.ps1 -Projects dotnet,Microsoft.DotNet.ProjectTools`
 
 Output Considerations:
 - When considering how output should look, solicit advice from baronfel.

--- a/eng/deploy-dogfood.ps1
+++ b/eng/deploy-dogfood.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+  Incrementally builds changed SDK projects and deploys DLLs into the dogfood redist layout.
+  Much faster than running build.cmd (~seconds vs ~minutes).
+
+.PARAMETER Projects
+  Names of projects to build and deploy (without .csproj extension).
+  Defaults to the common file-based-programs projects.
+
+.EXAMPLE
+  .\eng\deploy-dogfood.ps1
+  .\eng\deploy-dogfood.ps1 -Projects dotnet,Microsoft.DotNet.ProjectTools
+#>
+param(
+    [string[]]$Projects = @(
+        "dotnet",
+        "Microsoft.DotNet.ProjectTools"
+    )
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Split-Path $PSScriptRoot -Parent)
+
+$dotnet = Join-Path $repoRoot ".dotnet\dotnet"
+$sdkVersion = (Get-ChildItem (Join-Path $repoRoot "artifacts\bin\redist\Debug\dotnet\sdk") -Directory | Select-Object -First 1).Name
+if (-not $sdkVersion) {
+    Write-Error "No SDK version found in redist layout. Run build.cmd first."
+    exit 1
+}
+
+$redistTargets = @(
+    "artifacts\bin\redist\Debug\dotnet\sdk\$sdkVersion",
+    "artifacts\bin\redist\Debug\dotnet-installer\sdk\$sdkVersion"
+)
+
+foreach($proj in $Projects) {
+    # Find the .csproj file.
+    $csprojFiles = Get-ChildItem $repoRoot -Recurse -Filter "$proj.csproj" |
+        Where-Object { $_.FullName -notmatch "\\test\\" -and $_.FullName -notmatch "\\artifacts\\" }
+
+    if ($csprojFiles.Count -eq 0) {
+        Write-Warning "Project '$proj' not found, skipping."
+        continue
+    }
+
+    $csproj = $csprojFiles[0].FullName
+    Write-Host "Building $proj..." -ForegroundColor Cyan
+
+    & $dotnet build $csproj --no-restore -nologo -consoleLoggerParameters:NoSummary 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Build failed for $proj"
+        exit 1
+    }
+
+    # Find the built DLL by discovering the TFM folder dynamically.
+    $binDir = Join-Path $repoRoot "artifacts\bin\$proj\Debug"
+    $builtDll = $null
+    if (Test-Path $binDir) {
+        $builtDll = Get-ChildItem $binDir -Recurse -Filter "$proj.dll" |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    }
+    if (-not $builtDll) {
+        Write-Warning "Built DLL not found for $proj under $binDir, skipping deploy."
+        continue
+    }
+    $builtDll = $builtDll.FullName
+
+    # Copy to all redist targets.
+    foreach ($target in $redistTargets) {
+        $targetPath = Join-Path $repoRoot $target
+        $destDll = Join-Path $targetPath "$proj.dll"
+        if (Test-Path $destDll) {
+            Copy-Item $builtDll $destDll -Force
+            # Also copy PDB if available.
+            $builtPdb = [IO.Path]::ChangeExtension($builtDll, ".pdb")
+            $destPdb = [IO.Path]::ChangeExtension($destDll, ".pdb")
+            if (Test-Path $builtPdb) {
+                Copy-Item $builtPdb $destPdb -Force
+            }
+            Write-Host "  Deployed to $target" -ForegroundColor Green
+        }
+    }
+
+    # Also check dotnet-watch tool location.
+    foreach ($target in $redistTargets) {
+        $watchToolDir = Join-Path $repoRoot "$target\DotnetTools\dotnet-watch\$sdkVersion\tools"
+        if (Test-Path $watchToolDir) {
+            $watchDll = Get-ChildItem $watchToolDir -Recurse -Filter "$proj.dll" | Select-Object -First 1
+            if ($watchDll) {
+                Copy-Item $builtDll $watchDll.FullName -Force
+                Write-Host "  Deployed to dotnet-watch in $target" -ForegroundColor Green
+            }
+        }
+    }
+}
+
+Write-Host "`nDone! Dogfood SDK updated." -ForegroundColor Green

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileBasedProgramsResources.resx
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileBasedProgramsResources.resx
@@ -165,6 +165,14 @@
     <value>The '#:project' directive is invalid: {0}</value>
     <comment>{0} is the inner error message.</comment>
   </data>
+  <data name="InvalidRefDirective" xml:space="preserve">
+    <value>The '#:ref' directive is invalid: {0}</value>
+    <comment>{Locked="#:ref"}{0} is the inner error message.</comment>
+  </data>
+  <data name="CouldNotFindRefFile" xml:space="preserve">
+    <value>Could not find file `{0}`.</value>
+    <comment>{0} is the file path.</comment>
+  </data>
   <data name="MissingDirectiveName" xml:space="preserve">
     <value>Missing name of '{0}'.</value>
     <comment>{0} is the directive name like 'package' or 'sdk'.</comment>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -323,6 +323,7 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
             case "property": return Property.Parse(context);
             case "package": return Package.Parse(context);
             case "project": return Project.Parse(context);
+            case "ref": return Ref.Parse(context);
             case "include" or "exclude": return IncludeOrExclude.Parse(context);
             default:
                 context.ReportError(string.Format(FileBasedProgramsResources.UnrecognizedDirective, context.DirectiveKind));
@@ -585,6 +586,105 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
         }
 
         public override string ToString() => $"#:project {Name}";
+    }
+
+    /// <summary>
+    /// <c>#:ref</c> directive. References another file-based app.
+    /// </summary>
+    public sealed class Ref : Named
+    {
+        [SetsRequiredMembers]
+        public Ref(in ParseInfo info, string name) : base(info)
+        {
+            Name = name;
+            OriginalName = name;
+        }
+
+        /// <summary>
+        /// Preserved across <see cref="WithName"/> calls, i.e.,
+        /// this is the original directive text as entered by the user.
+        /// </summary>
+        public string OriginalName { get; init; }
+
+        /// <summary>
+        /// This is the <see cref="OriginalName"/> with MSBuild <c>$(..)</c> vars expanded.
+        /// </summary>
+        public string? ExpandedName { get; init; }
+
+        /// <summary>
+        /// The resolved full path to the referenced <c>.cs</c> file.
+        /// </summary>
+        public string? ResolvedPath { get; init; }
+
+        public static new Ref? Parse(in ParseContext context)
+        {
+            var directiveText = context.DirectiveText;
+            if (directiveText.IsWhiteSpace())
+            {
+                context.ReportError(string.Format(FileBasedProgramsResources.MissingDirectiveName, context.DirectiveKind));
+                return null;
+            }
+
+            return new Ref(context.Info, directiveText);
+        }
+
+        public enum NameKind
+        {
+            /// <summary>
+            /// Change <see cref="Named.Name"/> and <see cref="ExpandedName"/>.
+            /// </summary>
+            Expanded = 1,
+
+            /// <summary>
+            /// Change <see cref="Named.Name"/> and <see cref="ResolvedPath"/>.
+            /// </summary>
+            Resolved = 2,
+
+            /// <summary>
+            /// Change only <see cref="Named.Name"/>.
+            /// </summary>
+            Final = 3,
+        }
+
+        public Ref WithName(string name, NameKind kind)
+        {
+            return new Ref(Info, name)
+            {
+                OriginalName = OriginalName,
+                ExpandedName = kind == NameKind.Expanded ? name : ExpandedName,
+                ResolvedPath = kind == NameKind.Resolved ? name : ResolvedPath,
+            };
+        }
+
+        /// <summary>
+        /// Resolves the directive path to a full file path and validates the file exists.
+        /// </summary>
+        public Ref EnsureResolvedPath(ErrorReporter errorReporter)
+        {
+            var sourcePath = Info.SourceFile.Path;
+
+            var sourceDirectory = Path.GetDirectoryName(sourcePath)
+                ?? throw new InvalidOperationException($"Source file path '{sourcePath}' does not have a containing directory.");
+
+            var resolvedFilePath = Path.GetFullPath(Path.Combine(sourceDirectory, Name.Replace('\\', '/')));
+
+            if (!File.Exists(resolvedFilePath))
+            {
+                errorReporter(Info.SourceFile.Text, sourcePath, Info.Span,
+                    string.Format(FileBasedProgramsResources.InvalidRefDirective,
+                        string.Format(FileBasedProgramsResources.CouldNotFindRefFile, resolvedFilePath)));
+            }
+
+            // Name keeps the (possibly relative) display path; ResolvedPath stores the full path.
+            return new Ref(Info, Name)
+            {
+                OriginalName = OriginalName,
+                ExpandedName = ExpandedName,
+                ResolvedPath = resolvedFilePath,
+            };
+        }
+
+        public override string ToString() => $"#:ref {Name}";
     }
 
     public enum IncludeOrExcludeKind

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
@@ -71,6 +71,20 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property.Property(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info) -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property.Value.get -> string!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property.Value.init -> void
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.EnsureResolvedPath(Microsoft.DotNet.FileBasedPrograms.ErrorReporter! errorReporter) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref!
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.ExpandedName.get -> string?
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.ExpandedName.init -> void
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind.Expanded = 1 -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind.Final = 3 -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind.Resolved = 2 -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.OriginalName.get -> string!
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.OriginalName.init -> void
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.Ref(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info, string! name) -> void
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.ResolvedPath.get -> string?
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.ResolvedPath.init -> void
+Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.WithName(string! name, Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.NameKind kind) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Sdk(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info) -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Version.get -> string?
@@ -123,6 +137,7 @@ override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.ToS
 override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Package.ToString() -> string!
 override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Project.ToString() -> string!
 override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property.ToString() -> string!
+override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.ToString() -> string!
 override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.ToString() -> string!
 override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang.ToString() -> string!
 override Microsoft.DotNet.FileBasedPrograms.SourceFile.GetHashCode() -> int
@@ -134,6 +149,7 @@ static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Package.Parse(in Micro
 static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Parse(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseContext context) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named?
 static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Project.Parse(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseContext context) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Project?
 static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property.Parse(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseContext context) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Property?
+static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref.Parse(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseContext context) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Ref?
 static Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Parse(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseContext context) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk?
 static Microsoft.DotNet.FileBasedPrograms.ErrorReporters.CreateCollectingReporter(out System.Collections.Immutable.ImmutableArray<Microsoft.DotNet.FileBasedPrograms.SimpleDiagnostic!>.Builder! builder) -> Microsoft.DotNet.FileBasedPrograms.ErrorReporter!
 static Microsoft.DotNet.FileBasedPrograms.ExternalHelpers.CombineHashCodes(int value1, int value2) -> int

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Nenašel se projekt ani adresář {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">chyba</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">Direktiva #:project je neplatná: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.de.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Das Projekt oder Verzeichnis "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">Fehler</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">Die Anweisung „#:p roject“ ist ungültig: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.es.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">No se encuentra el proyecto o directorio "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">error</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">La directiva "#:project" no es válida: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Projet ou répertoire '{0}' introuvable.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">erreur</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">La directive « #:project » n’est pas valide : {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.it.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Non sono stati trovati progetti o directory `{0}`.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">errore</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">La direttiva '#:project' non è valida: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">プロジェクトまたはディレクトリ `{0}` が見つかりませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">エラー</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">'#:p roject' ディレクティブが無効です: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">프로젝트 또는 디렉터리 {0}을(를) 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">오류</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">'#:p roject' 지시문이 잘못되었습니다. {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Nie można odnaleźć projektu ani katalogu „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">błąd</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">Dyrektywa „#:project” jest nieprawidłowa: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Não foi possível encontrar o projeto ou diretório ‘{0}’.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">erro</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">A diretiva '#:project' é inválida:{0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Не удалось найти проект или каталог "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">ошибка</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">Недопустимая директива "#:project": {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">`{0}` projesi veya dizini bulunamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">hata</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">‘#:project’ yönergesi geçersizdir: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">找不到项目或目录“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">错误</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">'#:project' 指令无效: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/xlf/FileBasedProgramsResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">找不到專案或目錄 `{0}`。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CouldNotFindRefFile">
+        <source>Could not find file `{0}`.</source>
+        <target state="new">Could not find file `{0}`.</target>
+        <note>{0} is the file path.</note>
+      </trans-unit>
       <trans-unit id="DirectiveError">
         <source>error</source>
         <target state="translated">錯誤</target>
@@ -56,6 +61,11 @@
         <source>The '#:project' directive is invalid: {0}</source>
         <target state="translated">'#:project' 指示詞無效: {0}</target>
         <note>{0} is the inner error message.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRefDirective">
+        <source>The '#:ref' directive is invalid: {0}</source>
+        <target state="new">The '#:ref' directive is invalid: {0}</target>
+        <note>{Locked="#:ref"}{0} is the inner error message.</note>
       </trans-unit>
       <trans-unit id="MissingDirectiveName">
         <source>Missing name of '{0}'.</source>

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -268,6 +268,26 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     continue;
                 }
 
+                // Convert #:ref directives to #:project directives pointing to the referenced file's
+                // expected converted project location (i.e., sibling directory named after the .cs file).
+                if (directive is CSharpDirective.Ref refDirective)
+                {
+                    var refPath = refDirective.ResolvedPath ?? Path.GetFullPath(Path.Combine(sourceDirectory, refDirective.Name.Replace('\\', '/')));
+                    var refName = Path.GetFileNameWithoutExtension(refPath);
+                    var refDir = Path.GetDirectoryName(refPath)!;
+
+                    // The referenced file's converted project is expected at: <refDir>/<refName>/<refName>.csproj
+                    var convertedProjectPath = Path.Combine(refDir, refName, refName + ".csproj");
+                    var relativePath = Path.GetRelativePath(relativeTo: targetDirectory, path: convertedProjectPath);
+
+                    // Create a Project directive in place of the Ref directive.
+                    result.Add(new CSharpDirective.Project(refDirective.Info, relativePath)
+                    {
+                        OriginalName = refDirective.OriginalName,
+                    });
+                    continue;
+                }
+
                 result.Add(directive);
             }
 

--- a/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/VirtualProjectBuildingCommand.cs
@@ -272,6 +272,13 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
                 Environment.SetEnvironmentVariable(key, value);
             }
 
+            // Build referenced file-based apps before the main build.
+            var refExitCode = BuildReferencedApps();
+            if (refExitCode != 0)
+            {
+                return refExitCode;
+            }
+
             // Set up MSBuild.
             ReadOnlySpan<ILogger> binaryLoggers = binaryLogger is null ? [] : [binaryLogger.Value];
             IEnumerable<ILogger> loggers = [.. binaryLoggers, consoleLogger];
@@ -500,6 +507,12 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
             if (EvaluatedDirectives.Any(static d => d is CSharpDirective.Project))
             {
                 Reporter.Verbose.WriteLine("Not saving cache because there is a project directive.");
+                return false;
+            }
+
+            if (EvaluatedDirectives.Any(static d => d is CSharpDirective.Ref))
+            {
+                Reporter.Verbose.WriteLine("Not saving cache because there is a ref directive.");
                 return false;
             }
 
@@ -1106,6 +1119,71 @@ internal sealed class VirtualProjectBuildingCommand : CommandBase
         {
             Reporter.Verbose.WriteLine($"Cannot touch folder '{directory}': {ex}");
         }
+    }
+
+    /// <summary>
+    /// Builds all file-based apps referenced via <c>#:ref</c> directives (with <c>OutputType=Library</c>).
+    /// Each referenced app is built independently using its own virtual project.
+    /// Must be called before the main app's MSBuild session starts.
+    /// </summary>
+    private int BuildReferencedApps()
+    {
+        var refDirectives = Directives.OfType<CSharpDirective.Ref>().ToArray();
+        if (refDirectives.Length == 0)
+        {
+            return 0;
+        }
+
+        foreach (var refDirective in refDirectives)
+        {
+            var refFilePath = refDirective.ResolvedPath;
+            if (refFilePath is null)
+            {
+                // Path was not resolved (e.g., file not found error already reported).
+                // Try to resolve it here for the build attempt.
+                var sourceDirectory = Path.GetDirectoryName(Builder.EntryPointFileFullPath)!;
+                refFilePath = Path.GetFullPath(Path.Combine(sourceDirectory, refDirective.Name.Replace('\\', '/')));
+            }
+
+            if (!File.Exists(refFilePath))
+            {
+                continue;
+            }
+
+            Reporter.Verbose.WriteLine($"Building referenced file-based app: {refFilePath}");
+
+            // Create MSBuildArgs for the referenced app with OutputType=Library.
+            var refGlobalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "OutputType", "Library" },
+            };
+            if (MSBuildArgs.GlobalProperties is not null)
+            {
+                foreach (var (key, value) in MSBuildArgs.GlobalProperties)
+                {
+                    refGlobalProperties.TryAdd(key, value);
+                }
+            }
+
+            var refMsbuildArgs = MSBuildArgs.CloneWithAdditionalProperties(
+                new ReadOnlyDictionary<string, string>(refGlobalProperties));
+
+            var refCommand = new VirtualProjectBuildingCommand(refFilePath, refMsbuildArgs)
+            {
+                NoRestore = NoRestore,
+                NoCache = NoCache,
+                NoBuild = NoBuild,
+                NoWriteBuildMarkers = NoWriteBuildMarkers,
+            };
+
+            var refExitCode = refCommand.Execute();
+            if (refExitCode != 0)
+            {
+                return refExitCode;
+            }
+        }
+
+        return 0;
     }
 
     private void MarkBuildStart()

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -157,7 +157,7 @@ public sealed class VirtualProjectBuilder
         ImmutableArray<CSharpDirective> directives,
         ErrorReporter reportError)
     {
-        if (!directives.Any(static d => d is CSharpDirective.Project or CSharpDirective.IncludeOrExclude))
+        if (!directives.Any(static d => d is CSharpDirective.Project or CSharpDirective.IncludeOrExclude or CSharpDirective.Ref))
         {
             return directives;
         }
@@ -175,6 +175,13 @@ public sealed class VirtualProjectBuilder
                     projectDirective = projectDirective.EnsureProjectFilePath(reportError);
 
                     builder.Add(projectDirective);
+                    break;
+
+                case CSharpDirective.Ref refDirective:
+                    refDirective = refDirective.WithName(project.ExpandString(refDirective.Name), CSharpDirective.Ref.NameKind.Expanded);
+                    refDirective = refDirective.EnsureResolvedPath(reportError);
+
+                    builder.Add(refDirective);
                     break;
 
                 case CSharpDirective.IncludeOrExclude includeOrExcludeDirective:
@@ -444,6 +451,7 @@ public sealed class VirtualProjectBuilder
         var propertyDirectives = directives.OfType<CSharpDirective.Property>();
         var packageDirectives = directives.OfType<CSharpDirective.Package>();
         var projectDirectives = directives.OfType<CSharpDirective.Project>();
+        var refDirectives = directives.OfType<CSharpDirective.Ref>();
         var includeOrExcludeDirectives = directives.OfType<CSharpDirective.IncludeOrExclude>();
 
         const string defaultSdkName = "Microsoft.NET.Sdk";
@@ -706,6 +714,48 @@ public sealed class VirtualProjectBuilder
                   </ItemGroup>
 
                 """);
+        }
+
+        if (refDirectives.Any())
+        {
+            bool hasAnyResolved = false;
+
+            foreach (var refDirective in refDirectives)
+            {
+                if (refDirective.ResolvedPath is null)
+                {
+                    // Not yet evaluated (pre-evaluation pass). Skip emitting Reference items.
+                    processedDirectives++;
+                    continue;
+                }
+
+                if (!hasAnyResolved)
+                {
+                    hasAnyResolved = true;
+                    writer.WriteLine("""
+                          <ItemGroup>
+                        """);
+                }
+
+                var resolvedPath = refDirective.ResolvedPath;
+                var refArtifactsPath = GetArtifactsPath(resolvedPath);
+                var refAssemblyName = Path.GetFileNameWithoutExtension(resolvedPath);
+                var hintPath = Path.Combine(refArtifactsPath, "bin", "$(Configuration)", refAssemblyName + ".dll");
+
+                writer.WriteLine($"""
+                        <Reference Include="{EscapeValue(refAssemblyName)}" HintPath="{EscapeValue(hintPath)}" />
+                    """);
+
+                processedDirectives++;
+            }
+
+            if (hasAnyResolved)
+            {
+                writer.WriteLine("""
+                      </ItemGroup>
+
+                    """);
+            }
         }
 
         Debug.Assert(processedDirectives + directives.OfType<CSharpDirective.Shebang>().Count() == directives.Length);

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -204,6 +204,45 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void RefDirective()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "lib.cs"), """
+            namespace MyLib;
+            public static class Greeter
+            {
+                public static string Greet(string name) => $"Hello, {name}!";
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            Console.WriteLine(MyLib.Greeter.Greet("World"));
+            """);
+
+        var expectedOutput = "Hello, World!";
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        var outputDirFullPath = Path.Join(testInstance.Path, "Project");
+        new DotnetCommand(Log, "project", "convert", "app.cs", "-o", outputDirFullPath)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        // #:ref lib.cs should become a ProjectReference to ../lib/lib.csproj
+        File.ReadAllText(Path.Join(outputDirFullPath, "app.csproj"))
+            .Should().Contain($"""
+                <ProjectReference Include="..{Path.DirectorySeparatorChar}lib{Path.DirectorySeparatorChar}lib.csproj" />
+                """);
+    }
+
+    [Fact]
     public void ProjectReference_FullPath_WithVars()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3181,6 +3181,65 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
                 string.Format(FileBasedProgramsResources.CouldNotFindRefFile, Path.Join(testInstance.Path, "nonexistent.cs"))));
     }
 
+    /// <summary>
+    /// Verifies that <c>#:ref</c> produces a metadata (assembly) reference,
+    /// meaning internal members are not accessible unless <c>InternalsVisibleTo</c> is used.
+    /// </summary>
+    [Fact]
+    public void RefDirective_InternalsNotAccessible()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "lib.cs"), """
+            namespace MyLib;
+            public static class PublicClass
+            {
+                public static string PublicMethod() => "public";
+                internal static string InternalMethod() => "internal";
+            }
+            internal static class InternalClass
+            {
+                public static string Method() => "internal class";
+            }
+            """);
+
+        // Accessing internal member should fail.
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            Console.WriteLine(MyLib.PublicClass.InternalMethod());
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdOutContaining("error CS");
+
+        // Accessing internal class should fail.
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            Console.WriteLine(MyLib.InternalClass.Method());
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdOutContaining("error CS");
+
+        // Accessing public member should succeed.
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            Console.WriteLine(MyLib.PublicClass.PublicMethod());
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("public");
+    }
+
     [Theory, CombinatorialData]
     public void IncludeDirective(
         [CombinatorialValues("Util.cs", "**/*.cs", "**/*.$(MyProp1)")] string includePattern,

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3098,6 +3098,89 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOut("Hello");
     }
 
+    [Fact]
+    public void RefDirective()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "lib.cs"), """
+            namespace MyLib;
+            public static class Greeter
+            {
+                public static string Greet(string name) => $"Hello, {name}!";
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            Console.WriteLine(MyLib.Greeter.Greet("World"));
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello, World!");
+    }
+
+    [Fact]
+    public void RefDirective_Subdirectory()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var libDir = Path.Join(testInstance.Path, "lib");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "mylib.cs"), """
+            namespace MyLib;
+            public static class Greeter
+            {
+                public static string Greet(string name) => $"Hello, {name}!";
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib/mylib.cs
+            Console.WriteLine(MyLib.Greeter.Greet("World"));
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello, World!");
+    }
+
+    [Fact]
+    public void RefDirective_Errors()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var filePath = Path.Join(testInstance.Path, "Program.cs");
+
+        // Missing name.
+        File.WriteAllText(filePath, """
+            #:ref
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErrContaining(DirectiveError(filePath, 1, FileBasedProgramsResources.MissingDirectiveName, "ref"));
+
+        // File does not exist.
+        File.WriteAllText(filePath, """
+            #:ref nonexistent.cs
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErrContaining(DirectiveError(filePath, 1, FileBasedProgramsResources.InvalidRefDirective,
+                string.Format(FileBasedProgramsResources.CouldNotFindRefFile, Path.Join(testInstance.Path, "nonexistent.cs"))));
+    }
+
     [Theory, CombinatorialData]
     public void IncludeDirective(
         [CombinatorialValues("Util.cs", "**/*.cs", "**/*.$(MyProp1)")] string includePattern,

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3240,6 +3240,43 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOut("public");
     }
 
+    /// <summary>
+    /// Verifies transitive <c>#:ref</c> references work: app.cs → lib1.cs → lib2.cs.
+    /// </summary>
+    [Fact]
+    public void RefDirective_Transitive()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "lib2.cs"), """
+            namespace Lib2;
+            public static class Base
+            {
+                public static string Value() => "from lib2";
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "lib1.cs"), """
+            #:ref lib2.cs
+            namespace Lib1;
+            public static class Middle
+            {
+                public static string Value() => $"from lib1 and {Lib2.Base.Value()}";
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib1.cs
+            Console.WriteLine(Lib1.Middle.Value());
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("from lib1 and from lib2");
+    }
+
     [Theory, CombinatorialData]
     public void IncludeDirective(
         [CombinatorialValues("Util.cs", "**/*.cs", "**/*.$(MyProp1)")] string includePattern,

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -3277,6 +3277,78 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOut("from lib1 and from lib2");
     }
 
+    /// <summary>
+    /// Diamond dependency: app.cs uses both <c>#:ref lib.cs</c> and <c>#:project ProjectLib</c>,
+    /// and both lib.cs (<c>#:project Common</c>) and ProjectLib reference a common project.
+    /// </summary>
+    [Fact]
+    public void RefDirective_DiamondWithProject()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        // Common project referenced by both lib.cs and ProjectLib.
+        var commonDir = Path.Join(testInstance.Path, "Common");
+        Directory.CreateDirectory(commonDir);
+        File.WriteAllText(Path.Join(commonDir, "Common.cs"), """
+            namespace Common;
+            public static class Shared
+            {
+                public static string Value() => "shared";
+            }
+            """);
+        File.WriteAllText(Path.Join(commonDir, "Common.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        // ProjectLib: a regular project referencing Common.
+        var projectLibDir = Path.Join(testInstance.Path, "ProjectLib");
+        Directory.CreateDirectory(projectLibDir);
+        File.WriteAllText(Path.Join(projectLibDir, "ProjectLib.cs"), """
+            namespace ProjectLib;
+            public static class ProjClass
+            {
+                public static string Value() => $"ProjectLib({Common.Shared.Value()})";
+            }
+            """);
+        File.WriteAllText(Path.Join(projectLibDir, "ProjectLib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="../Common/Common.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        // lib.cs: a file-based library referencing Common via #:project.
+        File.WriteAllText(Path.Join(testInstance.Path, "lib.cs"), """
+            #:project Common
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string Value() => $"Lib({Common.Shared.Value()})";
+            }
+            """);
+
+        // app.cs: references both lib.cs and ProjectLib.
+        File.WriteAllText(Path.Join(testInstance.Path, "app.cs"), """
+            #:ref lib.cs
+            #:project ProjectLib
+            Console.WriteLine($"{Lib.LibClass.Value()} {ProjectLib.ProjClass.Value()}");
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Lib(shared) ProjectLib(shared)");
+    }
+
     [Theory, CombinatorialData]
     public void IncludeDirective(
         [CombinatorialValues("Util.cs", "**/*.cs", "**/*.$(MyProp1)")] string includePattern,

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -5436,6 +5436,50 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
     }
 
     /// <summary>
+    /// See <see cref="CscOnly_AfterMSBuild_ProjectReferences"/>.
+    /// CSC-only optimization is also disabled when <c>#:ref</c> directives are present,
+    /// since we cannot detect updates in the referenced file-based app.
+    /// </summary>
+    [Fact]
+    public void CscOnly_AfterMSBuild_RefDirective()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var libPath = Path.Join(testInstance.Path, "lib.cs");
+        var libCode = """
+            namespace Lib;
+            public class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib v1";
+            }
+            """;
+        File.WriteAllText(libPath, libCode);
+
+        var code = """
+            #:ref lib.cs
+            Console.WriteLine("v1 " + Lib.LibClass.GetMessage());
+            """;
+
+        var programPath = Path.Join(testInstance.Path, "app.cs");
+        File.WriteAllText(programPath, code);
+
+        // Remove artifacts from possible previous runs of this test.
+        var artifactsDir = VirtualProjectBuilder.GetArtifactsPath(programPath);
+        if (Directory.Exists(artifactsDir)) Directory.Delete(artifactsDir, recursive: true);
+
+        Build(testInstance, BuildLevel.All, expectedOutput: "v1 Hello from Lib v1", programFileName: "app.cs");
+
+        code = code.Replace("v1", "v2");
+        File.WriteAllText(programPath, code);
+
+        libCode = libCode.Replace("v1", "v2");
+        File.WriteAllText(libPath, libCode);
+
+        // Cannot use CSC because we cannot detect updates in the referenced file-based app.
+        Build(testInstance, BuildLevel.All, expectedOutput: "v2 Hello from Lib v2", programFileName: "app.cs");
+    }
+
+    /// <summary>
     /// See <see cref="CscOnly_AfterMSBuild"/>.
     /// If users have more complex build customizations, they can opt out of the optimization.
     /// </summary>


### PR DESCRIPTION
Add support for referencing one file-based app from another via the
#:ref directive. When a file uses #:ref lib.cs, the referenced file is
built as a library (OutputType=Library) using the existing virtual
project infrastructure, and the output DLL is referenced via a
<Reference HintPath=...> item in the referencing app's virtual project.

Key changes:
- Add CSharpDirective.Ref class with path resolution (similar to Project)
- Register 'ref' in the directive parser switch
- Handle Ref in VirtualProjectBuilder.EvaluateDirectives
- Emit <Reference> items in WriteProjectFile for evaluated #:ref directives
- Build referenced apps before main app in VirtualProjectBuildingCommand
- Disable CSC cache optimization when #:ref is present
- Convert #:ref to #:project in dotnet project convert
- Add integration tests for basic ref, subdirectory ref, and error cases
- Add resource strings for #:ref error messages
- Update InternalAPI.Unshipped.txt and xlf files

Resolves https://github.com/dotnet/sdk/issues/53478.