### PR TITLE
Add skill for incremental building

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@ Testing:
   - Examples:
     - `dotnet test test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~ItShowsTheAppropriateMessageToTheUser"`
     - `dotnet exec artifacts/bin/redist/Debug/dotnet.Tests.dll -method "*ItShowsTheAppropriateMessageToTheUser*"`
+- For incremental test runs of `dotnet.Tests` (avoids slow full `build.cmd`), see the skill at `.github/copilot/skills/incremental-test.md`. In short: build only the modified projects, copy their output DLLs into the redist SDK layout, then run the tests.
 - To test CLI command changes:
   - Build the redist SDK: `./build.sh` from repo root
   - Create a dogfood environment: `source eng/dogfood.sh` 

--- a/.github/copilot/skills/incremental-test.md
+++ b/.github/copilot/skills/incremental-test.md
@@ -1,0 +1,103 @@
+# Incremental Test Runner for dotnet.Tests
+
+This skill enables fast incremental test runs of `dotnet.Tests` without a full `build.cmd` rebuild.
+Use it after making source code changes to quickly build only the modified projects and deploy their outputs into the redist SDK layout so tests can run against them.
+
+## Prerequisites
+
+A full build must have been completed at least once (via `build.cmd` or `build.sh`) so that the redist SDK layout exists at `artifacts\bin\redist\Debug\dotnet\sdk\<version>\`.
+
+## When to use
+
+Use this skill when you need to run `dotnet.Tests` after modifying source code in one or more SDK projects. It avoids the slow full `build.cmd` by only rebuilding the changed projects and copying their output DLLs into the redist layout.
+
+## Workflow
+
+### Step 1: Identify modified projects
+
+Determine which projects have been modified. Use context from:
+- The files you just edited in this session.
+- Or `git status`/`git diff` to find changed `.cs` files and map them to their `.csproj` projects.
+
+### Step 2: Build modified projects
+
+Build each modified project individually using the repo-local dotnet:
+
+```
+.\.dotnet\dotnet build <path-to-project.csproj>
+```
+
+For example:
+```
+.\.dotnet\dotnet build src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj
+```
+
+If the `dotnet` CLI project itself was modified, build it:
+```
+.\.dotnet\dotnet build src\Cli\dotnet\dotnet.csproj
+```
+
+### Step 3: Copy output DLLs to the redist SDK layout
+
+Discover the SDK version directory name:
+```powershell
+$sdkVersion = (Get-ChildItem artifacts\bin\redist\Debug\dotnet\sdk -Directory).Name
+```
+
+For each modified project, copy its output DLL (and any satellite assemblies) from the project's build output to the redist SDK directory:
+
+```
+Source: artifacts\bin\<ProjectName>\Debug\net10.0\<AssemblyName>.dll
+Target: artifacts\bin\redist\Debug\dotnet\sdk\<version>\
+```
+
+For example:
+```powershell
+Copy-Item artifacts\bin\Microsoft.DotNet.ProjectTools\Debug\net10.0\Microsoft.DotNet.ProjectTools.dll artifacts\bin\redist\Debug\dotnet\sdk\$sdkVersion\
+Copy-Item artifacts\bin\Microsoft.DotNet.Cli.Utils\Debug\net10.0\Microsoft.DotNet.Cli.Utils.dll artifacts\bin\redist\Debug\dotnet\sdk\$sdkVersion\
+```
+
+The `dotnet` project is special — it builds into `artifacts\bin\dotnet\Debug\net10.0\` and its `dotnet.dll` must be copied to the SDK directory:
+```powershell
+Copy-Item artifacts\bin\dotnet\Debug\net10.0\dotnet.dll artifacts\bin\redist\Debug\dotnet\sdk\$sdkVersion\
+```
+
+**Important notes:**
+- Only copy DLLs that are **already present** in the target directory. If a DLL doesn't exist in the redist SDK dir, it probably doesn't belong there.
+- Some projects multi-target (e.g., `net10.0` and `net472`). Always use the `net10.0` output.
+- If localization resource DLLs were changed (in subdirectories like `cs\`, `de\`, etc.), copy those too.
+
+### Step 4: Build the test project (if test code was modified)
+
+The test project `test\dotnet.Tests\dotnet.Tests.csproj` outputs directly to `artifacts\bin\redist\Debug\` (via `TestHostFolder`), so just build it:
+
+```
+.\.dotnet\dotnet build test\dotnet.Tests\dotnet.Tests.csproj
+```
+
+### Step 5: Run the tests
+
+Run specific tests:
+```
+.\.dotnet\dotnet exec artifacts\bin\redist\Debug\dotnet.Tests.dll -method "*TestMethodName*"
+```
+
+Or run filtered tests via `dotnet test`:
+```
+.\.dotnet\dotnet test test\dotnet.Tests\dotnet.Tests.csproj --no-build --filter "Name~TestMethodName"
+```
+
+## Common project paths
+
+| Assembly | Project Path |
+|---|---|
+| `dotnet.dll` | `src\Cli\dotnet\dotnet.csproj` |
+| `Microsoft.DotNet.Cli.Utils.dll` | `src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj` |
+| `Microsoft.DotNet.Cli.Definitions.dll` | `src\Cli\Microsoft.DotNet.Cli.Definitions\Microsoft.DotNet.Cli.Definitions.csproj` |
+| `Microsoft.DotNet.Cli.CoreUtils.dll` | `src\Cli\Microsoft.DotNet.Cli.CoreUtils\Microsoft.DotNet.Cli.CoreUtils.csproj` |
+| `Microsoft.DotNet.Configurer.dll` | `src\Cli\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj` |
+| `Microsoft.DotNet.ProjectTools.dll` | `src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj` |
+| `Microsoft.DotNet.NativeWrapper.dll` | `src\Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj` |
+| `Microsoft.DotNet.TemplateLocator.dll` | `src\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj` |
+| `Microsoft.DotNet.InternalAbstractions.dll` | `src\Cli\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj` |
+| `dotnet.Tests.dll` | `test\dotnet.Tests\dotnet.Tests.csproj` |

--- a/.github/copilot/skills/incremental-test.md
+++ b/.github/copilot/skills/incremental-test.md
@@ -5,7 +5,8 @@ Use it after making source code changes to quickly build only the modified proje
 
 ## Prerequisites
 
-A full build must have been completed at least once (via `build.cmd` or `build.sh`) so that the redist SDK layout exists at `artifacts\bin\redist\Debug\dotnet\sdk\<version>\`.
+- A full build must have been completed at least once (via `build.cmd` or `build.sh`) so that the redist SDK layout exists at `artifacts\bin\redist\Debug\dotnet\sdk\<version>\`.
+- This workflow uses Windows/PowerShell commands and paths. On macOS/Linux, substitute forward slashes and use `cp` instead of `Copy-Item`.
 
 ## When to use
 
@@ -24,24 +25,24 @@ Determine which projects have been modified. Use context from:
 Build each modified project individually using the repo-local dotnet:
 
 ```
