### PR TITLE
Warn when a vulnerable or EOL SDK version is resolved

### DIFF
--- a/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
+++ b/src/Cli/dotnet/Commands/Restore/RestoringCommand.cs
@@ -4,6 +4,7 @@
 using System.Collections.ObjectModel;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
+using Microsoft.DotNet.Cli.SdkVulnerability;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 
@@ -41,6 +42,7 @@ public class RestoringCommand : MSBuildForwardingApp
     {
         userProfileDir = CliFolderPathCalculator.DotnetUserProfileFolderPath;
         Task.Run(() => WorkloadManifestUpdater.BackgroundUpdateAdvertisingManifestsAsync(userProfileDir));
+        SdkVulnerabilityNotifier.BackgroundUpdateCacheIfNeeded();
         SeparateRestoreCommand = GetSeparateRestoreCommand(msbuildArgs, noRestore, msbuildPath);
         AdvertiseWorkloadUpdates = advertiseWorkloadUpdates ?? msbuildArgs.OtherMSBuildArgs.All(arg => FlagsThatTriggerSilentRestore.All(f => !arg.Contains(f, StringComparison.OrdinalIgnoreCase)));
 

--- a/src/Cli/dotnet/SdkVulnerability/SdkReleaseMetadataCache.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkReleaseMetadataCache.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.DotNet.Configurer;
+
+namespace Microsoft.DotNet.Cli.SdkVulnerability;
+
+/// <summary>
+/// Manages a local cache of .NET release metadata used for SDK vulnerability and EOL checks.
+/// The cache lives at ~/.dotnet/sdk-vulnerability-cache/ and is refreshed in the background
+/// on a sentinel-based interval (default 24 hours).
+/// </summary>
+internal sealed class SdkReleaseMetadataCache
+{
+    private const string CacheDirectoryName = "sdk-vulnerability-cache";
+    private const string SentinelFileName = ".sentinel";
+    private const string SummaryFilePrefix = "sdk-status-";
+    private const int DefaultUpdateIntervalHours = 24;
+
+    private readonly string _cacheDirectory;
+    private readonly Func<string, string?> _getEnvironmentVariable;
+
+    public SdkReleaseMetadataCache()
+        : this(
+            Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath, CacheDirectoryName),
+            Environment.GetEnvironmentVariable)
+    {
+    }
+
+    internal SdkReleaseMetadataCache(string cacheDirectory, Func<string, string?> getEnvironmentVariable)
+    {
+        _cacheDirectory = cacheDirectory;
+        _getEnvironmentVariable = getEnvironmentVariable;
+    }
+
+    /// <summary>
+    /// Returns true if the vulnerability check is disabled via environment variable.
+    /// </summary>
+    public bool IsDisabled()
+    {
+        return bool.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_DISABLE), out bool disabled) && disabled;
+    }
+
+    /// <summary>
+    /// Returns true if the sentinel file indicates the cache is due for a refresh.
+    /// </summary>
+    public bool IsDueForUpdate()
+    {
+        var sentinelPath = Path.Combine(_cacheDirectory, SentinelFileName);
+
+        if (!int.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_INTERVAL_HOURS), out int updateIntervalHours)
+            || updateIntervalHours < 1)
+        {
+            updateIntervalHours = DefaultUpdateIntervalHours;
+        }
+
+        if (File.Exists(sentinelPath))
+        {
+            var lastWriteTime = File.GetLastWriteTimeUtc(sentinelPath);
+            if (lastWriteTime.AddHours(updateIntervalHours) > DateTime.UtcNow)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reads a previously cached vulnerability summary for the given SDK version.
+    /// Returns null if no cached data is available.
+    /// </summary>
+    public SdkVulnerabilityInfo? ReadCachedSummary(string sdkVersion)
+    {
+        if (sdkVersion.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return null;
+        }
+
+        var summaryPath = GetSummaryPath(sdkVersion);
+        if (!File.Exists(summaryPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(summaryPath);
+            return JsonSerializer.Deserialize(json, SdkVulnerabilityJsonContext.Default.SdkVulnerabilityInfo);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetches release metadata, computes vulnerability status for the given SDK version,
+    /// writes the result to cache, and updates the sentinel. This is intended to be called
+    /// from a background task.
+    /// </summary>
+    public async Task UpdateCacheAsync(string sdkVersion, CancellationToken cancellationToken = default)
+    {
+        ProductCollection productCollection = await ProductCollection.GetAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!ReleaseVersion.TryParse(sdkVersion, out ReleaseVersion? parsedVersion))
+        {
+            TouchSentinel();
+            return;
+        }
+
+        string channelVersion = $"{parsedVersion.Major}.{parsedVersion.Minor}";
+        Product? product = productCollection
+            .FirstOrDefault(p => p.ProductVersion.Equals(channelVersion));
+
+        if (product is null)
+        {
+            TouchSentinel();
+            return;
+        }
+
+        IEnumerable<ProductRelease> releases;
+        try
+        {
+            releases = await product.GetReleasesAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            releases = [];
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+
+        SdkVulnerabilityInfo? info = SdkVulnerabilityChecker.Check(sdkVersion, productCollection, _ => releases);
+        if (info is null)
+        {
+            TouchSentinel();
+            return;
+        }
+
+        WriteSummary(sdkVersion, info);
+    }
+
+    private void WriteSummary(string sdkVersion, SdkVulnerabilityInfo info)
+    {
+        try
+        {
+            Directory.CreateDirectory(_cacheDirectory);
+            var summaryPath = GetSummaryPath(sdkVersion);
+            var json = JsonSerializer.Serialize(info, SdkVulnerabilityJsonContext.Default.SdkVulnerabilityInfo);
+
+            // Atomic write: write to temp file then move, so concurrent readers
+            // (e.g., the MSBuild task) never see partially-written JSON.
+            var tempPath = Path.Combine(_cacheDirectory, Path.GetRandomFileName());
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, summaryPath, overwrite: true);
+
+            // Only mark the cache as fresh after a successful write.
+            TouchSentinel();
+        }
+        catch
+        {
+            // Silently fail — cache write failure should not break the CLI
+        }
+    }
+
+    private void TouchSentinel()
+    {
+        try
+        {
+            var sentinelPath = Path.Combine(_cacheDirectory, SentinelFileName);
+            Directory.CreateDirectory(_cacheDirectory);
+            if (File.Exists(sentinelPath))
+            {
+                File.SetLastWriteTimeUtc(sentinelPath, DateTime.UtcNow);
+            }
+            else
+            {
+                File.Create(sentinelPath).Close();
+            }
+        }
+        catch
+        {
+            // Silently fail
+        }
+    }
+
+    private string GetSummaryPath(string sdkVersion) =>
+        Path.Combine(_cacheDirectory, $"{SummaryFilePrefix}{sdkVersion}.json");
+}
+
+[JsonSerializable(typeof(SdkVulnerabilityInfo))]
+[JsonSerializable(typeof(SdkCveInfo))]
+internal partial class SdkVulnerabilityJsonContext : JsonSerializerContext
+{
+}

--- a/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityChecker.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityChecker.cs
@@ -95,15 +95,28 @@ internal static class SdkVulnerabilityChecker
         // Deduplicate CVEs by ID (same CVE can appear in multiple releases)
         cves = cves.DistinctBy(c => c.Id).ToList();
 
-        // Find the latest SDK version in the same feature band
+        // Find the latest SDK version, preferring the same feature band.
+        // If the user's band has no newer SDK but a newer SDK exists in a different
+        // band on the channel, recommend that and flag the band as discontinued.
         string? latestInBand = FindLatestSdkInFeatureBand(sdkVersion, product, releaseList);
+        string? recommendedVersion = latestInBand;
+        bool featureBandDiscontinued = false;
+
+        if (latestInBand is null
+            && product.LatestSdkVersion is not null
+            && product.LatestSdkVersion > sdkVersion)
+        {
+            recommendedVersion = product.LatestSdkVersion.ToString();
+            featureBandDiscontinued = true;
+        }
 
         return new SdkVulnerabilityInfo
         {
             IsEol = isEol,
             EolDate = eolDate,
             Cves = cves,
-            LatestSdkVersion = latestInBand,
+            LatestSdkVersion = recommendedVersion,
+            FeatureBandDiscontinued = featureBandDiscontinued,
         };
     }
 

--- a/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityChecker.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityChecker.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+
+namespace Microsoft.DotNet.Cli.SdkVulnerability;
+
+/// <summary>
+/// Checks an SDK version against release metadata for vulnerabilities and EOL status.
+/// Pure logic — no I/O or network calls.
+/// </summary>
+internal static class SdkVulnerabilityChecker
+{
+    /// <summary>
+    /// Checks the given SDK version against the product collection and release data.
+    /// </summary>
+    /// <param name="sdkVersionString">The resolved SDK version string (e.g. "9.0.300").</param>
+    /// <param name="productCollection">The product collection from releases-index.json.</param>
+    /// <param name="getProductReleases">A function to get releases for a product (may read from cache).</param>
+    /// <returns>Vulnerability info, or null if the SDK version cannot be matched to release data.</returns>
+    public static SdkVulnerabilityInfo? Check(
+        string sdkVersionString,
+        ProductCollection productCollection,
+        Func<Product, IEnumerable<ProductRelease>> getProductReleases)
+    {
+        if (!ReleaseVersion.TryParse(sdkVersionString, out ReleaseVersion? sdkVersion))
+        {
+            return null;
+        }
+
+        // Find the product channel for this SDK version (e.g. "9.0" for SDK "9.0.300")
+        string channelVersion = $"{sdkVersion.Major}.{sdkVersion.Minor}";
+        Product? product = productCollection
+            .FirstOrDefault(p => p.ProductVersion.Equals(channelVersion));
+
+        if (product is null)
+        {
+            return null;
+        }
+
+        bool isEol = product.IsOutOfSupport();
+        DateTime? eolDate = product.EndOfLifeDate;
+
+        // Get all releases for this channel to find CVEs
+        IEnumerable<ProductRelease> releases = getProductReleases(product);
+        List<ProductRelease> releaseList = releases.ToList();
+
+        if (releaseList.Count == 0)
+        {
+            // No release data available — can still report EOL status
+            return new SdkVulnerabilityInfo
+            {
+                IsEol = isEol,
+                EolDate = eolDate,
+            };
+        }
+
+        // Find which release contains this SDK version
+        int currentReleaseIndex = -1;
+        for (int i = 0; i < releaseList.Count; i++)
+        {
+            if (releaseList[i].Sdks.Any(sdk => sdk.Version == sdkVersion))
+            {
+                currentReleaseIndex = i;
+                break;
+            }
+        }
+
+        // If the SDK version isn't present in any release, we can't determine
+        // its vulnerability status — return null per the documented contract.
+        if (currentReleaseIndex < 0)
+        {
+            return null;
+        }
+
+        // Collect CVEs from all releases newer than the current one.
+        // Releases are ordered newest-first from the API.
+        // All CVEs in releases after our SDK's release are vulnerabilities that affect us.
+        var cves = new List<SdkCveInfo>();
+        if (currentReleaseIndex > 0)
+        {
+            for (int i = 0; i < currentReleaseIndex; i++)
+            {
+                foreach (var cve in releaseList[i].Cves)
+                {
+                    cves.Add(new SdkCveInfo
+                    {
+                        Id = cve.Id,
+                        Url = cve.DescriptionLink?.ToString() ?? $"https://cve.mitre.org/cgi-bin/cvename.cgi?name={cve.Id}"
+                    });
+                }
+            }
+        }
+
+        // Deduplicate CVEs by ID (same CVE can appear in multiple releases)
+        cves = cves.DistinctBy(c => c.Id).ToList();
+
+        // Find the latest SDK version in the same feature band
+        string? latestInBand = FindLatestSdkInFeatureBand(sdkVersion, product, releaseList);
+
+        return new SdkVulnerabilityInfo
+        {
+            IsEol = isEol,
+            EolDate = eolDate,
+            Cves = cves,
+            LatestSdkVersion = latestInBand,
+        };
+    }
+
+    private static string? FindLatestSdkInFeatureBand(
+        ReleaseVersion sdkVersion,
+        Product product,
+        List<ProductRelease> releases)
+    {
+        // If the product's latest SDK is in the same feature band, use it directly
+        if (product.LatestSdkVersion?.SdkFeatureBand == sdkVersion.SdkFeatureBand
+            && product.LatestSdkVersion > sdkVersion)
+        {
+            return product.LatestSdkVersion.ToString();
+        }
+
+        // Otherwise, search through releases for the newest SDK in our feature band
+        ReleaseVersion? latest = null;
+        foreach (var release in releases)
+        {
+            foreach (var sdk in release.Sdks)
+            {
+                if (sdk.Version.SdkFeatureBand == sdkVersion.SdkFeatureBand
+                    && sdk.Version > sdkVersion
+                    && (latest is null || sdk.Version > latest))
+                {
+                    latest = sdk.Version;
+                }
+            }
+        }
+
+        return latest?.ToString();
+    }
+}

--- a/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityInfo.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityInfo.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.SdkVulnerability;
+
+/// <summary>
+/// Contains vulnerability and end-of-life status for a resolved SDK version.
+/// </summary>
+internal sealed class SdkVulnerabilityInfo
+{
+    public bool IsEol { get; init; }
+    public DateTime? EolDate { get; init; }
+    public IReadOnlyList<SdkCveInfo> Cves { get; init; } = [];
+    public string? LatestSdkVersion { get; init; }
+    public bool HasVulnerabilities => Cves.Count > 0;
+}
+
+/// <summary>
+/// Represents a single CVE that affects an SDK version.
+/// </summary>
+internal sealed class SdkCveInfo
+{
+    public required string Id { get; init; }
+    public required string Url { get; init; }
+}

--- a/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityInfo.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityInfo.cs
@@ -11,7 +11,21 @@ internal sealed class SdkVulnerabilityInfo
     public bool IsEol { get; init; }
     public DateTime? EolDate { get; init; }
     public IReadOnlyList<SdkCveInfo> Cves { get; init; } = [];
+
+    /// <summary>
+    /// The recommended SDK version to update to. When <see cref="FeatureBandDiscontinued"/>
+    /// is false, this is the latest SDK in the same feature band. When it is true,
+    /// this is the channel's latest SDK (in a different feature band).
+    /// </summary>
     public string? LatestSdkVersion { get; init; }
+
+    /// <summary>
+    /// True when there is no newer SDK in the user's feature band, but the channel
+    /// has a newer SDK in a different band. Callers should phrase the upgrade
+    /// recommendation as a band switch in that case.
+    /// </summary>
+    public bool FeatureBandDiscontinued { get; init; }
+
     public bool HasVulnerabilities => Cves.Count > 0;
 }
 

