### PR TITLE
Skip crossgen for DotnetTools-unique assemblies to reduce SDK size

### DIFF
--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -56,9 +56,6 @@
 
       <RemainingFiles Include="$(InstallerOutputDirectory)**\*" Exclude="$(InstallerOutputDirectory)FSharp\FSharp.Build.dll;@(RoslynFiles);@(FSharpFiles);$(InstallerOutputDirectory)Roslyn\binfx\**\*" />
 
-      <!-- Don't crossgen VB since the usage doesn't justify the size cost for everyone -->
-      <RoslynFiles Remove="$(InstallerOutputDirectory)Roslyn\bincore\Microsoft.CodeAnalysis.VisualBasic.dll" />
-
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error, and they need to stay their original architecture. -->
       <RemainingFiles Remove="$(InstallerOutputDirectory)TestHost*\**\*" />
       <!-- Removing Full CLR built DumpMiniTool executables from Crossgen, because they need to stay their original architecture to allow creating dumps with a given bitness. -->
@@ -83,7 +80,8 @@
       <RemainingFiles Include="$(ContainerTasks)**\*" />
 
       <!-- Don't crossgen VB since the usage doesn't justify the size cost for everyone -->
-      <RemainingFiles Remove="$(NetSdkAnalyzers)Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll" />
+      <RoslynFiles Remove="$(InstallerOutputDirectory)**\Microsoft.CodeAnalysis.VisualBasic*.dll" />
+      <RemainingFiles Remove="$(InstallerOutputDirectory)**\Microsoft.CodeAnalysis.VisualBasic*.dll" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(InstallerOutputDirectory)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
@@ -104,6 +102,29 @@
       <!-- Don't crossgen reference assemblies redisted with msbuild for RoslynCodeTaskFactory -->
       <RazorToolFiles Remove="$(InstallerOutputDirectory)**\ref\*.dll" />
       <RemainingFiles Remove="$(InstallerOutputDirectory)**\ref\*.dll" />
+
+      <!-- Don't crossgen DotnetTools assemblies that are unique to DotnetTools. Crossgen'ing these provides
+           limited value given usage/scenarios. Crossgen'ing assemblies that exist elsewhere in the layout
+           provides value because they will be deduplicated with the other copies therefore reducing the
+           overall size of the layout. -->
+      <_DotnetToolsCandidateFiles Include="$(InstallerOutputDirectory)DotnetTools\**\*" />
+      <_NonDotnetToolsReferenceFiles Include="@(RoslynFiles)" />
+      <_NonDotnetToolsReferenceFiles Include="@(FSharpFiles)" />
+      <_NonDotnetToolsReferenceFiles Include="@(RazorToolFiles)" />
+      <_NonDotnetToolsReferenceFiles Include="@(RemainingFiles)" />
+      <_NonDotnetToolsReferenceFiles Remove="$(InstallerOutputDirectory)DotnetTools\**\*" />
+    </ItemGroup>
+
+    <!-- Filter DotnetTools assemblies: only crossgen those that also exist elsewhere in the layout. -->
+    <FilterItemsByDuplicateHash
+        CandidateFiles="@(_DotnetToolsCandidateFiles)"
+        ReferenceFiles="@(_NonDotnetToolsReferenceFiles)">
+      <Output TaskParameter="UnmatchedFiles" ItemName="_DotnetToolsUniqueFiles" />
+    </FilterItemsByDuplicateHash>
+
+    <!-- Remove DotnetTools-unique assemblies from crossgen -->
+    <ItemGroup>
+      <RemainingFiles Remove="@(_DotnetToolsUniqueFiles)" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(RoslynFiles)">

