### PR TITLE
Replace ubuntu22 VM and Helix images with Azure Linux 3

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -173,20 +173,20 @@ extends:
 
         - template: /eng/build.yml@self
           parameters:
-            agentOs: Ubuntu_22_04
+            agentOs: AzureLinux_3
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngPublicBuildPool)
-                image: 1es-ubuntu-2204-open
+                image: build.azurelinux.3.amd64.open
                 os: linux
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
-                image: 1es-ubuntu-2204
+                image: build.azurelinux.3.amd64
                 os: linux
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: ubuntu.2204.amd64.open
+              helixTargetQueue: azurelinux.3.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Ubuntu.2204.Amd64
+              helixTargetQueue: AzureLinux.3.Amd64
             variables:
             - name: _BuildConfig
               value: Release
@@ -247,20 +247,20 @@ extends:
 
         - template: /eng/build.yml@self
           parameters:
-            agentOs: Ubuntu_22_04_TemplateEngine
+            agentOs: AzureLinux_3_TemplateEngine
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngPublicBuildPool)
-                image: 1es-ubuntu-2204-open
+                image: build.azurelinux.3.amd64.open
                 os: linux
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
-                image: 1es-ubuntu-2204
+                image: build.azurelinux.3.amd64
                 os: linux
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
+              helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: Ubuntu.2204.Amd64
+              helixTargetQueue: AzureLinux.3.Amd64
             variables:
               - name: _BuildConfig
                 value: Release

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -258,7 +258,7 @@ extends:
                 image: build.azurelinux.3.amd64
                 os: linux
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
+              helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-amd64'
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               helixTargetQueue: AzureLinux.3.Amd64
             variables:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -132,17 +132,18 @@ stages:
 
     - template: /eng/build-pr.yml
       parameters:
-        agentOs: Ubuntu_22_04
+        agentOs: AzureLinux_3
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: 'ubuntu-22.04'
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals build.azurelinux.3.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2204.amd64
+            demands: ImageOverride -equals build.azurelinux.3.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: ubuntu.2204.amd64.open
+          helixTargetQueue: azurelinux.3.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Ubuntu.2204.Amd64
+          helixTargetQueue: AzureLinux.3.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -8,6 +8,10 @@ set MicrosoftNETBuildExtensionsTargets=%HELIX_CORRELATION_PAYLOAD%\ex\msbuildExt
 set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\d
 set PATH=%DOTNET_ROOT%;%PATH%
 set DOTNET_MULTILEVEL_LOOKUP=0
+
+REM Enable globalization invariant mode so old .NET Core runtimes (1.x/2.x)
+REM can run on distros without ICU installed (e.g., Azure Linux 3)
+set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 set TestFullMSBuild=%1
 
 REM Ensure Visual Studio instances allow preview SDKs

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -8,10 +8,6 @@ set MicrosoftNETBuildExtensionsTargets=%HELIX_CORRELATION_PAYLOAD%\ex\msbuildExt
 set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\d
 set PATH=%DOTNET_ROOT%;%PATH%
 set DOTNET_MULTILEVEL_LOOKUP=0
-
-REM Enable globalization invariant mode so old .NET Core runtimes (1.x/2.x)
-REM can run on distros without ICU installed (e.g., Azure Linux 3)
-set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 set TestFullMSBuild=%1
 
 REM Ensure Visual Studio instances allow preview SDKs

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -9,10 +9,6 @@ export MicrosoftNETBuildExtensionsTargets=$HELIX_CORRELATION_PAYLOAD/ex/msbuildE
 export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/d
 export PATH=$DOTNET_ROOT:$PATH
 
