### PR TITLE
Ignore Cache files generated by Official C# Dev Kit

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -394,6 +394,9 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
+# Offical VS Code C# Dev Kit Extension exclusion
+*.lscache
+
 # Local History for Visual Studio Code
 .history/
 


### PR DESCRIPTION
Update .gitignore template to add `*.lscache` to ignore cache files generated by the Official C# Dev Kit
Fixes #53751 

