### PR TITLE
Remove Identity-without-backing-file quirk from Static Web Assets

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
@@ -371,7 +371,7 @@ Integration with static web assets:
 
 </Target>
 
-<Target Name="_ComputeScopedCssStaticWebAssets" DependsOnTargets="ResolveScopedCssOutputs;ResolveStaticWebAssetsConfiguration">
+<Target Name="_ComputeScopedCssStaticWebAssets" DependsOnTargets="_ProcessScopedCssFiles;ResolveStaticWebAssetsConfiguration">
   <ItemGroup>
     <_ScopedCssCandidateFile Include="%(_ScopedCss.OutputFile)" Condition="@(_ScopedCss) != ''">
       <RelativePath>%(_ScopedCss.RelativePath)</RelativePath>

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ServiceWorker.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ServiceWorker.targets
@@ -188,8 +188,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <_BuildAssetsForManifestCandidate Include="@(StaticWebAsset)" Condition="'%(AssetRole)' != 'Alternative' and Exists('%(Identity)')" />
-      <_BuildAssetsForManifestCandidate Include="@(StaticWebAsset->'%(OriginalItemSpec)')" Condition="'%(AssetRole)' != 'Alternative' and !Exists('%(Identity)')" />
+      <_BuildAssetsForManifestCandidate Include="@(StaticWebAsset)" Condition="'%(AssetRole)' != 'Alternative'" />
     </ItemGroup>
 
     <MakeDir Directories="$(IntermediateOutputPath)service-worker" />

