### PR TITLE
Copy HotReload dll to intermediate to avoid duplicate identity in multi-client WASM

### DIFF
--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -28,15 +28,20 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmHotReloadIntermediatePath>$(IntermediateOutputPath)hotreload\</_WasmHotReloadIntermediatePath>
     </PropertyGroup>
 
-    <!-- Copy the JS module to intermediate folder to avoid duplicate identity when multiple projects reference the same SDK file -->
+    <!-- Copy the JS module and DLL to intermediate folder to avoid duplicate identity when multiple projects reference the same SDK file -->
     <Copy
       SourceFiles="$(_WasmHotReloadPath)Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js"
       DestinationFolder="$(_WasmHotReloadIntermediatePath)"
       SkipUnchangedFiles="true"
       Condition="'$(_WasmHotReloadPath)' != ''" />
+    <Copy
+      SourceFiles="$(_WasmHotReloadPath)Microsoft.DotNet.HotReload.WebAssembly.Browser.dll"
+      DestinationFolder="$(_WasmHotReloadIntermediatePath)"
+      SkipUnchangedFiles="true"
+      Condition="'$(_WasmHotReloadPath)' != ''" />
 
     <ItemGroup Condition="'$(_WasmHotReloadPath)' != ''">
-      <ReferenceCopyLocalPaths Include="$(_WasmHotReloadPath)Microsoft.DotNet.HotReload.WebAssembly.Browser.dll">
+      <ReferenceCopyLocalPaths Include="$(_WasmHotReloadIntermediatePath)Microsoft.DotNet.HotReload.WebAssembly.Browser.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </ReferenceCopyLocalPaths>

--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -52,6 +52,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <OriginalItemSpec>%(Identity)</OriginalItemSpec>
       </_WasmHotReloadModule>
       <FileWrites Include="$(_WasmHotReloadIntermediatePath)Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js" />
+      <FileWrites Include="$(_WasmHotReloadIntermediatePath)Microsoft.DotNet.HotReload.WebAssembly.Browser.dll" />
     </ItemGroup>
 
     <DefineStaticWebAssets


### PR DESCRIPTION
## Summary

Copy the HotReload dll to `$(IntermediateOutputPath)hotreload/` before adding it to `ReferenceCopyLocalPaths`, matching the pattern already used for the `.js` module (dotnet/sdk#52816).

## Problem

In multi-client hosted Blazor WASM scenarios, both clients reference the same HotReload dll from the shared SDK path. During publish, `ComputeWasmPublishAssets` uses this shared-path item to replace Framework-materialized per-project assets, causing duplicate key crashes in `ApplyCompressionNegotiation`.

## Fix

Copy the dll to `obj/{config}/{tfm}/hotreload/` (same as the .js module), then reference from there. Each project gets a unique path.

## Context

- The .js module already uses this pattern (dotnet/sdk#52816)
- Traced via binlog: `ComputeWasmPublishAssets` replaces materialized per-client asset with raw SDK-path item
- Related: dotnet/runtime#126211, dotnet/runtime#125329