### PR TITLE
Skip _ResolveBlazorWasmOutputs for .NET 11+ and move BlazorRoutingEnableRegexConstraint to SDK

### DIFF
--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -41,6 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_TargetingNET80OrLater>$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '8.0'))</_TargetingNET80OrLater>
     <_TargetingNETBefore100>$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '10.0'))</_TargetingNETBefore100>
     <_TargetingNET100OrLater>$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))</_TargetingNET100OrLater>
+    <_TargetingNET110OrLater>$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '11.0'))</_TargetingNET110OrLater>
 
     <SelfContained>true</SelfContained>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -107,7 +108,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveBlazorWasmOutputs" DependsOnTargets="ResolveWasmOutputs;ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_BlazorWasmNativeForBuild" BeforeTargets="_RazorPrepareForRun">
+  <!--
+    For .NET 11+, blazor.webassembly.js is provided as a framework static web asset from the package
+    and is automatically materialized by UpdateExistingPackageStaticWebAssets. No custom detection needed.
+    For .NET 10 and earlier, we still resolve it from BlazorWebAssemblyJSPath set by the package .props file.
+  -->
+  <Target Name="_ResolveBlazorWasmOutputs"
+    Condition="'$(_TargetingNET110OrLater)' != 'true'"
+    DependsOnTargets="ResolveWasmOutputs;ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_BlazorWasmNativeForBuild"
+    BeforeTargets="_RazorPrepareForRun">
     <ItemGroup>
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSPath)" />
       <_BlazorJSFile Include="$(BlazorWebAssemblyJSMapPath)" Condition="Exists('$(BlazorWebAssemblyJSMapPath)')" />

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -109,12 +109,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!--
-    For .NET 11+, blazor.webassembly.js is provided as a framework static web asset from the package
+    For .NET 11+, blazor.webassembly.js is usually provided as a framework static web asset from the package
     and is automatically materialized by UpdateExistingPackageStaticWebAssets. No custom detection needed.
-    For .NET 10 and earlier, we still resolve it from BlazorWebAssemblyJSPath set by the package .props file.
+    For projects (including some .NET 11+ projects) that still use pre-.NET11 packages, we resolve it from
+    BlazorWebAssemblyJSPath set by the package .props file.
   -->
   <Target Name="_ResolveBlazorWasmOutputs"
-    Condition="'$(_TargetingNET110OrLater)' != 'true'"
+    Condition="'$(BlazorWebAssemblyJSPath)' != '' Or '$(_TargetingNET110OrLater)' != 'true'"
     DependsOnTargets="ResolveWasmOutputs;ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_BlazorWasmNativeForBuild"
     BeforeTargets="_RazorPrepareForRun">
     <ItemGroup>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets
@@ -75,6 +75,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DisableAutoWasmPublishApp>true</DisableAutoWasmPublishApp>
   </PropertyGroup>
 
+  <!-- Blazor routing regex constraint support via runtimeconfig.json -->
+  <ItemGroup Condition="'$(BlazorRoutingEnableRegexConstraint)' != ''">
+    <RuntimeHostConfigurationOption Include="Microsoft.AspNetCore.Components.Routing.RegexConstraintSupport"
+      Value="$(BlazorRoutingEnableRegexConstraint)"
+      Trim="true" />
+  </ItemGroup>
+
   <!-- Wire-up static web assets -->
   <PropertyGroup>
     <ResolveBuildRelatedStaticWebAssetsDependsOn>

--- a/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
+++ b/src/BlazorWasmSdk/Targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.props
@@ -33,6 +33,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <StaticWebAssetStandaloneHosting Condition="'$(StaticWebAssetStandaloneHosting)' == '' and '$(StaticWebAssetProjectMode)' == 'Root'">true</StaticWebAssetStandaloneHosting>
     <StaticWebAssetMakeReferencedAssetOriginalItemSpecAbsolute Condition="'$(StaticWebAssetMakeReferencedAssetOriginalItemSpecAbsolute)' == ''">true</StaticWebAssetMakeReferencedAssetOriginalItemSpecAbsolute>
     <StaticWebAssetsGetEmbeddedPublishAssetsTargets>ComputeFilesToPublish;GetCurrentProjectEmbeddedPublishStaticWebAssetItems</StaticWebAssetsGetEmbeddedPublishAssetsTargets>
+
+    <!-- Regex route constraint support for Blazor routing -->
+    <BlazorRoutingEnableRegexConstraint Condition="'$(BlazorRoutingEnableRegexConstraint)' == ''">false</BlazorRoutingEnableRegexConstraint>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.Razor" Project="Sdk.props" />


### PR DESCRIPTION
## Summary

Updates the Blazor WebAssembly SDK to:
1. Skip the legacy `_ResolveBlazorWasmOutputs` target for .NET 11+ (framework assets handle `blazor.webassembly.js`)
2. Own the `BlazorRoutingEnableRegexConstraint` feature (moved from the package props file)

## Changes

### `Microsoft.NET.Sdk.BlazorWebAssembly.Current.props`
- Added `BlazorRoutingEnableRegexConstraint` property default (`false`) — previously shipped in the `Microsoft.AspNetCore.Components.WebAssembly` package props

### `Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets`
- Added `_TargetingNET110OrLater` version check property
- Conditioned `_ResolveBlazorWasmOutputs` with `Condition="'$(_TargetingNET110OrLater)' != 'true'"` so it only runs for .NET 10 and earlier
- Added `RuntimeHostConfigurationOption` item for `Microsoft.AspNetCore.Components.Routing.RegexConstraintSupport` — flows the `BlazorRoutingEnableRegexConstraint` value to `runtimeconfig.json` `configProperties`, which the Mono WASM runtime reads and applies as an `AppContext` switch

## How it works

**For .NET 11+**: The `Microsoft.AspNetCore.Components.WebAssembly` package now uses the SWA Framework Assets system. `blazor.webassembly.js` is declared with `SourceType=Framework` in the package props and automatically materialized by `UpdateExistingPackageStaticWebAssets`. No custom detection via `BlazorWebAssemblyJSPath` is needed.

**For .NET 10 and earlier**: `_ResolveBlazorWasmOutputs` continues to run as before, reading `BlazorWebAssemblyJSPath` from the package props file for backward compatibility.

**Regex constraint support**: The `RuntimeHostConfigurationOption` flows `BlazorRoutingEnableRegexConstraint` to `runtimeconfig.json`. The Mono WASM runtime reads `configProperties` and passes them to `mono_wasm_load_runtime` as AppContext key-value pairs, so `AppContext.TryGetSwitch()` works natively. The old `AssemblyMetadataAttribute` workaround in the aspnetcore repo has been removed.

## Companion PR

- aspnetcore: https://github.com/dotnet/aspnetcore/pull/65984

## Testing

- .NET 11 Blazor WASM app: builds and runs with framework assets (no `_ResolveBlazorWasmOutputs`)
- .NET 10 Blazor WASM app: builds with backward-compatible `BlazorWebAssemblyJSPath` flow