### PR TITLE
Update dotnet run tests for launch settings message on stderr

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -418,8 +418,9 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute();
 
             cmd.Should().Pass()
-                .And.NotHaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
+
+            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -392,6 +392,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -400,7 +401,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("Second");
 
-            cmd.StdErr.Should().Contain("Using launch settings from");
+            cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]
@@ -431,6 +432,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -439,7 +441,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<First>>>");
 
-            cmd.StdErr.Should().Contain("Using launch settings from");
+            cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]
@@ -450,6 +452,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -458,7 +461,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<Second>>>");
 
-            cmd.StdErr.Should().Contain("Using launch settings from");
+            cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]
@@ -527,6 +530,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -535,7 +539,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:12345/");
 
-            cmd.StdErr.Should().Contain("Using launch settings from");
+            cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]
@@ -546,6 +550,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -554,7 +559,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:54321/");
 
-            cmd.StdErr.Should().Contain("Using launch settings from");
+            cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("Second");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -418,10 +418,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute();
 
             cmd.Should().Pass()
-                .And.NotHaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.NotHaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]
@@ -441,7 +439,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<First>>>");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -461,7 +459,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<Second>>>");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -518,10 +516,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("-v:m");
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]
@@ -540,7 +536,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:12345/");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -559,7 +555,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:54321/");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -412,7 +412,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
-            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run", "--verbosity", "quiet")
                 .WithWorkingDirectory(testProjectDirectory)

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -431,7 +431,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
-            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
@@ -451,7 +450,6 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
-            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
@@ -99,14 +99,14 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSource();
 
             var testProjectDirectory = testInstance.Path;
-            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "My Project", "launchSettings.json");
 
             var cmd = new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute();
 
             cmd.Should().Pass()
-                .And.NotHaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
         }
 

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
@@ -80,6 +80,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             var testInstance = TestAssetsManager.CopyTestAsset(testAppName, identifier: $"LaunchProfileSuccess-{launchProfileName}")
                             .WithSource();
 
+            var launchSettingsPath = Path.Combine(testInstance.Path, "My Project", "launchSettings.json");
+
             new DotnetCommand(Log, "run")
                 .WithWorkingDirectory(testInstance.Path)
                 .Execute("--launch-profile", launchProfileName)
@@ -88,7 +90,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And
                 .HaveStdOutContaining("Second")
                 .And
-                .HaveStdErrContaining("Using launch settings from");
+                .HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And
                 .HaveStdOutContaining("Second")
                 .And
-                .NotHaveStdErr();
+                .HaveStdErrContaining("Using launch settings from");
         }
 
         [Fact]
@@ -106,10 +106,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute();
 
             cmd.Should().Pass()
-                .And.NotHaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.NotHaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]
@@ -126,10 +124,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("-v:m");
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectTools;

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -68,7 +68,7 @@ public sealed class RunCommandTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOutContaining("TEST_VAR1=<<<VALUE1>>>")
             .And.HaveStdOutContaining("ARGS=arg1,arg2,arg3");
 
-        cmd.StdErr.Should().Contain("Using launch settings from");
+        cmd.StdErr.Should().Contain(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
     }
 
     [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -68,7 +68,7 @@ public sealed class RunCommandTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOutContaining("TEST_VAR1=<<<VALUE1>>>")
             .And.HaveStdOutContaining("ARGS=arg1,arg2,arg3");
 
-        cmd.StdErr.Should().BeEmpty();
+        cmd.StdErr.Should().Contain("Using launch settings from");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/53879

PR #53797 moved the 'Using launch settings from...' message from stdout to stderr but only updated dotnet test assertions. This updates the dotnet run test assertions to match:

- StdErr.Should().BeEmpty() → StdErr.Should().Contain('Using launch settings from') for tests that use launch profiles
- HaveStdOutContaining(UsingLaunchSettingsFromMessage) → HaveStdErrContaining
- NotHaveStdOutContaining(UsingLaunchSettingsFromMessage) → NotHaveStdErrContaining

Fixes ~11 test failures across Windows, Linux, and macOS CI legs.

These test failures weren't surfaced in #53797 because we had a test outage last week.