### PR TITLE
Fix TargetsWindows when VMR passes TargetOS=windows

### DIFF
--- a/eng/OSArch.props
+++ b/eng/OSArch.props
@@ -7,9 +7,11 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
   </PropertyGroup>
 
-  <!-- Host and target OS detection -->
+  <!-- Host and target OS detection.
+       Uses full OS names (windows, linux, osx, freebsd, etc.) matching the VMR convention.
+       See https://github.com/dotnet/dotnet/blob/main/docs/VMR-Controls.md#output-controls -->
   <PropertyGroup Label="CalculateTargetOS">
-    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">win</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">windows</HostOS>
     <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</HostOS>
     <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">freebsd</HostOS>
     <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('OPENBSD'))">openbsd</HostOS>
@@ -19,19 +21,19 @@
     <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">linux</HostOS>
     <IsLinux Condition="'$(HostOS)' == 'linux'">true</IsLinux>
 
-    <!-- TargetOS defaults to HostOS; overridable via /p:TargetOS from build scripts.
-         Uses RID-style OS names (win, osx, linux) for compatibility with existing SDK code. -->
+    <!-- TargetOS defaults to HostOS; overridable via /p:TargetOS from build scripts. -->
     <TargetOS Condition="'$(TargetOS)' == ''">$(HostOS)</TargetOS>
 
-    <!-- OSName preserved for backward compatibility with Layout projects -->
+    <!-- OSName uses RID-style names (win, not windows) for downstream RID construction. -->
     <OSName Condition="'$(OSName)' == '' AND '$(PortableTargetRid)' != ''">$(PortableTargetRid.Substring(0, $(PortableTargetRid.LastIndexOf('-'))))</OSName>
     <OSName Condition="'$(OSName)' == '' AND '$(TargetRid)' != ''">$(TargetRid.Substring(0, $(TargetRid.LastIndexOf('-'))))</OSName>
+    <OSName Condition="'$(OSName)' == '' AND '$(TargetOS)' == 'windows'">win</OSName>
     <OSName Condition="'$(OSName)' == ''">$(TargetOS)</OSName>
   </PropertyGroup>
 
   <!-- Boolean targeting properties -->
   <PropertyGroup Label="CalculateTargetOSFlags">
-    <TargetsWindows Condition="'$(TargetOS)' == 'win'">true</TargetsWindows>
+    <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
     <TargetsLinux Condition="'$(TargetOS)' == 'linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(TargetOS)' == 'osx'">true</TargetsOSX>
     <TargetsFreeBSD Condition="'$(TargetOS)' == 'freebsd'">true</TargetsFreeBSD>

--- a/eng/OSArch.props
+++ b/eng/OSArch.props
@@ -23,15 +23,19 @@
          Uses RID-style OS names (win, osx, linux) for compatibility with existing SDK code. -->
     <TargetOS Condition="'$(TargetOS)' == ''">$(HostOS)</TargetOS>
 
-    <!-- OSName preserved for backward compatibility with Layout projects -->
+    <!-- OSName preserved for backward compatibility with Layout projects.
+         Uses RID-style names (win, not windows) for downstream RID construction. -->
     <OSName Condition="'$(OSName)' == '' AND '$(PortableTargetRid)' != ''">$(PortableTargetRid.Substring(0, $(PortableTargetRid.LastIndexOf('-'))))</OSName>
     <OSName Condition="'$(OSName)' == '' AND '$(TargetRid)' != ''">$(TargetRid.Substring(0, $(TargetRid.LastIndexOf('-'))))</OSName>
+    <OSName Condition="'$(OSName)' == '' AND '$(TargetOS)' == 'windows'">win</OSName>
     <OSName Condition="'$(OSName)' == ''">$(TargetOS)</OSName>
   </PropertyGroup>
 
-  <!-- Boolean targeting properties -->
+  <!-- Boolean targeting properties.
+       TargetOS may be set externally with either RID-style names (win, osx, linux)
+       or full names (windows, osx, linux) as used by the runtime repo and the VMR. -->
   <PropertyGroup Label="CalculateTargetOSFlags">
-    <TargetsWindows Condition="'$(TargetOS)' == 'win'">true</TargetsWindows>
+    <TargetsWindows Condition="'$(TargetOS)' == 'win' OR '$(TargetOS)' == 'windows'">true</TargetsWindows>
     <TargetsLinux Condition="'$(TargetOS)' == 'linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(TargetOS)' == 'osx'">true</TargetsOSX>
     <TargetsFreeBSD Condition="'$(TargetOS)' == 'freebsd'">true</TargetsFreeBSD>

--- a/eng/OSArch.props
+++ b/eng/OSArch.props
@@ -31,9 +31,7 @@
     <OSName Condition="'$(OSName)' == ''">$(TargetOS)</OSName>
   </PropertyGroup>
 
-  <!-- Boolean targeting properties.
-       TargetOS may be set externally with either RID-style names (win, osx, linux)
-       or full names (windows, osx, linux) as used by the runtime repo and the VMR. -->
+  <!-- Boolean targeting properties. -->
   <PropertyGroup Label="CalculateTargetOSFlags">
     <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
     <TargetsLinux Condition="'$(TargetOS)' == 'linux'">true</TargetsLinux>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -2,7 +2,7 @@
 Param(
   [switch][Alias('h')]$help,
   [ValidateSet("Debug","Release")][string[]][Alias('c')]$configuration = @("Debug"),
-  [ValidateSet("win","linux","osx","freebsd")][string]$os,
+  [ValidateSet("windows","linux","osx","freebsd")][string]$os,
   [ValidateSet("x86","x64","arm","arm64")][string][Alias('a')]$arch,
   [switch][Alias('t')]$test,
   [switch]$pack,
@@ -15,7 +15,7 @@ if ($help) {
   Write-Host "Common settings:"
   Write-Host "  -arch (-a)           Target architecture: x86, x64, arm, arm64 [default: x64]"
   Write-Host "  -configuration (-c)  Build configuration: Debug or Release [default: Debug]"
-  Write-Host "  -os                  Target OS: win, linux, osx, freebsd [default: host OS]"
+  Write-Host "  -os                  Target OS: windows, linux, osx, freebsd [default: host OS]"
   Write-Host "  -test (-t)           Run tests after building"
   Write-Host "  -pack                Build installers and packages"
   Write-Host ""


### PR DESCRIPTION
The VMR (dotnet/dotnet) passes TargetOS=windows as a global MSBuild property, using the full OS name convention from the runtime repo (dotnet/runtime). However, eng/OSArch.props only checked for the RID-style short name (TargetOS == 'win'), so TargetsWindows was never set to true in VMR builds on Windows.

This caused IncludeWpfAndWinForms to evaluate to false, which meant the Microsoft.WindowsDesktop.App.Ref pack was excluded from the redist layout. The GenerateRuntimeAnalyzersSWR task then failed with a DirectoryNotFoundException when trying to enumerate the missing WindowsDesktopAnalyzers directory.

Fix:
- Accept both 'win' and 'windows' for the TargetsWindows condition, matching the runtime repo's convention (eng/RuntimeIdentifier.props line 67: TargetsWindows Condition="'$(TargetOS)' == 'windows'").
- Add an OSName normalization so that when TargetOS=windows is passed and no RID is available, OSName falls back to 'win' (not 'windows') for correct RID construction downstream.

Fixes: https://github.com/dotnet/dotnet/pull/5690#issuecomment-4127797114