### PR TITLE
Strip fingerprint tokens from path in MaterializeFrameworkAsset

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/UpdatePackageStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/UpdatePackageStaticWebAssets.cs
@@ -137,7 +137,8 @@ public class UpdatePackageStaticWebAssets : Task
         var oldIdentity = asset.Identity;
 
         var fxDir = Path.Combine(IntermediateOutputPath, "fx", originalSourceId);
-        var destPath = Path.Combine(fxDir, StaticWebAsset.Normalize(relativePath));
+        var fileSystemRelativePath = asset.ComputePathWithoutTokens(relativePath);
+        var destPath = Path.Combine(fxDir, StaticWebAsset.Normalize(fileSystemRelativePath));
         destPath = Path.GetFullPath(destPath);
 
         var sourceFile = asset.Identity;


### PR DESCRIPTION
## Summary

`MaterializeFrameworkAsset` (introduced in #53135) constructs the destination file path using `asset.RelativePath` directly. When `RelativePath` contains fingerprint tokens (e.g. `dotnet.js#[.{fingerprint}]?.map`), the characters `#`, `{`, `}`, `?` are illegal in Windows file paths, causing:

```
System.IO.IOException: The filename, directory name, or volume label syntax is incorrect.
  : 'obj\Debug\net11.0\fx\BlazorBasicTestApp\_framework\dotnet.js#[.{fingerprint}]?.map'
  at UpdatePackageStaticWebAssets.MaterializeFrameworkAsset(...)
```

## Fix

Use `ComputePathWithoutTokens()` to strip token expressions before constructing the materialized file path. The asset's `RelativePath` metadata (with tokens) is preserved for URL/endpoint resolution — only the file system destination path is cleaned.

This follows the same pattern used in `ResolveCompressedAssets`, `DefineStaticWebAssetEndpoints`, and `DefineStaticWebAssets` which all strip tokens when constructing filesystem paths.

## Impact

This fixes 12 test failures per Helix work item across all 4 WASM build test legs in [dotnet/runtime#125329](https://github.com/dotnet/runtime/pull/125329), which depends on SDK #53135.

Failing tests: `Wasm.Build.Tests.Blazor.WorkloadRequiredTests` — all Blazor template build tests that use the `no-workload` and `no-webcil` configurations.

cc @javiercn