### PR TITLE
Assert trusted roots relative path with respect to NuGet.Packaging

### DIFF
--- a/test/trustedroots.Tests/GivenNuGetPackagingDllAndBundleLayout.cs
+++ b/test/trustedroots.Tests/GivenNuGetPackagingDllAndBundleLayout.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tests
+{
+    /// <summary>
+    /// NuGet.Packaging.dll locates trusted root certificate bundles using AppContext.BaseDirectory
+    /// (see FallbackCertificateBundleX509ChainFactory in NuGet.Packaging). This test ensures that
+    /// NuGet.Packaging.dll and the trustedroots bundle directory remain co-located in the SDK layout.
+    /// Do not move either without coordinating with the NuGet team (https://github.com/NuGet/Home).
+    /// </summary>
+    public class GivenNuGetPackagingDllAndBundleLayout : SdkTest
+    {
+        private const string ContractViolationMessage =
+            "NuGet.Packaging.dll resolves trusted root certificate bundles relative to AppContext.BaseDirectory " +
+            "(see FallbackCertificateBundleX509ChainFactory in NuGet.Packaging). " +
+            "Do not move NuGet.Packaging.dll or the trustedroots directory without coordinating with the NuGet team.";
+
+        private readonly string _sdkFolder;
+
+        public GivenNuGetPackagingDllAndBundleLayout(ITestOutputHelper log)
+            : base(log)
+        {
+            _sdkFolder = SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest;
+        }
+
+        [Fact]
+        public void NuGetPackagingDllIsCoLocatedWithTrustedRootsBundles()
+        {
+            string nugetPackagingDll = Path.Combine(_sdkFolder, "NuGet.Packaging.dll");
+            string codeSigningBundle = Path.Combine(_sdkFolder, "trustedroots", "codesignctl.pem");
+            string timestampingBundle = Path.Combine(_sdkFolder, "trustedroots", "timestampctl.pem");
+
+            File.Exists(nugetPackagingDll)
+                .Should()
+                .BeTrue($"NuGet.Packaging.dll must exist in the SDK folder ('{_sdkFolder}'). {ContractViolationMessage}");
+
+            File.Exists(codeSigningBundle)
+                .Should()
+                .BeTrue($"trustedroots/codesignctl.pem must exist in the SDK folder ('{_sdkFolder}'). {ContractViolationMessage}");
+
+            File.Exists(timestampingBundle)
+                .Should()
+                .BeTrue($"trustedroots/timestampctl.pem must exist in the SDK folder ('{_sdkFolder}'). {ContractViolationMessage}");
+        }
+    }
+}


### PR DESCRIPTION
 This test ensures NuGet package signing is not broken if any changes are made to the relative path of the trusted root certificate bundles.

`NuGet.Packaging.dll` has an invariant that trusted root bundles must be located at the relative path `./trustedroots/`