### PR TITLE
Use `source-build-assets` repo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -451,10 +451,10 @@
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.26152.3">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>e6a837a05532cb8e89eda3ce8aa08d0f55ce7b04</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-assets" Version="9.0.0-alpha.1.26208.6">
+      <Uri>https://github.com/dotnet/source-build-assets</Uri>
+      <Sha>8e19a1b4f607fcbecc4edbd322d77a60d4e25c3c</Sha>
+      <SourceBuild RepoName="source-build-assets" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="2.0.0-rtm.1.25059.4">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -173,7 +173,7 @@
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
     <DotNetBuildPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', '$(MSBuildProjectName)'))</DotNetBuildPrebuiltReportDir>
     
-    <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
+    <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-assets', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
 
             DiscoverPackagesFromAllSourceBuildSources(pkgSourcesElement);
 
-            // Discover all SBRP packages if source-build-reference-package-cache source is present in NuGet.config
+            // Discover all SBRP packages if source-build-assets-cache source is present in NuGet.config
             XElement sbrpCacheSourceElement = GetElement(pkgSourcesElement, "add", SbrpCacheSourceName);
             if (sbrpCacheSourceElement != null)
             {
@@ -326,7 +326,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
 
         private void DiscoverPackagesFromSbrpCacheSource()
         {
-            // 'source-build-reference-package-cache' is a dynamic source, populated by SBRP build.
+            // 'source-build-assets-cache' is a dynamic source, populated by SBA build.
             // Discover all SBRP packages from checked in nuspec files.
 
             if (!Directory.Exists(SbrpRepoSrcPath))

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WritePackageVersionsProps.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WritePackageVersionsProps.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                     });
 
             // We may have multiple versions of the same package. We'll keep the latest one.
-            // This can even happen in the KnownPackages list, as a repo (such as source-build-reference-packages)
+            // This can even happen in the KnownPackages list, as a repo (such as source-build-assets)
             // may have multiple versions of the same package.
             IEnumerable<VersionEntry> packageElementsToWrite = knownPackages
                 .GroupBy(identity => identity.Name)

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
@@ -16,13 +16,13 @@ using NuGet.ProjectModel;
 namespace Microsoft.DotNet.UnifiedBuild.Tasks;
 
 /// <summary>
-/// Reports the usage of the source-build-reference-packages:
-/// 1. SBRP references
+/// Reports the usage of the source-build-assets:
+/// 1. SB-Assets references
 /// 2. Unreferenced packages
 /// </summary>
 public class WriteSbrpUsageReport : Task
 {
-    private const string SbrpRepoName = "source-build-reference-packages";
+    private const string SbrpRepoName = "source-build-assets";
 
     private readonly Dictionary<string, PackageInfo> _sbrpPackages = [];
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -43,7 +43,7 @@
 
     <SourceBuiltSdksDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-built-sdks'))</SourceBuiltSdksDir>
 
-    <SbrpCacheNuGetSourceName>source-build-reference-package-cache</SbrpCacheNuGetSourceName>
+    <SbrpCacheNuGetSourceName>source-build-assets-cache</SbrpCacheNuGetSourceName>
     <SourceBuiltSourceNamePrefix>source-built-</SourceBuiltSourceNamePrefix>
 
     <!-- Set the bootstrap version to the VMR's version if empty. (no bootstrap set). -->

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -91,7 +91,7 @@
   <!-- Wraps the transitive repo references with additional metadata -->
   <Target Name="GetRepositoryReferenceInfo"
           DependsOnTargets="GetTransitiveRepositoryReferences">
-    <!-- SBRP is explicitly excluded since it is output to its own special directory, $(ReferencePackagesDir). -->
+    <!-- source-build-assets (formerly SBRP) is explicitly excluded since it is output to its own special directory, $(ReferencePackagesDir). -->
     <ItemGroup Condition="'@(TransitiveRepositoryReference)' != ''">
       <RepositoryReferenceInfo Include="@(TransitiveRepositoryReference)"
                                Exclude="source-build-assets">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -94,7 +94,7 @@
     <!-- SBRP is explicitly excluded since it is output to its own special directory, $(ReferencePackagesDir). -->
     <ItemGroup Condition="'@(TransitiveRepositoryReference)' != ''">
       <RepositoryReferenceInfo Include="@(TransitiveRepositoryReference)"
-                               Exclude="source-build-reference-packages">
+                               Exclude="source-build-assets">
         <ShippingSourceName>$(SourceBuiltSourceNamePrefix)%(Identity)</ShippingSourceName>
         <NonShippingSourceName>$(SourceBuiltSourceNamePrefix)transport-%(Identity)</NonShippingSourceName>
         <ShippingPackagesPath>$(ArtifactsShippingPackagesDir)/%(Identity)/</ShippingPackagesPath>

--- a/src/SourceBuild/content/repo-projects/arcade.proj
+++ b/src/SourceBuild/content/repo-projects/arcade.proj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RepositoryReference Include="source-build-reference-packages" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+    <RepositoryReference Include="source-build-assets" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -32,7 +32,7 @@
     <RepositoryReference Include="nuget-client" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
     <RepositoryReference Include="symreader" />
   </ItemGroup>
 

--- a/src/SourceBuild/content/repo-projects/cecil.proj
+++ b/src/SourceBuild/content/repo-projects/cecil.proj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/command-line-api.proj
+++ b/src/SourceBuild/content/repo-projects/command-line-api.proj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/deployment-tools.proj
+++ b/src/SourceBuild/content/repo-projects/deployment-tools.proj
@@ -6,7 +6,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/diagnostics.proj
+++ b/src/SourceBuild/content/repo-projects/diagnostics.proj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/emsdk.proj
+++ b/src/SourceBuild/content/repo-projects/emsdk.proj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/fsharp.proj
+++ b/src/SourceBuild/content/repo-projects/fsharp.proj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/msbuild.proj
+++ b/src/SourceBuild/content/repo-projects/msbuild.proj
@@ -19,7 +19,7 @@
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="runtime" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/razor.proj
+++ b/src/SourceBuild/content/repo-projects/razor.proj
@@ -14,7 +14,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="aspnetcore" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/roslyn-analyzers.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn-analyzers.proj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -37,7 +37,7 @@
     <RepositoryReference Include="roslyn-analyzers" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
     <RepositoryReference Include="symreader" />
   </ItemGroup>
 

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -44,7 +44,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -17,7 +17,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
   <Target Name="SetupNuGetConfig"

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -66,7 +66,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
   <!--

--- a/src/SourceBuild/content/repo-projects/source-build-assets.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-assets.proj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <!-- All packages built in SBRP repo are copied to prereqs/package/reference.
+    <!-- All packages built in SBA repo are copied to prereqs/package/reference.
          Nothing gets copied to the artifacts/packages folder. -->
     <ReferenceOnlyRepoArtifacts>true</ReferenceOnlyRepoArtifacts>
 
-    <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->
+    <!-- SBA builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
 
-    <LocalNuGetPackageCacheDirectory>$(ArtifactsObjDir)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
+    <LocalNuGetPackageCacheDirectory>$(ArtifactsObjDir)source-build-assets-cache</LocalNuGetPackageCacheDirectory>
 
     <BuildArgs>$(BuildArgs) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(NETCoreSdkRuntimeIdentifier)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory)</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/source-build-externals.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-externals.proj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/sourcelink.proj
