### PR TITLE
Handle duplicate Identity in SWA dictionary construction

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/DiscoverPrecompressedAssets.cs
@@ -32,7 +32,16 @@ public class DiscoverPrecompressedAssets : Task
         var candidates = StaticWebAsset.FromTaskItemGroup(CandidateAssets);
         var assetsToUpdate = new List<ITaskItem>();
 
-        var candidatesByIdentity = candidates.ToDictionary(asset => asset.Identity, OSPath.PathComparer);
+        // Build lookup dictionary, handling duplicate Identities from multiple projects
+        // referencing the same physical file (e.g. NuGet cache assets shared across WASM clients).
+        var candidatesByIdentity = new Dictionary<string, StaticWebAsset>(candidates.Length, OSPath.PathComparer);
+        foreach (var candidate in candidates)
+        {
+            if (!candidatesByIdentity.ContainsKey(candidate.Identity))
+            {
+                candidatesByIdentity.Add(candidate.Identity, candidate);
+            }
+        }
 
         foreach (var candidate in candidates)
         {

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1234,7 +1234,13 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         for (var i = 0; i < candidateAssets.Length; i++)
         {
             var candidateAsset = FromTaskItem(candidateAssets[i], validate);
-            dictionary.Add(candidateAsset.Identity, candidateAsset);
+            // Multiple projects may reference the same physical file (e.g. NuGet cache assets
+            // shared across WASM clients). Since Identity is the FullPath, same Identity means
+            // same file on disk — keeping the first occurrence is correct.
+            if (!dictionary.ContainsKey(candidateAsset.Identity))
+            {
+                dictionary.Add(candidateAsset.Identity, candidateAsset);
+            }
         }
 
         return dictionary;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsManifest.cs
@@ -64,8 +64,17 @@ public class GenerateStaticWebAssetEndpointsManifest : Task
 
             // Get the list of the asset that need to be part of the manifest (this is similar to GenerateStaticWebAssetsDevelopmentManifest)
             var assets = StaticWebAsset.FromTaskItemGroup(Assets);
-            var manifestAssets = ComputeManifestAssets(assets, ManifestType)
-                .ToDictionary(a => a.ResolvedAsset.Identity, a => a, OSPath.PathComparer);
+            // Build dictionary handling duplicate Identities from multiple projects
+            // referencing the same physical file (e.g. NuGet cache assets shared across WASM clients).
+            var manifestAssetsList = ComputeManifestAssets(assets, ManifestType);
+            var manifestAssets = new Dictionary<string, TargetPathAssetPair>(OSPath.PathComparer);
+            foreach (var a in manifestAssetsList)
+            {
+                if (!manifestAssets.ContainsKey(a.ResolvedAsset.Identity))
+                {
+                    manifestAssets.Add(a.ResolvedAsset.Identity, a);
+                }
+            }
 
             // Build exclusion matcher if patterns are provided
             StaticWebAssetGlobMatcher exclusionMatcher = null;

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -99,7 +99,16 @@ public class GenerateStaticWebAssetsManifest : Task
         // inside the manifest because its cumbersome to do it in MSBuild directly.
         if (StaticWebAssetsManifest.ManifestTypes.IsPublish(ManifestType))
         {
-            var assetsByIdentity = assets.ToDictionary(a => a.Identity, a => a, OSPath.PathComparer);
+            // Build dictionary handling duplicate Identities from multiple projects
+            // referencing the same physical file (e.g. NuGet cache assets shared across WASM clients).
+            var assetsByIdentity = new Dictionary<string, StaticWebAsset>(assets.Length, OSPath.PathComparer);
+            foreach (var a in assets)
+            {
+                if (!assetsByIdentity.ContainsKey(a.Identity))
+                {
+                    assetsByIdentity.Add(a.Identity, a);
+                }
+            }
             var filteredEndpoints = new List<StaticWebAssetEndpoint>();
 
             foreach (var endpoint in Endpoints.Select(StaticWebAssetEndpoint.FromTaskItem))


### PR DESCRIPTION
## Problem

When multiple Blazor WebAssembly client projects reference the same runtime pack (e.g. a host app with two WASM clients), NuGet cache assets like `dotnet.js`, `dotnet.js.map`, ICU data, and native wasm files get **identical Identity values** because Identity is derived from the file's FullPath. This causes `ToDictionary`/`Dictionary.Add` crashes in multiple SDK tasks:

```
error : ArgumentException: An item with the same key has already been added.
Key: .../.nuget/packages/microsoft.netcore.app.runtime.mono.browser-wasm/.../dotnet.js.map
```

This crash was introduced by [dotnet/runtime#124125](https://github.com/dotnet/runtime/pull/124125), which correctly changed WASM asset ContentRoot from a shared output directory to per-item `%(RootDir)%(Directory)` (the NuGet cache path). That fix was needed for SRI integrity on incremental builds ([aspnetcore#65271](https://github.com/dotnet/aspnetcore/issues/65271)), but it means multiple WASM clients now produce assets with the same Identity for shared NuGet cache files.

This blocks aspnetcore codeflow ([dotnet/aspnetcore#65673](https://github.com/dotnet/aspnetcore/pull/65673)).

## Root Cause

The duplicate Identity scenario is **valid, not a bug**: Identity = FullPath, so same Identity means same physical file on disk. Multiple WASM clients legitimately reference the same NuGet cache files. The `.Add()` / `.ToDictionary()` calls assumed Identity uniqueness, which was true when Identity pointed to a per-project copy but is no longer true with the runtime#124125 fix.

## Fix

Replace bare `Dictionary.Add()` and `.ToDictionary()` with `ContainsKey` + `Add` (skip-duplicate) pattern in all affected tasks:

1. **`StaticWebAsset.ToAssetDictionary`** — used by 6+ tasks (`ApplyCompressionNegotiation`, `ComputeEndpointsForReferenceStaticWebAssets`, `FilterStaticWebAssetEndpoints`, `GenerateStaticWebAssetEndpointsPropsFile`, `ResolveStaticWebAssetEndpointRoutes`, and more)
2. **`DiscoverPrecompressedAssets`** — the original crashing task (line 653 in targets)
3. **`GenerateStaticWebAssetsManifest`** — crashes on publish
4. **`GenerateStaticWebAssetEndpointsManifest`** — crashes on build

`TryAdd` is not available on net472, so the `ContainsKey` + `Add` pattern is used instead.

## Testing

Validated with a multi-client WASM project (Host + Client1 + Client2 with different StaticWebAssetBasePath):
- ✅ Build succeeds
- ✅ Publish succeeds (both clients produce fingerprinted output)
- ✅ Crash reproduces without fix (confirmed regression)
- ✅ No runtime changes needed — this is an SDK-only fix

## Why not copy pass-throughs to per-project location?

An alternative approach (copying NuGet cache pass-throughs to `obj/`) was prototyped in [dotnet/runtime#125309](https://github.com/dotnet/runtime/pull/125309), but:
- It re-introduces the staleness problem that runtime#124125 fixed: if the runtime pack changes on incremental build, copies in `obj/` go stale
- It adds unnecessary I/O (copying files that don't need copying)
- It conflicts with the long-term direction of minimizing asset copying

The SDK-only fix is simpler, more correct, and doesn't require runtime changes.

Closes [dotnet/sdk#53305](https://github.com/dotnet/sdk/pull/53305) (supersedes that approach)