### PR TITLE
Fix greedy test filter causing double-running tests in Helix

### DIFF
--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     {
                         _builder.Append("|");
                     }
-                    _builder.Append($@"{typeInfo.FullName}");
+                    _builder.Append($@"{typeInfo.FullName}.");
 
                     CheckForPartitionLimit(done: false);
                 }


### PR DESCRIPTION
The AssemblyScheduler builds a dotnet test --filter string using pipe-separated fully qualified class names (e.g. Namespace.ClassA|Namespace.ClassB). Since --filter uses substring matching (FullyQualifiedName~value), if ClassA is a substring of ClassAExtended, filtering for ClassA also matches ClassAExtended, causing those tests to run twice when split into different Helix partitions.

Fix by appending a '.' after each class name. Since test FQNs have the format Namespace.ClassName.MethodName, filtering for 'Namespace.ClassA.' will only match methods in ClassA, not in ClassAExtended.