### PR TITLE
Add AdditionalEndpointDefinitions to DefineStaticWebAssetEndpoints

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -396,6 +396,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Static web assets endpoint metadata -->
     <_StaticWebAssetEndpointCanonicalMetadata Include="AssetFile" />
+    <_StaticWebAssetEndpointCanonicalMetadata Include="Order" />
     <_StaticWebAssetEndpointCanonicalMetadata Include="Selectors" />
     <_StaticWebAssetEndpointCanonicalMetadata Include="EndpointProperties" />
     <_StaticWebAssetEndpointCanonicalMetadata Include="ResponseHeaders" />
@@ -434,6 +435,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAssetMergeTarget Condition="'$(TargetFrameworks)' != '' and '$(TargetPlatformIdentifier)' == 'browser'">Browser</StaticWebAssetMergeTarget>
       <StaticWebAssetMergeTarget Condition="'$(TargetFrameworks)' != '' and '$(TargetPlatformIdentifier)' == ''">Server</StaticWebAssetMergeTarget>
       <StaticWebAssetsCacheDefineStaticWebAssetsEnabled Condition="'$(StaticWebAssetsCacheDefineStaticWebAssetsEnabled)' == ''">true</StaticWebAssetsCacheDefineStaticWebAssetsEnabled>
+      <StaticWebAssetDefaultDocumentEnabled Condition="'$(StaticWebAssetDefaultDocumentEnabled)' == ''">false</StaticWebAssetDefaultDocumentEnabled>
+      <StaticWebAssetSpaFallbackEnabled Condition="'$(StaticWebAssetSpaFallbackEnabled)' == ''">false</StaticWebAssetSpaFallbackEnabled>
 
       <!-- Manifest paths -->
       <_StaticWebAssetsManifestBase Condition="'$(_StaticWebAssetsManifestBase)' == ''">$(IntermediateOutputPath)</_StaticWebAssetsManifestBase>
@@ -476,6 +479,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MakeDir
       Directories="$(_StaticWebAssetsIntermediateOutputPath)"
       Condition="!Exists('$(_StaticWebAssetsIntermediateOutputPath)')" />
+
+    <ItemGroup Condition="'$(StaticWebAssetDefaultDocumentEnabled)' == 'true'">
+      <StaticWebAssetAdditionalEndpointDefinition Include="DefaultDocument">
+        <Pattern>**/index.html</Pattern>
+        <Replacement></Replacement>
+        <Order></Order>
+      </StaticWebAssetAdditionalEndpointDefinition>
+    </ItemGroup>
+    <ItemGroup Condition="'$(StaticWebAssetSpaFallbackEnabled)' == 'true'">
+      <StaticWebAssetAdditionalEndpointDefinition Include="SpaFallback">
+        <Pattern>index.html</Pattern>
+        <Replacement>{**fallback:nonfile}</Replacement>
+        <Order>2147483647</Order>
+      </StaticWebAssetAdditionalEndpointDefinition>
+    </ItemGroup>
   </Target>
 
   <!-- Build -->
@@ -721,6 +739,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefineStaticWebAssetEndpoints
       CandidateAssets="@(_CurrentProjectStaticWebAsset)"
       ContentTypeMappings="@(StaticWebAssetContentTypeMapping)"
+      AdditionalEndpointDefinitions="@(StaticWebAssetAdditionalEndpointDefinition)"
     >
       <Output TaskParameter="Endpoints" ItemName="StaticWebAssetEndpoint" />
     </DefineStaticWebAssetEndpoints>

--- a/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ApplyCompressionNegotiation.cs
@@ -273,6 +273,7 @@ public class ApplyCompressionNegotiation : Task
         {
             AssetFile = compressedAsset.Identity,
             Route = relatedEndpointCandidate.Route,
+            Order = relatedEndpointCandidate.Order,
             Selectors = [
                 ..relatedEndpointCandidate.Selectors,
                 encodingSelector

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAssetEndpoint.cs
@@ -6,6 +6,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
@@ -19,6 +20,8 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
     private StaticWebAssetEndpointSelector[] _selectors;
     private string _assetFile;
     private string _route;
+    private string _order;
+    private bool _orderRead;
     private bool _modified;
     private string _selectorsString;
     private bool _selectorsModified;
@@ -40,6 +43,29 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         set
         {
             _route = value;
+            _modified = true;
+        }
+    }
+
+    // Optional order for the endpoint in the routing table.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Order
+    {
+        get
+        {
+            if (!_orderRead && _order == null && _originalItem != null)
+            {
+                var value = _originalItem.GetMetadata(nameof(Order));
+                _order = string.IsNullOrEmpty(value) ? null : value;
+                _orderRead = true;
+            }
+            return _order;
+        }
+
+        set
+        {
+            _order = value;
+            _orderRead = true;
             _modified = true;
         }
     }
@@ -421,6 +447,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
 
     private static readonly string[] _defaultPropertyNames = [
         nameof(AssetFile),
+        nameof(Order),
         nameof(Selectors),
         nameof(ResponseHeaders),
         nameof(EndpointProperties)
@@ -454,6 +481,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         return metadataName switch
         {
             nameof(AssetFile) => AssetFile ?? "",
+            nameof(Order) => Order ?? "",
             nameof(Selectors) => !_selectorsModified ? SelectorsString ?? "" : StaticWebAssetEndpointSelector.ToMetadataValue(Selectors),
             nameof(ResponseHeaders) => !_responseHeadersModified ? ResponseHeadersString ?? "" : StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders),
             nameof(EndpointProperties) => !_endpointPropertiesModified ? EndpointPropertiesString ?? "" : StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties),
@@ -468,6 +496,9 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         {
             case nameof(AssetFile):
                 AssetFile = metadataValue;
+                break;
+            case nameof(Order):
+                Order = metadataValue;
                 break;
             case nameof(Selectors):
                 _selectorsString = metadataValue;
@@ -497,6 +528,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
         var result = new Dictionary<string, string>(((ITaskItem)this).MetadataCount)
         {
             { nameof(AssetFile), AssetFile ?? "" },
+            { nameof(Order), Order ?? "" },
             { nameof(Selectors), !_selectorsModified ? SelectorsString ?? "" : StaticWebAssetEndpointSelector.ToMetadataValue(Selectors) },
             { nameof(ResponseHeaders), !_responseHeadersModified ? ResponseHeadersString ?? "" : StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders) },
             { nameof(EndpointProperties), !_endpointPropertiesModified ? EndpointPropertiesString ?? "" : StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties) }
@@ -522,6 +554,7 @@ public class StaticWebAssetEndpoint : IEquatable<StaticWebAssetEndpoint>, ICompa
     void ITaskItem.CopyMetadataTo(ITaskItem destinationItem)
     {
         destinationItem.SetMetadata(nameof(AssetFile), AssetFile ?? "");
+        destinationItem.SetMetadata(nameof(Order), Order ?? "");
         destinationItem.SetMetadata(nameof(Selectors), !_selectorsModified ? SelectorsString ?? "" : StaticWebAssetEndpointSelector.ToMetadataValue(Selectors));
         destinationItem.SetMetadata(nameof(ResponseHeaders), !_responseHeadersModified ? ResponseHeadersString ?? "" : StaticWebAssetEndpointResponseHeader.ToMetadataValue(ResponseHeaders));
         destinationItem.SetMetadata(nameof(EndpointProperties), !_endpointPropertiesModified ? EndpointPropertiesString ?? "" : StaticWebAssetEndpointProperty.ToMetadataValue(EndpointProperties));

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -18,6 +18,8 @@ public class DefineStaticWebAssetEndpoints : Task
     [Required]
     public ITaskItem[] ContentTypeMappings { get; set; }
 
+    public ITaskItem[] AdditionalEndpointDefinitions { get; set; }
+
     [Output]
     public ITaskItem[] Endpoints { get; set; }
 
@@ -26,6 +28,7 @@ public class DefineStaticWebAssetEndpoints : Task
         var existingEndpointsByAssetFile = CreateEndpointsByAssetFile();
         var contentTypeMappings = CreateAdditionalContentTypeMappings();
         var contentTypeProvider = new ContentTypeProvider(contentTypeMappings);
+        var additionalEndpointDefinitions = CreateAdditionalEndpointDefinitions();
         var endpoints = new List<StaticWebAssetEndpoint>(CandidateAssets.Length);
 
         Parallel.For(
@@ -37,7 +40,8 @@ public class DefineStaticWebAssetEndpoints : Task
                 CandidateAssets,
                 existingEndpointsByAssetFile,
                 Log,
-                contentTypeProvider),
+                contentTypeProvider,
+                additionalEndpointDefinitions),
             static (i, loop, state) => state.Process(i, loop),
             static worker => worker.Finally());
 