--- a/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityNotifier.cs
+++ b/src/Cli/dotnet/SdkVulnerability/SdkVulnerabilityNotifier.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.SdkVulnerability;
+
+/// <summary>
+/// Triggers background cache refresh for SDK vulnerability/EOL metadata.
+/// Called from RestoringCommand (build/restore commands only).
+/// </summary>
+internal static class SdkVulnerabilityNotifier
+{
+    /// <summary>
+    /// Kicks off a background cache refresh if the sentinel indicates it's due.
+    /// Does not emit warnings — that's handled by the CheckSdkVulnerabilities MSBuild task.
+    /// </summary>
+    public static void BackgroundUpdateCacheIfNeeded(string? sdkVersion = null)
+    {
+#if !DOT_NET_BUILD_FROM_SOURCE
+        try
+        {
+            sdkVersion ??= Product.Version;
+
+            var cache = new SdkReleaseMetadataCache();
+
+            if (cache.IsDisabled())
+            {
+                return;
+            }
+
+            // Check if either the sentinel is stale or we don't have cached data
+            // for this specific SDK version. Covers the case where the user switches
+            // between SDK versions (e.g., via global.json) within the sentinel interval.
+            if (!cache.IsDueForUpdate() && cache.ReadCachedSummary(sdkVersion) is not null)
+            {
+                return;
+            }
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await cache.UpdateCacheAsync(sdkVersion).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Never surface errors from background updates
+                }
+            });
+        }
+        catch
+        {
+            // Never let vulnerability cache refresh break CLI execution
+        }
+#endif
+    }
+}

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(RepoRoot)src\Common\WorkloadFileBasedInstall.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
     <Compile Include="$(RepoRoot)src\Common\NuGetUtils.NuGet.cs" LinkBase="Common" />
