### PR TITLE
CA1826: use index-from-end expression for Last() code fix in C# 8+

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyFixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyFixer.cs
@@ -2,16 +2,39 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Composition;
+using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.NetCore.Analyzers.Runtime;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 {
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpDoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyFixer : DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyFixer
     {
+        private protected sealed override SyntaxNode CreateLastElementAccessExpression(Document document,SyntaxGenerator generator,SyntaxNode adjustedCollectionSyntaxNoTrailingTrivia,SyntaxNode collectionSyntax)
+        {
+            if (document.Project.ParseOptions is CSharpParseOptions { LanguageVersion: >= LanguageVersion.CSharp8 })
+            {
+                var expression = (ExpressionSyntax)adjustedCollectionSyntaxNoTrailingTrivia;
+
+                var indexExpression = PrefixUnaryExpression(
+                    SyntaxKind.IndexExpression,
+                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(1)));
+
+                return ElementAccessExpression(
+                    expression,
+                    BracketedArgumentList(
+                        SingletonSeparatedList(
+                            Argument(indexExpression))));
+            }
+
+            return base.CreateLastElementAccessExpression(document, generator, adjustedCollectionSyntaxNoTrailingTrivia, collectionSyntax);
+        }
         private protected sealed override SyntaxNode? AdjustSyntaxNode(SyntaxNode? syntaxNode)
         {
             if (syntaxNode?.Parent.IsKind(SyntaxKind.SuppressNullableWarningExpression) == true)

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.Fixer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             var generator = SyntaxGenerator.GetGenerator(document);
 
-            var elementAccessNode = GetReplacementNode(methodName, generator, collectionSyntax);
+            var elementAccessNode = GetReplacementNode(document, methodName, generator, collectionSyntax);
             if (elementAccessNode == null)
             {
                 return Task.FromResult(document);
@@ -95,7 +95,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             return Task.FromResult(document.WithSyntaxRoot(newRoot));
         }
 
-        private SyntaxNode? GetReplacementNode(string methodName, SyntaxGenerator generator, SyntaxNode collectionSyntax)
+        private SyntaxNode? GetReplacementNode(Document document,string methodName, SyntaxGenerator generator, SyntaxNode collectionSyntax)
         {
             var adjustedCollectionSyntax = AdjustSyntaxNode(collectionSyntax);
             var adjustedCollectionSyntaxNoTrailingTrivia = adjustedCollectionSyntax.WithoutTrailingTrivia();
@@ -108,15 +108,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             if (methodName == LastPropertyName)
             {
-                // TODO: Handle C# 8 index expression (and vb.net equivalent if any)
-
-                // TODO: Handle cases were `collectionSyntax` is an invocation. We would need to create some intermediate variable.
-                var countMemberAccess = generator.MemberAccessExpression(collectionSyntax.WithoutTrailingTrivia(), CountPropertyName);
-                var oneLiteral = generator.LiteralExpression(1);
-
-                // The SubstractExpression method will wrap left and right in parenthesis but those will be automatically removed later on
-                var substraction = generator.SubtractExpression(countMemberAccess, oneLiteral);
-                return generator.ElementAccessExpression(adjustedCollectionSyntaxNoTrailingTrivia, substraction);
+                return CreateLastElementAccessExpression(document, generator, adjustedCollectionSyntaxNoTrailingTrivia, collectionSyntax);
             }
 
             if (methodName == CountPropertyName)
@@ -126,6 +118,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             Debug.Fail($"Unexpected method name '{methodName}' for {DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyAnalyzer.RuleId} code fix.");
             return null;
+        }
+
+        private protected virtual SyntaxNode CreateLastElementAccessExpression(Document document,SyntaxGenerator generator,SyntaxNode adjustedCollectionSyntaxNoTrailingTrivia,SyntaxNode collectionSyntax)
+        {
+            // TODO: Handle cases where `collectionSyntax` is an invocation. We would need to create some intermediate variable.
+            var countMemberAccess = generator.MemberAccessExpression(collectionSyntax.WithoutTrailingTrivia(), CountPropertyName);
+            var oneLiteral = generator.LiteralExpression(1);
+
+            // The SubtractExpression method will wrap left and right in parenthesis but those will be automatically removed later on
+            var subtraction = generator.SubtractExpression(countMemberAccess, oneLiteral);
+            return generator.ElementAccessExpression(adjustedCollectionSyntaxNoTrailingTrivia, subtraction);
         }
 
         [return: NotNullIfNotNull(nameof(syntaxNode))]

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectlyTests.cs
@@ -1139,6 +1139,59 @@ class C
 ");
         }
 
+        [Fact, WorkItem(1932, "https://github.com/dotnet/roslyn-analyzers/issues/1932")]
+        public async Task CA1826_CSharp8_EnumerableLastExtensionCall_UsesIndexExpressionAsync()
+        {
+            var test = new VerifyCS.Test
+        {
+        TestCode = @"
+using System;
+using System.Collections.Generic;
+#pragma warning disable CS8019 //Unnecessary using directive
+using System.Linq;
+#pragma warning restore CS8019
+class C
+{
+    void M()
+    {
+        var list = GetList();
+        var f1 = [|list.Last()|];
+        Console.WriteLine([|list.Last()|]);
+    }
+
+    IReadOnlyList<int> GetList()
+    {
+        return new List<int> { 1, 2, 3 };
+    }
+}
+",
+        FixedCode = @"
+using System;
+using System.Collections.Generic;
+#pragma warning disable CS8019 //Unnecessary using directive
+using System.Linq;
+#pragma warning restore CS8019
+class C
+{
+    void M()
+    {
+        var list = GetList();
+        var f1 = list[^1];
+        Console.WriteLine(list[^1]);
+    }
+
+    IReadOnlyList<int> GetList()
+    {
+        return new List<int> { 1, 2, 3 };
+    }
+}
+",
+        LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8
+    };
+
+    await test.RunAsync();
+}
+
         [Fact, WorkItem(5795, "https://github.com/dotnet/roslyn-analyzers/issues/5795")]
         public async Task CA1826_CSharp_NullForgivingOperator()
         {
@@ -1170,7 +1223,7 @@ public class Test
 
     public static string Method()
     {
-        return Strings![Strings.Count - 1];
+        return Strings![^1];
     }
 }
 ";


### PR DESCRIPTION
Fixes part of #1932.

This updates the CA1826 code fix for `Last()` in C# to use the index-from-end operator (`[^1]`) when the project language version is C# 8.0 or later.

Changes:
- Extracted `Last()` replacement into an overridable helper in the shared fixer
- Added a C#-specific override that produces `[^1]` for C# 8+
- Preserved the existing `Count - 1` behavior for older C# language versions and VB
- Added test coverage for the C# 8 index-expression code fix
- Updated the nullable test expectation to match the new behavior in that context

Validation:
- `dotnet test src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj --filter CA1826`