### PR TITLE
Fix MSBuild property values containing '/dotnet' misinterpreted

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildArgs.cs
@@ -102,7 +102,8 @@ public sealed class MSBuildArgs
     /// <param name="forwardedAndUserFacingArgs">the complete set of forwarded MSBuild arguments and un-parsed, potentially MSBuild-relevant arguments</param>
     public static MSBuildArgs AnalyzeMSBuildArguments(IEnumerable<string> forwardedAndUserFacingArgs, params Option[] options)
     {
-        var fakeCommand = new System.CommandLine.Command("dotnet");
+        // Avoid a command name that is likely to appear in MSBuild property values.
+        var fakeCommand = new System.CommandLine.Command("__msbuild-args-analysis__");
         foreach (var option in options)
         {
             fakeCommand.Options.Add(option);

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildInvocation.cs
@@ -23,5 +23,20 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 command.GetArgumentTokensToMSBuild().Should().BeEquivalentTo([..ExpectedPrefix, ..expectedAdditionalArgs]);
             });
         }
+
+        [Theory]
+        [InlineData("/p:DockerImage=registry.example.com/myproject/dotnet")]
+        [InlineData("-p:DockerImage=registry.example.com/myproject/dotnet")]
+        public void PropertyValuesContainingSlashDotnetArePreserved(string propertyArg)
+        {
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
+            {
+                var command = MSBuildCommand.FromArgs([propertyArg], "<msbuildpath>");
+
+                command.GetArgumentTokensToMSBuild()
+                    .Should()
+                    .Contain("--property:DockerImage=registry.example.com/myproject/dotnet");
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary

  Fixes https://github.com/dotnet/command-line-api/issues/2797

  `MSBuildArgs.AnalyzeMSBuildArguments` creates a synthetic `System.CommandLine.Command` named `"dotnet"` to re-parse forwarded MSBuild arguments.
  `System.CommandLine` treats `/<command-name>` inside option values as a reference to the command itself, so any `/p:` property value containing
  `/dotnet` (e.g., `/p:DockerImage=registry.example.com/myproject/dotnet`) causes the parser to silently reject the token. The rejected value is then
  forwarded to MSBuild as a bare argument (without the `/p:` prefix), which MSBuild interprets as a project file path — resulting in `MSB1009: Project
  file does not exist`.

  This was introduced by dotnet/sdk#49526.

  ## Reproduction

  ```bash
  mkdir repro && cd repro
  dotnet new console
  dotnet msbuild -p:MyProp=something/dotnet   # MSB1009
  dotnet msbuild -p:MyProp=something/other    # works
  ```

  ## Fix

  Rename the synthetic command from `"dotnet"` to `"__msbuild-args-analysis__"` so it is unlikely to collide with values that appear in real MSBuild
  property arguments. Only the command's own name triggers this `System.CommandLine` behavior.

  ## Test

  Added `PropertyValuesContainingSlashDotnetArePreserved` regression test covering both `/p:` and `-p:` forms.