### PR TITLE
Fix latest/preview SDK garbage collection

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -9,6 +9,8 @@ internal class UpdateChannel
 {
     public string Name { get; }
 
+    private static bool IsStableRelease(ReleaseVersion version) => string.IsNullOrEmpty(version.Prerelease);
+
     public UpdateChannel(string name)
     {
         Name = name;
@@ -78,14 +80,19 @@ internal class UpdateChannel
         // Named channels
         if (Name.Equals("lts", StringComparison.OrdinalIgnoreCase))
         {
-            // LTS releases are even major versions
-            return version.Major % 2 == 0;
+            // LTS releases are even major versions and must be stable releases.
+            return version.Major % 2 == 0 && IsStableRelease(version);
         }
 
-        // These channels match any version. The "preview" channel may resolve to a stable version
-        // when no preview exists yet (e.g., after a major release before the next preview).
-        if (Name.Equals("latest", StringComparison.OrdinalIgnoreCase) ||
-            Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
+        // "latest" should only match stable releases so a preview SDK doesn't satisfy the
+        // stable channel during garbage collection. "preview" continues to allow stable
+        // matches so existing preview specs can keep a GA SDK when no preview exists yet.
+        if (Name.Equals("latest", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsStableRelease(version);
+        }
+
+        if (Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/test/dotnetup.Tests/GarbageCollectorTests.cs
+++ b/test/dotnetup.Tests/GarbageCollectorTests.cs
@@ -102,6 +102,55 @@ public class GarbageCollectorTests
     }
 
     [Fact]
+    public void KeepsStableAndPreviewInstallationsWhenLatestAndPreviewSpecsExist()
+    {
+        using var testEnv = new TestEnvironment();
+        using var mutex = new ScopedMutex(Constants.MutexNames.ModifyInstallationStates);
+
+        var manifest = new DotnetupSharedManifest(testEnv.ManifestPath);
+        var installRoot = new DotnetInstallRoot(testEnv.InstallPath, InstallArchitecture.x64);
+
+        manifest.AddInstallSpec(installRoot, new InstallSpec
+        {
+            Component = InstallComponent.SDK,
+            VersionOrChannel = "latest",
+            InstallSource = InstallSource.Explicit
+        });
+        manifest.AddInstallSpec(installRoot, new InstallSpec
+        {
+            Component = InstallComponent.SDK,
+            VersionOrChannel = "preview",
+            InstallSource = InstallSource.Explicit
+        });
+
+        manifest.AddInstallation(installRoot, new Installation
+        {
+            Component = InstallComponent.SDK,
+            Version = "10.0.100",
+            Subcomponents = ["sdk/10.0.100"]
+        });
+        manifest.AddInstallation(installRoot, new Installation
+        {
+            Component = InstallComponent.SDK,
+            Version = "11.0.100-preview.1",
+            Subcomponents = ["sdk/11.0.100-preview.1"]
+        });
+
+        Directory.CreateDirectory(Path.Combine(testEnv.InstallPath, "sdk", "10.0.100"));
+        Directory.CreateDirectory(Path.Combine(testEnv.InstallPath, "sdk", "11.0.100-preview.1"));
+
+        var gc = new GarbageCollector(manifest);
+        var deleted = gc.Collect(installRoot);
+
+        deleted.Should().BeEmpty();
+
+        manifest.GetInstallations(installRoot)
+            .Select(i => i.Version)
+            .Should()
+            .BeEquivalentTo(["10.0.100", "11.0.100-preview.1"]);
+    }
+
+    [Fact]
     public void RemovesStaleGlobalJsonSpecs()
     {
         using var testEnv = new TestEnvironment();

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Dotnet.Installation.Internal;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
+
+public class UpdateChannelTests
+{
+    [Theory]
+    [InlineData("10.0.103", "10.0.103", true)]
+    [InlineData("10.0.103", "10.0.104", false)]
+    [InlineData("10", "10.0.103", true)]
+    [InlineData("10", "11.0.100", false)]
+    [InlineData("10.0", "10.0.103", true)]
+    [InlineData("10.0", "10.1.100", false)]
+    [InlineData("10.0.1xx", "10.0.103", true)]
+    [InlineData("10.0.1xx", "10.0.204", false)]
+    [InlineData("latest", "10.0.100", true)]
+    [InlineData("latest", "11.0.100-preview.1", false)]
+    [InlineData("preview", "10.0.100", true)]
+    [InlineData("preview", "11.0.100-preview.1", true)]
+    [InlineData("lts", "10.0.100", true)]
+    [InlineData("lts", "10.0.100-preview.1", false)]
+    [InlineData("lts", "9.0.100", false)]
+    public void Matches_ReturnsExpectedResult(string channel, string versionString, bool expected)
+    {
+        var updateChannel = new UpdateChannel(channel);
+        var version = new ReleaseVersion(versionString);
+
+        updateChannel.Matches(version).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
Fix a dotnetup regression where installing latest and then preview could cause the stable SDK to be garbage collected because both install specs collapsed onto the preview install.

## Changes
- make UpdateChannel.Matches("latest") only match stable releases
- keep preview semantics intact for fallback scenarios
- add direct UpdateChannel.Matches unit coverage
- add a garbage collection regression test for latest + preview coexistence