### PR TITLE
Fix dotnet remove package project argument not recognized

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/RemovePackageCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/RemovePackageCommandDefinition.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Package.Remove;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.Remove.Package;
@@ -8,4 +9,9 @@ namespace Microsoft.DotNet.Cli.Commands.Hidden.Remove.Package;
 internal sealed class RemovePackageCommandDefinition() : PackageRemoveCommandDefinitionBase(Name)
 {
     public new const string Name = "package";
+
+    public RemoveCommandDefinition Parent => (RemoveCommandDefinition)Parents.Single();
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => Parent.ProjectOrFileArgument;
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Package/PackageRemoveCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Package/PackageRemoveCommandDefinition.cs
@@ -16,6 +16,9 @@ internal sealed class PackageRemoveCommandDefinition : PackageRemoveCommandDefin
         Options.Add(ProjectOption);
         Options.Add(FileOption);
     }
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => null;
 }
 
 internal abstract class PackageRemoveCommandDefinitionBase : Command
@@ -36,4 +39,6 @@ internal abstract class PackageRemoveCommandDefinitionBase : Command
         Arguments.Add(CmdPackageArgument);
         Options.Add(InteractiveOption);
     }
+
+    public abstract Argument<string>? GetProjectOrFileArgument();
 }

--- a/src/Cli/dotnet/Commands/Package/Remove/PackageRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Package/Remove/PackageRemoveCommand.cs
@@ -25,7 +25,11 @@ internal sealed class PackageRemoveCommand(ParseResult parseResult) : CommandBas
             throw new GracefulException(CliCommandStrings.PackageRemoveSpecifyExactlyOnePackageReference);
         }
 
-        var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(_definition.FileOption, _definition.ProjectOption, projectOrFileArgument: null, _parseResult);
+        var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(
+            _definition.FileOption,
+            _definition.ProjectOption,
+            _definition.GetProjectOrFileArgument(),
+            _parseResult);
 
         if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuilder.IsValidEntryPointPath(fileOrDirectory))
         {

--- a/test/dotnet.Tests/CommandTests/Package/Remove/GivenDotnetRemovePackage.cs
+++ b/test/dotnet.Tests/CommandTests/Package/Remove/GivenDotnetRemovePackage.cs
@@ -87,6 +87,33 @@ Commands:
         }
 
         [Fact]
+        public void WhenReferencedPackageIsRemovedUsingPositionalProjectArgumentItGetsRemoved()
+        {
+            const string testAsset = "TestAppSimple";
+            var projectDirectory = TestAssetsManager
+                .CopyTestAsset(testAsset)
+                .WithSource().Path;
+
+            var packageName = "Newtonsoft.Json";
+            var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+            var parentDirectory = Directory.GetParent(projectDirectory)!.FullName;
+            var relativeProjectPath = Path.GetRelativePath(parentDirectory, projectFilePath);
+
+            new DotnetCommand(Log)
+                .WithWorkingDirectory(projectDirectory)
+                .Execute("add", "package", packageName)
+                .Should().Pass();
+
+            var remove = new DotnetCommand(Log)
+                .WithWorkingDirectory(parentDirectory)
+                .Execute("remove", relativeProjectPath, "package", packageName);
+
+            remove.Should().Pass();
+            remove.StdOut.Should().Contain($"Removing PackageReference for package '{packageName}' from project '{relativeProjectPath}'.");
+            remove.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
         public void FileBasedApp()
         {
             var testInstance = TestAssetsManager.CreateTestDirectory();


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/14801

### NuGet Product Used

dotnet.exe

### Product Version

.NET SDK Version: 10.0.300-preview.26126.103

### Worked before?

It is a regression since it doesn’t repro on VS Main/11405.173 + NuGet Client Dev/7.3.0.51.

### Impact

It's more difficult to complete my work

### Repro Steps & Context

#### Note:
1.	Repro rate: 100%.
2.	The command 'dotnet add [ProjectFilePath] package xxx' in step 2 can be run successfully.
#### Repro Steps:
1.	Create a solution folder (called CMD in this instance) and cd to the folder in ‘Developer Command Prompt for VS’.
2.	Run the command one by one as below.
```
dotnet new console -n MyApp 
dotnet restore --use-lock-file MyApp\MyApp.csproj 
dotnet new classlib -n MyLib 
dotnet add MyLib\MyLib.csproj package NUnit --version 4.4.0 
dotnet add MyApp\MyApp.csproj reference MyLib\MyLib.csproj
dotnet restore MyApp\MyApp.csproj 
dotnet add MyApp\MyApp.csproj package NUnit --version 4.4.0 
dotnet restore MyApp\MyApp.csproj 
```
3.	Run the command below to remove the package:
`dotnet remove MyApp\MyApp.csproj package NUnit `
#### Expected Result:
No error occurs and the package is removed successfully.
#### Actual Result:
An error ‘could not find any project’ occurs as the red line in the screenshot below.

<img width="1574" height="591" alt="Image" src="https://github.com/user-attachments/assets/3ffae532-2146-4630-a323-b9510f46fd82" />