### PR TITLE
Only download runtimes for referenced frameworks

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -1010,5 +1010,9 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1234: RoslynCompilerType 'Framework' is deprecated and will be removed in a future version. Please refer to {0} for more information.</value>
     <comment>{StrBegins="NETSDK1234: "}{Locked="RoslynCompilerType"}{Locked="Framework"}{Locked="{0}"}</comment>
   </data>
-  <!-- The latest message added is RoslynCompilerTypeFrameworkIsDeprecated. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="NoRuntimePackAvailable_TransitiveReference" xml:space="preserve">
+    <value>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</value>
+    <comment>{StrBegins="NETSDK1235: "}</comment>
+  </data>
+  <!-- The latest message added is NoRuntimePackAvailable_TransitiveReference. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Pokud chcete nainstalovat tyto úlohy, spusťte následující příkaz: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Führen Sie den folgenden Befehl aus, um diese Workloads zu installieren: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Para instalar estas cargas de trabajo, ejecute el comando siguiente: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Pour installer ces charges de travail, exécutez la commande suivante : dotnet workload restore.</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Per installare questi carichi di lavoro, eseguire il seguente comando: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 これらのワークロードをインストールするには、次のコマンドを実行します: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
  이러한 워크로드를 설치하려면 dotnet workload restore 명령을 실행합니다.</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Aby zainstalować te pakiety robocze, uruchom następujące polecenie: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -1138,6 +1138,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Para instalar essas cargas de trabalho, execute o seguinte comando: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Чтобы установить эти рабочие нагрузки, выполните следующую команду: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 Bu iş yüklerini yüklemek için şu komutu çalıştırın: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 要安装这些工作负载，请运行以下命令: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -1137,6 +1137,11 @@ To install these workloads, run the following command: dotnet workload restore</
 若要安裝這些工作負載，請執行下列命令: dotnet workload restore</target>
         <note>{StrBegins="NETSDK1147: "}{Locked="dotnet workload restore"}</note>
       </trans-unit>
+      <trans-unit id="NoRuntimePackAvailable_TransitiveReference">
+        <source>NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</source>
+        <target state="new">NETSDK1235: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'. This framework reference was transitively included from a package or project dependency. Consider adding a direct FrameworkReference to '{0}' in your project to resolve this.</target>
+        <note>{StrBegins="NETSDK1235: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/GivenAResolveRuntimePackAssetsTask.cs
@@ -54,5 +54,93 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             string expectedResource = Path.Combine("runtimes", "de", "a.resources.dll");
             task.RuntimePackAssets.FirstOrDefault().ItemSpec.Should().Contain(expectedResource);
         }
+
+        [Fact]
+        public void It_detects_transitive_framework_reference_with_no_runtime_pack()
+        {
+            // Scenario: AddTransitiveFrameworkReferences added a transitive reference after
+            // ProcessFrameworkReferences ran, so there's no RuntimePack or UnavailableRuntimePack
+            // for it.  ResolveRuntimePackAssets should detect this and produce NETSDK1235.
+
+            var buildEngine = new MockBuildEngine();
+
+            var task = new ResolveRuntimePackAssets()
+            {
+                BuildEngine = buildEngine,
+                RuntimeIdentifier = "linux-x64",
+                FrameworkReferences = new TaskItem[]
+                {
+                    new TaskItem("Microsoft.NETCore.App"),
+                    new TaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>
+                    {
+                        ["IsTransitiveFrameworkReference"] = "true"
+                    })
+                },
+                // Only NETCore.App has a resolved runtime pack — AspNetCore does not
+                ResolvedRuntimePacks = Array.Empty<TaskItem>(),
+                UnavailableRuntimePacks = Array.Empty<TaskItem>(),
+                // RuntimeFrameworks produced by PFR for all KnownFrameworkReferences.
+                // Non-profile frameworks have FrameworkName == ItemSpec.
+                RuntimeFrameworks = new TaskItem[]
+                {
+                    new TaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        [MetadataKeys.FrameworkName] = "Microsoft.NETCore.App"
+                    }),
+                    new TaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>
+                    {
+                        [MetadataKeys.FrameworkName] = "Microsoft.AspNetCore.App"
+                    })
+                }
+            };
+
+            task.Execute().Should().BeFalse("should fail due to missing transitive runtime pack");
+
+            buildEngine.Errors.Should().ContainSingle(e =>
+                e.Code == "NETSDK1235" && e.Message.Contains("Microsoft.AspNetCore.App"),
+                "should report NETSDK1235 for the transitive AspNetCore framework reference");
+        }
+
+        [Fact]
+        public void It_does_not_flag_profile_framework_references_as_missing()
+        {
+            // Profile framework references (e.g. Microsoft.WindowsDesktop.App.WindowsForms)
+            // share their parent's runtime pack and should not be flagged as missing.
+
+            var buildEngine = new MockBuildEngine();
+
+            var task = new ResolveRuntimePackAssets()
+            {
+                BuildEngine = buildEngine,
+                RuntimeIdentifier = "win-x64",
+                FrameworkReferences = new TaskItem[]
+                {
+                    new TaskItem("Microsoft.NETCore.App"),
+                    new TaskItem("Microsoft.WindowsDesktop.App.WindowsForms", new Dictionary<string, string>
+                    {
+                        ["IsTransitiveFrameworkReference"] = "true"
+                    })
+                },
+                ResolvedRuntimePacks = Array.Empty<TaskItem>(),
+                UnavailableRuntimePacks = Array.Empty<TaskItem>(),
+                RuntimeFrameworks = new TaskItem[]
+                {
+                    new TaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
+                    {
+                        [MetadataKeys.FrameworkName] = "Microsoft.NETCore.App"
+                    }),
+                    // Profile: FrameworkName != ItemSpec
+                    new TaskItem("Microsoft.WindowsDesktop.App", new Dictionary<string, string>
+                    {
+                        [MetadataKeys.FrameworkName] = "Microsoft.WindowsDesktop.App.WindowsForms"
+                    })
+                }
+            };
+
+            task.Execute().Should().BeTrue("profile framework references should not produce errors");
+
+            buildEngine.Errors.Should().BeEmpty(
+                "WindowsForms is a profile — it shares WindowsDesktop.App's runtime pack");
+        }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/Mocks/MockTaskItem.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
@@ -20,16 +19,20 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
         }
 
-        public MockTaskItem(string itemSpec, Dictionary<string, string> metadata)
+        [SetsRequiredMembers]
+        public MockTaskItem(string itemSpec, Dictionary<string, string>? metadata) : this()
         {
             ItemSpec = itemSpec;
-            foreach (var m in metadata)
+            if (metadata != null)
             {
-                _metadata.Add(m.Key, m.Value);
+                foreach (var m in metadata)
+                {
+                    _metadata.Add(m.Key, m.Value);
+                }
             }
         }
 
-        public string ItemSpec { get; set; }
+        public required string ItemSpec { get; set; }
 
         public int MetadataCount
         {
@@ -62,8 +65,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         public string GetMetadata(string metadataName)
         {
-            string metadataValue = null;
-            if (_metadata.TryGetValue(metadataName, out metadataValue))
+            if (_metadata.TryGetValue(metadataName, out string? metadataValue))
             {
                 return metadataValue ?? string.Empty;
             }
@@ -73,8 +75,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         public void RemoveMetadata(string metadataName)
         {
-            string metadataValue = null;
-            if (_metadata.TryGetValue(metadataName, out metadataValue))
+            if (_metadata.TryGetValue(metadataName, out string? metadataValue))
             {
                 _metadata.Remove(metadataName);
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -1223,6 +1223,77 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     "WindowsDesktop runtime pack is unavailable for linux-x64");
         }
 
+        [Fact]
+        public void It_resolves_WindowsDesktop_runtime_pack_when_only_WinForms_profile_is_referenced()
+        {
+            // Scenario: a WinForms project on macOS (with EnableWindowsTargeting) publishes self-contained
+            // for win-arm64.  The project's FrameworkReference is the profile
+            // "Microsoft.WindowsDesktop.App.WindowsForms", not the parent "Microsoft.WindowsDesktop.App".
+            // The parent's runtime pack must still be resolved and queued for download because profile
+            // KFRs share their runtime pack with the parent.
+
+            var netCoreAppRef = CreateNetCoreAppFrameworkReference(
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                "linux-x64;win-x64;win-x86;win-arm64;osx-x64;osx-arm64");
+
+            var windowsDesktopRef = CreateKnownFrameworkReference(
+                "Microsoft.WindowsDesktop.App",
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                runtimePackPattern: "Microsoft.WindowsDesktop.App.Runtime.**RID**",
+                runtimeIdentifiers: "win-x64;win-x86;win-arm64",
+                additionalMetadata: new Dictionary<string, string>
+                {
+                    ["IsWindowsOnly"] = "true"
+                });
+
+            // WindowsForms profile: Name != RuntimeFrameworkName, shares runtime pack with parent
+            var winFormsProfileRef = CreateKnownFrameworkReference(
+                "Microsoft.WindowsDesktop.App.WindowsForms",
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                runtimePackPattern: "Microsoft.WindowsDesktop.App.Runtime.**RID**",
+                runtimeIdentifiers: "win-x64;win-x86;win-arm64",
+                additionalMetadata: new Dictionary<string, string>
+                {
+                    ["IsWindowsOnly"] = "true",
+                    ["RuntimeFrameworkName"] = "Microsoft.WindowsDesktop.App",
+                    ["Profile"] = "WindowsForms"
+                });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                EnableRuntimePackDownload = true,
+                EnableTargetingPackDownload = true,
+                EnableWindowsTargeting = true,
+                SelfContained = true,
+                NETCoreSdkRuntimeIdentifier = "osx-arm64",
+                RuntimeIdentifier = "win-arm64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
+                    // Only the profile is referenced — NOT the parent
+                    new MockTaskItem("Microsoft.WindowsDesktop.App.WindowsForms", null)
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, windowsDesktopRef, winFormsProfileRef]
+            };
+
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue("self-contained publish with WinForms profile + EnableWindowsTargeting should succeed");
+
+            // The WindowsDesktop runtime pack for win-arm64 must be downloaded even though only the profile was referenced
+            task.PackagesToDownload.Should().Contain(
+                p => p.ItemSpec == "Microsoft.WindowsDesktop.App.Runtime.win-arm64",
+                "WindowsDesktop runtime pack should be downloaded when a profile (WindowsForms) is referenced");
+
+            // NETCore runtime pack should also be resolved
+            task.PackagesToDownload.Should().Contain(
+                p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-arm64",
+                "NETCore runtime pack for win-arm64 must be downloaded");
+        }
+
         [Theory]
         [InlineData(null, "linux-x64")]
         [InlineData("linux-x64", "linux-x64")]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -212,6 +212,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             if (config.EnableSingleFileAnalyzer.HasValue) task.EnableSingleFileAnalyzer = config.EnableSingleFileAnalyzer.Value;
             if (config.ReadyToRunEnabled.HasValue) task.ReadyToRunEnabled = config.ReadyToRunEnabled.Value;
             if (config.ReadyToRunUseCrossgen2.HasValue) task.ReadyToRunUseCrossgen2 = config.ReadyToRunUseCrossgen2.Value;