+    <Compile Include="$(RepoRoot)src\Common\SdkVulnerabilityCacheReader.cs" LinkBase="Common" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' != 'windows'">

--- a/src/Common/EnvironmentVariableNames.cs
+++ b/src/Common/EnvironmentVariableNames.cs
@@ -34,6 +34,8 @@ internal static class EnvironmentVariableNames
     public static readonly string DOTNET_CLI_TELEMETRY_LOG_PATH = nameof(DOTNET_CLI_TELEMETRY_LOG_PATH);
     public static readonly string DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT = nameof(DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT);
     public static readonly string DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER = nameof(DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER);
+    public static readonly string SDK_VULNERABILITY_CHECK_DISABLE = "DOTNET_SDK_VULNERABILITY_CHECK_DISABLE";
+    public static readonly string SDK_VULNERABILITY_CHECK_INTERVAL_HOURS = "DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS";
 
 #if NET7_0_OR_GREATER
     private static readonly Version s_version6_0 = new(6, 0);

--- a/src/Common/SdkVulnerabilityCacheReader.cs
+++ b/src/Common/SdkVulnerabilityCacheReader.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DotNet.Cli;
+
+/// <summary>
+/// Reads pre-computed SDK vulnerability/EOL cache summaries from ~/.dotnet/sdk-vulnerability-cache/.
+/// This class is intentionally kept simple and dependency-free so it can be used by both
+/// the CLI (src/Cli/dotnet/) and the MSBuild SDK resolver (src/Resolvers/).
+/// It performs no network calls — only reads from disk.
+/// </summary>
+internal static class SdkVulnerabilityCacheReader
+{
+    private const string CacheDirectoryName = "sdk-vulnerability-cache";
+    private const string SummaryFilePrefix = "sdk-status-";
+
+    /// <summary>
+    /// Reads a cached vulnerability summary for the given SDK version.
+    /// Returns null if no cached data is available or if the check is disabled.
+    /// </summary>
+    /// <param name="sdkVersion">The SDK version to check.</param>
+    /// <param name="getEnvironmentVariable">Environment variable accessor.</param>
+    /// <param name="userProfileDir">The user profile directory (e.g. ~/.dotnet/).</param>
+    public static SdkVulnerabilityCacheSummary? ReadSummary(
+        string sdkVersion,
+        Func<string, string?> getEnvironmentVariable,
+        string? userProfileDir)
+    {
+        if (bool.TryParse(getEnvironmentVariable(EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_DISABLE), out bool disabled) && disabled)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(userProfileDir))
+        {
+            return null;
+        }
+
+        // Validate version format to prevent path traversal via malformed version strings
+        if (sdkVersion.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return null;
+        }
+
+        string summaryPath = Path.Combine(userProfileDir, CacheDirectoryName, $"{SummaryFilePrefix}{sdkVersion}.json");
+        if (!File.Exists(summaryPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            string json = File.ReadAllText(summaryPath);
+            return JsonSerializer.Deserialize(json, SdkVulnerabilityCacheJsonContext.Default.SdkVulnerabilityCacheSummary);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// A simple DTO for deserializing the cached vulnerability summary.
+/// This type must remain serialization-compatible with SdkVulnerabilityInfo in the CLI project.
+/// </summary>
+internal sealed class SdkVulnerabilityCacheSummary
+{
+    public bool IsEol { get; set; }
+    public DateTime? EolDate { get; set; }
+    public List<SdkCveCacheSummary>? Cves { get; set; }
+    public string? LatestSdkVersion { get; set; }
+    public bool HasVulnerabilities => Cves is not null && Cves.Count > 0;
+}
+
+internal sealed class SdkCveCacheSummary
+{
+    public string? Id { get; set; }
+    public string? Url { get; set; }
+}
+
+[JsonSerializable(typeof(SdkVulnerabilityCacheSummary))]
+internal partial class SdkVulnerabilityCacheJsonContext : JsonSerializerContext
+{
+}

--- a/src/Common/SdkVulnerabilityCacheReader.cs
+++ b/src/Common/SdkVulnerabilityCacheReader.cs
@@ -73,6 +73,7 @@ internal sealed class SdkVulnerabilityCacheSummary
     public DateTime? EolDate { get; set; }
     public List<SdkCveCacheSummary>? Cves { get; set; }
     public string? LatestSdkVersion { get; set; }
+    public bool FeatureBandDiscontinued { get; set; }
     public bool HasVulnerabilities => Cves is not null && Cves.Count > 0;
 }
 

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -1034,5 +1034,9 @@ You may need to build the project on another operating system or architecture, o
     <value>Update to version {0}.</value>
     <comment>{Locked="{0}"}</comment>
   </data>
-  <!-- The latest message added is SdkVersionUpdateRecommendation_Info. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="SdkFeatureBandDiscontinued" xml:space="preserve">
+    <value>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</value>
+    <comment>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</comment>
+  </data>
+  <!-- The latest message added is SdkFeatureBandDiscontinued. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -1022,5 +1022,17 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1237: Assembly '{0}' was listed in PublishReadyToRunPartialAssemblies but is being compiled into a composite image. Partial compilation is only supported for assemblies compiled separately. The assembly will be compiled fully into the composite image.</value>
     <comment>{StrBegins="NETSDK1237: "}{Locked="{0}"}</comment>
   </data>
-  <!-- The latest message added is ReadyToRunPartialCompileIgnoredInCompositeMode. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="SdkVersionHasVulnerabilities" xml:space="preserve">
+    <value>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</value>
+    <comment>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</comment>
+  </data>
+  <data name="SdkVersionIsEol" xml:space="preserve">
+    <value>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</value>
+    <comment>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</comment>
+  </data>
+  <data name="SdkVersionUpdateRecommendation_Info" xml:space="preserve">
+    <value>Update to version {0}.</value>
+    <comment>{Locked="{0}"}</comment>
+  </data>
+  <!-- The latest message added is SdkVersionUpdateRecommendation_Info. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Sada Runtime Pack pro FrameworkReference {0} nebyla k dispozici. Důvodem může být to, že vlastnost DisableTransitiveFrameworkReferenceDownloads byla nastavena na hodnotu true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Sada Runtime Pack pro FrameworkReference {0} nebyla k dispozici. Důvodem může být to, že vlastnost DisableTransitiveFrameworkReferenceDownloads byla nastavena na hodnotu true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: odkazovaný projekt {0} je spustitelný soubor, který není samostatně obsažený.  Na spustitelný soubor, který není samostatně obsažený, nelze odkazovat pomocí samostatně obsaženého spustitelného souboru. Další informace najdete na https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Das Runtimepaket für FrameworkReference „{0}“ war nicht verfügbar. Dies kann daran liegen, dass DisableTransitiveFrameworkReferenceDownloads auf TRUE festgelegt wurde.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Das referenzierte Projekt „{0}“ ist keine eigenständige ausführbare Datei. Auf eine nicht eigenständige ausführbare Datei kann nicht von einer eigenständigen ausführbaren Datei verwiesen werden. Weitere Informationen finden Sie unter https://aka.ms/netsdk1150.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Das Runtimepaket für FrameworkReference „{0}“ war nicht verfügbar. Dies kann daran liegen, dass DisableTransitiveFrameworkReferenceDownloads auf TRUE festgelegt wurde.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: El paquete en tiempo de ejecución para FrameworkReference "{0}" no estaba disponible. Esto puede deberse a que DisableTransitiveFrameworkReferenceDownloads se ha establecido en true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: El proyecto al que se hace referencia '{0}' es un ejecutable no independiente. Un archivo ejecutable independiente no puede hacer referencia a un ejecutable que no es independiente.  Para obtener más información, consulte https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: El paquete en tiempo de ejecución para FrameworkReference "{0}" no estaba disponible. Esto puede deberse a que DisableTransitiveFrameworkReferenceDownloads se ha establecido en true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Le pack d'exécution pour FrameworkReference '{0}' n'était pas disponible. Cela peut être dû au fait que DisableTransitiveFrameworkReferenceDownloads a été défini sur true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Le pack d'exécution pour FrameworkReference '{0}' n'était pas disponible. Cela peut être dû au fait que DisableTransitiveFrameworkReferenceDownloads a été défini sur true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: le projet référencé « {0} » est un exécutable qui n’est pas autonome.  Un exécutable non autonome ne peut pas être référencé par un exécutable autonome. Pour plus d’informations, voir https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: il Runtime Pack per FrameworkReference '{0}' non è disponibile. È possibile che DisableTransitiveFrameworkReferenceDownloads sia stato impostato su true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: il Runtime Pack per FrameworkReference '{0}' non è disponibile. È possibile che DisableTransitiveFrameworkReferenceDownloads sia stato impostato su true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: il progetto '{0}' a cui viene fatto riferimento è un eseguibile non autonomo. Non è possibile fare riferimento a un eseguibile non autonomo da un eseguibile autonomo. Per altre informazioni, vedere https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}' のランタイム パックは使用できませんでした。DisableTransitiveFrameworkReferenceDownloads が true に設定されたことが原因である可能性があります。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 参照先プロジェクト '{0}' は自己完結型以外の実行可能ファイルです。 自己完結型以外の実行可能ファイルは、自己完結型の実行可能ファイルでは参照できません。詳細については、「https://aka.ms/netsdk1150」を参照してください</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}' のランタイム パックは使用できませんでした。DisableTransitiveFrameworkReferenceDownloads が true に設定されたことが原因である可能性があります。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}'용 런타임 팩을 사용할 수 없습니다. DisableTransitiveFrameworkReferenceDownloads가 true로 설정되었기 때문일 수 있습니다.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 참조된 프로젝트 '{0}'은(는) self-contained가 아닌 실행 파일입니다. self-contained가 아닌  실행 파일은 self-contained 실행 파일에서 참조할 수 없습니다. 자세한 내용은 https://aka.ms/netsdk1150을 참조하세요</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}'용 런타임 팩을 사용할 수 없습니다. DisableTransitiveFrameworkReferenceDownloads가 true로 설정되었기 때문일 수 있습니다.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Pakiet środowiska uruchomieniowego dla elementu FrameworkReference „{0}” był niedostępny. Może to być spowodowane tym, że parametr DisableTransitiveFrameworkReferenceDownloads został ustawiony na wartość true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Projekt „{0}”, do którego istnieje odwołanie, jest niesamodzielnym plikiem wykonywalnym.  Niesamodzielny plik wykonywalny nie może być przywoływany przez samodzielny plik wykonywalny. Aby uzyskać więcej informacji, zobacz: https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: Pakiet środowiska uruchomieniowego dla elementu FrameworkReference „{0}” był niedostępny. Może to być spowodowane tym, że parametr DisableTransitiveFrameworkReferenceDownloads został ustawiony na wartość true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: O Runtime Pack para FrameworkReference '{0}' não estava disponível. Isso pode ser porque DisableTransitiveFrameworkReferenceDownloads foi definido como true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: O projeto referenciado '{0}' é um executável não autossuficiente.  Um executável não autossuficiente não pode ser referenciado por um executável autossuficiente. Para mais informações, consulte https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: O Runtime Pack para FrameworkReference '{0}' não estava disponível. Isso pode ser porque DisableTransitiveFrameworkReferenceDownloads foi definido como true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: пакет среды выполнения для FrameworkReference "{0}" недоступен. Причиной этого может быть то, что параметру DisableTransitiveFrameworkReferenceDownloads присвоено значение true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: проект "{0}", на который указывает ссылка, является неавтономным исполняемым файлом.  Автономный исполняемый файл не может ссылаться на неавтономный исполняемый файл. Дополнительные сведения см. на странице https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: пакет среды выполнения для FrameworkReference "{0}" недоступен. Причиной этого может быть то, что параметру DisableTransitiveFrameworkReferenceDownloads присвоено значение true.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}' için Çalışma Zamanı Paketi bulunamadı. Bunun nedeni DisableTransitiveFrameworkReferenceDownloads değerinin true olarak ayarlanmış olması olabilir.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: Başvurulan '{0}' projesi bağımsız olmayan bir yürütülebilir dosyadır. Bağımsız olmayan bir yürütülebilir dosyaya, bağımsız bir yürütülebilir dosya tarafından başvurulamaz.  Daha fazla bilgi için bkz. https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference '{0}' için Çalışma Zamanı Paketi bulunamadı. Bunun nedeni DisableTransitiveFrameworkReferenceDownloads değerinin true olarak ayarlanmış olması olabilir.</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference“{0}”的运行时包不可用。这可能是因为 DisableTransitiveFrameworkReferenceDownloads 设置为 true。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: FrameworkReference“{0}”的运行时包不可用。这可能是因为 DisableTransitiveFrameworkReferenceDownloads 设置为 true。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 引用的项目“{0}”是非自包含的可执行文件。非自包含可执行文件不能由自包含可执行文件引用。如需获取更多信息，请访问 https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -911,6 +911,11 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: 無法提供 FrameworkReference '{0}' 的執行階段套件。這可能是因為 DisableTransitiveFrameworkReferenceDownloads 已設為 true。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkFeatureBandDiscontinued">
+        <source>NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1240: The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1240: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
       <trans-unit id="SdkVersionHasVulnerabilities">
         <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
         <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -911,6 +911,21 @@ The following are names of parameters or literal values and should not be transl
         <target state="translated">NETSDK1185: 無法提供 FrameworkReference '{0}' 的執行階段套件。這可能是因為 DisableTransitiveFrameworkReferenceDownloads 已設為 true。</target>
         <note>{StrBegins="NETSDK1185: "}</note>
       </trans-unit>
+      <trans-unit id="SdkVersionHasVulnerabilities">
+        <source>NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1238: The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1238: "}{Locked="{0}"}{Locked="{1}"}{Locked="{2}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionIsEol">
+        <source>NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</source>
+        <target state="new">NETSDK1239: The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: https://dotnet.microsoft.com/download</target>
+        <note>{StrBegins="NETSDK1239: "}{Locked="{0}"}{Locked="{1}"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionUpdateRecommendation_Info">
+        <source>Update to version {0}.</source>
+        <target state="new">Update to version {0}.</target>
+        <note>{Locked="{0}"}</note>
+      </trans-unit>
       <trans-unit id="SelfContainedExeCannotReferenceNonSelfContained">
         <source>NETSDK1150: The referenced project '{0}' is a non self-contained executable.  A non self-contained executable cannot be referenced by a self-contained executable.  For more information, see https://aka.ms/netsdk1150</source>
         <target state="translated">NETSDK1150: 參照的專案 '{0}' 是非獨立式可執行檔。獨立式可執行檔無法參照非獨立式可執行檔。如需詳細資料，請參閱 https://aka.ms/netsdk1150</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckSdkVulnerabilities.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckSdkVulnerabilities.cs
@@ -10,9 +10,10 @@ namespace Microsoft.NET.Build.Tasks;
 
 /// <summary>
 /// MSBuild task that reads cached SDK vulnerability/EOL data and emits
-/// NETSDK1238 (vulnerabilities) and NETSDK1239 (EOL) warnings.
-/// The cache is populated by the CLI during restore (background, no blocking).
-/// This task only reads from disk — it never makes network calls.
+/// NETSDK1238 (vulnerabilities), NETSDK1239 (EOL), and NETSDK1240 (feature band
+/// discontinued) warnings. The cache is populated by the CLI during restore
+/// (background, no blocking). This task only reads from disk — it never makes
+/// network calls.
 /// </summary>
 public class CheckSdkVulnerabilities : TaskBase
 {
@@ -87,6 +88,14 @@ public class CheckSdkVulnerabilities : TaskBase
                     upgradeSuffix);
             }
         }
+
+        if (summary.FeatureBandDiscontinued && !string.IsNullOrEmpty(summary.LatestSdkVersion))
+        {
+            Log.LogWarning(
+                Strings.SdkFeatureBandDiscontinued,
+                SdkVersion,
+                summary.LatestSdkVersion);
+        }
     }
 
     // Local DTOs for deserializing the cached summary.