--- a/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
+++ b/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
@@ -43,31 +43,8 @@ public class CollectStaticWebAssetsToCopy : Task
                 {
                     // We have an asset we want to copy to the output folder.
                     fileOutputPath = Path.Combine(normalizedOutputPath, asset.ComputeTargetPath("", Path.DirectorySeparatorChar, StaticWebAssetTokenResolver.Instance));
-                    string source = null;
-                    if (asset.IsComputed())
-                    {
-                        if (asset.Identity.StartsWith(normalizedOutputPath, StringComparison.Ordinal))
-                        {
-                            Log.LogMessage(MessageImportance.Low, "Source for asset '{0}' is '{1}' since the identity points to the output path.", asset.Identity, asset.OriginalItemSpec);
-                            source = asset.OriginalItemSpec;
-                        }
-                        else if (File.Exists(asset.Identity))
-                        {
-                            Log.LogMessage(MessageImportance.Low, "Source for asset '{0}' is '{0}' since the asset exists.", asset.Identity);
-                            source = asset.Identity;
-                        }
-                        else
-                        {
-                            Log.LogMessage(MessageImportance.Low, "Source for asset '{0}' is '{1}' since the asset does not exist.", asset.Identity, asset.OriginalItemSpec);
-                            source = asset.OriginalItemSpec;
-                        }
-                    }
-                    else
-                    {
-                        source = asset.Identity;
-                    }
 
-                    copyToOutputFolder.Add(new TaskItem(source, new Dictionary<string, string>
+                    copyToOutputFolder.Add(new TaskItem(asset.Identity, new Dictionary<string, string>
                     {
                         ["OriginalItemSpec"] = asset.Identity,
                         ["TargetPath"] = fileOutputPath,

--- a/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Compression/ResolveCompressedAssets.cs
@@ -156,7 +156,6 @@ public class ResolveCompressedAssets : Task
                     out var compressedAsset))
                 {
                     var result = compressedAsset.ToTaskItem();
-                    result.SetMetadata("RelatedAssetOriginalItemSpec", asset.OriginalItemSpec);
 
                     assetsToCompress[assetCounter++] = result;
                     existingFormats.Add(format);

--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -830,7 +830,7 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         AssetRole = string.IsNullOrEmpty(AssetRole) ? AssetRoles.Primary : AssetRole;
         if (string.IsNullOrEmpty(Fingerprint) || string.IsNullOrEmpty(Integrity) || FileLength == -1 || LastWriteTime == DateTimeOffset.MinValue)
         {
-            var file = ResolveFile(Identity, OriginalItemSpec);
+            var file = ResolveFile();
             (Fingerprint, Integrity) = string.IsNullOrEmpty(Fingerprint) || string.IsNullOrEmpty(Integrity) ?
                 ComputeFingerprintAndIntegrityIfNeeded(file) : (Fingerprint, Integrity);
             FileLength = FileLength == -1 ? file.Length : FileLength;
@@ -859,9 +859,9 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         return (FileHasher.ToBase36(hash), Convert.ToBase64String(hash));
     }
 
-    internal static string ComputeIntegrity(string identity, string originalItemSpec)
+    internal static string ComputeIntegrity(string identity)
     {
-        var fileInfo = ResolveFile(identity, originalItemSpec);
+        var fileInfo = ResolveFile(identity);
         return ComputeIntegrity(fileInfo);
     }
 
@@ -1540,22 +1540,11 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
         return pattern.RawPattern.ToString();
     }
 
-    internal FileInfo ResolveFile() => ResolveFile(Identity, OriginalItemSpec);
+    internal FileInfo ResolveFile() => new FileInfo(Identity);
 
-    internal static FileInfo ResolveFile(string identity, string originalItemSpec)
+    internal static FileInfo ResolveFile(string identity)
     {
-        var fileInfo = new FileInfo(identity);
-        if (fileInfo.Exists)
-        {
-            return fileInfo;
-        }
-        fileInfo = new FileInfo(originalItemSpec);
-        if (fileInfo.Exists)
-        {
-            return fileInfo;
-        }
-
-        throw new InvalidOperationException($"No file exists for the asset at either location '{identity}' or '{originalItemSpec}'.");
+        return new FileInfo(identity);
     }
 
     internal static Dictionary<string, StaticWebAsset> ToAssetDictionary(ITaskItem[] candidateAssets, bool validate = false)

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.Cache.cs
@@ -70,7 +70,6 @@ public partial class DefineStaticWebAssets : Task
     internal class DefineStaticWebAssetsCache
     {
         private readonly List<ITaskItem> _assets = [];
-        private readonly List<ITaskItem> _copyCandidates = [];
         private string? _manifestPath;
         private IDictionary<string, ITaskItem>? _inputByHash;
         private ITaskItem[]? _noCacheCandidates;
@@ -90,7 +89,6 @@ public partial class DefineStaticWebAssets : Task
 
         // Outputs for the cache
         public Dictionary<string, StaticWebAsset> CachedAssets { get; set; } = [];
-        public Dictionary<string, CopyCandidate> CachedCopyCandidates { get; set; } = [];
 
         internal static DefineStaticWebAssetsCache ReadOrCreateCache(TaskLoggingHelper log, string manifestPath)
         {
@@ -131,16 +129,6 @@ public partial class DefineStaticWebAssets : Task
             }
         }
 
-        internal void AppendCopyCandidate(string hash, string identity, string targetPath)
-        {
-            var copyCandidate = new CopyCandidate(identity, targetPath);
-            _copyCandidates.Add(copyCandidate.ToTaskItem());
-            if (!string.IsNullOrEmpty(hash))
-            {
-                CachedCopyCandidates[hash] = copyCandidate;
-            }
-        }
-
         internal void Update(
             byte[] propertiesHash,
             byte[] fingerprintPatternsHash,
@@ -166,7 +154,6 @@ public partial class DefineStaticWebAssets : Task
             FingerprintPatternsHash = fingerprintPatternsHash;
             PropertyOverridesHash = propertyOverridesHash;
             CachedAssets.Clear();
-            CachedCopyCandidates.Clear();
             InputHashes = [.. inputsByHash.Keys];
             _inputByHash = inputsByHash;
         }
@@ -189,10 +176,6 @@ public partial class DefineStaticWebAssets : Task
                 {
                     _assets.Add(cachedAsset.Value.ToTaskItem());
                 }
-                foreach (var cachedCopyCandidate in CachedCopyCandidates)
-                {
-                    _copyCandidates.Add(cachedCopyCandidate.Value.ToTaskItem());
-                }
 
                 _cacheUpToDate = true;
                 _log?.LogMessage(MessageImportance.Low, "Cache is fully up to date.");
@@ -212,10 +195,6 @@ public partial class DefineStaticWebAssets : Task
                 {
                     _log?.LogMessage(MessageImportance.Low, "Asset {0} is up to date", candidate.ItemSpec);
                     _assets.Add(asset.ToTaskItem());
-                    if (CachedCopyCandidates.TryGetValue(hash, out var copyCandidate))
-                    {
-                        _copyCandidates.Add(copyCandidate.ToTaskItem());
-                    }
                 }
             }
 
@@ -225,7 +204,6 @@ public partial class DefineStaticWebAssets : Task
             foreach (var hash in assetsToRemove)
             {
                 CachedAssets.Remove(hash);
-                CachedCopyCandidates.Remove(hash);
             }
 
             _inputByHash = remainingCandidates;
@@ -233,7 +211,7 @@ public partial class DefineStaticWebAssets : Task
 
         internal void SetPathAndLogger(string? manifestPath, TaskLoggingHelper log) => (_manifestPath, _log) = (manifestPath, log);
 
-        public (IList<ITaskItem> CopyCandidates, IList<ITaskItem> Assets) GetComputedOutputs() => (_copyCandidates, _assets);
+        public IList<ITaskItem> GetComputedOutputs() => _assets;
 
         internal void NoCache(ITaskItem[] candidateAssets)
         {
@@ -262,14 +240,6 @@ public partial class DefineStaticWebAssets : Task
         }
 
         internal bool IsUpToDate() => _cacheUpToDate;
-    }
-
-    internal class CopyCandidate(string identity, string targetPath)
-    {
-        public string Identity { get; set; } = identity;
-        public string TargetPath { get; set; } = targetPath;
-
-        internal ITaskItem ToTaskItem() => new TaskItem(Identity, new Dictionary<string, string> { ["TargetPath"] = TargetPath });
     }
 
     [JsonSerializable(typeof(DefineStaticWebAssetsCache))]

--- a/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
+++ b/src/StaticWebAssetsSdk/Tasks/DefineStaticWebAssets.cs
@@ -72,9 +72,6 @@ public partial class DefineStaticWebAssets : Task
     [Output]
     public ITaskItem[] Assets { get; set; }
 
-    [Output]
-    public ITaskItem[] CopyCandidates { get; set; }
-
     public Func<string, string, (FileInfo file, long fileLength, DateTimeOffset lastWriteTimeUtc)> TestResolveFileDetails { get; set; }
 
     private HashSet<string> _overrides;
@@ -99,9 +96,7 @@ public partial class DefineStaticWebAssets : Task
 
         if (assetsCache.IsUpToDate())
         {
-            var outputs = assetsCache.GetComputedOutputs();
-            Assets = [.. outputs.Assets];
-            CopyCandidates = [.. outputs.CopyCandidates];
+            Assets = [.. assetsCache.GetComputedOutputs()];
         }
         else
         {
@@ -266,23 +261,7 @@ public partial class DefineStaticWebAssets : Task
                 {
                     // We ignore the content root for publish only assets since it doesn't matter.
                     var contentRootPrefix = StaticWebAsset.AssetKinds.IsPublish(assetKind) ? null : contentRoot;
-                    (identity, var computed) = ComputeCandidateIdentity(candidate, contentRootPrefix, relativePathCandidate, matcher, matchContext);
-
-                    if (computed)
-                    {
-                        // If we synthesized identity and there is a fingerprint placeholder pattern in the file name
-                        // expand it to the concrete fingerprinted file name while keeping RelativePath pattern form.
-                        if (FingerprintCandidates && !string.IsNullOrEmpty(fingerprint))
-                        {
-                            var fileNamePattern = Path.GetFileName(identity);
-                            if (fileNamePattern.Contains("#["))
-                            {
-                                var expanded = StaticWebAssetPathPattern.ExpandIdentityFileNameForFingerprint(fileNamePattern, fingerprint);
-                                identity = Path.Combine(Path.GetDirectoryName(identity) ?? string.Empty, expanded);
-                            }
-                        }
-                        assetsCache.AppendCopyCandidate(hash, candidate.ItemSpec, identity);
-                    }
+                    identity = ComputeCandidateIdentity(candidate, contentRootPrefix);
                 }
 
                 var asset = StaticWebAsset.FromProperties(
@@ -340,13 +319,9 @@ public partial class DefineStaticWebAssets : Task
                 assetsCache.AppendAsset(hash, asset, item);
             }
 
-            var outputs = assetsCache.GetComputedOutputs();
-            var results = outputs.Assets;
-
             assetsCache.WriteCacheManifest();
 
-            Assets = [.. outputs.Assets];
-            CopyCandidates = [.. outputs.CopyCandidates];
+            Assets = [.. assetsCache.GetComputedOutputs()];
             }
             catch (Exception ex)
             {
@@ -365,75 +340,39 @@ public partial class DefineStaticWebAssets : Task
         {
             return TestResolveFileDetails(identity, originalItemSpec);
         }
-        var file = StaticWebAsset.ResolveFile(identity, originalItemSpec);
+        var file = new FileInfo(identity);
+        if (!file.Exists)
+        {
+            throw new InvalidOperationException($"No file exists for the asset at location '{identity}'.");
+        }
         var fileLength = file.Length;
         var lastWriteTimeUtc = file.LastWriteTimeUtc;
         return (file, fileLength, lastWriteTimeUtc);
     }
 
-    private (string identity, bool computed) ComputeCandidateIdentity(
+    private string ComputeCandidateIdentity(
         ITaskItem candidate,
-        string contentRoot,
-        string relativePath,
-        StaticWebAssetGlobMatcher matcher,
-        StaticWebAssetGlobMatcher.MatchContext matchContext)
+        string contentRoot)
     {
         var candidateFullPath = Path.GetFullPath(candidate.GetMetadata("FullPath"));
         if (contentRoot == null)
         {
             Log.LogMessage(MessageImportance.Low, "Identity for candidate '{0}' is '{1}' because content root is not defined.", candidate.ItemSpec, candidateFullPath);
-            return (candidateFullPath, false);
+            return candidateFullPath;
         }
 
         var normalizedContentRoot = StaticWebAsset.NormalizeContentRootPath(contentRoot);
         if (candidateFullPath.StartsWith(normalizedContentRoot))
         {
             Log.LogMessage(MessageImportance.Low, "Identity for candidate '{0}' is '{1}' because it starts with content root '{2}'.", candidate.ItemSpec, candidateFullPath, normalizedContentRoot);
-            return (candidateFullPath, false);
         }
         else
         {
-            // We want to support assets that are part of the source codebase but that might get transformed during the build or
-            // publish processes, so we want to allow defining these assets by setting up a different content root path from their
-            // original location in the project. For example the asset can be wwwroot\my-prod-asset.js, the content root can be
-            // obj\transform and the final asset identity can be <<FullPathTo>>\obj\transform\my-prod-asset.js
-            GlobMatch matchResult = default;
-            if (matcher != null)
-            {
-                matchContext.SetPathAndReinitialize(StaticWebAssetPathPattern.PathWithoutTokens(candidate.ItemSpec));
-                matchResult = matcher.Match(matchContext);
-            }
-            if (matcher == null)
-            {
-                // If no relative path pattern was specified, we are going to suggest that the identity is `%(ContentRoot)\RelativePath\OriginalFileName`
-                // We don't want to use the relative path file name since multiple assets might map to that and conflicts might arise.
-                // Alternatively, we could be explicit here and support ContentRootSubPath to indicate where it needs to go.
-                var identitySubPath = Path.GetDirectoryName(relativePath);
-                var itemSpecFileName = Path.GetFileName(candidateFullPath);
-                var relativeFileName = Path.GetFileName(relativePath);
-                // If the relative path filename has been modified (e.g. fingerprint pattern appended) use it when synthesizing identity.
-                if (!string.IsNullOrEmpty(relativeFileName) && !string.Equals(relativeFileName, itemSpecFileName, StringComparison.OrdinalIgnoreCase))
-                {
-                    itemSpecFileName = relativeFileName;
-                }
-                var finalIdentity = Path.Combine(normalizedContentRoot, identitySubPath ?? string.Empty, itemSpecFileName);
-                Log.LogMessage(MessageImportance.Low, "Identity for candidate '{0}' is '{1}' because it did not start with the content root '{2}'", candidate.ItemSpec, finalIdentity, normalizedContentRoot);
-                return (finalIdentity, true);
-            }
-            else if (!matchResult.IsMatch)
-            {
-                Log.LogMessage(MessageImportance.Low, "Identity for candidate '{0}' is '{1}' because it didn't match the relative path pattern", candidate.ItemSpec, candidateFullPath);
-                return (candidateFullPath, false);
-            }
-            else
-            {
-                var stem = matchResult.Stem;
-                var assetIdentity = Path.GetFullPath(Path.Combine(normalizedContentRoot, stem));
-                Log.LogMessage(MessageImportance.Low, "Computed identity '{0}' for candidate '{1}'", assetIdentity, candidate.ItemSpec);
-
-                return (assetIdentity, true);
-            }
+            // The asset is not under the content root. Use the candidate's real file path as the identity.
+            Log.LogMessage(MessageImportance.Low, "Identity for candidate '{0}' is '{1}' because it did not start with the content root '{2}'", candidate.ItemSpec, candidateFullPath, normalizedContentRoot);
         }
+
+        return candidateFullPath;
     }
 
     private string ComputePropertyValue(ITaskItem element, string metadataName, string propertyValue, bool isRequired = true)

--- a/src/StaticWebAssetsSdk/Tasks/Utils/AssetToCompress.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Utils/AssetToCompress.cs
@@ -12,8 +12,6 @@ internal static class AssetToCompress
 {
     public static bool TryFindInputFilePath(ITaskItem assetToCompress, TaskLoggingHelper log, out string fullPath)
     {
-        // Check RelatedAsset first (the asset's Identity path) as it's more reliable.
-        // RelatedAssetOriginalItemSpec may point to a project file (e.g., .esproj) rather than the actual asset.
         var relatedAsset = assetToCompress.GetMetadata("RelatedAsset");
         if (File.Exists(relatedAsset))
         {
@@ -24,20 +22,9 @@ internal static class AssetToCompress
             return true;
         }
 
-        var relatedAssetOriginalItemSpec = assetToCompress.GetMetadata("RelatedAssetOriginalItemSpec");
-        if (File.Exists(relatedAssetOriginalItemSpec))
-        {
-            log.LogMessage(MessageImportance.Low, "Asset '{0}' found at original item spec '{1}'.",
-                assetToCompress.ItemSpec,
-                relatedAssetOriginalItemSpec);
-            fullPath = relatedAssetOriginalItemSpec;
-            return true;
-        }
-
-        log.LogError("The asset '{0}' can not be found at any of the searched locations '{1}' and '{2}'.",
+        log.LogError("The asset '{0}' can not be found at the searched location '{1}'.",
             assetToCompress.ItemSpec,
-            relatedAsset,
-            relatedAssetOriginalItemSpec);
+            relatedAsset);
         fullPath = null;
         return false;
     }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/AssetToCompressTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/AssetToCompressTest.cs
@@ -65,31 +65,12 @@ public class AssetToCompressTest : IDisposable
     }
 
     [Fact]
-    public void TryFindInputFilePath_FallsBackToRelatedAssetOriginalItemSpec_WhenRelatedAssetDoesNotExist()
+    public void TryFindInputFilePath_ReturnsError_WhenRelatedAssetDoesNotExist()
     {
         // Arrange
+        var nonExistentPath = Path.Combine(_testDirectory, "non-existent.js");
         var assetToCompress = new TaskItem("test.js.gz");
-        assetToCompress.SetMetadata("RelatedAsset", Path.Combine(_testDirectory, "non-existent.js"));
-        assetToCompress.SetMetadata("RelatedAssetOriginalItemSpec", _testFilePath);
-
-        // Act
-        var result = AssetToCompress.TryFindInputFilePath(assetToCompress, _log, out var fullPath);
-
-        // Assert
-        result.Should().BeTrue();
-        fullPath.Should().Be(_testFilePath);
-        _errorMessages.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void TryFindInputFilePath_ReturnsError_WhenNeitherPathExists()
-    {
-        // Arrange
-        var nonExistentPath1 = Path.Combine(_testDirectory, "non-existent1.js");
-        var nonExistentPath2 = Path.Combine(_testDirectory, "non-existent2.js");
-        var assetToCompress = new TaskItem("test.js.gz");
-        assetToCompress.SetMetadata("RelatedAsset", nonExistentPath1);
-        assetToCompress.SetMetadata("RelatedAssetOriginalItemSpec", nonExistentPath2);
+        assetToCompress.SetMetadata("RelatedAsset", nonExistentPath);
 
         // Act
         var result = AssetToCompress.TryFindInputFilePath(assetToCompress, _log, out var fullPath);
@@ -99,75 +80,43 @@ public class AssetToCompressTest : IDisposable
         fullPath.Should().BeNull();
         _errorMessages.Should().ContainSingle();
         _errorMessages[0].Should().Contain("can not be found");
-        _errorMessages[0].Should().Contain(nonExistentPath1);
-        _errorMessages[0].Should().Contain(nonExistentPath2);
+        _errorMessages[0].Should().Contain(nonExistentPath);
     }
 
     [Fact]
-    public void TryFindInputFilePath_PrefersRelatedAsset_OverRelatedAssetOriginalItemSpec_WhenBothExist()
-    {
-        // Arrange - create two files to simulate the scenario where both metadata values point to existing files
-        var relatedAssetPath = Path.Combine(_testDirectory, "correct-asset.js");
-        var originalItemSpecPath = Path.Combine(_testDirectory, "project-file.esproj");
-        File.WriteAllText(relatedAssetPath, "// correct JavaScript content");
-        File.WriteAllText(originalItemSpecPath, "<Project></Project>");
-
-        var assetToCompress = new TaskItem("test.js.gz");
-        assetToCompress.SetMetadata("RelatedAsset", relatedAssetPath);
-        assetToCompress.SetMetadata("RelatedAssetOriginalItemSpec", originalItemSpecPath);
-
-        // Act
-        var result = AssetToCompress.TryFindInputFilePath(assetToCompress, _log, out var fullPath);
-
-        // Assert - should prefer RelatedAsset (the actual JavaScript file) over RelatedAssetOriginalItemSpec (the esproj file)
-        result.Should().BeTrue();
-        fullPath.Should().Be(relatedAssetPath);
-        fullPath.Should().NotBe(originalItemSpecPath);
-        _errorMessages.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void TryFindInputFilePath_HandlesEmptyRelatedAsset_AndUsesRelatedAssetOriginalItemSpec()
+    public void TryFindInputFilePath_ReturnsError_WhenRelatedAssetIsEmpty()
     {
         // Arrange
         var assetToCompress = new TaskItem("test.js.gz");
         assetToCompress.SetMetadata("RelatedAsset", "");
-        assetToCompress.SetMetadata("RelatedAssetOriginalItemSpec", _testFilePath);
 
         // Act
         var result = AssetToCompress.TryFindInputFilePath(assetToCompress, _log, out var fullPath);
 
         // Assert
-        result.Should().BeTrue();
-        fullPath.Should().Be(_testFilePath);
-        _errorMessages.Should().BeEmpty();
+        result.Should().BeFalse();
+        fullPath.Should().BeNull();
+        _errorMessages.Should().ContainSingle();
     }
 
     [Fact]
-    public void TryFindInputFilePath_HandlesEsprojScenario_WhereOriginalItemSpecPointsToProjectFile()
+    public void TryFindInputFilePath_HandlesEsprojScenario_WhereRelatedAssetPointsToActualFile()
     {
-        // Arrange - simulate the esproj bug scenario where RelatedAssetOriginalItemSpec
-        // incorrectly points to the .esproj project file instead of the actual JS asset
-        var esprojFile = Path.Combine(_testDirectory, "MyProject.esproj");
+        // Arrange - simulate the esproj scenario where RelatedAsset points to the actual JS file
         var actualJsFile = Path.Combine(_testDirectory, "dist", "app.min.js");
 
         Directory.CreateDirectory(Path.GetDirectoryName(actualJsFile));
-        File.WriteAllText(esprojFile, "<Project Sdk=\"Microsoft.VisualStudio.JavaScript.Sdk\"></Project>");
         File.WriteAllText(actualJsFile, "// actual JavaScript content");
 
         var assetToCompress = new TaskItem(Path.Combine(_testDirectory, "compressed", "app.min.js.gz"));
-        // RelatedAsset should contain the correct path to the actual JS file
         assetToCompress.SetMetadata("RelatedAsset", actualJsFile);
-        // RelatedAssetOriginalItemSpec may incorrectly point to .esproj due to esproj SDK bug
-        assetToCompress.SetMetadata("RelatedAssetOriginalItemSpec", esprojFile);
 
         // Act
         var result = AssetToCompress.TryFindInputFilePath(assetToCompress, _log, out var fullPath);
 
-        // Assert - should use RelatedAsset (correct JS file) not RelatedAssetOriginalItemSpec (esproj file)
+        // Assert - should use RelatedAsset (the actual JavaScript file)
         result.Should().BeTrue();
         fullPath.Should().Be(actualJsFile);
-        fullPath.Should().NotBe(esprojFile);
         _errorMessages.Should().BeEmpty();
     }
 }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverStaticWebAssetsTest.cs
@@ -219,7 +219,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
 
     [Fact]
     [Trait("Category", "FingerprintIdentity")]
-    public void ComputesIdentity_UsingFingerprintPattern_ForComputedAssets_WhenIdentityNeedsComputation()
+    public void ComputesIdentity_UsingRealFilePath_ForComputedAssets_WhenFileIsOutsideContentRoot()
         {
             // Arrange: simulate a packaged asset (outside content root) with a RelativePath inside the app
             var errorMessages = new List<string>();
@@ -227,7 +227,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
             buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
                 .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
 
-            // Create a physical file to allow fingerprint computation (tests override ResolveFileDetails returning null file otherwise)
+            // Create a physical file to allow fingerprint computation
             var tempRoot = Path.Combine(Path.GetTempPath(), "swafp_identity_test");
             var nugetPackagePath = Path.Combine(tempRoot, "microsoft.aspnetcore.components.webassembly", "10.0.0-rc.1.25451.107", "build", "net10.0");
             Directory.CreateDirectory(nugetPackagePath);
@@ -250,7 +250,6 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
                         ["RelativePath"] = relativePath
                     })
                 ],
-                // No RelativePathPattern, we trigger the branch that synthesizes identity under content root.
                 FingerprintPatterns = [ new TaskItem("Js", new Dictionary<string,string>{{"Pattern","*.js"},{"Expression","#[.{fingerprint}]!"}})],
                 FingerprintCandidates = true,
                 SourceType = "Computed",
@@ -270,14 +269,11 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
             task.Assets.Length.Should().Be(1);
             var asset = task.Assets[0];
 
-            // RelativePath should still contain the hard fingerprint pattern placeholder (not expanded yet)
+            // RelativePath should still contain the fingerprint pattern placeholder
             asset.GetMetadata(nameof(StaticWebAsset.RelativePath)).Should().Be("_framework/blazor.webassembly#[.{fingerprint}]!.js");
 
-            // Identity must contain the ACTUAL fingerprint value in the file name (placeholder expanded)
-            var actualFingerprint = asset.GetMetadata(nameof(StaticWebAsset.Fingerprint));
-            actualFingerprint.Should().NotBeNullOrEmpty();
-            var expectedIdentity = Path.GetFullPath(Path.Combine(contentRoot, "_framework", $"blazor.webassembly.{actualFingerprint}.js"));
-            asset.ItemSpec.Should().Be(expectedIdentity);
+            // Identity should be the real file path (no synthesized identity under content root)
+            asset.ItemSpec.Should().Be(Path.GetFullPath(assetFullPath));
         }
 
         [Fact]
