### PR TITLE
Merge dotnet/templating catch-up: 4 commits missed in Phase 1

### DIFF
--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -138,7 +138,7 @@ extends:
           displayName: Install latest daily .NET version
 
         - bash: >
-            $(Build.SourcesDirectory)/.dotnet/dotnet run --no-build
+            $(Build.SourcesDirectory)/.dotnet/dotnet run --framework net11.0 --no-build
             --project $(Build.SourcesDirectory)/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
             -- --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
           displayName: Run Cache Updater

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -5,8 +5,8 @@
 trigger: none
 # Trigger periodically instead.
 schedules:
-- cron: 0 * * * *
-  displayName: Run every hour
+- cron: 0 0 * * *
+  displayName: Run once a day
   branches:
     include:
     - main

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -137,10 +137,14 @@ extends:
             -SkipNonVersionedFiles
           displayName: Install latest daily .NET version
 
-        - bash: >
-            $(Build.SourcesDirectory)/.dotnet/dotnet run --framework net11.0 --no-build
-            --project $(Build.SourcesDirectory)/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
-            -- --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
+        - bash: |
+            projectPath=$(Build.SourcesDirectory)/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+            netCurrent=$($(Build.SourcesDirectory)/.dotnet/dotnet msbuild $projectPath -getProperty:NetCurrent)
+            echo "Resolved NetCurrent: $netCurrent"
+            $(Build.SourcesDirectory)/.dotnet/dotnet run --no-build \
+              --framework $netCurrent \
+              --project $projectPath \
+              -- --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
           displayName: Run Cache Updater
 
         - task: CopyFiles@2

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -92,10 +92,10 @@ namespace Microsoft.TemplateEngine.Mocks
         public bool PreferDefaultName => _preferDefaultName;
 
         [Obsolete("Use ParameterDefinitionSet instead.")]
-        IReadOnlyDictionary<string, ICacheTag> ITemplateInfo.Tags => throw new NotImplementedException();
+        IReadOnlyDictionary<string, ICacheTag> ITemplateInfo.Tags => null!;
 
         [Obsolete("Use ParameterDefinitionSet instead.")]
-        IReadOnlyDictionary<string, ICacheParameter> ITemplateInfo.CacheParameters => throw new NotImplementedException();
+        IReadOnlyDictionary<string, ICacheParameter> ITemplateInfo.CacheParameters => null!;
 
         public IParameterDefinitionSet ParameterDefinitions
         {


### PR DESCRIPTION
Migrates 4 commits from `dotnet/templating` that were not included in the Phase 1 merge (#53647).

### Commits

| Original SHA | Author | Description |
|---|---|---|
| dotnet/templating@2eeb88874 | @lewing | Fix MockTemplateInfo for System.Text.Json serialization |
| dotnet/templating@a7fa48a6e | @NikolaMilosavljevic | Specify target framework (search-cache-pipeline) |
| dotnet/templating@89cd90392 | @NikolaMilosavljevic | Use NetCurrent (search-cache-pipeline) |
| dotnet/templating@9c09d7680 | @NikolaMilosavljevic | Run once a day (search-cache-pipeline) |

All commits follow the Phase 1 conventions:
- Paths mapped per the [Phase 1 mapping](https://github.com/dotnet/sdk/pull/53647) (`test/` → `test/TemplateEngine/`, `search-cache-pipeline.yml` → `eng/pipelines/search-cache-pipeline.yml`)
- `#NNN` references fully qualified to `dotnet/templating#NNN`
- Migration note appended: `Commit migrated from https://github.com/dotnet/templating/commit/<sha>`
- Original author and date preserved

This accounts for all commits on `dotnet/templating` main that touch migrated paths (`src/`, `test/`, `tools/`, `template_feed/`, `docs/`, `dotnet-template-samples/`, `Microsoft.TemplateEngine.sln`, `search-cache-pipeline.yml`) since the Phase 1 cutoff.

Related: #53647