### PR TITLE
Handle duplicate static web asset identities gracefully

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
@@ -35,16 +35,31 @@ public class DiscoverPrecompressedAssets : Task
         var candidatesByIdentity = new Dictionary<string, StaticWebAsset>(OSPath.PathComparer);
         foreach (var asset in candidates)
         {
-            if (!candidatesByIdentity.ContainsKey(asset.Identity))
+            if (candidatesByIdentity.TryGetValue(asset.Identity, out var existing))
             {
-                candidatesByIdentity[asset.Identity] = asset;
+                if (existing.SourceId != asset.SourceId ||
+                    existing.RelativePath != asset.RelativePath)
+                {
+                    Log.LogWarning(
+                        "Duplicate candidate asset '{0}' with differing metadata (SourceId='{1}' vs '{2}', RelativePath='{3}' vs '{4}'). Keeping first occurrence.",
+                        asset.Identity,
+                        existing.SourceId,
+                        asset.SourceId,
+                        existing.RelativePath,
+                        asset.RelativePath);
+                }
+                else
+                {
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        "Skipping duplicate candidate asset '{0}' (SourceId='{1}'). Assets are identical.",
+                        asset.Identity,
+                        asset.SourceId);
+                }
             }
             else
             {
-                Log.LogMessage(
-                    MessageImportance.Low,
-                    "Skipping duplicate candidate asset '{0}'. The asset was already added from a different source.",
-                    asset.Identity);
+                candidatesByIdentity[asset.Identity] = asset;
             }
         }
 

--- a/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
@@ -32,7 +32,21 @@ public class DiscoverPrecompressedAssets : Task
         var candidates = StaticWebAsset.FromTaskItemGroup(CandidateAssets);
         var assetsToUpdate = new List<ITaskItem>();
 
