### PR TITLE
Create a prompt file for doing the monthly mirror check.

### DIFF
--- a/.github/prompts/branch-mirror-status.prompt.md
+++ b/.github/prompts/branch-mirror-status.prompt.md
@@ -31,11 +31,15 @@ Parameters for each call:
 
 Record the **commit SHA** and **commit message** from each response.
 
-### Step 2: Check if each commit exists in Azure DevOps
+### Step 2: Check if each commit exists on the corresponding AzDo branch
 
-For **each** row, search for the GitHub commit SHA in the corresponding AzDo branch. Make all calls **in parallel**.
+For **each** row, verify the GitHub commit SHA is present on the correct AzDo branch. Make all calls **in parallel**.
 
-Use `dnceng-azure-devop-repo_search_commits` with:
+The AzDo `search_commits` tool name varies by session — look for one matching `*repo_search_commits` that can access the `internal` project in the `dnceng` org. Common names include `dnceng-azure-devop-repo_search_commits` or `azure-devops-repo_search_commits`.
+
+#### Step 2a: Search for merge commits referencing the GitHub SHA
+
+Use `search_commits` with:
 - `project`: `internal`
 - `repository`: the AzDo repo name (e.g., `dotnet-sdk` or `dotnet-installer`)
 - `version`: the AzDo branch name (e.g., `internal/release/8.0.1xx`)
@@ -43,11 +47,24 @@ Use `dnceng-azure-devop-repo_search_commits` with:
 - `searchText`: the GitHub commit SHA from Step 1
 - `top`: 5
 
-This searches the branch history for commits whose message contains the GitHub SHA. The mirroring service creates merge commits with messages like `Merge commit '<GitHub SHA>'`, so a match confirms the commit was mirrored to the correct branch.
+This searches the branch history for commits whose message contains the GitHub SHA. The mirroring service typically creates merge commits with messages like `Merge commit '<GitHub SHA>'`, so a match confirms the commit was mirrored to the correct branch.
 
-**Important:** Do **not** use `commitIds` without `version`/`versionType` — that searches the entire repo and does not confirm the commit is on the target branch.
+If a match is found, the mirror is **up to date**.
 
-If the search returns a matching commit, the mirror is **up to date**. If it returns no results, the mirror is **behind**.
+#### Step 2b: If no match, check for direct push (same SHA on branch)
+
+Sometimes commits are pushed directly to the AzDo branch without a merge commit wrapper, so the SHA is identical but doesn't appear in any commit message. If Step 2a returns no results, get the latest commits on the AzDo branch:
+
+Use `search_commits` with:
+- `project`: `internal`
+- `repository`: the AzDo repo name
+- `version`: the AzDo branch name
+- `versionType`: `Branch`
+- `top`: 5
+
+Then check if any returned commit's `commitId` exactly matches the GitHub SHA from Step 1. If it does, the mirror is **up to date** (direct push). If not, the mirror is **behind**.
+
+**Important:** Do **not** use `commitIds` alone — that searches the entire repo regardless of branch and does not confirm the commit is on the target branch.
 
 ### Step 3: Present results
 
