### PR TITLE
[dotnet run] Fix `NETSDK1005` when project refs different TFMs

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
@@ -33,6 +33,10 @@ internal sealed class RunCommandSelector : IDisposable
     private ProjectCollection? _collection;
     private Microsoft.Build.Evaluation.Project? _project;
 
+    // Project/collection without TargetFramework, used for restore. Lazily populated.
+    private ProjectCollection? _restoreCollection;
+    private Microsoft.Build.Evaluation.Project? _restoreProject;
+
     /// <summary>
     /// Gets whether the selector has a valid project that can be evaluated.
     /// This is false for .sln files or other invalid project files.
@@ -137,15 +141,29 @@ internal sealed class RunCommandSelector : IDisposable
     /// </summary>
     public void InvalidateGlobalProperties(Dictionary<string, string> updatedProperties)
     {
+        // When TargetFramework is first added, save the current project for restore use
+        // instead of disposing it. See https://github.com/dotnet/sdk/issues/53488
+        if (_restoreProject is null &&
+            _project is not null &&
+            updatedProperties.ContainsKey("TargetFramework") &&
+            !_globalProperties.ContainsKey("TargetFramework"))
+        {
+            _restoreProject = _project;
+            _restoreCollection = _collection;
+        }
+        else
+        {
+            _collection?.Dispose();
+        }
+
         // Update our stored global properties
         foreach (var (key, value) in updatedProperties)
         {
             _globalProperties[key] = value;
         }
 
-        // Dispose existing project to force re-evaluation
+        // Reset to force re-evaluation with new global properties
         _project = null;
-        _collection?.Dispose();
         _collection = null;
         HasValidProject = false;
     }
@@ -188,6 +206,38 @@ internal sealed class RunCommandSelector : IDisposable
     {
         // NOTE: _binaryLogger is not disposed here because it is *owned* by the caller
         _collection?.Dispose();
+        _restoreCollection?.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a ProjectInstance without TargetFramework for use during restore,
+    /// preventing the TFM from cascading to dependency projects.
+    /// Reuses the pre-TF project when available (saved by InvalidateGlobalProperties),
+    /// or the current project if it was already loaded without TargetFramework.
+    /// </summary>
+    private ProjectInstance CreateRestoreProjectInstance()
+    {
+        if (_restoreProject is not null)
+        {
+            return _restoreProject.CreateProjectInstance();
+        }
+
+        // If the current project was loaded without TargetFramework, reuse it directly.
+        if (_project is not null && !_globalProperties.ContainsKey("TargetFramework"))
+        {
+            return _project.CreateProjectInstance();
+        }
+
+        // TargetFramework is set and no pre-TF project was saved (e.g. --framework was explicit).
+        // Create a new project without TargetFramework.
+        var restoreProperties = new Dictionary<string, string>(_globalProperties, StringComparer.OrdinalIgnoreCase);
+        restoreProperties.Remove("TargetFramework");
+        _restoreCollection = new ProjectCollection(
+            globalProperties: restoreProperties,
+            loggers: null,
+            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+        _restoreProject = _restoreCollection.LoadProject(_projectFilePath);
+        return _restoreProject.CreateProjectInstance();
     }
 
     /// <summary>
@@ -290,8 +340,9 @@ internal sealed class RunCommandSelector : IDisposable
         // If restore is allowed, run restore first so device computation sees the restored assets
         if (!noRestore)
         {
-            // Run the Restore target
-            var restoreResult = projectInstance.Build(
+            // Run restore without TargetFramework to prevent it from cascading to
+            // dependency projects. See https://github.com/dotnet/sdk/issues/53488
+            var restoreResult = CreateRestoreProjectInstance().Build(
                 targets: ["Restore"],
                 loggers: GetLoggers(),
                 remoteLoggers: null,

--- a/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/App/App.csproj
+++ b/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/App/App.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(CurrentTargetFramework)-windows;$(CurrentTargetFramework)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharedLib\SharedLib.csproj" />
+  </ItemGroup>
+  <Target Name="ComputeAvailableDevices" Returns="@(AvailableDevice)">
+    <ItemGroup>
+      <AvailableDevice Include="local-machine" Description="Local Machine" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/App/Program.cs
+++ b/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/App/Program.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+Console.WriteLine(SharedLib.Helper.GetMessage());

--- a/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/SharedLib/Helper.cs
+++ b/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/SharedLib/Helper.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace SharedLib;
+
+public static class Helper
+{
+    public static string GetMessage() => "This string came from the test library!";
+}

--- a/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/SharedLib/SharedLib.csproj
+++ b/test/TestAssets/TestProjects/RunWindowsAppWithLibRef/SharedLib/SharedLib.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -1050,6 +1050,44 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             }
         }
 
+        [WindowsOnlyFact]
+        public void ItCanRunWindowsAppReferencingNonPlatformSpecificLibrary()
+        {
+            // Reproduces https://github.com/dotnet/sdk/issues/53488 with explicit --framework:
+            // dotnet run -f <platform-specific-TFM> fails with NETSDK1005 when
+            // the project references a library that targets only the base TFM.
+            var testInstance = _testAssetsManager.CopyTestAsset("RunWindowsAppWithLibRef")
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(Path.Combine(testInstance.Path, "App"))
+                .Execute("--framework", $"{ToolsetInfo.CurrentTargetFramework}-windows")
+                .Should().Pass()
+                .And.HaveStdOutContaining("This string came from the test library!");
+        }
+
+        [WindowsOnlyFact]
+        public void ItCanRunWindowsAppReferencingNonPlatformSpecificLibraryWithoutExplicitFramework()
+        {
+            // Same scenario as above but without --framework: exercises the
+            // auto-selected TFM path (saved pre-TF project reuse).
+            var testInstance = _testAssetsManager.CopyTestAsset("RunWindowsAppWithLibRef")
+                .WithSource();
+
+            // Reduce to a single-entry TargetFrameworks so the framework is auto-selected.
+            var appCsproj = Path.Combine(testInstance.Path, "App", "App.csproj");
+            File.WriteAllText(appCsproj, File.ReadAllText(appCsproj)
+                .Replace(
+                    $"<TargetFrameworks>{ToolsetInfo.CurrentTargetFramework}-windows;{ToolsetInfo.CurrentTargetFramework}</TargetFrameworks>",
+                    $"<TargetFrameworks>{ToolsetInfo.CurrentTargetFramework}-windows</TargetFrameworks>"));
+
+            new DotnetCommand(Log, "run")
+                .WithWorkingDirectory(Path.Combine(testInstance.Path, "App"))
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("This string came from the test library!");
+        }
+
         [Fact]
         public void ItCanRunWithExecutableLaunchProfile()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/53488

`TryComputeAvailableDevices` was running restore with `$(TargetFramework)` as a global MSBuild property, which cascaded to dependency projects and corrupted their `project.assets.json` (e.g. restoring a `net10.0` library for `net10.0-windows`).

Add `CreateRestoreProjectInstance()` that provides a `ProjectInstance` *without* `TargetFramework` for restore, matching `RestoringCommand` behavior. When `TargetFramework` is selected interactively, the pre-TF project is reused. When `--framework` is explicit, a temporary one is created lazily.

Created tests for both scenarios: `--framework` and automatic selection.