@@ -97,6 +106,7 @@ public class CheckSdkVulnerabilities : TaskBase
         public DateTime? EolDate { get; set; }
         public List<SdkCveSummary>? Cves { get; set; }
         public string? LatestSdkVersion { get; set; }
+        public bool FeatureBandDiscontinued { get; set; }
     }
 
     internal sealed class SdkCveSummary

--- a/src/Tasks/Microsoft.NET.Build.Tasks/CheckSdkVulnerabilities.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/CheckSdkVulnerabilities.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Configurer;
+
+namespace Microsoft.NET.Build.Tasks;
+
+/// <summary>
+/// MSBuild task that reads cached SDK vulnerability/EOL data and emits
+/// NETSDK1238 (vulnerabilities) and NETSDK1239 (EOL) warnings.
+/// The cache is populated by the CLI during restore (background, no blocking).
+/// This task only reads from disk — it never makes network calls.
+/// </summary>
+public class CheckSdkVulnerabilities : TaskBase
+{
+    private const string CacheDirectoryName = "sdk-vulnerability-cache";
+    private const string SummaryFilePrefix = "sdk-status-";
+
+    [Required]
+    public string SdkVersion { get; set; } = string.Empty;
+
+    protected override void ExecuteCore()
+    {
+        if (bool.TryParse(Environment.GetEnvironmentVariable(Microsoft.DotNet.Cli.EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_DISABLE), out bool disabled) && disabled)
+        {
+            return;
+        }
+
+        string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
+        if (string.IsNullOrEmpty(userProfileDir))
+        {
+            return;
+        }
+
+        // Validate version to prevent path traversal via malformed version strings
+        if (SdkVersion.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return;
+        }
+
+        string summaryPath = Path.Combine(userProfileDir, CacheDirectoryName, $"{SummaryFilePrefix}{SdkVersion}.json");
+        if (!File.Exists(summaryPath))
+        {
+            return;
+        }
+
+        SdkVulnerabilitySummary? summary;
+        try
+        {
+            string json = File.ReadAllText(summaryPath);
+            summary = JsonSerializer.Deserialize(json, SdkVulnerabilitySummaryContext.Default.SdkVulnerabilitySummary);
+        }
+        catch
+        {
+            // Corrupt or partially-written cache — skip silently
+            return;
+        }
+
+        if (summary is null)
+        {
+            return;
+        }
+
+        if (summary.IsEol && summary.EolDate.HasValue)
+        {
+            Log.LogWarning(
+                Strings.SdkVersionIsEol,
+                SdkVersion,
+                summary.EolDate.Value.ToString("yyyy-MM-dd"));
+        }
+
+        if (summary.Cves is { Count: > 0 })
+        {
+            string cveIds = string.Join(", ", summary.Cves.Where(c => c.Id is not null).Select(c => c.Id));
+            if (!string.IsNullOrEmpty(cveIds))
+            {
+                string upgradeSuffix = summary.LatestSdkVersion is not null
+                    ? $" {string.Format(Strings.SdkVersionUpdateRecommendation_Info, summary.LatestSdkVersion)}"
+                    : string.Empty;
+                Log.LogWarning(
+                    Strings.SdkVersionHasVulnerabilities,
+                    SdkVersion,
+                    cveIds,
+                    upgradeSuffix);
+            }
+        }
+    }
+
+    // Local DTOs for deserializing the cached summary.
+    // Must stay serialization-compatible with SdkVulnerabilityInfo written by the CLI cache.
+    internal sealed class SdkVulnerabilitySummary
+    {
+        public bool IsEol { get; set; }
+        public DateTime? EolDate { get; set; }
+        public List<SdkCveSummary>? Cves { get; set; }
+        public string? LatestSdkVersion { get; set; }
+    }
+
+    internal sealed class SdkCveSummary
+    {
+        public string? Id { get; set; }
+        public string? Url { get; set; }
+    }
+}
+
+[JsonSerializable(typeof(CheckSdkVulnerabilities.SdkVulnerabilitySummary))]
+internal partial class SdkVulnerabilitySummaryContext : JsonSerializerContext
+{
+}

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets
@@ -87,6 +87,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Checks for deprecated Aspire workload usage -->
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.AspireWorkloadDeprecation.targets" />
 