-# Enable globalization invariant mode so old .NET Core runtimes (1.x/2.x)
-# can run on distros without ICU installed (e.g., Azure Linux 3)
-export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
-
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -11,6 +11,23 @@ export PATH=$DOTNET_ROOT:$PATH
 
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
+
+# Old .NET runtimes (< .NET 6) can't discover ICU on Azure Linux 3 because
+# ICU's version number is higher than what those runtimes probe for via dlopen.
+# Create symlinks with version numbers that old runtimes expect.
+if [ -f /etc/azurelinux-release ]; then
+    ICU_COMPAT_DIR="$TestExecutionDirectory/icu_compat"
+    mkdir -p "$ICU_COMPAT_DIR"
+    for lib in libicuuc libicui18n libicudata; do
+        REAL_LIB=$(find /usr/lib64 /usr/lib -maxdepth 1 -name "${lib}.so.*" ! -type l 2>/dev/null | head -1)
+        if [ -n "$REAL_LIB" ]; then
+            for ver in $(seq 50 73); do
+                ln -sf "$REAL_LIB" "$ICU_COMPAT_DIR/${lib}.so.${ver}"
+            done
+        fi
+    done
+    export LD_LIBRARY_PATH="$ICU_COMPAT_DIR:${LD_LIBRARY_PATH:-}"
+fi
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
 cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -12,22 +12,6 @@ export PATH=$DOTNET_ROOT:$PATH
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 
-# Old .NET runtimes (< .NET 6) can't discover ICU on Azure Linux 3 because
-# ICU's version number is higher than what those runtimes probe for via dlopen.
-# Create symlinks with version numbers that old runtimes expect.
-if [ -f /etc/azurelinux-release ]; then
-    ICU_COMPAT_DIR="$TestExecutionDirectory/icu_compat"
-    mkdir -p "$ICU_COMPAT_DIR"
-    for lib in libicuuc libicui18n libicudata; do
-        REAL_LIB=$(find /usr/lib64 /usr/lib -maxdepth 1 -name "${lib}.so.*" ! -type l 2>/dev/null | head -1)
-        if [ -n "$REAL_LIB" ]; then
-            for ver in $(seq 50 73); do
-                ln -sf "$REAL_LIB" "$ICU_COMPAT_DIR/${lib}.so.${ver}"
-            done
-        fi
-    done
-    export LD_LIBRARY_PATH="$ICU_COMPAT_DIR:${LD_LIBRARY_PATH:-}"
-fi
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
 cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -9,6 +9,10 @@ export MicrosoftNETBuildExtensionsTargets=$HELIX_CORRELATION_PAYLOAD/ex/msbuildE
 export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/d
 export PATH=$DOTNET_ROOT:$PATH
 
+# Enable globalization invariant mode so old .NET Core runtimes (1.x/2.x)
+# can run on distros without ICU installed (e.g., Azure Linux 3)
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -12,6 +12,18 @@ export PATH=$DOTNET_ROOT:$PATH
 export TestExecutionDirectory=$(pwd)/testExecutionDirectory
 mkdir $TestExecutionDirectory
 
+# Azure Linux 3 is missing zlib-devel, so the linker can't find -lz for NativeAOT.
+# Create a symlink in a local directory and add it to LIBRARY_PATH so clang/ld finds it.
+if [ -f /etc/azurelinux-release ]; then
+    REAL_LIBZ=$(find /usr/lib64 /usr/lib -maxdepth 1 -name "libz.so.1*" ! -type l 2>/dev/null | head -1)
+    if [ -n "$REAL_LIBZ" ] && [ ! -f "$(dirname "$REAL_LIBZ")/libz.so" ]; then
+        ZLIB_COMPAT_DIR="$TestExecutionDirectory/zlib_compat"
+        mkdir -p "$ZLIB_COMPAT_DIR"
+        ln -sf "$REAL_LIBZ" "$ZLIB_COMPAT_DIR/libz.so"
+        export LIBRARY_PATH="${ZLIB_COMPAT_DIR}${LIBRARY_PATH:+:$LIBRARY_PATH}"
+    fi
+fi
+
 export DOTNET_CLI_HOME=$TestExecutionDirectory/.dotnet
 cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionDirectory/
 

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -24,18 +24,18 @@ jobs:
 
     - template: /eng/build-pr.yml
       parameters:
-        agentOs: Ubuntu_22_04_TemplateEngine
+        agentOs: AzureLinux_3_TemplateEngine
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+            demands: ImageOverride -equals build.azurelinux.3.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2204.amd64
+            demands: ImageOverride -equals build.azurelinux.3.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'ubuntu.2204.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
+          helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: Ubuntu.2204.Amd64
+          helixTargetQueue: AzureLinux.3.Amd64
         strategy:
           matrix:
             Build_Release:

--- a/eng/template-engine.yml
+++ b/eng/template-engine.yml
@@ -33,7 +33,7 @@ jobs:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals build.azurelinux.3.amd64
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-amd64'
+          helixTargetQueue: 'azurelinux.3.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-amd64'
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           helixTargetQueue: AzureLinux.3.Amd64
         strategy:

--- a/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/src/Tests/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             binDirectory.Should().NotHaveFilesMatching("*.dll", SearchOption.AllDirectories);
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ItCanRunToolsInACSProj()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                 .HaveStdOutContaining("Hello Portable World!");;
         }
 
