### PR TITLE
[release/8.0.1xx] Update branding to 8.0.127

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -100,9 +100,9 @@ extends:
               image: 1es-windows-2022
               os: windows
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+            helixTargetQueue: Windows.Amd64.VS2022.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            helixTargetQueue: Windows.Amd64.VS2022.Pre
+            helixTargetQueue: Windows.Amd64.VS2022
           variables:
           - name: _BuildConfig
             value: Release
@@ -138,9 +138,9 @@ extends:
                 image: 1es-windows-2022
                 os: windows
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+              helixTargetQueue: Windows.Amd64.VS2022.Open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Windows.Amd64.VS2022.Pre
+              helixTargetQueue: Windows.Amd64.VS2022
             variables:
             - name: _BuildConfig
               value: Debug
@@ -232,9 +232,9 @@ extends:
                 image: 1es-windows-2022
                 os: windows
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+              helixTargetQueue: Windows.Amd64.VS2022.Open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Windows.Amd64.VS2022.Pre
+              helixTargetQueue: Windows.Amd64.VS2022
             variables:
               - name: _BuildConfig
                 value: Release

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -71,9 +71,9 @@ stages:
           name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2022
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+        helixTargetQueue: Windows.Amd64.VS2022.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        helixTargetQueue: Windows.Amd64.VS2022.Pre
+        helixTargetQueue: Windows.Amd64.VS2022
       strategy:
         matrix:
           Build_Release:
@@ -103,9 +103,9 @@ stages:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+          helixTargetQueue: Windows.Amd64.VS2022.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre
+          helixTargetQueue: Windows.Amd64.VS2022
         strategy:
           matrix:
             Build_Debug:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>8.0.126</VersionPrefix>
+    <VersionPrefix>8.0.127</VersionPrefix>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -11,9 +11,9 @@ jobs:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre.Open
+          helixTargetQueue: Windows.Amd64.VS2022.Open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Windows.Amd64.VS2022.Pre
+          helixTargetQueue: Windows.Amd64.VS2022
         strategy:
           matrix:
             Build_Release:


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.1xx`.

**Changes:**
- Repository: sdk
  - PatchVersion: `26` → `27`

**Files Modified:**
- eng/Versions.props (+1 -1)