+  <!-- Checks for SDK vulnerabilities and EOL status (opt-in) -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.NET.SdkVulnerabilityCheck.targets" />
+
   <!-- Check if the Target Framework is coreclr based -->
   <PropertyGroup Condition="'$(_IsNETCoreOrNETStandard)' == ''">
     <_IsNETCoreOrNETStandard Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_IsNETCoreOrNETStandard>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SdkVulnerabilityCheck.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SdkVulnerabilityCheck.targets
@@ -1,0 +1,25 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.SdkVulnerabilityCheck.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="CheckSdkVulnerabilities" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <PropertyGroup>
+    <!-- Opt-in: set to true to check for SDK vulnerabilities and EOL status during build.
+         Suppressible via NoWarn with NETSDK1238 (vulnerabilities) or NETSDK1239 (EOL). -->
+    <CheckSdkVulnerabilities Condition="'$(CheckSdkVulnerabilities)' == ''">false</CheckSdkVulnerabilities>
+  </PropertyGroup>
+
+  <Target Name="_CheckForSdkVulnerabilities" AfterTargets="_CheckForUnsupportedNETCoreVersion"
+          Condition="'$(CheckSdkVulnerabilities)' == 'true'">
+    <CheckSdkVulnerabilities SdkVersion="$(NETCoreSdkVersion)" />
+  </Target>
+</Project>

