### PR TITLE
dotnet test MTP: Disable ANSI output in LLM environments

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Extensions;
+using Microsoft.DotNet.Cli.Telemetry;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -106,7 +107,9 @@ internal partial class MicrosoftTestingPlatformTestCommand
         bool inCI = string.Equals(Environment.GetEnvironmentVariable("TF_BUILD"), "true", StringComparison.OrdinalIgnoreCase) || string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
 
         AnsiMode ansiMode = AnsiMode.AnsiIfPossible;
-        if (noAnsi)
+        // In LLM environments, prefer simple text output so that LLM can parse it easily.
+        // Note that NoAnsi also implies also no progress.
+        if (noAnsi || new LLMEnvironmentDetectorForTelemetry().IsLLMEnvironment())
         {
             // User explicitly specified --no-ansi.
             // We should respect that.

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -108,7 +108,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         AnsiMode ansiMode = AnsiMode.AnsiIfPossible;
         // In LLM environments, prefer simple text output so that LLM can parse it easily.
-        // Note that NoAnsi also implies also no progress.
+        // Note that NoAnsi also implies no progress.
         if (noAnsi || new LLMEnvironmentDetectorForTelemetry().IsLLMEnvironment())
         {
             // User explicitly specified --no-ansi.


### PR DESCRIPTION
MTP side change: https://github.com/microsoft/testfx/pull/7649