### PR TITLE
Fix static lock in TestApplicationActionQueue

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -15,7 +15,7 @@ internal class TestApplicationActionQueue
 
     private int? _aggregateExitCode;
 
-    private static readonly Lock _lock = new();
+    private readonly Lock _lock = new();
 
     public TestApplicationActionQueue(int degreeOfParallelism, BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested)
     {


### PR DESCRIPTION
## Summary

Changes `_lock` in `TestApplicationActionQueue` from `static` to an instance field.

## Problem

The `_lock` field is `static`, meaning all `TestApplicationActionQueue` instances share the same lock. However, the lock protects instance state (`_aggregateExitCode`), so it should be scoped to the instance. A static lock incorrectly serializes exit code aggregation across all instances, which would cause unnecessary contention if multiple instances were ever created (e.g., in tests or future refactoring).

## Changes

- `src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs`: `static readonly Lock _lock` → `readonly Lock _lock`