--- a/test/TestAssets/TestReleases/VulnerabilityTestRelease/7.0/releases.json
+++ b/test/TestAssets/TestReleases/VulnerabilityTestRelease/7.0/releases.json
@@ -1,0 +1,66 @@
+{
+    "channel-version": "7.0",
+    "latest-release": "7.0.20",
+    "latest-release-date": "2024-05-28",
+    "latest-runtime": "7.0.20",
+    "latest-sdk": "7.0.410",
+    "support-phase": "eol",
+    "eol-date": "2024-05-14",
+    "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+    "releases": [
+        {
+            "release-date": "2024-05-28",
+            "release-version": "7.0.20",
+            "security": true,
+            "cve-list": [
+                {
+                    "cve-id": "CVE-2024-88888",
+                    "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-88888"
+                }
+            ],
+            "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.20/7.0.20.md",
+            "runtime": {
+                "version": "7.0.20",
+                "version-display": "7.0.20",
+                "files": []
+            },
+            "sdks": [
+                {
+                    "version": "7.0.410",
+                    "version-display": "7.0.410",
+                    "runtime-version": "7.0.20",
+                    "vs-version": "",
+                    "vs-support": "",
+                    "csharp-version": "11.0",
+                    "fsharp-version": "7.0",
+                    "vb-version": "16.9",
+                    "files": []
+                }
+            ]
+        },
+        {
+            "release-date": "2024-04-09",
+            "release-version": "7.0.19",
+            "security": false,
+            "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.19/7.0.19.md",
+            "runtime": {
+                "version": "7.0.19",
+                "version-display": "7.0.19",
+                "files": []
+            },
+            "sdks": [
+                {
+                    "version": "7.0.409",
+                    "version-display": "7.0.409",
+                    "runtime-version": "7.0.19",
+                    "vs-version": "",
+                    "vs-support": "",
+                    "csharp-version": "11.0",
+                    "fsharp-version": "7.0",
+                    "vb-version": "16.9",
+                    "files": []
+                }
+            ]
+        }
+    ]
+}

--- a/test/TestAssets/TestReleases/VulnerabilityTestRelease/9.0/releases.json
+++ b/test/TestAssets/TestReleases/VulnerabilityTestRelease/9.0/releases.json
@@ -1,0 +1,95 @@
+{
+    "channel-version": "9.0",
+    "latest-release": "9.0.2",
+    "latest-release-date": "2025-02-11",
+    "latest-runtime": "9.0.2",
+    "latest-sdk": "9.0.200",
+    "support-phase": "active",
+    "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+    "releases": [
+        {
+            "release-date": "2025-02-11",
+            "release-version": "9.0.2",
+            "security": true,
+            "cve-list": [
+                {
+                    "cve-id": "CVE-2025-99999",
+                    "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-99999"
+                }
+            ],
+            "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.2/9.0.2.md",
+            "runtime": {
+                "version": "9.0.2",
+                "version-display": "9.0.2",
+                "files": []
+            },
+            "sdks": [
+                {
+                    "version": "9.0.200",
+                    "version-display": "9.0.200",
+                    "runtime-version": "9.0.2",
+                    "vs-version": "",
+                    "vs-support": "",
+                    "csharp-version": "13.0",
+                    "fsharp-version": "9.0",
+                    "vb-version": "16.9",
+                    "files": []
+                }
+            ]
+        },
+        {
+            "release-date": "2025-01-14",
+            "release-version": "9.0.1",
+            "security": true,
+            "cve-list": [
+                {
+                    "cve-id": "CVE-2025-12345",
+                    "cve-url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-12345"
+                }
+            ],
+            "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.1/9.0.1.md",
+            "runtime": {
+                "version": "9.0.1",
+                "version-display": "9.0.1",
+                "files": []
+            },
+            "sdks": [
+                {
+                    "version": "9.0.102",
+                    "version-display": "9.0.102",
+                    "runtime-version": "9.0.1",
+                    "vs-version": "",
+                    "vs-support": "",
+                    "csharp-version": "13.0",
+                    "fsharp-version": "9.0",
+                    "vb-version": "16.9",
+                    "files": []
+                }
+            ]
+        },
+        {
+            "release-date": "2024-11-12",
+            "release-version": "9.0.0",
+            "security": false,
+            "release-notes": "https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.0/9.0.0.md",
+            "runtime": {
+                "version": "9.0.0",
+                "version-display": "9.0.0",
+                "files": []
+            },
+            "sdks": [
+                {
+                    "version": "9.0.100",
+                    "version-display": "9.0.100",
+                    "runtime-version": "9.0.0",
+                    "vs-version": "",
+                    "vs-support": "",
+                    "csharp-version": "13.0",
+                    "fsharp-version": "9.0",
+                    "vb-version": "16.9",
+                    "files": []
+                }
+            ]
+        }
+    ]
+}

--- a/test/TestAssets/TestReleases/VulnerabilityTestRelease/releases-index.json
+++ b/test/TestAssets/TestReleases/VulnerabilityTestRelease/releases-index.json
@@ -1,0 +1,28 @@
+{
+    "releases-index": [
+        {
+            "channel-version": "9.0",
+            "latest-release": "9.0.2",
+            "latest-release-date": "2025-02-11",
+            "security": true,
+            "latest-runtime": "9.0.2",
+            "latest-sdk": "9.0.200",
+            "product": ".NET",
+            "support-phase": "active",
+            "eol-date": null,
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/releases.json"
+        },
+        {
+            "channel-version": "7.0",
+            "latest-release": "7.0.20",
+            "latest-release-date": "2024-05-28",
+            "security": true,
+            "latest-runtime": "7.0.20",
+            "latest-sdk": "7.0.410",
+            "product": ".NET",
+            "support-phase": "eol",
+            "eol-date": "2024-05-14",
+            "releases.json": "https://builds.dotnet.microsoft.com/dotnet/release-metadata/7.0/releases.json"
+        }
+    ]
+}