--- a/src/Tasks/sdk-tasks/DeduplicateAssembliesWithLinks.cs
+++ b/src/Tasks/sdk-tasks/DeduplicateAssembliesWithLinks.cs
@@ -69,7 +69,7 @@ public sealed class DeduplicateAssembliesWithLinks : Task
             try
             {
                 var fileInfo = new FileInfo(filePath);
-                var hash = ComputeFileHash(filePath);
+                var hash = FileHasher.ComputeFileHash(filePath);
                 var entry = new FileEntry(
                     filePath,
                     hash,
@@ -147,21 +147,6 @@ public sealed class DeduplicateAssembliesWithLinks : Task
             var relativePath = Path.GetRelativePath(duplicateDirectory, primaryFilePath);
             File.CreateSymbolicLink(duplicateFilePath, relativePath);
         }
-    }
-
-    private static string ComputeFileHash(string filePath)
-    {
-        var xxHash = new XxHash64();
-        using var stream = File.OpenRead(filePath);
-
-        byte[] buffer = new byte[65536]; // 64KB buffer
-        int bytesRead;
-        while ((bytesRead = stream.Read(buffer)) > 0)
-        {
-            xxHash.Append(buffer[..bytesRead]);
-        }
-
-        return Convert.ToHexString(xxHash.GetCurrentHash());
     }
 
     private static int GetPathDepth(string filePath, string rootDirectory)

