### PR TITLE
Add SWA agent and skills for Static Web Assets development

### DIFF
--- a/.claude/skills/author-swa-integration-test/SKILL.md
+++ b/.claude/skills/author-swa-integration-test/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: author-swa-integration-test
+description: 'Author end-to-end Static Web Assets integration tests that exercise MSBuild targets through build, publish, or pack. USE FOR: writing new SWA integration tests, choosing a test asset and base class, dynamically modifying projects at runtime, selecting the right manifest to assert on, verifying the full asset pipeline (primary, compressed, endpoints). DO NOT USE FOR: unit tests of individual tasks (write those directly), baseline regeneration (use swa-baseline-regeneration), troubleshooting failures (use swa-troubleshooting).'
+---
+
+# Author SWA Integration Test
+
+## Workflow
+
+Every SWA integration test follows four steps:
+
+1. **Find a test asset** — search the catalog in [references/test-asset-catalog.md](references/test-asset-catalog.md). Prefer reusing an existing asset over creating a new one. If no asset has the right project shape, pick the closest one and modify it at runtime.
+2. **Copy and modify** — `CreateAspNetSdkTestAsset()` copies the asset to an isolated temp directory. Use `WithProjectChanges()` for csproj modifications and `File.WriteAllText()` for new files (.targets, .js, .css). Each test gets its own copy — changes never affect other tests.
+3. **Execute the action** — build, publish, or pack the project.
+4. **Assert on the right manifest** — choose the manifest that answers the question you're asking (see Manifest Selection below).
+
+Read `src/StaticWebAssetsSdk/Architecture.md` for the authoritative reference on asset properties, pipeline invariants, and endpoint rules.
+
+## Choose Base Class
+
+| Scenario | Base Class |
+|----------|-----------|
+| Build or publish, no baseline comparison | `AspNetSdkTest` |
+| Build or publish with baseline JSON comparison | `AspNetSdkBaselineTest` |
+| Pack, or pack → restore → build | `IsolatedNuGetPackageFolderAspNetSdkBaselineTest` |
+
+Use `AspNetSdkTest` when you only need to check specific properties on the manifest. Use baseline classes when you need to verify the entire manifest shape matches an expected snapshot.
+
+## Dynamic Project Modification
+
+Never modify the source test asset on disk. The test infrastructure copies assets to a temp directory — modify that copy.
+
+### Modify .csproj via XDocument
+
+```csharp
+var projectDirectory = CreateAspNetSdkTestAsset("RazorAppWithP2PReference", identifier: "uniqueId")
+    .WithProjectChanges((path, document) =>
+    {
+        if (Path.GetFileName(path) == "ClassLibrary.csproj")
+        {
+            document.Root.Add(new XElement("ItemGroup",
+                new XElement("StaticWebAssetGroupDefinition",
+                    new XAttribute("Include", "MyGroup"),
+                    new XAttribute("Value", "v1"))));
+            document.Root.Add(new XElement("Import",
+                new XAttribute("Project", "Custom.targets")));
+        }
+    });
+```
+
+### Add files at runtime
+
+```csharp
+var projectDir = Path.Combine(projectDirectory.TestRoot, "ClassLibrary");
+File.WriteAllText(Path.Combine(projectDir, "wwwroot", "app.js"), "console.log('hello');");
+File.WriteAllText(Path.Combine(projectDir, "Custom.targets"), "<Project>...</Project>");
+```
+
+The `identifier` parameter prevents temp directory collisions when multiple tests reuse the same asset name.
+
+## Manifest Selection
+
+| Manifest | File | What it contains | When to use |
+|----------|------|------------------|-------------|
+| Build | `staticwebassets.build.json` | All assets — the complete pipeline output | Source of truth for asset properties, roles, source types. Shows the final result of pipeline execution including all variants. |
+| Endpoints | `staticwebassets.build.endpoints.json` | Only endpoints surviving group filtering | What the app will "see" at runtime. Use to verify endpoint routes, selectors, response headers, and that group exclusion actually removes endpoints. |
+| Publish | `staticwebassets.publish.json` | Assets scoped to publish output | Checking what ships in the published app. |
+
+The build manifest is **unfiltered** — it retains all asset variants so downstream consumers can select at restore time. To verify that a feature *excludes* content, check the **endpoints manifest**, not the build manifest.
+
+### How to load each
+
+```csharp
+// Build manifest
+var path = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(path));
+
+// Endpoints manifest
+var endpointsPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.endpoints.json");
+var endpointsManifest = JsonSerializer.Deserialize<StaticWebAssetEndpointsManifest>(
+    File.ReadAllBytes(endpointsPath),
+    StaticWebAssetsJsonSerializerContext.Default.StaticWebAssetEndpointsManifest);
+var endpoints = endpointsManifest?.Endpoints ?? [];
+```
+
+## Asserting the Full Pipeline
+
+When a feature adds or modifies assets, verify the full chain — not just one layer.
+
+**Assets in the build manifest:**
+- Primary asset: `AssetRole == "Primary"`, correct `RelativePath` and `SourceId`
+- Compressed alternatives: `AssetRole == "Alternative"`, `AssetTraitName == "Content-Encoding"`, `AssetTraitValue` is `gzip` or `br`
+
+**Endpoints in the endpoints manifest:**
+- Uncompressed endpoint: route matches `RelativePath`, `Selectors.Length == 0`
+- Content-negotiated endpoints: same route, `Selectors[0].Name == "Content-Encoding"`
+- Direct compressed routes: route ends with `.gz` or `.br`
+
+**For excluded assets:** confirm the build manifest still contains them (unfiltered), but the endpoints manifest has zero matching endpoints.
+
+**For unrelated assets:** verify they're unaffected — existing endpoints for other files still present.
+
+## Test Scope Checklist
+
+Before writing tests, decide which scenarios need coverage. Ask these questions:
+
+- [ ] **Build** — Does the feature affect build-time asset resolution or the build manifest?
+- [ ] **Publish** — Does it change what gets published, publish paths, or the publish manifest?
+- [ ] **Pack** — Does it affect nupkg layout, the generated `.targets`, or the JSON manifest inside the package?
+- [ ] **Pack → Restore → Build** — Does the feature involve cross-package asset flow (e.g., a library consumed via PackageReference)?
+- [ ] **P2P reference** — Does it affect how assets propagate between projects via ProjectReference?
+- [ ] **Incremental build** — Must the feature survive modify-then-rebuild without a clean? (modify file → rebuild → assert manifest updated)
+- [ ] **Group filtering** — Does it involve asset groups, deferred groups, or the FilterStaticWebAssetGroups task?
+
+Not every feature needs all of these. A change to pack layout only needs pack tests. A change to asset resolution during build needs build + possibly P2P tests. Use the checklist to avoid missing a scenario, not to mandate exhaustive coverage.
+
+## Integration Test Patterns
+
+### Build test
+```csharp
+var build = CreateBuildCommand(projectDirectory, "AppWithP2PReference");
+ExecuteCommand(build).Should().Pass();
+var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+```
+
+### Publish test
+```csharp
+var publish = CreatePublishCommand(projectDirectory);
+ExecuteCommand(publish).Should().Pass();
+// Check files in publish output directory
+```
+
+### Pack test
+```csharp
+var pack = CreatePackCommand(projectDirectory, "LibraryProject");
+ExecuteCommand(pack).Should().Pass();
+// Open .nupkg as ZipFile, inspect entries
+```
+
+### Pack → Restore → Build
+```csharp
+var pack = CreatePackCommand(projectDirectory, "LibraryProject");
+ExecuteCommand(pack).Should().Pass();
+var restore = CreateRestoreCommand(projectDirectory, "ConsumerProject");
+ExecuteCommand(restore).Should().Pass();
+var build = CreateBuildCommand(projectDirectory, "ConsumerProject");
+ExecuteCommand(build).Should().Pass();
+```
+
+### Incremental build
+```csharp
+ExecuteCommand(CreateBuildCommand(projectDirectory)).Should().Pass();
+File.WriteAllText(Path.Combine(projectDirectory.TestRoot, "wwwroot", "new.js"), "...");
+ExecuteCommand(CreateBuildCommand(projectDirectory)).Should().Pass();
+// Assert manifest reflects the new file
+```
+
+## Reference
+
+- **Architecture**: `src/StaticWebAssetsSdk/Architecture.md` — asset properties, pipeline invariants, endpoint rules
+- **Targets**: `src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets` — build pipeline
+- **Test assets**: `test/TestAssets/TestProjects/` — see [references/test-asset-catalog.md](references/test-asset-catalog.md)
+- **Existing tests**: `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/` — follow patterns from neighboring test classes

--- a/.claude/skills/author-swa-integration-test/references/test-asset-catalog.md
+++ b/.claude/skills/author-swa-integration-test/references/test-asset-catalog.md
@@ -1,0 +1,168 @@
+# SWA Test Asset Catalog
+
+Test assets live under `test/TestAssets/TestProjects/`. Use `CreateAspNetSdkTestAsset("AssetName")` to copy one into an isolated temp directory.
+
+## Choosing an Asset
+
+Pick the simplest asset that has the project shape you need. Prefer reusing an existing asset with runtime modifications over creating a new one.
+
+| Need | Asset |
+|------|-------|
+| Standalone web app with wwwroot files | RazorSimpleMvc |
+| Standalone app with scoped CSS / JS modules | RazorComponentApp |
+| P2P reference chain (app → RCL) | RazorAppWithP2PReference |
+| P2P + NuGet package references | RazorAppWithPackageAndP2PReference |
+| Asset groups (`StaticWebAssetGroupDefinition`) | AssetGroupsSample |
+| Framework assets (`StaticWebAssetFrameworkPattern`) | FrameworkAssetsSample |
+| Fingerprinting / endpoint manipulation | VanillaWasm |
+| Cross-targeting (multiple TFMs) | RazorComponentAppMultitarget |
+| Blazor WASM standalone | BlazorWasmMinimal |
+| Blazor WASM with RCL | BlazorWasmWithLibrary |
+| Blazor WASM hosted behind server | BlazorHosted |
+| Legacy component library pack | RazorComponentLibrary |
+
+---
+
+## Standalone Apps
+
+### RazorComponentApp
+- **SDK**: Microsoft.NET.Sdk.Web
+- **Project**: `ComponentApp.csproj`
+- **wwwroot**: No — SWA content comes from scoped CSS (`.razor.css`) and JS module generation
+- **Used for**: Scoped CSS, JS modules, endpoints, fingerprinting, core SWA build/publish
+- **Test classes**: `ScopedCssIntegrationTests`, `JsModulesIntegrationTest`, `StaticWebAssetEndpointsIntegrationTest`, `StaticWebAssetsFingerprintingTest`, `StaticWebAssetsIntegrationTest`
+
+### RazorSimpleMvc
+- **SDK**: Microsoft.NET.Sdk.Web
+- **Project**: `SimpleMvc.csproj`
+- **wwwroot**: `css/site.css`, `js/SimpleMvc.js`, `.well-known/security.txt`, `.not-copied/test.txt`
+- **Used for**: Static files in wwwroot, dot-prefixed folder handling
+- **Test classes**: `ScopedCssIntegrationTests`
+
+### RazorMvcWithComponents
+- **SDK**: Microsoft.NET.Sdk.Web
+- **Project**: `MvcWithComponents.csproj`
+- **wwwroot**: No
+- **Used for**: MVC + Razor component mixed hosting
+- **Test classes**: `ScopedCssIntegrationTests`
+
+---
+
+## Multi-Project (P2P)
+
+### RazorAppWithP2PReference
+- **SDK**: Web (app) + Razor (libraries)
+- **Projects**: `AppWithP2PReference.csproj` → `ClassLibrary.csproj` → transitive chain, plus `AnotherClassLib.csproj`, `ClassLibraryMvc21.csproj` (netstandard2.0 legacy)
+- **wwwroot**: In libraries — `AnotherClassLib/wwwroot/` (css, js), `ClassLibrary/wwwroot/` (js with versioned `.v4.js`)
+- **Used for**: P2P asset resolution (direct + transitive), compression, design-time, deferred asset groups
+- **Test classes**: `DeferredAssetGroupsIntegrationTest`, `StaticWebAssetsCompressionIntegrationTest`, `StaticWebAssetsDesignTimeTest`, `StaticWebAssetsIntegrationTest`
+- **Notes**: Best general-purpose P2P asset. Dynamic modification friendly — add items to `ClassLibrary.csproj` via `WithProjectChanges`.
+
+### RazorAppWithPackageAndP2PReference
+- **SDK**: Web (app) + Razor (libraries, some packable)
+- **Projects**: 5 projects — app, two P2P libraries, two packable libraries (`PackageVersion=1.0.2`)
+- **wwwroot**: In all libraries — css and js files
+- **Used for**: Combined P2P + NuGet package asset resolution, pack pipeline, scoped CSS, JS modules, V1 manifest compat
+- **Test classes**: `JsModulesIntegrationTest`, `LegacyStaticWebAssetsV1IntegrationTest`, `ScopedCssIntegrationTests`, `StaticWebAssetsIntegrationTest`
+- **Notes**: Most complex test asset. Requires `IsolatedNuGetPackageFolderAspNetSdkBaselineTest` base class for pack → restore → build tests.
+
+### RazorComponentAppWithReferenceMultitarget
+- **SDK**: Web (app, single TFM) + Web/Library (lib, dual TFM)
+- **Projects**: `ComponentApp.csproj` → `RazorComponentLibrary.csproj` (multi-target: server + browser)
+- **wwwroot**: No
+- **Used for**: Single-TFM app consuming multi-TFM library via P2P
+- **Notes**: Not currently referenced by SWA tests.
+
+---
+
+## Package / Pack
+
+### AssetGroupsSample
+- **SDK**: Razor (lib, packable) + Web (three consumer variants)
+- **Projects**: `IdentityUILib.csproj` (packable), `IdentityUIConsumer.csproj`, `IdentityUIConsumerV4.csproj`, `IdentityUIConsumerV5.csproj`
+- **wwwroot**: `IdentityUILib/wwwroot/` — `V4/css/site.css`, `V4/js/site.js`, `V5/css/site.css`, `V5/js/site.js`
+- **Used for**: `StaticWebAssetGroupDefinition` feature — group selection via `IncludePattern`, `RelativePathPattern`, `ContentRootSuffix`. Has `StaticWebAssets.Groups.targets` for consumer-side group selection.
+- **Test classes**: `AssetGroupsIntegrationTest`
+- **Notes**: Three consumer projects test default, V4, and V5 group selection. `StaticWebAssetBasePath=Identity`.
+
+### FrameworkAssetsSample
+- **SDK**: Razor (lib, packable) + Web (consumer)
+- **Projects**: `FrameworkAssetsLib.csproj` (packable), `FrameworkAssetsConsumer.csproj`
+- **wwwroot**: `FrameworkAssetsLib/wwwroot/` — `css/site.css`, `js/framework.js`
+- **Used for**: `StaticWebAssetFrameworkPattern` — marking JS files as framework-provided
+- **Test classes**: `FrameworkAssetsIntegrationTest`
+
+### RazorComponentLibrary
+- **SDK**: Microsoft.NET.Sdk.Razor
+- **Project**: `ComponentLibrary.csproj`
+- **TFM**: netstandard2.0 (legacy)
+- **wwwroot**: No
+- **Used for**: Legacy Blazor 3.1 component library pack behavior
+- **Test classes**: `StaticWebAssetsPackIntegrationTest`
+
+---
+
+## Blazor WASM
+
+### BlazorWasmMinimal
+- **SDK**: Microsoft.NET.Sdk.BlazorWebAssembly
+- **Project**: `blazorwasm-minimal.csproj`
+- **wwwroot**: `index.html`, `css/app.css`
+- **Used for**: Minimal WASM baseline, fingerprinting
+- **Test classes**: `StaticWebAssetsFingerprintingTest`
+
+### BlazorWasmWithLibrary
+- **SDK**: BlazorWebAssembly (app) + Razor (library)
+- **Projects**: `blazorwasm.csproj` → `RazorClassLibrary.csproj`, plus satellite assembly lib
+- **wwwroot**: In app (index.html, css, service workers) and library (styles.css, js)
+- **Used for**: WASM with RCL, service worker manifest, `LinkBase`, content link patterns, endpoints
+- **Test classes**: `StaticWebAssetEndpointsIntegrationTest`
+
+### BlazorHosted
+- **SDK**: Web (server host) + BlazorWebAssembly (client) + Razor (library)
+- **Projects**: 4 projects — server host → WASM client → RCL + satellite lib
+- **wwwroot**: Same structure as BlazorWasmWithLibrary
+- **Used for**: WASM hosted behind ASP.NET Core server, endpoint generation for hosted apps
+- **Test classes**: `StaticWebAssetEndpointsIntegrationTest`
+- **Notes**: RCL has `UseStaticWebAssetsV2=true`.
+
+---
+
+## Special-Purpose
+
+### VanillaWasm
+- **SDK**: Microsoft.NET.Sdk.WebAssembly (non-Blazor)
+- **Project**: `VanillaWasm.csproj`
+- **wwwroot**: `index.html`, `main.js`
+- **Used for**: Advanced endpoint manipulation (`FilterStaticWebAssetEndpoints`, `UpdateStaticWebAssetEndpoints`), preload properties, fingerprinting
+- **Test classes**: `StaticWebAssetsFingerprintingTest`
+- **Notes**: Uses the low-level WebAssembly SDK directly. Has custom MSBuild targets that add preload attributes to endpoints.
+
+### RazorComponentAppMultitarget
+- **SDK**: Microsoft.NET.Sdk.Web
+- **Project**: `RazorComponentAppMultitarget.csproj`
+- **TFM**: Dual — `$(AspNetTestTfm);$(AspNetTestTfm)-browser1.0`
+- **wwwroot**: No
+- **Used for**: Cross-targeting (TargetFrameworks plural), conditional WASM references
+- **Test classes**: `StaticWebAssetsCrossTargetingTests`
+
+---
+
+## Feature Coverage Map
+
+| Feature | Primary Asset |
+|---------|--------------|
+| Scoped CSS | RazorComponentApp |
+| JS modules | RazorComponentApp |
+| P2P asset resolution | RazorAppWithP2PReference |
+| P2P + package resolution | RazorAppWithPackageAndP2PReference |
+| Asset groups | AssetGroupsSample |
+| Framework assets | FrameworkAssetsSample |
+| Compression | RazorAppWithP2PReference |
+| Fingerprinting | VanillaWasm, RazorComponentApp |
+| Endpoints | BlazorHosted, RazorComponentApp |
+| Cross-targeting | RazorComponentAppMultitarget |
+| Blazor WASM | BlazorWasmMinimal |
+| Hosted WASM | BlazorHosted |
+| Pack pipeline | RazorAppWithPackageAndP2PReference |
+| Deferred groups | RazorAppWithP2PReference (via dynamic modification) |

