### PR TITLE
Fix CA1825 false positive on collection expressions

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
@@ -18,5 +18,10 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         {
             return node is AttributeSyntax;
         }
+
+        protected override bool IsCollectionExpressionSyntax(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKindEx.CollectionExpression);
+        }
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.NetCore.Analyzers.Runtime;
+using Analyzer.Utilities.Lightup;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.Fixer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // When Type is null in cases like 'T[] goo = { }', use ConvertedType instead (https://github.com/dotnet/roslyn/issues/23545).
             // When Type isn't null, do not use ConvertedType. For cases like `object[] goo = new string[0]`,
             // we want to return the string type symbol, not the object one.
-            var arrayType = (IArrayTypeSymbol?)(typeInfo.Type ?? typeInfo.ConvertedType);
+            var arrayType = (typeInfo.Type ?? typeInfo.ConvertedType) as IArrayTypeSymbol;
             return arrayType?.ElementType;
         }
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             // Bail out for compiler-generated array creations synthesized
             // during lowering of collection expressions (e.g. `List<int> x = [1, 2, 3]`).
-            if (arrayCreationExpression.Syntax.AncestorsAndSelf().Any(isCollectionExpressionSyntax))
+            if (isCollectionExpressionSyntax(arrayCreationExpression.Syntax))
             {
                 return;
             }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -68,12 +68,19 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType)
         {
-            AnalyzeOperation(context, arrayEmptyMethodSymbol, linqExpressionType, IsAttributeSyntax);
+            AnalyzeOperation(context, arrayEmptyMethodSymbol, linqExpressionType, IsAttributeSyntax, IsCollectionExpressionSyntax);
         }
 
-        private static void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType, Func<SyntaxNode, bool> isAttributeSyntax)
+        private static void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType, Func<SyntaxNode, bool> isAttributeSyntax, Func<SyntaxNode, bool> isCollectionExpressionSyntax)
         {
             IArrayCreationOperation arrayCreationExpression = (IArrayCreationOperation)context.Operation;
+
+            // Bail out for compiler-generated array creations synthesized
+            // during lowering of collection expressions (e.g. `List<int> x = [1, 2, 3]`).
+            if (arrayCreationExpression.Syntax.AncestorsAndSelf().Any(isCollectionExpressionSyntax))
+            {
+                return;
+            }
 
             // We can't replace array allocations in attributes, as they're persisted to metadata
             // TODO: Once we have operation walkers, we can replace this syntactic check with an operation-based check.
@@ -192,5 +199,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         }
 
         protected abstract bool IsAttributeSyntax(SyntaxNode node);
+
+        /// <summary>
+        /// Checks whether the given syntax node represents a collection expression (e.g. <c>[1, 2, 3]</c> in C#).
+        /// </summary>
+        protected abstract bool IsCollectionExpressionSyntax(SyntaxNode node);
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
@@ -16,5 +16,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Protected Overrides Function IsAttributeSyntax(node As SyntaxNode) As Boolean
             Return TypeOf node Is AttributeSyntax
         End Function
+
+        Protected Overrides Function IsCollectionExpressionSyntax(node As SyntaxNode) As Boolean
+            Return False
+        End Function
     End Class
 End Namespace

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -803,5 +803,41 @@ class C
                 TestCode = source,
             }.RunAsync();
         }
+
+        [Fact]
+        [WorkItem(82484, "https://github.com/dotnet/roslyn/issues/82484")]
+        public async Task DiagnosticForZeroLengthArrayInsideCollectionExpression_CSharpAsync()
+        {
+            const string badSource = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    List<int[]> l1 = [new int[0]];
+}
+";
+            const string fixedSource = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    List<int[]> l1 = [Array.Empty<int>()];
+}
+";
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+                TestCode = badSource,
+                FixedCode = fixedSource,
+                ExpectedDiagnostics =
+                {
+#pragma warning disable RS0030 // Do not use banned APIs
+                    VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(7, 23).WithArguments("Array.Empty<int>()"),
+#pragma warning restore RS0030 // Do not use banned APIs
+                },
+            }.RunAsync();
+        }
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -764,5 +764,44 @@ End Class
 ";
             await VerifyVB.VerifyCodeFixAsync(source, source);
         }
+
+        [Fact]
+        [WorkItem(82484, "https://github.com/dotnet/roslyn/issues/82484")]
+        public async Task NoDiagnosticForCollectionExpression_NonArrayTargetType_CSharpAsync()
+        {
+            const string source = @"
+using System.Collections.Generic;
+
+class C
+{
+    List<string> l1 = [""a"", ""b"", ""c""];
+    List<int> l2 = [];
+    IEnumerable<int> l3 = [1, 2, 3];
+}
+";
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+                TestCode = source,
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(82484, "https://github.com/dotnet/roslyn/issues/82484")]
+        public async Task NoDiagnosticForCollectionExpression_EmptyArrayTargetType_CSharpAsync()
+        {
+
+            const string source = @"
+class C
+{
+    int[] arr = [];
+}
+";
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+                TestCode = source,
+            }.RunAsync();
+        }
     }
 }


### PR DESCRIPTION
Fixes dotnet/roslyn#82484

In .NET 11, the compiler lowers collection expressions and CA1825 incorrectly flagged these as zero-length array allocations, and the code fixer crashed with an InvalidCastException when the target type wasn't an array.

This adds a check in the analyzer to skip array creation operations whose syntax originates from a collection expression and switches from a direct cast to an as cast.