@@ -99,13 +103,64 @@ public class DefineStaticWebAssetEndpoints : Task
         return null;
     }
 
+    private AdditionalEndpointDefinition[] CreateAdditionalEndpointDefinitions()
+    {
+        if (AdditionalEndpointDefinitions == null || AdditionalEndpointDefinitions.Length == 0)
+        {
+            return [];
+        }
+
+        var result = new AdditionalEndpointDefinition[AdditionalEndpointDefinitions.Length];
+        for (var i = 0; i < AdditionalEndpointDefinitions.Length; i++)
+        {
+            var item = AdditionalEndpointDefinitions[i];
+            var pattern = item.GetMetadata("Pattern");
+            var replacement = item.GetMetadata("Replacement");
+            var order = item.GetMetadata("Order");
+
+            var builder = new StaticWebAssetGlobMatcherBuilder();
+            builder.AddIncludePatterns(pattern);
+            var matcher = builder.Build();
+
+            // Compute the suffix after the recursive wildcard so we can strip it
+            // from the matched route to get the portion captured by **.
+            // For "**/index.html" the suffix is "index.html".
+            // For "index.html" (no **) the suffix is empty.
+            var suffix = "";
+            var rwcIndex = pattern.IndexOf("**", StringComparison.Ordinal);
+            if (rwcIndex >= 0)
+            {
+                var afterRwc = pattern.AsSpan().Slice(rwcIndex + 2);
+                if (afterRwc.Length > 0 && (afterRwc[0] == '/' || afterRwc[0] == '\\'))
+                {
+                    afterRwc = afterRwc.Slice(1);
+                }
+                suffix = afterRwc.ToString();
+            }
+
+            result[i] = new AdditionalEndpointDefinition(pattern, replacement, order, suffix, matcher);
+        }
+
+        return result;
+    }
+
+    internal readonly struct AdditionalEndpointDefinition(string pattern, string replacement, string order, string suffix, StaticWebAssetGlobMatcher matcher)
+    {
+        public string Pattern { get; } = pattern;
+        public string Replacement { get; } = replacement;
+        public string Order { get; } = order;
+        public string Suffix { get; } = suffix;
+        public StaticWebAssetGlobMatcher Matcher { get; } = matcher;
+    }
+
     private readonly struct ParallelWorker(
         List<StaticWebAssetEndpoint> collectedEndpoints,
         List<StaticWebAssetEndpoint> currentEndpoints,
         ITaskItem[] candidateAssets,
         Dictionary<string, HashSet<string>> existingEndpointsByAssetFile,
         TaskLoggingHelper log,
-        ContentTypeProvider contentTypeProvider)
+        ContentTypeProvider contentTypeProvider,
+        DefineStaticWebAssetEndpoints.AdditionalEndpointDefinition[] additionalEndpointDefinitions)
     {
         public List<StaticWebAssetEndpoint> CollectedEndpoints { get; } = collectedEndpoints;
         public List<StaticWebAssetEndpoint> CurrentEndpoints { get; } = currentEndpoints;
@@ -113,6 +168,7 @@ public class DefineStaticWebAssetEndpoints : Task
         public Dictionary<string, HashSet<string>> ExistingEndpointsByAssetFile { get; } = existingEndpointsByAssetFile;
         public TaskLoggingHelper Log { get; } = log;
         public ContentTypeProvider ContentTypeProvider { get; } = contentTypeProvider;
+        public DefineStaticWebAssetEndpoints.AdditionalEndpointDefinition[] AdditionalEndpointDefinitions { get; } = additionalEndpointDefinitions;
 
         private readonly List<StaticWebAsset.StaticWebAssetResolvedRoute> _resolvedRoutes = new(2);
 
@@ -196,6 +252,93 @@ public class DefineStaticWebAssetEndpoints : Task
 
                 Log.LogMessage(MessageImportance.Low, $"Adding endpoint {endpoint.Route} for asset {asset.Identity}.");
                 CurrentEndpoints.Add(endpoint);
+
+                // Generate additional endpoints from definitions
+                if (AdditionalEndpointDefinitions.Length > 0)
+                {
+                    CreateAdditionalEndpoints(endpoint);
+                }
+            }
+        }
+
+        private void CreateAdditionalEndpoints(StaticWebAssetEndpoint sourceEndpoint)
+        {
+            var matchContext = StaticWebAssetGlobMatcher.CreateMatchContext();
+            for (var d = 0; d < AdditionalEndpointDefinitions.Length; d++)
+            {
+                var definition = AdditionalEndpointDefinitions[d];
+                matchContext.SetPathAndReinitialize(sourceEndpoint.Route);
+                var match = definition.Matcher.Match(matchContext);
+                if (!match.IsMatch)
+                {
+                    continue;
+                }
+
+                // The glob matcher's Stem captures everything from the ** start to the
+                // end of the path, including the literal suffix of the pattern.
+                // For example, **/index.html matching admin/index.html produces
+                // stem="admin/index.html". We need to strip the suffix ("index.html")
+                // to get the actual ** captured portion ("admin").
+                var route = sourceEndpoint.Route;
+                string stem;
+                if (!string.IsNullOrEmpty(definition.Suffix))
+                {
+                    // Strip the suffix from the route to get the ** portion.
+                    if (route.Length > definition.Suffix.Length &&
+                        route.EndsWith(definition.Suffix, StringComparison.OrdinalIgnoreCase) &&
+                        route[route.Length - definition.Suffix.Length - 1] == '/')
+                    {
+                        // e.g., "admin/index.html" → "admin"
+                        stem = route.Substring(0, route.Length - definition.Suffix.Length - 1);
+                    }
+                    else if (route.Equals(definition.Suffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // e.g., "index.html" → ""
+                        stem = "";
+                    }
+                    else
+                    {
+                        stem = "";
+                    }
+                }
+                else
+                {
+                    stem = "";
+                }
+
+                // Build the new route from the captured stem and the replacement.
+                string newRoute;
+                if (string.IsNullOrEmpty(definition.Replacement))
+                {
+                    // When replacement is empty, the new route is just the stem (e.g., **/index.html -> the ** part)
+                    newRoute = stem;
+                }
+                else if (string.IsNullOrEmpty(stem))
+                {
+                    // When there's no stem, the replacement becomes the full route (e.g., index.html -> {**fallback:nonfile})
+                    newRoute = definition.Replacement;
+                }
+                else
+                {
+                    // Combine stem with replacement (e.g., stem=admin, replacement=something -> admin/something)
+                    newRoute = $"{stem}/{definition.Replacement}";
+                }
+
+                // Normalize the route
+                newRoute = StaticWebAsset.Normalize(newRoute);
+
+                var additionalEndpoint = new StaticWebAssetEndpoint()
+                {
+                    Route = newRoute,
+                    AssetFile = sourceEndpoint.AssetFile,
+                    Selectors = sourceEndpoint.Selectors.ToArray(),
+                    ResponseHeaders = sourceEndpoint.ResponseHeaders.ToArray(),
+                    EndpointProperties = sourceEndpoint.EndpointProperties.ToArray(),
+                    Order = !string.IsNullOrEmpty(definition.Order) ? definition.Order : null,
+                };
+
+                Log.LogMessage(MessageImportance.Low, $"Adding additional endpoint {additionalEndpoint.Route} (order={definition.Order}) for asset {sourceEndpoint.AssetFile} from pattern {definition.Pattern}.");
+                CurrentEndpoints.Add(additionalEndpoint);
             }
         }
 

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssetEndpoints.cs
@@ -122,34 +122,17 @@ public class DefineStaticWebAssetEndpoints : Task
             builder.AddIncludePatterns(pattern);
             var matcher = builder.Build();
 
-            // Compute the suffix after the recursive wildcard so we can strip it
-            // from the matched route to get the portion captured by **.
-            // For "**/index.html" the suffix is "index.html".
-            // For "index.html" (no **) the suffix is empty.
-            var suffix = "";
-            var rwcIndex = pattern.IndexOf("**", StringComparison.Ordinal);
-            if (rwcIndex >= 0)
-            {
-                var afterRwc = pattern.AsSpan().Slice(rwcIndex + 2);
-                if (afterRwc.Length > 0 && (afterRwc[0] == '/' || afterRwc[0] == '\\'))
-                {
-                    afterRwc = afterRwc.Slice(1);
-                }
-                suffix = afterRwc.ToString();
-            }
-
-            result[i] = new AdditionalEndpointDefinition(pattern, replacement, order, suffix, matcher);
+            result[i] = new AdditionalEndpointDefinition(pattern, replacement, order, matcher);
         }
 
         return result;
     }
 