@@ -61,11 +78,11 @@ Display a summary table:
 ```
 
 For any ❌ entries, also check the latest commit on the AzDo branch to show how far behind it is:
-- Use `dnceng-azure-devop-repo_search_commits` with `project`, `repository`, `version` (the AzDo branch name), and `top: 1` to get the most recent AzDo commit.
+- Use `search_commits` with `project`, `repository`, `version` (the AzDo branch name), and `top: 1` to get the most recent AzDo commit.
 - Report the AzDo branch's latest commit SHA and date in the Details column.
 
 ## Troubleshooting
 
-If the AzDo tools return errors about the project or repository not being found, the `dnceng-azure-devop-*` tools may not be connected to the `dnceng-internal` organization. In that case:
-- Verify tool connectivity by listing repos: `dnceng-azure-devop-repo_list_repos_by_project` with `project: internal`.
-- If the project is not accessible, inform the user that the AzDo MCP connection may need to be configured for the `dnceng-internal` organization.
+If the AzDo tools return errors about the project or repository not being found, the AzDo MCP connection may not be configured for the `dnceng` organization. In that case:
+- Try other available `*repo_search_commits` or `*repo_list_repos_by_project` tools to find one that can access `project: internal`.
+- If no tool can access the project, inform the user that the AzDo MCP connection may need to be configured for the `dnceng` organization.

--- a/.github/prompts/branch-mirror-status.prompt.md
+++ b/.github/prompts/branch-mirror-status.prompt.md
@@ -40,11 +40,14 @@ Use `dnceng-azure-devop-repo_search_commits` with:
 - `repository`: the AzDo repo name (e.g., `dotnet-sdk` or `dotnet-installer`)
 - `version`: the AzDo branch name (e.g., `internal/release/8.0.1xx`)
 - `versionType`: `Branch`
-- `top`: 1
+- `searchText`: the GitHub commit SHA from Step 1
+- `top`: 5
 
-Do **not** use `commitIds` — that searches the entire repo regardless of branch. Instead, get the latest commit on the specific AzDo branch and compare its commit message or SHA to the GitHub commit. The mirroring service creates merge commits with messages like `Merge commit '<GitHub SHA>'`, so check whether the AzDo head commit references the expected GitHub SHA.
+This searches the branch history for commits whose message contains the GitHub SHA. The mirroring service creates merge commits with messages like `Merge commit '<GitHub SHA>'`, so a match confirms the commit was mirrored to the correct branch.
 
-If the AzDo branch head references the GitHub commit SHA, the mirror is **up to date**. If it references an older commit, the mirror is **behind**.
+**Important:** Do **not** use `commitIds` without `version`/`versionType` — that searches the entire repo and does not confirm the commit is on the target branch.
+
+If the search returns a matching commit, the mirror is **up to date**. If it returns no results, the mirror is **behind**.
 
 ### Step 3: Present results
 

--- a/.github/prompts/branch-mirror-status.prompt.md
+++ b/.github/prompts/branch-mirror-status.prompt.md
@@ -1,0 +1,68 @@
+---
+description: "Check if public GitHub release branches have been mirrored to internal Azure DevOps repos for dotnet/sdk and dotnet/installer."
+---
+
+# Branch Mirror Status Check
+
+Check whether the latest commits on public GitHub release branches have been mirrored to the corresponding `internal/release/*` branches in Azure DevOps.
+
+## Branch Mappings
+
+| GitHub Repo | GitHub Branch | AzDo Project | AzDo Repo | AzDo Branch |
+|---|---|---|---|---|
+| dotnet/sdk | release/8.0.1xx | internal | dotnet-sdk | internal/release/8.0.1xx |
+| dotnet/sdk | release/8.0.4xx | internal | dotnet-sdk | internal/release/8.0.4xx |
+| dotnet/sdk | release/9.0.1xx | internal | dotnet-sdk | internal/release/9.0.1xx |
+| dotnet/sdk | release/9.0.3xx | internal | dotnet-sdk | internal/release/9.0.3xx |
+| dotnet/installer | release/8.0.1xx | internal | dotnet-installer | internal/release/8.0.1xx |
+| dotnet/installer | release/8.0.4xx | internal | dotnet-installer | internal/release/8.0.4xx |
+
+## Procedure
+
+### Step 1: Get latest commits from GitHub
+
+For **each** row in the table above, call `github-mcp-server-list_commits` to get the most recent commit on the public branch. Make all calls **in parallel** for efficiency.
+
+Parameters for each call:
+- `owner`: the GitHub org (e.g., `dotnet`)
+- `repo`: the GitHub repo name (e.g., `sdk` or `installer`)
+- `sha`: the branch name (e.g., `release/8.0.1xx`)
+- `perPage`: 1 (we only need the latest commit)
+
+Record the **commit SHA** and **commit message** from each response.
+
+### Step 2: Check if each commit exists in Azure DevOps
+
+For **each** row, search for the GitHub commit SHA in the corresponding AzDo branch. Make all calls **in parallel**.
+
+Use `dnceng-azure-devop-repo_search_commits` with:
+- `project`: `internal`
+- `repository`: the AzDo repo name (e.g., `dotnet-sdk` or `dotnet-installer`)
+- `version`: the AzDo branch name (e.g., `internal/release/8.0.1xx`)
+- `versionType`: `Branch`
+- `top`: 1
+
+Do **not** use `commitIds` — that searches the entire repo regardless of branch. Instead, get the latest commit on the specific AzDo branch and compare its commit message or SHA to the GitHub commit. The mirroring service creates merge commits with messages like `Merge commit '<GitHub SHA>'`, so check whether the AzDo head commit references the expected GitHub SHA.
+
+If the AzDo branch head references the GitHub commit SHA, the mirror is **up to date**. If it references an older commit, the mirror is **behind**.
+
+### Step 3: Present results
+
+Display a summary table:
+
+```
+| Repo | Branch | Latest GH Commit | Mirrored? | Details |
+|---|---|---|---|---|
+| dotnet/sdk | release/8.0.1xx | abc1234 "commit msg" | ✅ / ❌ | |
+| ... | ... | ... | ... | |
+```
+
+For any ❌ entries, also check the latest commit on the AzDo branch to show how far behind it is:
+- Use `dnceng-azure-devop-repo_search_commits` with `project`, `repository`, `version` (the AzDo branch name), and `top: 1` to get the most recent AzDo commit.
+- Report the AzDo branch's latest commit SHA and date in the Details column.
+
+## Troubleshooting
+
+If the AzDo tools return errors about the project or repository not being found, the `dnceng-azure-devop-*` tools may not be connected to the `dnceng-internal` organization. In that case:
+- Verify tool connectivity by listing repos: `dnceng-azure-devop-repo_list_repos_by_project` with `project: internal`.
+- If the project is not accessible, inform the user that the AzDo MCP connection may need to be configured for the `dnceng-internal` organization.


### PR DESCRIPTION
Every month, we do branding changes in 8 and 9. After the branding changes, we start approving codeflow PRs. The thing is, those codeflow PRs modify the nuget.config file which then conflicts with the internal flow we've gotten from the runtime repos.

This triggers issues getting filed like https://github.com/dotnet/installer/issues/20832 as the mirror to internal/release/* gets broken.

This typically get resolved when we do the internal to public merges on release day. To confirm that though, someone has to go through every single internal/release branch and compare the commits to the public release/* branch to make sure the mirror is working again. I created this prompt to have the agent do it for me. You'll need dnceng and GH configured through MCP servers for this to work.