+            task.EnableWindowsTargeting = config.EnableWindowsTargeting;
+            task.DisableTransitiveFrameworkReferenceDownloads = config.DisableTransitiveFrameworkReferenceDownloads;
 
             if (!string.IsNullOrEmpty(config.NetCoreRoot)) task.NetCoreRoot = config.NetCoreRoot;
             if (!string.IsNullOrEmpty(config.NETCoreSdkVersion)) task.NETCoreSdkVersion = config.NETCoreSdkVersion;
@@ -252,6 +254,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public bool? EnableSingleFileAnalyzer { get; set; }
             public bool? ReadyToRunEnabled { get; set; }
             public bool? ReadyToRunUseCrossgen2 { get; set; }
+            public bool EnableWindowsTargeting { get; set; }
+            public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
             public string? NetCoreRoot { get; set; }
             public string? NETCoreSdkVersion { get; set; }
             public string? NETCoreSdkPortableRuntimeIdentifier { get; set; }
@@ -1050,6 +1054,173 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             // AspNetCore runtime packs must not appear — it is not in FrameworkReferences
             task.PackagesToDownload.Should().NotContain(p => p.ItemSpec.StartsWith("Microsoft.AspNetCore.App.Runtime."),
                 "AspNetCore runtime pack must not be downloaded — it is not in FrameworkReferences");
+        }
+
+        [Fact]
+        public void It_only_downloads_runtime_packs_for_referenced_frameworks_in_self_contained_console_app()
+        {
+            // A self-contained console app references only Microsoft.NETCore.App.  The SDK always
+            // populates KnownFrameworkReferences with NETCore, AspNetCore, and WindowsDesktop entries.
+            // Only the NETCore runtime pack should be downloaded — not AspNetCore or WindowsDesktop.
+
+            var netCoreAppRef = CreateNetCoreAppFrameworkReference(ToolsetInfo.CurrentTargetFramework, $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0", "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var aspNetCoreRef = CreateAspNetCoreFrameworkReference(ToolsetInfo.CurrentTargetFramework, $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0", "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var windowsDesktopRef = CreateKnownFrameworkReference(
+                "Microsoft.WindowsDesktop.App",
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                runtimePackPattern: "Microsoft.WindowsDesktop.App.Runtime.**RID**",
+                runtimeIdentifiers: "win-x64;win-x86;win-arm64",
+                additionalMetadata: new Dictionary<string, string>
+                {
+                    ["IsWindowsOnly"] = "true"
+                });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                EnableRuntimePackDownload = true,
+                EnableTargetingPackDownload = true,
+                EnableWindowsTargeting = true,
+                SelfContained = true,
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                RuntimeIdentifier = "win-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                // Project only references the base .NET runtime
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                // SDK supplies knowledge of all three frameworks
+                KnownFrameworkReferences = [netCoreAppRef, aspNetCoreRef, windowsDesktopRef]
+            };
+
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue();
+
+            // NETCore runtime pack for the target RID should be queued
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64",
+                "NETCore runtime pack for win-x64 must be downloaded");
+
+            // AspNetCore runtime packs must not appear — it is not in FrameworkReferences
+            task.PackagesToDownload.Should().NotContain(p => p.ItemSpec.StartsWith("Microsoft.AspNetCore.App.Runtime."),
+                "AspNetCore runtime pack must not be downloaded — it is not in FrameworkReferences");
+
+            // WindowsDesktop runtime packs must not appear — it is not in FrameworkReferences
+            task.PackagesToDownload.Should().NotContain(p => p.ItemSpec.StartsWith("Microsoft.WindowsDesktop.App.Runtime."),
+                "WindowsDesktop runtime pack must not be downloaded — it is not in FrameworkReferences");
+        }
+
+        [Fact]
+        public void It_can_build_WindowsDesktop_on_non_Windows_with_EnableWindowsTargeting()
+        {
+            // Scenario: a Linux user has a project (or transitive dependency) that references
+            // Microsoft.WindowsDesktop.App.  With EnableWindowsTargeting=true the project should
+            // still *build* (compile against the targeting pack).  Runtime packs for Windows Desktop
+            // are only available for Windows RIDs, so a self-contained publish for linux-x64 would
+            // produce an UnavailableRuntimePack — but a plain build should succeed.
+
+            var netCoreAppRef = CreateNetCoreAppFrameworkReference(
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var windowsDesktopRef = CreateKnownFrameworkReference(
+                "Microsoft.WindowsDesktop.App",
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                runtimePackPattern: "Microsoft.WindowsDesktop.App.Runtime.**RID**",
+                runtimeIdentifiers: "win-x64;win-x86;win-arm64",
+                additionalMetadata: new Dictionary<string, string>
+                {
+                    ["IsWindowsOnly"] = "true"
+                });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                EnableRuntimePackDownload = true,
+                EnableTargetingPackDownload = true,
+                EnableWindowsTargeting = true,
+                SelfContained = false,
+                NETCoreSdkRuntimeIdentifier = "linux-x64",
+                RuntimeIdentifier = null,
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
+                    new MockTaskItem("Microsoft.WindowsDesktop.App", null)
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, windowsDesktopRef]
+            };
+
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue("a non-self-contained build should succeed even on non-Windows with EnableWindowsTargeting");
+
+            // Targeting packs for both frameworks should be queued for download
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.WindowsDesktop.App.Ref",
+                "WindowsDesktop targeting pack should be downloaded for compilation");
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref",
+                "NETCore targeting pack should be downloaded for compilation");
+
+            // No WindowsDesktop runtime packs should be queued (non-self-contained, no RID)
+            task.PackagesToDownload.Should().NotContain(p => p.ItemSpec.StartsWith("Microsoft.WindowsDesktop.App.Runtime."),
+                "WindowsDesktop runtime packs are not needed for a non-self-contained build");
+
+            // No unavailable runtime packs should be reported
+            task.UnavailableRuntimePacks.Should().BeNullOrEmpty(
+                "a plain build (no RID) should not produce unavailable runtime pack errors");
+        }
+
+        [Fact]
+        public void It_reports_unavailable_runtime_pack_for_WindowsDesktop_on_linux_self_contained()
+        {
+            // Scenario: a Linux user tries to publish self-contained for linux-x64 with a WindowsDesktop
+            // framework reference.  The WindowsDesktop runtime pack only supports Windows RIDs, so it
+            // must appear in UnavailableRuntimePacks.
+
+            var netCoreAppRef = CreateNetCoreAppFrameworkReference(
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var windowsDesktopRef = CreateKnownFrameworkReference(
+                "Microsoft.WindowsDesktop.App",
+                ToolsetInfo.CurrentTargetFramework,
+                $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0",
+                runtimePackPattern: "Microsoft.WindowsDesktop.App.Runtime.**RID**",
+                runtimeIdentifiers: "win-x64;win-x86;win-arm64",
+                additionalMetadata: new Dictionary<string, string>
+                {
+                    ["IsWindowsOnly"] = "true"
+                });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                EnableRuntimePackDownload = true,
+                EnableTargetingPackDownload = true,
+                EnableWindowsTargeting = true,
+                SelfContained = true,
+                NETCoreSdkRuntimeIdentifier = "linux-x64",
+                RuntimeIdentifier = "linux-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
+                    new MockTaskItem("Microsoft.WindowsDesktop.App", null)
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, windowsDesktopRef]
+            };
+
+            var task = CreateTask(config);
+            task.Execute().Should().BeTrue("the task should succeed — unavailable packs are reported as items, not errors");
+
+            // NETCore runtime packs should still be resolved and queued
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64",
+                "NETCore runtime pack for linux-x64 must be downloaded");
+
+            // WindowsDesktop runtime pack is not available for linux-x64
+            task.UnavailableRuntimePacks.Should().NotBeNullOrEmpty()
+                .And.Contain(p => p.ItemSpec == "Microsoft.WindowsDesktop.App",
+                    "WindowsDesktop runtime pack is unavailable for linux-x64");
         }
 
         [Theory]