-    internal readonly struct AdditionalEndpointDefinition(string pattern, string replacement, string order, string suffix, StaticWebAssetGlobMatcher matcher)
+    internal readonly struct AdditionalEndpointDefinition(string pattern, string replacement, string order, StaticWebAssetGlobMatcher matcher)
     {
         public string Pattern { get; } = pattern;
         public string Replacement { get; } = replacement;
         public string Order { get; } = order;
-        public string Suffix { get; } = suffix;
         public StaticWebAssetGlobMatcher Matcher { get; } = matcher;
     }
 
@@ -256,14 +239,13 @@ public class DefineStaticWebAssetEndpoints : Task
                 // Generate additional endpoints from definitions
                 if (AdditionalEndpointDefinitions.Length > 0)
                 {
-                    CreateAdditionalEndpoints(endpoint);
+                    CreateAdditionalEndpoints(endpoint, matchContext);
                 }
             }
         }
 
-        private void CreateAdditionalEndpoints(StaticWebAssetEndpoint sourceEndpoint)
+        private void CreateAdditionalEndpoints(StaticWebAssetEndpoint sourceEndpoint, StaticWebAssetGlobMatcher.MatchContext matchContext)
         {
-            var matchContext = StaticWebAssetGlobMatcher.CreateMatchContext();
             for (var d = 0; d < AdditionalEndpointDefinitions.Length; d++)
             {
                 var definition = AdditionalEndpointDefinitions[d];
@@ -274,54 +256,28 @@ public class DefineStaticWebAssetEndpoints : Task
                     continue;
                 }
 
-                // The glob matcher's Stem captures everything from the ** start to the
-                // end of the path, including the literal suffix of the pattern.
-                // For example, **/index.html matching admin/index.html produces
-                // stem="admin/index.html". We need to strip the suffix ("index.html")
-                // to get the actual ** captured portion ("admin").
-                var route = sourceEndpoint.Route;
-                string stem;
-                if (!string.IsNullOrEmpty(definition.Suffix))
-                {
-                    // Strip the suffix from the route to get the ** portion.
-                    if (route.Length > definition.Suffix.Length &&
-                        route.EndsWith(definition.Suffix, StringComparison.OrdinalIgnoreCase) &&
-                        route[route.Length - definition.Suffix.Length - 1] == '/')
-                    {
-                        // e.g., "admin/index.html" → "admin"
-                        stem = route.Substring(0, route.Length - definition.Suffix.Length - 1);
-                    }
-                    else if (route.Equals(definition.Suffix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // e.g., "index.html" → ""
-                        stem = "";
-                    }
-                    else
-                    {
-                        stem = "";
-                    }
-                }
-                else
-                {
-                    stem = "";
-                }
+                // Use the CapturedStem from the match, which contains only the portion matched by **,
+                // without any trailing literal segments from the pattern.
+                // For **/index.html matching admin/index.html: CapturedStem="admin".
+                // For index.html (no **) matching index.html: CapturedStem="".
+                var capturedStem = match.CapturedStem;
 
                 // Build the new route from the captured stem and the replacement.
                 string newRoute;
                 if (string.IsNullOrEmpty(definition.Replacement))
                 {
-                    // When replacement is empty, the new route is just the stem (e.g., **/index.html -> the ** part)
-                    newRoute = stem;
+                    // When replacement is empty, the new route is just the captured stem (e.g., **/index.html -> the ** part)
+                    newRoute = capturedStem;
                 }
-                else if (string.IsNullOrEmpty(stem))
+                else if (string.IsNullOrEmpty(capturedStem))
                 {
-                    // When there's no stem, the replacement becomes the full route (e.g., index.html -> {**fallback:nonfile})
+                    // When there's no captured stem, the replacement becomes the full route (e.g., index.html -> {**fallback:nonfile})
                     newRoute = definition.Replacement;
                 }
                 else
                 {
-                    // Combine stem with replacement (e.g., stem=admin, replacement=something -> admin/something)
-                    newRoute = $"{stem}/{definition.Replacement}";
+                    // Combine captured stem with replacement (e.g., capturedStem=admin, replacement=something -> admin/something)
+                    newRoute = $"{capturedStem}/{definition.Replacement}";
                 }
 
                 // Normalize the route

--- a/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/GlobMatch.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/GlobMatch.cs
@@ -5,11 +5,16 @@
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public struct GlobMatch(bool isMatch, string pattern = null, string stem = null)
+public struct GlobMatch(bool isMatch, string pattern = null, string stem = null, string capturedStem = null)
 {
     public bool IsMatch { get; set; } = isMatch;
 
     public string Pattern { get; set; } = pattern;
 
     public string Stem { get; set; } = stem;
+
+    // The portion of the path matched exclusively by **, without any trailing literal segments from the pattern.
+    // For **/index.html matching admin/index.html: "admin". For wwwroot/** matching wwwroot/css/file.css: "css/file.css".
+    // Empty string for patterns without ** or when ** captures nothing.
+    public string CapturedStem { get; set; } = capturedStem;
 }

--- a/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/StaticWebAssetGlobMatcher.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/Globbing/StaticWebAssetGlobMatcher.cs
@@ -57,7 +57,8 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
                         if (node.Match != null)
                         {
                             var stem = ComputeStem(segments, state.StemStartIndex);
-                            return new(true, node.Match, stem);
+                            var capturedStem = ComputeCapturedStem(segments, state.StemStartIndex, state.StemEndIndex);
+                            return new(true, node.Match, stem, capturedStem);
                         }
 
                         // We got to the end with no matches, pop the next element on the stack.
@@ -150,6 +151,32 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
         }
         return stem.ToString();
 #endif
+    }
+
+    // Computes only the portion of the path captured by **, excluding any trailing literal segments in the pattern.
+    // For **/index.html matching admin/index.html: returns "admin" (not "admin/index.html").
+    // For wwwroot/** matching wwwroot/css/style.css: returns "css/style.css" (same as Stem since ** is at the end).
+    // For patterns without **: returns empty string.
+    private static string ComputeCapturedStem(PathTokenizer.SegmentCollection segments, int stemStartIndex, int stemEndIndex)
+    {
+        if (stemStartIndex == -1 || stemEndIndex <= stemStartIndex)
+        {
+            return string.Empty;
+        }
+        var stem = new StringBuilder();
+        for (var i = stemStartIndex; i < stemEndIndex; i++)
+        {
+#if NET
+            stem.Append(segments[i]);
+#else
+            stem.Append(segments[i].ToString());
+#endif
+            if (i < stemEndIndex - 1)
+            {
+                stem.Append('/');
+            }
+        }
+        return stem.ToString();
     }
 
     private static void MatchComplex(PathTokenizer.SegmentCollection segments, Stack<MatchState> stateStack, MatchState state)
