### PR TITLE
Remove ValidateBundledManifestSigning target

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,6 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Installer.Windows.Security.TestData" Version="$(MicrosoftDotNetInstallerWindowsSecurityTestDataPackageVersion)" />
-    <PackageVersion Include="Microsoft.DotNet.SignCheck" Version="$(ArcadeSdkVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />

--- a/src/Layout/redist/targets/BundledManifests.targets
+++ b/src/Layout/redist/targets/BundledManifests.targets
@@ -51,7 +51,6 @@
       <Version>[%(Version)]</Version>
     </PackageDownload>
 
-    <PackageReference Include="Microsoft.DotNet.SignCheck" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target Name="LayoutManifests">

--- a/src/Layout/redist/targets/BundledManifests.targets
+++ b/src/Layout/redist/targets/BundledManifests.targets
@@ -54,44 +54,6 @@
     <PackageReference Include="Microsoft.DotNet.SignCheck" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="ValidateBundledManifestSigning"
-          Condition=" '$(OS)' == 'Windows_NT' and
-          '$(Architecture)' != 'arm' and
-          $(BUILD_SOURCEBRANCH) != '' and
-          $(BUILD_SOURCEBRANCH.Contains('release')) "
-          BeforeTargets="GenerateWorkloadManifestsWxs">
-    <PropertyGroup>
-      <SignCheckExe>$(PkgMicrosoft_DotNet_SignCheck)\tools\Microsoft.DotNet.SignCheck.exe</SignCheckExe>
-      <SignCheckLog Condition="'$(SignCheckLog)' == ''">$(ArtifactsLogDir)\workloadmanifestsigncheck.log</SignCheckLog>
-      <SignCheckErrorLog Condition="'$(SignCheckErrorLog)' == ''">$(ArtifactsLogDir)\workloadmanifestsigncheck.errors.log</SignCheckErrorLog>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <!-- Don't try to validate signing for workload manifests that will be signed as part of post-build signing -->
-      <BundledManifestsToValidateSigning Include="@(BundledManifests)">
-        <RestoredMsiPathInNupkg>$([MSBuild]::NormalizePath($([System.IO.Directory]::GetFiles('%(RestoredMsiNupkgContentPath)/data/', '*$(MsiArchitectureForWorkloadManifests).msi'))))</RestoredMsiPathInNupkg>
-      </BundledManifestsToValidateSigning>
-
-      <SignCheckWorkloadManifestMsiInputFiles Include="@(BundledManifestsToValidateSigning->'%(RestoredMsiPathInNupkg)')" />
-    </ItemGroup>
-
-    <Exec Condition="'@(SignCheckWorkloadManifestMsiInputFiles->Count())' != '0'"
-                   Command="$(SignCheckExe) ^
-                   --recursive ^
-                   -f UnsignedFiles ^
-                   -i @(SignCheckWorkloadManifestMsiInputFiles, ' ') ^
-                   -l $(SignCheckLog) ^
-                   -e $(SignCheckErrorLog)" />
-
-    <Error
-      Text="Signing validation failed for workload manifest MSI. Check $(SignCheckErrorLog) for more information."
-      Condition="Exists($(SignCheckErrorLog)) and '$([System.IO.File]::ReadAllText($(SignCheckErrorLog)))' != ''" />
-
-    <Message
-      Text="##vso[artifact.upload containerfolder=LogFiles;artifactname=LogFiles]{SignCheckErrorLog}"
-      Condition="Exists($(SignCheckErrorLog)) and '$([System.IO.File]::ReadAllText($(SignCheckErrorLog)))' != ''" />
-  </Target>
-
   <Target Name="LayoutManifests">
     <ItemGroup>
       <ManifestContent Include="%(BundledManifests.RestoredNupkgContentPath)\data\*"


### PR DESCRIPTION
Removed the ValidateBundledManifestSigning target and its associated logic. Signcheck is run in the VMR now. This code existed pre-VMR to try to catch that the workloads weren't signed before we got to VS insertions