--- a/.claude/skills/swa-baseline-regeneration/SKILL.md
+++ b/.claude/skills/swa-baseline-regeneration/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: swa-baseline-regeneration
+description: 'Regenerate Static Web Assets test baselines. USE FOR: fixing "generated manifest should match the expected baseline" errors, updating baseline JSON files after legitimate build output changes, understanding the baseline comparison system.'
+---
+
+# SWA Baseline Regeneration
+
+Baseline tests compare generated manifests against stored JSON files. When build output legitimately changes, baselines must be regenerated.
+
+## Error Signature
+
+```
+Expected collection to be empty because the generated manifest should match
+the expected baseline. If the difference in baselines is expected, please
+re-generate the baselines.
+```
+
+## Baseline File Location
+
+```
+test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsBaselines/
+```
+
+Two types per test:
+
+| Pattern | Content |
+|---------|---------|
+| `{TestName}.Build.staticwebassets.json` | Full build manifest (assets, endpoints, discovery patterns) |
+| `{TestName}.Build.files.json` | Expected files on disk |
+| `{TestName}.Publish.staticwebassets.json` | Publish manifest |
+| `{TestName}.Publish.files.json` | Publish file list |
+
+Baselines use template variables for path portability:
+- `${ProjectPath}` — test project directory
+- `${RestorePath}` — NuGet cache path
+- `${Tfm}` — target framework moniker
+
+## How Baselines Work
+
+Baselines are **embedded resources** compiled into the test DLL via `Assembly.GetManifestResourceStream()`. The comparison flow:
+
+1. Test runs a full MSBuild build/publish against a test asset project
+2. Loads the generated `staticwebassets.build.json` manifest from intermediate output
+3. Calls `AssertManifest(actual, LoadBuildManifest())` — templatizes actual paths (`${ProjectPath}`, etc.) and compares against the embedded baseline
+4. Calls `AssertBuildAssets(manifest, outputPath, intermediateOutputPath)` — compares file lists
+
+The templatization is done by `StaticWebAssetsBaselineFactory.ToTemplate()` in `AspNetSdkBaselineTest.cs`.
+
+## Regeneration Procedure
+
+```powershell
+# 1. Build the test project to embed current baselines
+.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build `
+  test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj `
+  -c Debug --no-restore
+
+# 2. Run affected tests with the regeneration flag
+$env:ASPNETCORE_TEST_BASELINES = "true"
+.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test `
+  artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll `
+  --no-build --filter "FullyQualifiedName~AffectedTestClassName"
+
+# 3. Clear the flag
+Remove-Item Env:\ASPNETCORE_TEST_BASELINES
+
+# 4. Rebuild the test project to embed the NEW baselines
+.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build `
+  test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj `
+  -c Debug --no-restore
+
+# 5. Validate — run the same tests WITHOUT the flag
+.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test `
+  artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll `
+  --no-build --filter "FullyQualifiedName~AffectedTestClassName"
+```
+
+## Critical: Why Steps 4 and 5 Are Mandatory
+
+Step 2 writes new `.json` files to disk in `StaticWebAssetsBaselines/`, but they are **embedded resources**. The test DLL must be rebuilt (step 4) before the tests can read the updated baselines. Skipping step 4 means step 5 still compares against the old embedded baselines and will fail.
+
+## Alternative: Script-Based Regeneration
+
+The repo includes `src/RazorSdk/update-test-baselines.ps1`:
+
+```powershell
+# Regenerate:
+dotnet test --no-build -c Release -l "console;verbosity=normal" <TestProject> `
+  -e ASPNETCORE_TEST_BASELINES=true --filter AspNetCore=BaselineTest
+
+# Validate:
+dotnet test --no-build -c Release -l "console;verbosity=normal" <TestProject> `
+  --filter AspNetCore=BaselineTest
+```
+
+## Test Classes That Use Baselines
+
+| Class | Test Asset |
+|-------|-----------|
+| `StaticWebAssetsAppWithPackagesIntegrationTest` | `RazorAppWithPackageAndP2PReference` |
+| `JsModulesPackagesIntegrationTest` | `RazorAppWithPackageAndP2PReference` |
+| `ScopedCssCompatibilityIntegrationTest` | `RazorAppWithPackageAndP2PReference` |
+| `ScopedCssPackageReferences` | `RazorAppWithPackageAndP2PReference` |
+| `LegacyStaticWebAssetsV1IntegrationTest` | `RazorAppWithPackageAndP2PReference` |
+| `StaticWebAssetsIntegrationTest` | Various |

--- a/.claude/skills/swa-pack-format/SKILL.md
+++ b/.claude/skills/swa-pack-format/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: swa-pack-format
+description: 'Understand and fix Static Web Assets Pack tests. USE FOR: fixing Pack test assertion failures after nupkg content changes, tracing MSBuild conditions to expected nupkg content, updating test assertions for new or changed package layouts, understanding conditional pack logic in .targets files.'
+---
+
+# SWA Pack Testing
+
+Pack tests validate that `dotnet pack` produces nupkg files with the correct content (import files, manifests, static assets). The nupkg layout is defined by MSBuild `.targets` files that use conditions to branch on TFM version, project configuration, or feature flags.
+
+## How Pack Content Is Defined
+
+Pack targets live in `src/StaticWebAssetsSdk/Targets/` (primarily `Microsoft.NET.Sdk.StaticWebAssets.Pack.targets`). They populate nupkg content using `<Content>` or `<None>` items with `Pack="true"` and `PackagePath` metadata.
+
+The targets use **MSBuild conditions** to determine which files to include. Common condition axes:
+
+- **Target Framework Version** — different TFMs may produce different nupkg layouts
+- **Feature flags** — MSBuild properties that gate new behavior behind conditions
+- **Asset presence** — whether the project has scoped CSS, JS modules, etc.
+
+When a condition branches, **each branch produces a different set of nupkg entries**. Test assertions must match the branch that the test's TFM and configuration activate.
+
+## How Pack Tests Work
+
+Pack tests are in `StaticWebAssetsPackIntegrationTest`. They:
+
+1. Create a test project via `CreateAspNetSdkTestAsset()` (optionally overriding the TFM)
+2. Run `dotnet pack` against it
+3. Assert nupkg contents using helper methods:
+   - `NuPkgContainsPatterns(nupkgPath, ...patterns)` — glob matching
+   - `NuPkgContain(nupkgPath, ...exactPaths)` — exact path matching
+
+## Fixing Pack Test Assertion Failures
+
+When a pack test fails because the nupkg contains different files than expected:
+
+### Step 1: Identify the test's TFM
+
+Check how the test creates its asset:
+```csharp
+// Uses the repo's default TFM (current)
+var testAsset = ProjectDirectory.CreateAspNetSdkTestAsset(testAssetName);
+
+// Explicitly targets an older TFM
+var testAsset = ProjectDirectory.CreateAspNetSdkTestAsset(testAssetName, identifier: "net60")
+    .WithProjectChanges(p => { /* sets TargetFramework to net6.0 */ });
+```
+
+### Step 2: Trace the condition in Pack.targets
+
+Open `Microsoft.NET.Sdk.StaticWebAssets.Pack.targets` and find the `Condition` attributes on the `<ItemGroup>` elements that populate pack content. Evaluate which branch fires for the test's TFM.
+
+### Step 3: Update assertions to match the active branch
+
+The test assertion must list exactly what the active condition branch puts into the nupkg — no more, no less. Common nupkg paths:
+- `build/{file}` — build-time imports and manifests
+- `buildMultiTargeting/{file}` — multi-targeting imports
+- `buildTransitive/{file}` — transitive dependency imports
+- `staticwebassets/**` — the actual asset files
+
+### Step 4: Preserve backward-compat tests
+
+Tests that explicitly target older TFMs exist to verify backward compatibility. Their assertions match the older format and must not be updated to the current format. Only update tests whose TFM activates the new condition branch.
+
+## Intermediate File Assertions
+
+Some tests verify names of intermediate outputs (files generated during the build but not shipped in the nupkg). These file names are also conditioned — trace the `.targets` to find the correct intermediate filename for the test's configuration.
+
+## Key Locations
+
+| What | Where |
+|------|-------|
+| Pack targets | `src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Pack.targets` |
+| Pack tests | `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Pack/StaticWebAssetsPackIntegrationTest.cs` |
+| Test helpers | `NuPkgContainsPatterns`, `NuPkgContain` in the test utilities |
+
+## General Principle
+
+When you change pack-related `.targets` logic (new conditions, new files, changed paths), find every pack test whose TFM and configuration activate the changed branch, and update its assertions. Leave tests on other branches untouched.

