### PR TITLE
Fix dnx not authenticating for private feeds

### DIFF
--- a/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -114,8 +114,9 @@ internal sealed class ToolExecuteCommand : CommandBase<ToolExecuteCommandDefinit
             //  other feeds, but this is probably OK.
             var downloadPackageLocation = new PackageLocation(
                 nugetConfig: _configFile != null ? new(_configFile) : null,
-                sourceFeedOverrides: [packageSource.Source],
-                additionalFeeds: _addSource);
+                sourceFeedOverrides: _sources,
+                additionalFeeds: _addSource,
+                packageSourceOverrides: [packageSource]);
 
             toolPackage = _toolPackageDownloader.InstallPackage(
                 downloadPackageLocation,

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -468,6 +468,11 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
 
     public IEnumerable<PackageSource> LoadNuGetSources(PackageId packageId, PackageSourceLocation packageSourceLocation = null, PackageSourceMapping packageSourceMapping = null)
     {
+        if (packageSourceLocation?.PackageSourceOverrides?.Any() ?? false)
+        {
+            return packageSourceLocation.PackageSourceOverrides;
+        }
+
         var sources = (packageSourceLocation?.SourceFeedOverrides.Any() ?? false) ?
             LoadOverrideSources(packageSourceLocation) :
             LoadDefaultSources(packageId, packageSourceLocation, packageSourceMapping);

--- a/src/Cli/dotnet/NugetPackageDownloader/PackageSourceLocation.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/PackageSourceLocation.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Configuration;
 
 namespace Microsoft.DotNet.Cli.NuGetPackageDownloader;
 
@@ -14,7 +15,8 @@ internal class PackageSourceLocation
         DirectoryPath? rootConfigDirectory = null,
         string[] sourceFeedOverrides = null,
         string[] additionalSourceFeeds = null,
-        string basePath = null)
+        string basePath = null,
+        PackageSource[] packageSourceOverrides = null)
     {
         basePath = basePath ?? Directory.GetCurrentDirectory();
 
@@ -24,12 +26,15 @@ internal class PackageSourceLocation
         SourceFeedOverrides = ExpandLocalFeed(sourceFeedOverrides, basePath);
         // Feeds to be using in addition to config
         AdditionalSourceFeed = ExpandLocalFeed(additionalSourceFeeds, basePath);
+        // Feeds that have already been evaluated and selected to be used
+        PackageSourceOverrides = packageSourceOverrides;
     }
 
     public FilePath? NugetConfig { get; }
     public DirectoryPath? RootConfigDirectory { get; }
     public string[] SourceFeedOverrides { get; private set; }
     public string[] AdditionalSourceFeed { get; private set; }
+    public PackageSource[] PackageSourceOverrides { get; private set; }
 
     private static string[] ExpandLocalFeed(string[] sourceFeedOverrides, string basePath)
     {

--- a/src/Cli/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/Cli/dotnet/ToolPackage/PackageLocation.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Configuration;
 
 namespace Microsoft.DotNet.Cli.ToolPackage;
 
@@ -11,10 +12,12 @@ internal class PackageLocation(
     FilePath? nugetConfig = null,
     DirectoryPath? rootConfigDirectory = null,
     string[] additionalFeeds = null,
-    string[] sourceFeedOverrides = null)
+    string[] sourceFeedOverrides = null,
+    PackageSource[] packageSourceOverrides = null)
 {
     public FilePath? NugetConfig { get; } = nugetConfig;
     public DirectoryPath? RootConfigDirectory { get; } = rootConfigDirectory;
     public string[] AdditionalFeeds { get; } = additionalFeeds ?? [];
     public string[] SourceFeedOverrides { get; } = sourceFeedOverrides ?? [];
+    public PackageSource[] PackageSourceOverrides { get; } = packageSourceOverrides ?? [];
 }

--- a/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
+++ b/src/Cli/dotnet/ToolPackage/ToolPackageDownloaderBase.cs
@@ -110,7 +110,7 @@ internal abstract class ToolPackageDownloaderBase : IToolPackageDownloader
             verbosity,
             restoreActionConfig);
 
-        var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, packageLocation.SourceFeedOverrides, packageLocation.AdditionalFeeds, _currentWorkingDirectory);
+        var packageSourceLocation = new PackageSourceLocation(packageLocation.NugetConfig, packageLocation.RootConfigDirectory, packageLocation.SourceFeedOverrides, packageLocation.AdditionalFeeds, _currentWorkingDirectory, packageLocation.PackageSourceOverrides);
 
         NuGetVersion packageVersion = nugetPackageDownloader.GetBestPackageVersionAsync(packageId, versionRange, packageSourceLocation).GetAwaiter().GetResult();
 

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -242,6 +242,21 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
             packagePath.Should().Contain(TestPackageId + "." + TestPreviewPackageVersion,
                 "Package should download higher package version");
+        }
+
+        [Fact]
+        public void GivenPackageOverrideSourceWithCredentialsNugetFeedReturnsSelectedSource()
+        {
+            PackageSource source = new PackageSource("NuGet")
+            {
+                Credentials = new PackageSourceCredential("NuGet", "user", "pass", true, "basic")
+            };
+
+            IEnumerable<PackageSource> selectedSources = _toolInstaller.LoadNuGetSources(
+                TestPackageId,
+                packageSourceLocation: new PackageSourceLocation(packageSourceOverrides: new[] { source }));
+
+            selectedSources.Should().HaveCount(1).And.Contain(x => x.Credentials != null);
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
Fixes #51375 

For `dnx` execution (`dotnet tool exec`), if the package source is authenticated the previous method of passing an override source meant that the credentials are lost, since this is the equivalient of passing `--source https://mysource` and ignoring any config in `NuGet.config`. We need to pass the explicit source for `dnx` because we confirm with the user that we will be downloading from a particular source (which may be authenticated).