### PR TITLE
Adds backport label to backport workflow PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,7 @@ jobs:
   backport:
     uses: dotnet/arcade/.github/workflows/backport-base.yml@main
     with:
+        pr_labels: backport
         pr_description_template: |
           Backport of #%source_pr_number% to %target_branch%
 


### PR DESCRIPTION
Related: https://github.com/dotnet/arcade/pull/16575

## Summary

I wanted to have a way to filter PRs from bots in my build duty query. I've [added label input](https://github.com/dotnet/arcade/pull/16575) into Arcade for the backport template. Once that Arcade update flows to the SDK, this label functionality should begin working. This will add the label `backport` to PRs created by the backport workflow.