### PR TITLE
Implements target framework selection for multi-targeted projects

### DIFF
--- a/src/Dotnet.Watch/HotReloadClient/Logging/LogEvents.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Logging/LogEvents.cs
@@ -76,5 +76,6 @@ internal static class LogEvents
     public static readonly LogEvent<string> SendingStaticAssetUpdateRequest = Create<string>(LogLevel.Debug, "Sending static asset update request to connected browsers: '{0}'.");
     public static readonly LogEvent<string> RefreshServerRunningAt = Create<string>(LogLevel.Debug, "Refresh server running at {0}.");
     public static readonly LogEvent<None> ConnectedToRefreshServer = Create(LogLevel.Debug, "Connected to refresh server.");
+    public static readonly LogEvent<string> ManifestFileNotFound = Create<string>(LogLevel.Debug, "Manifest file '{0}' not found.");
 }
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/StaticWebAssetsManifest.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/StaticWebAssetsManifest.cs
@@ -92,7 +92,7 @@ internal sealed class StaticWebAssetsManifest(ImmutableDictionary<string, string
         }
         catch (FileNotFoundException)
         {
-            logger.LogDebug("File '{FilePath}' does not exist.", path);
+            logger.Log(LogEvents.ManifestFileNotFound, path);
             return null;
         }
         catch (Exception e)