@@ -273,9 +300,12 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
             var nextSegment = state.NextSegment(node.RecursiveWildCard, i);
             // The stem is calculated as the first time the /**/ pattern is matched til the remainder of the path, otherwise, the stem is
             // the file name.
+            // StemStartIndex and StemEndIndex are set per iteration since NextSegment propagates the current values (-1 initially).
+            // Each state pushed onto the stack has a distinct i, so StemEndIndex correctly reflects how many segments ** consumed.
             if (nextSegment.StemStartIndex == -1)
             {
                 nextSegment.StemStartIndex = state.SegmentIndex;
+                nextSegment.StemEndIndex = state.SegmentIndex + i;
             }
 
             stateStack.Push(nextSegment);
@@ -360,6 +390,10 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
 
         public int StemStartIndex { get; set; } = -1;
 
+        // Tracks the segment index where ** stopped consuming (exclusive end of the ** captured portion).
+        // Set alongside StemStartIndex in MatchRecursiveWildCard.
+        public int StemEndIndex { get; set; } = -1;
+
         internal readonly bool HasValue => Node != null;
 
         public readonly void Deconstruct(out GlobNode node, out MatchStage stage, out int segmentIndex, out int extensionIndex, out int complexIndex)
@@ -372,7 +406,7 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
         }
 
         internal MatchState NextSegment(GlobNode candidate, int elements = 1, int complexIndex = 0) =>
-            new(candidate, GetInitialStage(candidate), SegmentIndex + elements, 0, complexIndex) { StemStartIndex = StemStartIndex };
+            new(candidate, GetInitialStage(candidate), SegmentIndex + elements, 0, complexIndex) { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
 
         internal MatchState NextStage()
         {
@@ -382,68 +416,68 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
                     if (Node.HasExtensions())
                     {
                         return new(Node, MatchStage.Extension, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
 
                     if (Node.ComplexGlobSegments != null && Node.ComplexGlobSegments.Count > 0)
                     {
                         return new(Node, MatchStage.Complex, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
 
                     if (Node.WildCard != null)
                     {
                         return new(Node, MatchStage.WildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
 
                     if (Node.RecursiveWildCard != null)
                     {
                         return new(Node, MatchStage.RecursiveWildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
                     break;
                 case MatchStage.Extension:
                     if (Node.ComplexGlobSegments != null && Node.ComplexGlobSegments.Count > 0)
                     {
                         return new(Node, MatchStage.Complex, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
 
                     if (Node.WildCard != null)
                     {
                         return new(Node, MatchStage.WildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
 
                     if (Node.RecursiveWildCard != null)
                     {
                         return new(Node, MatchStage.RecursiveWildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
                     break;
                 case MatchStage.Complex:
                     if (Node.WildCard != null)
                     {
                         return new(Node, MatchStage.WildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
                     if (Node.RecursiveWildCard != null)
                     {
                         return new(Node, MatchStage.RecursiveWildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
                     break;
                 case MatchStage.WildCard:
                     if (Node.RecursiveWildCard != null)
                     {
                         return new(Node, MatchStage.RecursiveWildCard, SegmentIndex, 0, 0)
-                        { StemStartIndex = StemStartIndex };
+                        { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
                     }
                     break;
                 case MatchStage.RecursiveWildCard:
                     return new(Node, MatchStage.Done, SegmentIndex, 0, 0)
-                    { StemStartIndex = StemStartIndex };
+                    { StemStartIndex = StemStartIndex, StemEndIndex = StemEndIndex };
             }
 
             return default;
@@ -481,7 +515,8 @@ public class StaticWebAssetGlobMatcher(GlobNode includes, GlobNode excludes)
 
         internal readonly MatchState NextExtension(int extensionIndex) => new(Node, MatchStage.Extension, SegmentIndex, extensionIndex, ComplexSegmentIndex)
         {
-            StemStartIndex = StemStartIndex
+            StemStartIndex = StemStartIndex,
+            StemEndIndex = StemEndIndex
         };
 
         internal readonly MatchState NextComplex() => new(Node, MatchStage.Complex, SegmentIndex, ExtensionSegmentIndex, ComplexSegmentIndex + 1);

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetEndpointsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetEndpointsIntegrationTest.cs
@@ -506,6 +506,47 @@ public partial class StaticWebAssetEndpointsIntegrationTest(ITestOutputHelper lo
         VerifyEndpointsCollection(publishOutputDirectory, "blazorhosted");
     }
 
+    [Fact]
+    public void Build_DefaultDocumentAndSpaFallback_CreatesAdditionalEndpoints()
+    {
+        ProjectDirectory = CreateAspNetSdkTestAsset("RazorComponentApp")
+            .WithProjectChanges(document =>
+            {
+                document.Root.AddFirst(
+                    new XElement("PropertyGroup",
+                        new XElement("StaticWebAssetDefaultDocumentEnabled", "true"),
+                        new XElement("StaticWebAssetSpaFallbackEnabled", "true")));
+            });
+        var root = ProjectDirectory.TestRoot;
+
+        var dir = Directory.CreateDirectory(Path.Combine(root, "wwwroot"));
+        File.WriteAllText(Path.Combine(dir.FullName, "index.html"), "<html><body>Hello</body></html>");
+
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+
+        var path = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        new FileInfo(path).Should().Exist();
+        var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(path));
+
+        var endpoints = manifest.Endpoints;
+
+        // There should be endpoints for index.html (original + fingerprinted + default document + spa fallback)
+        var indexHtmlEndpoints = endpoints.Where(ep => ep.AssetFile.Contains("index.html") && !ep.AssetFile.Contains(".gz") && !ep.AssetFile.Contains(".br"));
+
+        // Original index.html endpoint
+        indexHtmlEndpoints.Should().Contain(e => e.Route == "index.html");
+
+        // SPA fallback endpoint with catch-all route and max int order
+        var fallback = endpoints.FirstOrDefault(e => e.Route == "{**fallback:nonfile}");
+        fallback.Should().NotBeNull();
+        fallback.Order.Should().Be("2147483647");
+
+        AssertManifest(manifest, LoadBuildManifest());
+    }
+
     // Makes several assertions about the endpoints we defined.
     // All assets have at least one endpoint.
     // No endpoint points to a non-existent asset

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
@@ -661,8 +661,11 @@ public class DefineStaticWebAssetEndpointsTest
         });
     }
 
-    [Fact]
-    public void AdditionalEndpointDefinitions_DefaultDocument_CreatesEndpointWithoutSuffix()
+    [Theory]
+    [InlineData("index.html", "index.html", "/")]
+    [InlineData("admin/index.html", "admin/index.html", "admin")]
+    public void AdditionalEndpointDefinitions_DefaultDocument_CreatesEndpointWithCapturedStem(
+        string relativeSubPath, string expectedOriginalRoute, string expectedAdditionalRoute)
     {
         var errorMessages = new List<string>();
         var buildEngine = new Mock<IBuildEngine>();
@@ -670,15 +673,16 @@ public class DefineStaticWebAssetEndpointsTest
             .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
 
         var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+        var physicalPath = Path.Combine(new[] { "wwwroot" }.Concat(relativeSubPath.Split('/')).ToArray());
 
         var task = new DefineStaticWebAssetEndpoints
         {
             BuildEngine = buildEngine.Object,
             CandidateAssets = [CreateCandidate(
-                Path.Combine("wwwroot", "index.html"),
+                physicalPath,
                 "MyPackage",
                 "Discovered",
-                "index.html",
+                relativeSubPath,
                 "All",
                 "All",
                 fileLength: 100,
@@ -697,58 +701,14 @@ public class DefineStaticWebAssetEndpointsTest
         // Should have original endpoint + additional endpoint
         endpoints.Length.Should().Be(2);
 
-        var original = endpoints.First(e => e.Route == "index.html");
+        var original = endpoints.First(e => e.Route == expectedOriginalRoute);
         original.Should().NotBeNull();
         original.Order.Should().BeNullOrEmpty();
 
-        // The additional endpoint should have the suffix stripped (index.html matches **/index.html, stem is empty -> route is empty -> normalized to "/")
-        var additional = endpoints.First(e => e.Route != "index.html");
+        var additional = endpoints.First(e => e.Route != expectedOriginalRoute);
+        additional.Route.Should().Be(expectedAdditionalRoute);
         additional.AssetFile.Should().Be(original.AssetFile);
         additional.ResponseHeaders.Should().BeEquivalentTo(original.ResponseHeaders);
-    }
-
-    [Fact]
-    public void AdditionalEndpointDefinitions_DefaultDocument_NestedPath_CapturesStem()
-    {
-        var errorMessages = new List<string>();
-        var buildEngine = new Mock<IBuildEngine>();
-        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
-            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
-
-        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
-
-        var task = new DefineStaticWebAssetEndpoints
-        {
-            BuildEngine = buildEngine.Object,
-            CandidateAssets = [CreateCandidate(
-                Path.Combine("wwwroot", "admin", "index.html"),
-                "MyPackage",
-                "Discovered",
-                "admin/index.html",
-                "All",
-                "All",
-                fileLength: 100,
-                lastWriteTime: lastWrite)],
-            ExistingEndpoints = [],
-            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
-            AdditionalEndpointDefinitions = [
-                CreateAdditionalEndpointDefinition("DefaultDocument", "**/index.html", "")
-            ],
-        };
-
-        var result = task.Execute();
-
-        result.Should().Be(true);
-        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
-        endpoints.Length.Should().Be(2);
-
-        var original = endpoints.First(e => e.Route == "admin/index.html");
-        original.Should().NotBeNull();
-
-        // The stem is "admin", replacement is empty -> new route is "admin"
-        var additional = endpoints.First(e => e.Route != "admin/index.html");
-        additional.Route.Should().Be("admin");
-        additional.AssetFile.Should().Be(original.AssetFile);
     }
 
     [Fact]
@@ -874,6 +834,7 @@ public class DefineStaticWebAssetEndpointsTest
         endpoints.Length.Should().Be(3);
 
         endpoints.Should().Contain(e => e.Route == "index.html");
+        endpoints.Should().Contain(e => e.Route == "/");
         endpoints.Should().Contain(e => e.Route == "{**fallback:nonfile}" && e.Order == "2147483647");
     }
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetEndpointsTest.cs
@@ -650,4 +650,265 @@ public class DefineStaticWebAssetEndpointsTest
             Selectors = responseSelector ?? []
         }.ToTaskItem();
     }
+
+    private static TaskItem CreateAdditionalEndpointDefinition(string name, string pattern, string replacement, string order = "")
+    {
+        return new TaskItem(name, new Dictionary<string, string>
+        {
+            { "Pattern", pattern },
+            { "Replacement", replacement },
+            { "Order", order }
+        });
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_DefaultDocument_CreatesEndpointWithoutSuffix()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "index.html"),
+                "MyPackage",
+                "Discovered",
+                "index.html",
+                "All",
+                "All",
+                fileLength: 100,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
+            AdditionalEndpointDefinitions = [
+                CreateAdditionalEndpointDefinition("DefaultDocument", "**/index.html", "")
+            ],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        // Should have original endpoint + additional endpoint
+        endpoints.Length.Should().Be(2);
+
+        var original = endpoints.First(e => e.Route == "index.html");
+        original.Should().NotBeNull();
+        original.Order.Should().BeNullOrEmpty();
+
+        // The additional endpoint should have the suffix stripped (index.html matches **/index.html, stem is empty -> route is empty -> normalized to "/")
+        var additional = endpoints.First(e => e.Route != "index.html");
+        additional.AssetFile.Should().Be(original.AssetFile);
+        additional.ResponseHeaders.Should().BeEquivalentTo(original.ResponseHeaders);
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_DefaultDocument_NestedPath_CapturesStem()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "admin", "index.html"),
+                "MyPackage",
+                "Discovered",
+                "admin/index.html",
+                "All",
+                "All",
+                fileLength: 100,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
+            AdditionalEndpointDefinitions = [
+                CreateAdditionalEndpointDefinition("DefaultDocument", "**/index.html", "")
+            ],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        endpoints.Length.Should().Be(2);
+
+        var original = endpoints.First(e => e.Route == "admin/index.html");
+        original.Should().NotBeNull();
+
+        // The stem is "admin", replacement is empty -> new route is "admin"
+        var additional = endpoints.First(e => e.Route != "admin/index.html");
+        additional.Route.Should().Be("admin");
+        additional.AssetFile.Should().Be(original.AssetFile);
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_SpaFallback_CreatesEndpointWithFallbackRoute()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "index.html"),
+                "MyPackage",
+                "Discovered",
+                "index.html",
+                "All",
+                "All",
+                fileLength: 100,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
+            AdditionalEndpointDefinitions = [
+                CreateAdditionalEndpointDefinition("SpaFallback", "index.html", "{**fallback:nonfile}", "2147483647")
+            ],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        endpoints.Length.Should().Be(2);
+
+        var original = endpoints.First(e => e.Route == "index.html");
+        original.Should().NotBeNull();
+        original.Order.Should().BeNullOrEmpty();
+
+        var fallback = endpoints.First(e => e.Route != "index.html");
+        fallback.Route.Should().Be("{**fallback:nonfile}");
+        fallback.AssetFile.Should().Be(original.AssetFile);
+        fallback.Order.Should().Be("2147483647");
+        fallback.ResponseHeaders.Should().BeEquivalentTo(original.ResponseHeaders);
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_DoesNotMatchNonMatchingRoutes()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "app.js"),
+                "MyPackage",
+                "Discovered",
+                "app.js",
+                "All",
+                "All",
+                fileLength: 50,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.js", "text/javascript")],
+            AdditionalEndpointDefinitions = [
+                CreateAdditionalEndpointDefinition("DefaultDocument", "**/index.html", ""),
+                CreateAdditionalEndpointDefinition("SpaFallback", "index.html", "{**fallback:nonfile}", "2147483647")
+            ],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        // Only the original endpoint, no additional ones
+        endpoints.Should().ContainSingle();
+        endpoints[0].Route.Should().Be("app.js");
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_BothRules_CreateMultipleAdditionalEndpoints()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "index.html"),
+                "MyPackage",
+                "Discovered",
+                "index.html",
+                "All",
+                "All",
+                fileLength: 100,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
+            AdditionalEndpointDefinitions = [
+                CreateAdditionalEndpointDefinition("DefaultDocument", "**/index.html", ""),
+                CreateAdditionalEndpointDefinition("SpaFallback", "index.html", "{**fallback:nonfile}", "2147483647")
+            ],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        // Original + DefaultDocument + SpaFallback
+        endpoints.Length.Should().Be(3);
+
+        endpoints.Should().Contain(e => e.Route == "index.html");
+        endpoints.Should().Contain(e => e.Route == "{**fallback:nonfile}" && e.Order == "2147483647");
+    }
+
+    [Fact]
+    public void AdditionalEndpointDefinitions_EmptyArray_NoAdditionalEndpoints()
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var lastWrite = new DateTime(1990, 11, 15, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        var task = new DefineStaticWebAssetEndpoints
+        {
+            BuildEngine = buildEngine.Object,
+            CandidateAssets = [CreateCandidate(
+                Path.Combine("wwwroot", "index.html"),
+                "MyPackage",
+                "Discovered",
+                "index.html",
+                "All",
+                "All",
+                fileLength: 100,
+                lastWriteTime: lastWrite)],
+            ExistingEndpoints = [],
+            ContentTypeMappings = [CreateContentMapping("**/*.html", "text/html")],
+            AdditionalEndpointDefinitions = [],
+        };
+
+        var result = task.Execute();
+
+        result.Should().Be(true);
+        var endpoints = StaticWebAssetEndpoint.FromItemGroup(task.Endpoints);
+        endpoints.Should().ContainSingle();
+        endpoints[0].Route.Should().Be("index.html");
+    }
 }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsBaselineComparer.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsBaselineComparer.cs
@@ -440,6 +440,10 @@ For {expectedAsset.AssetFile}:
         {
             assetDifferences.Add($"Expected manifest SourceType of {expectedAsset.AssetFile} but found {manifestAsset.AssetFile}.");
         }
+        if ((manifestAsset.Order ?? "") != (expectedAsset.Order ?? ""))
+        {
+            assetDifferences.Add($"Expected manifest Order of '{expectedAsset.Order}' but found '{manifestAsset.Order}'.");
+        }
 
         ComputeSelectorDifferences(assetDifferences, manifestAsset.Selectors, expectedAsset.Selectors);
         ComputeResponseHeaderDifferences(assetDifferences, manifestAsset.ResponseHeaders, expectedAsset.ResponseHeaders);

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsBaselines/Build_DefaultDocumentAndSpaFallback_CreatesAdditionalEndpoints.Build.staticwebassets.json
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsBaselines/Build_DefaultDocumentAndSpaFallback_CreatesAdditionalEndpoints.Build.staticwebassets.json
@@ -1,0 +1,1687 @@
+{
+  "Version": 1,
+  "Hash": "__hash__",
+  "Source": "ComponentApp",
+  "BasePath": "/",
+  "Mode": "Root",
+  "ManifestType": "Build",
+  "ReferencedProjectsConfiguration": [],
+  "DiscoveryPatterns": [
+    {
+      "Name": "ComponentApp\\wwwroot",
+      "Source": "ComponentApp",
+      "ContentRoot": "${ProjectPath}\\wwwroot\\",
+      "BasePath": "/",
+      "Pattern": "**"
+    }
+  ],
+  "Assets": [
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Computed",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "/",
+      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "AssetKind": "All",
+      "AssetMode": "Reference",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp.bundle.scp.css",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Computed",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "/",
+      "RelativePath": "ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp.styles.css",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.server.js.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "/",
+      "RelativePath": "_framework/blazor.server.js.gz",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.server.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\_framework\\blazor.server.js.gz",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "/",
+      "RelativePath": "_framework/blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.web.js",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\index.html.gz",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\",
+      "BasePath": "/",
+      "RelativePath": "index.html.gz",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Alternative",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "${ProjectPath}\\wwwroot\\index.html",
+      "AssetTraitName": "Content-Encoding",
+      "AssetTraitValue": "gzip",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\wwwroot\\index.html.gz",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp.styles.css",
+      "SourceId": "ComponentApp",
+      "SourceType": "Computed",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\",
+      "BasePath": "/",
+      "RelativePath": "ComponentApp#[.{fingerprint}]?.styles.css",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Primary",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "",
+      "AssetTraitName": "ScopedCss",
+      "AssetTraitValue": "ApplicationBundle",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp.styles.css",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp.bundle.scp.css",
+      "SourceId": "ComponentApp",
+      "SourceType": "Computed",
+      "ContentRoot": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\",
+      "BasePath": "/",
+      "RelativePath": "ComponentApp#[.{fingerprint}]!.bundle.scp.css",
+      "AssetKind": "All",
+      "AssetMode": "Reference",
+      "AssetRole": "Primary",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "",
+      "AssetTraitName": "ScopedCss",
+      "AssetTraitValue": "ProjectBundle",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp.bundle.scp.css",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${ProjectPath}\\wwwroot\\index.html",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${ProjectPath}\\wwwroot\\",
+      "BasePath": "/",
+      "RelativePath": "index.html",
+      "AssetKind": "All",
+      "AssetMode": "All",
+      "AssetRole": "Primary",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "",
+      "AssetTraitName": "",
+      "AssetTraitValue": "",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "wwwroot\\index.html",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.server.js",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\",
+      "BasePath": "/",
+      "RelativePath": "_framework/blazor.server.js",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Primary",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "",
+      "AssetTraitName": "",
+      "AssetTraitValue": "",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\build\\..\\_framework\\blazor.server.js",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    },
+    {
+      "Identity": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.web.js",
+      "SourceId": "ComponentApp",
+      "SourceType": "Discovered",
+      "ContentRoot": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\",
+      "BasePath": "/",
+      "RelativePath": "_framework/blazor.web#[.{fingerprint}]?.js",
+      "AssetKind": "All",
+      "AssetMode": "CurrentProject",
+      "AssetRole": "Primary",
+      "AssetMergeBehavior": "",
+      "AssetMergeSource": "",
+      "RelatedAsset": "",
+      "AssetTraitName": "",
+      "AssetTraitValue": "",
+      "Fingerprint": "__fingerprint__",
+      "Integrity": "__integrity__",
+      "CopyToOutputDirectory": "Never",
+      "CopyToPublishDirectory": "PreserveNewest",
+      "OriginalItemSpec": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\build\\..\\_framework\\blazor.web.js",
+      "FileLength": -1,
+      "LastWriteTime": "0001-01-01T00:00:00+00:00"
+    }
+  ],
+  "Endpoints": [
+    {
+      "Route": "ComponentApp.bundle.scp.css.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css.gz"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.bundle.scp.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]!.bundle.scp.css.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.styles.css.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.styles.css.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css.gz"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.styles.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.styles.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\ComponentApp#[.{fingerprint=__fingerprint__}]?.styles.css.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.server.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.server.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.server.js.gz"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.server.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.server.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.server.js"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.web.js.gz"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\_framework\\blazor.web#[.{fingerprint=__fingerprint__}]?.js.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.web.js"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "index.html.gz",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\index.html.gz",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "index.html",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\index.html.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "/",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\index.html.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "{**fallback:nonfile}",
+      "Order": "2147483647",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\compressed\\index.html.gz",
+      "Selectors": [
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip",
+          "Quality": "__quality__"
+        }
+      ],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Encoding",
+          "Value": "gzip"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "original-resource",
+          "Value": "__original-resource__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.styles.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp.styles.css",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.styles.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\bundle\\ComponentApp.styles.css",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.styles.css"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.bundle.scp.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp.bundle.scp.css",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "ComponentApp.__fingerprint__.bundle.scp.css",
+      "AssetFile": "${ProjectPath}\\obj\\Debug\\${Tfm}\\scopedcss\\projectbundle\\ComponentApp.bundle.scp.css",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/css"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "ComponentApp.bundle.scp.css"
+        }
+      ]
+    },
+    {
+      "Route": "index.html",
+      "AssetFile": "${ProjectPath}\\wwwroot\\index.html",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "/",
+      "AssetFile": "${ProjectPath}\\wwwroot\\index.html",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "{**fallback:nonfile}",
+      "Order": "2147483647",
+      "AssetFile": "${ProjectPath}\\wwwroot\\index.html",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js",
+      "AssetFile": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.server.js",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.server.js",
+      "AssetFile": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.server.js",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.server.js"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js",
+      "AssetFile": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.web.js",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        }
+      ]
+    },
+    {
+      "Route": "_framework/blazor.web.js",
+      "AssetFile": "${RestorePath}\\microsoft.aspnetcore.app.internal.assets\\${PackageVersion}\\_framework\\blazor.web.js",
+      "Selectors": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "max-age=31536000, immutable"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "__content-length__"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/javascript"
+        },
+        {
+          "Name": "ETag",
+          "Value": "__etag__"
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "__last-modified__"
+        },
+        {
+          "Name": "Vary",
+          "Value": "Accept-Encoding"
+        }
+      ],
+      "EndpointProperties": [
+        {
+          "Name": "fingerprint",
+          "Value": "__fingerprint__"
+        },
+        {
+          "Name": "integrity",
+          "Value": "__integrity__"
+        },
+        {
+          "Name": "label",
+          "Value": "_framework/blazor.web.js"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Understand reviewer comments and plan changes
- [x] Fix `StaticWebAssetGlobMatcher` to track `StemEndIndex` and expose `CapturedStem` in `GlobMatch`
  - Added `StemEndIndex` to `MatchState` struct
  - Set `StemEndIndex` in `MatchRecursiveWildCard` alongside `StemStartIndex`
  - Propagate `StemEndIndex` through all `NextSegment`, `NextStage`, and `NextExtension` calls
  - Added `ComputeCapturedStem` method (returns only the `**`-captured portion)
  - Added `CapturedStem` property to `GlobMatch`
- [x] Simplify `DefineStaticWebAssetEndpoints`
  - Removed manual suffix computation from pattern string (was parsing `**/index.html` → suffix `index.html`)
  - Removed `Suffix` from `AdditionalEndpointDefinition`
  - Use `match.CapturedStem` from matcher instead of suffix stripping logic
  - Moved `MatchContext` creation outside `CreateAdditionalEndpoints`, passed as parameter from `CreateAnAddEndpoints`
- [x] Test improvements
  - Combined `DefaultDocument_CreatesEndpointWithoutSuffix` and `DefaultDocument_NestedPath_CapturesStem` into a single `Theory` with `InlineData` for root-level and nested paths
  - Added route assertions to all test cases
  - Added assertion for `"/"` route in `BothRules` test
- [x] Validate changes with tests (173 tests pass)

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