--- a/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks.UnitTests/ProcessFrameworkReferencesTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             }
             """;
-        
+
         private const string WindowsRuntimeGraph = """
             {
                 "runtimes": {
@@ -41,7 +41,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 }
             }
             """;
-        
+
         private const string MultiPlatformRuntimeGraph = """
             {
                 "runtimes": {
@@ -107,8 +107,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             """;
 
         // Shared known framework references
-        private readonly MockTaskItem _validWindowsSDKKnownFrameworkReference = CreateKnownFrameworkReference(
-            "Microsoft.Windows.SDK.NET.Ref", "net5.0-windows10.0.18362", "10.0.18362.1-preview", 
+        private readonly MockTaskItem _validWindowsSDK50KnownFrameworkReference = CreateKnownFrameworkReference(
+            "Microsoft.Windows.SDK.NET.Ref", "net5.0-windows10.0.18362", "10.0.18362.1-preview",
             additionalMetadata: new Dictionary<string, string> {
                 {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
                 {"IsWindowsOnly", "true"},
@@ -116,13 +116,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"}
             });
 
-        private readonly MockTaskItem _netcoreAppKnownFrameworkReference = CreateKnownFrameworkReference(
-            "Microsoft.NETCore.App", "net5.0", "5.0.0-preview.4.20251.6", 
-            runtimePackPattern: "Microsoft.NETCore.App.Runtime.**RID**", 
+        private readonly MockTaskItem _netcoreApp50KnownFrameworkReference = CreateKnownFrameworkReference(
+            "Microsoft.NETCore.App", "net5.0", "5.0.0-preview.4.20251.6",
+            runtimePackPattern: "Microsoft.NETCore.App.Runtime.**RID**",
             runtimeIdentifiers: "win-x64");
 
         // Helper methods for creating common test objects
-        private static MockTaskItem CreateKnownFrameworkReference(string name, string targetFramework, string version, 
+        private static MockTaskItem CreateKnownFrameworkReference(string name, string targetFramework, string version,
             string? runtimePackPattern = null, string? runtimeIdentifiers = null, Dictionary<string, string>? additionalMetadata = null)
         {
             var metadata = new Dictionary<string, string>
@@ -134,7 +134,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 {"TargetingPackName", name.EndsWith(".Ref") ? name : $"{name}.Ref"},
                 {"TargetingPackVersion", version}
             };
-            
+
             if (runtimePackPattern != null) metadata["RuntimePackNamePatterns"] = runtimePackPattern;
             if (runtimeIdentifiers != null) metadata["RuntimePackRuntimeIdentifiers"] = runtimeIdentifiers;
             if (additionalMetadata != null)
@@ -142,10 +142,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 foreach (var kvp in additionalMetadata)
                     metadata[kvp.Key] = kvp.Value;
             }
-            
+
             return new MockTaskItem(name, metadata);
         }
-        
+
+        private static MockTaskItem CreateNetCoreAppFrameworkReference(string targetFramework, string version, string runtimeIdentifiers) => CreateKnownFrameworkReference("Microsoft.NETCore.App", targetFramework, version, runtimePackPattern: "Microsoft.NETCore.App.Runtime.**RID**", runtimeIdentifiers: runtimeIdentifiers);
+        private static MockTaskItem CreateAspNetCoreFrameworkReference(string targetFramework, string version, string runtimeIdentifiers) => CreateKnownFrameworkReference("Microsoft.AspNetCore.App", targetFramework, version, runtimePackPattern: "Microsoft.AspNetCore.App.Runtime.**RID**", runtimeIdentifiers: runtimeIdentifiers);
+
         private static MockTaskItem CreateKnownILCompilerPack(string targetFramework, string version, string runtimeIdentifiers)
         {
             return new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
@@ -156,14 +159,24 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ["ILCompilerRuntimeIdentifiers"] = runtimeIdentifiers
             });
         }
-        
+
         private static string CreateRuntimeGraphFile(string content)
         {
             var path = Path.GetTempFileName();
             File.WriteAllText(path, content);
             return path;
         }
-        
+
+        /// <summary>
+        /// Helper to have a project use the base .NET Runtime.
+        /// </summary>
+        private readonly MockTaskItem NetCoreAppFrameworkReference = new MockTaskItem("Microsoft.NETCore.App", null);
+
+        /// <summary>
+        /// Helper to have a project use the ASP.NET Core Runtime.
+        /// </summary>
+        private readonly MockTaskItem AspNetCoreFrameworkReference = new MockTaskItem("Microsoft.AspNetCore.App", null);
+
         private static ProcessFrameworkReferences CreateTask(TaskConfiguration config)
         {
             var task = new ProcessFrameworkReferences
@@ -179,7 +192,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = config.TargetLatestRuntimePatch,
                 TargetLatestRuntimePatchIsDefault = config.TargetLatestRuntimePatchIsDefault,
             };
-            
+
             // Set nullable properties conditionally to avoid warnings
             if (config.TargetPlatformIdentifier != null) task.TargetPlatformIdentifier = config.TargetPlatformIdentifier;
             if (config.TargetPlatformVersion != null) task.TargetPlatformVersion = config.TargetPlatformVersion;
@@ -189,7 +202,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             if (config.KnownRuntimePacks != null) task.KnownRuntimePacks = config.KnownRuntimePacks;
             if (config.KnownILLinkPacks != null) task.KnownILLinkPacks = config.KnownILLinkPacks;
             if (config.KnownILCompilerPacks != null) task.KnownILCompilerPacks = config.KnownILCompilerPacks;
-            
+
             // Set additional AOT/trimming properties
             if (config.PublishAot.HasValue) task.PublishAot = config.PublishAot.Value;
             if (config.PublishTrimmed.HasValue) task.PublishTrimmed = config.PublishTrimmed.Value;
@@ -199,17 +212,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             if (config.EnableSingleFileAnalyzer.HasValue) task.EnableSingleFileAnalyzer = config.EnableSingleFileAnalyzer.Value;
             if (config.ReadyToRunEnabled.HasValue) task.ReadyToRunEnabled = config.ReadyToRunEnabled.Value;
             if (config.ReadyToRunUseCrossgen2.HasValue) task.ReadyToRunUseCrossgen2 = config.ReadyToRunUseCrossgen2.Value;
-            
+
             if (!string.IsNullOrEmpty(config.NetCoreRoot)) task.NetCoreRoot = config.NetCoreRoot;
             if (!string.IsNullOrEmpty(config.NETCoreSdkVersion)) task.NETCoreSdkVersion = config.NETCoreSdkVersion;
             if (!string.IsNullOrEmpty(config.NETCoreSdkPortableRuntimeIdentifier)) task.NETCoreSdkPortableRuntimeIdentifier = config.NETCoreSdkPortableRuntimeIdentifier;
-            
+
             // Missing assignment that was causing the issue
             task.RuntimeIdentifiers = config.RuntimeIdentifiers;
-            
+
             return task;
         }
-        
+
         private class TaskConfiguration
         {
             public bool UseCachingEngine { get; set; }
@@ -249,26 +262,26 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [InlineData(true)]  // With target platform
         public void It_resolves_AspNetCore_FrameworkReferences(bool withTargetPlatform)
         {
-            var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", 
-                ToolsetInfo.CurrentTargetFramework, "1.9.5", additionalMetadata: new Dictionary<string, string> 
+            var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App",
+                ToolsetInfo.CurrentTargetFramework, "1.9.5", additionalMetadata: new Dictionary<string, string>
                 {
                     {"LatestRuntimeFrameworkVersion", "1.9.6"},
                     {"TargetingPackVersion", "1.9.0"}
                 });
-            
+
             var config = new TaskConfiguration
             {
                 UseCachingEngine = true,
                 TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
                 TargetPlatformIdentifier = withTargetPlatform ? "Windows" : null,
                 TargetPlatformVersion = withTargetPlatform ? "10.0.18362" : null,
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { aspNetCoreRef }
+                FrameworkReferences = [AspNetCoreFrameworkReference],
+                KnownFrameworkReferences = [aspNetCoreRef]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue();
-            
+
             task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks[0].ItemSpec.Should().Be("Microsoft.AspNetCore.App");
@@ -279,19 +292,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void It_does_not_resolve_FrameworkReferences_if_targetframework_doesnt_match()
         {
             var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", "netcoreapp3.0", "1.9.5");
-            
+
             var config = new TaskConfiguration
             {
                 UseCachingEngine = true,
                 EnableTargetingPackDownload = false, // Explicitly disable to test non-resolution
                 TargetFrameworkVersion = "2.0", // Mismatched version
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { aspNetCoreRef }
+                FrameworkReferences = [AspNetCoreFrameworkReference],
+                KnownFrameworkReferences = [aspNetCoreRef]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue();
-            
+
             task.PackagesToDownload.Should().BeNull();
             task.RuntimeFrameworks.Should().BeNull();
         }
@@ -299,27 +312,27 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void Given_KnownFrameworkReferences_with_RuntimePackAlwaysCopyLocal_It_resolves_FrameworkReferences()
         {
-            var windowsSDKRef = CreateKnownFrameworkReference("Microsoft.Windows.SDK.NET.Ref", 
-                "net5.0-windows10.0.17760", "10.0.17760.1-preview", 
+            var windowsSDKRef = CreateKnownFrameworkReference("Microsoft.Windows.SDK.NET.Ref",
+                "net5.0-windows10.0.17760", "10.0.17760.1-preview",
                 additionalMetadata: new Dictionary<string, string> {
                     {MetadataKeys.RuntimePackAlwaysCopyLocal, "true"},
                     {"IsWindowsOnly", "true"},
                     {"RuntimePackRuntimeIdentifiers", "any"},
                     {"RuntimePackNamePatterns", "Microsoft.Windows.SDK.NET.Ref"}
                 });
-                
+
             var config = new TaskConfiguration
             {
                 EnableRuntimePackDownload = true,
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
                 RuntimeGraphPath = CreateRuntimeGraphFile(MinimalRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { windowsSDKRef, _validWindowsSDKKnownFrameworkReference }
+                FrameworkReferences = [new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())],
+                KnownFrameworkReferences = [windowsSDKRef, _validWindowsSDK50KnownFrameworkReference]
             };
-            
+
             var task = CreateTask(config);
-            
+
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
@@ -329,14 +342,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.Execute().Should().BeTrue();
             task.PackagesToDownload.Should().NotBeNull().And.HaveCount(1);
             task.RuntimeFrameworks.Should().BeNullOrEmpty("Should not contain RuntimePackAlwaysCopyLocal framework");
-            
+
             // Validate targeting pack
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
             var targetingPack = task.TargetingPacks[0];
             targetingPack.ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
             targetingPack.GetMetadata(MetadataKeys.NuGetPackageId).Should().Be("Microsoft.Windows.SDK.NET.Ref");
             targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be("10.0.18362.1-preview");
-            
+
             // Validate runtime pack
             task.RuntimePacks.Should().NotBeNull().And.HaveCount(1);
             var runtimePack = task.RuntimePacks[0];
@@ -357,15 +370,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
-                FrameworkReferences = new[] {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[] { _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference }
+                ],
+                KnownFrameworkReferences = [_netcoreApp50KnownFrameworkReference, _validWindowsSDK50KnownFrameworkReference]
             };
-            
+
             var task = CreateTask(config);
-            
+
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
                 task.Execute().Should().BeTrue();
@@ -391,21 +404,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
-                FrameworkReferences = new[] {
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[] { _netcoreAppKnownFrameworkReference, _validWindowsSDKKnownFrameworkReference }
+                ],
+                KnownFrameworkReferences = [_netcoreApp50KnownFrameworkReference, _validWindowsSDK50KnownFrameworkReference]
             };
-            
+
             var task = CreateTask(config);
-            
+
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
                 return;
             }
-            
+
             task.Execute().Should().BeTrue();
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.Windows.SDK.NET.Ref");
@@ -424,7 +437,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net5.0", "5.0.0",
                 "Microsoft.NETCore.App.Runtime.**RID**", "win-x64;win-x86;linux-x64");
-                
+
             var config = new TaskConfiguration
             {
                 EnableRuntimePackDownload = true,
@@ -432,22 +445,22 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 RuntimeIdentifier = runtimeIdentifier,
                 RuntimeIdentifiers = runtimeIdentifiers,
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { netCoreAppRef }
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [netCoreAppRef]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue($"Task should succeed for scenario: {scenario}");
-            
+
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref", $"Should contain targeting pack for scenario: {scenario}");
-            
+
             // Validate expected runtime packs based on scenario
             if (runtimeIdentifiers != null && runtimeIdentifiers.Length > 0)
             {
                 foreach (var rid in runtimeIdentifiers)
                 {
-                    task.PackagesToDownload.Should().Contain(p => p.ItemSpec == $"Microsoft.NETCore.App.Runtime.{rid}", 
+                    task.PackagesToDownload.Should().Contain(p => p.ItemSpec == $"Microsoft.NETCore.App.Runtime.{rid}",
                         $"Should contain runtime pack for {rid} in scenario: {scenario}");
                 }
             }
@@ -462,14 +475,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetPlatformIdentifier = "Windows",
                 TargetPlatformVersion = "10.0.18362",
                 RuntimeIdentifier = null,
-                RuntimeIdentifiers = new[] { "win-x64" },
+                RuntimeIdentifiers = ["win-x64"],
                 RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { _validWindowsSDKKnownFrameworkReference }
+                FrameworkReferences = [new MockTaskItem("Microsoft.Windows.SDK.NET.Ref", new Dictionary<string, string>())],
+                KnownFrameworkReferences = [_validWindowsSDK50KnownFrameworkReference]
             };
-            
+
             var task = CreateTask(config);
-            
+
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("IsWindowsOnly=true");
@@ -488,14 +501,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             // This test reproduces the exact scenario from the reported issue
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.0-rc.2.25457.102",
                 "Microsoft.NETCore.App.Runtime.**RID**", "linux-arm;linux-arm64;osx-arm64;osx-x64;win-x64;win-x86");
-                
+
             var macOSRef = CreateKnownFrameworkReference("Microsoft.macOS", "net10.0", "15.5.10834-ci.darc-net10-0-3e2d6574-3e2e-4233-aab9-99cf75de33e4",
-                "Microsoft.macOS.Runtime.osx.net10.0_15.5", "osx-x64;osx-arm64", 
+                "Microsoft.macOS.Runtime.osx.net10.0_15.5", "osx-x64;osx-arm64",
                 new Dictionary<string, string> {
                     ["TargetingPackName"] = "Microsoft.macOS.Ref.net10.0_15.5",
                     ["Profile"] = "macOS"
                 });
-                
+
             var nativeAOTRuntimePack = new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
@@ -505,13 +518,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ["RuntimePackRuntimeIdentifiers"] = "osx-arm64;osx-x64;win-x64;linux-x64",
                 ["RuntimePackLabels"] = "NativeAOT"
             });
-            
+
             var ilLinkPack = new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
                 ["ILLinkPackVersion"] = "10.0.0-rc.2.25457.102"
             });
-            
+
             var ilCompilerPack = new MockTaskItem("Microsoft.DotNet.ILCompiler", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
@@ -536,31 +549,31 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 NETCoreSdkRuntimeIdentifier = "osx-arm64",
                 NETCoreSdkPortableRuntimeIdentifier = "osx-arm64",
                 RuntimeIdentifier = null, // Key: No primary RuntimeIdentifier
-                RuntimeIdentifiers = new[] { "osx-arm64", "osx-x64" }, // But has RuntimeIdentifiers
+                RuntimeIdentifiers = ["osx-arm64", "osx-x64"], // But has RuntimeIdentifiers
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
                 NetCoreRoot = "/usr/local/share/dotnet",
                 NETCoreSdkVersion = "10.0.100-rc.2.25457.102",
-                FrameworkReferences = new[] {
+                FrameworkReferences = [
                     new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" }),
                     new MockTaskItem("Microsoft.macOS", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
-                },
-                KnownFrameworkReferences = new[] { netCoreAppRef, macOSRef },
-                KnownRuntimePacks = new[] { nativeAOTRuntimePack },
-                KnownILLinkPacks = new[] { ilLinkPack },
-                KnownILCompilerPacks = new[] { ilCompilerPack }
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, macOSRef],
+                KnownRuntimePacks = [nativeAOTRuntimePack],
+                KnownILLinkPacks = [ilLinkPack],
+                KnownILCompilerPacks = [ilCompilerPack]
             };
-            
+
             var task = CreateTask(config);
-            
+
             // Key validation: The task should complete successfully without crashing
             // This was the main issue - null RuntimeIdentifier with RuntimeIdentifiers would crash
             task.Execute().Should().BeTrue("Task should not crash with null RuntimeIdentifier but present RuntimeIdentifiers");
-            
+
             // Validate that frameworks are processed correctly
             task.TargetingPacks.Should().NotBeNull();
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.macOS.Ref.net10.0_15.5");
-            
+
             // Validate that AOT tooling is processed
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec.Contains("Microsoft.DotNet.ILCompiler"), "Should include AOT compiler tooling");
@@ -577,20 +590,20 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableRuntimePackDownload = true,
                 NETCoreSdkRuntimeIdentifier = "linux-x64",
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { 
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [
                     CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "linux-x64")
-                },
-                KnownILCompilerPacks = new[] {
+                ],
+                KnownILCompilerPacks = [
                     CreateKnownILCompilerPack("net8.0", "8.0.0", "linux-x64;win-x64;osx-x64;osx-arm64")
-                },
+                ],
                 PublishAot = true
             };
-            
+
             var task = CreateTask(config);
-            
+
             task.Execute().Should().BeTrue("Task should handle AOT properties without failing");
-            
+
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64");
         }
@@ -607,17 +620,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 RuntimeIdentifier = "win-x64",
                 EnableRuntimePackDownload = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { 
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [
                     CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "win-x64")
-                }
+                ]
             };
-            
+
             var task = CreateTask(config);
             task.FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0";
-            
+
             task.Execute().Should().BeTrue("Trimming scenario should be handled");
-            
+
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
         }
@@ -633,21 +646,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableRuntimePackDownload = true,
                 NETCoreSdkRuntimeIdentifier = "osx-arm64",
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { 
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [
                     CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "osx-arm64")
-                },
-                KnownILCompilerPacks = new[] {
+                ],
+                KnownILCompilerPacks = [
                     CreateKnownILCompilerPack("net8.0", "8.0.0", "linux-x64;win-x64;osx-x64;osx-arm64")
-                },
+                ],
                 PublishAot = true,
                 PublishTrimmed = true
             };
-            
+
             var task = CreateTask(config);
-            
+
             task.Execute().Should().BeTrue("Combined publish properties should be handled");
-            
+
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.osx-arm64");
         }
@@ -660,7 +673,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             var iosFrameworkRef = CreateKnownFrameworkReference("Microsoft.iOS", "net8.0-ios17.0", "17.0.8478",
                 "Microsoft.iOS.Runtime.**RID**", "ios-arm64;iossimulator-x64;iossimulator-arm64",
                 new Dictionary<string, string> { ["Profile"] = "iOS" });
-                
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "8.0",
@@ -669,16 +682,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableRuntimePackDownload = true,
                 RuntimeIdentifier = "ios-arm64",
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { 
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem("Microsoft.iOS", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[] { netCoreRef, iosFrameworkRef }
+                ],
+                KnownFrameworkReferences = [netCoreRef, iosFrameworkRef]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue();
-            
+
             // Should include both .NET and iOS targeting packs
             task.TargetingPacks.Should().NotBeNull();
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
@@ -700,18 +713,18 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableTrimAnalyzer = trimAnalyzer,
                 EnableSingleFileAnalyzer = singleFileAnalyzer,
                 RuntimeGraphPath = CreateRuntimeGraphFile(WindowsRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { 
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [
                     CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", "win-x64")
-                }
+                ]
             };
-            
+
             var task = CreateTask(config);
             // Set framework version thresholds for analyzer support
             task.FirstTargetFrameworkVersionToSupportAotAnalyzer = "7.0";
             task.FirstTargetFrameworkVersionToSupportTrimAnalyzer = "6.0";
             task.FirstTargetFrameworkVersionToSupportSingleFileAnalyzer = "6.0";
-            
+
             task.Execute().Should().BeTrue($"Task should succeed for scenario: {scenario}");
             task.PackagesToDownload.Should().NotBeNull();
         }
@@ -724,11 +737,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             var platformFrameworkRef = CreateKnownFrameworkReference($"Microsoft.{platformId}", "net8.0", "8.0.0",
                 $"Microsoft.{platformId}.Runtime.**RID**", runtimeId,
-                new Dictionary<string, string> { 
+                new Dictionary<string, string> {
                     ["Profile"] = platformId,
                     ["IsWindowsOnly"] = (platformId == "Windows").ToString().ToLower()
                 });
-                
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "8.0",
@@ -737,25 +750,25 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 EnableRuntimePackDownload = true,
                 RuntimeIdentifier = runtimeId,
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { 
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem($"Microsoft.{platformId}", new Dictionary<string, string>())
-                },
-                KnownFrameworkReferences = new[] { 
+                ],
+                KnownFrameworkReferences = [
                     CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0", "Microsoft.NETCore.App.Runtime.**RID**", runtimeId),
-                    platformFrameworkRef 
-                }
+                    platformFrameworkRef
+                ]
             };
-            
+
             var task = CreateTask(config);
-            
+
             // Windows-only framework should fail on non-Windows
             if (platformId == "Windows" && Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 task.Execute().Should().BeFalse("Windows-only framework should fail on non-Windows platforms");
                 return;
             }
-            
+
             task.Execute().Should().BeTrue($"Should handle {platformId} platform targeting");
             task.TargetingPacks.Should().NotBeNull();
         }
@@ -765,21 +778,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         {
             // This test validates the "good" behavior from good-processframeworkreferences-selfcontained.txt
             // When SelfContained=true with a RuntimeIdentifier, runtime packs should be resolved
-            
+
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.0",
-                "Microsoft.NETCore.App.Runtime.**RID**", 
+                "Microsoft.NETCore.App.Runtime.**RID**",
                 "linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64;linux-s390x;linux-loongarch64;linux-bionic-arm;linux-bionic-arm64;linux-bionic-x64;linux-bionic-x86;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-musl-loongarch64;android-arm64;android-x64");
-            
+
             var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", "net10.0", "10.0.0",
                 "Microsoft.AspNetCore.App.Runtime.**RID**",
                 "win-x64;win-x86;osx-x64;linux-musl-x64;linux-musl-arm64;linux-x64;linux-arm;linux-arm64;linux-musl-arm;win-arm64;osx-arm64;linux-s390x;linux-loongarch64;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-loongarch64;linux-musl-loongarch64");
-            
+
             var ilLinkPack = new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
                 ["ILLinkPackVersion"] = "10.0.0"
             });
-            
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "10.0",
@@ -792,39 +805,39 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { 
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
-                },
-                KnownFrameworkReferences = new[] { netCoreAppRef, aspNetCoreRef },
-                KnownILLinkPacks = new[] { ilLinkPack }
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, aspNetCoreRef],
+                KnownILLinkPacks = [ilLinkPack]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue("SelfContained deployment should succeed");
-            
+
             // Validate PackagesToDownload contains runtime packs
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-arm64",
                 "Should download NETCore runtime pack for target RID");
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.AspNetCore.App.Runtime.linux-arm64",
                 "Should download AspNetCore runtime pack for target RID");
-            
+
             // Validate RuntimePacks output
             task.RuntimePacks.Should().NotBeNull().And.HaveCount(2, "Should have runtime packs for both frameworks");
             task.RuntimePacks.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-arm64");
             task.RuntimePacks.Should().Contain(p => p.ItemSpec == "Microsoft.AspNetCore.App.Runtime.linux-arm64");
-            
+
             // Validate RuntimeFrameworks
             task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(2);
             task.RuntimeFrameworks.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App");
             task.RuntimeFrameworks.Should().Contain(p => p.ItemSpec == "Microsoft.AspNetCore.App");
-            
+
             // Validate TargetingPacks
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.NETCore.App.Ref");
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.AspNetCore.App.Ref");
-            
+
             // Validate ILLink pack is included
             task.ImplicitPackageReferences.Should().NotBeNull();
             task.ImplicitPackageReferences.Should().Contain(p => p.ItemSpec == "Microsoft.NET.ILLink.Tasks");
@@ -836,21 +849,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             // This test validates that PublishTrimmed should trigger runtime pack resolution
             // even when SelfContained=false (addresses the issue in bad-processframeworkreferences-publishtrimmed)
             // PublishTrimmed requires runtime-specific assets, similar to SelfContained
-            
+
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.0",
-                "Microsoft.NETCore.App.Runtime.**RID**", 
+                "Microsoft.NETCore.App.Runtime.**RID**",
                 "linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm64;win-x64;win-x86;linux-musl-arm;osx-arm64;linux-s390x;linux-loongarch64;linux-bionic-arm;linux-bionic-arm64;linux-bionic-x64;linux-bionic-x86;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-musl-loongarch64;android-arm64;android-x64");
-            
+
             var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", "net10.0", "10.0.0",
                 "Microsoft.AspNetCore.App.Runtime.**RID**",
                 "win-x64;win-x86;osx-x64;linux-musl-x64;linux-musl-arm64;linux-x64;linux-arm;linux-arm64;linux-musl-arm;win-arm64;osx-arm64;linux-s390x;linux-loongarch64;linux-ppc64le;freebsd-x64;freebsd-arm64;linux-riscv64;linux-musl-riscv64;linux-loongarch64;linux-musl-loongarch64");
-            
+
             var ilLinkPack = new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
                 ["ILLinkPackVersion"] = "10.0.0"
             });
-            
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "10.0",
@@ -864,17 +877,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = false,
                 TargetLatestRuntimePatchIsDefault = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { 
-                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()),
+                FrameworkReferences = [
+                    NetCoreAppFrameworkReference,
                     new MockTaskItem("Microsoft.AspNetCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
-                },
-                KnownFrameworkReferences = new[] { netCoreAppRef, aspNetCoreRef },
-                KnownILLinkPacks = new[] { ilLinkPack }
+                ],
+                KnownFrameworkReferences = [netCoreAppRef, aspNetCoreRef],
+                KnownILLinkPacks = [ilLinkPack]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue("PublishTrimmed deployment should succeed");
-            
+
             // The key assertion: runtime packs should be resolved even when SelfContained=false
             // because PublishTrimmed requires runtime-specific assets
             task.PackagesToDownload.Should().NotBeNull();
@@ -882,19 +895,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "Should download NETCore runtime pack for PublishTrimmed even when SelfContained=false");
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.AspNetCore.App.Runtime.linux-arm64",
                 "Should download AspNetCore runtime pack for PublishTrimmed even when SelfContained=false");
-            
+
             // Validate RuntimePacks output
-            task.RuntimePacks.Should().NotBeNull().And.HaveCount(2, 
+            task.RuntimePacks.Should().NotBeNull().And.HaveCount(2,
                 "Should have runtime packs for both frameworks when PublishTrimmed=true");
             task.RuntimePacks.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-arm64");
             task.RuntimePacks.Should().Contain(p => p.ItemSpec == "Microsoft.AspNetCore.App.Runtime.linux-arm64");
-            
+
             // Validate RuntimeFrameworks
             task.RuntimeFrameworks.Should().NotBeNull().And.HaveCount(2);
-            
+
             // Validate TargetingPacks
             task.TargetingPacks.Should().NotBeNull().And.HaveCount(2);
-            
+
             // Validate ILLink pack is included for trimming
             task.ImplicitPackageReferences.Should().NotBeNull();
             task.ImplicitPackageReferences.Should().Contain(p => p.ItemSpec == "Microsoft.NET.ILLink.Tasks",
@@ -913,19 +926,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             bool selfContained, bool publishTrimmed, bool publishReadyToRun, bool publishAot, string scenario)
         {
             // This test validates that runtime packs are resolved for any scenario requiring runtime-specific assets
-            
+
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.0",
-                "Microsoft.NETCore.App.Runtime.**RID**", 
+                "Microsoft.NETCore.App.Runtime.**RID**",
                 "linux-x64;linux-arm64;win-x64;osx-x64;osx-arm64");
-            
+
             var ilLinkPack = new MockTaskItem("Microsoft.NET.ILLink.Tasks", new Dictionary<string, string>
             {
                 ["TargetFramework"] = "net10.0",
                 ["ILLinkPackVersion"] = "10.0.0"
             });
-            
+
             var ilCompilerPack = CreateKnownILCompilerPack("net10.0", "10.0.0", "linux-x64;linux-arm64;win-x64;osx-x64;osx-arm64");
-            
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "10.0",
@@ -940,20 +953,20 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetLatestRuntimePatch = true,
                 TargetLatestRuntimePatchIsDefault = true,
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { netCoreAppRef },
-                KnownILLinkPacks = new[] { ilLinkPack },
-                KnownILCompilerPacks = new[] { ilCompilerPack }
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [netCoreAppRef],
+                KnownILLinkPacks = [ilLinkPack],
+                KnownILCompilerPacks = [ilCompilerPack]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue($"Task should succeed for scenario: {scenario}");
-            
+
             // All of these scenarios require runtime-specific assets, so runtime packs should be resolved
             task.PackagesToDownload.Should().NotBeNull($"PackagesToDownload should not be null for scenario: {scenario}");
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64",
                 $"Should download runtime pack for scenario: {scenario}");
-            
+
             task.RuntimePacks.Should().NotBeNull($"RuntimePacks should not be null for scenario: {scenario}");
             task.RuntimePacks.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64",
                 $"Should have runtime pack in output for scenario: {scenario}");
@@ -964,26 +977,26 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void It_handles_complex_cross_compilation_RuntimeIdentifiers()
         {
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0",
-                "Microsoft.NETCore.App.Runtime.**RID**", 
+                "Microsoft.NETCore.App.Runtime.**RID**",
                 "linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64;alpine-x64;alpine-arm64");
-                
+
             var config = new TaskConfiguration
             {
                 TargetFrameworkVersion = "8.0",
                 EnableRuntimePackDownload = true,
                 RuntimeIdentifier = null, // No primary RID
-                RuntimeIdentifiers = new[] { "linux-x64", "linux-musl-x64", "alpine-x64", "linux-arm64" }, // Mixed supported/unsupported
+                RuntimeIdentifiers = ["linux-x64", "linux-musl-x64", "alpine-x64", "linux-arm64"], // Mixed supported/unsupported
                 RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { netCoreAppRef }
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [netCoreAppRef]
             };
-            
+
             var task = CreateTask(config);
             task.Execute().Should().BeTrue("Should handle mixed supported/unsupported RIDs gracefully");
-            
+
             task.PackagesToDownload.Should().NotBeNull();
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Ref");
-            
+
             // Should download runtime packs for supported RIDs only
             var supportedRids = new[] { "linux-x64", "linux-musl-x64", "linux-arm64" };
             foreach (var rid in supportedRids)
@@ -991,6 +1004,52 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 task.PackagesToDownload.Should().Contain(p => p.ItemSpec == $"Microsoft.NETCore.App.Runtime.{rid}",
                     $"Should include runtime pack for supported RID: {rid}");
             }
+        }
+
+        [Fact]
+        public void It_only_downloads_runtime_packs_for_referenced_frameworks_in_single_file_console_app()
+        {
+            // A single-file console app (EnableSingleFileAnalyzer, not self-contained) references only
+            // Microsoft.NETCore.App. The SDK always populates KnownFrameworkReferences with both NETCore
+            // and AspNetCore entries. When publishing with RuntimeIdentifiers the task must only queue
+            // runtime pack downloads for frameworks the project actually references — not for every
+            // KnownFrameworkReference that happens to match the TFM.
+
+            var netCoreAppRef = CreateNetCoreAppFrameworkReference(ToolsetInfo.CurrentTargetFramework, $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0", "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var aspNetCoreRef = CreateAspNetCoreFrameworkReference(ToolsetInfo.CurrentTargetFramework, $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0", "linux-x64;win-x64;osx-x64;osx-arm64");
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
+                EnableRuntimePackDownload = true,
+                EnableTargetingPackDownload = true,
+                EnableSingleFileAnalyzer = true,
+                SelfContained = false,
+                NETCoreSdkRuntimeIdentifier = "linux-x64",
+                RuntimeIdentifier = null,
+                // RuntimeIdentifiers drives the multi-RID publish download path that the fix addresses
+                RuntimeIdentifiers = ["linux-x64", "win-x64"],
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                // Project only references the base .NET runtime — not AspNetCore
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                // SDK supplies knowledge of both frameworks
+                KnownFrameworkReferences = [netCoreAppRef, aspNetCoreRef]
+            };
+
+            var task = CreateTask(config);
+            task.FirstTargetFrameworkVersionToSupportSingleFileAnalyzer = "6.0";
+            task.Execute().Should().BeTrue();
+
+            // NETCore runtime packs for each publish RID should be queued
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64",
+                "NETCore runtime pack for linux-x64 must be downloaded");
+            task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64",
+                "NETCore runtime pack for win-x64 must be downloaded");
+
+            // AspNetCore runtime packs must not appear — it is not in FrameworkReferences
+            task.PackagesToDownload.Should().NotContain(p => p.ItemSpec.StartsWith("Microsoft.AspNetCore.App.Runtime."),
+                "AspNetCore runtime pack must not be downloaded — it is not in FrameworkReferences");
         }
 
         [Theory]
@@ -1021,9 +1080,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 NETCoreSdkPortableRuntimeIdentifier = "linux-x64",
                 RuntimeIdentifier = runtimeIdentifier,
                 RuntimeGraphPath = CreateRuntimeGraphFile(NonPortableRuntimeGraph),
-                FrameworkReferences = new[] { new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string>()) },
-                KnownFrameworkReferences = new[] { netCoreAppRef },
-                KnownILCompilerPacks = new[] { ilCompilerPack }
+                FrameworkReferences = [NetCoreAppFrameworkReference],
+                KnownFrameworkReferences = [netCoreAppRef],
+                KnownILCompilerPacks = [ilCompilerPack]
             };
 
             var task = CreateTask(config);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -248,6 +248,21 @@ namespace Microsoft.NET.Build.Tasks
 
             HashSet<string> unrecognizedRuntimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
 
+            //  Build a set of RuntimeFrameworkNames that are referenced via a profile framework reference.
+            //  Profile KFRs (e.g. Microsoft.WindowsDesktop.App.WindowsForms) share a runtime pack with their
+            //  parent framework (Microsoft.WindowsDesktop.App). When a profile is referenced, the parent's
+            //  runtime pack must still be resolved and downloaded even though the parent itself is not directly
+            //  listed in the project's FrameworkReferences.
+            var runtimeFrameworkNamesReferencedViaProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kfr in knownFrameworkReferencesForTargetFramework)
+            {
+                if (!kfr.Name.Equals(kfr.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase) &&
+                    frameworkReferencesForThisProject.ContainsKey(kfr.Name))
+                {
+                    runtimeFrameworkNamesReferencedViaProfile.Add(kfr.RuntimeFrameworkName);
+                }
+            }
+
             bool windowsOnlyErrorLogged = false;
             foreach (var knownFrameworkReference in knownFrameworkReferencesForTargetFramework)
             {
@@ -396,8 +411,10 @@ namespace Microsoft.NET.Build.Tasks
                 //  Only resolve and download runtime packs for framework references that are part of this
                 //  task's input. Iterating all KnownFrameworkReferences for the TFM is required to build
                 //  targeting packs and RuntimeFramework items, but runtime pack resolution must be scoped
-                //  to frameworks the project actually references.
-                if (frameworkReferenceForThisProject != null)
+                //  to frameworks the project actually references — either directly or via a profile.
+                bool isReferencedByProject = frameworkReferenceForThisProject != null
+                    || runtimeFrameworkNamesReferencedViaProfile.Contains(knownFrameworkReference.Name);
+                if (isReferencedByProject)
                 {
                     var hasRuntimePackAlwaysCopyLocal =
                         selectedRuntimePack != null && selectedRuntimePack.Value.RuntimePackAlwaysCopyLocal;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -185,6 +185,35 @@ namespace Microsoft.NET.Build.Tasks
         private bool DeploymentModelRequiresRuntimeComponents =>
             SelfContained || ReadyToRunEnabled || RequiresILLinkPack; // RequiresILLinkPack indicates trimming/AOT scenarios, see the _ComputeToolPackInputsToProcessFrameworkReferences Target.
 
+
+        /// <summary>
+        /// Resolves all known framework references applicable to the current target framework and populates
+        /// the output lists with targeting packs, runtime frameworks, runtime packs, and packages to download.
+        /// </summary>
+        /// <remarks>
+        /// For each <see cref="KnownFrameworkReference"/> that matches the target framework, this method:
+        /// <list type="bullet">
+        ///   <item><description>Selects the best matching runtime pack for the current or requested runtime identifiers.</description></item>
+        ///   <item><description>Adds targeting pack items (resolving versions from workload manifests or pack roots).</description></item>
+        ///   <item><description>Queues targeting pack NuGet downloads when the pack is not already on disk.</description></item>
+        ///   <item><description>Adds runtime framework items (written to the runtimeconfig.json).</description></item>
+        ///   <item><description>Processes each runtime identifier (primary + additional publish RIDs) to produce runtime pack items
+        ///   and additional package downloads for self-contained, ReadyToRun, and trimming/AOT scenarios if requested</description></item>
+        ///   <item><description>Skips Windows-only frameworks (e.g. WPF, WinForms) when not targeting Windows unless the user opts in</description></item>
+        /// </list>
+        /// Profile-style framework references (e.g. WindowsForms / WPF) share a runtime pack with their parent
+        /// framework and are therefore excluded from independent runtime pack resolution.
+        /// </remarks>
+        /// <param name="packagesToDownload">Accumulates NuGet packages that must be restored before the build can continue.</param>
+        /// <param name="runtimeFrameworks">Accumulates <c>RuntimeFramework</c> items that describe the frameworks required at run time (written to runtimeconfig.json).</param>
+        /// <param name="targetingPacks">Accumulates <c>TargetingPack</c> items that supply reference assemblies for compilation.</param>
+        /// <param name="runtimePacks">Accumulates <c>RuntimePack</c> items whose assets are copied to the publish output for the primary RID.</param>
+        /// <param name="unavailableRuntimePacks">Accumulates <c>UnavailableRuntimePack</c> items for runtime identifiers that have no matching runtime pack.</param>
+        /// <param name="knownRuntimePacksForTargetFramework">
+        /// Returns all <see cref="KnownRuntimePack"/> entries applicable to the current target framework,
+        /// derived from both <see cref="KnownFrameworkReferences"/> and the standalone <see cref="KnownRuntimePacks"/> input.
+        /// Callers use this list to resolve tool packs (e.g. crossgen2, ILLink) after this method returns.
+        /// </param>
         void AddPacksForFrameworkReferences(
             List<ITaskItem> packagesToDownload,
             List<ITaskItem> runtimeFrameworks,
@@ -213,8 +242,8 @@ namespace Microsoft.NET.Build.Tasks
                 KnownRuntimePacks.Select(item => new KnownRuntimePack(item))
                                  .Where(krp => KnownFrameworkReferenceAppliesToTargetFramework(krp.TargetFramework)));
 
-            var frameworkReferenceMap = FrameworkReferences.ToDictionary(fr => fr.ItemSpec, StringComparer.OrdinalIgnoreCase);
-            Log.LogMessage(MessageImportance.Low, $"Found {frameworkReferenceMap.Count} known framework references for target framework {TargetFrameworkIdentifier}");
+            var frameworkReferencesForThisProject = FrameworkReferences.ToDictionary(fr => fr.ItemSpec, StringComparer.OrdinalIgnoreCase);
+            Log.LogMessage(MessageImportance.Low, $"Found {frameworkReferencesForThisProject.Count} known framework references for target framework {TargetFrameworkIdentifier}");
             Log.LogMessage(MessageImportance.Low, $"Found {knownRuntimePacksForTargetFramework.Count} known runtime packs for target framework {TargetFrameworkIdentifier}");
 
             HashSet<string> unrecognizedRuntimeIdentifiers = new(StringComparer.OrdinalIgnoreCase);
@@ -222,7 +251,7 @@ namespace Microsoft.NET.Build.Tasks
             bool windowsOnlyErrorLogged = false;
             foreach (var knownFrameworkReference in knownFrameworkReferencesForTargetFramework)
             {
-                frameworkReferenceMap.TryGetValue(knownFrameworkReference.Name, out ITaskItem? frameworkReference);
+                frameworkReferencesForThisProject.TryGetValue(knownFrameworkReference.Name, out ITaskItem? frameworkReferenceForThisProject);
 
                 // Handle Windows-only frameworks on non-Windows platforms
                 if (knownFrameworkReference.IsWindowsOnly &&
@@ -230,7 +259,7 @@ namespace Microsoft.NET.Build.Tasks
                     !EnableWindowsTargeting)
                 {
                     // It is an error to reference the framework from non-Windows
-                    if (!windowsOnlyErrorLogged && frameworkReference != null)
+                    if (!windowsOnlyErrorLogged && frameworkReferenceForThisProject != null)
                     {
                         Log.LogError(Strings.WindowsDesktopFrameworkRequiresWindows);
                         windowsOnlyErrorLogged = true;
@@ -240,7 +269,6 @@ namespace Microsoft.NET.Build.Tasks
                     continue;
                 }
 
-                KnownRuntimePack? selectedRuntimePack = SelectRuntimePack(frameworkReference, knownFrameworkReference, knownRuntimePacksForTargetFramework);
 
                 //  Add targeting pack and all known runtime packs to "preferred packages" list.
                 //  These are packages that will win in conflict resolution for assets that have identical assembly and file versions
@@ -248,6 +276,8 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     knownFrameworkReference.TargetingPackName
                 };
+
+                KnownRuntimePack? selectedRuntimePack = SelectRuntimePack(frameworkReferenceForThisProject, knownFrameworkReference, knownRuntimePacksForTargetFramework);
 
                 if (selectedRuntimePack is KnownRuntimePack selectedPack)
                 {
@@ -271,12 +301,8 @@ namespace Microsoft.NET.Build.Tasks
                 targetingPack.SetMetadata(MetadataKeys.NuGetPackageId, knownFrameworkReference.TargetingPackName);
                 targetingPack.SetMetadata(MetadataKeys.PackageConflictPreferredPackages, string.Join(";", preferredPackages));
 
-                string? targetingPackVersion = null;
-                if (frameworkReference != null)
-                {
-                    //  Allow targeting pack version to be overridden via metadata on FrameworkReference
-                    targetingPackVersion = frameworkReference.GetMetadata("TargetingPackVersion");
-                }
+                //  Allow targeting pack version to be overridden via metadata on FrameworkReference
+                string? targetingPackVersion = frameworkReferenceForThisProject?.GetMetadata("TargetingPackVersion");
                 if (string.IsNullOrEmpty(targetingPackVersion))
                 {
                     targetingPackVersion = knownFrameworkReference.TargetingPackVersion;
@@ -312,7 +338,7 @@ namespace Microsoft.NET.Build.Tasks
                     //  If transitive framework reference downloads are disabled, then don't download targeting packs where there isn't
                     //  a direct framework reference
                     if (EnableTargetingPackDownload &&
-                        !(DisableTransitiveFrameworkReferenceDownloads && frameworkReference == null))
+                        !(DisableTransitiveFrameworkReferenceDownloads && frameworkReferenceForThisProject == null))
                     {
                         //  Download targeting pack
                         TaskItem packageToDownload = new(knownFrameworkReference.TargetingPackName);
@@ -327,16 +353,16 @@ namespace Microsoft.NET.Build.Tasks
                 Log.LogMessage(MessageImportance.Low, $"Selected targeting pack '{targetingPack.ItemSpec}@{targetingPackVersion}'");
 
                 string runtimeFrameworkVersion = GetRuntimeFrameworkVersion(
-                    frameworkReference,
+                    frameworkReferenceForThisProject,
                     knownFrameworkReference,
                     selectedRuntimePack,
                     out string runtimePackVersion);
 
                 string? isTrimmable = null;
-                if (frameworkReference != null)
+                if (frameworkReferenceForThisProject != null)
                 {
                     // Allow IsTrimmable to be overridden via metadata on FrameworkReference
-                    isTrimmable = frameworkReference.GetMetadata(MetadataKeys.IsTrimmable);
+                    isTrimmable = frameworkReferenceForThisProject.GetMetadata(MetadataKeys.IsTrimmable);
                 }
                 if (string.IsNullOrEmpty(isTrimmable))
                 {
@@ -367,57 +393,64 @@ namespace Microsoft.NET.Build.Tasks
 
                 bool processedPrimaryRuntimeIdentifier = false;
 
-                var hasRuntimePackAlwaysCopyLocal =
-                    selectedRuntimePack != null && selectedRuntimePack.Value.RuntimePackAlwaysCopyLocal;
-                var runtimeRequiredByDeployment
-                    = DeploymentModelRequiresRuntimeComponents &&
-                      ProjectIsPlatformSpecific &&
-                      selectedRuntimePack?.HasRuntimePackages == true;
-
-                if (hasRuntimePackAlwaysCopyLocal || runtimeRequiredByDeployment)
+                //  Only resolve and download runtime packs for framework references that are part of this
+                //  task's input. Iterating all KnownFrameworkReferences for the TFM is required to build
+                //  targeting packs and RuntimeFramework items, but runtime pack resolution must be scoped
+                //  to frameworks the project actually references.
+                if (frameworkReferenceForThisProject != null)
                 {
-                    //  Find other KnownFrameworkReferences that map to the same runtime pack, if any
-                    List<string>? additionalFrameworkReferencesForRuntimePack = null;
-                    foreach (var additionalKnownFrameworkReference in knownFrameworkReferencesForTargetFramework)
+                    var hasRuntimePackAlwaysCopyLocal =
+                        selectedRuntimePack != null && selectedRuntimePack.Value.RuntimePackAlwaysCopyLocal;
+                    var runtimeRequiredByDeployment
+                        = DeploymentModelRequiresRuntimeComponents &&
+                          ProjectIsPlatformSpecific &&
+                          selectedRuntimePack?.HasRuntimePackages == true;
+
+                    if (hasRuntimePackAlwaysCopyLocal || runtimeRequiredByDeployment)
                     {
-                        if (additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase) &&
-                            !additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(additionalKnownFrameworkReference.Name, StringComparison.OrdinalIgnoreCase))
+                        //  Find other KnownFrameworkReferences that map to the same runtime pack, if any
+                        List<string>? additionalFrameworkReferencesForRuntimePack = null;
+                        foreach (var additionalKnownFrameworkReference in knownFrameworkReferencesForTargetFramework)
                         {
-                            additionalFrameworkReferencesForRuntimePack ??= [];
-                            additionalFrameworkReferencesForRuntimePack.Add(additionalKnownFrameworkReference.Name);
+                            if (additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(knownFrameworkReference.RuntimeFrameworkName, StringComparison.OrdinalIgnoreCase) &&
+                                !additionalKnownFrameworkReference.RuntimeFrameworkName.Equals(additionalKnownFrameworkReference.Name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                additionalFrameworkReferencesForRuntimePack ??= [];
+                                additionalFrameworkReferencesForRuntimePack.Add(additionalKnownFrameworkReference.Name);
+                            }
                         }
+
+                        //  Process primary runtime identifier
+                        ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier ?? RuntimeIdentifierForPlatformAgnosticComponents, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
+                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
+                            wasReferencedDirectly: true);
+
+                        processedPrimaryRuntimeIdentifier = true;
                     }
 
-                    //  Process primary runtime identifier
-                    ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier ?? RuntimeIdentifierForPlatformAgnosticComponents, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                        unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                        wasReferencedDirectly: frameworkReference != null);
-
-                    processedPrimaryRuntimeIdentifier = true;
-                }
-
-                if (RuntimeIdentifiers != null)
-                {
-                    foreach (var runtimeIdentifier in RuntimeIdentifiers)
+                    if (RuntimeIdentifiers != null)
                     {
-                        if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == EffectiveRuntimeIdentifier)
+                        foreach (var runtimeIdentifier in RuntimeIdentifiers)
                         {
-                            //  We've already processed this RID
-                            continue;
-                        }
+                            if (processedPrimaryRuntimeIdentifier && runtimeIdentifier == EffectiveRuntimeIdentifier)
+                            {
+                                //  We've already processed this RID
+                                continue;
+                            }
 
-                        if (runtimeIdentifier == RuntimeIdentifierForPlatformAgnosticComponents)
-                        {
-                            // The `any` RID represents a platform-agnostic target. As such, it has no
-                            // platform-specific runtime pack associated with it.
-                            continue;
-                        }
+                            if (runtimeIdentifier == RuntimeIdentifierForPlatformAgnosticComponents)
+                            {
+                                // The `any` RID represents a platform-agnostic target. As such, it has no
+                                // platform-specific runtime pack associated with it.
+                                continue;
+                            }
 
-                        //  Pass in null for the runtimePacks list, as for these runtime identifiers we only want to
-                        //  download the runtime packs, but not use the assets from them
-                        ProcessRuntimeIdentifier(runtimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack: null,
-                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                            wasReferencedDirectly: frameworkReference != null);
+                            //  Pass in null for the runtimePacks list, as for these runtime identifiers we only want to
+                            //  download the runtime packs, but not use the assets from them
+                            ProcessRuntimeIdentifier(runtimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack: null,
+                                unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
+                                wasReferencedDirectly: true);
+                        }
                     }
                 }
 
@@ -636,6 +669,49 @@ namespace Microsoft.NET.Build.Tasks
             return true;
         }
 
+        /// <summary>
+        /// Selects the single best-matching <see cref="KnownRuntimePack"/> for a given framework reference.
+        /// </summary>
+        /// <remarks>
+        /// Matching is performed in two steps:
+        /// <list type="number">
+        ///   <item>
+        ///     <description>
+        ///       Filter <paramref name="knownRuntimePacks"/> to entries whose <c>Name</c> equals
+        ///       <see cref="KnownFrameworkReference.RuntimeFrameworkName"/> (case-insensitive).
+        ///     </description>
+        ///   </item>
+        ///   <item>
+        ///     <description>
+        ///       Filter by runtime pack labels:
+        ///       <list type="bullet">
+        ///         <item><description>
+        ///           When <paramref name="frameworkReference"/> is <see langword="null"/> (transitive reference),
+        ///           only packs with <em>no</em> labels are eligible.
+        ///         </description></item>
+        ///         <item><description>
+        ///           When <paramref name="frameworkReference"/> is present, the pack's labels must exactly match
+        ///           the semicolon-separated <c>RuntimePackLabels</c> metadata on the item.
+        ///         </description></item>
+        ///       </list>
+        ///     </description>
+        ///   </item>
+        /// </list>
+        /// If no pack matches, <see langword="null"/> is returned (the framework has no associated runtime pack,
+        /// e.g. a profile-only reference such as WPF or WinForms whose runtime comes from its parent framework).
+        /// If more than one pack matches, <see cref="Strings.ConflictingRuntimePackInformation"/> is logged as an
+        /// error and the pack derived from <paramref name="knownFrameworkReference"/> itself is returned as a fallback.
+        /// </remarks>
+        /// <param name="frameworkReference">
+        ///   The <c>FrameworkReference</c> item from the project, or <see langword="null"/> for transitive references
+        ///   that were not explicitly listed in the project file.
+        /// </param>
+        /// <param name="knownFrameworkReference">The resolved metadata for the framework being processed.</param>
+        /// <param name="knownRuntimePacks">
+        ///   All <see cref="KnownRuntimePack"/> entries applicable to the current target framework, as produced by
+        ///   <see cref="AddPacksForFrameworkReferences"/>.
+        /// </param>
+        /// <returns>The matching <see cref="KnownRuntimePack"/>, or <see langword="null"/> if none applies.</returns>
         private KnownRuntimePack? SelectRuntimePack(ITaskItem? frameworkReference, KnownFrameworkReference knownFrameworkReference, List<KnownRuntimePack> knownRuntimePacks)
         {
             var requiredLabelsMetadata = frameworkReference?.GetMetadata(MetadataKeys.RuntimePackLabels) ?? "";
@@ -919,7 +995,6 @@ namespace Microsoft.NET.Build.Tasks
                                     aotPackRuntimeIdentifiers.Add(aotPackRuntimeIdentifier);
                                 }
                             }
-                            
 
                             foreach (var aotPackRuntimeIdentifier in aotPackRuntimeIdentifiers)
                             {
@@ -961,7 +1036,6 @@ namespace Microsoft.NET.Build.Tasks
                                         TargetILCompilerPacks = new[] { targetIlcPack };
                                         Log.LogMessage(MessageImportance.Low, $"Added {targetIlcPackName}@{packVersion} for cross-targeting compilation for {aotPackRuntimeIdentifier}");
                                     }
-                                    
 
                                     string? targetILCompilerPackPath = GetPackPath(targetIlcPackName, packVersion);
                                     if (targetILCompilerPackPath != null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -774,6 +774,7 @@ namespace Microsoft.NET.Build.Tasks
             var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
             var knownFrameworkReferenceRuntimePackExcludedRuntimeIdentifiers = selectedRuntimePack.RuntimePackExcludedRuntimeIdentifiers.Split(';');
             Log.LogMessage(MessageImportance.Low, $"Finding best RID match for pack {selectedRuntimePack.Name}@{runtimePackVersion} for target RID '{runtimeIdentifier}' from '{selectedRuntimePack.RuntimePackRuntimeIdentifiers}' excluding '{selectedRuntimePack.RuntimePackExcludedRuntimeIdentifiers}'");
+            // this acts as a compat check so we know that we are choosing one of the packs that does exist for the framework reference
             string? runtimePackRuntimeIdentifier = NuGetUtils.GetBestMatchingRidWithExclusion(
                     runtimeGraph,
                     runtimeIdentifier,

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -439,8 +439,7 @@ namespace Microsoft.NET.Build.Tasks
 
                         //  Process primary runtime identifier
                         ProcessRuntimeIdentifier(EffectiveRuntimeIdentifier ?? RuntimeIdentifierForPlatformAgnosticComponents, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack,
-                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                            wasReferencedDirectly: true);
+                            unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary);
 
                         processedPrimaryRuntimeIdentifier = true;
                     }
@@ -465,8 +464,7 @@ namespace Microsoft.NET.Build.Tasks
                             //  Pass in null for the runtimePacks list, as for these runtime identifiers we only want to
                             //  download the runtime packs, but not use the assets from them
                             ProcessRuntimeIdentifier(runtimeIdentifier, runtimePackForRuntimeIDProcessing, runtimePackVersion, additionalFrameworkReferencesForRuntimePack: null,
-                                unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary,
-                                wasReferencedDirectly: true);
+                                unrecognizedRuntimeIdentifiers, unavailableRuntimePacks, runtimePacks: null, packagesToDownload, isTrimmable, useRuntimePackAndDownloadIfNecessary);
                         }
                     }
                 }
@@ -784,8 +782,7 @@ namespace Microsoft.NET.Build.Tasks
             List<ITaskItem>? runtimePacks,
             List<ITaskItem> packagesToDownload,
             string? isTrimmable,
-            bool addRuntimePackAndDownloadIfNecessary,
-            bool wasReferencedDirectly)
+            bool addRuntimePackAndDownloadIfNecessary)
         {
             var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
             var knownFrameworkReferenceRuntimePackRuntimeIdentifiers = selectedRuntimePack.RuntimePackRuntimeIdentifiers.Split(';');
@@ -803,11 +800,10 @@ namespace Microsoft.NET.Build.Tasks
             {
                 if (wasInGraph)
                 {
-                    //  Report this as an error later, if necessary.  This is because we try to download
-                    //  all available runtime packs in case there is a transitive reference to a shared
-                    //  framework we don't directly reference.  But we don't want to immediately error out
-                    //  here if a runtime pack that we might not need to reference isn't available for the
-                    //  targeted RID (e.g. Microsoft.WindowsDesktop.App for a linux RID).
+                    //  Report this as an error later, if necessary.  Not all runtime packs
+                    //  are available for all RIDs (e.g. Microsoft.WindowsDesktop.App for a
+                    //  linux RID), so we defer the error to ResolveRuntimePackAssets where
+                    //  we can check if the pack is actually needed.
                     var unavailableRuntimePack = new TaskItem(selectedRuntimePack.Name);
                     unavailableRuntimePack.SetMetadata(MetadataKeys.RuntimeIdentifier, runtimeIdentifier);
                     unavailableRuntimePacks.Add(unavailableRuntimePack);
@@ -858,8 +854,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
 
                     if (EnableRuntimePackDownload &&
-                        runtimePackPath == null &&
-                        (wasReferencedDirectly || !DisableTransitiveFrameworkReferenceDownloads))
+                        runtimePackPath == null)
                     {
                         TaskItem packageToDownload = new(runtimePackName);
                         packageToDownload.SetMetadata(MetadataKeys.Version, resolvedRuntimePackVersion);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -24,6 +24,8 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool DisableTransitiveFrameworkReferenceDownloads { get; set; }
 
+        public string RuntimeIdentifier { get; set; }
+
         [Output]
         public ITaskItem[] RuntimePackAssets { get; set; }
 
@@ -42,16 +44,76 @@ namespace Microsoft.NET.Build.Tasks
                         fxReference.ItemSpec.Equals(rtFx.GetMetadata(MetadataKeys.FrameworkName), StringComparison.OrdinalIgnoreCase)))
                         .ToList() : null;
 
-            HashSet<string> frameworkReferenceNames = new(FrameworkReferences.Select(item => item.ItemSpec), StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, ITaskItem> frameworkReferencesByName = new(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in FrameworkReferences)
+            {
+                // Last one wins in case of duplicates, matching prior HashSet behavior
+                frameworkReferencesByName[item.ItemSpec] = item;
+            }
 
+            //  UnavailableRuntimePacks are produced by ProcessFrameworkReferences for directly-referenced
+            //  frameworks whose runtime pack has no matching RID.  PFR runs before transitive framework
+            //  references are added, so these items only cover direct references.
+            HashSet<string> unavailableRuntimePackNames = new(StringComparer.OrdinalIgnoreCase);
             foreach (var unavailableRuntimePack in UnavailableRuntimePacks)
             {
-                if (frameworkReferenceNames.Contains(unavailableRuntimePack.ItemSpec))
+                unavailableRuntimePackNames.Add(unavailableRuntimePack.ItemSpec);
+
+                if (frameworkReferencesByName.ContainsKey(unavailableRuntimePack.ItemSpec))
                 {
-                    //  This is a runtime pack that should be used, but wasn't available for the specified RuntimeIdentifier
                     //  NETSDK1082: There was no runtime pack for {0} available for the specified RuntimeIdentifier '{1}'.
                     Log.LogError(Strings.NoRuntimePackAvailable, unavailableRuntimePack.ItemSpec,
                         unavailableRuntimePack.GetMetadata(MetadataKeys.RuntimeIdentifier));
+                }
+            }
+
+            //  Detect transitive framework references whose runtime packs were never processed.
+            //  ProcessFrameworkReferences runs before AddTransitiveFrameworkReferences, so transitive
+            //  refs never get RuntimePack or UnavailableRuntimePack items.  We detect them here by
+            //  finding FrameworkReferences marked IsTransitiveFrameworkReference=true that:
+            //    - are non-profile frameworks (have a RuntimeFramework where FrameworkName == ItemSpec)
+            //    - have no ResolvedRuntimePack
+            //    - have no UnavailableRuntimePack
+            if (RuntimeFrameworks != null)
+            {
+                //  Build the set of non-profile framework names that should have their own runtime packs.
+                //  A non-profile RuntimeFramework has FrameworkName == ItemSpec (e.g. Microsoft.AspNetCore.App).
+                //  Profiles (e.g. Microsoft.WindowsDesktop.App.WindowsForms) have FrameworkName != ItemSpec
+                //  and share their parent's runtime pack.
+                HashSet<string> frameworksWithOwnRuntimePack = new(StringComparer.OrdinalIgnoreCase);
+                foreach (var rtFx in RuntimeFrameworks)
+                {
+                    var frameworkName = rtFx.GetMetadata(MetadataKeys.FrameworkName);
+                    if (rtFx.ItemSpec.Equals(frameworkName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        frameworksWithOwnRuntimePack.Add(frameworkName);
+                    }
+                }
+
+                //  Build the set of framework names that have a resolved runtime pack
+                HashSet<string> resolvedRuntimePackFrameworkNames = new(StringComparer.OrdinalIgnoreCase);
+                foreach (var runtimePack in ResolvedRuntimePacks)
+                {
+                    resolvedRuntimePackFrameworkNames.Add(runtimePack.GetMetadata(MetadataKeys.FrameworkName));
+                }
+
+                foreach (var kvp in frameworkReferencesByName)
+                {
+                    var fxName = kvp.Key;
+                    var fxItem = kvp.Value;
+
+                    bool isTransitive = fxItem.GetMetadata("IsTransitiveFrameworkReference")
+                        is string val && val.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+                    if (isTransitive
+                        && frameworksWithOwnRuntimePack.Contains(fxName)
+                        && !resolvedRuntimePackFrameworkNames.Contains(fxName)
+                        && !unavailableRuntimePackNames.Contains(fxName))
+                    {
+                        //  NETSDK1235: transitive framework reference has no runtime pack available.
+                        Log.LogError(Strings.NoRuntimePackAvailable_TransitiveReference, fxName,
+                            RuntimeIdentifier ?? string.Empty);
+                    }
                 }
             }
 
@@ -59,11 +121,11 @@ namespace Microsoft.NET.Build.Tasks
 
             foreach (var runtimePack in ResolvedRuntimePacks)
             {
-                if (!frameworkReferenceNames.Contains(runtimePack.GetMetadata(MetadataKeys.FrameworkName)))
+                if (!frameworkReferencesByName.ContainsKey(runtimePack.GetMetadata(MetadataKeys.FrameworkName)))
                 {
                     var additionalFrameworkReferences = runtimePack.GetMetadata(MetadataKeys.AdditionalFrameworkReferences);
                     if (additionalFrameworkReferences == null ||
-                        !additionalFrameworkReferences.Split(';').Any(afr => frameworkReferenceNames.Contains(afr)))
+                        !additionalFrameworkReferences.Split(';').Any(afr => frameworkReferencesByName.ContainsKey(afr)))
                     {
                         //  This is a runtime pack for a shared framework that ultimately wasn't referenced, so don't include its assets
                         continue;

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -68,8 +68,11 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             //  Detect transitive framework references whose runtime packs were never processed.
-            //  ProcessFrameworkReferences runs before AddTransitiveFrameworkReferences, so transitive
-            //  refs never get RuntimePack or UnavailableRuntimePack items.  We detect them here by
+            //  ProcessFrameworkReferences runs before NuGet restore (as it adds items to download),
+            //  while AddTransitiveFrameworkReferences runs after restore (as transitive references
+            //  may come from NuGet packages).  Because of this ordering, transitive refs never get
+            //  RuntimePack or UnavailableRuntimePack items from ProcessFrameworkReferences.
+            //  We detect them here by
             //  finding FrameworkReferences marked IsTransitiveFrameworkReference=true that:
             //    - are non-profile frameworks (have a RuntimeFramework where FrameworkName == ItemSpec)
             //    - have no ResolvedRuntimePack

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -547,7 +547,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                               UnavailableRuntimePacks="@(UnavailableRuntimePack)"
                               SatelliteResourceLanguages="$(SatelliteResourceLanguages)"
                               DesignTimeBuild="$(DesignTimeBuild)"
-                              DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)">
+                              DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)"
+                              RuntimeIdentifier="$(RuntimeIdentifier)">
       <Output TaskParameter="RuntimePackAssets" ItemName="RuntimePackAsset" />
     </ResolveRuntimePackAssets>
 

--- a/test/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -13,45 +13,23 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TargetingPacksAreNotDownloadedIfNotDirectlyReferenced(bool referenceAspNet)
-        {
-            TestPackagesNotDownloaded(referenceAspNet, selfContained: false);
-        }
-
         [Fact]
-        public void RuntimePacksAreNotDownloadedIfNotDirectlyReferenced()
+        public void TargetingPacksAreNotDownloadedIfNotDirectlyReferenced()
         {
-            TestPackagesNotDownloaded(referenceAspNet: false, selfContained: true);
-        }
+            // With DisableTransitiveFrameworkReferenceDownloads=true, only targeting packs for
+            // directly referenced frameworks should be downloaded — not for transitive ones.
+            // Since this project only references NETCore.App (implicitly), only that targeting
+            // pack should appear in the packages folder.
+            string nugetPackagesFolder = _testAssetsManager.CreateTestDirectory(identifier: "packages").Path;
 
-        void TestPackagesNotDownloaded(bool referenceAspNet, bool selfContained, [CallerMemberName] string testName = null)
-        {
-            string nugetPackagesFolder = _testAssetsManager.CreateTestDirectory(testName, identifier: "packages_" + referenceAspNet).Path;
-
-            var testProject = new TestProject(testName)
+            var testProject = new TestProject()
             {
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true,
             };
 
-            if (selfContained)
-            {
-                testProject.RuntimeIdentifier = EnvironmentInfo.GetCompatibleRid();
-                testProject.SelfContained = "true";
-            }
-            else
-            {
-                //  Don't use AppHost in order to avoid additional download to packages folder
-                testProject.AdditionalProperties["UseAppHost"] = "False";
-            }
-
-            if (referenceAspNet)
-            {
-                testProject.FrameworkReferences.Add("Microsoft.AspNetCore.App");
-            }
+            //  Don't use AppHost in order to avoid additional download to packages folder
+            testProject.AdditionalProperties["UseAppHost"] = "False";
 
             testProject.AdditionalProperties["DisableTransitiveFrameworkReferenceDownloads"] = "True";
             testProject.AdditionalProperties["RestorePackagesPath"] = nugetPackagesFolder;
@@ -65,7 +43,7 @@ namespace Microsoft.NET.Build.Tests
             //  root, we need to allow it to succeed even if it can't find that data.
             testProject.AdditionalProperties["AllowMissingPrunePackageData"] = "true";
 
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, testName, identifier: referenceAspNet.ToString());
+            var testAsset = _testAssetsManager.CreateTestProject(testProject);
 
             var buildCommand = new BuildCommand(testAsset);
 
@@ -78,29 +56,8 @@ namespace Microsoft.NET.Build.Tests
                 "microsoft.netcore.app.ref"
             };
 
-            if (selfContained)
-            {
-                expectedPackages.Add("microsoft.netcore.app.runtime.**RID**");
-                expectedPackages.Add("microsoft.netcore.app.host.**RID**");
-            }
-
-            if (referenceAspNet)
-            {
-                expectedPackages.Add("microsoft.aspnetcore.app.ref");
-            }
-
             Directory.EnumerateDirectories(nugetPackagesFolder)
                 .Select(Path.GetFileName)
-                .Select(package =>
-                {
-                    if (package.Contains(".runtime.") || (package.Contains(".host.")))
-                    {
-                        //  Replace RuntimeIdentifier, which should be the last dotted segment in the package name, with "**RID**"
-                        package = package.Substring(0, package.LastIndexOf('.') + 1) + "**RID**";
-                    }
-
-                    return package;
-                })
                 .Should().BeEquivalentTo(expectedPackages);
         }
 
@@ -178,11 +135,14 @@ namespace Microsoft.NET.Build.Tests
 
             var buildCommand = new BuildCommand(testAsset);
 
+            //  ProcessFrameworkReferences runs before AddTransitiveFrameworkReferences, so it never
+            //  creates RuntimePack items for the transitive ASP.NET reference.  ResolveRuntimePackAssets
+            //  detects this and reports NETSDK1235, suggesting the user add a direct FrameworkReference.
             buildCommand
                 .Execute()
                 .Should()
                 .Fail()
-                .And.HaveStdOutContaining("NETSDK1185:");
+                .And.HaveStdOutContaining("NETSDK1235:");
         }
 
     }


### PR DESCRIPTION
Potential fix for #53386

We should only add runtime packs to the PackagesToDownload if they are required for the FrameworkReferences that the user's project is actually referencing.  We have this idea of 'transitive' framework references currently, but that doesn't seem to distinguish between just 'known' framework references and those that are truly transitive.