### PR TITLE
Update Azure Linux 3.0 RID mapping

### DIFF
--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -68,7 +68,7 @@
   <PropertyGroup>
     <NetRuntimeRid Condition="'$(NetRuntimeRid)' == ''">$(HostRid)</NetRuntimeRid>
     <NetRuntimeRid Condition="('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd' or '$(OSName)' == 'openbsd' or '$(OSName)' == 'illumos' or '$(OSName)' == 'solaris' or '$(OSName)' == 'haiku') and '$(DotNetBuildSourceOnly)' != 'true'">$(OSName)-$(TargetArchitecture)</NetRuntimeRid>
-    <NetRuntimeRid Condition="'$(DotNetBuild)' != 'true' and $(NetRuntimeRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</NetRuntimeRid>
+    <NetRuntimeRid Condition="'$(DotNetBuild)' != 'true' and $(NetRuntimeRid.StartsWith('azurelinux.3.0'))">$(HostRid.Replace('azurelinux.3.0', 'cm.2'))</NetRuntimeRid>
 
     <SharedFrameworkRid>$(NetRuntimeRid)</SharedFrameworkRid>
     <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary
Update the layout RID normalization to key off Azure Linux 3.0 instead of the old Mariner 2.0 RID string while continuing to map to the existing `cm.2` runtime assets.

- replace the stale `mariner.2.0` string match with `azurelinux.3.0`
- keep the existing `cm.2` runtime RID normalization behavior

Follow-up to dotnet/runtime#126528.