### PR TITLE
Add getting-started scripts for dotnetup

### DIFF
--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -1,0 +1,233 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Downloads the latest dotnetup binary from the dotnetup CI pipeline and installs it locally.
+
+.DESCRIPTION
+    Uses the Azure CLI (az) to query the dotnetup CI pipeline in dnceng/internal,
+    download the platform-appropriate artifact, and install it to a local directory.
+
+    You must have the Azure CLI installed with the azure-devops extension, and be
+    logged in with 'az login' with access to the dnceng/internal project.
+
+.PARAMETER InstallDir
+    Directory to install dotnetup into. Defaults to ~/.dotnetup.
+
+.PARAMETER Branch
+    The branch to get the latest build from. Defaults to 'release/dnup'.
+
+.PARAMETER RuntimeId
+    Override automatic OS/architecture detection with an explicit RID
+    (e.g. win-x64, linux-arm64, osx-arm64, linux-musl-x64).
+
+.EXAMPLE
+    # Ensure you're logged in, then run:
+    az login
+    ./get-dotnetup.ps1
+
+.EXAMPLE
+    # Override RID and install directory:
+    ./get-dotnetup.ps1 -RuntimeId linux-musl-x64 -InstallDir /opt/dotnetup
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallDir = (Join-Path $HOME ".dotnetup"),
+    [string]$Branch = "release/dnup",
+    [string]$RuntimeId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$AzdoOrg = "https://dev.azure.com/dnceng"
+$AzdoProject = "internal"
+$PipelineId = 1544
+
+function Get-RuntimeId {
+    if ($RuntimeId) {
+        return $RuntimeId
+    }
+
+    # Detect OS
+    if ($IsWindows -or ($env:OS -eq "Windows_NT")) {
+        $os = "win"
+    }
+    elseif ($IsMacOS) {
+        $os = "osx"
+    }
+    elseif ($IsLinux) {
+        $os = "linux"
+
+        # Detect musl vs glibc
+        $isMusl = $false
+        try {
+            $lddOutput = & ldd --version 2>&1 | Out-String
+            if ($lddOutput -match "musl") {
+                $isMusl = $true
+            }
+        }
+        catch { }
+
+        if (-not $isMusl) {
+            try {
+                $null = & getconf GNU_LIBC_VERSION 2>&1
+                # If getconf succeeds, it's glibc
+            }
+            catch {
+                # getconf failed — likely musl
+                $isMusl = $true
+            }
+        }
+
+        if ($isMusl) {
+            $os = "linux-musl"
+        }
+    }
+    else {
+        throw "Unsupported operating system. Use -RuntimeId to specify a RID manually."
+    }
+
+    # Detect architecture
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $archStr = switch ($arch) {
+        "X64" { "x64" }
+        "Arm64" { "arm64" }
+        default { throw "Unsupported architecture: $arch. Use -RuntimeId to specify a RID manually." }
+    }
+
+    return "$os-$archStr"
+}
+
+# --- Main ---
+
+# Check for Azure CLI
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw @"
+Azure CLI (az) is required but was not found on PATH.
+Install it from: https://aka.ms/install-az-cli
+
+After installing, log in with:
+    az login
+"@
+}
+
+$rid = Get-RuntimeId
+Write-Host "Detected runtime: $rid" -ForegroundColor Cyan
+
+# Get latest successful build for the specified branch
+Write-Host "Querying for latest successful build on $Branch..." -ForegroundColor Cyan
+
+$runsJson = az pipelines runs list `
+    --pipeline-ids $PipelineId `
+    --branch $Branch `
+    --status completed `
+    --query-order FinishTimeDesc `
+    --top 10 `
+    --org $AzdoOrg `
+    --project $AzdoProject `
+    --query "[?result=='succeeded' || result=='partiallySucceeded'] | [0].id" `
+    --output tsv
+
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+Failed to query pipeline runs. Ensure you are logged in and have access to dnceng/internal:
+
+    az login
+    az devops configure --defaults organization=$AzdoOrg project=$AzdoProject
+
+Error: $runsJson
+"@
+}
+
+$runId = ($runsJson | Out-String).Trim()
+if (-not $runId) {
+    throw "No successful builds found for pipeline $PipelineId on branch $Branch."
+}
+
+$buildUrl = "$AzdoOrg/$AzdoProject/_build/results?buildId=$runId"
+Write-Host "Found build $runId" -ForegroundColor Green
+Write-Host "  $buildUrl" -ForegroundColor DarkGray
+
+# Download the artifact
+$artifactName = "dotnetup-executable-$rid"
+Write-Host "Downloading artifact '$artifactName'..." -ForegroundColor Cyan
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "dotnetup-install-$([System.IO.Path]::GetRandomFileName())"
+
+try {
+    az pipelines runs artifact download `
+        --artifact-name $artifactName `
+        --path $tempDir `
+        --run-id $runId `
+        --org $AzdoOrg `
+        --project $AzdoProject 2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        throw @"
+Failed to download artifact '$artifactName' for run $runId.
+Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64
+Use -RuntimeId to specify the correct RID.
+"@
+    }
+
+    # Find the binary in the downloaded contents
+    $binaryName = if ($rid -like "win-*") { "dotnetup.exe" } else { "dotnetup" }
+    $foundBinary = Get-ChildItem -Path $tempDir -Recurse -Filter $binaryName | Select-Object -First 1
+    if (-not $foundBinary) {
+        throw "Could not find '$binaryName' in the downloaded artifact. Contents: $(Get-ChildItem -Path $tempDir -Recurse | Select-Object -ExpandProperty FullName)"
+    }
+
+    # Install just the binary
+    Write-Host "Installing to $InstallDir..." -ForegroundColor Cyan
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    Copy-Item -Path $foundBinary.FullName -Destination $InstallDir -Force
+
+    # Verify the binary is present
+    $installedBinary = Join-Path $InstallDir $binaryName
+    if (-not (Test-Path $installedBinary)) {
+        throw "Installation failed: '$installedBinary' not found after copy."
+    }
+
+    # Set executable bit on non-Windows
+    if ($rid -notlike "win-*") {
+        chmod +x $installedBinary
+    }
+
+    Write-Host ""
+    Write-Host "dotnetup installed successfully to $InstallDir" -ForegroundColor Green
+    Write-Host ""
+
+    # Check if install dir is on PATH
+    $pathDirs = $env:PATH -split [System.IO.Path]::PathSeparator
+    $onPath = $pathDirs | Where-Object { $_ -eq $InstallDir -or $_ -eq "$InstallDir/" -or $_ -eq "$InstallDir\" }
+
+    if (-not $onPath) {
+        Write-Host "To add dotnetup to your PATH, run:" -ForegroundColor Yellow
+        Write-Host ""
+        if ($rid -like "win-*") {
+            Write-Host "  # Current session:" -ForegroundColor DarkGray
+            Write-Host "  `$env:PATH = `"$InstallDir;`$env:PATH`""
+            Write-Host ""
+            Write-Host "  # Permanently (current user):" -ForegroundColor DarkGray
+            Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$([Environment]::GetEnvironmentVariable('PATH', 'User'))`", 'User')"
+        }
+        else {
+            Write-Host "  # Current session:" -ForegroundColor DarkGray
+            Write-Host "  export PATH=`"$InstallDir`:`$PATH`""
+            Write-Host ""
+            Write-Host "  # Permanently (add to your shell profile):" -ForegroundColor DarkGray
+            Write-Host "  echo 'export PATH=`"$InstallDir`:`$PATH`"' >> ~/.bashrc"
+        }
+        Write-Host ""
+    }
+    else {
+        Write-Host "dotnetup is already on your PATH. Run 'dotnetup --help' to get started." -ForegroundColor Green
+    }
+}
+finally {
+    # Cleanup temp files
+    if (Test-Path $tempDir) { Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue }
+}

--- a/scripts/get-dotnetup.sh
+++ b/scripts/get-dotnetup.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# get-dotnetup.sh
+#
+# Downloads the latest dotnetup binary from the dotnetup CI pipeline and installs it locally.
+#
+# Uses the Azure CLI (az) with the azure-devops extension for all Azure DevOps interactions.
+# You must be logged in with 'az login' and have access to the dnceng/internal project.
+#
+# Usage:
+#   ./get-dotnetup.sh
+#   ./get-dotnetup.sh --install-dir /opt/dotnetup
+#   ./get-dotnetup.sh --runtime-id linux-musl-x64
+#   ./get-dotnetup.sh --branch release/dnup
+
+set -euo pipefail
+
+# --- Defaults ---
+INSTALL_DIR="$HOME/.dotnetup"
+BRANCH="release/dnup"
+RUNTIME_ID=""
+AZDO_ORG="https://dev.azure.com/dnceng"
+AZDO_PROJECT="internal"
+PIPELINE_ID=1544
+
+# --- Colors (disabled if not a terminal) ---
+if [ -t 1 ]; then
+    CYAN='\033[0;36m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    RED='\033[0;31m'
+    GRAY='\033[0;90m'
+    NC='\033[0m'
+else
+    CYAN='' GREEN='' YELLOW='' RED='' GRAY='' NC=''
+fi
+
+info()  { printf "${CYAN}%s${NC}\n" "$*"; }
+ok()    { printf "${GREEN}%s${NC}\n" "$*"; }
+warn()  { printf "${YELLOW}%s${NC}\n" "$*"; }
+err()   { printf "${RED}%s${NC}\n" "$*" >&2; }
+gray()  { printf "${GRAY}%s${NC}\n" "$*"; }
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install-dir)  INSTALL_DIR="$2"; shift 2 ;;
+        --branch)       BRANCH="$2"; shift 2 ;;
+        --runtime-id)   RUNTIME_ID="$2"; shift 2 ;;
+        --help|-h)
+            cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Downloads the latest dotnetup binary from CI and installs it locally.
+Requires the Azure CLI (az) with the azure-devops extension for authentication
+and artifact download. Log in with 'az login' first.
+
+Options:
+  --install-dir DIR     Installation directory (default: ~/.dotnetup)
+  --branch BRANCH       Branch to get the latest build from (default: release/dnup)
+  --runtime-id RID      Override OS/architecture detection (e.g. linux-musl-x64, osx-arm64)
+  --help, -h            Show this help message
+
+Prerequisites:
+  Azure CLI (az)        https://aka.ms/install-az-cli
+  azure-devops ext      az extension add --name azure-devops
+
+Examples:
+  az login
+  ./get-dotnetup.sh
+  ./get-dotnetup.sh --runtime-id linux-musl-x64
+EOF
+            exit 0
+            ;;
+        *)
+            err "Unknown option: $1"
+            err "Run '$(basename "$0") --help' for usage."
+            exit 1
+            ;;
+    esac
+done
+
+# --- Check prerequisites ---
+if ! command -v az &>/dev/null; then
+    err "Azure CLI (az) is required but was not found on PATH."
+    err "Install it from: https://aka.ms/install-az-cli"
+    err ""
+    err "After installing, log in with:"
+    err "  az login"
+    exit 1
+fi
+
+# --- Detect runtime ID ---
+detect_rid() {
+    if [ -n "$RUNTIME_ID" ]; then
+        echo "$RUNTIME_ID"
+        return
+    fi
+
+    local os arch
+
+    # Detect OS
+    case "$(uname -s)" in
+        Linux)
+            # Detect musl vs glibc
+            if is_musl; then
+                os="linux-musl"
+            else
+                os="linux"
+            fi
+            ;;
+        Darwin)
+            os="osx"
+            ;;
+        *)
+            err "Unsupported OS: $(uname -s). Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    # Detect architecture
+    case "$(uname -m)" in
+        x86_64|amd64)   arch="x64" ;;
+        aarch64|arm64)   arch="arm64" ;;
+        *)
+            err "Unsupported architecture: $(uname -m). Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+is_musl() {
+    # Layer 1: Check if getconf reports glibc
+    if getconf GNU_LIBC_VERSION &>/dev/null; then
+        return 1  # glibc
+    fi
+
+    # Layer 2: Check ldd --version output for "musl"
+    if ldd --version 2>&1 | grep -qi "musl"; then
+        return 0  # musl
+    fi
+
+    # Layer 3: Check if /lib contains musl libc
+    if ls /lib/ld-musl-* &>/dev/null; then
+        return 0  # musl
+    fi
+
+    # Default: assume glibc
+    return 1
+}
+
+# --- Main ---
+
+RID=$(detect_rid)
+info "Detected runtime: $RID"
+
+# Get latest successful build for the specified branch
+info "Querying for latest successful build on $BRANCH..."
+
+RUN_ID=$(az pipelines runs list \
+    --pipeline-ids "$PIPELINE_ID" \
+    --branch "$BRANCH" \
+    --status completed \
+    --query-order FinishTimeDesc \
+    --top 10 \
+    --org "$AZDO_ORG" \
+    --project "$AZDO_PROJECT" \
+    --query "[?result=='succeeded' || result=='partiallySucceeded'] | [0].id" \
+    --output tsv) || {
+    err "Failed to query pipeline runs. Ensure you are logged in and have access to dnceng/internal:"
+    err ""
+    err "  az login"
+    err "  az extension add --name azure-devops   # if not already installed"
+    err ""
+    err "Error: $RUN_ID"
+    exit 1
+}
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "None" ]; then
+    err "No successful builds found for pipeline $PIPELINE_ID on branch $BRANCH."
+    exit 1
+fi
+
+ok "Found build $RUN_ID"
+gray "  ${AZDO_ORG}/${AZDO_PROJECT}/_build/results?buildId=${RUN_ID}"
+
+# Download the artifact
+ARTIFACT_NAME="dotnetup-executable-${RID}"
+info "Downloading artifact '$ARTIFACT_NAME'..."
+
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+az pipelines runs artifact download \
+    --artifact-name "$ARTIFACT_NAME" \
+    --path "$TEMP_DIR" \
+    --run-id "$RUN_ID" \
+    --org "$AZDO_ORG" \
+    --project "$AZDO_PROJECT" 2>&1 || {
+    err "Failed to download artifact '$ARTIFACT_NAME' for run $RUN_ID."
+    err "Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64"
+    err "Use --runtime-id to specify the correct RID."
+    exit 1
+}
+
+# Find the binary in the downloaded contents
+BINARY_PATH=$(find "$TEMP_DIR" -name "dotnetup" -type f | head -1)
+if [ -z "$BINARY_PATH" ]; then
+    err "Could not find 'dotnetup' binary in the downloaded artifact."
+    err "Contents:"
+    find "$TEMP_DIR" -type f | sed 's/^/  /' >&2
+    exit 1
+fi
+
+# Install just the binary
+info "Installing to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR"
+cp "$BINARY_PATH" "$INSTALL_DIR/dotnetup"
+
+# Ensure the binary is executable
+chmod +x "$INSTALL_DIR/dotnetup"
+
+# Verify
+if [ ! -x "$INSTALL_DIR/dotnetup" ]; then
+    err "Installation failed: '$INSTALL_DIR/dotnetup' not found or not executable after copy."
+    exit 1
+fi
+
+echo ""
+ok "dotnetup installed successfully to $INSTALL_DIR"
+echo ""
+
+# Check if install dir is on PATH (resolve to absolute path, handle trailing slashes)
+RESOLVED_INSTALL_DIR=$(cd "$INSTALL_DIR" 2>/dev/null && pwd -P || echo "$INSTALL_DIR")
+on_path() {
+    local dir
+    while IFS= read -r -d ':' dir || [ -n "$dir" ]; do
+        dir="${dir%/}"
+        [ -z "$dir" ] && continue
+        local resolved
+        resolved=$(cd "$dir" 2>/dev/null && pwd -P || echo "$dir")
+        if [ "$resolved" = "$RESOLVED_INSTALL_DIR" ]; then
+            return 0
+        fi
+    done <<< "$PATH"
+    return 1
+}
+
+if on_path; then
+    ok "dotnetup is already on your PATH. Run 'dotnetup --help' to get started."
+else
+    warn "To add dotnetup to your PATH:"
+    echo ""
+    gray "  # Current session:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    gray "  # Permanently (add to your shell profile):"
+
+    # Detect current shell for profile recommendation
+    SHELL_NAME=$(basename "${SHELL:-/bin/bash}")
+    case "$SHELL_NAME" in
+        zsh)   PROFILE="~/.zshrc" ;;
+        fish)  PROFILE="~/.config/fish/config.fish" ;;
+        *)     PROFILE="~/.bashrc" ;;
+    esac
+
+    if [ "$SHELL_NAME" = "fish" ]; then
+        echo "  fish_add_path \"$INSTALL_DIR\""
+    else
+        echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $PROFILE"
+    fi
+    echo ""
+fi


### PR DESCRIPTION
Add PowerShell and bash scripts that download the latest dotnetup binary from the dotnetup CI pipeline (dnceng/internal, definition 1544) and install it to ~/.dotnetup. The only requirement is the `az` CLI.

Both scripts:
- Auto-detect OS and architecture, but allow overriding it
- Support --branch to target a specific CI branch (default: `release/dnup`)
- Support grabbing the arch-appropriate binary and putting it in a specific location
- Print PATH configuration instructions if that location isn't on PATH

Usage:
`scripts/get-dotnetup.ps1`
`scripts/get-dotnetup.ps1 -RuntimeId linux-musl-x64 -InstallDir /opt/dotnetup`
`scripts/get-dotnetup.sh`
`scripts/get-dotnetup.sh --runtime-id linux-musl-x64 -install-dir /opt/dotnetup`


<img width="601" height="333" alt="image" src="https://github.com/user-attachments/assets/4fb5f550-ebe5-4ee1-a260-a1833f5242ca" />
