### PR TITLE
 Add --OutputFileNamesWithoutVersion option to dotnet pack

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -1330,6 +1330,9 @@ To display a value, specify the corresponding command-line option without provid
   <data name="PackCmdVersionDescription" xml:space="preserve">
     <value>The version of the package to create</value>
   </data>
+  <data name="PackCmdOutputFileNamesWithoutVersionDescription" xml:space="preserve">
+    <value>Do not include the version in the output file name.</value>
+  </data>
   <data name="PackCmdVersion" xml:space="preserve">
     <value>VERSION</value>
   </data>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Pack/PackCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Pack/PackCommandDefinition.cs
@@ -51,6 +51,12 @@ internal sealed class PackCommandDefinition : Command
         Arity = ArgumentArity.Zero
     }.ForwardAs("-property:Serviceable=true");
 
+    public readonly Option<bool> OutputFileNamesWithoutVersionOption = new Option<bool>("--OutputFileNamesWithoutVersion")
+    {
+        Description = CommandDefinitionStrings.PackCmdOutputFileNamesWithoutVersionDescription,
+        Arity = ArgumentArity.Zero
+    }.ForwardAs("-property:OutputFileNamesWithoutVersion=true");
+
     public readonly Option<bool> NoLogoOption = CommonOptions.CreateNoLogoOption();
 
     public readonly Option<bool> NoRestoreOption = CommonOptions.CreateNoRestoreOption();
@@ -102,6 +108,7 @@ internal sealed class PackCommandDefinition : Command
         Options.Add(IncludeSymbolsOption);
         Options.Add(IncludeSourceOption);
         Options.Add(ServiceableOption);
+        Options.Add(OutputFileNamesWithoutVersionOption);
         Options.Add(NoLogoOption);
         Options.Add(InteractiveOption);
         Options.Add(NoRestoreOption);

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -1338,6 +1338,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">The output directory to place built packages in.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackCmdOutputFileNamesWithoutVersionDescription">
+        <source>Do not include the version in the output file name.</source>
+        <target state="new">Do not include the version in the output file name.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackCmdVersion">
         <source>VERSION</source>
         <target state="new">VERSION</target>

--- a/src/Cli/dotnet/Commands/Pack/PackCommand.cs
+++ b/src/Cli/dotnet/Commands/Pack/PackCommand.cs
@@ -109,6 +109,7 @@ public class PackCommand(
             Exclude = new List<string>(),
             OutputDirectory = parseResult.GetValue(definition.OutputOption),
             LogLevel = MappingVerbosityToNugetLogLevel(parseResult.GetValue(definition.VerbosityOption)),
+            OutputFileNamesWithoutVersion = parseResult.GetValue(definition.OutputFileNamesWithoutVersionOption),
             Arguments = [nuspecPath]
         };
 

--- a/test/dotnet.Tests/CommandTests/Pack/PackTests.cs
+++ b/test/dotnet.Tests/CommandTests/Pack/PackTests.cs
@@ -431,5 +431,45 @@ namespace Microsoft.DotNet.Pack.Tests
 
             result.Should().Fail();            
         }
+
+        [Fact]
+        public void DotnetPack_OutputFileNamesWithoutVersion_MSBuild()
+        {
+            var testInstance = TestAssetsManager.CopyTestAsset("TestLibraryWithConfiguration")
+                .WithSource();
+
+            var outputDir = new DirectoryInfo(Path.Combine(testInstance.Path, "bin2"));
+
+            new DotnetPackCommand(Log)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("-o", outputDir.FullName, "--OutputFileNamesWithoutVersion")
+                .Should().Pass();
+
+            outputDir.Should().Exist()
+                .And.HaveFile("TestLibraryWithConfiguration.nupkg");
+        }
+
+        [Fact]
+        public void DotnetPack_OutputFileNamesWithoutVersion_Nuspec()
+        {
+            var testInstance = TestAssetsManager.CopyTestAsset("TestNuspecProject")
+                .WithSource();
+
+            string nuspecPath = Path.Combine(testInstance.Path, "PackNoCsproj.nuspec");
+
+            var result = new DotnetPackCommand(Log)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute(nuspecPath, "--property", "id=PackNoCsproj",
+                "--property", "authors=CustomAuthor", "--OutputFileNamesWithoutVersion");
+
+            result.Should().Pass();
+
+            var outputDir = new DirectoryInfo(testInstance.Path);
+            outputDir.Should().Exist()
+                .And.HaveFile("PackNoCsproj.nupkg");
+
+            var nupkgPath = Path.Combine(testInstance.Path, "PackNoCsproj.nupkg");
+            File.Exists(nupkgPath).Should().BeTrue("The package should be created without version in the file name.");
+        }
     }
 }


### PR DESCRIPTION
 ## Description:

  This PR exposes the --OutputFileNamesWithoutVersion option in the dotnet pack CLI, matching the existing NuGet 
  -OutputFileNamesWithoutVersion switch.

 ## What it does

  When specified, the output .nupkg filename omits the version — e.g., MyPackage.nupkg instead of MyPackage.1.0.0.nupkg.

  How it works

   - MSBuild path (project files): Forwards -property:OutputFileNamesWithoutVersion=true to MSBuild, which NuGet's 
  Pack.targets already consumes.
   - NuSpec path (.nuspec files): Sets PackArgs.OutputFileNamesWithoutVersion, which flows through 
  PackCommandRunner.GetOutputFileName(excludeVersion: true).

  Changes

   - PackCommandDefinition.cs — Added OutputFileNamesWithoutVersionOption (bool, zero-arity flag)
   - PackCommand.cs — Wired option into PackArgs for the nuspec code path
   - CommandDefinitionStrings.resx + XLF files — Added localized description string
   - PackTests.cs — Added tests for both MSBuild and nuspec paths

For more details, see https://github.com/dotnet/sdk/issues/53780
