### PR TITLE
Fix StaticWebAssets FUTDC not tracking referenced project changes

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Design.targets
@@ -4,6 +4,7 @@
       $(CollectUpToDateCheckInputDesignTimeDependsOn);
       ResolveStaticWebAssetsConfiguration;
       ResolveProjectStaticWebAssets;
+      ResolveReferencedProjectsStaticWebAssetsConfiguration;
       CollectStaticWebAssetInputsDesignTime;
     </CollectUpToDateCheckInputDesignTimeDependsOn>
     <CollectUpToDateCheckOutputDesignTimeDependsOn>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.References.targets
@@ -53,7 +53,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WriteLinesToFile Condition="'$(BuildingInsideVisualStudio)' == 'true'"
       File="$(StaticWebAssetReferencesUpToDateCheckManifestPath)"
       Lines="@(_ReferenceManifestPath)"
-      Overwrite="false"
+      Overwrite="true"
       WriteOnlyWhenDifferent="true" />
 
     <MergeConfigurationProperties

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
@@ -123,6 +123,59 @@ public class StaticWebAssetsDesignTimeTest(ITestOutputHelper log) : AspNetSdkBas
         Path.GetFileName(outputFiles[0]).Should().Be("staticwebassets.build.json");
     }
 
+    [Fact]
+    public void CollectUpToDateCheckInputOutputsDesignTime_IncludesReferencedProjectsManifests_WithCleanObjFolder()
+    {
+        // Arrange - this test validates the fix for dotnet/aspnetcore#65738.
+        // The design-time target must resolve referenced project manifests even
+        // when no prior build has run (clean obj folder), because VS evaluates
+        // FUTDC inputs on initial project load before any build occurs.
+        var testAsset = "RazorAppWithP2PReference";
+        ProjectDirectory = AddIntrospection(CreateAspNetSdkTestAsset(testAsset));
+
+        var build = CreateBuildCommand(ProjectDirectory, "AppWithP2PReference");
+        var classLibBuild = CreateBuildCommand(ProjectDirectory, "ClassLibrary");
+
+        // Do NOT run a build first - go straight to design-time targets on a clean obj folder.
+        var msbuild = CreateMSBuildCommand(
+            ProjectDirectory,
+            "AppWithP2PReference",
+            "ResolveStaticWebAssetsConfiguration;ResolveProjectStaticWebAssets;ResolveReferencedProjectsStaticWebAssetsConfiguration;CollectStaticWebAssetInputsDesignTime;CollectStaticWebAssetOutputsDesignTime");
+
+        msbuild.Execute("/p:DesignTimeBuild=true", "/p:BuildingInsideVisualStudio=true", "/bl:design.binlog").Should().Pass();
+
+        // Verify the dependency chain wiring: CollectUpToDateCheckInputDesignTimeDependsOn
+        // must include ResolveReferencedProjectsStaticWebAssetsConfiguration so that VS
+        // invokes it during design-time evaluation. If this wiring is reverted, the
+        // references file would not exist on a clean obj folder and the FUTDC inputs
+        // would be empty.
+        var depChainFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsDependsOn.txt");
+        var depChainMsbuild = CreateMSBuildCommand(
+            ProjectDirectory,
+            "AppWithP2PReference",
+            "ReportDependsOn");
+        depChainMsbuild.Execute(
+            "/p:DesignTimeBuild=true",
+            "/p:BuildingInsideVisualStudio=true",
+            $"""/p:_ReportDependsOnOutputPath={depChainFilePath}""").Should().Pass();
+        new FileInfo(depChainFilePath).Should().Exist();
+        var depChain = File.ReadAllText(depChainFilePath);
+        depChain.Should().Contain("ResolveReferencedProjectsStaticWebAssetsConfiguration");
+
+        // The referenced project's manifest path should be included as a FUTDC input
+        // even though no prior build has created the references upToDateCheck file.
+        var inputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCInput.txt");
+        new FileInfo(inputFilePath).Should().Exist();
+        var inputFiles = File.ReadAllLines(inputFilePath);
+        inputFiles.Should().Contain(Path.Combine(classLibBuild.GetIntermediateDirectory().FullName, "staticwebassets.build.json"));
+
+        var outputFilePath = Path.Combine(build.GetIntermediateDirectory().FullName, "StaticWebAssetsUTDCOutput.txt");
+        new FileInfo(outputFilePath).Should().Exist();
+        var outputFiles = File.ReadAllLines(outputFilePath);
+        outputFiles.Should().ContainSingle();
+        Path.GetFileName(outputFiles[0]).Should().Be("staticwebassets.build.json");
+    }
+
     private static MSBuildCommand CreateMSBuildCommand(TestAsset testAsset, string relativeProjectPath, string targets)
     {
         return (MSBuildCommand)new MSBuildCommand(testAsset.Log, targets, testAsset.TestRoot, relativeProjectPath)
@@ -156,8 +209,18 @@ public class StaticWebAssetsDesignTimeTest(ITestOutputHelper log) : AspNetSdkBas
                                 Encoding="UTF-8"
                                 />
                         </Target>
-                        """
-                        ));
+                        """));
+                project.Document.Root.LastNode.AddAfterSelf(
+                    XElement.Parse("""
+                        <Target Name="ReportDependsOn">
+                            <WriteLinesToFile
+                                File="$(_ReportDependsOnOutputPath)"
+                                Lines="$(CollectUpToDateCheckInputDesignTimeDependsOn)"
+                                Overwrite="true"
+                                Encoding="UTF-8"
+                                />
+                        </Target>
+                        """));
             });
     }
 }


### PR DESCRIPTION
## Problem

When a Blazor Web App with WebAssembly + Global interactivity has a `.razor.css` file modified in the Client project, the Server project's build is skipped by VS's Fast Up-to-Date Check (FUTDC). The Server's `.staticwebassets.endpoints.json` manifest retains stale fingerprints and ETags, causing the app to fail at runtime with "An unhandled error has occurred."

Fixes #53425
Fixes [dotnet/aspnetcore#65738](https://github.com/dotnet/aspnetcore/issues/65738)

## Investigation

See #53425 for the analysis of the problem.

## Change

### `Microsoft.NET.Sdk.StaticWebAssets.Design.targets`

Added `ResolveReferencedProjectsStaticWebAssetsConfiguration` to `CollectUpToDateCheckInputDesignTimeDependsOn`. This ensures the references file is written during design-time evaluation, before `CollectStaticWebAssetInputsDesignTime` tries to read it.

### `Microsoft.NET.Sdk.StaticWebAssets.References.targets`

Changed `Overwrite="false"` to `Overwrite="true"` on the `WriteLinesToFile` call. The file is fully populated from `@(_ReferenceManifestPath)` on each build, so there is no need to append. The existing `WriteOnlyWhenDifferent="true"` attribute ensures the file timestamp only changes when the content actually differs, preserving correct FUTDC behavior.

## Risk

`ResolveReferencedProjectsStaticWebAssetsConfiguration` calls `GetStaticWebAssetsProjectConfiguration` on referenced projects, which is a metadata-only call (it does not resolve actual assets). The expensive `ResolveReferencedProjectsStaticWebAssets` target is not added to the design-time chain.
