### PR TITLE
Fix builtin workload manifests to use preview feature band in SDK archives

### DIFF
--- a/src/Workloads/Manifests/Directory.Build.targets
+++ b/src/Workloads/Manifests/Directory.Build.targets
@@ -2,7 +2,7 @@
 
   <Target Name="LayoutManifest" DependsOnTargets="Pack" Condition="'$(IsShipping)' == 'true'">
     <PropertyGroup>
-      <_manifestTargetDirectory>$(ManifestDirectory)$(BuiltinWorkloadFeatureBand)\$(MSBuildProjectName.Replace('.Manifest', '').ToLower())\$(Version)</_manifestTargetDirectory>
+      <_manifestTargetDirectory>$(ManifestDirectory)$(BuiltinWorkloadFeatureBand)$(_workloadVersionSuffix)\$(MSBuildProjectName.Replace('.Manifest', '').ToLower())\$(Version)</_manifestTargetDirectory>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
For preview SDK builds, the builtin workload manifests (mono toolchain, emscripten) were being placed under sdk-manifests/11.0.100/ instead of sdk-manifests/11.0.100-preview.4/. This happened because the layout target used BuiltinWorkloadFeatureBand (always stable, e.g. 11.0.100) without appending the _workloadVersionSuffix (e.g. -preview.4).

The _workloadVersionSuffix is already computed in Directory.Build.props and correctly used for package IDs. This change applies it to the manifest layout directory path as well.

Fixes #53234