@@ -669,7 +665,6 @@ for path 'candidate.js'");
             Assert.False(cache.IsUpToDate());
             Assert.Same(inputHashes, cache.OutOfDateInputs());
             Assert.Empty(cache.CachedAssets);
-            Assert.Empty(cache.CachedCopyCandidates);
         }
 
         [Fact]
@@ -687,7 +682,7 @@ for path 'candidate.js'");
             Assert.NotSame(inputHashes, cache.OutOfDateInputs());
             var input1 = Assert.Single(cache.OutOfDateInputs());
             var ouput = cache.GetComputedOutputs();
-            var input2 = Assert.Single(ouput.Assets);
+            var input2 = Assert.Single(ouput);
         }
 
         [Fact]
@@ -709,9 +704,9 @@ for path 'candidate.js'");
             Assert.Contains("input1", cache.CachedAssets.Keys);
 
             var ouput = cache.GetComputedOutputs();
-            Assert.Equal(2, ouput.Assets.Count);
-            Assert.Equal("input2", ouput.Assets[0].ItemSpec);
-            Assert.Equal("input1", ouput.Assets[1].ItemSpec);
+            Assert.Equal(2, ouput.Count);
+            Assert.Equal("input2", ouput[0].ItemSpec);
+            Assert.Equal("input1", ouput[1].ItemSpec);
         }
 
         [Fact]


### PR DESCRIPTION
Remove the legacy quirk where static web asset Identity could point to a non-existent file, with OriginalItemSpec used as a fallback source.

## Changes

**Core simplifications:**
- `ComputeCandidateIdentity` always returns the real file path — no more synthesizing identities under the content root
- Removed `CopyCandidates` output from `DefineStaticWebAssets` and all supporting infrastructure (`CopyCandidate` class, cache tracking)
- `ResolveFile` only uses Identity (removed OriginalItemSpec fallback)
- `CollectStaticWebAssetsToCopy` always uses `asset.Identity` as source (removed `IsComputed` branch with file-existence checks)

**Target/downstream simplifications:**
- `ServiceWorker.targets`: removed `Exists('%(Identity)')` / `OriginalItemSpec` fallback pattern
- `AssetToCompress`: removed `RelatedAssetOriginalItemSpec` fallback
- `ResolveCompressedAssets`: removed `RelatedAssetOriginalItemSpec` metadata emission

**Target ordering fix:**
- `_ComputeScopedCssStaticWebAssets` now depends on `_ProcessScopedCssFiles` to ensure scoped CSS output files exist before asset definition

9 files changed, 36 insertions, 181 deletions.