### PR TITLE
[dotnet-watch] Fix WebSocket transport crash on Ctrl+R restart

### DIFF
--- a/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
+++ b/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
@@ -44,7 +44,9 @@ internal sealed class WebSocketClientTransport : ClientTransport
     }
 
     public override bool IsExpectedConnectionTermination(Exception exception, CancellationToken cancellationToken)
-        => cancellationToken.IsCancellationRequested;
+        => cancellationToken.IsCancellationRequested
+        || exception is ObjectDisposedException
+        || (exception is System.Net.WebSockets.WebSocketException && _handler.IsClientSocketAborted);
 
     /// <summary>
     /// Creates and starts a new <see cref="WebSocketClientTransport"/> instance.
@@ -86,6 +88,9 @@ internal sealed class WebSocketClientTransport : ClientTransport
 
         private WebSocket? _clientSocket;
 
+        public bool IsClientSocketAborted
+            => _clientSocket?.State is System.Net.WebSockets.WebSocketState.Aborted;
+
         // Reused across WriteAsync calls to avoid allocations.
         // WriteAsync is invoked under a semaphore in DefaultHotReloadClient.
         private MemoryStream? _sendBuffer;
@@ -95,7 +100,17 @@ internal sealed class WebSocketClientTransport : ClientTransport
             logger.LogDebug("Disposing agent websocket transport");
 
             _sendBuffer?.Dispose();
-            _clientSocket?.Dispose();
+
+            try
+            {
+                _clientSocket?.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The underlying HTTP context may already be disposed when the
+                // child process was terminated (e.g. Ctrl+R restart).
+            }
+
             SharedSecretProvider.Dispose();
         }
 

--- a/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
@@ -38,4 +38,53 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
 
         await App.AssertOutputLineStartsWith("Changed!");
     }
+
+    [Fact]
+    public async Task CtrlC_ShutsDownCleanly()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchMobileApp")
+            .WithSource();
+
+        App.Start(testAsset, [], testFlags: TestFlags.ReadKeyFromStdin);
+
+        await App.WaitUntilOutputContains("Started");
+        await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
+        await App.WaitUntilOutputContains(WebSocketServerStartedPattern);
+        await App.WaitUntilOutputContains("WebSocket client connected");
+
+        App.SendControlC();
+
+        await App.WaitUntilOutputContains(MessageDescriptor.ShutdownRequested);
+        await App.WaitUntilOutputContains("exited with exit code");
+
+        App.AssertOutputDoesNotContain("ObjectDisposedException");
+        App.AssertOutputDoesNotContain("WebSocketException");
+        App.AssertOutputDoesNotContain("An unexpected error occurred");
+    }
+
+    [Fact]
+    public async Task CtrlR_RestartsCleanly()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchMobileApp")
+            .WithSource();
+
+        App.Start(testAsset, [], testFlags: TestFlags.ReadKeyFromStdin);
+
+        await App.WaitUntilOutputContains("Started");
+        await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
+        await App.WaitUntilOutputContains(WebSocketServerStartedPattern);
+        await App.WaitUntilOutputContains("WebSocket client connected");
+
+        App.SendControlR();
+
+        await App.WaitUntilOutputContains(MessageDescriptor.RestartRequested);
+
+        // App should restart and output "Started" again (iteration 2)
+        await App.WaitUntilOutputContains("DOTNET_WATCH_ITERATION = 2");
+        await App.WaitUntilOutputContains("Started");
+
+        App.AssertOutputDoesNotContain("ObjectDisposedException");
+        App.AssertOutputDoesNotContain("WebSocketException");
+        App.AssertOutputDoesNotContain("An unexpected error occurred");
+    }
 }

--- a/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
@@ -52,6 +52,7 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         await App.WaitUntilOutputContains(WebSocketServerStartedPattern);
         await App.WaitUntilOutputContains("WebSocket client connected");
 
+        App.Process.ClearOutput();
         App.SendControlC();
 
         await App.WaitUntilOutputContains(MessageDescriptor.ShutdownRequested);
@@ -75,6 +76,7 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         await App.WaitUntilOutputContains(WebSocketServerStartedPattern);
         await App.WaitUntilOutputContains("WebSocket client connected");
 
+        App.Process.ClearOutput();
         App.SendControlR();
 
         await App.WaitUntilOutputContains(MessageDescriptor.RestartRequested);


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/53634

When a mobile/WebSocket app is shut down (Ctrl+C) or restarted (Ctrl+R), the child process is killed which closes the TCP connection. Kestrel tears down the HTTP context, and then `RunningProject.DisposeAsync` tries to dispose the WebSocket — hitting an `ObjectDisposedException` on the already-disposed `IFeatureCollection`. The `ListenForResponsesAsync` loop also logs a spurious `WebSocketException` error.

**Fixes:**
- `RequestHandler.Dispose`: catch `ObjectDisposedException` when the underlying Kestrel HTTP context is already torn down
- `IsExpectedConnectionTermination`: treat `WebSocketException` as expected when the socket state is `Aborted` (remote disconnected)

**Tests:**
- `CtrlC_ShutsDownCleanly`: verifies clean shutdown with WebSocket transport
- `CtrlR_RestartsCleanly`: verifies restart without `WebSocketException` or `ObjectDisposedException` errors

Both tests fail without the fix.