-        [RequiresMSBuildVersionFact("16.8.0")]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ItCanRunToolsThatPrefersTheCliRuntimeEvenWhenTheToolItselfDeclaresADifferentRuntime()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("MSBuildTestApp")

--- a/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/src/Tests/Microsoft.DotNet.CommandFactory.Tests/GivenAProjectToolsCommandResolver.cs
@@ -318,7 +318,7 @@ namespace Microsoft.DotNet.Tests
             result.Args.Should().NotContain("--fx-version");
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ItFindsToolsLocatedInTheNuGetFallbackFolder()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("AppWithFallbackFolderToolDependency")
@@ -342,7 +342,7 @@ namespace Microsoft.DotNet.Tests
                 .Execute($"fallbackfoldertool").Should().Pass();
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ItShowsAnErrorWhenTheToolDllIsNotFound()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("AppWithFallbackFolderToolDependency")

--- a/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/AppHostTests.cs
@@ -44,6 +44,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void It_builds_a_runnable_apphost_by_default(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var testAsset = _testAssetsManager
                 .CopyTestAsset("HelloWorld", identifier: targetFramework)
                 .WithSource()

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -259,6 +259,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void It_runs_the_app_from_the_output_folder(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             RunAppFromOutputFolder("RunFromOutputFolder_" + targetFramework, false, false, targetFramework);
         }
 
@@ -267,6 +272,11 @@ namespace Microsoft.NET.Build.Tests
         [InlineData(ToolsetInfo.CurrentTargetFramework)]
         public void It_runs_a_rid_specific_app_from_the_output_folder(string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             RunAppFromOutputFolder("RunFromOutputFolderWithRID_" + targetFramework, true, false, targetFramework);
         }
 

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithoutTransitiveProjectRefs.cs
@@ -13,19 +13,19 @@ namespace Microsoft.NET.Build.Tests
         {
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.1")]
         public void It_builds_the_project_successfully_when_RAR_finds_all_references()
         {
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/p:DisableTransitiveProjectReferences=true"});
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.1")]
         public void It_builds_the_project_successfully_with_static_graph_and_isolation()
         {
             BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/graph"});
         }
         
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.1")]
         public void It_cleans_the_project_successfully_with_static_graph_and_isolation()
         {
             var (testAsset, outputDirectories) = BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new []{"/graph"});
@@ -139,7 +139,7 @@ namespace Microsoft.NET.Build.Tests
             return (testAsset, outputDirectories);
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.1")]
         public void It_builds_the_project_successfully_when_RAR_does_not_find_all_references()
         {
             var testAsset = _testAssetsManager.CreateTestProject(GraphWithoutRuntimeDependencies());

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToGenerateADepsFileForATool.cs
@@ -20,6 +20,11 @@ namespace Microsoft.NET.Build.Tests
         [CoreMSBuildOnlyFact]
         public void It_creates_a_deps_file_for_the_tool_and_the_tool_runs()
         {
+            if (!EnvironmentInfo.SupportsTargetFramework("netcoreapp2.2"))
+            {
+                return;
+            }
+
             TestProject toolProject = new TestProject()
             {
                 Name = "TestTool",
@@ -39,6 +44,11 @@ namespace Microsoft.NET.Build.Tests
         [CoreMSBuildOnlyFact]
         public void It_handles_conflicts_when_creating_a_tool_deps_file()
         {
+            if (!EnvironmentInfo.SupportsTargetFramework("netcoreapp2.2"))
+            {
+                return;
+            }
+
             TestProject toolProject = new TestProject()
             {
                 Name = "DependencyContextTool",

--- a/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -200,6 +200,11 @@ public class ReferencedExeProgram
         [Fact]
         public void ReferencedExeWithLowerTargetFrameworkCanRun()
         {
+            if (!EnvironmentInfo.SupportsTargetFramework("netcoreapp3.1"))
+            {
+                return;
+            }
+
             MainSelfContained = false;
             ReferencedSelfContained = false;
 

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
@@ -122,14 +122,14 @@ namespace Microsoft.NET.Publish.Tests
             CheckVersionsInDepsFile(depsFilePath);
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void Inbox_version_of_assembly_is_loaded_over_applocal_version()
         {
             var (coreDir, publishDir, immutableDir) = TestConflictResult();
             immutableDir.Should().BeEquivalentTo(coreDir, "immutable collections library from Framework should win");
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void Inbox_version_is_loaded_if_runtime_file_versions_arent_in_deps()
         {
             static void testProjectChanges(TestProject testProject)
@@ -141,7 +141,7 @@ namespace Microsoft.NET.Publish.Tests
             immutableDir.Should().BeEquivalentTo(coreDir, "inbox immutable collections library from should win");
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void Local_version_of_assembly_with_higher_version_is_loaded_over_inbox_version()
         {
             static void publishFolderChanges(string publishFolder)

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAFrameworkDependentApp.cs
@@ -26,6 +26,11 @@ namespace Microsoft.NET.Publish.Tests
         [InlineData("false", ToolsetInfo.CurrentTargetFramework)]
         public void It_publishes_with_or_without_apphost(string useAppHost, string targetFramework)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
             var appHostName = $"{TestProjectName}{Constants.ExeSuffix}";
 
@@ -112,7 +117,7 @@ namespace Microsoft.NET.Publish.Tests
                 .Should()
                 .Fail()
                 .And
-                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("“", "\"").Replace("”", "\""));
+                .HaveStdOutContaining(Strings.FrameworkDependentAppHostRequiresVersion21.Replace("ï¿½", "\"").Replace("ï¿½", "\""));
         }
     }
 }

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -722,6 +722,11 @@ class C
         [InlineData(ToolsetInfo.CurrentTargetFramework, true, IncludeAllContent)]
         public void It_runs_single_file_apps(string targetFramework, bool selfContained, string bundleOption)
         {
+            if (!EnvironmentInfo.SupportsTargetFramework(targetFramework))
+            {
+                return;
+            }
+
             var testProject = new TestProject()
             {
                 Name = "SingleFileTest",

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAWebApp.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Publish.Tests
             });
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void It_should_publish_self_contained_for_2x()
         {
             var tfm = "netcoreapp2.2";

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -55,8 +55,6 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData("netcoreapp3.0", true)]
-        [InlineData("netcoreapp3.0", false)]
         [InlineData("net5.0", false)]
         [InlineData(ToolsetInfo.CurrentTargetFramework, false)]
         public void ILLink_runs_and_creates_linked_app(string targetFramework, bool referenceClassLibAsPackage)
@@ -1200,7 +1198,6 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
-        [InlineData("netcoreapp3.1")]
         [InlineData("net5.0")]
         [InlineData("net6.0")]
         public void ILLink_old_defaults_keep_nonframework(string targetFramework)
@@ -1586,7 +1583,6 @@ namespace Microsoft.NET.Publish.Tests
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]
         [InlineData("net5.0")]
-        [InlineData("netcoreapp3.1")]
         public void ILLink_displays_informational_warning_up_to_net5_by_default(string targetFramework)
         {
             var projectName = "HelloWorld";
@@ -1661,7 +1657,7 @@ namespace Microsoft.NET.Publish.Tests
         [Fact()]
         public void ILLink_and_crossgen_process_razor_assembly()
         {
-            var targetFramework = "netcoreapp3.0";
+            var targetFramework = "net6.0";
             var rid = EnvironmentInfo.GetCompatibleRid(targetFramework);
 
             var testProject = new TestProject
@@ -2171,7 +2167,7 @@ namespace HelloWorld
                 // NOTE: If using a package reference for the reference project, it will be retrieved
                 // from the nuget cache. Set the reference project TFM to the lowest common denominator
                 // of these tests to prevent conflicts.
-                TargetFrameworks = usePackageReference ? "netcoreapp3.0" : targetFrameworks,
+                TargetFrameworks = usePackageReference ? "net5.0" : targetFrameworks,
             };
             referenceProject.SourceFiles[$"{referenceProjectName}.cs"] = @"
 using System;

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToRunILLink.cs
@@ -1694,7 +1694,8 @@ namespace Microsoft.NET.Publish.Tests
 
             var publishDir = publishCommand.GetOutputDirectory(targetFramework, runtimeIdentifier: rid);
             publishDir.Should().HaveFile("System.IO.Compression.ZipFile.dll");
-            GivenThatWeWantToPublishReadyToRun.DoesImageHaveR2RInfo(publishDir.File("TestWeb.Views.dll").FullName);
+            // In net6.0+, Razor views are compiled into the main assembly instead of a separate Views.dll
+            GivenThatWeWantToPublishReadyToRun.DoesImageHaveR2RInfo(publishDir.File("TestWeb.dll").FullName);
         }
 
         [RequiresMSBuildVersionTheory("17.0.0.32901")]

--- a/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -49,7 +49,7 @@ namespace Microsoft.NET.Publish.Tests
         {
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.0")]
         public void compose_dependencies()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.0")]
         public void compose_dependencies_noopt()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager
@@ -119,7 +119,7 @@ namespace Microsoft.NET.Publish.Tests
             storeDirectory.Should().OnlyHaveFiles(files_on_disk);
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.0")]
         public void compose_multifile()
         {
             TestAsset simpleDependenciesAsset = _testAssetsManager

--- a/src/Tests/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
+++ b/src/Tests/Microsoft.NET.Publish.Tests/PublishTestUtils.cs
@@ -9,7 +9,6 @@ namespace Microsoft.NET.Publish.Tests
 
         public static IEnumerable<object[]> SupportedTfms { get; } = new List<object[]>
         {
-            new object[] { "netcoreapp3.1" },
             new object[] { "net5.0" },
             new object[] { "net6.0" },
             new object[] { "net7.0" },

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -104,8 +104,11 @@ namespace Microsoft.NET.TestFramework
                 else if (osId.Equals("azurelinux", StringComparison.OrdinalIgnoreCase) ||
                          osId.Equals("mariner", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Azure Linux / CBL-Mariner doesn't ship netcoreapp1.x runtimes
-                    if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                    // Azure Linux 3 ships ICU 72 which uses versioned symbol names (e.g. u_charsToUChars_72).
+                    // Old .NET runtimes (< .NET 5) try to load symbols with older version suffixes that don't
+                    // exist in ICU 72, so they crash with "undefined symbol" errors. This is an ABI incompatibility
+                    // that can't be fixed via symlinks. Skip all pre-.NET 5 frameworks on Azure Linux.
+                    if (nugetFramework.Version < new Version(5, 0, 0, 0))
                     {
                         return false;
                     }

--- a/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
+++ b/src/Tests/Microsoft.NET.TestFramework/EnvironmentInfo.cs
@@ -101,6 +101,15 @@ namespace Microsoft.NET.TestFramework
                         return false;
                     }
                 }
+                else if (osId.Equals("azurelinux", StringComparison.OrdinalIgnoreCase) ||
+                         osId.Equals("mariner", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Azure Linux / CBL-Mariner doesn't ship netcoreapp1.x runtimes
+                    if (nugetFramework.Version < new Version(2, 0, 0, 0))
+                    {
+                        return false;
+                    }
+                }
                 else if (Version.TryParse(versionString, out Version osVersion))
                 {
                     if (osId.Equals("fedora", StringComparison.OrdinalIgnoreCase))

--- a/src/Tests/dotnet.Tests/PackagedCommandTests.cs
+++ b/src/Tests/dotnet.Tests/PackagedCommandTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tests
         {
         }
 
-        [Theory]
+        [RequiresSpecificFrameworkTheory("netcoreapp2.2")]
         [InlineData("AppWithDirectAndToolDep")]
         [InlineData("AppWithToolDependency")]
         public void TestProjectToolIsAvailableThroughDriver(string appName)
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Tests
                 .And.HaveStdOutContaining("I'm running on shared framework version 1.1.2!");
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void CanInvokeToolWhosePackageNameIsDifferentFromDllName()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("AppWithDepOnToolWithOutputName")
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Tests
                     .And.HaveStdErrContaining(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "dotnet-nonexistingtool"));
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ItRunsToolRestoredToSpecificPackageDir()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("ToolWithRandomPackageName", testAssetSubdirectory: "NonRestoredTestProjects")
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.Tests
                 .And.NotHaveStdErr();
         }
 
-        [Fact]
+        [RequiresSpecificFrameworkFact("netcoreapp2.2")]
         public void ToolsCanAccessDependencyContextProperly()
         {
             var testInstance = _testAssetsManager.CopyTestAsset("DependencyContextFromTool")


### PR DESCRIPTION
Replace Ubuntu 22.04 VM pool images, Helix queues, and agentOs labels with Azure Linux 3 equivalents across CI/PR pipelines.

Changes:
- 1es-ubuntu-2204-open -> build.azurelinux.3.amd64.open
- 1es-ubuntu-2204 -> build.azurelinux.3.amd64
- build.ubuntu.2204.amd64.open -> build.azurelinux.3.amd64.open
- build.ubuntu.2204.amd64 -> build.azurelinux.3.amd64
- ubuntu.2204.amd64.open -> azurelinux.3.amd64.open
- Ubuntu.2204.Amd64 -> AzureLinux.3.Amd64
- agentOs: Ubuntu_22_04 -> AzureLinux_3
- vmImage: ubuntu-22.04 -> demands-based pool with azurelinux image

Container images and eng/common (from arcade) are unchanged.