### PR TITLE
Fix crash in VSTestForwardingApp when trace is enabled with empty args

### DIFF
--- a/src/Cli/dotnet/Commands/Test/VSTest/VSTestForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/VSTestForwardingApp.cs
@@ -21,7 +21,7 @@ public class VSTestForwardingApp : ForwardingApp
             VSTestTrace.SafeWriteTrace(() => $"Root variable set {rootVariableName}:{rootValue}");
         }
 
-        VSTestTrace.SafeWriteTrace(() => $"Forwarding to '{GetVSTestExePath()}' with args \"{argsToForward?.Aggregate((a, b) => $"{a} | {b}")}\"");
+        VSTestTrace.SafeWriteTrace(() => $"Forwarding to '{GetVSTestExePath()}' with args \"{string.Join(" | ", argsToForward ?? [])}\"");
     }
 
     private static string GetVSTestExePath()


### PR DESCRIPTION
## Summary

Fixes a potential crash in `VSTestForwardingApp` constructor when VSTest trace logging is enabled and `argsToForward` is an empty sequence.

## Problem

The trace logging line uses `Aggregate()` to join args:

```csharp
argsToForward?.Aggregate((a, b) => $"{a} | {b}")
```

`Aggregate()` throws `InvalidOperationException` on an empty sequence. If `argsToForward` is non-null but empty and `VSTEST_TRACE` is enabled, the constructor crashes before the forwarding app can even start.

## Fix

Replace `Aggregate` with `string.Join`, which handles empty sequences safely and produces equivalent output.

## Changes

- `src/Cli/dotnet/Commands/Test/VSTest/VSTestForwardingApp.cs`