### PR TITLE
[DO NOT MERGE] CI test stability investigation

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -48,13 +48,14 @@ stages:
   displayName: Build
   jobs:
   ############### WINDOWS ###############
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-    parameters:
-      pool:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022.amd64.open
-        os: windows
-      helixTargetQueue: windows.amd64.vs2026.pre.scout.open
+  # Temporarily disabled for CI stability testing — linux x64 only
+  # - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+  #   parameters:
+  #     pool:
+  #       name: $(DncEngPublicBuildPool)
+  #       demands: ImageOverride -equals windows.vs2022.amd64.open
+  #       os: windows
+  #     helixTargetQueue: windows.amd64.vs2026.pre.scout.open
 
   ############### LINUX ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -66,26 +67,28 @@ stages:
       helixTargetQueue: ubuntu.2204.amd64.open
 
   ############### MACOS ###############
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
-    parameters:
-      pool:
-        name: Azure Pipelines
-        vmImage: macOS-latest
-        os: macOS
-      helixTargetQueue: osx.15.amd64.open
-  ### ARM64 ###
-  - ${{ if eq(parameters.enableArm64Job, true) }}:
-    - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
-      parameters:
-        pool:
-          name: Azure Pipelines
-          vmImage: macOS-latest
-          os: macOS
-        helixTargetQueue: osx.15.arm64.open
-        macOSJobParameterSets:
-        - categoryName: TestBuild
-          targetArchitecture: arm64
-          runtimeIdentifier: osx-arm64
+  # Temporarily disabled for CI stability testing — linux x64 only
+  # - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
+  #   parameters:
+  #     pool:
+  #       name: Azure Pipelines
+  #       vmImage: macOS-latest
+  #       os: macOS
+  #     helixTargetQueue: osx.15.amd64.open
+  # ### ARM64 ###
+  # - ${{ if eq(parameters.enableArm64Job, true) }}:
+  #   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
+  #     parameters:
+  #       pool:
+  #         name: Azure Pipelines
+  #         vmImage: macOS-latest
+  #         os: macOS
+  #       helixTargetQueue: osx.15.arm64.open
+  #       macOSJobParameterSets:
+  #       - categoryName: TestBuild
+  #         targetArchitecture: arm64
+  #         runtimeIdentifier: osx-arm64
 
   ############### DOTNET-FORMAT ###############
-  - template: /eng/dotnet-format/dotnet-format-integration.yml
+  # Temporarily disabled for CI stability testing
+  # - template: /eng/dotnet-format/dotnet-format-integration.yml

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -14,18 +14,19 @@ parameters:
   linuxJobParameterSets:
   - categoryName: TestBuild
     osProperties: $(linuxOsglibcProperties)
-  - categoryName: TestBuild
-    targetArchitecture: arm64
-    runtimeIdentifier: linux-arm64
-    osProperties: $(linuxOsglibcProperties)
-    # Don't run the tests on arm64. Only perform the build itself.
-    runTests: false
-  - categoryName: ContainerBased
-    container: azureLinux30Amd64
-    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
-    osProperties: /p:OSName=linux /p:BuildSdkDeb=true /p:BuildSdkRpm=true
-    # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-    disableJob: true
+  # Temporarily disabled for CI stability testing — linux x64 TestBuild only
+  # - categoryName: TestBuild
+  #   targetArchitecture: arm64
+  #   runtimeIdentifier: linux-arm64
+  #   osProperties: $(linuxOsglibcProperties)
+  #   # Don't run the tests on arm64. Only perform the build itself.
+  #   runTests: false
+  # - categoryName: ContainerBased
+  #   container: azureLinux30Amd64
+  #   helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
+  #   osProperties: /p:OSName=linux /p:BuildSdkDeb=true /p:BuildSdkRpm=true
+  #   # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+  #   disableJob: true
   ### MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild


### PR DESCRIPTION
## CI Test Stability Investigation

This PR narrows the CI pipeline to linux x64 TestBuild only for fast iteration while investigating intermittent test failures at the tip of main.

### Process
1. Run CI (linux x64 only, ~50 min)
2. Analyze failures, fix (separate commit per fix for cherry-pick)
3. Repeat until 5 consecutive clean runs
4. Re-enable full pipeline, get 5 more clean runs

### Status
- **Phase**: Linux x64 only
- **Clean run streak**: 0/5

⚠️ Pipeline changes are temporary — will be reverted before merge.