### PR TITLE
Fix MTP message handling bugs in TestApplicationHandler

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -210,7 +210,7 @@ internal sealed class TestApplicationHandler
 
             if (!_handshakeInfo.HasValue)
             {
-                throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(DiscoveredTestMessages)));
+                throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(TestSessionEvent)));
             }
 
             if (sessionEvent.ExecutionId != _handshakeInfo.Value.ExecutionId)
@@ -230,6 +230,10 @@ internal sealed class TestApplicationHandler
                 {
                     throw new InvalidOperationException(CliCommandStrings.UnexpectedTestSessionEnd);
                 }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(sessionEvent), $"Unknown session event type: {sessionEvent.SessionType}");
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes two bugs in `TestApplicationHandler.OnSessionEventReceived`:

### 1. Copy-paste bug: wrong `nameof` in exception message

The exception for a missing handshake incorrectly used `nameof(DiscoveredTestMessages)` instead of `nameof(TestSessionEvent)`, producing a misleading error message when a `TestSessionEvent` is received before handshake.

### 2. Unknown `SessionType` values silently ignored

If a new session event type were added to the protocol, it would be silently dropped. Added an `else` clause to throw `ArgumentOutOfRangeException` for unknown values, consistent with the pattern used in `ToOutcome()` which also throws for unrecognized values.

## Changes

- `src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs`