### PR TITLE
Keep strong reference to virtual project's ProjectRootElement to prevent GC

### DIFF
--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -22,6 +22,16 @@ public sealed class VirtualProjectBuilder
 
     private (ImmutableArray<CSharpDirective> Original, ImmutableArray<CSharpDirective> Evaluated)? _evaluatedDirectives;
 
+    /// <summary>
+    /// Prevents the virtual project's <see cref="ProjectRootElement"/> from being garbage collected
+    /// when MSBuild's <see cref="ProjectRootElementCache"/> demotes it to a weak reference
+    /// (which can happen when many SDK import files fill the cache during NuGet restore).
+    /// Without this, nested <c>&lt;MSBuild&gt;</c> tasks that re-evaluate the project with different properties
+    /// would fail to find the <see cref="ProjectRootElement"/> in the cache and try to load it from disk,
+    /// resulting in MSB4025 because the virtual project file does not exist on disk.
+    /// </summary>
+    private ProjectRootElement? _projectRootElement;
+
     internal string EntryPointFileFullPath { get; }
 
     internal SourceFile EntryPointSourceFile
@@ -394,6 +404,7 @@ public sealed class VirtualProjectBuilder
                 using var xmlReader = XmlReader.Create(reader);
                 var projectRoot = ProjectRootElement.Create(xmlReader, projectCollection);
                 projectRoot.FullPath = GetVirtualProjectPath(EntryPointFileFullPath);
+                _projectRootElement = projectRoot;
                 return projectRoot;
             }
         }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests.cs
@@ -6432,4 +6432,52 @@ public sealed class RunFileTests(ITestOutputHelper log) : SdkTest(log)
             return result;
         }
     }
+
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/52714.
+    /// The virtual project's <see cref="ProjectRootElement"/> must survive GC
+    /// even after being evicted from MSBuild's strong cache (LRU of size N).
+    /// We force eviction via <c>MSBUILDPROJECTROOTELEMENTCACHESIZE=1</c>
+    /// and trigger GC via an inline task during NuGet restore.
+    /// Without the fix (strong reference in <c>VirtualProjectBuilder._projectRootElement</c>),
+    /// this fails with MSB4025 "The project file could not be loaded".
+    /// </summary>
+    [Fact]
+    public void VirtualProject_SurvivesGCDuringRestore()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            Console.WriteLine("Hello from virtual project");
+            """);
+
+        // Directory.Build.targets that forces GC during restore,
+        // after SDK imports have already evicted the virtual PRE from the strong cache.
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.targets"), """
+            <Project>
+              <UsingTask TaskName="_ForceGCTask"
+                         TaskFactory="RoslynCodeTaskFactory"
+                         AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+                <Task>
+                  <Code Type="Fragment" Language="cs"><![CDATA[
+                    System.GC.Collect(2, System.GCCollectionMode.Forced, blocking: true);
+                    System.GC.WaitForPendingFinalizers();
+                    System.GC.Collect(2, System.GCCollectionMode.Forced, blocking: true);
+                  ]]></Code>
+                </Task>
+              </UsingTask>
+              <Target Name="_ForceGC" BeforeTargets="_FilterRestoreGraphProjectInputItems">
+                <_ForceGCTask />
+              </Target>
+            </Project>
+            """);
+
+        new DotnetCommand(Log, "run", "--no-cache", "Program.cs")
+            // A cache size of 1 ensures the virtual PRE is evicted from the strong cache
+            // as soon as any SDK .targets/.props file is loaded during evaluation.
+            .WithEnvironmentVariable("MSBUILDPROJECTROOTELEMENTCACHESIZE", "1")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello from virtual project");
+    }
 }


### PR DESCRIPTION
When `dotnet run --file` builds a virtual `.csproj` in memory, the `ProjectRootElement` is only held alive by MSBuild's `ProjectRootElementCache` which may demote it to a weak reference when many SDK import files fill the cache (e.g., in large repos with `Directory.Packages.props`). If GC collects the weakly referenced element, nested `<MSBuild>` tasks during NuGet restore that re-evaluate the project with different properties fail to find it in the cache, try to load from disk, and throw MSB4025 because the virtual file does not exist.

Fix: Store the `ProjectRootElement` in a field on `VirtualProjectBuilder` so it stays alive for the duration of the build.

Fixes #52714