### PR TITLE
Fix dotnet run tests for launch settings stderr change

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("Second");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -441,7 +441,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<First>>>");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -461,7 +461,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("DOTNET_LAUNCH_PROFILE=<<<Second>>>");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -518,10 +518,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("-v:m");
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]
@@ -540,7 +538,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:12345/");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -559,7 +557,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             cmd.Should().Pass()
                 .And.HaveStdOutContaining("http://localhost:54321/");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsVbProj.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And
                 .HaveStdOutContaining("Second")
                 .And
-                .NotHaveStdErr();
+                .HaveStdErrContaining("Using launch settings from");
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And.NotHaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
 
-            cmd.StdErr.Should().BeEmpty();
+            cmd.StdErr.Should().Contain("Using launch settings from");
         }
 
         [Fact]
@@ -126,10 +126,8 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Execute("-v:m");
 
             cmd.Should().Pass()
-                .And.HaveStdOutContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdErrContaining(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
-
-            cmd.StdErr.Should().BeEmpty();
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -68,7 +68,7 @@ public sealed class RunCommandTests(ITestOutputHelper log) : SdkTest(log)
             .And.HaveStdOutContaining("TEST_VAR1=<<<VALUE1>>>")
             .And.HaveStdOutContaining("ARGS=arg1,arg2,arg3");
 
-        cmd.StdErr.Should().BeEmpty();
+        cmd.StdErr.Should().Contain("Using launch settings from");
     }
 
     [Fact]


### PR DESCRIPTION
Commit 1ebcc5ee01 correctly moved the 'Using launch settings from...' message from stdout to stderr (fixing #45640), but only updated the dotnet test tests. The dotnet run tests still asserted empty stderr and checked stdout for the message, causing 10 tests to fail across all platforms in every CI build.

Update the dotnet run test assertions to match the new behavior:
- Tests using launch profiles now expect the message on stderr instead of asserting stderr is empty
- ItPrintsUsingLaunchSettingsMessageWhenNotQuiet checks stderr instead of stdout for the message
- Tests using --no-launch-profile or --verbosity quiet correctly continue to assert empty stderr

Fixes #53879