--- a/.claude/skills/swa-troubleshooting/SKILL.md
+++ b/.claude/skills/swa-troubleshooting/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: swa-troubleshooting
+description: 'Diagnose and fix common Static Web Assets test and build failures. USE FOR: analyzing CI failures, identifying root cause categories from error messages, fixing metadata propagation bugs, timing/ordering issues in MSBuild targets, test assertion mismatches.'
+---
+
+# SWA Troubleshooting
+
+Common failure patterns in Static Web Assets development and their fixes.
+
+## Pattern 1: Metadata Propagation Bugs
+
+**Error signature:**
+```
+Expected ... to contain "X" but actual path was "Y"
+```
+Asset paths, content roots, or other metadata don't match expectations.
+
+**Root cause:** An MSBuild task reads metadata from the wrong source. When the data model changes (e.g., a new manifest format, a new metadata field, a different resolution path), tasks that consume that metadata must be updated to read from the new source. A common case is `ContentRoot` — if a task computes it from a file path instead of reading it from item metadata, the result differs.
+
+**Diagnostic approach:**
+1. Find the task that produces the mismatched value (search for the property name in `src/StaticWebAssetsSdk/Tasks/`)
+2. Trace where the task reads that value — is it from item metadata, a computed path, or a hardcoded convention?
+3. Compare against the actual item metadata available at that point in the build (use `-bl` to inspect the binlog)
+
+**Fix:** Update the task to read from the correct metadata source.
+
+## Pattern 2: Target Ordering / DependsOnTargets
+
+**Error signature:**
+```
+Assets from package 'X' not found in build output
+```
+Missing assets, empty item groups, or incomplete resolution.
+
+**Root cause:** MSBuild targets that consume data run before the targets that produce it. The `DependsOnTargets` chain has a gap. This is especially common with targets that use `BeforeTargets` (which triggers them early, potentially before their own dependencies are ready).
+
+**Diagnostic approach:**
+1. Open the binlog (`-bl`) and find the target that should have produced the missing data
+2. Check its execution order relative to the target that consumes it
+3. Look for missing `DependsOnTargets` declarations
+
+**Fix:** Add explicit `DependsOnTargets` to ensure data-producing targets complete before data-consuming targets:
+```xml
+<Target Name="ConsumingTarget"
+        DependsOnTargets="ProducerTarget1;ProducerTarget2">
+```
+
+**Fix location:** The `.targets` file in `src/StaticWebAssetsSdk/Targets/`, or the `.csproj` of a test asset project.
+
+## Pattern 3: Baseline Drift
+
+**Error signature:**
+```
+Expected collection to be empty because the generated manifest should match
+the expected baseline.
+```
+
+**Root cause:** Legitimate build output changed but baseline JSON files were not regenerated.
+
+**Fix:** Use the `swa-baseline-regeneration` skill.
+
+## Pattern 4: Pack Content Mismatch
+
+**Error signature:**
+```
+Expected nupkg to contain "build\X" but it was not found
+```
+or unexpected files present in the nupkg.
+
+**Root cause:** Test assertions don't match what the build actually puts into the nupkg for the test's TFM and configuration. Pack targets use MSBuild conditions to determine nupkg content — if a condition branches on TFM version or feature flags, the test must assert the branch its configuration activates.
+
+**Fix:** Open `Microsoft.NET.Sdk.StaticWebAssets.Pack.targets`, find the condition that fires for the test's TFM, and update the test assertions to match what that branch produces. See the Pack Targets section in `AGENTS.md` for the full procedure.
+
+## Pattern 5: WASM/PWA Manifest Failures
+
+**Error signature:**
+```
+WasmPwaManifestTests ... Expected service-worker-assets.js to contain asset
+```
+
+**Root cause:** The Blazor WASM service worker manifest has specific expectations about asset paths and hashes that change when the underlying SWA system changes (asset discovery, fingerprinting, content hashing).
+
+**Fix location:** `test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/` — the Blazor WASM SDK test project. When SWA infrastructure changes, these tests often need matching updates.
+
+## Pattern 6: Test Assertions Expect Stale Metadata Shape
+
+**Error signature:**
+```
+Expected asset to have property 'X' with value 'Y'
+```
+
+**Root cause:** Integration tests assert specific metadata properties or values on resolved static web assets. When the data model changes (new fields, renamed fields, different default values), those assertions become stale.
+
+**Diagnostic approach:**
+1. Check what the test expects vs. what the build actually produces (inspect the test output or use `-bl`)
+2. Verify whether the change in metadata is intentional (part of the current feature work)
+3. Update assertions to match the new metadata shape
+
+**Fix location:** The integration test class making the assertion (often in `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/`).
+
+## Triage Strategy for CI Failures
+
+When facing multiple CI failures, categorize before fixing:
+
+1. **Count unique test classes** — multiple failures in one class likely share a root cause
+2. **Group by error signature** — match against the patterns above
+3. **Check TFM** — does the failing test target the current TFM or an older one? Older-TFM tests exercise backward-compat paths
+4. **Baseline vs. assertion** — baseline failures need regeneration; assertion failures need code or test changes
+5. **Infrastructure vs. code** — timeouts, network errors, and Helix agent issues are not code problems
+
+## AzDO / Helix Navigation
+
+Test results for CI runs live in Azure DevOps pipelines:
+
+1. Pipeline run → Tests tab → filter by "Failed"
+2. Group by "Test class" to identify root cause clusters
+3. For Helix-distributed tests, the work item log contains the full test output

--- a/.github/agents/static-web-assets-agent.agent.md
+++ b/.github/agents/static-web-assets-agent.agent.md
@@ -1,0 +1,94 @@
+---
+name: Static Web Assets Agent
+description: 'Specialist agent for developing, testing, and validating changes to the Static Web Assets SDK in dotnet/sdk. USE FOR: implementing SWA task/target changes, fixing SWA test failures, regenerating baselines, patching the redist SDK, running filtered SWA tests, diagnosing pack/publish/build pipeline issues. DO NOT USE FOR: non-SWA SDK work, Blazor runtime changes, general .NET project questions.'
+tools: [execute, read, edit, search, agent, todo]
+model: 'Claude Opus 4.6'
+---
+
+## Persona
+
+You are a senior engineer specializing in the Static Web Assets (SWA) SDK within the dotnet/sdk repository.
+
+## Commands You Can Use
+
+- **Full repo build:** `.\build.cmd` (~4 min, produces the redist SDK at `artifacts/bin/redist/Debug/dotnet/`)
+- **Build tasks only:** `cd src/StaticWebAssetsSdk/Tasks; dotnet build` (~15 s, inner loop)
+- **Build test project:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj -c Debug --no-restore`
+- **Run filtered tests:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll --no-build --filter "FullyQualifiedName~ClassName"`
+- **Run all unit tests:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll --no-build --filter "FullyQualifiedName!~IntegrationTest"`
+- **Test with a real project:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build <project> -bl`
+
+## Project Knowledge
+
+Read `src/StaticWebAssetsSdk/AGENTS.md` at the start of every session — it has the data model, target reference, task inventory, coding conventions, and pack logic. That file is the source of truth for how the SWA SDK works.
+
+- **Source:** `src/StaticWebAssetsSdk/` (Tasks in C#, Targets in XML, Sdk props/targets)
+- **Blazor WASM SDK:** `src/BlazorWasmSdk/` (WASM-specific tasks and targets, shares types from StaticWebAssetsSdk)
+- **Tests:** `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/` (unit tests in `StaticWebAssets/`, baselines in `StaticWebAssetsBaselines/`, pack tests in `Pack/`, integration tests as `*.cs` extending `AspNetSdkBaselineTest`)
+- **Redist SDK:** `artifacts/bin/redist/Debug/dotnet/` (repo-built SDK used for testing)
+- **Skills:**
+  - `swa-baseline-regeneration` — procedure for regenerating embedded baseline JSON files
+  - `swa-troubleshooting` — failure pattern catalog and CI triage strategy
+
+## Boundaries
+
+- ✅ **Always do:** Read AGENTS.md at session start, patch instead of full-building when only SWA files changed, use `--filter` during development, build the test project before running tests after code changes, validate through the full process before declaring done.
+- ⚠️ **Ask first:** Before running `.\build.cmd`, before editing files outside `src/StaticWebAssetsSdk/` and `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/`, before running the full unfiltered test suite, before modifying shared test asset projects.
+- 🚫 **Never do:** Modify the system-installed dotnet SDK, push commits, run `git clean -xdff` without reviewing unstaged files or `git reset --hard`, skip steps in the process, run integration tests during the inner development loop.
+
+# OUTCOME
+
+A change is complete when the feature has been implemented, necessary tests have been added, and all Static Web Assets tests and Blazor WebAssembly SDK tests pass.
+
+## Process
+
+### 1. Setup
+
+Check whether the redist SDK exists at `artifacts/bin/redist/Debug/dotnet/`. If it doesn't, run `.\build.cmd` — nothing else works without it.
+
+A full `.\build.cmd` is also needed after a rebase, after `git clean`, after version/toolset changes in `eng/` or `global.json`, or when changes span outside `src/StaticWebAssetsSdk/`.
+
+### 2. Inner Loop — Edit → Patch → Verify
+
+This is the fast feedback cycle. Do not write or run tests during this phase.
+
+1. **Edit** — Change task code in `Tasks/`, targets in `Targets/`, or SDK files in `Sdk/`.
+2. **Build** — If you changed `.cs` files, rebuild the tasks project. If you only changed `.targets`/`.props`, skip to step 3.
+3. **Patch the redist SDK** — Copy changed artifacts into the redist SDK to avoid a full rebuild. Use `git diff --name-only` to decide what to copy:
+   - `.cs` changes → copy the built DLL from the tasks build output into the redist SDK's `tasks/` folder
+   - `.targets`/`.props` changes → copy the source file directly into the redist SDK's `targets/` folder
+   - The redist SWA SDK lives at: `artifacts/bin/redist/Debug/dotnet/sdk/*/Sdks/Microsoft.NET.Sdk.StaticWebAssets/`
+4. **Verify** — Test with a real project using the repo-built dotnet. Use `-bl` to produce a binary log for inspection when needed. Check output assets, manifests, and endpoints.
+5. **Repeat** until the behavior is correct.
+
+### 3. Validate — Unit Tests
+
+Once the change works manually, run tests. The goal is fast regression detection while avoiding slow integration and baseline tests.
+
+1. **Build the test project** — required after any code change so the test DLL picks up the new code.
+2. **Run affected unit test classes** — unit tests live in `StaticWebAssets/` and do not extend SDK base classes. Filter to the specific class you changed or added.
+3. **Run all unit tests** — use the `!~IntegrationTest` filter to run every unit test without triggering integration or baseline tests. This catches regressions outside the class you focused on.
+
+Fix any failures before proceeding.
+
+### 4. Validate — Integration Tests
+
+SWA changes touch files that ship inside the .NET SDK. Integration tests exercise the full MSBuild build/publish pipeline against real test projects to verify everything works end-to-end.
+
+Run only the specific integration test class that covers your scenario:
+
+| Class | Covers |
+|-------|--------|
+| `StaticWebAssetsPackIntegrationTest` | Pack/nupkg content |
+| `StaticWebAssetsAppWithPackagesIntegrationTest` | Consumer-side build/publish with packages |
+| `FrameworkAssetsIntegrationTest` | Framework asset resolution |
+| `JsModulesPackagesIntegrationTest` | JS module manifests with package refs |
+| `ScopedCssCompatibilityIntegrationTest` | Scoped CSS backward compat |
+| `ScopedCssPackageReferences` | Scoped CSS with package refs |
+| `LegacyStaticWebAssetsV1IntegrationTest` | V1 class library compat |
+
+If a baseline test fails, invoke the `swa-baseline-regeneration` skill. For other failure patterns, invoke the `swa-troubleshooting` skill. For pack assertion failures, consult the Pack Targets section in `AGENTS.md`.
+
+### 5. Validate — Full Suite
+
+Run both the Static Web Assets test assembly (`Microsoft.NET.Sdk.StaticWebAssets.Tests`) and the Blazor WebAssembly SDK test assembly (`Microsoft.NET.Sdk.BlazorWebAssembly.Tests`) unfiltered. Only after steps 3-4 pass. Leave this step to CI unless you want extra confidence locally.

--- a/src/StaticWebAssetsSdk/AGENTS.md
+++ b/src/StaticWebAssetsSdk/AGENTS.md
@@ -20,358 +20,88 @@ test/Microsoft.NET.Sdk.StaticWebAssets.Tests/
 └── *.cs                            # Integration tests
 ```
 
-## Static Web Assets Build and Publish Flow
+## Architecture
 
-### Build Flow
-```
-StaticWebAssetsPrepareForRun
-├── ResolveBuildStaticWebAssets
-│   ├── ResolveCoreStaticWebAssets
-│   │   ├── UpdateExistingPackageStaticWebAssets
-│   │   ├── ResolveProjectStaticWebAssets
-│   │   ├── ResolveEmbeddedProjectsStaticWebAssets
-│   │   └── ResolveReferencedProjectsStaticWebAssets
-│   │       └── ResolveReferencedProjectsStaticWebAssetsConfiguration
-│   ├── ResolveStaticWebAssetsInputs
-│   │   ├── ResolveCoreStaticWebAssets (already run)
-│   │   ├── GenerateComputedBuildStaticWebAssets
-│   │   │   └── BundleScopedCssFiles (if ScopedCss enabled)
-│   │   ├── ResolveScopedCssAssets (if ScopedCss enabled)
-│   │   └── ResolveJSModuleManifestBuildStaticWebAssets (if JSModules enabled)
-│   └── ResolveBuildRelatedStaticWebAssets
-│       └── ResolveBuildCompressedStaticWebAssets (if Compression enabled)
-├── GenerateStaticWebAssetsManifest
-└── CopyStaticWebAssetsToOutputDirectory
-    └── LoadStaticWebAssetsBuildManifest
-```
+For the full technical architecture — data model (`StaticWebAsset`, `StaticWebAssetEndpoint`, `StaticWebAssetGroup`), asset lifecycle, cross-project boundaries, manifests, target execution order, and task/target reference tables — see [Architecture.md](Architecture.md).
 
-### Publish Flow
-```
-StaticWebAssetsPrepareForPublish
-├── ResolveStaticWebAssetsConfiguration
-├── GenerateStaticWebAssetsPublishManifest
-│   └── ResolveAllPublishStaticWebAssets
-│       ├── ResolveCorePublishStaticWebAssets
-│       │   ├── LoadStaticWebAssetsBuildManifest
-│       │   ├── ComputeReferencedProjectsEmbeddedPublishAssets
-│       │   └── ComputeReferencedProjectsPublishAssets
-│       ├── ResolvePublishStaticWebAssets
-│       │   ├── ResolveCorePublishStaticWebAssets (already run)
-│       │   └── GenerateComputedPublishStaticWebAssets
-│       └── ResolvePublishRelatedStaticWebAssets
-│           └── ResolvePublishCompressedStaticWebAssets
-└── CopyStaticWebAssetsToPublishDirectory
-    ├── StaticWebAssetsPrepareForPublish (already run)
-    └── LoadStaticWebAssetsPublishManifest
-```
+## Pipeline Invariants
 
-## Static Web Assets Targets
+These invariants must hold at all times. Violating any of them is a bug.
 
-### Main Targets (Microsoft.NET.Sdk.StaticWebAssets.targets)
+**Collection-level**
 
-| Target | Purpose |
-|--------|---------|
-| `StaticWebAssetsPrepareForRun` | Entry point - orchestrates build-time asset processing |
-| `ResolveBuildStaticWebAssets` | Master orchestration for 3-stage asset resolution |
-| `ResolveCoreStaticWebAssets` | Stage 1: Discover existing assets from disk |
-| `ResolveStaticWebAssetsInputs` | Stage 2: Generate computed assets |
-| `ResolveBuildRelatedStaticWebAssets` | Stage 3: Create derived assets (compression) |
-| `ResolveProjectStaticWebAssets` | Discover current project's wwwroot files |
-| `UpdateExistingPackageStaticWebAssets` | Update NuGet package assets |
-| `GenerateStaticWebAssetsManifest` | Generate all manifest files |
-| `GenerateComputedBuildStaticWebAssets` | Generate computed assets (hook) |
-| `CopyStaticWebAssetsToOutputDirectory` | Copy assets to output |
-| `ResolveStaticWebAssetsConfiguration` | Set up paths and properties |
-| `AddStaticWebAssetsManifest` | Add manifest to output |
-| `AddStaticWebAssetEndpointsBuildManifest` | Add endpoints manifest to output |
-| `LoadStaticWebAssetsBuildManifest` | Load manifest for publish |
-| `WriteStaticWebAssetsUpToDateCheck` | IDE up-to-date check support |
+- **Asset uniqueness**: Every `StaticWebAsset` is unique by `Identity`. No two assets share the same `Identity` within a given build or publish resolution.
+- **Target path uniqueness**: At a given target path, at most one asset per `AssetKind` slot (`Build`, `Publish`, `All`). Multiple assets at the same target path are only allowed if they have distinct `AssetGroups`.
+- **Referential integrity**: Every non-primary asset (`Related` or `Alternative`) must point to a valid asset definition via `RelatedAsset`. If an asset is removed, all assets that reference it must also be removed.
+- **Endpoint validity**: Every `StaticWebAssetEndpoint` must point to an existing `StaticWebAsset` via `AssetFile`. There must be no endpoints referencing non-existent assets.
+- **Endpoint uniqueness**: Endpoints are unique by the `(Route, AssetFile)` pair. No two endpoints share the same route and asset file combination.
 
-### Reference Targets (Microsoft.NET.Sdk.StaticWebAssets.References.targets)
+**Required properties (every asset must have)**
 
-| Target | Purpose |
-|--------|---------|
-| `ResolveReferencedProjectsStaticWebAssetsConfiguration` | Get configuration from project references |
-| `GetStaticWebAssetsProjectConfiguration` | Return this project's SWA config |
-| `ResolveReferencedProjectsStaticWebAssets` | Get assets from project references |
-| `GetCurrentProjectBuildStaticWebAssetItems` | Expose assets to referencing projects |
-| `GetCurrentProjectPublishStaticWebAssetItems` | Expose publish assets to references |
+- `Identity`, `SourceId`, `ContentRoot`, `BasePath`, `RelativePath`, `OriginalItemSpec` — non-empty strings.
+- `Fingerprint` (base-36 SHA-256), `Integrity` (base-64 SHA-256) — non-empty strings.
+- `FileLength` ≥ 0.
+- `LastWriteTime` ≠ `DateTimeOffset.MinValue`.
 
-### Publish Targets (Microsoft.NET.Sdk.StaticWebAssets.Publish.targets)
+**Valid values**
 
-| Target | Purpose |
-|--------|---------|
-| `StaticWebAssetsPrepareForPublish` | Entry point for publish |
-| `GenerateComputedPublishStaticWebAssets` | Generate publish-time computed assets |
-| `GenerateStaticWebAssetsPublishManifest` | Generate publish manifest |
-| `ResolveCorePublishStaticWebAssets` | Resolve core publish assets |
-| `ResolvePublishStaticWebAssets` | Resolve all publish assets |
-| `ResolveAllPublishStaticWebAssets` | Master orchestration for publish |
-| `ComputeReferencedProjectsPublishAssets` | Get publish assets from references |
-| `ComputeReferencedStaticWebAssetsPublishManifest` | Compute referenced manifests |
-| `CopyStaticWebAssetsToPublishDirectory` | Copy assets to publish output |
-| `CopyStaticWebAssetsEndpointsManifest` | Copy endpoints manifest |
-| `LoadStaticWebAssetsPublishManifest` | Load publish manifest |
+- `SourceType` ∈ {`Discovered`, `Computed`, `Project`, `Package`, `Framework`}.
+- `AssetKind` ∈ {`Build`, `Publish`, `All`}.
+- `AssetMode` ∈ {`All`, `CurrentProject`, `Reference`}.
+- `AssetRole` ∈ {`Primary`, `Related`, `Alternative`}.
 
-### Compression Targets (Microsoft.NET.Sdk.StaticWebAssets.Compression.targets)
+**Conditional requirements**
 
-| Target | Purpose |
-|--------|---------|
-| `ResolveBuildCompressedStaticWebAssets` | Create compressed variants (build) |
-| `GenerateBuildCompressedStaticWebAssets` | Generate compressed files (build) |
-| `ResolveBuildCompressedStaticWebAssetsConfiguration` | Configure build compression |
-| `ResolvePublishCompressedStaticWebAssets` | Create compressed variants (publish) |
-| `GeneratePublishCompressedStaticWebAssets` | Generate compressed files (publish) |
-| `ResolvePublishCompressedStaticWebAssetsConfiguration` | Configure publish compression |
+- `RelatedAsset` is required when `AssetRole` is `Related` or `Alternative`. Must reference a valid asset `Identity`.
+- `AssetTraitName` and `AssetTraitValue` are both required when `AssetRole` is `Alternative`.
 
-### Scoped CSS Targets (Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets)
+**Path normalization**
 
-| Target | Purpose |
-|--------|---------|
-| `ResolveScopedCssAssets` | Main scoped CSS processing |
-| `GenerateScopedCssFiles` | Generate scoped CSS |
-| `ResolveScopedCssInputs` | Discover scoped CSS inputs |
-| `ComputeCssScope` | Compute CSS scope identifiers |
-| `ResolveScopedCssOutputs` | Set output paths |
-| `BundleScopedCssFiles` | Create CSS bundle |
-| `ResolveBundledCssAssets` | Resolve bundled CSS |
-| `UpdateLegacyPackageScopedCssBundles` | Back-compat for legacy bundles |
+- `ContentRoot` is always an absolute path ending with a directory separator.
+- `BasePath` and `RelativePath` use forward slashes only, no leading or trailing slashes.
 
-### JS Modules Targets (Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets)
+**Defaults (applied when not explicitly set)**
 
-| Target | Purpose |
-|--------|---------|
-| `ResolveJsInitializerModuleStaticWebAssets` | Resolve JS initializer modules |
-| `ResolveJSModuleManifestBuildConfiguration` | Configure build JS manifest |
-| `GenerateJSModuleManifestBuildStaticWebAssets` | Generate build JS manifest |
-| `ResolveJSModuleManifestBuildStaticWebAssets` | Resolve build JS manifest |
-| `ResolveJSModuleManifestPublishConfiguration` | Configure publish JS manifest |
-| `GenerateJSModuleManifestPublishStaticWebAssets` | Generate publish JS manifest |
-| `ResolveJSModuleManifestPublishStaticWebAssets` | Resolve publish JS manifest |
-| `ResolveJSModuleStaticWebAssets` | Resolve component JS modules |
-
-### Embedded Assets Targets (Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets)
-
-| Target | Purpose |
-|--------|---------|
-| `GetStaticWebAssetsCrosstargetingProjectConfiguration` | Get embedded project config |
-| `ResolveStaticWebAssetsCrossTargetingConfiguration` | Resolve cross-targeting config |
-| `ResolveStaticWebAssetsEmbeddingRules` | Resolve embedding rules |
-| `ResolveEmbeddedProjectsStaticWebAssets` | Resolve embedded project assets |
-| `ResolveEmbeddedConfigurationsPackageAssets` | Resolve embedded package assets |
-| `GetEmbeddedReferencedPackageAssets` | Get embedded package assets |
-| `ComputeReferencedProjectsEmbeddedPublishAssets` | Compute embedded publish assets |
-| `GetCurrentProjectEmbeddedBuildStaticWebAssetItems` | Expose embedded build assets |
-| `GetCurrentProjectEmbeddedPublishStaticWebAssetItems` | Expose embedded publish assets |
-
-## Static Web Assets Tasks
-
-| Task | File | Purpose |
-|------|------|---------|
-| `DefineStaticWebAssets` | DefineStaticWebAssets.cs | Create asset definitions from candidates |
-| `DefineStaticWebAssetEndpoints` | DefineStaticWebAssetEndpoints.cs | Create endpoint definitions |
-| `UpdateExternallyDefinedStaticWebAssets` | UpdateExternallyDefinedStaticWebAssets.cs | Update imported assets |
-| `UpdateStaticWebAssetEndpoints` | UpdateStaticWebAssetEndpoints.cs | Update endpoint properties |
-| `UpdatePackageStaticWebAssets` | UpdatePackageStaticWebAssets.cs | Update package assets |
-| `FilterStaticWebAssetEndpoints` | FilterStaticWebAssetEndpoints.cs | Filter endpoints by criteria |
-| `ComputeReferenceStaticWebAssetItems` | ComputeReferenceStaticWebAssetItems.cs | Compute reference assets |
-| `ComputeEndpointsForReferenceStaticWebAssets` | ComputeEndpointsForReferenceStaticWebAssets.cs | Transform endpoint routes |
-| `ComputeStaticWebAssetsForCurrentProject` | ComputeStaticWebAssetsForCurrentProject.cs | Filter to current project |
-| `ComputeStaticWebAssetsTargetPaths` | ComputeStaticWebAssetsTargetPaths.cs | Compute target paths |
-| `CollectStaticWebAssetsToCopy` | CollectStaticWebAssetsToCopy.cs | Collect assets for copying |
-| `MergeStaticWebAssets` | MergeStaticWebAssets.cs | Merge assets from multiple TFMs |
-| `MergeConfigurationProperties` | MergeConfigurationProperties.cs | Merge project configurations |
-| `GenerateStaticWebAssetsManifest` | GenerateStaticWebAssetsManifest.cs | Generate main manifest |
-| `GenerateStaticWebAssetEndpointsManifest` | GenerateStaticWebAssetEndpointsManifest.cs | Generate endpoints manifest |
-| `GenerateStaticWebAssetsDevelopmentManifest` | GenerateStaticWebAssetsDevelopmentManifest.cs | Generate development manifest |
-| `ReadStaticWebAssetsManifestFile` | ReadStaticWebAssetsManifestFile.cs | Read manifest file |
-| `ResolveStaticWebAssetEndpointRoutes` | ResolveStaticWebAssetEndpointRoutes.cs | Resolve endpoint routes |
-| `ResolveFingerprintedStaticWebAssetEndpointsForAssets` | ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs | Resolve fingerprinted endpoints |
-| `ResolveStaticWebAssetsEmbeddedProjectConfiguration` | ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs | Resolve embedded config |
-| `ApplyCompressionNegotiation` | ApplyCompressionNegotiation.cs | Apply content negotiation |
-| `BrotliCompress` | Compression/BrotliCompress.cs | Brotli compression |
-| `GZipCompress` | Compression/GZipCompress.cs | Gzip compression |
-| `DiscoverPrecompressedAssets` | Compression/DiscoverPrecompressedAssets.cs | Find pre-compressed assets |
-| `ResolveCompressedAssets` | Compression/ResolveCompressedAssets.cs | Resolve compression candidates |
-| `DiscoverDefaultScopedCssItems` | DiscoverDefaultScopedCssItems.cs | Discover scoped CSS |
-| `ResolveAllScopedCssAssets` | ScopedCss/ResolveAllScopedCssAssets.cs | Resolve all scoped CSS |
-| `ApplyCssScopes` | ScopedCss/ApplyCssScopes.cs | Apply CSS scopes |
-| `ComputeCssScope` | ScopedCss/ComputeCssScope.cs | Compute scope identifiers |
-| `RewriteCss` | ScopedCss/RewriteCss.cs | Rewrite CSS with scopes |
-| `ConcatenateCssFiles` | ScopedCss/ConcatenateCssFiles.cs | Bundle CSS files |
-| `GenerateJsModuleManifest` | JSModules/GenerateJsModuleManifest.cs | Generate JS module manifest |
-| `ApplyJsModules` | JSModules/ApplyJsModules.cs | Apply JS modules to components |
-
-## Core Data Model
-
-The Static Web Assets system is built around two primary data structures: `StaticWebAsset` and `StaticWebAssetEndpoint`. Understanding their properties and relationships is essential for working with the codebase.
-
-### StaticWebAsset
-
-Defined in `Tasks/Data/StaticWebAsset.cs`. Represents a single static file (CSS, JS, image, etc.) that is tracked through the build and publish pipeline. Each asset carries metadata describing where it came from, how it should be served, and how it relates to other assets.
-
-#### Identity and Source Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Identity` | `string` | Full path to the file on disk. Used as the unique identifier for the asset. Defaults to the `FullPath` metadata of the original MSBuild item. |
-| `SourceId` | `string` | Identifier of the project or package that owns this asset (e.g., project name or NuGet package ID). Used to group assets by origin and detect conflicts between sources. |
-| `SourceType` | `string` | How the asset was discovered. One of: `Discovered` (found on disk in wwwroot), `Computed` (generated during build, e.g., scoped CSS bundles), `Project` (from a referenced project), `Package` (from a NuGet package). |
-| `ContentRoot` | `string` | Absolute path to the root directory containing the asset (always ends with a directory separator). For wwwroot assets this is the wwwroot folder; for package assets it is the package's staticwebassets folder. |
-| `OriginalItemSpec` | `string` | The original MSBuild item spec before normalization. Used as a fallback when resolving the file on disk. |
-
-#### Path and Routing Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `BasePath` | `string` | URL prefix under which the asset is served (e.g., `_content/MyLib`). For `Discovered` and `Computed` assets this is ignored when computing the target path since they are relative to the project root. Normalized to forward slashes with no leading/trailing slashes. |
-| `RelativePath` | `string` | Path relative to the content root. May contain **token expressions** like `#[.{fingerprint}]?` for fingerprinted file names. Normalized to forward slashes. |
-
-**Path Token Syntax:** The `RelativePath` can embed token expressions using the format `#[.{tokenName}]`. The `#` prefix ensures tokens are never confused with valid file paths. `[]` delimit the expression, `{}` delimit variables, `?` marks the expression as optional (non-fingerprinted on disk), and `!` marks it as optional but preferred (fingerprinted on disk). For example, `app#[.{fingerprint}]!.js` means the file on disk is named `app.<hash>.js` but can also be addressed as `app.js`. Currently the only supported token is `fingerprint` (a base-36 SHA-256 hash).
-
-#### Asset Classification Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `AssetKind` | `string` | When the asset is relevant. `Build` = build only, `Publish` = publish only, `All` = both build and publish. Defaults to `All` unless `CopyToPublishDirectory` is `Never`, in which case defaults to `Build`. |
-| `AssetMode` | `string` | Visibility scope. `All` = visible to current project and references, `CurrentProject` = only the owning project, `Reference` = only referencing projects. |
-| `AssetRole` | `string` | Relationship to other assets. `Primary` = standalone asset, `Related` = associated with a primary asset (e.g., `.map` file), `Alternative` = variant of a primary asset (e.g., compressed version). |
-| `RelatedAsset` | `string` | Full path to the primary asset this asset is related to. Required when `AssetRole` is `Related` or `Alternative`. |
-| `AssetTraitName` | `string` | Name of the trait that distinguishes an alternative asset (e.g., `Content-Encoding`). Required for `Alternative` assets. |
-| `AssetTraitValue` | `string` | Value of the distinguishing trait (e.g., `gzip`, `br`). Required for `Alternative` assets. |
-
-#### Merge Behavior Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `AssetMergeBehavior` | `string` | Controls conflict resolution when merging assets from multiple TFMs or embedded projects. Values: `None` (default), `PreferTarget`, `PreferSource`, `Exclude`. |
-| `AssetMergeSource` | `string` | Identifies the source of the asset during merge operations, used alongside `AssetMergeBehavior`. |
-
-#### Copy Behavior Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `CopyToOutputDirectory` | `string` | Whether to copy to the build output directory. Values: `Never` (default), `PreserveNewest`, `Always`. |
-| `CopyToPublishDirectory` | `string` | Whether to copy to the publish output directory. Values: `Never`, `PreserveNewest` (default), `Always`. |
-
-#### Integrity and File Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Fingerprint` | `string` | Base-36 encoded SHA-256 hash of the file. Used for cache-busting in URL paths via token expressions. |
-| `Integrity` | `string` | Base-64 encoded SHA-256 hash of the file. Used for Sub-Resource Integrity (SRI) in HTML tags and HTTP headers. |
-| `FileLength` | `long` | Size of the file in bytes. Used for `Content-Length` headers and up-to-date checks. |
-| `LastWriteTime` | `DateTimeOffset` | Last modification time of the file. Used for `Last-Modified` headers and incremental build checks. |
-
-### StaticWebAssetEndpoint
-
-Defined in `Tasks/Data/StaticWebAssetEndpoint.cs`. Represents a URL route through which a static web asset can be served at runtime. A single asset can have multiple endpoints (e.g., a fingerprinted URL and a non-fingerprinted URL). Endpoints carry the response headers, content-negotiation selectors, and metadata properties needed by the runtime to serve the asset correctly.
-
-#### Core Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Route` | `string` | URL path as it should be registered in the routing table (used as the MSBuild item identity). For example, `_content/MyLib/app.js` or `_content/MyLib/app.abc123.js` for a fingerprinted variant. |
-| `AssetFile` | `string` | Path to the physical file on disk, matching the `StaticWebAsset.Identity`. Links the endpoint back to its underlying asset. |
-
-#### Selectors (Content Negotiation)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Selectors` | `StaticWebAssetEndpointSelector[]` | JSON-serialized array of request conditions that must match for this endpoint to be selected. Used for content negotiation (e.g., selecting a gzip-compressed variant when the client sends `Accept-Encoding: gzip`). |
-
-Each `StaticWebAssetEndpointSelector` has:
-- **`Name`** – The request header or attribute to match (e.g., `Content-Encoding`).
-- **`Value`** – The expected value (e.g., `gzip`).
-- **`Quality`** – Preference weight used when multiple selectors match.
-
-#### Response Headers
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `ResponseHeaders` | `StaticWebAssetEndpointResponseHeader[]` | JSON-serialized array of HTTP response headers to include when serving this endpoint. Typical headers include `Content-Type`, `Cache-Control`, `ETag`, and `Content-Length`. |
-
-Each `StaticWebAssetEndpointResponseHeader` has:
-- **`Name`** – Header name (e.g., `Content-Type`).
-- **`Value`** – Header value (e.g., `text/css`).
-
-#### Endpoint Properties (Metadata)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `EndpointProperties` | `StaticWebAssetEndpointProperty[]` | JSON-serialized array of key-value metadata pairs associated with the endpoint. Used to carry build-time information (e.g., `fingerprint`, `integrity`, `label`) that the runtime or other tasks can consume. |
-
-Each `StaticWebAssetEndpointProperty` has:
-- **`Name`** – Property name (e.g., `integrity`, `fingerprint`, `label`).
-- **`Value`** – Property value.
-
-### Relationship Between Assets and Endpoints
-
-```
-StaticWebAsset (file on disk)
-├── Identity: D:\project\wwwroot\css\app.css
-├── RelativePath: css/app#[.{fingerprint}]!.css
-├── Fingerprint: abc123
-│
-├── Endpoint 1 (fingerprinted, preferred)
-│   ├── Route: css/app.abc123.css
-│   ├── AssetFile: D:\project\wwwroot\css\app.css
-│   ├── ResponseHeaders: [Content-Type=text/css, Cache-Control=max-age=31536000,immutable]
-│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-..., label=css/app.css]
-│
-├── Endpoint 2 (non-fingerprinted)
-│   ├── Route: css/app.css
-│   ├── AssetFile: D:\project\wwwroot\css\app.css
-│   ├── ResponseHeaders: [Content-Type=text/css, ETag="abc123"]
-│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-...]
-│
-└── Alternative Asset (gzip compressed)
-    ├── Identity: D:\project\obj\compressed\css\app.css.gz
-    ├── AssetRole: Alternative
-    ├── RelatedAsset: D:\project\wwwroot\css\app.css
-    ├── AssetTraitName: Content-Encoding
-    ├── AssetTraitValue: gzip
-    │
-    └── Endpoint 3 (compressed variant of Endpoint 1)
-        ├── Route: css/app.abc123.css
-        ├── AssetFile: D:\project\obj\compressed\css\app.css.gz
-        ├── Selectors: [Content-Encoding=gzip]
-        └── ResponseHeaders: [Content-Type=text/css, Content-Encoding=gzip, Vary=Content-Encoding]
-```
+- `CopyToOutputDirectory` → `Never`; `CopyToPublishDirectory` → `PreserveNewest`.
+- `AssetKind` → `All` (or `Build` when `CopyToPublishDirectory` is `Never`).
+- `AssetMode` → `All`; `AssetRole` → `Primary`.
 
 ## Development Workflow
 
-For detailed instructions on building, patching, and validating changes, see the [validate-static-web-asset-change skill](../../.claude/skills/validate-static-web-asset-change/SKILL.md).
-
-Do an initial build of the entire repo at the beginning following the instructions on the README.md.
-
-### Inner Loop: Make → Patch → Validate
-
-The primary development workflow is an iterative loop focused on fast feedback with a real project:
-
-1. **Make changes** — Edit task code in `src/StaticWebAssetsSdk/Tasks/` (or targets/props files)
-2. **Build the tasks** — `dotnet build` in `src/StaticWebAssetsSdk/Tasks`
-3. **Patch the SDK** — Copy the built DLL (and any changed `.targets`/`.props` files) into the redist SDK at `artifacts/bin/redist/{Configuration}/dotnet/sdk/{version}/Sdks/Microsoft.NET.Sdk.StaticWebAssets/`
-4. **Test with a real project** — Use the redist `dotnet` to `dotnet build` / `dotnet publish` a sample project and verify the behavior
-5. **Inspect results** — Check output assets, manifests (`.staticwebassets.runtime.json`, `.staticwebassets.endpoints.json`), and endpoints. Use binary logs (`-bl`) if needed.
-6. **Repeat** — Go back to step 1 until the behavior is correct
-
-**Do not write or run integration tests during the inner loop.** Scoped unit tests (run with `--filter "FullyQualifiedName~YourTestClassName"`) are fine for quick validation of task logic.
-
-### After Validation: Unit Tests
-
-Once the change is validated against a real project, write **unit tests** for the affected tasks. Unit tests live in `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/` and are plain test classes — they do **not** extend `AspNetSdkBaselineTest` or any SDK test base class. They test individual task logic in isolation by constructing task inputs and asserting outputs directly.
-
-```powershell
-dotnet test test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj --filter "FullyQualifiedName~YourTestClassName"
-```
-
-Never run all the tests — that takes a very long time. Always use `--filter` to run only the relevant test class.
-
-### Last: Integration Tests
-
-Integration tests extend `AspNetSdkBaselineTest` (or `IsolatedNuGetPackageFolderAspNetSdkBaselineTest`) and run full MSBuild builds against test project assets. They are slow and should **not** be part of the inner development loop. Write or update integration tests only after the change is validated and unit-tested.
-
-When running integration tests locally, only run the specific tests you wrote or modified — at most the tests from the same class using `--filter "FullyQualifiedName~YourIntegrationTestClassName"`. Leave running the full integration test suite to CI.
+For the full development workflow (inner loop, patching, testing, validation), use the **Static Web Assets** agent defined in `.github/agents/static-web-assets-agent.agent.md`. It has the step-by-step process, commands, and test strategy.
 
 **Never modify the system dotnet SDK.** Always use the repo-local redist SDK at `artifacts/bin/redist/{Configuration}/dotnet/` or a freshly downloaded copy for Blazor WASM scenarios.
+
+## Security Considerations When Working on Static Web Assets Features
+
+- Installed NuGet packages can inject and execute arbitrary code as part of the build via MSBuild tasks and targets.
+
+## Performance Considerations When Working on Static Web Assets Features
+
+- `StaticWebAsset` and `StaticWebAssetEndpoint` collections can be very large in real-world projects — a single application can produce thousands of assets, and each asset can have multiple endpoints (fingerprinted, non-fingerprinted, compressed variants). When compressed assets are generated, the endpoint count multiplies further.
+- **Avoid O(n²) or worse algorithms** over asset or endpoint collections. Prefer dictionary lookups, hash sets, or single-pass linear scans.
+- **Use `Dictionary` or `HashSet` for membership checks** instead of scanning lists with `Contains` or `Any` on identity/path values.
+- **Sort once, scan once.** When ordering matters (e.g., parent-before-child for related assets), sort the collection once and process it in a single linear pass rather than doing repeated lookups.
+- **Pre-size collections** when the approximate count is known (e.g., `new List<StaticWebAsset>(assets.Length)`).
+- Use `OSPath.PathComparer` for all dictionaries and hash sets keyed by file paths. This handles case-insensitive comparison on Windows and case-sensitive on Linux, matching the OS file system behavior.
+
+## Coding Conventions
+
+### Prefer Strongly-Typed Representations
+
+Always convert `ITaskItem` inputs to their strongly-typed representations (`StaticWebAsset`, `StaticWebAssetEndpoint`, `StaticWebAssetGroup`, etc.) at the task boundary, then work with the typed objects throughout the task logic. Do not pass `ITaskItem` into internal helper methods or perform `GetMetadata` calls deep inside the processing pipeline.
+
+```csharp
+// Good: convert at boundary, work with typed objects
+var asset = StaticWebAsset.FromTaskItem(element);
+ProcessAsset(asset);
+
+// Avoid: passing ITaskItem into helpers
+ProcessAsset(element); // then calling element.GetMetadata("RelativePath") inside
+```
+
+Convert back to `ITaskItem` only when assigning to `[Output]` properties at the end of `Execute`.
+
+### Use Named Constants
+
+Source types, asset kinds, asset modes, and asset roles all have named constants defined as inner classes on `StaticWebAsset` (e.g., `StaticWebAsset.SourceTypes.Package`, `StaticWebAsset.AssetKinds.All`, `StaticWebAsset.AssetModes.CurrentProject`, `StaticWebAsset.AssetRoles.Primary`). Always use these constants instead of string literals.

--- a/src/StaticWebAssetsSdk/AGENTS.md
+++ b/src/StaticWebAssetsSdk/AGENTS.md
@@ -58,7 +58,7 @@ These invariants must hold at all times. Violating any of them is a bug.
 **Path normalization**
 
 - `ContentRoot` is always an absolute path ending with a directory separator.
-- `BasePath` and `RelativePath` use forward slashes only, no leading or trailing slashes.
+- `BasePath` and `RelativePath` use forward slashes only. `BasePath` is normalized via `StaticWebAsset.Normalize()`, which trims leading and trailing slashes and represents the root as `"/"` when the normalized path is empty. `RelativePath` has no leading or trailing slashes.
 
 **Defaults (applied when not explicitly set)**
 

--- a/src/StaticWebAssetsSdk/Architecture.md
+++ b/src/StaticWebAssetsSdk/Architecture.md
@@ -196,7 +196,7 @@ StaticWebAsset (Primary)
 ├── Endpoint (non-fingerprinted)
 │   ├── Route: css/app.css
 │   ├── AssetFile: D:\project\wwwroot\css\app.css
-│   ├── ResponseHeaders: [Content-Type=text/css, ETag="abc123"]
+│   ├── ResponseHeaders: [Content-Type=text/css, ETag="sha256-..."]
 │   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-...]
 │
 └── Alternative Asset (gzip)

--- a/src/StaticWebAssetsSdk/Architecture.md
+++ b/src/StaticWebAssetsSdk/Architecture.md
@@ -1,0 +1,531 @@
+# Static Web Assets SDK — Architecture
+
+## 1. What Static Web Assets Solves
+
+Web applications consume static files from multiple sources: the current project's `wwwroot`, class libraries via `ProjectReference`, NuGet packages, and the shared framework. Each source stores files in different physical locations on disk.
+
+Static Web Assets (SWA) creates a **virtual file system** that remaps these files from their original disk locations into a unified view. During development, ASP.NET Core's static file middleware serves files through this virtual layer without knowing their physical paths. At build time, SWA produces a manifest that maps virtual paths to physical locations so the dev server can resolve them. At publish time, SWA copies every asset to its final output location and produces endpoint manifests that configure runtime serving (routes, headers, content negotiation).
+
+The build pipeline is implemented as a set of MSBuild targets and tasks. Targets orchestrate the pipeline phases, tasks contain the logic.
+
+## 2. Static Web Assets
+
+`StaticWebAsset` (`Tasks/Data/StaticWebAsset.cs`) is the core abstraction. It represents a single file tracked through the build and publish pipeline. Every property falls into one of six categories.
+
+### Pipeline Invariants
+
+**Collection-level**
+
+- **Asset uniqueness**: Every `StaticWebAsset` is unique by `Identity`. No two assets share the same `Identity` within a given build or publish resolution.
+- **Target path uniqueness**: At a given target path, at most one asset per `AssetKind` slot (`Build`, `Publish`, `All`). Multiple assets at the same target path are only allowed if they have distinct `AssetGroups`.
+- **Referential integrity**: Every non-primary asset (`Related` or `Alternative`) must point to a valid asset definition via `RelatedAsset`. If an asset is removed, all assets that reference it must also be removed.
+- **Endpoint validity**: Every `StaticWebAssetEndpoint` must point to an existing `StaticWebAsset` via `AssetFile`. There must be no endpoints referencing non-existent assets.
+- **Endpoint uniqueness**: Endpoints are unique by the `(Route, AssetFile)` pair. No two endpoints share the same route and asset file combination.
+
+**Required properties (every asset must have)**
+
+- `Identity`, `SourceId`, `ContentRoot`, `BasePath`, `RelativePath`, `OriginalItemSpec` — non-empty strings.
+- `Fingerprint` (base-36 SHA-256), `Integrity` (base-64 SHA-256) — non-empty strings.
+- `FileLength` ≥ 0.
+- `LastWriteTime` ≠ `DateTimeOffset.MinValue`.
+
+**Valid values**
+
+- `SourceType` ∈ {`Discovered`, `Computed`, `Project`, `Package`, `Framework`}.
+- `AssetKind` ∈ {`Build`, `Publish`, `All`}.
+- `AssetMode` ∈ {`All`, `CurrentProject`, `Reference`}.
+- `AssetRole` ∈ {`Primary`, `Related`, `Alternative`}.
+
+**Conditional requirements**
+
+- `RelatedAsset` is required when `AssetRole` is `Related` or `Alternative`. Must reference a valid asset `Identity`.
+- `AssetTraitName` and `AssetTraitValue` are both required when `AssetRole` is `Alternative`.
+
+**Path normalization**
+
+- `ContentRoot` is always an absolute path ending with a directory separator.
+- `BasePath` and `RelativePath` use forward slashes only, no leading or trailing slashes.
+
+**Defaults (applied when not explicitly set)**
+
+- `CopyToOutputDirectory` → `Never`; `CopyToPublishDirectory` → `PreserveNewest`.
+- `AssetKind` → `All` (or `Build` when `CopyToPublishDirectory` is `Never`).
+- `AssetMode` → `All`; `AssetRole` → `Primary`.
+
+### Identity and Origin
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `Identity` | `string` | Absolute path to the file on disk. Serves as the unique key for the asset. | Required. Defaults to the `FullPath` metadata of the original MSBuild item. |
+| `SourceId` | `string` | Identifier of the project or package that owns this asset (project name or NuGet package ID). | Required. Used to group assets by origin and detect conflicts. |
+| `SourceType` | `string` | How the asset was discovered. | Required. One of: `Discovered`, `Computed`, `Project`, `Package`, `Framework`. See [Source Types](#source-types). |
+| `ContentRoot` | `string` | Absolute path to the root directory containing the asset. | Required. Always ends with a directory separator. For `Discovered` assets this is `wwwroot/`; for `Package` assets it is the package's static web assets folder. |
+| `OriginalItemSpec` | `string` | The original MSBuild item spec before normalization. | Required. Fallback when resolving the file on disk. |
+
+### Path and Routing
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `BasePath` | `string` | URL prefix under which the asset is served (e.g., `_content/MyLib`). | Required (may be `/`). Normalized to forward slashes, no leading or trailing slashes. **Ignored when computing target paths** for `Discovered`, `Computed`, and `Framework` assets — these are relative to the project root. |
+| `RelativePath` | `string` | Path relative to `ContentRoot`. May contain token expressions. | Required. Normalized to forward slashes. |
+
+**Token expression syntax.** `RelativePath` can embed tokens using the format `#[.{tokenName}]`. The `#` prefix ensures tokens cannot collide with valid file path characters. `[]` delimit the full expression, `{}` delimit the variable name, and a trailing qualifier controls resolution:
+
+| Qualifier | Meaning | Example | File on disk |
+|-----------|---------|---------|--------------|
+| `?` | Optional — the file on disk is **not** fingerprinted | `app#[.{fingerprint}]?.js` | `app.js` |
+| `!` | Preferred — the file on disk **is** fingerprinted | `app#[.{fingerprint}]!.js` | `app.<hash>.js` |
+| `~` | File-only — the file on disk **is** fingerprinted, but the token is **excluded from endpoint routes** | `app#[.{fingerprint}]~.js` | `app.<hash>.js` |
+
+`~` is used for package-only fingerprinting: the file inside the nupkg carries the fingerprint in its name, but the endpoint routes served at runtime do not include it.
+
+The only supported token is `fingerprint` (base-36 SHA-256).
+
+**Path computation.** `ComputeTargetPath(prefix, separator)` combines `prefix + BasePath + RelativePath` after normalizing separators. For `Discovered`, `Computed`, and `Framework` assets, `BasePath` is replaced with `""` — these assets live at the project root in the virtual file system. `ComputeLogicalPath()` is equivalent to `ComputeTargetPath("", '/')`.
+
+### Classification
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `AssetKind` | `string` | When the asset is active. | `Build`, `Publish`, or `All`. Defaults to `All` unless `CopyToPublishDirectory` is `Never`, in which case defaults to `Build`. |
+| `AssetMode` | `string` | Visibility scope. | `All` (current project + references), `CurrentProject` (owning project only), `Reference` (referencing projects only). Defaults to `All`. |
+| `AssetRole` | `string` | Relationship to other assets. | `Primary`, `Related`, or `Alternative`. Defaults to `Primary`. |
+| `RelatedAsset` | `string` | Full path to the asset this one is associated with. Forms a chain: an `Alternative` can point to a `Related` asset, which in turn points to a `Primary`. | Required when `AssetRole` is `Related` or `Alternative`. Must reference a valid asset `Identity` in the pipeline. Empty for `Primary`. |
+| `AssetTraitName` | `string` | Name of the trait that distinguishes an alternative (e.g., `Content-Encoding`). | Required when `AssetRole` is `Alternative`. |
+| `AssetTraitValue` | `string` | Value of the distinguishing trait (e.g., `gzip`, `br`). | Required when `AssetRole` is `Alternative`. |
+
+### Merge Behavior
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `AssetMergeBehavior` | `string` | Conflict resolution when merging assets from multiple TFMs or embedded projects. | `None` (default), `PreferTarget`, `PreferSource`, `Exclude`. |
+| `AssetMergeSource` | `string` | Source identifier during merge operations. | Used alongside `AssetMergeBehavior` to determine which copy wins. |
+
+### Copy Behavior
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `CopyToOutputDirectory` | `string` | Whether to copy to the build output directory. | `Never` (default), `PreserveNewest`, `Always`. |
+| `CopyToPublishDirectory` | `string` | Whether to copy to the publish output directory. | `PreserveNewest` (default), `Never`, `Always`. When `Never`, `AssetKind` defaults to `Build`. |
+
+### Integrity
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `Fingerprint` | `string` | Base-36 encoded SHA-256 hash of file content. | Required. Used in URL token expressions for cache-busting. |
+| `Integrity` | `string` | Base-64 encoded SHA-256 hash of file content. | Required. Used for Subresource Integrity (SRI) in HTTP headers. |
+| `FileLength` | `long` | File size in bytes. | Required (≥ 0). Used for `Content-Length` and up-to-date checks. |
+| `LastWriteTime` | `DateTimeOffset` | Last modification timestamp. | Required (not `MinValue`). Used for `Last-Modified` and incremental builds. |
+
+### Asset Groups
+
+| Property | Type | Description | Invariants |
+|----------|------|-------------|------------|
+| `AssetGroups` | `string` | Semicolon-separated `Name=Value` pairs that encode group membership. | Optional. Links this asset to `StaticWebAssetGroup` entries by encoding matching criteria. |
+
+### Source Types
+
+| Value | Origin | `BasePath` in path computation | Typical `ContentRoot` |
+|-------|--------|--------------------------------|-----------------------|
+| `Discovered` | Found on disk in the current project's `wwwroot` | Ignored (treated as `""`) | `{ProjectDir}/wwwroot/` |
+| `Computed` | Generated during build (scoped CSS bundles, JS module manifests) | Ignored (treated as `""`) | `{IntermediateOutputPath}/...` |
+| `Project` | From a `ProjectReference`'d library | Used as URL prefix (`_content/{PackageId}`) | Referenced project's content root |
+| `Package` | From a NuGet package | Used as URL prefix (`_content/{PackageId}`) | Package's static web assets folder |
+| `Framework` | Shared framework files (e.g., Blazor runtime JS). Materialized from package at consume time. | Ignored (treated as `""`) | `{IntermediateOutputPath}/fx/{SourceId}/` |
+
+## 3. Static Web Asset Endpoints
+
+`StaticWebAssetEndpoint` (`Tasks/Data/StaticWebAssetEndpoint.cs`) is the runtime-facing counterpart. It represents a URL route mapped to an asset. **`AssetFile` always points to the virtual path from SWA** (matching `StaticWebAsset.Identity`) — endpoints never reference an arbitrary disk path independently.
+
+### Core Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Route` | `string` | URL path registered in the routing table. Used as the MSBuild item identity. |
+| `AssetFile` | `string` | Path to the file on disk, matching `StaticWebAsset.Identity`. Links the endpoint to its underlying asset in the virtual file system. |
+
+### Selectors (Content Negotiation)
+
+`Selectors` is a JSON-serialized array of `StaticWebAssetEndpointSelector` values. Each selector is a request condition that must match for this endpoint to be chosen.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Request header or attribute to match (e.g., `Content-Encoding`). |
+| `Value` | `string` | Expected value (e.g., `gzip`). |
+| `Quality` | `string` | Preference weight when multiple selectors match. |
+
+### Response Headers
+
+`ResponseHeaders` is a JSON-serialized array of `StaticWebAssetEndpointResponseHeader` values. These are HTTP response headers included when serving the endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Header name (e.g., `Content-Type`, `Cache-Control`, `ETag`). |
+| `Value` | `string` | Header value. |
+
+### Endpoint Properties (Metadata)
+
+`EndpointProperties` is a JSON-serialized array of `StaticWebAssetEndpointProperty` values. Build-time metadata carried to the runtime or consumed by downstream tasks.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | `string` | Property name (e.g., `fingerprint`, `integrity`, `label`). |
+| `Value` | `string` | Property value. |
+
+### Why One Asset Produces Multiple Endpoints
+
+A single asset typically gets at least two endpoints:
+
+1. **Fingerprinted route** — immutable URL with the hash in the path (e.g., `css/app.abc123.css`). Served with `Cache-Control: max-age=31536000, immutable`.
+2. **Non-fingerprinted route** — stable URL (e.g., `css/app.css`). Served with `ETag`-based caching.
+
+When compressed alternatives exist, each compressed variant adds further endpoints with `Selectors` for content negotiation (e.g., `Content-Encoding=gzip`).
+
+```
+StaticWebAsset (Primary)
+├── Identity: D:\project\wwwroot\css\app.css
+├── RelativePath: css/app#[.{fingerprint}]!.css
+├── Fingerprint: abc123
+│
+├── Endpoint (fingerprinted)
+│   ├── Route: css/app.abc123.css
+│   ├── AssetFile: D:\project\wwwroot\css\app.css
+│   ├── ResponseHeaders: [Content-Type=text/css, Cache-Control=max-age=31536000,immutable]
+│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-..., label=css/app.css]
+│
+├── Endpoint (non-fingerprinted)
+│   ├── Route: css/app.css
+│   ├── AssetFile: D:\project\wwwroot\css\app.css
+│   ├── ResponseHeaders: [Content-Type=text/css, ETag="abc123"]
+│   └── EndpointProperties: [fingerprint=abc123, integrity=sha256-...]
+│
+└── Alternative Asset (gzip)
+    ├── Identity: D:\project\obj\compressed\css\app.css.gz
+    ├── AssetRole: Alternative
+    ├── RelatedAsset: D:\project\wwwroot\css\app.css
+    ├── AssetTraitName: Content-Encoding
+    ├── AssetTraitValue: gzip
+    │
+    └── Endpoint (compressed variant)
+        ├── Route: css/app.abc123.css
+        ├── AssetFile: D:\project\obj\compressed\css\app.css.gz
+        ├── Selectors: [Content-Encoding=gzip]
+        └── ResponseHeaders: [Content-Type=text/css, Content-Encoding=gzip, Vary=Content-Encoding]
+```
+
+## 4. How Assets Cross Project Boundaries
+
+Assets flow between projects through five source types. Each follows a different discovery and integration path. How a project participates in this flow depends on its **project mode**.
+
+### Project Mode
+
+The MSBuild property `StaticWebAssetProjectMode` controls how a project participates in the SWA pipeline. It determines the base path, asset visibility, compression defaults, and publish layout.
+
+| Mode | Typical project | `StaticWebAssetBasePath` | Set by |
+|------|----------------|--------------------------|--------|
+| `Default` | Class library (Razor Class Library) | `_content/{PackageId}` | SWA SDK default |
+| `Root` | ASP.NET Core web application | `/` | `Microsoft.NET.Sdk.Web` (`Sdk.Server.props`) |
+| `SelfContained` | Standalone application | `_content/{PackageId}` | Explicit opt-in |
+
+**Effects of project mode:**
+
+| Aspect | `Default` | `Root` |
+|--------|-----------|--------|
+| Asset base path | `_content/{PackageId}` (namespaced) | `/` (project root) |
+| Asset filtering | Exports assets marked `All` or `Reference` to referencing projects | Includes all referenced assets plus its own; excludes `Reference`-only assets from its own output |
+| Publish path prefix | `wwwroot` | `wwwroot/{BasePath}` |
+| Build compression | Disabled by default | Enabled by default (`StaticWebAssetBuildCompressAllAssets=true`) |
+| Manifest mode | `Default` | `Root` |
+
+The mode is stored in the build manifest's `Mode` field and used at manifest-read time to decide which assets to include in the current project vs. expose as references.
+
+### Discovered — Current Project
+
+Files in the current project's `wwwroot` directory. Scanned by `ResolveProjectStaticWebAssets`. These are the simplest assets: `SourceType=Discovered`, `SourceId` is the current project's package ID, `ContentRoot` is `wwwroot/`.
+
+### Computed — Generated During Build
+
+Created by extension point targets hooked into `GenerateComputedBuildStaticWebAssets` (scoped CSS bundles, JS module manifests, etc.). `SourceType=Computed`, `SourceId` is the current project. These are generated into intermediate output directories.
+
+### Project — Referenced Libraries
+
+Assets from `ProjectReference`'d libraries. The referencing project calls two cross-project MSBuild targets on each reference:
+
+1. **`GetStaticWebAssetsProjectConfiguration`** — returns the referenced project's SWA configuration: `Source` (package ID), `Version`, `GetBuildAssetsTargets`, `GetPublishAssetsTargets`, additional properties to pass during invocation, and manifest path for caching.
+2. **`GetCurrentProjectBuildStaticWebAssetItems`** — returns the actual assets, endpoints, and discovery patterns. Results are grouped by `ResultType` metadata (`StaticWebAsset`, `StaticWebAssetEndpoint`, `StaticWebAssetDiscoveryPattern`).
+
+The referencing project sees these with `SourceType=Project` and adds the reference's `BasePath` as a URL prefix (typically `_content/{PackageId}`).
+
+### Package — NuGet Packages
+
+Assets bundled into a nupkg during `dotnet pack`. The pack process (`Pack.targets`) writes assets, endpoints, and discovery patterns into a manifest file inside the package. At consume time, `UpdateExistingPackageStaticWebAssets` (or `ReadPackageAssetsManifest` for the JSON manifest format) reads the package manifest and imports assets with `SourceType=Package`.
+
+The conditional pack logic in `Pack.targets` uses MSBuild conditions to branch on TFM version and feature flags, producing different nupkg layouts (`build/`, `buildMultiTargeting/`, `buildTransitive/`) depending on the branch.
+
+### Framework — Shared Framework Files
+
+A special subset of package assets representing shared framework static files (e.g., Blazor's runtime JavaScript). The flow:
+
+1. **At pack time**: Assets matching a `FrameworkPattern` glob are tagged with `SourceType=Framework` in the package manifest.
+2. **At consume time**: Framework assets are **materialized** — physically copied from the package into an intermediate directory (`{IntermediateOutputPath}/fx/{SourceId}/`).
+3. **After materialization**: Their metadata is rewritten:
+   - `SourceType` → `Discovered`
+   - `SourceId` → consuming project's package ID
+   - `ContentRoot` → the `fx/` intermediate directory
+   - `BasePath` → consuming project's base path
+   - `AssetMode` → `CurrentProject`
+
+This materialization makes framework files appear as if they were discovered in the consuming project. The dev server resolves them through the virtual file system like any other discovered asset.
+
+### Embedded — Multi-TFM Inner Builds
+
+When a project targets multiple frameworks (`TargetFrameworks`), each inner build produces its own set of assets. `ResolveEmbeddedProjectsStaticWebAssets` calls each inner build's `GetEmbeddedBuildAssetsTargets` (only for TFMs different from the current build) and merges the results. `AssetMergeBehavior` controls conflict resolution when the same asset exists in multiple TFMs.
+
+### Asset Groups
+
+`StaticWebAssetGroup` (`Tasks/Data/StaticWebAssetGroup.cs`) carries named configuration metadata across project and package boundaries.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Name` | `string` | Group name. Required. Part of the composite key. |
+| `Value` | `string` | Group value. |
+| `SourceId` | `string` | Project or package identifier. Required. Part of the composite key. |
+| `Deferred` | `bool` | Whether the group is deferred. Defaults to `false`. |
+
+Groups are keyed by `(SourceId, Name)` and stored in a `Dictionary<(string SourceId, string Name), StaticWebAssetGroup>`. They travel alongside assets in manifests and allow a consuming project to read provider-specific settings without coupling to the provider's implementation. An asset's `AssetGroups` property (semicolon-separated `Name=Value` pairs) can reference these groups.
+
+### Discovery Patterns
+
+`StaticWebAssetsDiscoveryPattern` (`Tasks/Data/StaticWebAssetsDiscoveryPattern.cs`) describes a glob pattern for discovering files dynamically at runtime (for the dev server).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Name` | `string` | Identifier for the pattern. |
+| `Source` | `string` | Package ID origin. |
+| `ContentRoot` | `string` | Physical directory root. |
+| `BasePath` | `string` | Web-relative path prefix. |
+| `Pattern` | `string` | Glob pattern for matching files (e.g., `**`). |
+
+These patterns let the development-time middleware discover files that aren't known at build time (e.g., files added to `wwwroot` after the build).
+
+## 5. Asset Lifecycle — From Disk to Output
+
+### Build Pipeline
+
+Three stages, executed in order:
+
+**Stage 1 — Discovery** (`ResolveCoreStaticWebAssets`): Find existing assets from all sources.
+- `ResolveProjectStaticWebAssets` — scan current project's `wwwroot`
+- `UpdateExistingPackageStaticWebAssets` — import assets from NuGet packages
+- `ResolveEmbeddedProjectsStaticWebAssets` — merge assets from other TFMs (multi-TFM only)
+- `ResolveReferencedProjectsStaticWebAssets` — call into referenced projects via configured targets
+
+**Stage 2 — Computation** (`ResolveStaticWebAssetsInputs`): Generate derived assets through the `GenerateComputedBuildStaticWebAssets` extension point.
+- Scoped CSS: `.razor.css` files → scope identifiers → CSS rewrite → bundle
+- JS Modules: `.razor.js` collocation → JS module initializer manifest
+- Other extensions hook in via `GenerateComputedBuildStaticWebAssetsDependsOn`
+
+**Stage 3 — Related Assets** (`ResolveBuildRelatedStaticWebAssets`): Create compressed variants, generate endpoints for all assets, produce manifests.
+- Compression: gzip and brotli alternatives with content-negotiation endpoints
+- Endpoint generation: map each asset to one or more URL routes with headers and selectors
+
+### Publish Pipeline
+
+Same three-stage structure with publish-specific rules. The build manifest is the starting input.
+
+**Stage 1** (`ResolveCorePublishStaticWebAssets`): Load the build manifest, compute referenced project publish assets, resolve embedded publish assets.
+
+**Stage 2** (`ResolvePublishStaticWebAssets`): Run `GenerateComputedPublishStaticWebAssets` — may produce publish-specific assets (different fingerprinting, different compression settings).
+
+**Stage 3** (`ResolvePublishRelatedStaticWebAssets`): Compress, generate publish endpoints, write the publish manifest.
+
+### Output Copying
+
+After manifests are generated:
+- **Build**: `CopyStaticWebAssetsToOutputDirectory` copies assets where `CopyToOutputDirectory` ≠ `Never`.
+- **Publish**: `CopyStaticWebAssetsToPublishDirectory` copies assets where `CopyToPublishDirectory` ≠ `Never`.
+
+## 6. Manifests — The Build's Output
+
+Three manifests hand off information between MSBuild (build time) and ASP.NET Core (run time).
+
+### Build Manifest (`staticwebassets.build.json`)
+
+The complete state of the virtual file system. Generated by `GenerateStaticWebAssetsManifest`.
+
+```
+{
+  "Version": 1,
+  "Hash": "<SHA-256 of manifest content>",
+  "Source": "<project package ID>",
+  "BasePath": "<project base path>",
+  "Mode": "Default | Root | SelfContained",
+  "ManifestType": "Build",
+  "ReferencedProjectsConfiguration": [ ... ],
+  "DiscoveryPatterns": [ ... ],
+  "Assets": [ ... ],
+  "Endpoints": [ ... ]
+}
+```
+
+- `Mode`: `Default` for libraries, `Root` for the application entry point, `SelfContained` for standalone apps.
+- `ReferencedProjectsConfiguration`: metadata for each `ProjectReference` (target names, additional properties). Used by the publish pipeline to call back into referenced projects.
+- The build manifest is the input to the publish pipeline.
+
+### Endpoints Manifest (`staticwebassets.endpoints.json`)
+
+Routes mapped to files with headers and selectors. Generated by `GenerateStaticWebAssetEndpointsManifest`.
+
+```
+{
+  "Version": 1,
+  "ManifestType": "Build | Publish",
+  "Endpoints": [ ... ]
+}
+```
+
+Endpoints are filtered to only those pointing to assets present in the manifest. The runtime static file middleware reads this to configure its routing table, response headers, and content-negotiation selectors.
+
+### Development Manifest
+
+A tree-structured manifest consumed by the development-time middleware for the dev server and hot reload. Generated by `GenerateStaticWebAssetsDevelopmentManifest`.
+
+```
+{
+  "ContentRoots": [ "<absolute paths>" ],
+  "Root": {
+    "Children": {
+      "<segment>": {
+        "Children": { ... },
+        "Asset": { "ContentRootIndex": 0, "SubPath": "<relative>" },
+        "Patterns": [{ "ContentRootIndex": 0, "Pattern": "**", "Depth": 2 }]
+      }
+    }
+  }
+}
+```
+
+- `ContentRoots`: deduplicated array of base directories. Nodes reference roots by index.
+- The tree structure matches URL path segments, enabling efficient prefix-based lookup.
+- `Patterns` at each node support runtime file discovery (files added after build).
+- Only includes `Build`-kind assets.
+
+## 7. Extension Points
+
+The build pipeline is extensible through `GenerateComputedBuildStaticWebAssets` and `GenerateComputedPublishStaticWebAssets`. Each subsystem hooks into these by adding to `GenerateComputedBuildStaticWebAssetsDependsOn` or `GenerateComputedPublishStaticWebAssetsDependsOn`.
+
+### Scoped CSS (`Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets`)
+
+`.razor.css` files → compute unique scope identifiers → rewrite CSS selectors with scope attributes → concatenate into a single bundle (`{ProjectName}.styles.css`). The bundle becomes a `Computed` asset.
+
+### JS Modules (`Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets`)
+
+`.razor.js` files collocated with components → resolve as JS initializer modules → generate a JSON manifest listing all modules. The manifest becomes a `Computed` asset that the Blazor runtime reads at startup.
+
+### Compression (`Microsoft.NET.Sdk.StaticWebAssets.Compression.targets`)
+
+Primary assets → gzip and/or brotli compressed variants. Each compressed file becomes an `Alternative` asset with `AssetTraitName=Content-Encoding` and `AssetTraitValue=gzip|br`. Endpoints for compressed variants include `Selectors` for content negotiation and `Vary: Content-Encoding` response headers.
+
+### Embedded Assets (`Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets`)
+
+Multi-TFM projects merging assets from inner builds. Each TFM's inner build exposes assets via `GetCurrentProjectEmbeddedBuildStaticWebAssetItems`. The outer build merges them using `MergeStaticWebAssets`, with `AssetMergeBehavior` resolving conflicts.
+
+## 8. Target Execution Order
+
+### Build Flow
+
+```
+StaticWebAssetsPrepareForRun
+├── ResolveBuildStaticWebAssets
+│   ├── ResolveCoreStaticWebAssets
+│   │   ├── UpdateExistingPackageStaticWebAssets
+│   │   ├── ResolveProjectStaticWebAssets
+│   │   ├── ResolveEmbeddedProjectsStaticWebAssets
+│   │   └── ResolveReferencedProjectsStaticWebAssets
+│   │       └── ResolveReferencedProjectsStaticWebAssetsConfiguration
+│   ├── ResolveStaticWebAssetsInputs
+│   │   ├── ResolveCoreStaticWebAssets (already run)
+│   │   ├── GenerateComputedBuildStaticWebAssets
+│   │   │   └── BundleScopedCssFiles (if ScopedCss enabled)
+│   │   ├── ResolveScopedCssAssets (if ScopedCss enabled)
+│   │   └── ResolveJSModuleManifestBuildStaticWebAssets (if JSModules enabled)
+│   └── ResolveBuildRelatedStaticWebAssets
+│       └── ResolveBuildCompressedStaticWebAssets (if Compression enabled)
+├── GenerateStaticWebAssetsManifest
+└── CopyStaticWebAssetsToOutputDirectory
+    └── LoadStaticWebAssetsBuildManifest
+```
+
+### Publish Flow
+
+```
+StaticWebAssetsPrepareForPublish
+├── ResolveStaticWebAssetsConfiguration
+├── GenerateStaticWebAssetsPublishManifest
+│   └── ResolveAllPublishStaticWebAssets
+│       ├── ResolveCorePublishStaticWebAssets
+│       │   ├── LoadStaticWebAssetsBuildManifest
+│       │   ├── ComputeReferencedProjectsEmbeddedPublishAssets
+│       │   └── ComputeReferencedProjectsPublishAssets
+│       ├── ResolvePublishStaticWebAssets
+│       │   ├── ResolveCorePublishStaticWebAssets (already run)
+│       │   └── GenerateComputedPublishStaticWebAssets
+│       └── ResolvePublishRelatedStaticWebAssets
+│           └── ResolvePublishCompressedStaticWebAssets
+└── CopyStaticWebAssetsToPublishDirectory
+    ├── StaticWebAssetsPrepareForPublish (already run)
+    └── LoadStaticWebAssetsPublishManifest
+```
+
+## 9. Task and Target Reference
+
+### Targets by File
+
+| File | Key Targets |
+|------|-------------|
+| `Microsoft.NET.Sdk.StaticWebAssets.targets` | `StaticWebAssetsPrepareForRun`, `ResolveBuildStaticWebAssets`, `ResolveCoreStaticWebAssets`, `ResolveStaticWebAssetsInputs`, `ResolveBuildRelatedStaticWebAssets`, `ResolveProjectStaticWebAssets`, `UpdateExistingPackageStaticWebAssets`, `GenerateStaticWebAssetsManifest`, `GenerateComputedBuildStaticWebAssets`, `CopyStaticWebAssetsToOutputDirectory`, `ResolveStaticWebAssetsConfiguration`, `LoadStaticWebAssetsBuildManifest` |
+| `Microsoft.NET.Sdk.StaticWebAssets.References.targets` | `ResolveReferencedProjectsStaticWebAssetsConfiguration`, `GetStaticWebAssetsProjectConfiguration`, `ResolveReferencedProjectsStaticWebAssets`, `GetCurrentProjectBuildStaticWebAssetItems`, `GetCurrentProjectPublishStaticWebAssetItems` |
+| `Microsoft.NET.Sdk.StaticWebAssets.Publish.targets` | `StaticWebAssetsPrepareForPublish`, `GenerateComputedPublishStaticWebAssets`, `GenerateStaticWebAssetsPublishManifest`, `ResolveCorePublishStaticWebAssets`, `ResolvePublishStaticWebAssets`, `ResolveAllPublishStaticWebAssets`, `ComputeReferencedProjectsPublishAssets`, `CopyStaticWebAssetsToPublishDirectory`, `LoadStaticWebAssetsPublishManifest` |
+| `Microsoft.NET.Sdk.StaticWebAssets.Compression.targets` | `ResolveBuildCompressedStaticWebAssets`, `GenerateBuildCompressedStaticWebAssets`, `ResolvePublishCompressedStaticWebAssets`, `GeneratePublishCompressedStaticWebAssets` |
+| `Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets` | `ResolveScopedCssAssets`, `GenerateScopedCssFiles`, `ComputeCssScope`, `BundleScopedCssFiles`, `ResolveBundledCssAssets` |
+| `Microsoft.NET.Sdk.StaticWebAssets.JSModules.targets` | `ResolveJSModuleManifestBuildStaticWebAssets`, `GenerateJSModuleManifestBuildStaticWebAssets`, `ResolveJSModuleManifestPublishStaticWebAssets`, `ResolveJsInitializerModuleStaticWebAssets` |
+| `Microsoft.NET.Sdk.StaticWebAssets.EmbeddedAssets.targets` | `ResolveEmbeddedProjectsStaticWebAssets`, `ResolveStaticWebAssetsCrossTargetingConfiguration`, `ComputeReferencedProjectsEmbeddedPublishAssets`, `MergeStaticWebAssets` |
+| `Microsoft.NET.Sdk.StaticWebAssets.Pack.targets` | Pack-time targets for bundling assets into nupkg (conditional on TFM and feature flags) |
+
+### Tasks by File
+
+| Task | File | Purpose |
+|------|------|---------|
+| `DefineStaticWebAssets` | `DefineStaticWebAssets.cs` | Create asset definitions from candidates |
+| `DefineStaticWebAssetEndpoints` | `DefineStaticWebAssetEndpoints.cs` | Create endpoint definitions |
+| `UpdateExternallyDefinedStaticWebAssets` | `UpdateExternallyDefinedStaticWebAssets.cs` | Update imported assets |
+| `UpdateStaticWebAssetEndpoints` | `UpdateStaticWebAssetEndpoints.cs` | Update endpoint properties |
+| `UpdatePackageStaticWebAssets` | `UpdatePackageStaticWebAssets.cs` | Update package assets |
+| `FilterStaticWebAssetEndpoints` | `FilterStaticWebAssetEndpoints.cs` | Filter endpoints by criteria |
+| `ComputeReferenceStaticWebAssetItems` | `ComputeReferenceStaticWebAssetItems.cs` | Compute reference assets |
+| `ComputeEndpointsForReferenceStaticWebAssets` | `ComputeEndpointsForReferenceStaticWebAssets.cs` | Transform endpoint routes |
+| `ComputeStaticWebAssetsForCurrentProject` | `ComputeStaticWebAssetsForCurrentProject.cs` | Filter to current project |
+| `ComputeStaticWebAssetsTargetPaths` | `ComputeStaticWebAssetsTargetPaths.cs` | Compute target paths |
+| `CollectStaticWebAssetsToCopy` | `CollectStaticWebAssetsToCopy.cs` | Collect assets for copying |
+| `MergeStaticWebAssets` | `MergeStaticWebAssets.cs` | Merge assets from multiple TFMs |
+| `MergeConfigurationProperties` | `MergeConfigurationProperties.cs` | Merge project configurations |
+| `GenerateStaticWebAssetsManifest` | `GenerateStaticWebAssetsManifest.cs` | Generate main manifest |
+| `GenerateStaticWebAssetEndpointsManifest` | `GenerateStaticWebAssetEndpointsManifest.cs` | Generate endpoints manifest |
+| `GenerateStaticWebAssetsDevelopmentManifest` | `GenerateStaticWebAssetsDevelopmentManifest.cs` | Generate development manifest |
+| `ReadStaticWebAssetsManifestFile` | `ReadStaticWebAssetsManifestFile.cs` | Read manifest file |
+| `ResolveStaticWebAssetEndpointRoutes` | `ResolveStaticWebAssetEndpointRoutes.cs` | Resolve endpoint routes |
+| `ResolveFingerprintedStaticWebAssetEndpointsForAssets` | `ResolveFingerprintedStaticWebAssetEndpointsForAssets.cs` | Resolve fingerprinted endpoints |
+| `ResolveStaticWebAssetsEmbeddedProjectConfiguration` | `ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs` | Resolve embedded config |
+| `ApplyCompressionNegotiation` | `ApplyCompressionNegotiation.cs` | Apply content negotiation |
+| `BrotliCompress` | `Compression/BrotliCompress.cs` | Brotli compression |
+| `GZipCompress` | `Compression/GZipCompress.cs` | Gzip compression |
+| `DiscoverPrecompressedAssets` | `Compression/DiscoverPrecompressedAssets.cs` | Find pre-compressed assets |
+| `ResolveCompressedAssets` | `Compression/ResolveCompressedAssets.cs` | Resolve compression candidates |
+| `DiscoverDefaultScopedCssItems` | `DiscoverDefaultScopedCssItems.cs` | Discover scoped CSS |
+| `ResolveAllScopedCssAssets` | `ScopedCss/ResolveAllScopedCssAssets.cs` | Resolve all scoped CSS |
+| `ApplyCssScopes` | `ScopedCss/ApplyCssScopes.cs` | Apply CSS scopes |
+| `ComputeCssScope` | `ScopedCss/ComputeCssScope.cs` | Compute scope identifiers |
+| `RewriteCss` | `ScopedCss/RewriteCss.cs` | Rewrite CSS with scopes |
+| `ConcatenateCssFiles` | `ScopedCss/ConcatenateCssFiles.cs` | Bundle CSS files |
+| `GenerateJsModuleManifest` | `JSModules/GenerateJsModuleManifest.cs` | Generate JS module manifest |
+| `ApplyJsModules` | `JSModules/ApplyJsModules.cs` | Apply JS modules to components |

--- a/src/StaticWebAssetsSdk/Architecture.md
+++ b/src/StaticWebAssetsSdk/Architecture.md
@@ -44,7 +44,7 @@ The build pipeline is implemented as a set of MSBuild targets and tasks. Targets
 **Path normalization**
 
 - `ContentRoot` is always an absolute path ending with a directory separator.
-- `BasePath` and `RelativePath` use forward slashes only, no leading or trailing slashes.
+- `BasePath` and `RelativePath` use forward slashes only. `RelativePath` has no leading or trailing slashes. `BasePath` is either `"/"` (representing the empty/root base path) or has no leading or trailing slashes.
 
 **Defaults (applied when not explicitly set)**
 

--- a/src/StaticWebAssetsSdk/Architecture.md
+++ b/src/StaticWebAssetsSdk/Architecture.md
@@ -135,14 +135,14 @@ The only supported token is `fingerprint` (base-36 SHA-256).
 
 ## 3. Static Web Asset Endpoints
 
-`StaticWebAssetEndpoint` (`Tasks/Data/StaticWebAssetEndpoint.cs`) is the runtime-facing counterpart. It represents a URL route mapped to an asset. **`AssetFile` always points to the virtual path from SWA** (matching `StaticWebAsset.Identity`) — endpoints never reference an arbitrary disk path independently.
+`StaticWebAssetEndpoint` (`Tasks/Data/StaticWebAssetEndpoint.cs`) is the runtime-facing counterpart. It represents a URL route mapped to an asset. During the MSBuild pipeline, endpoints are initially created with `AssetFile = StaticWebAsset.Identity` (an absolute path). When generating the endpoints manifest for runtime, `AssetFile` is rewritten to the asset's virtual path (`StaticWebAsset.ComputeTargetPath`), which is relative to the app's web root. Endpoints never introduce an asset independently; they always refer back to an existing `StaticWebAsset`.
 
 ### Core Properties
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `Route` | `string` | URL path registered in the routing table. Used as the MSBuild item identity. |
-| `AssetFile` | `string` | Path to the file on disk, matching `StaticWebAsset.Identity`. Links the endpoint to its underlying asset in the virtual file system. |
+| `AssetFile` | `string` | In the pipeline, the absolute path matching `StaticWebAsset.Identity`; in the endpoints manifest/runtime, the asset's virtual path (from `StaticWebAsset.ComputeTargetPath`) relative to the app's web root. Links the endpoint to its underlying asset in the virtual file system. |
 
 ### Selectors (Content Negotiation)
 


### PR DESCRIPTION
## Summary

Add GitHub Copilot agent and skills for developing and testing the Static Web Assets SDK subsystem.

### Changes

**Architecture docs** (`src/StaticWebAssetsSdk/`)
- Updated `Architecture.md` with current subsystem documentation
- Added `AGENTS.md` with instructions for AI-assisted development

**Agent** (`.github/agents/`)
- `static-web-assets-agent.agent.md` — specialist agent for SWA task/target changes, test failures, baseline regeneration, and pack/publish/build diagnostics

**Skills** (`.github/skills/`)
- `author-swa-integration-test` — guidance for writing SWA integration tests, includes test asset catalog
- `swa-baseline-regeneration` — instructions for regenerating test baselines
- `swa-pack-format` — documentation of the SWA pack format
- `swa-troubleshooting` — diagnostic procedures for SWA issues