-        var candidatesByIdentity = candidates.ToDictionary(asset => asset.Identity, OSPath.PathComparer);
+        var candidatesByIdentity = new Dictionary<string, StaticWebAsset>(OSPath.PathComparer);
+        foreach (var asset in candidates)
+        {
+            if (!candidatesByIdentity.ContainsKey(asset.Identity))
+            {
+                candidatesByIdentity[asset.Identity] = asset;
+            }
+            else
+            {
+                Log.LogMessage(
+                    MessageImportance.Low,
+                    "Skipping duplicate candidate asset '{0}'. The asset was already added from a different source.",
+                    asset.Identity);
+            }
+        }
 
         foreach (var candidate in candidates)
         {

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1240,12 +1240,25 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
             var candidateAsset = FromTaskItem(candidateAssets[i], validate);
             if (dictionary.TryGetValue(candidateAsset.Identity, out var existing))
             {
-                log?.LogMessage(
-                    MessageImportance.Low,
-                    "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
-                    candidateAsset.Identity,
-                    candidateAsset.SourceId,
-                    existing.SourceId);
+                if (existing.SourceId != candidateAsset.SourceId ||
+                    existing.RelativePath != candidateAsset.RelativePath)
+                {
+                    log?.LogWarning(
+                        "Duplicate static web asset '{0}' with differing metadata (SourceId='{1}' vs '{2}', RelativePath='{3}' vs '{4}'). Keeping first occurrence.",
+                        candidateAsset.Identity,
+                        existing.SourceId,
+                        candidateAsset.SourceId,
+                        existing.RelativePath,
+                        candidateAsset.RelativePath);
+                }
+                else
+                {
+                    log?.LogMessage(
+                        MessageImportance.Low,
+                        "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Assets are identical.",
+                        candidateAsset.Identity,
+                        candidateAsset.SourceId);
+                }
             }
             else
             {

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1230,7 +1230,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     internal static Dictionary<string, StaticWebAsset> ToAssetDictionary(ITaskItem[] candidateAssets, bool validate = false)
     {
-        var dictionary = new Dictionary<string, StaticWebAsset>(candidateAssets.Length, OSPath.PathComparer);
+        var dictionary = new Dictionary<string, StaticWebAsset>(candidateAssets.Length);
         for (var i = 0; i < candidateAssets.Length; i++)
         {
             var candidateAsset = FromTaskItem(candidateAssets[i], validate);

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.StaticWebAssets.Tasks.Utils;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
@@ -1228,13 +1229,25 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'.");
     }
 
-    internal static Dictionary<string, StaticWebAsset> ToAssetDictionary(ITaskItem[] candidateAssets, bool validate = false)
+    internal static Dictionary<string, StaticWebAsset> ToAssetDictionary(
+        ITaskItem[] candidateAssets,
+        bool validate = false,
+        TaskLoggingHelper log = null)
     {
         var dictionary = new Dictionary<string, StaticWebAsset>(candidateAssets.Length);
         for (var i = 0; i < candidateAssets.Length; i++)
         {
             var candidateAsset = FromTaskItem(candidateAssets[i], validate);
-            if (!dictionary.ContainsKey(candidateAsset.Identity))
+            if (dictionary.TryGetValue(candidateAsset.Identity, out var existing))
+            {
+                log?.LogMessage(
+                    MessageImportance.Low,
+                    "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
+                    candidateAsset.Identity,
+                    candidateAsset.SourceId,
+                    existing.SourceId);
+            }
+            else
             {
                 dictionary.Add(candidateAsset.Identity, candidateAsset);
             }

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1230,11 +1230,14 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
 
     internal static Dictionary<string, StaticWebAsset> ToAssetDictionary(ITaskItem[] candidateAssets, bool validate = false)
     {
-        var dictionary = new Dictionary<string, StaticWebAsset>(candidateAssets.Length);
+        var dictionary = new Dictionary<string, StaticWebAsset>(candidateAssets.Length, OSPath.PathComparer);
         for (var i = 0; i < candidateAssets.Length; i++)
         {
             var candidateAsset = FromTaskItem(candidateAssets[i], validate);
-            dictionary.Add(candidateAsset.Identity, candidateAsset);
+            if (!dictionary.ContainsKey(candidateAsset.Identity))
+            {
+                dictionary.Add(candidateAsset.Identity, candidateAsset);
+            }
         }
 
         return dictionary;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -70,12 +70,25 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
             {
                 if (manifestAssets.TryGetValue(a.ResolvedAsset.Identity, out var existing))
                 {
-                    Log.LogMessage(
-                        MessageImportance.Low,
-                        "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
-                        a.ResolvedAsset.Identity,
-                        a.ResolvedAsset.SourceId,
-                        existing.ResolvedAsset.SourceId);
+                    if (existing.TargetPath != a.TargetPath ||
+                        existing.ResolvedAsset.SourceId != a.ResolvedAsset.SourceId)
+                    {
+                        Log.LogWarning(
+                            "Duplicate static web asset '{0}' with differing metadata (TargetPath='{1}' vs '{2}', SourceId='{3}' vs '{4}'). Keeping first occurrence.",
+                            a.ResolvedAsset.Identity,
+                            existing.TargetPath,
+                            a.TargetPath,
+                            existing.ResolvedAsset.SourceId,
+                            a.ResolvedAsset.SourceId);
+                    }
+                    else
+                    {
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Assets are identical.",
+                            a.ResolvedAsset.Identity,
+                            a.ResolvedAsset.SourceId);
+                    }
                 }
                 else
                 {

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -64,8 +64,15 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
 
             // Get the list of the asset that need to be part of the manifest (this is similar to GenerateStaticWebAssetsDevelopmentManifest)
             var assets = StaticWebAsset.FromTaskItemGroup(Assets);
-            var manifestAssets = ComputeManifestAssets(assets, ManifestType)
-                .ToDictionary(a => a.ResolvedAsset.Identity, a => a, OSPath.PathComparer);
+            var manifestAssetsList = ComputeManifestAssets(assets, ManifestType);
+            var manifestAssets = new Dictionary<string, TargetPathAssetPair>(OSPath.PathComparer);
+            foreach (var a in manifestAssetsList)
+            {
+                if (!manifestAssets.ContainsKey(a.ResolvedAsset.Identity))
+                {
+                    manifestAssets[a.ResolvedAsset.Identity] = a;
+                }
+            }
 
             // Build exclusion matcher if patterns are provided
             StaticWebAssetGlobMatcher exclusionMatcher = null;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -68,7 +68,16 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
             var manifestAssets = new Dictionary<string, TargetPathAssetPair>(OSPath.PathComparer);
             foreach (var a in manifestAssetsList)
             {
-                if (!manifestAssets.ContainsKey(a.ResolvedAsset.Identity))
+                if (manifestAssets.TryGetValue(a.ResolvedAsset.Identity, out var existing))
+                {
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
+                        a.ResolvedAsset.Identity,
+                        a.ResolvedAsset.SourceId,
+                        existing.ResolvedAsset.SourceId);
+                }
+                else
                 {
                     manifestAssets[a.ResolvedAsset.Identity] = a;
                 }

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -104,12 +104,25 @@ public class GenerateStaticWebAssetsManifest : Task
             {
                 if (assetsByIdentity.TryGetValue(a.Identity, out var existing))
                 {
-                    Log.LogMessage(
-                        MessageImportance.Low,
-                        "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
-                        a.Identity,
-                        a.SourceId,
-                        existing.SourceId);
+                    if (existing.SourceId != a.SourceId ||
+                        existing.RelativePath != a.RelativePath)
+                    {
+                        Log.LogWarning(
+                            "Duplicate static web asset '{0}' with differing metadata (SourceId='{1}' vs '{2}', RelativePath='{3}' vs '{4}'). Keeping first occurrence.",
+                            a.Identity,
+                            existing.SourceId,
+                            a.SourceId,
+                            existing.RelativePath,
+                            a.RelativePath);
+                    }
+                    else
+                    {
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Assets are identical.",
+                            a.Identity,
+                            a.SourceId);
+                    }
                 }
                 else
                 {

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -99,7 +99,14 @@ public class GenerateStaticWebAssetsManifest : Task
         // inside the manifest because its cumbersome to do it in MSBuild directly.
         if (StaticWebAssetsManifest.ManifestTypes.IsPublish(ManifestType))
         {
-            var assetsByIdentity = assets.ToDictionary(a => a.Identity, a => a, OSPath.PathComparer);
+            var assetsByIdentity = new Dictionary<string, StaticWebAsset>(OSPath.PathComparer);
+            foreach (var a in assets)
+            {
+                if (!assetsByIdentity.ContainsKey(a.Identity))
+                {
+                    assetsByIdentity[a.Identity] = a;
+                }
+            }
             var filteredEndpoints = new List<StaticWebAssetEndpoint>();
 
             foreach (var endpoint in Endpoints.Select(StaticWebAssetEndpoint.FromTaskItem))

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -102,7 +102,16 @@ public class GenerateStaticWebAssetsManifest : Task
             var assetsByIdentity = new Dictionary<string, StaticWebAsset>(OSPath.PathComparer);
             foreach (var a in assets)
             {
-                if (!assetsByIdentity.ContainsKey(a.Identity))
+                if (assetsByIdentity.TryGetValue(a.Identity, out var existing))
+                {
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        "Skipping duplicate static web asset '{0}' (SourceId='{1}'). Keeping previously seen asset (SourceId='{2}').",
+                        a.Identity,
+                        a.SourceId,
+                        existing.SourceId);
+                }
+                else
                 {
                     assetsByIdentity[a.Identity] = a;
                 }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DuplicateAssetIdentityHandlingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DuplicateAssetIdentityHandlingTest.cs
@@ -1,0 +1,245 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Moq;
+
+namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
+
+/// <summary>
+/// Tests that tasks handle duplicate asset identities gracefully (first occurrence wins)
+/// instead of throwing ArgumentException from Dictionary operations.
+/// Regression tests for https://github.com/dotnet/sdk/issues/52089
+/// </summary>
+public class DuplicateAssetIdentityHandlingTest
+{
+    [Fact]
+    public void ToAssetDictionary_WithDuplicateIdentities_KeepsFirstOccurrence()
+    {
+        // Arrange — two assets with the same Identity but different SourceId
+        var firstAsset = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+        var secondAsset = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject2");
+
+        var taskItems = new ITaskItem[] { firstAsset.ToTaskItem(), secondAsset.ToTaskItem() };
+
+        // Act — should not throw ArgumentException
+        var dictionary = StaticWebAsset.ToAssetDictionary(taskItems);
+
+        // Assert — first occurrence wins
+        dictionary.Should().ContainSingle();
+        dictionary.Values.Single().SourceId.Should().Be("WasmProject1");
+    }
+
+    [Fact]
+    public void ToAssetDictionary_WithUniqueIdentities_ReturnsAll()
+    {
+        // Arrange
+        var asset1 = CreateAsset("wwwroot/app.js", sourceId: "Project1");
+        var asset2 = CreateAsset("wwwroot/site.css", sourceId: "Project2");
+
+        var taskItems = new ITaskItem[] { asset1.ToTaskItem(), asset2.ToTaskItem() };
+
+        // Act
+        var dictionary = StaticWebAsset.ToAssetDictionary(taskItems);
+
+        // Assert
+        dictionary.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void DiscoverPrecompressedAssets_WithDuplicateCandidates_DoesNotThrow()
+    {
+        // Arrange — simulate two WASM projects providing the same dotnet.js.map
+        var messages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogMessageEvent(It.IsAny<BuildMessageEventArgs>()))
+            .Callback<BuildMessageEventArgs>(args => messages.Add(args.Message));
+
+        var asset1 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+        var asset2 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject2");
+
+        var task = new DiscoverPrecompressedAssets
+        {
+            CandidateAssets = [asset1.ToTaskItem(), asset2.ToTaskItem()],
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert — task succeeds and logs the duplicate
+        result.Should().BeTrue();
+        messages.Should().Contain(m => m.Contains("Skipping duplicate candidate asset"));
+    }
+
+    [Fact]
+    public void DiscoverPrecompressedAssets_WithDuplicateCandidates_StillFindsCompressedPairs()
+    {
+        // Arrange — duplicate uncompressed + one compressed
+        var buildEngine = new Mock<IBuildEngine>();
+
+        var uncompressed1 = CreateAsset("wwwroot/site.js", sourceId: "Project1",
+            relativePath: "site#[.{fingerprint}]?.js");
+        var uncompressed2 = CreateAsset("wwwroot/site.js", sourceId: "Project2",
+            relativePath: "site#[.{fingerprint}]?.js");
+        var compressed = CreateAsset("wwwroot/site.js.gz", sourceId: "Project1",
+            relativePath: "site.js#[.{fingerprint}]?.gz");
+
+        var task = new DiscoverPrecompressedAssets
+        {
+            CandidateAssets = [
+                uncompressed1.ToTaskItem(),
+                uncompressed2.ToTaskItem(),
+                compressed.ToTaskItem()
+            ],
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert — task succeeds and compressed asset is discovered
+        result.Should().BeTrue();
+        task.DiscoveredCompressedAssets.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void GenerateStaticWebAssetsManifest_PublishMode_WithDuplicateIdentities_DoesNotThrow()
+    {
+        // Arrange — the Publish path in FilterPublishEndpointsIfNeeded builds an identity dictionary
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var tempPath = Path.Combine(
+            AppContext.BaseDirectory,
+            Guid.NewGuid().ToString("N") + ".json");
+
+        var asset1 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+        var asset2 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject2");
+        var endpoint = CreateEndpoint(asset1);
+
+        var task = new GenerateStaticWebAssetsManifest
+        {
+            BuildEngine = buildEngine.Object,
+            Assets = [asset1.ToTaskItem(), asset2.ToTaskItem()],
+            Endpoints = [endpoint.ToTaskItem()],
+            ReferencedProjectsConfigurations = [],
+            DiscoveryPatterns = [],
+            BasePath = "/",
+            Source = "TestProject",
+            ManifestType = "Publish",
+            Mode = "Default",
+            ManifestPath = tempPath,
+        };
+
+        // Act — should not throw ArgumentException
+        var result = task.Execute();
+
+        // Assert — task completes (may still report "conflicting assets" but no crash)
+        // The key assertion is that we don't get an unhandled ArgumentException.
+        // Whether result is true/false depends on downstream validation, not on our fix.
+        errorMessages.Should().NotContain(m => m.Contains("An item with the same key has already been added"));
+    }
+
+    [Fact]
+    public void GenerateStaticWebAssetEndpointsManifest_WithDuplicateIdentities_DoesNotThrow()
+    {
+        // Arrange
+        var buildEngine = new Mock<IBuildEngine>();
+
+        var tempPath = Path.Combine(
+            AppContext.BaseDirectory,
+            Guid.NewGuid().ToString("N") + "endpoints.json");
+
+        var asset1 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+        var asset2 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject2");
+        var endpoint = CreateEndpoint(asset1);
+
+        var task = new GenerateStaticWebAssetEndpointsManifest
+        {
+            Assets = [asset1.ToTaskItem(), asset2.ToTaskItem()],
+            Endpoints = [endpoint.ToTaskItem()],
+            ManifestType = "Build",
+            Source = "TestProject",
+            ManifestPath = tempPath,
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act — should not throw ArgumentException
+        var act = () => task.Execute();
+
+        // Assert — task completes without ArgumentException crash.
+        // The return value may be false due to downstream validation (e.g., conflicting assets),
+        // but the critical thing is no unhandled dictionary exception.
+        act.Should().NotThrow<ArgumentException>();
+    }
+
+    private static StaticWebAssetEndpoint CreateEndpoint(StaticWebAsset asset)
+    {
+        return new StaticWebAssetEndpoint
+        {
+            Route = asset.ComputeTargetPath("", '/'),
+            AssetFile = asset.Identity,
+            Selectors = [],
+            EndpointProperties = [],
+            ResponseHeaders =
+            [
+                new() { Name = "Content-Type", Value = "application/javascript" },
+                new() { Name = "Content-Length", Value = "10" },
+                new() { Name = "ETag", Value = "\"integrity\"" },
+                new() { Name = "Last-Modified", Value = "Sat, 01 Jan 2000 00:00:01 GMT" }
+            ]
+        };
+    }
+
+    private static StaticWebAsset CreateAsset(
+        string itemSpec,
+        string sourceId = "TestProject",
+        string sourceType = "Discovered",
+        string relativePath = null,
+        string assetKind = "All",
+        string assetMode = "All",
+        string basePath = "base",
+        string assetRole = "Primary",
+        string relatedAsset = "",
+        string assetTraitName = "",
+        string assetTraitValue = "",
+        string copyToOutputDirectory = "Never",
+        string copyToPublishDirectory = "PreserveNewest")
+    {
+        var result = new StaticWebAsset()
+        {
+            Identity = Path.GetFullPath(itemSpec),
+            SourceId = sourceId,
+            SourceType = sourceType,
+            ContentRoot = Directory.GetCurrentDirectory(),
+            BasePath = basePath,
+            RelativePath = relativePath ?? itemSpec,
+            AssetKind = assetKind,
+            AssetMode = assetMode,
+            AssetRole = assetRole,
+            AssetMergeBehavior = StaticWebAsset.MergeBehaviors.PreferTarget,
+            AssetMergeSource = "",
+            RelatedAsset = relatedAsset,
+            AssetTraitName = assetTraitName,
+            AssetTraitValue = assetTraitValue,
+            CopyToOutputDirectory = copyToOutputDirectory,
+            CopyToPublishDirectory = copyToPublishDirectory,
+            OriginalItemSpec = itemSpec,
+            Integrity = "integrity",
+            Fingerprint = "fingerprint",
+            FileLength = 10,
+            LastWriteTime = new DateTime(2000, 1, 1, 0, 0, 1)
+        };
+
+        result.ApplyDefaults();
+        result.Normalize();
+
+        return result;
+    }
+}

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DuplicateAssetIdentityHandlingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DuplicateAssetIdentityHandlingTest.cs
@@ -50,13 +50,39 @@ public class DuplicateAssetIdentityHandlingTest
     }
 
     [Fact]
-    public void DiscoverPrecompressedAssets_WithDuplicateCandidates_DoesNotThrow()
+    public void DiscoverPrecompressedAssets_WithIdenticalDuplicates_LogsLowMessage()
     {
-        // Arrange — simulate two WASM projects providing the same dotnet.js.map
+        // Arrange — truly identical duplicates (same SourceId) → Low-priority message
         var messages = new List<string>();
         var buildEngine = new Mock<IBuildEngine>();
         buildEngine.Setup(e => e.LogMessageEvent(It.IsAny<BuildMessageEventArgs>()))
             .Callback<BuildMessageEventArgs>(args => messages.Add(args.Message));
+
+        var asset1 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+        var asset2 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
+
+        var task = new DiscoverPrecompressedAssets
+        {
+            CandidateAssets = [asset1.ToTaskItem(), asset2.ToTaskItem()],
+            BuildEngine = buildEngine.Object
+        };
+
+        // Act
+        var result = task.Execute();
+
+        // Assert — task succeeds, logs at low importance
+        result.Should().BeTrue();
+        messages.Should().Contain(m => m.Contains("Assets are identical"));
+    }
+
+    [Fact]
+    public void DiscoverPrecompressedAssets_WithMismatchedDuplicates_LogsWarning()
+    {
+        // Arrange — duplicates with different SourceId → Warning
+        var warnings = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()))
+            .Callback<BuildWarningEventArgs>(args => warnings.Add(args.Message));
 
         var asset1 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject1");
         var asset2 = CreateAsset("wwwroot/dotnet.js.map", sourceId: "WasmProject2");
@@ -70,9 +96,9 @@ public class DuplicateAssetIdentityHandlingTest
         // Act
         var result = task.Execute();
 
-        // Assert — task succeeds and logs the duplicate
+        // Assert — task succeeds but emits a warning about mismatched metadata
         result.Should().BeTrue();
-        messages.Should().Contain(m => m.Contains("Skipping duplicate candidate asset"));
+        warnings.Should().Contain(m => m.Contains("differing metadata"));
     }
 
     [Fact]
@@ -83,7 +109,7 @@ public class DuplicateAssetIdentityHandlingTest
 
         var uncompressed1 = CreateAsset("wwwroot/site.js", sourceId: "Project1",
             relativePath: "site#[.{fingerprint}]?.js");
-        var uncompressed2 = CreateAsset("wwwroot/site.js", sourceId: "Project2",
+        var uncompressed2 = CreateAsset("wwwroot/site.js", sourceId: "Project1",
             relativePath: "site#[.{fingerprint}]?.js");
         var compressed = CreateAsset("wwwroot/site.js.gz", sourceId: "Project1",
             relativePath: "site.js#[.{fingerprint}]?.gz");


### PR DESCRIPTION
## Summary

Multiple `StaticWebAssets` MSBuild tasks crash with `ArgumentException: An item with the same key has already been added` when candidate assets contain duplicate `Identity` keys. This PR handles duplicates gracefully by keeping the first occurrence and skipping subsequent ones.

## What causes duplicates

Two known scenarios produce duplicate asset identities:

1. **Hosted Blazor WASM projects** referencing multiple WASM client projects — `dotnet.js.map` from `microsoft.netcore.app.runtime.mono.browser-wasm` appears multiple times via different dependency paths. This blocks the `dotnet/aspnetcore` CI codeflow PR ([aspnetcore#65673](https://github.com/dotnet/aspnetcore/pull/65673)).

2. **Blazor Web App referencing another Blazor Web App** — `blazor.web.js` from `Microsoft.AspNetCore.App.Internal.Assets` appears twice (repro: [DanielSundberg/DiscoverPrecompressedAssets](https://github.com/DanielSundberg/DiscoverPrecompressedAssets)).

## What this PR fixes

All four code paths that build Identity-keyed dictionaries from static web asset items:

| File | Change |
|------|--------|
| `DiscoverPrecompressedAssets.cs` | `ToDictionary` → `ContainsKey` loop with diagnostic log |
| `StaticWebAsset.ToAssetDictionary()` | `.Add` → `ContainsKey` guard (used by 5 other tasks) |
| `GenerateStaticWebAssetsManifest.cs` | `ToDictionary` → `ContainsKey` loop |
| `GenerateStaticWebAssetEndpointsManifest.cs` | `ToDictionary` → `ContainsKey` loop |

## Verified locally

- **Reproduced crash** on `dotnet/aspnetcore` codeflow branch (`darc-main-b867beb1-...`) with SDK `11.0.100-preview.3.26128.104`
- **Verified fix** — `HostedInAspNet.Server` builds successfully after patching
- **Reproduced crash** on [dotnet/sdk#52089](https://github.com/dotnet/sdk/issues/52089) minimal repro (`BlazorApp` referencing `BlazorPlugin`)
- **Verified fix** — the `DiscoverPrecompressedAssets` crash is eliminated

## What this does NOT fix

For the Blazor-references-Blazor scenario (#52089), eliminating the `ArgumentException` crash surfaces a **different**, pre-existing error:

`
Conflicting assets with the same target path '_framework/blazor.server.js'
`

This conflict occurs because the same framework asset arrives from two projects with different `SourceType` (`Discovered` vs `Project`). The proper architectural fix for this is tracked in **#53135** (`Framework` SourceType by @javiercn), which prevents framework asset duplicates from being generated in the first place.

This PR and #53135 are complementary:
- **This PR**: safety net — prevents `ToDictionary` crashes regardless of duplication source
- **#53135**: architectural fix — prevents framework asset duplication upstream

Fixes #52089
Fixes #52647