### PR TITLE
Quote arguments to [MSBuild]::MakeRelative

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -848,7 +848,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <TargetPath Condition="'%(Content.TargetPath)' != ''">%(Content.TargetPath)</TargetPath>
         <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' != ''">%(Content.Link)</TargetPath>
         <!-- Use MSBuildProjectDirectory as the base for relative path computation. DefiningProjectDirectory can point to sdk targets folder and lead to unexpected paths. -->
-        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == ''">$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(Content.FullPath)))</TargetPath>
+        <TargetPath Condition="'%(Content.TargetPath)' == '' and '%(Content.Link)' == ''">$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)', '%(Content.FullPath)'))</TargetPath>
       </_ContentWithPublishMetadata>
       
       <ContentWithTargetPath Include="@(_ContentWithPublishMetadata)" />

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -486,7 +486,7 @@ class Program { static void Main() => Console.WriteLine(""Hello""); }";
             var projectContent = File.ReadAllText(projectFile);
             projectContent = projectContent.Replace("</Project>", @"
   <ItemGroup>
-    <Content Include=""Doto-VariableFont_ROND,cwght.ttf"" CopyToPublishDirectory=""IfDifferent"" />Expand commentComment on line R489Resolved
+    <Content Include=""Doto-VariableFont_ROND,cwght.ttf"" CopyToPublishDirectory=""IfDifferent"" />
   </ItemGroup>
 </Project>");
             File.WriteAllText(projectFile, projectContent);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -472,7 +472,7 @@ class Program { static void Main() => Console.WriteLine(""Hello""); }";
 
             testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
 
-            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var projectDirectory = Path.Combine(testAsset.Path, testProject.Name);
 

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -486,7 +486,7 @@ class Program { static void Main() => Console.WriteLine(""Hello""); }";
             var projectContent = File.ReadAllText(projectFile);
             projectContent = projectContent.Replace("</Project>", @"
   <ItemGroup>
-    <Content Include=""Doto-VariableFont_ROND,cwght.ttf"" CopyToPublishDirectory=""IfDifferent"" />
+    <Content Include=""Doto-VariableFont_ROND,wght.ttf"" CopyToPublishDirectory=""IfDifferent"" />
   </ItemGroup>
 </Project>");
             File.WriteAllText(projectFile, projectContent);

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithIfDifferent.cs
@@ -455,5 +455,49 @@ class Program { static void Main() => Console.WriteLine(""Hello""); }";
                 .Where(f => !f.StartsWith(publishDirectory.FullName));
             potentialEscapedFiles.Should().BeEmpty("Content file should not escape to directories outside publish folder");
         }
+
+        [Fact]
+        public void It_publishes_content_with_comma_in_filename()
+        {
+            // This test verifies that Content items with commas in their filenames can be published
+            // without triggering MSB4186 due to the comma being interpreted as an argument separator
+            // in the [MSBuild]::MakeRelative property function call.
+
+            var testProject = new TestProject()
+            {
+                Name = "PublishCommaContent",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true
+            };
+
+            testProject.SourceFiles["Program.cs"] = "class Program { static void Main() { } }";
+
+            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+
+            var projectDirectory = Path.Combine(testAsset.Path, testProject.Name);
+
+            // Create a content file with a comma in the filename (e.g., a variable font file)
+            var contentFileName = "Doto-VariableFont_ROND,wght.ttf";
+            var contentFile = Path.Combine(projectDirectory, contentFileName);
+            File.WriteAllText(contentFile, "fake font content");
+
+            // Update the project file to include the content file with CopyToPublishDirectory
+            var projectFile = Path.Combine(projectDirectory, $"{testProject.Name}.csproj");
+            var projectContent = File.ReadAllText(projectFile);
+            projectContent = projectContent.Replace("</Project>", @"
+  <ItemGroup>
+    <Content Include=""Doto-VariableFont_ROND,cwght.ttf"" CopyToPublishDirectory=""IfDifferent"" />Expand commentComment on line R489Resolved
+  </ItemGroup>
+</Project>");
+            File.WriteAllText(projectFile, projectContent);
+
+            var publishCommand = new PublishCommand(testAsset);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDirectory = publishCommand.GetOutputDirectory(testProject.TargetFrameworks);
+            publishDirectory.Should().HaveFile(contentFileName);
+        }
     }
 }


### PR DESCRIPTION
Fix #53385 by quoting file-path arguments so any commas within the paths
do not leak into MSBuild's understanding of the arguments to the
property function.

Fixes #53385

### Summary

Customers with `Content` items that had commas in the filenames hit build/publish failures.

### Customer Impact

Build failures on update to 10.0.200.

### Regression?

Yes, from #52275.

### Testing

Privates tested against repro project from https://github.com/dotnet/sdk/issues/53385#issuecomment-4038824894.

### Risk

Low -- quoting arguments following the pattern used elsewhere.