+++ b/src/SourceBuild/content/repo-projects/sourcelink.proj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/symreader.proj
+++ b/src/SourceBuild/content/repo-projects/symreader.proj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/templating.proj
+++ b/src/SourceBuild/content/repo-projects/templating.proj
@@ -13,7 +13,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/test-templates.proj
+++ b/src/SourceBuild/content/repo-projects/test-templates.proj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -12,7 +12,7 @@
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -209,21 +209,21 @@ src/source-build-externals/src/humanizer/NuSpecs/*.nuspec*
 src/source-build-externals/src/spectre-console/README.md|unknown-license-reference
 
 #
-# source-build-reference-packages
+# source-build-assets
 #
 
 # False positive
-src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/8.0.0/THIRD-PARTY-NOTICES.TXT|unknown
-src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.netcore.app.ref/3.*/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/1.6.1/ThirdPartyNotices.txt|unknown-license-reference
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/2.0.*/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library.ref/2.1.0/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.*/1.*/ThirdPartyNotices.txt|unknown-license-reference
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.private.intellisense/*/IntellisenseFiles/*/1033/System.Security.Permissions.xml|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/8.0.0/THIRD-PARTY-NOTICES.TXT|unknown
+src/source-build-assets/src/targetPacks/ILsrc/microsoft.netcore.app.ref/3.*/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library/1.6.1/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library/2.0.*/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library.ref/2.1.0/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
+src/source-build-assets/src/textOnlyPackages/src/microsoft.netcore.*/1.*/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-assets/src/textOnlyPackages/src/microsoft.private.intellisense/*/IntellisenseFiles/*/1033/System.Security.Permissions.xml|unknown-license-reference
 
 # Contains references to licenses which are not applicable to the source
-src/source-build-reference-packages/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs|unknown-license-reference,ms-net-library-2018-11
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.private.intellisense/*/IntellisenseFiles/windowsdesktop/1033/PresentationCore.xml|proprietary-license
+src/source-build-assets/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs|unknown-license-reference,ms-net-library-2018-11
+src/source-build-assets/src/textOnlyPackages/src/microsoft.private.intellisense/*/IntellisenseFiles/windowsdesktop/1033/PresentationCore.xml|proprietary-license
 
 #
 # sourcelink

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -151,6 +151,10 @@
             "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
+            "name": "source-build-reference-packages",
+            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+        },
+        {
             "name": "sourcelink",
             "defaultRemote": "https://github.com/dotnet/sourcelink"
         },

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -151,8 +151,15 @@
             "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
+            // TODO: Remove the source-build-reference-packages mapping once
+            // the synchronization flags it as unused.
+            // We no longer synchronize it but we can't remove it yet until
+            // it disappears from all of the Version.Details.xml files.
+            // https://github.com/dotnet/source-build/issues/5533
             "name": "source-build-reference-packages",
-            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages",
+            "ignoreDefaults": true,
+            "exclude": [ "**/*" ]
         },
         {
             "name": "sourcelink",

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -147,8 +147,8 @@
             ]
         },
         {
-            "name": "source-build-reference-packages",
-            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+            "name": "source-build-assets",
+            "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
             "name": "sourcelink",


### PR DESCRIPTION
After `source-build-reference-packages` repo was renamed to `source-build-assets`, some changes are needed in `installer` repo to allow proper consumption of the new repo artifacts.

This PR updates repo-related properties or values.

This PR does not update various SBRP-named property names as there is no need for that. While repo was renamed, in .NET 9.0 repo still contains just reference packages, so the infra is correct and isn't confusing.

After this PR is merged and VMR updated, it will likely be necessary to manually delete old repo clone in VMR and potentially old repo's project file in `repo-projects`. I will prepare a follow up with those changes.

## Validation

[SDK build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2947782&view=results) - unrelated failures, present in other CI runs
[VMR build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2947556&view=results)