### PR TITLE
Delete unused LibraryImport call

### DIFF
--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -49,6 +49,9 @@ namespace Microsoft.DotNet.NativeWrapper
             // return value is intentionally ignored as we let the subsequent P/Invokes fail naturally.
             LoadLibraryExW(dllPath, IntPtr.Zero, LOAD_WITH_ALTERED_SEARCH_PATH);
         }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern IntPtr LoadLibraryExW(string lpFileName, nint hFile, int dwFlags);
 #endif
 
 #if NET
@@ -75,14 +78,6 @@ namespace Microsoft.DotNet.NativeWrapper
 
         // lpFileName passed to LoadLibraryEx must be a full path.
         private const int LOAD_WITH_ALTERED_SEARCH_PATH = 0x8;
-
-#if NET
-        [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial nint LoadLibraryExW(string lpFileName, nint hFile, int dwFlags);
-#else
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
-        private static extern IntPtr LoadLibraryExW(string lpFileName, nint hFile, int dwFlags);
-#endif
 
         /// <summary>
         ///  Flags that control SDK resolution behavior in <see cref="hostfxr_resolve_sdk2"/>.

--- a/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
+++ b/src/Resolvers/Microsoft.DotNet.NativeWrapper/Interop.cs
@@ -40,6 +40,9 @@ namespace Microsoft.DotNet.NativeWrapper
         // already be loaded in the process. Unfortunately there are no issues or pull requests tracking the original
         // implementation of this as it was committed directly from a dev branch into main.
 
+        // lpFileName passed to LoadLibraryEx must be a full path.
+        private const int LOAD_WITH_ALTERED_SEARCH_PATH = 0x8;
+
         private static void PreloadWindowsLibrary(string dllFileName)
         {
             string? basePath = Path.GetDirectoryName(typeof(Interop).Assembly.Location);
@@ -75,9 +78,6 @@ namespace Microsoft.DotNet.NativeWrapper
             return handle;
         }
 #endif
-
-        // lpFileName passed to LoadLibraryEx must be a full path.
-        private const int LOAD_WITH_ALTERED_SEARCH_PATH = 0x8;
 
         /// <summary>
         ///  Flags that control SDK resolution behavior in <see cref="hostfxr_resolve_sdk2"/>.


### PR DESCRIPTION
only used in .NET Framework