### PR TITLE
Stop setting the global tool path for our tests that get run. 

### DIFF
--- a/test/Microsoft.NET.TestFramework/SdkTestContext.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTestContext.cs
@@ -214,6 +214,10 @@ namespace Microsoft.NET.TestFramework
             //  Prevent test MSBuild nodes from persisting
             environment["MSBUILDDISABLENODEREUSE"] = "1";
 
+            //  Prevent local test runs from modifying the developer's user PATH.
+            //  Tests that validate first-time PATH setup can opt back in explicitly.
+            environment["DOTNET_ADD_GLOBAL_TOOLS_TO_PATH"] = "0";
+
             ToolsetUnderTest.AddTestEnvironmentVariables(environment);
         }
 

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -215,7 +215,8 @@ namespace Microsoft.DotNet.Tests
         {
             var dotnetFirstTime = new DotNetFirstTime();
 
-            var command = dotnetFirstTime.Setup(Log, TestAssetsManager);
+            var command = dotnetFirstTime.Setup(Log, TestAssetsManager)
+                .WithEnvironmentVariable("DOTNET_ADD_GLOBAL_TOOLS_TO_PATH", "true");
 
             var profiled = Path.Combine(dotnetFirstTime.TestDirectory, "profile.d");
 
@@ -231,7 +232,8 @@ namespace Microsoft.DotNet.Tests
         {
             var dotnetFirstTime = new DotNetFirstTime();
 
-            var command = dotnetFirstTime.Setup(Log, TestAssetsManager);
+            var command = dotnetFirstTime.Setup(Log, TestAssetsManager)
+                .WithEnvironmentVariable("DOTNET_ADD_GLOBAL_TOOLS_TO_PATH", "true");
 
             var pathsd = Path.Combine(dotnetFirstTime.TestDirectory, "paths.d");
 


### PR DESCRIPTION
This pollutes local user env when running tests. Copilot identified two tests that still rely on this behavior so if you run those tests, you'll still get the path added. Not too much I can do about that without designing additional changes to the product or mocks. This fix is the simplest way to reduce the impact with low risk.