### PR TITLE
Write launch settings message to stderr instead of stdout

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -469,7 +469,7 @@ public class RunCommand
 
         if (!RunCommandVerbosity.IsQuiet())
         {
-            Reporter.Output.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, LaunchProfile);

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -403,7 +403,7 @@ internal static class SolutionAndProjectUtility
         // If buildOptions.Verbosity is null, we still want to print the message.
         if (buildOptions.Verbosity != VerbosityOptions.quiet)
         {
-            Reporter.Output.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
+            Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         var result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -158,10 +158,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!SdkTestContext.IsLocalized())
             {
-                result.StdOut
+                result.StdErr
                     .Should().Contain("Using launch settings from")
-                    .And.Contain(runJson ? "TestProjectWithLaunchSettings.run.json..." : $"Properties{Path.DirectorySeparatorChar}launchSettings.json...")
-                    .And.Contain("Test run summary: Passed!")
+                    .And.Contain(runJson ? "TestProjectWithLaunchSettings.run.json..." : $"Properties{Path.DirectorySeparatorChar}launchSettings.json...");
+
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
                     .And.Contain("MY_VARIABLE_FROM_LAUNCH_SETTINGS=TestValue1")
                     .And.Contain("skipped Test1")
                     .And.Contain("total: 2")
@@ -217,10 +219,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute(
                     "-c", TestingConstants.Debug);
 
-            result.StdOut.Should()
+            result.StdErr.Should()
                 .Contain("Using launch settings from")
-                .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...")
-                .And.Contain("FAILED to find argument from launchSettings.json");
+                .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...");
+
+            result.StdOut.Should()
+                .Contain("FAILED to find argument from launchSettings.json");
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -237,10 +241,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                                         "-c", configuration,
                                         "--no-launch-profile-arguments", "true");
 
-            result.StdOut.Should()
+            result.StdErr.Should()
                 .Contain("Using launch settings from")
-                .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...")
-                .And.Contain("FAILED to find argument from launchSettings.json");
+                .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...");
+
+            result.StdOut.Should()
+                .Contain("FAILED to find argument from launchSettings.json");
         }
 
         [InlineData(TestingConstants.Debug)]
@@ -575,10 +581,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             if (!SdkTestContext.IsLocalized())
             {
-                result.StdOut
+                result.StdErr
                     .Should().Contain("Using launch settings from")
-                    .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...")
-                    .And.Contain("Test run summary: Failed!")
+                    .And.Contain($"Properties{Path.DirectorySeparatorChar}launchSettings.json...");
+
+                result.StdOut
+                    .Should().Contain("Test run summary: Failed!")
                     .And.Contain("total: 1")
                     .And.Contain("succeeded: 0")
                     .And.Contain("failed: 1")


### PR DESCRIPTION
## Summary

- Changed `Reporter.Output.WriteLine` to `Reporter.Error.WriteLine` for the "Using launch settings from ..." message in `RunCommand.cs` and `SolutionAndProjectUtility.cs`
- Updated tests to assert the message appears on stderr rather than stdout

Fixes #45640