### PR TITLE
[dotnet watch] Fix target framework selector being stuck

### DIFF
--- a/src/Dotnet.Watch/dotnet-watch/UI/SpectreBuildParametersSelectionPrompt.cs
+++ b/src/Dotnet.Watch/dotnet-watch/UI/SpectreBuildParametersSelectionPrompt.cs
@@ -74,15 +74,10 @@ internal sealed class SpectreBuildParametersSelectionPrompt(IAnsiConsole console
 
     private static IAnsiConsole CreateConsole(IConsole watchConsole)
     {
-        if (!Console.IsInputRedirected)
-        {
-            return AnsiConsole.Console;
-        }
-
-        // When stdin is redirected (e.g. in integration tests), Spectre.Console detects
-        // non-interactive mode and refuses to prompt. Create a console with forced
-        // interactivity that reads keys from IConsole.KeyPressed (fed by
-        // PhysicalConsole.ListenToStandardInputAsync).
+        // Always read keys from IConsole.KeyPressed (fed by PhysicalConsole) instead of
+        // letting Spectre.Console call Console.ReadKey() directly. PhysicalConsole already
+        // owns the Console.ReadKey() loop, so a second reader would race with it and never
+        // receive any key presses, making the selection prompt appear stuck.
         var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Ansi = AnsiSupport.Yes,


### PR DESCRIPTION
Testing `dotnet-watch` end-to end on a `dotnet new maui` project:

<img width="800" height="214" alt="image" src="https://github.com/user-attachments/assets/9ffaa77d-1c0d-4dc9-b8c6-404da84c4359" />

I found the Spectre.Console input was just "stuck", neither up/down arrows or typing to search did anything!

`PhysicalConsole` runs `Console.ReadKey()` in a tight background loop, consuming all key presses and dispatching them via the `KeyPressed` event. When `SpectreBuildParametersSelectionPrompt` returned `AnsiConsole.Console` for non-redirected stdin, Spectre.Console would also call `Console.ReadKey()` internally, creating a race where `PhysicalConsole` steals every key press and the selection prompt appears completely stuck (arrow keys, typing, and search all do nothing).

Fix by always using `KeyPressedAnsiConsole`, which reads keys from `PhysicalConsole.KeyPressed` events instead of competing for `Console.ReadKey()`. This ensures a single key reader (`PhysicalConsole`) distributes keys to all consumers including Spectre.Console.