--- a/src/Tasks/sdk-tasks/FilterItemsByDuplicateHash.cs
+++ b/src/Tasks/sdk-tasks/FilterItemsByDuplicateHash.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.DotNet.Build.Tasks;
+
+/// <summary>
+/// Filters a set of candidate files to only those whose content hash matches at least one file
+/// in a reference set. 
+/// </summary>
+public sealed class FilterItemsByDuplicateHash : Task
+{
+    /// <summary>
+    /// The candidate files to filter.
+    /// </summary>
+    [Required]
+    public ITaskItem[] CandidateFiles { get; set; } = Array.Empty<ITaskItem>();
+
+    /// <summary>
+    /// The reference files to compare against. These are not modified.
+    /// </summary>
+    [Required]
+    public ITaskItem[] ReferenceFiles { get; set; } = Array.Empty<ITaskItem>();
+
+    /// <summary>
+    /// Output: the subset of CandidateFiles whose content hash does NOT match any ReferenceFile.
+    /// </summary>
+    [Output]
+    public ITaskItem[] UnmatchedFiles { get; set; } = Array.Empty<ITaskItem>();
+
+    public override bool Execute()
+    {
+        // Hash all reference files
+        var referenceHashes = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in ReferenceFiles)
+        {
+            try
+            {
+                referenceHashes.Add(FileHasher.ComputeFileHash(item.ItemSpec));
+            }
+            catch (Exception ex)
+            {
+                Log.LogWarning($"Failed to hash reference file '{item.ItemSpec}': {ex.Message}");
+            }
+        }
+
+        Log.LogMessage(MessageImportance.Normal, $"Hashed {referenceHashes.Count} unique reference files.");
+
+        var unmatched = new List<ITaskItem>();
+        foreach (var item in CandidateFiles)
+        {
+            try
+            {
+                var hash = FileHasher.ComputeFileHash(item.ItemSpec);
+                if (!referenceHashes.Contains(hash))
+                {
+                    unmatched.Add(item);
+                    Log.LogMessage(MessageImportance.Normal, $"  Unmatched: {item.ItemSpec}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogWarning($"Failed to hash candidate file '{item.ItemSpec}': {ex.Message}");
+            }
+        }
+
+        UnmatchedFiles = unmatched.ToArray();
+
+        Log.LogMessage(MessageImportance.High,
+            $"FilterItemsByDuplicateHash: {unmatched.Count} of {CandidateFiles.Length} candidates are unique.");
+
+        return true;
+    }
+}
+#endif

--- a/src/Tasks/sdk-tasks/Utils/FileHasher.cs
+++ b/src/Tasks/sdk-tasks/Utils/FileHasher.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NETFRAMEWORK
+using System;
+using System.IO;
+using System.IO.Hashing;
+
+namespace Microsoft.DotNet.Build.Tasks;
+
+/// <summary>
+/// Shared utility for content-based file hashing.
+/// </summary>
+internal static class FileHasher
+{
+    /// <summary>
+    /// Computes an XxHash64 content hash for a file, returned as a hex string.
+    /// </summary>
+    public static string ComputeFileHash(string filePath)
+    {
+        var xxHash = new XxHash64();
+        using var stream = File.OpenRead(filePath);
+
+        byte[] buffer = new byte[65536]; // 64KB buffer
+        int bytesRead;
+        while ((bytesRead = stream.Read(buffer)) > 0)
+        {
+            xxHash.Append(buffer[..bytesRead]);
+        }
+
+        return Convert.ToHexString(xxHash.GetCurrentHash());
+    }
+}
+#endif

--- a/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
+++ b/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
@@ -43,6 +43,11 @@
              AssemblyFile="$(SdkTasksAssembly)"
              TaskFactory="TaskHostFactory" />
 
+  <UsingTask TaskName="FilterItemsByDuplicateHash"
+             Condition="'$(MSBuildRuntimeType)' == 'Core'"
+             AssemblyFile="$(SdkTasksAssembly)"
+             TaskFactory="TaskHostFactory" />
+
   <!-- Tasks from the Arcade SDK -->
   <UsingTask TaskName="DownloadFile" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 

--- a/test/sdk-tasks.Tests/FilterItemsByDuplicateHashTests.cs
+++ b/test/sdk-tasks.Tests/FilterItemsByDuplicateHashTests.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks;
+
+namespace Microsoft.CoreSdkTasks.Tests;
+
+public class FilterItemsByDuplicateHashTests(ITestOutputHelper log) : SdkTest(log)
+{
+#if !NETFRAMEWORK
+    [Fact]
+    public void UnmatchedFilesContainsOnlyCandidatesNotInReference()
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory().Path;
+
+        // Create reference files
+        var refFile1 = CreateFile(testDir, "ref", "shared.dll", "shared content");
+        var refFile2 = CreateFile(testDir, "ref", "other.dll", "other content");
+
+        // Create candidate files: one matching, one unique
+        var candShared = CreateFile(testDir, "candidates", "shared.dll", "shared content");
+        var candUnique = CreateFile(testDir, "candidates", "unique.dll", "unique content");
+
+        var task = CreateTask(
+            candidates: [ToTaskItem(candShared), ToTaskItem(candUnique)],
+            references: [ToTaskItem(refFile1), ToTaskItem(refFile2)]);
+
+        var result = task.Execute();
+
+        result.Should().BeTrue();
+        task.UnmatchedFiles.Should().HaveCount(1);
+        task.UnmatchedFiles[0].ItemSpec.Should().Be(candUnique);
+    }
+
+    [Fact]
+    public void MatchingIsByContentNotByFileName()
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory().Path;
+
+        // Same filename but different content should be unmatched
+        var refFile = CreateFile(testDir, "ref", "lib.dll", "version 1");
+        var candFile = CreateFile(testDir, "candidates", "lib.dll", "version 2");
+
+        var task = CreateTask(
+            candidates: [ToTaskItem(candFile)],
+            references: [ToTaskItem(refFile)]);
+
+        var result = task.Execute();
+
+        result.Should().BeTrue();
+        task.UnmatchedFiles.Should().HaveCount(1);
+    }
+
+    private static string CreateFile(string root, string subDir, string fileName, string content)
+    {
+        var dir = Path.Combine(root, subDir);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static ITaskItem ToTaskItem(string path) => new TaskItem(path);
+
+    private static FilterItemsByDuplicateHash CreateTask(ITaskItem[] candidates, ITaskItem[] references)
+    {
+        return new FilterItemsByDuplicateHash
+        {
+            CandidateFiles = candidates,
+            ReferenceFiles = references,
+            BuildEngine = new MockBuildEngine()
+        };
+    }
+#endif
+}


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/sdk/pull/53266

### Changes

**`FilterItemsByDuplicateHash` MSBuild task** (`src/Tasks/sdk-tasks/FilterItemsByDuplicateHash.cs`)
- New task that compares a set of candidate files against reference files by content hash (XxHash64)
- Returns unmatched files — those with no content-identical counterpart in the reference set
- Shares hashing logic with `DeduplicateAssembliesWithLinks` via `FileHasher` utility class

**`Crossgen.targets`**
- After all existing crossgen exclusions are applied, DotnetTools assemblies are compared against the rest of the layout using `FilterItemsByDuplicateHash`
- Only DotnetTools assemblies that also exist outside DotnetTools are crossgen'd (these will be deduplicated afterward, so crossgen adds startup benefit without size cost)
- Assemblies unique to DotnetTools are left as IL-only
- Broadened the VB crossgen exclusion (`Microsoft.CodeAnalysis.VisualBasic*.dll`) to apply globally, not just to `Roslyn/bincore`

On a linux-x64 dev build, this reduces the tarball by 23.6 MB