--- a/src/Dotnet.Watch/Watch.Aspire/Server/AspireWatcherLauncher.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/AspireWatcherLauncher.cs
@@ -31,7 +31,6 @@ internal abstract class AspireWatcherLauncher(GlobalOptions globalOptions, Envir
             EnvironmentOptions = EnvironmentOptions,
             MainProjectOptions = null,
             BuildArguments = [],
-            TargetFramework = null,
             RootProjects = rootProjects,
             BrowserRefreshServerFactory = new BrowserRefreshServerFactory(),
             BrowserLauncher = new BrowserLauncher(logger, Reporter, EnvironmentOptions),

--- a/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
+++ b/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxTokenParser;
 
 namespace Microsoft.DotNet.Watch;
 
@@ -17,23 +18,12 @@ internal sealed class EvaluationResult(
     IReadOnlyDictionary<ProjectInstanceId, StaticWebAssetsManifest> staticWebAssetsManifests,
     ProjectBuildManager buildManager)
 {
-    public readonly IReadOnlyDictionary<string, FileItem> Files = files;
-    public readonly LoadedProjectGraph ProjectGraph = projectGraph;
-    public readonly ProjectBuildManager BuildManager = buildManager;
+    public IReadOnlyDictionary<string, FileItem> Files => files;
+    public LoadedProjectGraph ProjectGraph => projectGraph;
+    public ProjectBuildManager BuildManager => buildManager;
 
     public readonly FilePathExclusions ItemExclusions
         = projectGraph != null ? FilePathExclusions.Create(projectGraph.Graph) : FilePathExclusions.Empty;
-
-    private readonly Lazy<IReadOnlySet<string>> _lazyBuildFiles
-        = new(() => projectGraph != null ? CreateBuildFileSet(projectGraph.Graph) : new HashSet<string>());
-
-    private static IReadOnlySet<string> CreateBuildFileSet(ProjectGraph projectGraph)
-        => projectGraph.ProjectNodes.SelectMany(p => p.ProjectInstance.ImportPaths)
-            .Concat(projectGraph.ProjectNodes.Select(p => p.ProjectInstance.FullPath))
-            .ToHashSet(PathUtilities.OSSpecificPathComparer);
-
-    public IReadOnlySet<string> BuildFiles
-        => _lazyBuildFiles.Value;
 
     public IReadOnlyDictionary<ProjectInstanceId, StaticWebAssetsManifest> StaticWebAssetsManifests
         => staticWebAssetsManifests;
@@ -41,15 +31,13 @@ internal sealed class EvaluationResult(
     public IReadOnlyDictionary<ProjectInstanceId, ProjectInstance> RestoredProjectInstances
         => restoredProjectInstances;
 
-    public void WatchFiles(FileWatcher fileWatcher)
+    public void WatchFileItems(FileWatcher fileWatcher)
     {
         fileWatcher.WatchContainingDirectories(Files.Keys, includeSubdirectories: true);
 
         fileWatcher.WatchContainingDirectories(
             StaticWebAssetsManifests.Values.SelectMany(static manifest => manifest.DiscoveryPatterns.Select(static pattern => pattern.Directory)),
             includeSubdirectories: true);
-
-        fileWatcher.WatchFiles(BuildFiles);
     }
 
     public static ImmutableDictionary<string, string> GetGlobalBuildProperties(IEnumerable<string> buildArguments, EnvironmentOptions environmentOptions)
@@ -70,31 +58,24 @@ internal sealed class EvaluationResult(
     /// Loads project graph and performs design-time build.
     /// </summary>
     public static async ValueTask<EvaluationResult?> TryCreateAsync(
-        ProjectGraphFactory factory,
+        LoadedProjectGraph projectGraph,
+        ILogger logger,
         GlobalOptions globalOptions,
         EnvironmentOptions environmentOptions,
+        string? mainProjectTargetFramework,
         bool restore,
         CancellationToken cancellationToken)
     {
-        var logger = factory.Logger;
+        logger.Log(MessageDescriptor.LoadingProjects);
+
+        var projectLoadingStopwatch = Stopwatch.StartNew();
         var stopwatch = Stopwatch.StartNew();
-
-        var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: true, cancellationToken);
-
-        if (projectGraph == null)
-        {
-            return null;
-        }
 
         var buildReporter = new BuildReporter(projectGraph.Logger, globalOptions, environmentOptions);
         var buildManager = new ProjectBuildManager(projectGraph.ProjectCollection, buildReporter);
 
-        logger.LogDebug("Project graph loaded in {Time}s.", stopwatch.Elapsed.TotalSeconds.ToString("0.0"));
-
         if (restore)
         {
-            stopwatch.Restart();
-
             var restoreRequests = projectGraph.Graph.GraphRoots.Select(node => BuildRequest.Create(node.ProjectInstance, [TargetNames.Restore])).ToArray();
 
             if (await buildManager.BuildAsync(
@@ -128,7 +109,17 @@ internal sealed class EvaluationResult(
 
         var buildRequests =
            (from node in projectGraph.Graph.ProjectNodesTopologicallySorted
-            where node.ProjectInstance.GetPropertyValue(PropertyNames.TargetFramework) != ""
+            let targetFramework = node.ProjectInstance.GetTargetFramework()
+
+            // skip outer-build projects
+            where targetFramework != ""
+
+            // skip root projects that do not match main project TFM, if specified:
+            where mainProjectTargetFramework == null ||
+                  targetFramework == mainProjectTargetFramework ||
+                  node.ReferencingProjects.Count != 1 ||
+                  !node.ReferencingProjects.First().IsRoot
+
             let targets = GetBuildTargets(node.ProjectInstance, environmentOptions)
             where targets is not []
             select BuildRequest.Create(node.ProjectInstance, [.. targets])).ToArray();
@@ -151,6 +142,7 @@ internal sealed class EvaluationResult(
         }
 
         logger.LogDebug("Design-time build completed in {Time}s.", stopwatch.Elapsed.TotalSeconds.ToString("0.0"));
+        logger.Log(MessageDescriptor.LoadedProjects, projectGraph.Graph.ProjectNodes.Count, projectLoadingStopwatch.Elapsed.TotalSeconds);
 
         ProcessBuildResults(buildResults, logger, out var fileItems, out var staticWebAssetManifests);
 

--- a/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
+++ b/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
@@ -106,22 +106,7 @@ internal sealed class EvaluationResult(
         // Update the project instances of the graph with design-time build results.
         // The properties and items set by DTB will be used by the Workspace to create Roslyn representation of projects.
 
-        var buildRequests =
-           (from node in projectGraph.Graph.ProjectNodesTopologicallySorted
-            let targetFramework = node.ProjectInstance.GetTargetFramework()
-
-            // skip outer-build projects
-            where targetFramework != ""
-
-            // skip root projects that do not match main project TFM, if specified:
-            where mainProjectTargetFramework == null ||
-                  targetFramework == mainProjectTargetFramework ||
-                  node.ReferencingProjects.Count != 1 ||
-                  !node.ReferencingProjects.First().IsRoot
-
-            let targets = GetBuildTargets(node.ProjectInstance, environmentOptions)
-            where targets is not []
-            select BuildRequest.Create(node.ProjectInstance, [.. targets])).ToArray();
+        var buildRequests = CreateDesignTimeBuildRequests(projectGraph.Graph, mainProjectTargetFramework, environmentOptions.SuppressHandlingStaticWebAssets).ToImmutableArray();
 
         var buildResults = await buildManager.BuildAsync(
             buildRequests,
@@ -148,6 +133,28 @@ internal sealed class EvaluationResult(
         BuildReporter.ReportWatchedFiles(logger, fileItems);
 
         return new EvaluationResult(projectGraph, restoredProjectInstances, fileItems, staticWebAssetManifests, buildManager);
+    }
+
+    // internal for testing
+    internal static IEnumerable<BuildRequest<object?>> CreateDesignTimeBuildRequests(ProjectGraph graph, string? mainProjectTargetFramework, bool suppressStaticWebAssets)
+    {
+        return from node in graph.ProjectNodesTopologicallySorted
+               let targetFramework = node.ProjectInstance.GetTargetFramework()
+
+               // skip outer-build projects
+               where targetFramework != ""
+
+               // skip root projects that do not match main project TFM, if specified:
+               where mainProjectTargetFramework == null ||
+                     targetFramework == mainProjectTargetFramework ||
+                     HasParentWithTargetFramework(node)
+
+               let targets = GetBuildTargets(node.ProjectInstance, suppressStaticWebAssets)
+               where targets is not []
+               select BuildRequest.Create(node.ProjectInstance, [.. targets]);
+
+        static bool HasParentWithTargetFramework(ProjectGraphNode node)
+            => node.ReferencingProjects.Any(p => p.ProjectInstance.GetTargetFramework() != "");
     }
 
     private static void ProcessBuildResults(
@@ -236,7 +243,7 @@ internal sealed class EvaluationResult(
         staticWebAssetManifests = staticWebAssetManifestsBuilder;
     }
 
-    private static string[] GetBuildTargets(ProjectInstance projectInstance, EnvironmentOptions environmentOptions)
+    private static string[] GetBuildTargets(ProjectInstance projectInstance, bool suppressStaticWebAssets)
     {
         var compileTarget = projectInstance.Targets.ContainsKey(TargetNames.CompileDesignTime)
             ? TargetNames.CompileDesignTime
@@ -254,7 +261,7 @@ internal sealed class EvaluationResult(
             compileTarget
         };
 
-        if (!environmentOptions.SuppressHandlingStaticWebAssets)
+        if (!suppressStaticWebAssets)
         {
             // generates static file asset manifest
             if (projectInstance.Targets.ContainsKey(TargetNames.GenerateComputedBuildStaticWebAssets))

--- a/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
+++ b/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
 using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxTokenParser;
 
 namespace Microsoft.DotNet.Watch;
 

--- a/src/Dotnet.Watch/Watch/Build/LoadedProjectGraph.cs
+++ b/src/Dotnet.Watch/Watch/Build/LoadedProjectGraph.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Graph;
 using Microsoft.Extensions.Logging;
@@ -9,21 +10,28 @@ namespace Microsoft.DotNet.Watch
 {
     internal sealed class LoadedProjectGraph(ProjectGraph graph, ProjectCollection collection, ILogger logger)
     {
-        // full path of proj file to list of nodes representing all target frameworks of the project:
-        public readonly IReadOnlyDictionary<string, IReadOnlyList<ProjectGraphNode>> Map = 
-            graph.ProjectNodes.GroupBy(n => n.ProjectInstance.FullPath).ToDictionary(
+        // full path of proj file to list of nodes representing all target frameworks of the project (excluding outer build nodes):
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<ProjectGraphNode>> _innerBuildNodes = 
+            graph.ProjectNodes.Where(n => n.ProjectInstance.GetTargetFramework() != "").GroupBy(n => n.ProjectInstance.FullPath).ToDictionary(
                 keySelector: static g => g.Key,
                 elementSelector: static g => (IReadOnlyList<ProjectGraphNode>)[.. g]);
+
+        private readonly Lazy<IReadOnlySet<string>> _lazyBuildFiles = new(() =>
+            graph.ProjectNodes.SelectMany(p => p.ProjectInstance.ImportPaths)
+                .Concat(graph.ProjectNodes.Select(p => p.ProjectInstance.FullPath))
+                .ToHashSet(PathUtilities.OSSpecificPathComparer));
 
         public ProjectGraph Graph => graph;
         public ILogger Logger => logger;
         public ProjectCollection ProjectCollection => collection;
 
+        public IReadOnlySet<string> BuildFiles => _lazyBuildFiles.Value;
+
         public IReadOnlyList<ProjectGraphNode> GetProjectNodes(string projectPath)
         {
-            if (Map.TryGetValue(projectPath, out var rootProjectNodes))
+            if (_innerBuildNodes.TryGetValue(projectPath, out var nodes))
             {
-                return rootProjectNodes;
+                return nodes;
             }
 
             logger.LogError("Project '{ProjectPath}' not found in the project graph.", projectPath);
@@ -52,7 +60,7 @@ namespace Microsoft.DotNet.Watch
             ProjectGraphNode? candidate = null;
             foreach (var node in projectNodes)
             {
-                if (node.ProjectInstance.GetPropertyValue("TargetFramework") == targetFramework)
+                if (node.ProjectInstance.GetTargetFramework() == targetFramework)
                 {
                     if (candidate != null)
                     {

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphFactory.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.Build.Evaluation;
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.Watch;
 
 internal sealed class ProjectGraphFactory(
     ImmutableArray<ProjectRepresentation> rootProjects,
-    string? targetFramework,
+    string? virtualProjectTargetFramework,
     ImmutableDictionary<string, string> buildProperties,
     ILogger logger)
 {
@@ -36,7 +37,7 @@ internal sealed class ProjectGraphFactory(
         useAsynchronousLogging: false,
         reuseProjectRootElementCache: true);
 
-    private readonly string _targetFramework = targetFramework ?? GetProductTargetFramework();
+    private readonly string _virtualProjectTargetFramework = virtualProjectTargetFramework ?? GetProductTargetFramework();
 
     public ILogger Logger => logger;
 
@@ -55,10 +56,14 @@ internal sealed class ProjectGraphFactory(
         var entryPoints = rootProjects.Select(p => new ProjectGraphEntryPoint(p.ProjectGraphPath, buildProperties));
         try
         {
-            return new LoadedProjectGraph(
+            var stopwatch = Stopwatch.StartNew();
+            var graph = new LoadedProjectGraph(
                 new ProjectGraph(entryPoints, _collection, (path, globalProperties, collection) => CreateProjectInstance(path, globalProperties, collection, logger), cancellationToken),
                 _collection,
                 logger);
+
+            logger.LogDebug("Project graph loaded in {Time}s.", stopwatch.Elapsed.TotalSeconds.ToString("0.0"));
+            return graph;
         }
         catch (ProjectCreationFailedException)
         {
@@ -120,7 +125,7 @@ internal sealed class ProjectGraphFactory(
 
             var projectInstance = VirtualProjectBuilder.CreateProjectInstance(
                 entryPointFilePath,
-                _targetFramework,
+                _virtualProjectTargetFramework,
                 projectCollection,
                 (path, line, message) =>
                 {

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -9,8 +9,14 @@ namespace Microsoft.DotNet.Watch;
 
 internal static class ProjectGraphUtilities
 {
-    public static string GetDisplayName(this ProjectGraphNode projectNode)
-        => projectNode.ProjectInstance.GetDisplayName();
+    extension(ProjectGraphNode projectNode)
+    {
+        public string GetDisplayName()
+            => projectNode.ProjectInstance.GetDisplayName();
+
+        public bool IsRoot
+            => projectNode.ReferencingProjects.Count == 0;
+    }
 
     public static string GetDisplayName(this ProjectInstance project)
         => $"{Path.GetFileNameWithoutExtension(project.FullPath)} ({project.GetTargetFramework()})";
@@ -18,7 +24,7 @@ internal static class ProjectGraphUtilities
     public static string GetTargetFramework(this ProjectInstance project)
         => project.GetPropertyValue(PropertyNames.TargetFramework);
 
-    public static IEnumerable<string> GetTargetFrameworks(this ProjectInstance project)
+    public static IReadOnlyList<string> GetTargetFrameworks(this ProjectInstance project)
         => project.GetStringListPropertyValue(PropertyNames.TargetFrameworks);
 
     public static Version? GetTargetFrameworkVersion(this ProjectGraphNode projectNode)
@@ -69,13 +75,13 @@ internal static class ProjectGraphUtilities
     public static bool AreDefaultItemsEnabled(this ProjectGraphNode projectNode)
         => projectNode.GetBooleanPropertyValue(PropertyNames.EnableDefaultItems);
 
-    public static IEnumerable<string> GetDefaultItemExcludes(this ProjectGraphNode projectNode)
+    public static IReadOnlyList<string> GetDefaultItemExcludes(this ProjectGraphNode projectNode)
         => projectNode.GetStringListPropertyValue(PropertyNames.DefaultItemExcludes);
 
-    public static IEnumerable<string> GetStringListPropertyValue(this ProjectGraphNode projectNode, string propertyName)
+    public static IReadOnlyList<string> GetStringListPropertyValue(this ProjectGraphNode projectNode, string propertyName)
         => projectNode.ProjectInstance.GetStringListPropertyValue(propertyName);
 
-    public static IEnumerable<string> GetStringListPropertyValue(this ProjectInstance project, string propertyName)
+    public static IReadOnlyList<string> GetStringListPropertyValue(this ProjectInstance project, string propertyName)
         => project.GetPropertyValue(propertyName).Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
     public static bool GetBooleanPropertyValue(this ProjectGraphNode projectNode, string propertyName, bool defaultValue = false)
@@ -87,15 +93,27 @@ internal static class ProjectGraphUtilities
     public static bool GetBooleanMetadataValue(this ProjectItemInstance item, string metadataName, bool defaultValue = false)
         => item.GetMetadataValue(metadataName) is { Length: > 0 } value ? bool.TryParse(value, out var result) && result : defaultValue;
 
+    /// <summary>
+    /// Yields the project itself and all its ancestors, excluding outer build nodes.
+    /// </summary>
     public static IEnumerable<ProjectGraphNode> GetAncestorsAndSelf(this ProjectGraphNode project)
         => GetAncestorsAndSelf([project]);
 
+    /// <summary>
+    /// Yields the given projects and all their ancestors, excluding outer build nodes.
+    /// </summary>
     public static IEnumerable<ProjectGraphNode> GetAncestorsAndSelf(this IEnumerable<ProjectGraphNode> projects)
         => GetTransitiveProjects(projects, static project => project.ReferencingProjects);
 
+    /// <summary>
+    /// Yields the project itself and all transitively referenced projects, excluding outer build nodes.
+    /// </summary>
     public static IEnumerable<ProjectGraphNode> GetDescendantsAndSelf(this ProjectGraphNode project)
         => GetDescendantsAndSelf([project]);
 
+    /// <summary>
+    /// Yields the given projects and all transitively referenced projects, excluding outer build nodes.
+    /// </summary>
     public static IEnumerable<ProjectGraphNode> GetDescendantsAndSelf(this IEnumerable<ProjectGraphNode> projects)
         => GetTransitiveProjects(projects, static project => project.ProjectReferences);
 
@@ -113,7 +131,10 @@ internal static class ProjectGraphUtilities
             var project = queue.Dequeue();
             if (visited.Add(project))
             {
-                yield return project;
+                if (project.ProjectInstance.GetTargetFramework() != "")
+                {
+                    yield return project;
+                }
 
                 foreach (var referencingProject in getEdges(project))
                 {

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -4,6 +4,7 @@
 using System.Runtime.Versioning;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
+using Microsoft.DotNet.HotReload;
 
 namespace Microsoft.DotNet.Watch;
 
@@ -13,9 +14,6 @@ internal static class ProjectGraphUtilities
     {
         public string GetDisplayName()
             => projectNode.ProjectInstance.GetDisplayName();
-
-        public bool IsRoot
-            => projectNode.ReferencingProjects.Count == 0;
     }
 
     public static string GetDisplayName(this ProjectInstance project)

--- a/src/Dotnet.Watch/Watch/Context/DotNetWatchContext.cs
+++ b/src/Dotnet.Watch/Watch/Context/DotNetWatchContext.cs
@@ -30,11 +30,6 @@ namespace Microsoft.DotNet.Watch
         public required ProjectOptions? MainProjectOptions { get; init; }
 
         /// <summary>
-        /// Default target framework.
-        /// </summary>
-        public required string? TargetFramework { get; init; }
-
-        /// <summary>
         /// Additional arguments passed to `dotnet build` when building projects.
         /// </summary>
         public required IReadOnlyList<string> BuildArguments { get; init; }

--- a/src/Dotnet.Watch/Watch/Context/ProjectOptions.cs
+++ b/src/Dotnet.Watch/Watch/Context/ProjectOptions.cs
@@ -15,6 +15,14 @@ internal sealed record ProjectOptions
     public required string WorkingDirectory { get; init; }
 
     /// <summary>
+    /// Target framework to use to launch the project.
+    /// If the project multi-targets and <see cref="TargetFramework"/> is null
+    /// the user will be prompted for the framework in interactive mode
+    /// or an error is reported in non-interactive mode.
+    /// </summary>
+    public string? TargetFramework { get; init; }
+
+    /// <summary>
     /// No value indicates that no launch profile should be used.
     /// Null value indicates that the default launch profile should be used.
     /// </summary>

--- a/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
@@ -96,11 +96,9 @@ namespace Microsoft.DotNet.Watch
             }
         }
 
-        public async ValueTask StartSessionAsync(CancellationToken cancellationToken)
+        public async ValueTask StartSessionAsync(ProjectGraph graph, CancellationToken cancellationToken)
         {
-            Logger.Log(MessageDescriptor.HotReloadSessionStartingNotification);
-
-            var solution = Workspace.CurrentSolution;
+            var solution = await UpdateProjectGraphAsync(graph, cancellationToken);
 
             await _hotReloadService.StartSessionAsync(solution, cancellationToken);
 
@@ -353,7 +351,7 @@ namespace Microsoft.DotNet.Watch
 
             var runningProjectInfos =
                (from project in currentSolution.Projects
-                let runningProject = GetCorrespondingRunningProject(project, runningProjects)
+                let runningProject = GetCorrespondingRunningProjects(runningProjects, project).FirstOrDefault()
                 where runningProject != null
                 let autoRestartProject = autoRestart || runningProject.ProjectNode.IsAutoRestartEnabled()
                 select (project.Id, info: new HotReloadService.RunningProjectInfo() { RestartWhenChangesHaveNoEffect = autoRestartProject }))
@@ -361,7 +359,7 @@ namespace Microsoft.DotNet.Watch
 
             var updates = await _hotReloadService.GetUpdatesAsync(currentSolution, runningProjectInfos, cancellationToken);
 
-            await DisplayResultsAsync(updates, runningProjectInfos, cancellationToken);
+            await DisplayResultsAsync(updates, currentSolution, runningProjectInfos, cancellationToken);
 
             if (updates.Status is HotReloadService.Status.NoChangesToApply or HotReloadService.Status.Blocked)
             {
@@ -530,24 +528,7 @@ namespace Microsoft.DotNet.Watch
             }
         }
 
-        private static RunningProject? GetCorrespondingRunningProject(Project project, ImmutableDictionary<string, ImmutableArray<RunningProject>> runningProjects)
-        {
-            if (project.FilePath == null || !runningProjects.TryGetValue(project.FilePath, out var projectsWithPath))
-            {
-                return null;
-            }
-
-            // msbuild workspace doesn't set TFM if the project is not multi-targeted
-            var tfm = HotReloadService.GetTargetFramework(project);
-            if (tfm == null)
-            {
-                return projectsWithPath[0];
-            }
-
-            return projectsWithPath.SingleOrDefault(p => string.Equals(p.ProjectNode.ProjectInstance.GetTargetFramework(), tfm, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private async ValueTask DisplayResultsAsync(HotReloadService.Updates updates, ImmutableDictionary<ProjectId, HotReloadService.RunningProjectInfo> runningProjectInfos, CancellationToken cancellationToken)
+        private async ValueTask DisplayResultsAsync(HotReloadService.Updates updates, Solution solution, ImmutableDictionary<ProjectId, HotReloadService.RunningProjectInfo> runningProjectInfos, CancellationToken cancellationToken)
         {
             switch (updates.Status)
             {
@@ -607,7 +588,8 @@ namespace Microsoft.DotNet.Watch
                         continue;
                     }
 
-                    ReportDiagnostic(diagnostic, autoPrefix: "");
+                    // TODO: we don't currently have a project associated with the diagnostic
+                    ReportDiagnostic(diagnostic, projectDisplayPrefix: "", autoPrefix: "");
                 }
             }
 
@@ -628,6 +610,10 @@ namespace Microsoft.DotNet.Watch
 
                 foreach (var (projectId, diagnostics) in updates.TransientDiagnostics)
                 {
+                    // The diagnostic may be reported for a project that has been deleted.
+                    var project = solution.GetProject(projectId);
+                    var projectDisplay = project != null ? $"[{GetProjectInstance(project).GetDisplayName()}] " : "";
+
                     foreach (var diagnostic in diagnostics)
                     {
                         var prefix =
@@ -635,7 +621,7 @@ namespace Microsoft.DotNet.Watch
                             projectsRebuiltDueToRudeEdits.Contains(projectId) ? "[auto-rebuild] " :
                             "";
 
-                        ReportDiagnostic(diagnostic, prefix);
+                        ReportDiagnostic(diagnostic, projectDisplay, prefix);
                     }
                 }
             }
@@ -643,23 +629,23 @@ namespace Microsoft.DotNet.Watch
             bool IsAutoRestartEnabled(ProjectId id)
                 => runningProjectInfos.TryGetValue(id, out var info) && info.RestartWhenChangesHaveNoEffect;
 
-            void ReportDiagnostic(Diagnostic diagnostic, string autoPrefix)
+            void ReportDiagnostic(Diagnostic diagnostic, string projectDisplayPrefix, string autoPrefix)
             {
-                var display = CSharpDiagnosticFormatter.Instance.Format(diagnostic);
+                var message = projectDisplayPrefix + autoPrefix + CSharpDiagnosticFormatter.Instance.Format(diagnostic);
 
                 if (autoPrefix != "")
                 {
-                    Logger.Log(MessageDescriptor.ApplyUpdate_AutoVerbose, autoPrefix, display);
+                    Logger.Log(MessageDescriptor.ApplyUpdate_AutoVerbose, message);
                     errorsToDisplayInApp.Add(MessageDescriptor.RestartingApplicationToApplyChanges.GetMessage());
                 }
                 else
                 {
                     var descriptor = GetMessageDescriptor(diagnostic);
-                    Logger.Log(descriptor, display);
+                    Logger.Log(descriptor, message);
 
                     if (descriptor.Level != LogLevel.None)
                     {
-                        errorsToDisplayInApp.Add(descriptor.GetMessage(display));
+                        errorsToDisplayInApp.Add(descriptor.GetMessage(message));
                     }
                 }
             }
@@ -695,6 +681,9 @@ namespace Microsoft.DotNet.Watch
             Stopwatch stopwatch,
             CancellationToken cancellationToken)
         {
+            // capture snapshot:
+            var runningProjects = _runningProjects;
+
             var assets = new Dictionary<ProjectInstance, Dictionary<string, StaticWebAsset>>();
             var projectInstancesToRegenerate = new HashSet<ProjectInstanceId>();
 
@@ -710,18 +699,10 @@ namespace Microsoft.DotNet.Watch
 
                 foreach (var containingProjectPath in file.ContainingProjectPaths)
                 {
-                    if (!evaluationResult.ProjectGraph.Map.TryGetValue(containingProjectPath, out var containingProjectNodes))
-                    {
-                        // Shouldn't happen.
-                        Logger.LogWarning("Project '{Path}' not found in the project graph.", containingProjectPath);
-                        continue;
-                    }
-
-                    foreach (var containingProjectNode in containingProjectNodes)
+                    foreach (var containingProjectNode in evaluationResult.ProjectGraph.GetProjectNodes(containingProjectPath))
                     {
                         if (isScopedCss)
                         {
-                            // The outer build project instance(that specifies TargetFrameworks) won't have the target.
                             if (!HasScopedCssTargets(containingProjectNode.ProjectInstance))
                             {
                                 continue;
@@ -733,7 +714,8 @@ namespace Microsoft.DotNet.Watch
                         foreach (var referencingProjectNode in containingProjectNode.GetAncestorsAndSelf())
                         {
                             var applicationProjectInstance = referencingProjectNode.ProjectInstance;
-                            if (!TryGetRunningProject(applicationProjectInstance.FullPath, out _))
+                            var runningApplicationProject = GetCorrespondingRunningProjects(runningProjects, applicationProjectInstance).FirstOrDefault();
+                            if (runningApplicationProject == null)
                             {
                                 continue;
                             }
@@ -758,14 +740,14 @@ namespace Microsoft.DotNet.Watch
                                 if (!evaluationResult.StaticWebAssetsManifests.TryGetValue(applicationProjectInstance.GetId(), out var manifest))
                                 {
                                     // Shouldn't happen.
-                                    Logger.LogWarning("[{Project}] Static web asset manifest not found.", containingProjectNode.GetDisplayName());
+                                    runningApplicationProject.ClientLogger.Log(MessageDescriptor.StaticWebAssetManifestNotFound);
                                     continue;
                                 }
 
                                 if (!manifest.TryGetBundleFilePath(bundleFileName, out var bundleFilePath))
                                 {
                                     // Shouldn't happen.
-                                    Logger.LogWarning("[{Project}] Scoped CSS bundle file '{BundleFile}' not found.", containingProjectNode.GetDisplayName(), bundleFileName);
+                                    runningApplicationProject.ClientLogger.Log(MessageDescriptor.ScopedCssBundleFileNotFound, bundleFileName);
                                     continue;
                                 }
 
@@ -838,12 +820,7 @@ namespace Microsoft.DotNet.Watch
                     continue;
                 }
 
-                if (!TryGetRunningProject(applicationProjectInstance.FullPath, out var runningProjects))
-                {
-                    continue;
-                }
-
-                foreach (var runningProject in runningProjects)
+                foreach (var runningProject in GetCorrespondingRunningProjects(runningProjects, applicationProjectInstance))
                 {
                     if (!builder.StaticAssetsToUpdate.TryGetValue(runningProject, out var updatesPerRunningProject))
                     {
@@ -954,12 +931,7 @@ namespace Microsoft.DotNet.Watch
             {
                 foreach (var containingProjectPath in changedFile.Item.ContainingProjectPaths)
                 {
-                    if (!projectGraph.Map.TryGetValue(containingProjectPath, out var containingProjectNodes))
-                    {
-                        // Shouldn't happen.
-                        Logger.LogWarning("Project '{Path}' not found in the project graph.", containingProjectPath);
-                        continue;
-                    }
+                    var containingProjectNodes = projectGraph.GetProjectNodes(containingProjectPath);
 
                     // Relaunch all projects whose dependency is affected by this file change.
                     foreach (var ancestor in containingProjectNodes[0].GetAncestorsAndSelf())
@@ -982,12 +954,52 @@ namespace Microsoft.DotNet.Watch
             return relaunchOperations;
         }
 
-        public bool TryGetRunningProject(string projectPath, out ImmutableArray<RunningProject> projects)
+        private static IEnumerable<RunningProject> GetCorrespondingRunningProjects(ImmutableDictionary<string, ImmutableArray<RunningProject>> runningProjects, Project project)
         {
-            lock (_runningProjectsAndUpdatesGuard)
+            if (project.FilePath == null || !runningProjects.TryGetValue(project.FilePath, out var projectsWithPath))
             {
-                return _runningProjects.TryGetValue(projectPath, out projects);
+                return [];
             }
+
+            // msbuild workspace doesn't set TFM if the project is not multi-targeted
+            var tfm = HotReloadService.GetTargetFramework(project);
+            if (tfm == null)
+            {
+                Debug.Assert(projectsWithPath.All(p => string.Equals(p.GetTargetFramework(), projectsWithPath[0].GetTargetFramework(), StringComparison.OrdinalIgnoreCase)));
+                return projectsWithPath;
+            }
+
+            return projectsWithPath.Where(p => string.Equals(p.GetTargetFramework(), tfm, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static IEnumerable<RunningProject> GetCorrespondingRunningProjects(ImmutableDictionary<string, ImmutableArray<RunningProject>> runningProjects, ProjectInstance project)
+        {
+            if (!runningProjects.TryGetValue(project.FullPath, out var projectsWithPath))
+            {
+                return [];
+            }
+
+            var tfm = project.GetTargetFramework();
+            return projectsWithPath.Where(p => string.Equals(p.GetTargetFramework(), tfm, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private ProjectInstance GetProjectInstance(Project project)
+        {
+            Debug.Assert(project.FilePath != null);
+
+            if (!_projectInstances.TryGetValue(project.FilePath, out var instances))
+            {
+                throw new InvalidOperationException($"Project '{project.FilePath}' (id = '{project.Id}') not found in project graph");
+            }
+
+            // msbuild workspace doesn't set TFM if the project is not multi-targeted
+            var tfm = HotReloadService.GetTargetFramework(project);
+            if (tfm == null)
+            {
+                return instances.Single();
+            }
+
+            return instances.Single(instance => string.Equals(instance.GetTargetFramework(), tfm, StringComparison.OrdinalIgnoreCase));
         }
 
         private static ImmutableArray<HotReloadManagedCodeUpdate> ToManagedCodeUpdates(IEnumerable<HotReloadService.Update> updates)
@@ -1000,12 +1012,13 @@ namespace Microsoft.DotNet.Watch
                     keySelector: static group => group.Key,
                     elementSelector: static group => group.Select(static node => node.ProjectInstance).ToImmutableArray());
 
-        public async Task UpdateProjectGraphAsync(ProjectGraph projectGraph, CancellationToken cancellationToken)
+        public async Task<Solution> UpdateProjectGraphAsync(ProjectGraph projectGraph, CancellationToken cancellationToken)
         {
             _projectInstances = CreateProjectInstanceMap(projectGraph);
 
             var solution = await Workspace.UpdateProjectGraphAsync([.. projectGraph.EntryPointNodes.Select(n => n.ProjectInstance.FullPath)], cancellationToken);
             await SolutionUpdatedAsync(solution, "project update", cancellationToken);
+            return solution;
         }
 
         public async Task UpdateFileContentAsync(IReadOnlyList<ChangedFile> changedFiles, CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
@@ -5,6 +5,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.Encodings.Web;
 using System.Xml.Linq;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Graph;
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
@@ -19,6 +21,7 @@ namespace Microsoft.DotNet.Watch
         private readonly IConsole _console;
         private readonly IRuntimeProcessLauncherFactory? _runtimeProcessLauncherFactory;
         private readonly RestartPrompt? _rudeEditRestartPrompt;
+        private readonly TargetFrameworkSelectionPrompt? _targetFrameworkSelectionPrompt;
 
         private readonly DotNetWatchContext _context;
         private readonly ProjectGraphFactory _designTimeBuildGraphFactory;
@@ -41,11 +44,12 @@ namespace Microsoft.DotNet.Watch
                 }
 
                 _rudeEditRestartPrompt = new RestartPrompt(context.Logger, consoleInput, noPrompt ? true : null);
+                _targetFrameworkSelectionPrompt = new TargetFrameworkSelectionPrompt(consoleInput);
             }
 
             _designTimeBuildGraphFactory = new ProjectGraphFactory(
                 context.RootProjects,
-                context.TargetFramework,
+                context.MainProjectOptions?.TargetFramework,
                 buildProperties: EvaluationResult.GetGlobalBuildProperties(
                     context.BuildArguments,
                     context.EnvironmentOptions),
@@ -85,37 +89,76 @@ namespace Microsoft.DotNet.Watch
                 IRuntimeProcessLauncher? runtimeProcessLauncher = null;
                 CompilationHandler? compilationHandler = null;
                 Action<ChangedPath>? fileChangedCallback = null;
+                LoadedProjectGraph? projectGraph = null;
+                BuildProjectsResult? rootProjectsBuildResult = null;
 
                 try
                 {
-                    var buildSucceeded = await BuildProjectsAsync(_context.RootProjects, iterationCancellationToken);
-                    if (!buildSucceeded)
+                    rootProjectsBuildResult = await BuildProjectsAsync(
+                        _context.RootProjects,
+                        fileWatcher,
+                        _context.MainProjectOptions,
+                        frameworkSelector: _targetFrameworkSelectionPrompt != null ? _targetFrameworkSelectionPrompt.SelectAsync : null,
+                        iterationCancellationToken);
+
+                    // Try load project graph and perform design-time build even if the build failed.
+                    // This allows us to watch the project and source files for changes that will trigger restart.
+
+                    projectGraph = rootProjectsBuildResult.ProjectGraph ?? TryLoadProjectGraph(iterationCancellationToken);
+                    if (projectGraph == null)
                     {
                         continue;
                     }
 
-                    // Evaluate the target to find out the set of files to watch.
-                    // In case the app fails to start due to build or other error we can wait for these files to change.
+                    fileWatcher.WatchFiles(projectGraph.BuildFiles);
+
                     // Avoid restore since the build above already restored all root projects.
-                    evaluationResult = await EvaluateProjectGraphAsync(restore: false, iterationCancellationToken);
+                    evaluationResult = await TryEvaluateProjectGraphAsync(projectGraph, rootProjectsBuildResult.MainProjectTargetFramework, restore: false, iterationCancellationToken);
+                    if (evaluationResult == null)
+                    {
+                        continue;
+                    }
+
+                    evaluationResult.ItemExclusions.Report(_context.Logger);
+                    evaluationResult.WatchFileItems(fileWatcher);
+
+                    if (!rootProjectsBuildResult.Success)
+                    {
+                        continue;
+                    }
 
                     compilationHandler = new CompilationHandler(_context);
-                    var projectLauncher = new ProjectLauncher(_context, evaluationResult.ProjectGraph, compilationHandler, iteration);
-                    evaluationResult.ItemExclusions.Report(_context.Logger);
 
-                    var mainProjectOptions = _context.MainProjectOptions;
-                    var mainProject = (mainProjectOptions != null) ? evaluationResult.ProjectGraph.Graph.GraphRoots.Single() : null;
+                    // The session must start after the project is built and design time build completes,
+                    // so that the EnC service can read document checksums from the PDB and the solution
+                    // can be initialized from the current state of the project instances in the graph.
+                    //
+                    // Starting the session hydrates the contents of solution documents from disk.
+                    // Session must be started before we start accepting file changes to avoid race condition
+                    // when the EnC session hydrates solution documents with their file content after the changes have already been observed.
+                    await compilationHandler.StartSessionAsync(evaluationResult.ProjectGraph.Graph, iterationCancellationToken);
+
+                    var projectLauncher = new ProjectLauncher(_context, projectGraph, compilationHandler, iteration);
 
                     var runtimeProcessLauncherFactory = _runtimeProcessLauncherFactory;
 
-                    if (mainProject?.GetCapabilities().Contains(AspireServiceFactory.AppHostProjectCapability) == true)
+                    var mainProjectOptions = _context.MainProjectOptions;
+                    if (mainProjectOptions != null)
                     {
-                        Debug.Assert(mainProjectOptions != null);
-                        runtimeProcessLauncherFactory ??= new AspireServiceFactory(mainProjectOptions);
-                        _context.Logger.LogDebug("Using Aspire process launcher.");
+                        mainProjectOptions = mainProjectOptions with { TargetFramework = rootProjectsBuildResult.MainProjectTargetFramework };
+
+                        if (projectGraph.Graph.GraphRoots.Single()?.GetCapabilities().Contains(AspireServiceFactory.AppHostProjectCapability) == true)
+                        {
+                            runtimeProcessLauncherFactory ??= new AspireServiceFactory(mainProjectOptions);
+                            _context.Logger.LogDebug("Using Aspire process launcher.");
+                        }
                     }
 
-                    runtimeProcessLauncher = runtimeProcessLauncherFactory?.Create(projectLauncher);
+                    if (runtimeProcessLauncherFactory != null)
+                    {
+                        runtimeProcessLauncher = runtimeProcessLauncherFactory.Create(projectLauncher);
+                        _context.Logger.Log(MessageDescriptor.RuntimeProcessLauncherCreatedNotification);
+                    }
 
                     if (mainProjectOptions != null)
                     {
@@ -146,28 +189,13 @@ namespace Microsoft.DotNet.Watch
 
                         // Cancel iteration as soon as the main process exits, so that we don't spent time loading solution, etc. when the process is already dead.
                         mainRunningProject.Process.ExitedCancellationToken.Register(iterationCancellationSource.Cancel);
-
-                        if (shutdownCancellationToken.IsCancellationRequested)
-                        {
-                            // Ctrl+C:
-                            return;
-                        }
                     }
-
-                    await compilationHandler.UpdateProjectGraphAsync(evaluationResult.ProjectGraph.Graph, iterationCancellationToken);
-
-                    // Solution must be initialized after we load the solution but before we start watching for file changes to avoid race condition
-                    // when the EnC session captures content of the file after the changes has already been made.
-                    // The session must also start after the project is built, so that the EnC service can read document checksums from the PDB.
-                    await compilationHandler.StartSessionAsync(iterationCancellationToken);
 
                     if (shutdownCancellationToken.IsCancellationRequested)
                     {
                         // Ctrl+C:
                         return;
                     }
-
-                    evaluationResult.WatchFiles(fileWatcher);
 
                     var changedFilesAccumulator = ImmutableList<ChangedPath>.Empty;
 
@@ -242,22 +270,17 @@ namespace Microsoft.DotNet.Watch
                             {
                                 iterationCancellationToken.ThrowIfCancellationRequested();
 
-                                // pause accumulating file changes during build:
-                                fileWatcher.SuppressEvents = true;
-                                try
-                                {
-                                    var success = await BuildProjectsAsync([.. updates.ProjectsToRebuild.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath)], iterationCancellationToken);
-                                    if (success)
-                                    {
-                                        break;
-                                    }
-                                }
-                                finally
-                                {
-                                    fileWatcher.SuppressEvents = false;
-                                }
+                                var result = await BuildProjectsAsync(
+                                    [.. updates.ProjectsToRebuild.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath)],
+                                    fileWatcher,
+                                    mainProjectOptions,
+                                    frameworkSelector: null,
+                                    iterationCancellationToken);
 
-                                iterationCancellationToken.ThrowIfCancellationRequested();
+                                if (result.Success)
+                                {
+                                    break;
+                                }
 
                                 _ = await fileWatcher.WaitForFileChangeAsync(
                                     change => AcceptChange(change, evaluationResult),
@@ -328,11 +351,32 @@ namespace Microsoft.DotNet.Watch
 
                             if (evaluationRequired)
                             {
-                                // TODO: consider re-evaluating only affected projects instead of the whole graph.
-                                evaluationResult = await EvaluateProjectGraphAsync(restore: true, iterationCancellationToken);
+                                // TODO: consider reloading/reevaluating only affected projects instead of the whole graph.
+
+                                while (true)
+                                {
+                                    iterationCancellationToken.ThrowIfCancellationRequested();
+
+                                    projectGraph = TryLoadProjectGraph(iterationCancellationToken);
+                                    if (projectGraph != null)
+                                    {
+                                        fileWatcher.WatchFiles(projectGraph.BuildFiles);
+
+                                        evaluationResult = await TryEvaluateProjectGraphAsync(projectGraph, mainProjectOptions?.TargetFramework, restore: true, iterationCancellationToken);
+                                        if (evaluationResult != null)
+                                        {
+                                            break;
+                                        }
+                                    }
+
+                                    _ = await fileWatcher.WaitForFileChangeAsync(
+                                        acceptChange: AcceptChange,
+                                        startedWatching: () => _context.Logger.Log(MessageDescriptor.FixBuildError),
+                                        shutdownCancellationToken);
+                                }
 
                                 // additional files/directories may have been added:
-                                evaluationResult.WatchFiles(fileWatcher);
+                                evaluationResult.WatchFileItems(fileWatcher);
 
                                 await compilationHandler.UpdateProjectGraphAsync(evaluationResult.ProjectGraph.Graph, iterationCancellationToken);
 
@@ -442,7 +486,12 @@ namespace Microsoft.DotNet.Watch
                     else if (mainRunningProject?.IsRestarting != true && !suppressWaitForFileChange)
                     {
                         using var shutdownOrForcedRestartSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellationToken, forceRestartCancellationSource.Token);
-                        await WaitForFileChangeBeforeRestarting(fileWatcher, evaluationResult, shutdownOrForcedRestartSource.Token);
+                        await WaitForFileChangeBeforeRestarting(
+                            fileWatcher,
+                            evaluationResult,
+                            projectGraph,
+                            rootProjectsBuildResult?.Success == true,
+                            shutdownOrForcedRestartSource.Token);
                     }
                 }
             }
@@ -489,7 +538,7 @@ namespace Microsoft.DotNet.Watch
         {
             // If any build file changed (project, props, targets) we need to re-evaluate the projects.
             // Currently we re-evaluate the whole project graph even if only a single project file changed.
-            if (changedFiles.Select(f => f.Item.FilePath).FirstOrDefault(path => evaluationResult.BuildFiles.Contains(path) || MatchesBuildFile(path)) is { } firstBuildFilePath)
+            if (changedFiles.Select(f => f.Item.FilePath).FirstOrDefault(path => evaluationResult.ProjectGraph.BuildFiles.Contains(path) || MatchesBuildFile(path)) is { } firstBuildFilePath)
             {
                 _context.Logger.Log(MessageDescriptor.ProjectChangeTriggeredReEvaluation, firstBuildFilePath);
                 evaluationRequired = true;
@@ -678,28 +727,28 @@ namespace Microsoft.DotNet.Watch
             await Task.WhenAll(copyTasks);
         }
 
-        private async ValueTask WaitForFileChangeBeforeRestarting(FileWatcher fileWatcher, EvaluationResult? evaluationResult, CancellationToken cancellationToken)
+        private async ValueTask WaitForFileChangeBeforeRestarting(FileWatcher fileWatcher, EvaluationResult? evaluationResult, LoadedProjectGraph? projectGraph, bool buildSucceeded, CancellationToken cancellationToken)
         {
+            var messageDescriptor = buildSucceeded ? MessageDescriptor.WaitingForFileChangeBeforeRestarting : MessageDescriptor.FixBuildError;
+
             if (evaluationResult != null)
             {
-                if (!fileWatcher.WatchingDirectories)
-                {
-                    evaluationResult.WatchFiles(fileWatcher);
-                }
-
                 _ = await fileWatcher.WaitForFileChangeAsync(
                     evaluationResult.Files,
-                    startedWatching: () => _context.Logger.Log(MessageDescriptor.WaitingForFileChangeBeforeRestarting),
+                    startedWatching: () => _context.Logger.Log(messageDescriptor),
                     cancellationToken);
             }
             else
             {
-                // evaluation cancelled - watch for any changes in the directory trees containing root projects or entry-point files:
-                fileWatcher.WatchContainingDirectories(_context.RootProjects.Select(p => p.ProjectOrEntryPointFilePath), includeSubdirectories: true);
+                // build failed or was cancelled - watch for any changes in the directory trees containing root projects or entry-point files:
+                if (projectGraph == null)
+                {
+                    fileWatcher.WatchContainingDirectories(_context.RootProjects.Select(p => p.ProjectOrEntryPointFilePath), includeSubdirectories: true);
+                }
 
                 _ = await fileWatcher.WaitForFileChangeAsync(
                     acceptChange: AcceptChange,
-                    startedWatching: () => _context.Logger.Log(MessageDescriptor.WaitingForFileChangeBeforeRestarting),
+                    startedWatching: () => _context.Logger.Log(messageDescriptor),
                     cancellationToken);
             }
         }
@@ -722,7 +771,7 @@ namespace Microsoft.DotNet.Watch
             }
 
             // changes in *.*proj, *.props, *.targets:
-            if (evaluationResult.BuildFiles.Contains(path))
+            if (evaluationResult.ProjectGraph.BuildFiles.Contains(path))
             {
                 return true;
             }
@@ -872,48 +921,106 @@ namespace Microsoft.DotNet.Watch
                 };
         }
 
-        private async ValueTask<EvaluationResult> EvaluateProjectGraphAsync(bool restore, CancellationToken cancellationToken)
+        private LoadedProjectGraph? TryLoadProjectGraph(CancellationToken cancellationToken)
+            => _designTimeBuildGraphFactory.TryLoadProjectGraph(projectGraphRequired: true, cancellationToken);
+
+        private ValueTask<EvaluationResult?> TryEvaluateProjectGraphAsync(LoadedProjectGraph projectGraph, string? mainProjectTargetFramework, bool restore, CancellationToken cancellationToken)
+            => EvaluationResult.TryCreateAsync(
+                projectGraph,
+                _context.BuildLogger,
+                _context.Options,
+                _context.EnvironmentOptions,
+                mainProjectTargetFramework,
+                restore,
+                cancellationToken);
+
+        private enum BuildAction
         {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+            RestoreOnly,
+            RestoreAndBuild,
+            BuildOnly,
+        }
 
-                _context.Logger.Log(MessageDescriptor.LoadingProjects);
-                var stopwatch = Stopwatch.StartNew();
-
-                var result = await EvaluationResult.TryCreateAsync(_designTimeBuildGraphFactory, _context.Options, _context.EnvironmentOptions, restore, cancellationToken);
-
-                if (result != null)
-                {
-                    _context.Logger.Log(MessageDescriptor.LoadedProjects, result.ProjectGraph.Graph.ProjectNodes.Count, stopwatch.Elapsed.TotalSeconds);
-                    return result;
-                }
-
-                await FileWatcher.WaitForFileChangeAsync(
-                    _context.RootProjects.Select(static p => p.ProjectOrEntryPointFilePath),
-                    _context.Logger,
-                    _context.EnvironmentOptions,
-                    startedWatching: () => _context.Logger.Log(MessageDescriptor.FixBuildError),
-                    cancellationToken);
-            }
+        internal sealed class BuildProjectsResult(string? mainProjectTargetFramework, LoadedProjectGraph? projectGraph, bool success)
+        {
+            public string? MainProjectTargetFramework { get; } = mainProjectTargetFramework;
+            public LoadedProjectGraph? ProjectGraph { get; } = projectGraph;
+            public bool Success { get; } = success;
         }
 
         // internal for testing
-        internal async Task<bool> BuildProjectsAsync(ImmutableArray<ProjectRepresentation> projects, CancellationToken cancellationToken)
+        internal async Task<BuildProjectsResult> BuildProjectsAsync(
+            ImmutableArray<ProjectRepresentation> projects,
+            FileWatcher fileWatcher,
+            ProjectOptions? mainProjectOptions,
+            Func<IReadOnlyList<string>, CancellationToken, ValueTask<string>>? frameworkSelector,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(projects.Any());
 
+            LoadedProjectGraph? projectGraph = null;
+            var targetFramework = mainProjectOptions?.TargetFramework;
+
             _context.Logger.Log(MessageDescriptor.BuildStartedNotification, projects);
-            var success = await BuildAsync();
-            _context.Logger.Log(MessageDescriptor.BuildCompletedNotification, (projects, success));
 
-            return success;
+            // pause accumulating file changes during build:
+            fileWatcher.SuppressEvents = true;
+            try
+            {
+                var success = await BuildWithFrameworkSelectionAsync();
+                _context.Logger.Log(MessageDescriptor.BuildCompletedNotification, (projects, success));
+                return new BuildProjectsResult(targetFramework, projectGraph, success);
+            }
+            finally
+            {
+                fileWatcher.SuppressEvents = false;
+            }
 
-            async Task<bool> BuildAsync()
+            async ValueTask<bool> BuildWithFrameworkSelectionAsync()
+            {
+                if (mainProjectOptions == null ||
+                    frameworkSelector == null ||
+                    targetFramework != null ||
+                    !mainProjectOptions.Representation.IsProjectFile)
+                {
+                    return await BuildAsync(BuildAction.RestoreAndBuild, targetFramework);
+                }
+
+                if (!await BuildAsync(BuildAction.RestoreOnly, targetFramework: null))
+                {
+                    return false;
+                }
+
+                // load project graph after restore so that props and targets files from packages are imported:
+                projectGraph = TryLoadProjectGraph(cancellationToken);
+                if (projectGraph == null)
+                {
+                    return false;
+                }
+
+                var rootProject = projectGraph.Graph.GraphRoots.Single().ProjectInstance;
+                if (rootProject.GetTargetFramework() is var framework and not "")
+                {
+                    targetFramework = framework;
+                }
+                else if (rootProject.GetTargetFrameworks() is var frameworks and not [])
+                {
+                    targetFramework = await frameworkSelector(frameworks, cancellationToken);
+                }
+                else
+                {
+                    _context.BuildLogger.LogError("Project '{Path}' does not specify a target framework.", rootProject.FullPath);
+                    return false;
+                }
+
+                return await BuildAsync(BuildAction.BuildOnly, targetFramework);
+            }
+
+            async Task<bool> BuildAsync(BuildAction action, string? targetFramework)
             {
                 if (projects is [var singleProject])
                 {
-                    return await BuildFileOrProjectOrSolutionAsync(singleProject.ProjectOrEntryPointFilePath, cancellationToken);
+                    return await BuildFileOrProjectOrSolutionAsync(singleProject.ProjectOrEntryPointFilePath, targetFramework, action, cancellationToken);
                 }
 
                 // TODO: workaround for https://github.com/dotnet/sdk/issues/51311
@@ -922,7 +1029,7 @@ namespace Microsoft.DotNet.Watch
 
                 if (projectPaths is [var singleProjectPath])
                 {
-                    if (!await BuildFileOrProjectOrSolutionAsync(singleProjectPath, cancellationToken))
+                    if (!await BuildFileOrProjectOrSolutionAsync(singleProjectPath, targetFramework, action, cancellationToken))
                     {
                         return false;
                     }
@@ -942,7 +1049,7 @@ namespace Microsoft.DotNet.Watch
 
                     try
                     {
-                        if (!await BuildFileOrProjectOrSolutionAsync(solutionFile, cancellationToken))
+                        if (!await BuildFileOrProjectOrSolutionAsync(solutionFile, targetFramework, action, cancellationToken))
                         {
                             return false;
                         }
@@ -963,7 +1070,7 @@ namespace Microsoft.DotNet.Watch
                 // To maximize parallelism of building dependencies, build file-based projects after all physical projects:
                 foreach (var file in projects.Where(p => p.EntryPointFilePath != null).Select(p => p.EntryPointFilePath!))
                 {
-                    if (!await BuildFileOrProjectOrSolutionAsync(file, cancellationToken))
+                    if (!await BuildFileOrProjectOrSolutionAsync(file, targetFramework, action, cancellationToken))
                     {
                         return false;
                     }
@@ -973,8 +1080,31 @@ namespace Microsoft.DotNet.Watch
             }
         }
 
-        private async Task<bool> BuildFileOrProjectOrSolutionAsync(string path, CancellationToken cancellationToken)
+        private async Task<bool> BuildFileOrProjectOrSolutionAsync(string path, string? targetFramework, BuildAction action, CancellationToken cancellationToken)
         {
+            var arguments = new List<string>
+            {
+                action is BuildAction.RestoreOnly ? "restore" : "build",
+                path
+            };
+
+            arguments.AddRange(_context.BuildArguments);
+
+            if (action != BuildAction.RestoreOnly && targetFramework != null)
+            {
+                arguments.Add("--framework");
+                arguments.Add(targetFramework);
+            }
+
+            if (action == BuildAction.BuildOnly)
+            {
+                arguments.Add("--no-restore");
+            }
+            else if (action == BuildAction.RestoreOnly)
+            {
+                arguments.Add("-consoleLoggerParameters:NoSummary");
+            }
+
             List<OutputLine>? capturedOutput = _context.EnvironmentOptions.TestFlags != TestFlags.None ? [] : null;
             var processSpec = new ProcessSpec
             {
@@ -995,17 +1125,25 @@ namespace Microsoft.DotNet.Watch
                     : null,
 
                 // pass user-specified build arguments last to override defaults:
-                Arguments = ["build", path, .. _context.BuildArguments]
+                Arguments = arguments
             };
 
-            _context.BuildLogger.Log(MessageDescriptor.Building, path);
+            _context.BuildLogger.Log(action == BuildAction.RestoreOnly ? MessageDescriptor.Restoring : MessageDescriptor.Building, path);
 
             var success = await _context.ProcessRunner.RunAsync(processSpec, _context.Logger, launchResult: null, cancellationToken) == 0;
 
             if (capturedOutput != null)
             {
                 // To avoid multiple status messages, only log the status if the output of `dotnet build` is not being streamed to the console:
-                _context.BuildLogger.Log(success ? MessageDescriptor.BuildSucceeded : MessageDescriptor.BuildFailed, path);
+                _context.BuildLogger.Log(
+                    (action, success) switch
+                    {
+                        (BuildAction.RestoreOnly, true) => MessageDescriptor.RestoreSucceeded,
+                        (BuildAction.RestoreOnly, false) => MessageDescriptor.RestoreFailed,
+                        (_, true) => MessageDescriptor.BuildSucceeded,
+                        (_, false) => MessageDescriptor.BuildFailed,
+                    },
+                    path);
 
                 BuildOutput.ReportBuildOutput(_context.BuildLogger, capturedOutput, success);
             }

--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
@@ -941,6 +941,7 @@ namespace Microsoft.DotNet.Watch
             BuildOnly,
         }
 
+        // internal for testing
         internal sealed class BuildProjectsResult(string? mainProjectTargetFramework, LoadedProjectGraph? projectGraph, bool success)
         {
             public string? MainProjectTargetFramework { get; } = mainProjectTargetFramework;

--- a/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
+++ b/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
@@ -37,7 +37,7 @@ internal sealed class ProjectLauncher(
         RestartOperation restartOperation,
         CancellationToken cancellationToken)
     {
-        var projectNode = projectGraph.TryGetProjectNode(projectOptions.Representation.ProjectGraphPath, context.TargetFramework);
+        var projectNode = projectGraph.TryGetProjectNode(projectOptions.Representation.ProjectGraphPath, projectOptions.TargetFramework);
         if (projectNode == null)
         {
             // error already reported
@@ -113,6 +113,12 @@ internal sealed class ProjectLauncher(
             projectOptions.Command,
             "--no-build"
         };
+
+        if (projectOptions.TargetFramework != null)
+        {
+            arguments.Add("--framework");
+            arguments.Add(projectOptions.TargetFramework);
+        }
 
         foreach (var (name, value) in environmentBuilder)
         {

--- a/src/Dotnet.Watch/Watch/Process/RunningProject.cs
+++ b/src/Dotnet.Watch/Watch/Process/RunningProject.cs
@@ -28,6 +28,9 @@ namespace Microsoft.DotNet.Watch
         public ImmutableArray<string> ManagedCodeUpdateCapabilities => managedCodeUpdateCapabilities;
         public RunningProcess Process => process;
 
+        public string GetTargetFramework()
+            => projectNode.ProjectInstance.GetTargetFramework();
+
         /// <summary>
         /// Set to true when the process termination is being requested so that it can be auto-restarted.
         /// </summary>

--- a/src/Dotnet.Watch/Watch/UI/ConsoleInputReader.cs
+++ b/src/Dotnet.Watch/Watch/UI/ConsoleInputReader.cs
@@ -9,11 +9,11 @@ namespace Microsoft.DotNet.Watch
     {
         private readonly object _writeLock = new();
 
-        public async Task<ConsoleKey> GetKeyAsync(string prompt, Func<ConsoleKeyInfo, bool> validateInput, CancellationToken cancellationToken)
+        public async Task<ConsoleKeyInfo> GetKeyAsync(string prompt, Func<ConsoleKeyInfo, bool> validateInput, CancellationToken cancellationToken)
         {
             if (logLevel > LogLevel.Information)
             {
-                return ConsoleKey.Escape;
+                return new ConsoleKeyInfo('\u001b', ConsoleKey.Escape, shift: false, alt: false, control: false);
             }
 
             var questionMark = suppressEmojis ? "?" : "❔";
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Watch
             {
                 // Start listening to the key before printing the prompt to avoid race condition
                 // in tests that wait for the prompt before sending the key press.
-                var tcs = new TaskCompletionSource<ConsoleKey>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource<ConsoleKeyInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
                 console.KeyPressed += KeyPressed;
 
                 WriteLine($"  {questionMark} {prompt}");
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Watch
                     if (validateInput(key))
                     {
                         WriteLine(keyDisplay);
-                        tcs.TrySetResult(key.Key);
+                        tcs.TrySetResult(key);
                     }
                     else
                     {

--- a/src/Dotnet.Watch/Watch/UI/IReporter.cs
+++ b/src/Dotnet.Watch/Watch/UI/IReporter.cs
@@ -184,8 +184,8 @@ namespace Microsoft.DotNet.Watch
         // predefined messages used for testing:
         public static readonly MessageDescriptor<string> CommandDoesNotSupportHotReload = Create<string>("Command '{0}' does not support Hot Reload.", Emoji.HotReload, LogLevel.Debug);
         public static readonly MessageDescriptor<None> HotReloadDisabledByCommandLineSwitch = Create("Hot Reload disabled by command line switch.", Emoji.HotReload, LogLevel.Debug);
-        public static readonly MessageDescriptor<None> HotReloadSessionStartingNotification = CreateNotification<None>();
         public static readonly MessageDescriptor<None> HotReloadSessionStarted = Create("Hot reload session started.", Emoji.HotReload, LogLevel.Debug);
+        public static readonly MessageDescriptor<None> RuntimeProcessLauncherCreatedNotification = CreateNotification<None>();
         public static readonly MessageDescriptor<int> ProjectsRebuilt = Create<int>("Projects rebuilt ({0})", Emoji.HotReload, LogLevel.Debug);
         public static readonly MessageDescriptor<int> ProjectsRestarted = Create<int>("Projects restarted ({0})", Emoji.HotReload, LogLevel.Debug);
         public static readonly MessageDescriptor<IEnumerable<ProjectRepresentation>> RestartingProjectsNotification = CreateNotification<IEnumerable<ProjectRepresentation>>();
@@ -200,6 +200,8 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor<(string, string, int)> LaunchedProcess = Create<(string, string, int)>("Launched '{0}' with arguments '{1}': process id {2}", Emoji.Launch, LogLevel.Debug);
         public static readonly MessageDescriptor<long> ManagedCodeChangesApplied = Create<long>("C# and Razor changes applied in {0}ms.", Emoji.HotReload, LogLevel.Information);
         public static readonly MessageDescriptor<long> StaticAssetsChangesApplied = Create<long>("Static asset changes applied in {0}ms.", Emoji.HotReload, LogLevel.Information);
+        public static readonly MessageDescriptor<None> StaticWebAssetManifestNotFound = Create("Static web asset manifest not found.", Emoji.Warning, LogLevel.Warning);
+        public static readonly MessageDescriptor<string> ScopedCssBundleFileNotFound = Create<string>("Scoped CSS bundle file '{BundleFile}' not found.", Emoji.Warning, LogLevel.Warning);
         public static readonly MessageDescriptor<IEnumerable<ProjectRepresentation>> ChangesAppliedToProjectsNotification = CreateNotification<IEnumerable<ProjectRepresentation>>();
         public static readonly MessageDescriptor<int> SendingUpdateBatch = Create(LogEvents.SendingUpdateBatch, Emoji.HotReload);
         public static readonly MessageDescriptor<int> UpdateBatchCompleted = Create(LogEvents.UpdateBatchCompleted, Emoji.HotReload);
@@ -217,7 +219,7 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor<string> ApplyUpdate_Error = Create<string>("{0}", Emoji.Error, LogLevel.Error);
         public static readonly MessageDescriptor<string> ApplyUpdate_Warning = Create<string>("{0}", Emoji.Warning, LogLevel.Warning);
         public static readonly MessageDescriptor<string> ApplyUpdate_Verbose = Create<string>("{0}", Emoji.Default, LogLevel.Debug);
-        public static readonly MessageDescriptor<(string, string)> ApplyUpdate_AutoVerbose = Create<(string, string)>("{0}{1}", Emoji.Default, LogLevel.Debug);
+        public static readonly MessageDescriptor<string> ApplyUpdate_AutoVerbose = Create<string>("{0}", Emoji.Default, LogLevel.Debug);
         public static readonly MessageDescriptor<string> ApplyUpdate_ChangingEntryPoint = Create<string>("{0} Press \"Ctrl + R\" to restart.", Emoji.Warning, LogLevel.Warning);
         public static readonly MessageDescriptor<None> ConfiguredToLaunchBrowser = Create("dotnet-watch is configured to launch a browser on ASP.NET Core application startup.", Emoji.Watch, LogLevel.Debug);
         public static readonly MessageDescriptor<None> ConfiguredToUseBrowserRefresh = Create("Using browser-refresh middleware", Emoji.Default, LogLevel.Debug);
@@ -273,10 +275,14 @@ namespace Microsoft.DotNet.Watch
         public static readonly MessageDescriptor<None> LoadingProjects = Create("Loading projects ...", Emoji.Watch, LogLevel.Information);
         public static readonly MessageDescriptor<(int, double)> LoadedProjects = Create<(int, double)>("Loaded {0} project(s) in {1:0.0}s.", Emoji.Watch, LogLevel.Information);
         public static readonly MessageDescriptor<string> Building = Create<string>("Building {0} ...", Emoji.Default, LogLevel.Debug);
+        public static readonly MessageDescriptor<string> Restoring = Create<string>("Restoring {0} ...", Emoji.Default, LogLevel.Debug);
         public static readonly MessageDescriptor<string> BuildFailed = Create<string>("Build failed: {0}", Emoji.Default, LogLevel.Debug);
         public static readonly MessageDescriptor<string> BuildSucceeded = Create<string>("Build succeeded: {0}", Emoji.Default, LogLevel.Debug);
+        public static readonly MessageDescriptor<string> RestoreFailed = Create<string>("Restore failed: {0}", Emoji.Default, LogLevel.Debug);
+        public static readonly MessageDescriptor<string> RestoreSucceeded = Create<string>("Restore succeeded: {0}", Emoji.Default, LogLevel.Debug);
         public static readonly MessageDescriptor<IEnumerable<ProjectRepresentation>> BuildStartedNotification = CreateNotification<IEnumerable<ProjectRepresentation>>();
         public static readonly MessageDescriptor<(IEnumerable<ProjectRepresentation> projects, bool success)> BuildCompletedNotification = CreateNotification<(IEnumerable<ProjectRepresentation> projects, bool success)>();
+        public static readonly MessageDescriptor<string> ManifestFileNotFound = Create(LogEvents.ManifestFileNotFound, Emoji.Default);
     }
 
     internal sealed class MessageDescriptor<TArgs>(string? format, Emoji emoji, LogLevel level, EventId id)

--- a/src/Dotnet.Watch/Watch/UI/PhysicalConsole.cs
+++ b/src/Dotnet.Watch/Watch/UI/PhysicalConsole.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DotNet.Watch
                     CtrlR => new ConsoleKeyInfo('R', ConsoleKey.R, shift: false, alt: false, control: true),
                     >= 'a' and <= 'z' => new ConsoleKeyInfo(c, ConsoleKey.A + (c - 'a'), shift: false, alt: false, control: false),
                     >= 'A' and <= 'Z' => new ConsoleKeyInfo(c, ConsoleKey.A + (c - 'A'), shift: true, alt: false, control: false),
+                    >= '0' and <= '9' => new ConsoleKeyInfo(c, ConsoleKey.NumPad0 + (c - '0'), shift: false, alt: false, control: false),
                     _ => default
                 };
 

--- a/src/Dotnet.Watch/Watch/UI/RestartPrompt.cs
+++ b/src/Dotnet.Watch/Watch/UI/RestartPrompt.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch
 {
-    internal sealed class RestartPrompt(ILogger logger, ConsoleInputReader requester, bool? noPrompt)
+    internal sealed class RestartPrompt(ILogger logger, ConsoleInputReader inputReader, bool? noPrompt)
     {
         public bool? AutoRestartPreference { get; private set; } = noPrompt;
 
@@ -17,12 +17,12 @@ namespace Microsoft.DotNet.Watch
                 return AutoRestartPreference.Value;
             }
 
-            var key = await requester.GetKeyAsync(
+            var keyInfo = await inputReader.GetKeyAsync(
                 $"{question} Yes (y) / No (n) / Always (a) / Never (v)",
                 AcceptKey,
                 cancellationToken);
 
-            switch (key)
+            switch (keyInfo.Key)
             {
                 case ConsoleKey.Escape:
                 case ConsoleKey.Y:

--- a/src/Dotnet.Watch/Watch/UI/TargetFrameworkSelectionPrompt.cs
+++ b/src/Dotnet.Watch/Watch/UI/TargetFrameworkSelectionPrompt.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Watch;
+
+internal sealed class TargetFrameworkSelectionPrompt(ConsoleInputReader inputReader)
+{
+    public IReadOnlyList<string>? PreviousTargetFrameworks { get; set; }
+    public string? PreviousSelection { get; set; }
+
+    public async ValueTask<string> SelectAsync(IReadOnlyList<string> targetFrameworks, CancellationToken cancellationToken)
+    {
+        var orderedTargetFrameworks = targetFrameworks.Order().ToArray();
+
+        if (PreviousSelection != null && PreviousTargetFrameworks?.SequenceEqual(orderedTargetFrameworks, StringComparer.OrdinalIgnoreCase) == true)
+        {
+            return PreviousSelection;
+        }
+
+        PreviousTargetFrameworks = orderedTargetFrameworks;
+
+        var keyInfo = await inputReader.GetKeyAsync(
+            $"Select target framework:{Environment.NewLine}{string.Join(Environment.NewLine, targetFrameworks.Select((tfm, i) => $"{i + 1}) {tfm}"))}",
+            AcceptKey,
+            cancellationToken);
+
+        _ = TryGetIndex(keyInfo, out var index);
+        return PreviousSelection = targetFrameworks[index];
+
+        bool TryGetIndex(ConsoleKeyInfo info, out int index)
+        {
+            index = info.KeyChar - '1';
+            return index >= 0 && index < targetFrameworks.Count;
+        }
+
+        bool AcceptKey(ConsoleKeyInfo info)
+            => info is { Modifiers: ConsoleModifiers.None } && TryGetIndex(info, out _);
+    }
+}

--- a/src/Dotnet.Watch/dotnet-watch/CommandLine/CommandLineOptions.cs
+++ b/src/Dotnet.Watch/dotnet-watch/CommandLine/CommandLineOptions.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Data;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Build;
@@ -65,7 +66,10 @@ internal sealed class CommandLineOptions
 
         // determine subcommand:
         var command = GetSubcommand(parseResult, out bool isExplicitCommand);
-        var buildOptions = command.Options.Where(o => o.ForwardingFunction is not null);
+
+        // Options that the subcommand forwards to build command.
+        // Exclude --framework option as it is passed to `dotnet build` and `dotnet run` explicitly by the watcher.
+        var buildOptions = command.Options.Where(o => o.ForwardingFunction is not null && o.Name != CommonOptions.FrameworkOptionName);
 
         foreach (var buildOption in buildOptions)
         {
@@ -112,14 +116,15 @@ internal sealed class CommandLineOptions
             out var binLogPath);
 
         // We assume that forwarded options, if any, are intended for dotnet build.
-        var buildArguments = buildOptions.Select(option => option.ForwardingFunction!(parseResult)).SelectMany(args => args).ToList();
+        var buildArguments = buildOptions
+            .Select(option => option.ForwardingFunction!(parseResult))
+            .SelectMany(args => args)
+            .ToList();
 
         if (binLogToken != null)
         {
             buildArguments.Add(binLogToken);
         }
-
-        var targetFrameworkOption = (Option<string>?)buildOptions.SingleOrDefault(option => option.Name == "--framework");
 
         var logLevel = parseResult.GetValue(definition.VerboseOption)
             ? LogLevel.Debug
@@ -150,7 +155,7 @@ internal sealed class CommandLineOptions
             FilePath = parseResult.GetValue(definition.FileOption),
             LaunchProfileName = launchProfile,
             BuildArguments = buildArguments,
-            TargetFramework = targetFrameworkOption != null ? parseResult.GetValue(targetFrameworkOption) : null,
+            TargetFramework = parseResult.GetValue(definition.FrameworkOption),
         };
     }
 
@@ -196,7 +201,7 @@ internal sealed class CommandLineOptions
             {
                 continue;
             }
-            
+
             // forward forwardable option if the subcommand supports it:
             if (!command.Options.Any(option => option.Name == optionResult.Option.Name))
             {
@@ -351,6 +356,7 @@ internal sealed class CommandLineOptions
             IsMainProject = true,
             Representation = project,
             WorkingDirectory = workingDirectory,
+            TargetFramework = TargetFramework,
             Command = Command,
             CommandArguments = CommandArguments,
             LaunchEnvironmentVariables = [],

--- a/src/Dotnet.Watch/dotnet-watch/CommandLine/DotnetWatchCommandDefinition.cs
+++ b/src/Dotnet.Watch/dotnet-watch/CommandLine/DotnetWatchCommandDefinition.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 
 namespace Microsoft.DotNet.Watch;
@@ -15,12 +16,53 @@ internal sealed class DotnetWatchCommandDefinition : RootCommand
     public readonly Option<bool> NoHotReloadOption = new("--no-hot-reload") { Description = Resources.Help_NoHotReload, Arity = ArgumentArity.Zero };
     public readonly Option<bool> NonInteractiveOption = new("--non-interactive") { Description = Resources.Help_NonInteractive, Arity = ArgumentArity.Zero };
 
+    /// <summary>
+    /// Specifies target framework. The watcher passes the value explicitly instead of forwarding the subcommand's --framework option.
+    /// </summary>
+    public readonly Option<string?> FrameworkOption = new(CommonOptions.FrameworkOptionName, "-f")
+    {
+        Description = CommandDefinitionStrings.BuildFrameworkOptionDescription,
+        HelpName = CommandDefinitionStrings.FrameworkArgumentName,
+    };
+
     // Options we need to know about. They are passed through to the subcommand if the subcommand supports them.
-    public readonly Option<string> ShortProjectOption = new("-p") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
-    public readonly Option<string> LongProjectOption = new("--project") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
-    public readonly Option<string> FileOption = new("--file") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
-    public readonly Option<string> LaunchProfileOption = new("--launch-profile", "-lp") { Hidden = true, Arity = ArgumentArity.ZeroOrOne, AllowMultipleArgumentsPerToken = false };
-    public readonly Option<bool> NoLaunchProfileOption = new("--no-launch-profile") { Hidden = true, Arity = ArgumentArity.Zero };
+
+    public readonly Option<string> ShortProjectOption = new("-p")
+    {
+        Hidden = true,
+        Arity = ArgumentArity.ZeroOrOne,
+        AllowMultipleArgumentsPerToken = false
+    };
+
+    public readonly Option<string> LongProjectOption = new("--project")
+    {
+        Description = CommandDefinitionStrings.CmdProjectDescriptionFormat,
+        HelpName = CommandDefinitionStrings.CommandOptionProjectHelpName,
+        Arity = ArgumentArity.ZeroOrOne,
+        AllowMultipleArgumentsPerToken = false
+    };
+
+    public readonly Option<string> FileOption = new("--file")
+    {
+        Description = CommandDefinitionStrings.CommandOptionFileDescription,
+        HelpName = CommandDefinitionStrings.CommandOptionFileHelpName,
+        Arity = ArgumentArity.ZeroOrOne,
+        AllowMultipleArgumentsPerToken = false
+    };
+
+    public readonly Option<string> LaunchProfileOption = new("--launch-profile", "-lp")
+    {
+        Description = CommandDefinitionStrings.CommandOptionLaunchProfileDescription,
+        HelpName = CommandDefinitionStrings.CommandOptionLaunchProfileHelpName,
+        Arity = ArgumentArity.ZeroOrOne,
+        AllowMultipleArgumentsPerToken = false
+    };
+
+    public readonly Option<bool> NoLaunchProfileOption = new("--no-launch-profile")
+    {
+        Description = CommandDefinitionStrings.CommandOptionNoLaunchProfileDescription,
+        Arity = ArgumentArity.Zero
+    };
 
     public DotnetWatchCommandDefinition()
         : base(Resources.Help)
@@ -37,6 +79,7 @@ internal sealed class DotnetWatchCommandDefinition : RootCommand
         Options.Add(ListOption);
         Options.Add(NoHotReloadOption);
         Options.Add(NonInteractiveOption);
+        Options.Add(FrameworkOption);
 
         Options.Add(LongProjectOption);
         Options.Add(ShortProjectOption);
@@ -74,5 +117,6 @@ internal sealed class DotnetWatchCommandDefinition : RootCommand
            option == VerboseOption ||
            option == ListOption ||
            option == NoHotReloadOption ||
-           option == NonInteractiveOption;
+           option == NonInteractiveOption ||
+           option == FrameworkOption;
 }

--- a/src/Dotnet.Watch/dotnet-watch/Program.cs
+++ b/src/Dotnet.Watch/dotnet-watch/Program.cs
@@ -310,7 +310,6 @@ namespace Microsoft.DotNet.Watch
                 MainProjectOptions = mainProjectOptions,
                 RootProjects = [mainProjectOptions.Representation],
                 BuildArguments = options.BuildArguments,
-                TargetFramework = options.TargetFramework,
                 BrowserRefreshServerFactory = new BrowserRefreshServerFactory(),
                 BrowserLauncher = new BrowserLauncher(logger, processOutputReporter, environmentOptions),
             };

--- a/src/Dotnet.Watch/dotnet-watch/Watch/BuildEvaluator.cs
+++ b/src/Dotnet.Watch/dotnet-watch/Watch/BuildEvaluator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Watch
 
             return new(
                 MainProjectOptions.Representation.PhysicalPath,
-                _context.TargetFramework,
+                MainProjectOptions.TargetFramework,
                 _context.BuildArguments,
                 _context.ProcessRunner,
                 _context.BuildLogger,
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Watch
 
         public IReadOnlyList<string> GetProcessArguments(int iteration)
         {
+            var noRestore = false;
             if (!_context.EnvironmentOptions.SuppressMSBuildIncrementalism &&
                 iteration > 0 &&
                 MainProjectOptions.IsCodeExecutionCommand)
@@ -67,11 +68,29 @@ namespace Microsoft.DotNet.Watch
                 else
                 {
                     _context.Logger.LogDebug("Modifying command to use --no-restore");
-                    return [MainProjectOptions.Command, "--no-restore", .. MainProjectOptions.CommandArguments];
+                    noRestore = true;
                 }
             }
 
-            return [MainProjectOptions.Command, .. MainProjectOptions.CommandArguments];
+            var arguments = new List<string>()
+            {
+                MainProjectOptions.Command
+            };
+
+            if (noRestore)
+            {
+                arguments.Add("--no-restore");
+            }
+
+            if (MainProjectOptions.TargetFramework != null)
+            {
+                arguments.Add("--framework");
+                arguments.Add(MainProjectOptions.TargetFramework);
+            }
+
+            arguments.AddRange(MainProjectOptions.CommandArguments);
+
+            return arguments;
         }
 
         public async ValueTask<MSBuildFileSetFactory.EvaluationResult> EvaluateAsync(ChangedFile? changedFile, CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/dotnet-watch/Watch/StaticFileHandler.cs
+++ b/src/Dotnet.Watch/dotnet-watch/Watch/StaticFileHandler.cs
@@ -31,14 +31,7 @@ namespace Microsoft.DotNet.Watch
 
                 foreach (var containingProjectPath in file.ContainingProjectPaths)
                 {
-                    if (!projectGraph.Map.TryGetValue(containingProjectPath, out var projectNodes))
-                    {
-                        // Shouldn't happen.
-                        logger.LogWarning("Project '{Path}' not found in the project graph.", containingProjectPath);
-                        return allFilesHandled;
-                    }
-
-                    foreach (var projectNode in projectNodes)
+                    foreach (var projectNode in projectGraph.GetProjectNodes(containingProjectPath))
                     {
                         if (browserConnector.TryGetRefreshServer(projectNode, out var refreshServer))
                         {

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -34,7 +34,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         App.UseTestBrowser();
 
         var url = $"http://localhost:{TestOptions.GetTestPort()}";
-        var tfm = ToolsetInfo.CurrentTargetFramework;
+        var projectDisplay = $"RazorApp ({ToolsetInfo.CurrentTargetFramework})";
 
         App.Start(testAsset, ["--urls", url], relativeProjectDirectory: "RazorApp", testFlags: TestFlags.ReadKeyFromStdin);
 
@@ -57,7 +57,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             public virtual int F() => 1;
             """));
 
-        var errorMessage = $"{homePagePath}(13,9): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.";
+        var errorMessage = $"[{projectDisplay}] {homePagePath}(13,9): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.";
         var jsonErrorMessage = JsonSerializer.Serialize(errorMessage);
 
         await App.WaitUntilOutputContains(errorMessage);
@@ -72,7 +72,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         App.SendKey('a');
 
         // browser page is reloaded when the app restarts:
-        await App.WaitUntilOutputContains(MessageDescriptor.ReloadingBrowser, $"RazorApp ({tfm})");
+        await App.WaitUntilOutputContains(MessageDescriptor.ReloadingBrowser, projectDisplay);
 
         // browser page was reloaded after the app restarted:
         await App.WaitUntilOutputContains("""
@@ -89,8 +89,8 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         // another rude edit:
         UpdateSourceFile(homePagePath, src => src.Replace("public virtual int F() => 1;", "/* member placeholder */"));
 
-        errorMessage = $"{homePagePath}(11,5): error ENC0033: Deleting method 'F()' requires restarting the application.";
-        await App.WaitUntilOutputContains("[auto-restart] " + errorMessage);
+        errorMessage = $"[{projectDisplay}] [auto-restart] {homePagePath}(11,5): error ENC0033: Deleting method 'F()' requires restarting the application.";
+        await App.WaitUntilOutputContains(errorMessage);
 
         await App.WaitUntilOutputContains($$"""
             🧪 Received: {"type":"ReportDiagnostics","diagnostics":["Restarting application to apply changes ..."]}

--- a/test/dotnet-watch.Tests/Build/EvaluationResultTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationResultTests.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Graph;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class EvaluationResultTests
+{
+    public ProjectGraph CreateGraph(TestDirectory testDir, params (string projectName, string[] targetFrameworks, string[] referencedProjects)[] projects)
+    {
+        var projectDefinitions = new Dictionary<string, (string[] targetFrameworks, string[] references)>();
+        foreach (var (projectName, targetFrameworks, referencedProjects) in projects)
+        {
+            projectDefinitions[projectName] = (targetFrameworks, referencedProjects);
+        }
+
+        var allReferencedProjects = projects
+            .SelectMany(p => p.referencedProjects)
+            .ToHashSet();
+
+        var entryPoints = projects
+            .Where(p => !allReferencedProjects.Contains(p.projectName))
+            .Select(p => new ProjectGraphEntryPoint(Path.Combine(testDir.Path, p.projectName)));
+
+        return new ProjectGraph(
+            entryPoints,
+            ProjectCollection.GlobalProjectCollection,
+            (path, globalProperties, collection) =>
+            {
+                var (targetFrameworks, references) = projectDefinitions[Path.GetFileName(path)];
+
+                var projectXml = ProjectRootElement.Create(collection);
+                projectXml.FullPath = Path.Combine(testDir.Path, path);
+                projectXml.Sdk = "Microsoft.NET.Sdk";
+
+                var propertyGroup = projectXml.AddPropertyGroup();
+                if (targetFrameworks.Length == 1)
+                {
+                    propertyGroup.AddProperty("TargetFramework", targetFrameworks[0]);
+                }
+                else if (targetFrameworks.Length > 1)
+                {
+                    propertyGroup.AddProperty("TargetFrameworks", string.Join(";", targetFrameworks));
+                }
+
+                if (references.Length > 0)
+                {
+                    var itemGroup = projectXml.AddItemGroup();
+                    foreach (var reference in references)
+                    {
+                        itemGroup.AddItem("ProjectReference", reference);
+                    }
+                }
+
+                return new ProjectInstance(
+                    projectXml,
+                    globalProperties,
+                    toolsVersion: null,
+                    subToolsetVersion: null,
+                    collection);
+            });
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net9.0")]
+    public void CreateDesignTimeBuildRequests_SingleTfm(string? mainTfm)
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
+
+        var graph = CreateGraph(
+            testDir,
+            ("main.csproj", ["net9.0"], []));
+
+        var requests = EvaluationResult.CreateDesignTimeBuildRequests(graph, mainProjectTargetFramework: mainTfm, suppressStaticWebAssets: false);
+
+        AssertEx.SequenceEqual(["main (net9.0)"], requests.Select(r => r.ProjectInstance.GetDisplayName()));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net9.0")]
+    public void CreateDesignTimeBuildRequests_SingleTfm_WithDependencies(string? mainTfm)
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
+
+        var graph = CreateGraph(
+            testDir,
+            ("main.csproj", ["net9.0"], ["dep.csproj"]),
+            ("dep.csproj", ["netstandard2.0"], []));
+
+        var requests = EvaluationResult.CreateDesignTimeBuildRequests(graph, mainProjectTargetFramework: mainTfm, suppressStaticWebAssets: false);
+
+        AssertEx.SequenceEqual(
+        [
+            "dep (netstandard2.0)",
+            "main (net9.0)",
+        ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net9.0")]
+    public void CreateDesignTimeBuildRequests_SingleTfm_WithMultiTargetedDependencies(string? mainTfm)
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
+
+        var graph = CreateGraph(
+            testDir,
+            ("main.csproj", ["net9.0"], ["dep.csproj"]),
+            ("dep.csproj", ["netstandard2.0", "net8.0"], []));
+
+        var requests = EvaluationResult.CreateDesignTimeBuildRequests(graph, mainProjectTargetFramework: mainTfm, suppressStaticWebAssets: false);
+
+        AssertEx.SequenceEqual(
+        [
+            "dep (net8.0)",
+            "dep (netstandard2.0)",
+            "main (net9.0)",
+        ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
+    }
+
+    [Fact]
+    public void CreateDesignTimeBuildRequests_MultiTfm_WithDependencies_NoMainTfm()
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory();
+
+        var graph = CreateGraph(
+            testDir,
+            ("main.csproj", ["net8.0", "net9.0"], ["dep.csproj"]),
+            ("dep.csproj", ["netstandard2.0", "net8.0"], []));
+
+        var requests = EvaluationResult.CreateDesignTimeBuildRequests(graph, mainProjectTargetFramework: null, suppressStaticWebAssets: false);
+
+        AssertEx.SequenceEqual(
+        [
+            "dep (net8.0)",
+            "dep (netstandard2.0)",
+            "main (net9.0)",
+            "main (net8.0)",
+        ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
+    }
+
+    [Fact]
+    public void CreateDesignTimeBuildRequests_MultiTfm_WithDependencies_MainTfm()
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory();
+
+        var graph = CreateGraph(
+            testDir,
+            ("main.csproj", ["net8.0", "net9.0"], ["dep.csproj"]),
+            ("dep.csproj", ["netstandard2.0", "net8.0", "net9.0"], []));
+
+        var requests = EvaluationResult.CreateDesignTimeBuildRequests(graph, mainProjectTargetFramework: "net8.0", suppressStaticWebAssets: false);
+
+        // main (net9.0) should not be built:
+        AssertEx.SequenceEqual(
+        [
+            "dep (net9.0)",
+            "dep (net8.0)",
+            "dep (netstandard2.0)",
+            "main (net8.0)",
+        ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
+    }
+}

--- a/test/dotnet-watch.Tests/Build/ProjectGraphFactoryTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphFactoryTests.cs
@@ -20,7 +20,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         var projectPath = Path.Combine(testAsset.Path, "WatchNoDepsApp.csproj");
 
         var projectRepr = new ProjectRepresentation(projectPath, entryPointFilePath: null);
-        var factory = new ProjectGraphFactory([projectRepr], targetFramework: null, buildProperties: [], _testLogger);
+        var factory = new ProjectGraphFactory([projectRepr], virtualProjectTargetFramework: null, buildProperties: [], _testLogger);
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, CancellationToken.None);
         Assert.NotNull(graph);
@@ -40,7 +40,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
             """);
 
         var projectRepr = new ProjectRepresentation(projectPath: null, entryPointFilePath);
-        var factory = new ProjectGraphFactory([projectRepr], targetFramework: null, buildProperties: [], _testLogger);
+        var factory = new ProjectGraphFactory([projectRepr], virtualProjectTargetFramework: null, buildProperties: [], _testLogger);
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, CancellationToken.None);
         Assert.NotNull(graph);
@@ -60,7 +60,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
             """);
 
         var projectRepr = new ProjectRepresentation(projectPath: null, entryPointFilePath);
-        var factory = new ProjectGraphFactory([projectRepr], targetFramework: null, buildProperties: [], _testLogger);
+        var factory = new ProjectGraphFactory([projectRepr], virtualProjectTargetFramework: null, buildProperties: [], _testLogger);
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, CancellationToken.None);
         Assert.Null(graph);
@@ -92,7 +92,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
             """);
 
         var projectRepr = new ProjectRepresentation(projectPath: null, entryPointFilePath);
-        var factory = new ProjectGraphFactory([projectRepr], targetFramework: null, buildProperties: [], _testLogger);
+        var factory = new ProjectGraphFactory([projectRepr], virtualProjectTargetFramework: null, buildProperties: [], _testLogger);
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, CancellationToken.None);
         Assert.NotNull(graph);

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -316,11 +316,13 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Equal("P", options.ProjectPath);
             Assert.Equal("F", options.TargetFramework);
 
-            // the forwarding function of --property property joins the properties with `:`:
-            AssertEx.SequenceEqual(["--property:TargetFramework=F", "--property:P1=V1", "--property:P2=V2", NugetInteractiveProperty], options.BuildArguments);
+            // The forwarding function of --property property joins the properties with `:`
+            // --framework is not forwarded as property.
+            AssertEx.SequenceEqual(["--property:P1=V1", "--property:P2=V2", NugetInteractiveProperty], options.BuildArguments);
 
-            // it's ok to keep the two arguments and not to join them with `:` since `run` command handles these options correctly
-            AssertEx.SequenceEqual(["--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
+            // It's ok to keep the two arguments and not to join them with `:` since `run` command handles these options correctly
+            // --framework is not forwarded, it will be specified explicitly.
+            AssertEx.SequenceEqual(["--project", "P", "--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
         }
 
         public enum ArgPosition
@@ -462,7 +464,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         /// </summary>
         [Theory]
         [InlineData(new[] { "--configuration", "release" }, new[] { "--property:Configuration=release", NugetInteractiveProperty })]
-        [InlineData(new[] { "--framework", "net9.0" }, new[] { "--property:TargetFramework=net9.0", NugetInteractiveProperty })]
+        [InlineData(new[] { "--framework", "net9.0" }, new[] { NugetInteractiveProperty }, new string[0])]
         [InlineData(new[] { "--runtime", "arm64" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=arm64", "--property:_CommandLineDefinedRuntimeIdentifier=true" })]
         [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
         [InlineData(new[] { "--project", "x.csproj" }, new[] { NugetInteractiveProperty }, new[] { "--project", "x.csproj" })]

--- a/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
@@ -84,11 +84,17 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Assert.Equal("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
         }
 
-        [Fact]
-        public async Task RunsWithIterationEnvVariable()
+        [Theory]
+        [CombinatorialData]
+        public async Task RunsWithIterationEnvVariable(bool hotReload)
         {
             var testAsset = TestAssets.CopyTestAsset(AppName)
                 .WithSource();
+
+            if (!hotReload)
+            {
+                App.WatchArgs.Add("--no-hot-reload");
+            }
 
             App.Start(testAsset, []);
 

--- a/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
@@ -12,9 +12,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53058, https://github.com/dotnet/sdk/issues/53061, https://github.com/dotnet/sdk/issues/53114
         public async Task Aspire_BuildError_ManualRestart()
         {
-            var tfm = ToolsetInfo.CurrentTargetFramework;
             var testAsset = TestAssets.CopyTestAsset("WatchAspire")
                 .WithSource();
+
+            var serviceProjectDisplay = $"WatchAspire.ApiService ({ToolsetInfo.CurrentTargetFramework})";
+            var webProjectDisplay = $"WatchAspire.Web ({ToolsetInfo.CurrentTargetFramework})";
+            var hostProjectDisplay = $"WatchAspire.AppHost ({ToolsetInfo.CurrentTargetFramework})";
 
             var serviceSourcePath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "Program.cs");
             var serviceProjectPath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "WatchAspire.ApiService.csproj");
@@ -63,7 +66,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains("  ❔ Do you want to restart these projects? Yes (y) / No (n) / Always (a) / Never (v)");
             await App.WaitUntilOutputContains(MessageDescriptor.RestartNeededToApplyChanges);
 
-            await App.WaitUntilOutputContains($"dotnet watch ❌ {serviceSourcePath}(40,1): error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
+            await App.WaitUntilOutputContains($"dotnet watch ❌ [{serviceProjectDisplay}] {serviceSourcePath}(40,1): error ENC0020: Renaming record 'WeatherForecast' requires restarting the application.");
             await App.WaitUntilOutputContains("dotnet watch ⌚ Affected projects:");
             await App.WaitUntilOutputContains("dotnet watch ⌚   WatchAspire.ApiService");
             App.Process.ClearOutput();
@@ -74,7 +77,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             await App.WaitUntilOutputContains("Application is shutting down...");
 
-            await App.WaitUntilOutputContains($"[WatchAspire.ApiService ({tfm})] Exited");
+            await App.WaitUntilOutputContains(MessageDescriptor.Exited, serviceProjectDisplay);
 
             await App.WaitUntilOutputContains(MessageDescriptor.Building);
             await App.WaitUntilOutputContains("error CS0246: The type or namespace name 'WeatherForecast' could not be found");
@@ -95,7 +98,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             // The agent startup hook might not be initialized yet (signal handlers registered),
             // so the process might need to be forcefully killed. We could wait until the agent is initialized
             // but it's good to test this scenario.
-            await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, $"WatchAspire.ApiService ({tfm})");
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, serviceProjectDisplay);
 
             App.Process.ClearOutput();
 
@@ -103,9 +106,10 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             await App.WaitUntilOutputContains(MessageDescriptor.ShutdownRequested);
 
-            await App.WaitUntilOutputContains($"[WatchAspire.ApiService ({tfm})] Exited");
-            await App.WaitUntilOutputContains($"[WatchAspire.Web ({tfm})] Exited");
-            await App.WaitUntilOutputContains($"[WatchAspire.AppHost ({tfm})] Exited");
+            // Not checking specific exited message since on shutdown we might see non-zero exit codes
+            await App.WaitUntilOutputContains($"[{serviceProjectDisplay}] Exited");
+            await App.WaitUntilOutputContains($"[{webProjectDisplay}] Exited");
+            await App.WaitUntilOutputContains($"[{hostProjectDisplay}] Exited");
 
             await App.WaitUntilOutputContains("dotnet watch ⭐ Waiting for server to shutdown ...");
 

--- a/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
                     });
             }
 
+            var projectDisplay = $"WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})";
             var programPath = Path.Combine(testAsset.Path, "Program.cs");
 
             App.Start(testAsset, nonInteractive ? ["--non-interactive"] : []);
@@ -42,9 +43,9 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
             await App.WaitUntilOutputContains(MessageDescriptor.RestartNeededToApplyChanges);
-            await App.WaitUntilOutputContains($"⌚ [auto-restart] {programPath}(39,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            await App.WaitUntilOutputContains($"⌚ [{projectDisplay}] [auto-restart] {programPath}(39,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
+            await App.WaitUntilOutputContains(MessageDescriptor.Exited, projectDisplay);
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, projectDisplay);
             App.Process.ClearOutput();
 
             // valid edit:
@@ -122,6 +123,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
                 .WithSource();
 
+            var projectDisplay = $"WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})";
             var programPath = Path.Combine(testAsset.Path, "Program.cs");
 
             App.Start(testAsset, [], testFlags: TestFlags.ReadKeyFromStdin);
@@ -133,18 +135,18 @@ namespace Microsoft.DotNet.Watch.UnitTests
             UpdateSourceFile(programPath, src => src.Replace("/* member placeholder */", "public virtual void F() {}"));
 
             // the prompt is printed into stdout while the error is printed into stderr, so they might arrive in any order:
-            await App.WaitUntilOutputContains("  ❔ Do you want to restart your app? Yes (y) / No (n) / Always (a) / Never (v)");
             await App.WaitUntilOutputContains(MessageDescriptor.RestartNeededToApplyChanges);
+            await App.WaitUntilOutputContains($"❌ [{projectDisplay}] {programPath}(39,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
+            await App.WaitUntilOutputContains("  ❔ Do you want to restart your app? Yes (y) / No (n) / Always (a) / Never (v)");
 
-            await App.WaitUntilOutputContains($"❌ {programPath}(39,11): error ENC0023: Adding an abstract method or overriding an inherited method requires restarting the application.");
             App.Process.ClearOutput();
 
             App.SendKey('a');
 
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
-            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
-            App.AssertOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            App.AssertOutputContains(MessageDescriptor.Exited, projectDisplay);
+            App.AssertOutputContains(MessageDescriptor.LaunchedProcess, projectDisplay);
             App.Process.ClearOutput();
 
             // rude edit: deleting virtual method
@@ -153,9 +155,9 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
             await App.WaitUntilOutputContains(MessageDescriptor.RestartNeededToApplyChanges);
-            await App.WaitUntilOutputContains($"⌚ [auto-restart] {programPath}(39,1): error ENC0033: Deleting method 'F()' requires restarting the application.");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            await App.WaitUntilOutputContains($"⌚ [{projectDisplay}] [auto-restart] {programPath}(39,1): error ENC0033: Deleting method 'F()' requires restarting the application.");
+            await App.WaitUntilOutputContains(MessageDescriptor.Exited, projectDisplay);
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, projectDisplay);
         }
 
         [Theory]
@@ -178,6 +180,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
                     });
             }
 
+            var projectDisplay = $"WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})";
             var programPath = Path.Combine(testAsset.Path, "Program.cs");
 
             App.Start(testAsset, nonInteractive ? ["--non-interactive"] : []);
@@ -191,9 +194,9 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
             await App.WaitUntilOutputContains(MessageDescriptor.RestartNeededToApplyChanges);
-            await App.WaitUntilOutputContains($"⌚ [auto-restart] {programPath}(17,19): warning ENC0118: Changing 'top-level code' might not have any effect until the application is restarted.");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Exited");
-            await App.WaitUntilOutputContains($"[WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Launched");
+            await App.WaitUntilOutputContains($"⌚ [{projectDisplay}] [auto-restart] {programPath}(17,19): warning ENC0118: Changing 'top-level code' might not have any effect until the application is restarted.");
+            await App.WaitUntilOutputContains(MessageDescriptor.Exited, projectDisplay);
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, projectDisplay);
             await App.WaitUntilOutputContains("<Updated>");
             App.Process.ClearOutput();
 

--- a/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
@@ -1,76 +1,142 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class BuildProjectsTests : IDisposable
+public class BuildProjects(ITestOutputHelper output)
 {
-    private readonly HotReloadDotNetWatcher _watcher;
-    private readonly List<string> _buildFiles = [];
-    private string? _solutionFile;
-
-    public BuildProjectsTests(ITestOutputHelper output)
+    private class TestContext : IDisposable
     {
-        var environmentOptions = TestOptions.GetEnvironmentOptions();
-        var processOutputReporter = new TestProcessOutputReporter();
+        public readonly HotReloadDotNetWatcher Watcher;
+        public readonly FileWatcher FileWatcher;
+        public readonly TestConsole Console;
 
-        var runner = new TestProcessRunner()
+        public readonly List<string> BuildInvocations = [];
+        public string? SolutionFile;
+
+        public TestContext(ITestOutputHelper output, ImmutableArray<ProjectRepresentation> rootProjects)
         {
-            RunImpl = (processSpec, _, _) =>
+            var environmentOptions = TestOptions.GetEnvironmentOptions();
+            var processOutputReporter = new TestProcessOutputReporter();
+
+            var processRunner = new TestProcessRunner()
             {
-                Assert.Equal("build", processSpec.Arguments[0]);
-                Assert.Equal("arg1", processSpec.Arguments[2]);
-                Assert.Equal("arg2", processSpec.Arguments[3]);
-
-                var target = processSpec.Arguments[1];
-                if (Path.GetExtension(target) == ".slnx")
+                RunImpl = (processSpec, _, _) =>
                 {
-                    _solutionFile = target;
-                    target = "<solution>";
+                    LogBuildInvocation(processSpec);
+                    return 0;
                 }
+            };
 
-                _buildFiles.Add(target);
-                return 0;
-            }
-        };
+            var context = new DotNetWatchContext()
+            {
+                ProcessOutputReporter = processOutputReporter,
+                LoggerFactory = NullLoggerFactory.Instance,
+                Logger = NullLogger.Instance,
+                BuildLogger = NullLogger.Instance,
+                ProcessRunner = processRunner,
+                Options = new(),
+                MainProjectOptions = null,
+                RootProjects = rootProjects,
+                BuildArguments = ["-p", "A=1"],
+                EnvironmentOptions = environmentOptions,
+                BrowserLauncher = new BrowserLauncher(NullLogger.Instance, processOutputReporter, environmentOptions),
+                BrowserRefreshServerFactory = new BrowserRefreshServerFactory()
+            };
 
-        var context = new DotNetWatchContext()
+            FileWatcher = new FileWatcher(NullLogger.Instance, environmentOptions);
+
+            Console = new TestConsole(output);
+            Watcher = new HotReloadDotNetWatcher(context, Console, runtimeProcessLauncherFactory: null);
+        }
+
+        public void LogBuildInvocation(ProcessSpec processSpec)
         {
-            ProcessOutputReporter = processOutputReporter,
-            LoggerFactory = NullLoggerFactory.Instance,
-            Logger = NullLogger.Instance,
-            BuildLogger = NullLogger.Instance,
-            ProcessRunner = runner,
-            Options = new(),
-            MainProjectOptions = null,
-            RootProjects = [],
-            TargetFramework = null,
-            BuildArguments = ["arg1", "arg2"],
-            EnvironmentOptions = environmentOptions,
-            BrowserLauncher = new BrowserLauncher(NullLogger.Instance, processOutputReporter, environmentOptions),
-            BrowserRefreshServerFactory = new BrowserRefreshServerFactory()
-        };
+            SolutionFile = processSpec.Arguments.FirstOrDefault(a => a.EndsWith(".slnx"));
 
-        var console = new TestConsole(output);
-        _watcher = new HotReloadDotNetWatcher(context, console, runtimeProcessLauncherFactory: null);
+            // Replace path to solution, which is a temp path, with placeholder to make assertions easier.
+            BuildInvocations.Add(string.Join(" ", processSpec.Arguments.Select(a => a == SolutionFile ? "<solution>" : a)));
+        }
+
+        public void Dispose()
+        {
+            Assert.False(File.Exists(SolutionFile));
+        }
     }
 
-    public void Dispose()
-    {
-        Assert.False(File.Exists(_solutionFile));
-    }
+    private TestContext CreateContext(string[]? rootProjects = null)
+        => new(output, rootProjects?.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath).ToImmutableArray() ?? []);
+
+    private static TestDirectory CreateTestDirectory([CallerMemberName] string? testName = null, object[]? identifiers = null)
+        => TestDirectory.Create(TestAssetsManager.GetTestDestinationDirectoryPath(
+            testName,
+            testName,
+            identifiers != null ? string.Join(';', identifiers.Select(id => id.ToString())) : string.Empty,
+            baseDirectory: null));
 
     [Fact]
-    public async Task SingleProject()
+    public async Task SingleProject_NotMain()
     {
         var dir = Path.GetTempPath();
         var project1 = Path.Combine(dir, "Project1.csproj");
 
-        Assert.True(await _watcher.BuildProjectsAsync([new ProjectRepresentation(project1, entryPointFilePath: null)], CancellationToken.None));
+        using var context = CreateContext();
 
-        AssertEx.SequenceEqual([project1], _buildFiles);
+        var result = await context.Watcher.BuildProjectsAsync(
+            [new ProjectRepresentation(project1, entryPointFilePath: null)],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: (_, _) =>
+            {
+                Assert.Fail("Selector should not be invoked");
+                return ValueTask.FromResult("n/a");
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+
+        AssertEx.SequenceEqual([$"build {project1} -p A=1"], context.BuildInvocations);
+    }
+
+    [Fact]
+    public async Task SingleProject_Main()
+    {
+        var dir = Path.GetTempPath();
+        var project1 = Path.Combine(dir, "Project1.csproj");
+
+        File.WriteAllText(project1, $"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFramework>net9.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """);
+
+        using var context = CreateContext([project1]);
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            [new ProjectRepresentation(project1, entryPointFilePath: null)],
+            context.FileWatcher,
+            mainProjectOptions: TestOptions.ProjectOptions,
+            frameworkSelector: (_, _) =>
+            {
+                Assert.Fail("Selector should not be invoked");
+                return ValueTask.FromResult("n/a");
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+
+        AssertEx.SequenceEqual(
+        [
+            $"restore {project1} -p A=1 -consoleLoggerParameters:NoSummary",
+            $"build {project1} -p A=1 --framework net9.0 --no-restore"
+        ], context.BuildInvocations);
     }
 
     [Fact]
@@ -80,24 +146,47 @@ public class BuildProjectsTests : IDisposable
         var project1 = Path.Combine(dir, "Project1.csproj");
         var project2 = Path.Combine(dir, "Project2.csproj");
 
-        Assert.True(await _watcher.BuildProjectsAsync(
-        [
-            new ProjectRepresentation(project1, entryPointFilePath: null),
-            new ProjectRepresentation(project2, entryPointFilePath: null)
-        ], CancellationToken.None));
+        using var context = CreateContext();
 
-        AssertEx.SequenceEqual(["<solution>"], _buildFiles);
+        var result = await context.Watcher.BuildProjectsAsync(
+            projects:
+            [
+                new ProjectRepresentation(project1, entryPointFilePath: null),
+                new ProjectRepresentation(project2, entryPointFilePath: null)
+            ],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: null,
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+
+        AssertEx.SequenceEqual(["build <solution> -p A=1"], context.BuildInvocations);
     }
 
-    [Fact]
-    public async Task SingleFile()
+    [Theory]
+    [CombinatorialData]
+    public async Task SingleFile(bool isMain)
     {
         var dir = Path.GetTempPath();
         var file1 = Path.Combine(dir, "File1.cs");
 
-        Assert.True(await _watcher.BuildProjectsAsync([new ProjectRepresentation(projectPath: null, entryPointFilePath: file1)], CancellationToken.None));
+        using var context = CreateContext([file1]);
 
-        AssertEx.SequenceEqual([file1], _buildFiles);
+        var result = await context.Watcher.BuildProjectsAsync(
+            [new ProjectRepresentation(projectPath: null, entryPointFilePath: file1)],
+            context.FileWatcher,
+            mainProjectOptions: isMain ? TestOptions.GetProjectOptions(["--file", file1]) : null,
+            frameworkSelector: (_, _) =>
+            {
+                Assert.Fail("Selector should not be invoked");
+                return ValueTask.FromResult("n/a");
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+
+        AssertEx.SequenceEqual([$"build {file1} -p A=1"], context.BuildInvocations);
     }
 
     [Fact]
@@ -107,17 +196,26 @@ public class BuildProjectsTests : IDisposable
         var file1 = Path.Combine(dir, "File1.cs");
         var file2 = Path.Combine(dir, "File2.cs");
 
-        Assert.True(await _watcher.BuildProjectsAsync(
-        [
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
-        ], CancellationToken.None));
+        using var context = CreateContext();
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            projects:
+            [
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
+            ],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: null,
+            CancellationToken.None);
+
+        Assert.True(result.Success);
 
         AssertEx.SequenceEqual(
         [
-            file1,
-            file2
-        ], _buildFiles);
+            $"build {file1} -p A=1",
+            $"build {file2} -p A=1"
+        ], context.BuildInvocations);
     }
 
     [Fact]
@@ -128,19 +226,28 @@ public class BuildProjectsTests : IDisposable
         var file1 = Path.Combine(dir, "File1.cs");
         var file2 = Path.Combine(dir, "File2.cs");
 
-        Assert.True(await _watcher.BuildProjectsAsync(
-        [
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
-            new ProjectRepresentation(project1, entryPointFilePath: null),
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
-        ], CancellationToken.None));
+        using var context = CreateContext();
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            projects:
+            [
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
+                new ProjectRepresentation(project1, entryPointFilePath: null),
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
+            ],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: null,
+            CancellationToken.None);
+
+        Assert.True(result.Success);
 
         AssertEx.SequenceEqual(
         [
-            project1,
-            file1,
-            file2
-        ], _buildFiles);
+            $"build {project1} -p A=1",
+            $"build {file1} -p A=1",
+            $"build {file2} -p A=1"
+        ], context.BuildInvocations);
     }
 
     [Fact]
@@ -152,19 +259,151 @@ public class BuildProjectsTests : IDisposable
         var file1 = Path.Combine(dir, "File1.cs");
         var file2 = Path.Combine(dir, "File2.cs");
 
-        Assert.True(await _watcher.BuildProjectsAsync(
-        [
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
-            new ProjectRepresentation(project1, entryPointFilePath: null),
-            new ProjectRepresentation(project2, entryPointFilePath: null),
-            new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
-        ], CancellationToken.None));
+        using var context = CreateContext();
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            projects:
+            [
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file1),
+                new ProjectRepresentation(project1, entryPointFilePath: null),
+                new ProjectRepresentation(project2, entryPointFilePath: null),
+                new ProjectRepresentation(projectPath: null, entryPointFilePath: file2)
+            ],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: null,
+            CancellationToken.None);
+
+        Assert.True(result.Success);
 
         AssertEx.SequenceEqual(
         [
-            "<solution>",
-            file1,
-            file2
-        ], _buildFiles);
+            "build <solution> -p A=1",
+            $"build {file1} -p A=1",
+            $"build {file2} -p A=1"
+        ], context.BuildInvocations);
+    }
+
+    [Theory]
+    [InlineData(ToolsetInfo.CurrentTargetFramework)]
+    [InlineData("net9.0")]
+    public async Task MultiTfm_FrameworkSelection(string expectedTfm)
+    {
+        var dir = CreateTestDirectory(identifiers: [expectedTfm]);
+        var project1 = Path.Combine(dir.Path, "Project1.csproj");
+
+        var currentTfm = ToolsetInfo.CurrentTargetFramework;
+
+        File.WriteAllText(project1, $"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFrameworks>{currentTfm};net9.0</TargetFrameworks>
+          </PropertyGroup>
+        </Project>
+        """);
+
+        using var context = CreateContext(rootProjects: [project1]);
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            [ProjectRepresentation.FromProjectOrEntryPointFilePath(project1)],
+            context.FileWatcher,
+            mainProjectOptions: TestOptions.ProjectOptions,
+            frameworkSelector: (frameworks, _) =>
+            {
+                AssertEx.SequenceEqual([currentTfm, "net9.0"], frameworks);
+                return ValueTask.FromResult(expectedTfm);
+            },
+            CancellationToken.None);
+        
+        Assert.True(result.Success);
+        Assert.NotNull(result.ProjectGraph);
+        Assert.Equal(expectedTfm, result.MainProjectTargetFramework);
+
+        AssertEx.SequenceEqual(
+        [
+            $"restore {project1} -p A=1 -consoleLoggerParameters:NoSummary",
+            $"build {project1} -p A=1 --framework {expectedTfm} --no-restore"
+        ], context.BuildInvocations);
+    }
+
+    [Fact]
+    public async Task MultiTfm_CommandLineOption()
+    {
+        var dir = CreateTestDirectory();
+        var project1 = Path.Combine(dir.Path, "Project1.csproj");
+
+        var currentTfm = ToolsetInfo.CurrentTargetFramework;
+
+        File.WriteAllText(project1, $"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFrameworks>{currentTfm};net9.0</TargetFrameworks>
+          </PropertyGroup>
+        </Project>
+        """);
+
+        using var context = CreateContext(rootProjects: [project1]);
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            [ProjectRepresentation.FromProjectOrEntryPointFilePath(project1)],
+            context.FileWatcher,
+            mainProjectOptions: TestOptions.GetProjectOptions(["-f", "net9.0"]),
+            frameworkSelector: (frameworks, _) =>
+            {
+                Assert.Fail("Selector should not be invoked");
+                return ValueTask.FromResult("n/a");
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Null(result.ProjectGraph);
+        Assert.Equal("net9.0", result.MainProjectTargetFramework);
+
+        AssertEx.SequenceEqual(
+        [
+            $"build {project1} -p A=1 --framework net9.0"
+        ], context.BuildInvocations);
+    }
+
+    [Fact]
+    public async Task MultiTfm_NoMainProject()
+    {
+        var dir = CreateTestDirectory();
+        var project1 = Path.Combine(dir.Path, "Project1.csproj");
+
+        var currentTfm = ToolsetInfo.CurrentTargetFramework;
+
+        File.WriteAllText(project1, $"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <OutputType>Exe</OutputType>
+            <TargetFrameworks>{currentTfm};net9.0</TargetFrameworks>
+          </PropertyGroup>
+        </Project>
+        """);
+
+        using var context = CreateContext(rootProjects: [project1]);
+
+        var result = await context.Watcher.BuildProjectsAsync(
+            [ProjectRepresentation.FromProjectOrEntryPointFilePath(project1)],
+            context.FileWatcher,
+            mainProjectOptions: null,
+            frameworkSelector: (frameworks, _) =>
+            {
+                Assert.Fail("Selector should not be invoked");
+                return ValueTask.FromResult("n/a");
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Null(result.ProjectGraph);
+        Assert.Null(result.MainProjectTargetFramework);
+
+        AssertEx.SequenceEqual(
+        [
+            $"build {project1} -p A=1"
+        ], context.BuildInvocations);
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
@@ -71,13 +71,6 @@ public class BuildProjects(ITestOutputHelper output)
     private TestContext CreateContext(string[]? rootProjects = null)
         => new(output, rootProjects?.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath).ToImmutableArray() ?? []);
 
-    private static TestDirectory CreateTestDirectory([CallerMemberName] string? testName = null, object[]? identifiers = null)
-        => TestDirectory.Create(TestAssetsManager.GetTestDestinationDirectoryPath(
-            testName,
-            testName,
-            identifiers != null ? string.Join(';', identifiers.Select(id => id.ToString())) : string.Empty,
-            baseDirectory: null));
-
     [Fact]
     public async Task SingleProject_NotMain()
     {
@@ -289,7 +282,7 @@ public class BuildProjects(ITestOutputHelper output)
     [InlineData("net9.0")]
     public async Task MultiTfm_FrameworkSelection(string expectedTfm)
     {
-        var dir = CreateTestDirectory(identifiers: [expectedTfm]);
+        var dir = TestAssetsManager.CreateTestDirectory(identifiers: [expectedTfm]);
         var project1 = Path.Combine(dir.Path, "Project1.csproj");
 
         var currentTfm = ToolsetInfo.CurrentTargetFramework;
@@ -330,7 +323,7 @@ public class BuildProjects(ITestOutputHelper output)
     [Fact]
     public async Task MultiTfm_CommandLineOption()
     {
-        var dir = CreateTestDirectory();
+        var dir = TestAssetsManager.CreateTestDirectory();
         var project1 = Path.Combine(dir.Path, "Project1.csproj");
 
         var currentTfm = ToolsetInfo.CurrentTargetFramework;
@@ -370,7 +363,7 @@ public class BuildProjects(ITestOutputHelper output)
     [Fact]
     public async Task MultiTfm_NoMainProject()
     {
-        var dir = CreateTestDirectory();
+        var dir = TestAssetsManager.CreateTestDirectory();
         var project1 = Path.Combine(dir.Path, "Project1.csproj");
 
         var currentTfm = ToolsetInfo.CurrentTargetFramework;

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -22,7 +22,7 @@ public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTest
         var projectOptions = TestOptions.GetProjectOptions(cmdOptions);
         var environmentOptions = TestOptions.GetEnvironmentOptions(Environment.CurrentDirectory);
 
-        var factory = new ProjectGraphFactory([hostProjectRepr], targetFramework: null, buildProperties: [], NullLogger.Instance);
+        var factory = new ProjectGraphFactory([hostProjectRepr], virtualProjectTargetFramework: null, buildProperties: [], NullLogger.Instance);
         var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: false, CancellationToken.None);
         Assert.NotNull(projectGraph);
 
@@ -39,7 +39,6 @@ public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTest
             MainProjectOptions = TestOptions.ProjectOptions,
             RootProjects = [hostProjectRepr],
             BuildArguments = [],
-            TargetFramework = null,
             EnvironmentOptions = environmentOptions,
             BrowserLauncher = new BrowserLauncher(NullLogger.Instance, processOutputReporter, environmentOptions),
             BrowserRefreshServerFactory = new BrowserRefreshServerFactory()

--- a/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
@@ -13,10 +13,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
         /// Currently only works on Windows.
         /// Add TestPlatforms.OSX once https://github.com/dotnet/sdk/issues/45521 is fixed.
         /// </summary>
-        [PlatformSpecificFact(TestPlatforms.Windows)]
-        public async Task MauiBlazor()
+        [PlatformSpecificTheory(TestPlatforms.Windows)]
+        [CombinatorialData]
+        public async Task MauiBlazor(bool selectTfm)
         {
-            var testAsset = TestAssets.CopyTestAsset("WatchMauiBlazor")
+            var testAsset = TestAssets.CopyTestAsset("WatchMauiBlazor", identifier: selectTfm.ToString())
                 .WithSource();
 
             var workloadInstallCommandSpec = new DotnetCommand(Logger, ["workload", "install", "maui", "--include-previews"])
@@ -29,9 +30,19 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             var platform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows10.0.19041.0" : "maccatalyst";
             var tfm = $"{ToolsetInfo.CurrentTargetFramework}-{platform}";
-            App.Start(testAsset, ["-f", tfm]);
+            App.Start(testAsset, selectTfm ? [] : ["-f", tfm], testFlags: TestFlags.ReadKeyFromStdin);
+
+            if (selectTfm)
+            {
+                await App.WaitUntilOutputContains("❔ Select target framework");
+                App.SendKey(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '2' : '1');
+            }
 
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
+
+            // only the selected target framework is built:
+            Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", "net10.0-windows10.0.19041.0", "win-x64", "maui-blazor.dll")));
+            Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", "net10.0-maccatalyst", "maccatalyst-x64", "maui-blazor.dll")));
 
             // update code file:
             var razorPath = Path.Combine(testAsset.Path, "Components", "Pages", "Home.razor");
@@ -58,6 +69,11 @@ namespace Microsoft.DotNet.Watch.UnitTests
             await App.WaitUntilOutputContains(MessageDescriptor.StaticAssetsChangesApplied);
             await App.WaitUntilOutputContains("Microsoft.AspNetCore.Components.WebView.StaticContentHotReloadManager.UpdateContent");
             await App.WaitUntilOutputContains(MessageDescriptor.NoManagedCodeChangesToApply);
+
+            // no warnings - these would be reported if we tried to access web asset manifest from unbuilt TFMs:
+            App.AssertOutputDoesNotContain(MessageDescriptor.StaticWebAssetManifestNotFound);
+            App.AssertOutputDoesNotContain(MessageDescriptor.ScopedCssBundleFileNotFound);
+            App.AssertOutputDoesNotContain(MessageDescriptor.ManifestFileNotFound);
         }
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
@@ -55,13 +55,14 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps", identifier: isDirectoryProps.ToString())
                 .WithSource();
 
+            var dependencyProjectDisplay = $"Dependency ({ToolsetInfo.CurrentTargetFramework})";
             var symbolName = isDirectoryProps ? "BUILD_CONST_IN_PROPS" : "BUILD_CONST_IN_CSPROJ";
 
             var dependencyDir = Path.Combine(testAsset.Path, "Dependency");
-            var libSourcePath = Path.Combine(dependencyDir, "Foo.cs");
+            var dependencySourcePath = Path.Combine(dependencyDir, "Foo.cs");
             var buildFilePath = isDirectoryProps ? Path.Combine(testAsset.Path, "Directory.Build.props") : Path.Combine(dependencyDir, "Dependency.csproj");
 
-            File.WriteAllText(libSourcePath, $$"""
+            File.WriteAllText(dependencySourcePath, $$"""
                 public class Lib
                 {
                     public static void Print()
@@ -85,7 +86,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
             await App.WaitUntilOutputContains(MessageDescriptor.ProjectChangeTriggeredReEvaluation);
-            await App.WaitUntilOutputContains("dotnet watch ⌚ [auto-restart] error ENC1102: Changing project setting 'DefineConstants'");
+            await App.WaitUntilOutputContains($"dotnet watch ⌚ [{dependencyProjectDisplay}] [auto-restart] error ENC1102: Changing project setting 'DefineConstants'");
 
             await App.WaitUntilOutputContains($"{symbolName} not set");
         }

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -7,8 +7,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 {
     public enum TriggerEvent
     {
-        HotReloadSessionStarting,
-        HotReloadSessionStarted,
+        RuntimeProcessLauncherCreated,
         WaitingForChanges,
     }
 
@@ -40,8 +39,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
 
         w.Observer.RegisterAction(trigger switch
         {
-            TriggerEvent.HotReloadSessionStarting => MessageDescriptor.HotReloadSessionStartingNotification,
-            TriggerEvent.HotReloadSessionStarted => MessageDescriptor.HotReloadSessionStarted,
+            TriggerEvent.RuntimeProcessLauncherCreated => MessageDescriptor.RuntimeProcessLauncherCreatedNotification,
             TriggerEvent.WaitingForChanges => MessageDescriptor.WaitingForChanges,
             _ => throw new InvalidOperationException(),
         }, () =>
@@ -52,7 +50,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
                 return;
             }
 
-            // service should have been created before Hot Reload session started:
+            // service should have been created after MessageDescriptor.RuntimeProcessLauncherCreatedNotification has been received:
             Assert.NotNull(w.Service);
 
             w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token).Wait();

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.ComponentModel.DataAnnotations;
+
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
@@ -13,7 +15,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
         [InlineData("StartupHookSupport", "False")]
         public async Task ChangeFileInAotProject(string propertyName, string propertyValue)
         {
-            var tfm = ToolsetInfo.CurrentTargetFramework;
+            var projectDisplay = $"WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})";
 
             var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: $"{propertyName};{propertyValue}")
                 .WithSource()
@@ -28,13 +30,14 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             App.Start(testAsset, ["--non-interactive"]);
 
-            await App.WaitForOutputLineContaining($"[WatchHotReloadApp ({tfm})] " + MessageDescriptor.ProjectDoesNotSupportHotReload.GetMessage($"'{propertyName}' property is '{propertyValue}'"));
+            var message = MessageDescriptor.ProjectDoesNotSupportHotReload.GetMessage($"'{propertyName}' property is '{propertyValue}'");
+            await App.WaitForOutputLineContaining($"[{projectDisplay}] {message}");
             await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
             App.Process.ClearOutput();
 
             UpdateSourceFile(programPath, content => content.Replace("Console.WriteLine(\".\");", "Console.WriteLine(\"<updated>\");"));
 
-            await App.WaitForOutputLineContaining($"[auto-restart] {programPath}(1,1): error ENC0097"); //  Applying source changes while the application is running is not supported by the runtime.
+            await App.WaitForOutputLineContaining($"[{projectDisplay}] [auto-restart] {programPath}(1,1): error ENC0097"); //  Applying source changes while the application is running is not supported by the runtime.
             await App.WaitForOutputLineContaining("<updated>");
         }
 

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.ComponentModel.DataAnnotations;
-
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logger) : DotNetWatchTestBase(logger)

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
 
             App.Start(testAsset, []);
 
-            await App.WaitUntilOutputContains(MessageDescriptor.WaitingForFileChangeBeforeRestarting);
+            await App.WaitUntilOutputContains(MessageDescriptor.FixBuildError);
 
             UpdateSourceFile(programPath, """
                 System.Console.WriteLine("<Updated>");

--- a/test/dotnet-watch.Tests/HotReload/TargetFrameworkSelectionPromptTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/TargetFrameworkSelectionPromptTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+public class TargetFrameworkSelectionPromptTests(ITestOutputHelper output)
+{
+    [Theory]
+    [CombinatorialData]
+    public async Task PreviousSelection([CombinatorialRange(0, count: 3)] int index)
+    {
+        var console = new TestConsole(output);
+        var consoleInput = new ConsoleInputReader(console, LogLevel.Debug, suppressEmojis: false);
+        var prompt = new TargetFrameworkSelectionPrompt(consoleInput);
+
+        var frameworks = new[] { "net7.0", "net8.0", "net9.0" };
+        var expectedTfm = frameworks[index];
+
+        // first selection:
+        console.QueuedKeyPresses.Add(new ConsoleKeyInfo((char)('1' + index), ConsoleKey.D1 + index, shift: false, alt: false, control: false));
+
+        Assert.Equal(expectedTfm, await prompt.SelectAsync(frameworks, CancellationToken.None));
+        Assert.Equal(expectedTfm, prompt.PreviousSelection);
+        console.QueuedKeyPresses.Clear();
+
+        // should use previous selection:
+        Assert.Equal(expectedTfm, await prompt.SelectAsync(["NET9.0", "net7.0", "net8.0"], CancellationToken.None));
+
+        // second selection:
+        console.QueuedKeyPresses.Add(new ConsoleKeyInfo('3', ConsoleKey.D3, shift: false, alt: false, control: false));
+
+        // should prompt again:
+        Assert.Equal("net10.0", await prompt.SelectAsync(["net9.0", "net7.0", "net10.0"], CancellationToken.None));
+    }
+}

--- a/test/dotnet-watch.Tests/TestUtilities/TestAssetsManagerExtensions.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestAssetsManagerExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+internal static class TestAssetsManagerExtensions
+{
+    extension(TestAssetsManager)
+    {
+        public static TestDirectory CreateTestDirectory([CallerMemberName] string? testName = null, object[]? identifiers = null)
+            => TestDirectory.Create(TestAssetsManager.GetTestDestinationDirectoryPath(
+                testName,
+                testName,
+                identifiers != null ? string.Join(';', identifiers.Select(id => id != null ? "_" + id.ToString() : "null")) : string.Empty,
+                baseDirectory: null));
+    }
+}

--- a/test/dotnet-watch.Tests/TestUtilities/TestConsole.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestConsole.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
-
 namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal class TestConsole : IConsole
     {
-        public event Action<ConsoleKeyInfo>? KeyPressed;
+        private Action<ConsoleKeyInfo>? _keyPressed;
 
         private readonly TestOutputWriter _testWriter;
 
@@ -19,6 +17,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
         public bool IsErrorRedirected { get; } = false;
         public ConsoleColor ForegroundColor { get; set; }
 
+        public readonly List<ConsoleKeyInfo> QueuedKeyPresses = [];
+
         public TestConsole(ITestOutputHelper output)
         {
             _testWriter = new TestOutputWriter(output);
@@ -26,12 +26,29 @@ namespace Microsoft.DotNet.Watch.UnitTests
             Out = _testWriter;
         }
 
+        public event Action<ConsoleKeyInfo> KeyPressed
+        {
+            add
+            {
+                _keyPressed += value;
+                foreach (var key in QueuedKeyPresses)
+                {
+                    value.Invoke(key);
+                }
+                QueuedKeyPresses.Clear();
+            }
+            remove
+            {
+                _keyPressed -= value;
+            }
+        }
+
         public void Clear() { }
 
         public void PressKey(ConsoleKeyInfo key)
         {
-            Assert.NotNull(KeyPressed);
-            KeyPressed.Invoke(key);
+            Assert.NotNull(_keyPressed);
+            _keyPressed.Invoke(key);
         }
 
         public void ResetColor()

--- a/test/dotnet-watch.Tests/TestUtilities/TestOptions.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestOptions.cs
@@ -27,6 +27,11 @@ internal static class TestOptions
     public static CommandLineOptions GetCommandLineOptions(string[] args)
         => CommandLineOptions.Parse(args, NullLogger.Instance, TextWriter.Null, out _) ?? throw new InvalidOperationException();
 
+    public static ProjectOptions GetProjectOptions(string[] args)
+        => GetProjectOptions(GetCommandLineOptions(args));
+
     public static ProjectOptions GetProjectOptions(CommandLineOptions options)
-        => options.GetMainProjectOptions(new ProjectRepresentation(options.ProjectPath ?? "test.csproj", entryPointFilePath: null), workingDirectory: "");
+        => options.GetMainProjectOptions(
+            new ProjectRepresentation(options.ProjectPath == null && options.FilePath == null ? "test.csproj" : options.ProjectPath, options.FilePath),
+            workingDirectory: "");
 }

--- a/test/dotnet-watch.Tests/TestUtilities/TestProcessRunner.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestProcessRunner.cs
@@ -8,8 +8,11 @@ namespace Microsoft.DotNet.Watch.UnitTests;
 internal class TestProcessRunner()
     : ProcessRunner(processCleanupTimeout: TimeSpan.MaxValue)
 {
-    public Func<ProcessSpec, ILogger, ProcessLaunchResult?, int>? RunImpl;
+    public Func<ProcessSpec, ILogger, ProcessLaunchResult?, int?>? RunImpl;
 
-    public override Task<int> RunAsync(ProcessSpec processSpec, ILogger logger, ProcessLaunchResult? launchResult, CancellationToken processTerminationToken)
-        => Task.FromResult(RunImpl?.Invoke(processSpec, logger, launchResult) ?? throw new NotImplementedException());
+    public async override Task<int> RunAsync(ProcessSpec processSpec, ILogger logger, ProcessLaunchResult? launchResult, CancellationToken processTerminationToken)
+    {
+        var result = RunImpl?.Invoke(processSpec, logger, launchResult);
+        return result ?? await base.RunAsync(processSpec, logger, launchResult, processTerminationToken);
+    }   
 }

--- a/test/dotnet-watch.Tests/TestUtilities/TestProcessRunner.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestProcessRunner.cs
@@ -14,5 +14,5 @@ internal class TestProcessRunner()
     {
         var result = RunImpl?.Invoke(processSpec, logger, launchResult);
         return result ?? await base.RunAsync(processSpec, logger, launchResult, processTerminationToken);
-    }   
+    }
 }

--- a/test/dotnet-watch.Tests/Watch/BuildEvaluatorTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BuildEvaluatorTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 Options = new(),
                 MainProjectOptions = TestOptions.ProjectOptions,
                 RootProjects = [TestOptions.ProjectOptions.Representation],
-                TargetFramework = null,
                 BuildArguments = [],
                 EnvironmentOptions = environmentOptions,
                 BrowserLauncher = new BrowserLauncher(NullLogger.Instance, processOutputReporter, environmentOptions),

--- a/test/dotnet-watch.Tests/Watch/NoRestoreTests.cs
+++ b/test/dotnet-watch.Tests/Watch/NoRestoreTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.DotNet.Watch.UnitTests
                 Options = new(),
                 MainProjectOptions = projectOptions,
                 RootProjects = [projectOptions.Representation],
-                TargetFramework = cmdOptions.TargetFramework,
                 BuildArguments = cmdOptions.BuildArguments,
                 EnvironmentOptions = environmentOptions,
                 BrowserLauncher = new BrowserLauncher(NullLogger.Instance, processOutputReporter, environmentOptions),
@@ -113,8 +112,8 @@ namespace Microsoft.DotNet.Watch.UnitTests
             var context = CreateContext(["run", "-f", ToolsetInfo.CurrentTargetFramework]);
             var evaluator = new BuildEvaluator(context);
 
-            AssertEx.SequenceEqual(["run", "-f", ToolsetInfo.CurrentTargetFramework], evaluator.GetProcessArguments(iteration: 0));
-            AssertEx.SequenceEqual(["run", "--no-restore", "-f", ToolsetInfo.CurrentTargetFramework], evaluator.GetProcessArguments(iteration: 1));
+            AssertEx.SequenceEqual(["run", "--framework", ToolsetInfo.CurrentTargetFramework], evaluator.GetProcessArguments(iteration: 0));
+            AssertEx.SequenceEqual(["run", "--no-restore", "--framework", ToolsetInfo.CurrentTargetFramework], evaluator.GetProcessArguments(iteration: 1));
         }
 
         [Fact]


### PR DESCRIPTION
Change command line parsing to treat `--framework` option as watch-specific option, not auto-forwarded to a subcommand or build. Forward the option explicitly when invoking the subcommand/build.

Refactor `BuildProjectsAsync` to allow for target framework detection. If `--framework` is not specified, we do not know whether a project is multi-targeting until we load it. We can only load it correctly after it's been restored. We do not want to load it multiple times. 

Therefore, split the build to 3 steps:
1) `dotnet restore` on project graph roots, 
2) load the project graph,
3) select target framework if the project multi-targets,
4) `dotnet build --no-restore` on project graph roots.

Add `TargetFrameworkSelectionPrompt`, which implements a simple framework selection TUI. This will be replaced in future with more sophisticated UI used by `dotnet run`.

Update all operations (except for restore) on a project graph to ignore outer-build project nodes. Only work with instances with `TargetFramework` set.

For multi-targeted root projects only consider instances with `TargetFramework` that matches the framework given on command line via `--framework` option, or manually selected.

Include project display name in rude edit messages.

