### PR TITLE
Remove outdated TODO comment from Microsoft.NET.Sdk.FrameworkReferenceResolution.targets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -52,7 +52,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </CreateWindowsSdkKnownFrameworkReferences>
   </Target>
   
-  <!-- TODO: https://github.com/dotnet/sdk/issues/49917 Remove the framework based condition when the data for netcoreapp2.1 and below is fixed-->
   <!-- Package pruning is expected to be enable for all TFMs for multi-targeted projects, so still generate the pruning data when RestoreEnablePackagePruning is '' which implies a multi-targeted project. -->
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
           DependsOnTargets="ProcessFrameworkReferences"


### PR DESCRIPTION
The condition got fixed in https://github.com/dotnet/sdk/commit/2304819f02bf4c6c5bdefaa5aa01560454963d27 but the comment wasn't removed.

Stumbled over this while looking at an unrelated issue