### PR TITLE
[api-diff] Prevent blank lines between new attributes + unchanged member

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -730,6 +730,10 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
         string unchangedText = unchangedNode.ToFullString();
         foreach (var line in InlineDiffBuilder.Diff(oldText: unchangedText, newText: unchangedText).Lines)
         {
+            if (string.IsNullOrWhiteSpace(line.Text))
+            {
+                continue;
+            }
             sb.AppendLine($"  {line.Text}");
         }
         return sb.ToString();


### PR DESCRIPTION
This bug was found during the review of dotnet/core#10351. Worked around it by removing the blank lines in https://github.com/dotnet/core/pull/10351/commits/41ec2c140c3ea48596a1e6a4fa33cf7f891584d1.

The scenario is when attributes are being added to otherwise unchanged API members.