--- a/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkReleaseMetadataCache.cs
+++ b/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkReleaseMetadataCache.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.DotNet.Cli.SdkVulnerability;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+public class GivenSdkReleaseMetadataCache : SdkTest, IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    public GivenSdkReleaseMetadataCache(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void IsDisabledWhenEnvVarIsSet()
+    {
+        var cache = new SdkReleaseMetadataCache(
+            GetTempCacheDir(),
+            name => name == EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_DISABLE ? "true" : null);
+
+        cache.IsDisabled().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNotDisabledByDefault()
+    {
+        var cache = new SdkReleaseMetadataCache(
+            GetTempCacheDir(),
+            _ => null);
+
+        cache.IsDisabled().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDueForUpdateWhenNoSentinelExists()
+    {
+        var cache = new SdkReleaseMetadataCache(
+            GetTempCacheDir(),
+            _ => null);
+
+        cache.IsDueForUpdate().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNotDueForUpdateWhenSentinelIsRecent()
+    {
+        string cacheDir = GetTempCacheDir();
+        Directory.CreateDirectory(cacheDir);
+        string sentinelPath = Path.Combine(cacheDir, ".sentinel");
+        File.Create(sentinelPath).Close();
+        File.SetLastWriteTimeUtc(sentinelPath, DateTime.UtcNow);
+
+        var cache = new SdkReleaseMetadataCache(cacheDir, _ => null);
+
+        cache.IsDueForUpdate().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDueForUpdateWhenSentinelIsOld()
+    {
+        string cacheDir = GetTempCacheDir();
+        Directory.CreateDirectory(cacheDir);
+        string sentinelPath = Path.Combine(cacheDir, ".sentinel");
+        File.Create(sentinelPath).Close();
+        File.SetLastWriteTimeUtc(sentinelPath, DateTime.UtcNow.AddHours(-25));
+
+        var cache = new SdkReleaseMetadataCache(cacheDir, _ => null);
+
+        cache.IsDueForUpdate().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadsNullWhenNoCacheExists()
+    {
+        var cache = new SdkReleaseMetadataCache(
+            GetTempCacheDir(),
+            _ => null);
+
+        cache.ReadCachedSummary("9.0.100").Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadsCachedSummarySuccessfully()
+    {
+        string cacheDir = GetTempCacheDir();
+        Directory.CreateDirectory(cacheDir);
+
+        var info = new SdkVulnerabilityInfo
+        {
+            IsEol = true,
+            EolDate = new DateTime(2024, 5, 14),
+            Cves = [new SdkCveInfo { Id = "CVE-2025-12345", Url = "https://example.com" }],
+            LatestSdkVersion = "9.0.200"
+        };
+
+        string json = JsonSerializer.Serialize(info, SdkVulnerabilityJsonContext.Default.SdkVulnerabilityInfo);
+        File.WriteAllText(Path.Combine(cacheDir, "sdk-status-9.0.100.json"), json);
+
+        var cache = new SdkReleaseMetadataCache(cacheDir, _ => null);
+        var result = cache.ReadCachedSummary("9.0.100");
+
+        result.Should().NotBeNull();
+        result!.IsEol.Should().BeTrue();
+        result.HasVulnerabilities.Should().BeTrue();
+        result.Cves.Should().Contain(c => c.Id == "CVE-2025-12345");
+        result.LatestSdkVersion.Should().Be("9.0.200");
+    }
+
+    [Fact]
+    public void ReturnsNullForCorruptCacheFile()
+    {
+        string cacheDir = GetTempCacheDir();
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(Path.Combine(cacheDir, "sdk-status-9.0.100.json"), "not valid json");
+
+        var cache = new SdkReleaseMetadataCache(cacheDir, _ => null);
+
+        cache.ReadCachedSummary("9.0.100").Should().BeNull();
+    }
+
+    [Fact]
+    public void CustomIntervalHoursIsRespected()
+    {
+        string cacheDir = GetTempCacheDir();
+        Directory.CreateDirectory(cacheDir);
+        string sentinelPath = Path.Combine(cacheDir, ".sentinel");
+        File.Create(sentinelPath).Close();
+        // Set sentinel to 2 hours ago
+        File.SetLastWriteTimeUtc(sentinelPath, DateTime.UtcNow.AddHours(-2));
+
+        // With default 24h interval, should not be due
+        var cache24h = new SdkReleaseMetadataCache(cacheDir, _ => null);
+        cache24h.IsDueForUpdate().Should().BeFalse();
+
+        // With 1h interval, should be due
+        var cache1h = new SdkReleaseMetadataCache(
+            cacheDir,
+            name => name == EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_INTERVAL_HOURS ? "1" : null);
+        cache1h.IsDueForUpdate().Should().BeTrue();
+    }
+
+    private string GetTempCacheDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "sdk-vuln-test-" + Guid.NewGuid().ToString("N")[..8]);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+}

--- a/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityCacheReader.cs
+++ b/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityCacheReader.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.DotNet.Cli;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+public class GivenSdkVulnerabilityCacheReader : SdkTest
+{
+    public GivenSdkVulnerabilityCacheReader(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    [Fact]
+    public void ReturnsNullWhenDisabled()
+    {
+        string nonexistentDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var result = SdkVulnerabilityCacheReader.ReadSummary(
+            "9.0.100",
+            name => name == EnvironmentVariableNames.SDK_VULNERABILITY_CHECK_DISABLE ? "true" : null,
+            nonexistentDir);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReturnsNullWhenNoCacheFileExists()
+    {
+        string nonexistentDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var result = SdkVulnerabilityCacheReader.ReadSummary(
+            "99.99.999",
+            _ => null,
+            nonexistentDir);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadsSummaryFromCacheFile()
+    {
+        // Create a temp directory mimicking the ~/.dotnet/ structure
+        string tempProfileDir = Path.Combine(Path.GetTempPath(), "sdk-vuln-reader-test-" + Guid.NewGuid().ToString("N")[..8]);
+        string cacheDir = Path.Combine(tempProfileDir, "sdk-vulnerability-cache");
+        Directory.CreateDirectory(cacheDir);
+
+        try
+        {
+            var summary = new SdkVulnerabilityCacheSummary
+            {
+                IsEol = true,
+                EolDate = new DateTime(2024, 5, 14),
+                Cves = [new SdkCveCacheSummary { Id = "CVE-2025-12345", Url = "https://example.com" }],
+                LatestSdkVersion = "9.0.200"
+            };
+
+            string json = JsonSerializer.Serialize(summary);
+            File.WriteAllText(Path.Combine(cacheDir, "sdk-status-9.0.100.json"), json);
+
+            var result = SdkVulnerabilityCacheReader.ReadSummary(
+                "9.0.100",
+                _ => null,
+                tempProfileDir);
+
+            result.Should().NotBeNull();
+            result!.IsEol.Should().BeTrue();
+            result.HasVulnerabilities.Should().BeTrue();
+            result.Cves.Should().HaveCount(1);
+            result.Cves![0].Id.Should().Be("CVE-2025-12345");
+            result.LatestSdkVersion.Should().Be("9.0.200");
+        }
+        finally
+        {
+            try { Directory.Delete(tempProfileDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void DeserializesSummaryCorrectly()
+    {
+        // Test the deserialization roundtrip independently
+        var summary = new SdkVulnerabilityCacheSummary
+        {
+            IsEol = true,
+            EolDate = new DateTime(2024, 5, 14),
+            Cves = [new SdkCveCacheSummary { Id = "CVE-2025-12345", Url = "https://example.com/cve" }],
+            LatestSdkVersion = "9.0.200"
+        };
+
+        string json = JsonSerializer.Serialize(summary);
+        var deserialized = JsonSerializer.Deserialize<SdkVulnerabilityCacheSummary>(json);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.IsEol.Should().BeTrue();
+        deserialized.EolDate.Should().Be(new DateTime(2024, 5, 14));
+        deserialized.HasVulnerabilities.Should().BeTrue();
+        deserialized.Cves.Should().HaveCount(1);
+        deserialized.Cves![0].Id.Should().Be("CVE-2025-12345");
+        deserialized.LatestSdkVersion.Should().Be("9.0.200");
+    }
+
+    [Fact]
+    public void HasVulnerabilitiesIsFalseWhenNoCves()
+    {
+        var summary = new SdkVulnerabilityCacheSummary
+        {
+            IsEol = false,
+            Cves = []
+        };
+
+        summary.HasVulnerabilities.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasVulnerabilitiesIsFalseWhenCvesIsNull()
+    {
+        var summary = new SdkVulnerabilityCacheSummary
+        {
+            IsEol = false,
+            Cves = null
+        };
+
+        summary.HasVulnerabilities.Should().BeFalse();
+    }
+}

--- a/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityChecker.cs
+++ b/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityChecker.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.DotNet.Cli.SdkVulnerability;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+public class GivenSdkVulnerabilityChecker : SdkTest
+{
+    private readonly string _testReleasesPath;
+
+    public GivenSdkVulnerabilityChecker(ITestOutputHelper log) : base(log)
+    {
+        _testReleasesPath = Path.Combine(TestAssetsManager.TestAssetsRoot, "TestReleases", "VulnerabilityTestRelease");
+    }
+
+    private ProductCollection GetProductCollection()
+    {
+        return ProductCollection.GetFromFileAsync(
+            Path.Combine(_testReleasesPath, "releases-index.json"), false).Result;
+    }
+
+    private IEnumerable<ProductRelease> GetProductReleases(Product product)
+    {
+        return product.GetReleasesAsync(
+            Path.Combine(_testReleasesPath, product.ProductVersion, "releases.json"), false).Result;
+    }
+
+    [Fact]
+    public void VulnerableSdkReportsCves()
+    {
+        // SDK 9.0.100 is the oldest release — two newer releases have CVEs
+        var result = SdkVulnerabilityChecker.Check("9.0.100", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.HasVulnerabilities.Should().BeTrue();
+        result.Cves.Should().Contain(c => c.Id == "CVE-2025-12345");
+        result.Cves.Should().Contain(c => c.Id == "CVE-2025-99999");
+        result.IsEol.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LatestSdkReportsNoVulnerabilities()
+    {
+        // SDK 9.0.200 is the latest release — no newer CVEs
+        var result = SdkVulnerabilityChecker.Check("9.0.200", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.HasVulnerabilities.Should().BeFalse();
+        result.Cves.Should().BeEmpty();
+        result.IsEol.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EolSdkReportsEolStatus()
+    {
+        // SDK 7.0.409 is on an EOL channel
+        var result = SdkVulnerabilityChecker.Check("7.0.409", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.IsEol.Should().BeTrue();
+        result.EolDate.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void EolSdkWithVulnerabilitiesReportsBoth()
+    {
+        // SDK 7.0.409 is EOL and has a newer release with a CVE
+        var result = SdkVulnerabilityChecker.Check("7.0.409", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.IsEol.Should().BeTrue();
+        result.HasVulnerabilities.Should().BeTrue();
+        result.Cves.Should().Contain(c => c.Id == "CVE-2024-88888");
+    }
+
+    [Fact]
+    public void LatestEolSdkReportsEolButNoVulnerabilities()
+    {
+        // SDK 7.0.410 is the latest in its band on an EOL channel — no newer CVEs
+        var result = SdkVulnerabilityChecker.Check("7.0.410", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.IsEol.Should().BeTrue();
+        result.HasVulnerabilities.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnknownSdkVersionReturnsNull()
+    {
+        var result = SdkVulnerabilityChecker.Check("99.0.100", GetProductCollection(), GetProductReleases);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void KnownChannelButUnknownSdkVersionReturnsNull()
+    {
+        // Channel 9.0 exists, but SDK 9.0.999 is not in any release
+        var result = SdkVulnerabilityChecker.Check("9.0.999", GetProductCollection(), GetProductReleases);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void InvalidVersionStringReturnsNull()
+    {
+        var result = SdkVulnerabilityChecker.Check("not-a-version", GetProductCollection(), GetProductReleases);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void PartiallyVulnerableSdkReportsCorrectCves()
+    {
+        // SDK 9.0.102 is in the middle — only one newer release has CVE-2025-99999
+        var result = SdkVulnerabilityChecker.Check("9.0.102", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.HasVulnerabilities.Should().BeTrue();
+        result.Cves.Should().HaveCount(1);
+        result.Cves.Should().Contain(c => c.Id == "CVE-2025-99999");
+    }
+
+    [Fact]
+    public void FindsLatestSdkInSameFeatureBand()
+    {
+        // SDK 9.0.100 should recommend latest in the 1xx band (9.0.102)
+        var result = SdkVulnerabilityChecker.Check("9.0.100", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.LatestSdkVersion.Should().Be("9.0.102");
+    }
+}

--- a/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityChecker.cs
+++ b/test/dotnet.Tests/SdkVulnerabilityTests/GivenSdkVulnerabilityChecker.cs
@@ -104,6 +104,17 @@ public class GivenSdkVulnerabilityChecker : SdkTest
     }
 
     [Fact]
+    public void EolChannelWithUnknownSdkVersionReturnsNull()
+    {
+        // Channel 7.0 is EOL, but SDK 7.0.411 is not in any release.
+        // Covers the historical .NET 5.0.4xx-on-VS scenario where an SDK ships
+        // under a channel after that channel goes EOL.
+        var result = SdkVulnerabilityChecker.Check("7.0.411", GetProductCollection(), GetProductReleases);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void InvalidVersionStringReturnsNull()
     {
         var result = SdkVulnerabilityChecker.Check("not-a-version", GetProductCollection(), GetProductReleases);
@@ -131,5 +142,42 @@ public class GivenSdkVulnerabilityChecker : SdkTest
 
         result.Should().NotBeNull();
         result!.LatestSdkVersion.Should().Be("9.0.102");
+        result.FeatureBandDiscontinued.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DiscontinuedFeatureBandRecommendsChannelLatest()
+    {
+        // SDK 9.0.102 is in the 1xx band; no newer SDK exists in that band,
+        // but the channel has 9.0.200 in the 2xx band. The user should be told
+        // to switch bands.
+        var result = SdkVulnerabilityChecker.Check("9.0.102", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.FeatureBandDiscontinued.Should().BeTrue();
+        result.LatestSdkVersion.Should().Be("9.0.200");
+    }
+
+    [Fact]
+    public void LatestSdkInBandDoesNotFlagFeatureBandDiscontinued()
+    {
+        // SDK 9.0.200 is the channel latest — no upgrade target at all
+        var result = SdkVulnerabilityChecker.Check("9.0.200", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.FeatureBandDiscontinued.Should().BeFalse();
+        result.LatestSdkVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public void LatestEolSdkDoesNotFlagFeatureBandDiscontinued()
+    {
+        // SDK 7.0.410 is the channel latest on an EOL channel — no upgrade target.
+        // FeatureBandDiscontinued should remain false.
+        var result = SdkVulnerabilityChecker.Check("7.0.410", GetProductCollection(), GetProductReleases);
+
+        result.Should().NotBeNull();
+        result!.FeatureBandDiscontinued.Should().BeFalse();
+        result.LatestSdkVersion.Should().BeNull();
     }
 }


### PR DESCRIPTION
Closes #49552

NuGet warns about vulnerable packages (NU1901-NU1904) but nothing warns about the SDK itself. This adds opt-in build warnings when the resolved SDK has known CVEs or is end of life.

Set `<CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>` in your project or Directory.Build.props. Off by default. Two warning codes: NETSDK1237 for vulnerabilities, NETSDK1238 for EOL. Suppressible with `<NoWarn>` if you want one but not the other.

During restore, the CLI fetches release metadata in the background (same releases-index.json that `dotnet sdk check` uses) and caches it to `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild task reads from that cache during build. It never hits the network itself. No cache file means no warnings, so air-gapped builds work fine.

Cache refresh runs alongside the workload manifest updater in `RestoringCommand`, 24h sentinel. Skipped in source-build. `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE` and `DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS` are there if you need them.

```
warning NETSDK1237: The current .NET SDK (9.0.100) has known vulnerabilities (CVE-2025-12345, CVE-2025-99999). Update to version 9.0.102: https://dotnet.microsoft.com/download
```

```
warning NETSDK1238: The current .NET SDK (7.0.410) is end of life as of 2024-05-14. It will receive no further security updates: https://dotnet.microsoft.com/download
```

@baronfel would appreciate your input.