-.\.dotnet\dotnet build <path-to-project.csproj>
+.\.dotnet\dotnet build <path-to-project.csproj> -c Debug
 ```
 
 For example:
 ```
-.\.dotnet\dotnet build src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj
+.\.dotnet\dotnet build src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj -c Debug
 ```
 
 If the `dotnet` CLI project itself was modified, build it:
 ```
-.\.dotnet\dotnet build src\Cli\dotnet\dotnet.csproj
+.\.dotnet\dotnet build src\Cli\dotnet\dotnet.csproj -c Debug
 ```
 
 ### Step 3: Copy output DLLs to the redist SDK layout
 
 Discover the SDK version directory name:
 ```powershell
-$sdkVersion = (Get-ChildItem artifacts\bin\redist\Debug\dotnet\sdk -Directory).Name
+$sdkVersion = (Get-ChildItem artifacts\bin\redist\Debug\dotnet\sdk -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1).Name
 ```
 
 For each modified project, copy its output DLL (and any satellite assemblies) from the project's build output to the redist SDK directory:
@@ -63,7 +64,7 @@ Copy-Item artifacts\bin\dotnet\Debug\net10.0\dotnet.dll artifacts\bin\redist\Deb
 ```
 
 **Important notes:**
-- Only copy DLLs that are **already present** in the target directory. If a DLL doesn't exist in the redist SDK dir, it probably doesn't belong there.
+- For typical incremental edits, only copy DLLs that are **already present** in the target directory. If your change introduces a new shipped assembly or moves assemblies, you will need a full `build.cmd`/`build.sh` to update the layout correctly.
 - Some projects multi-target (e.g., `net10.0` and `net472`). Always use the `net10.0` output.
 - If localization resource DLLs were changed (in subdirectories like `cs\`, `de\`, etc.), copy those too.
 


### PR DESCRIPTION
When using agent to work on dotnet CLI, I don't want it to perform `.\build.cmd` every time it makes a change - that's very slow and I don't do that either when working on dotnet CLI, instead I just copy the DLLs manually once the redist layout is in place.