### PR TITLE
dotnetup: Unify version properties across projects

### DIFF
--- a/src/Installer/Directory.Build.props
+++ b/src/Installer/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Shared version for dotnetup CLI and Microsoft.Dotnet.Installation library -->
+    <DotnetupVersionPrefix>0.1.1</DotnetupVersionPrefix>
+    <DotnetupPreReleaseVersionLabel>preview</DotnetupPreReleaseVersionLabel>
+  </PropertyGroup>
+
+</Project>

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -14,8 +14,8 @@
     <PackageId>Microsoft.Dotnet.Installation</PackageId>
     <IsShipping>false</IsShipping>
     <Title>.NET Installation Library</Title>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>$(DotnetupVersionPrefix)</VersionPrefix>
+    <PreReleaseVersionLabel>$(DotnetupPreReleaseVersionLabel)</PreReleaseVersionLabel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -15,8 +15,8 @@
     <NoWarn>$(NoWarn);CS8002;CS1591</NoWarn>
 
     <!-- dotnetup versioning -->
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>$(DotnetupVersionPrefix)</VersionPrefix>
+    <PreReleaseVersionLabel>$(DotnetupPreReleaseVersionLabel)</PreReleaseVersionLabel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Centralizes version properties for dotnetup and Microsoft.Dotnet.Installation into a shared `Directory.Build.props` so both projects stay in sync.

## Changes

- Created `src/Installer/Directory.Build.props` with shared `DotnetupVersionPrefix` (0.1.1) and `DotnetupPreReleaseVersionLabel` (preview) properties
- Updated `dotnetup.csproj` and `Microsoft.Dotnet.Installation.csproj` to reference shared properties instead of hardcoding version values

## Conflicts

> [!WARNING]
> This branch conflicts with PR #53464 (walkthrough UX improvements) which also creates/modifies `src/Installer/Directory.Build.props`.

> [!NOTE]
> This PR was created by Copilot CLI and has not yet been reviewed by a human.

Fixes #52795