### PR TITLE
fix: FileSystemWatcher stack overflow and excessive instances on macOS

### DIFF
--- a/src/Dotnet.Watch/Watch/FileWatcher/EventBasedDirectoryWatcher.cs
+++ b/src/Dotnet.Watch/Watch/FileWatcher/EventBasedDirectoryWatcher.cs
@@ -13,6 +13,7 @@ internal sealed class EventBasedDirectoryWatcher : DirectoryWatcher
     private volatile bool _disposed;
     private FileSystemWatcher? _fileSystemWatcher;
     private readonly Lock _createLock = new();
+    private bool _isRecreating;
 
     internal EventBasedDirectoryWatcher(string watchedDirectory, ImmutableHashSet<string> watchedFileNames, bool includeSubdirectories)
         : base(watchedDirectory, watchedFileNames, includeSubdirectories)
@@ -39,13 +40,20 @@ internal sealed class EventBasedDirectoryWatcher : DirectoryWatcher
 
         Logger?.Invoke(exception.ToString());
 
-        // Win32Exception may be triggered when setting EnableRaisingEvents on a file system type
-        // that is not supported, such as a network share. Don't attempt to recreate the watcher
-        // in this case as it will cause a StackOverflowException
-        if (exception is not Win32Exception)
+        // Don't recreate on Win32Exception (unsupported file system) or during re-entrant
+        // calls (StartRaisingEvents can synchronously fire Error, causing infinite recursion).
+        if (exception is not Win32Exception && !_isRecreating)
         {
-            // Recreate the watcher if it is a recoverable error.
-            CreateFileSystemWatcher();
+            _isRecreating = true;
+            try
+            {
+                // Recreate the watcher if it is a recoverable error.
+                CreateFileSystemWatcher();
+            }
+            finally
+            {
+                _isRecreating = false;
+            }
         }
 
         NotifyError(exception);

--- a/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
+++ b/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
@@ -77,6 +77,14 @@ internal class FileWatcher(ILogger logger, EnvironmentOptions environmentOptions
             into g
             select (g.Key, containingDirectories ? [] : g.Select(Path.GetFileName).ToImmutableHashSet(PathUtilities.OSSpecificPathComparer));
 
+        // Consolidate sibling directories to reduce the number of FileSystemWatcher instances.
+        if (containingDirectories && includeSubdirectories && OperatingSystem.IsMacOS())
+        {
+            var directories = filesByDirectory.Select(d => d.Key).ToList();
+            var consolidated = ConsolidateDirectories(directories);
+            filesByDirectory = consolidated.Select(d => (d, ImmutableHashSet<string>.Empty)).ToList();
+        }
+
         foreach (var (directory, fileNames) in filesByDirectory)
         {
             // the directory is watched by active directory watcher:
@@ -149,6 +157,67 @@ internal class FileWatcher(ILogger logger, EnvironmentOptions environmentOptions
                 _directoryWatchers.Add(directory, newWatcher);
             }
         }
+    }
+
+    /// <summary>
+    /// Reduces the number of watched directories by finding the longest common path prefix.
+    /// This minimizes the number of FileSystemWatcher instances to a single watcher on the
+    /// common ancestor directory with includeSubdirectories. Extra file change events from
+    /// unwatched sibling directories are filtered by DirectoryWatcher's filename matching.
+    /// </summary>
+    internal static List<string> ConsolidateDirectories(List<string> directories)
+    {
+        if (directories.Count <= 1)
+        {
+            return directories;
+        }
+
+        var commonRoot = GetLongestCommonPath(directories);
+        return commonRoot != null ? [commonRoot] : directories;
+    }
+
+    internal static string? GetLongestCommonPath(List<string> paths)
+    {
+        if (paths.Count == 0)
+        {
+            return null;
+        }
+
+        // Split first path into segments as reference.
+        var referencePath = paths[0].TrimEnd(Path.DirectorySeparatorChar);
+        var segments = referencePath.Split(Path.DirectorySeparatorChar);
+
+        var commonLength = segments.Length;
+
+        for (var i = 1; i < paths.Count; i++)
+        {
+            var other = paths[i].TrimEnd(Path.DirectorySeparatorChar);
+            var otherSegments = other.Split(Path.DirectorySeparatorChar);
+            var limit = Math.Min(commonLength, otherSegments.Length);
+            var matched = 0;
+
+            for (var j = 0; j < limit; j++)
+            {
+                if (string.Equals(segments[j], otherSegments[j], PathUtilities.OSSpecificPathComparison))
+                {
+                    matched++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            commonLength = matched;
+
+            if (commonLength == 0)
+            {
+                return null;
+            }
+        }
+
+        var common = string.Join(Path.DirectorySeparatorChar, segments, 0, commonLength);
+        return PathUtilities.EnsureTrailingSlash(common);
     }
 
     private void WatcherErrorHandler(object? sender, Exception error)

--- a/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
+++ b/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
@@ -246,6 +246,13 @@ internal class FileWatcher(ILogger logger, EnvironmentOptions environmentOptions
         }
 
         var common = string.Join(Path.DirectorySeparatorChar, segments, 0, commonLength);
+
+        // On Unix, splitting an absolute path produces an empty first segment (e.g. "/a/b" -> ["", "a", "b"]). If only the empty root segment matched, there's no meaningful common path.
+        if (common.Length == 0)
+        {
+            return null;
+        }
+
         return PathUtilities.EnsureTrailingSlash(common);
     }
 

--- a/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
+++ b/src/Dotnet.Watch/Watch/FileWatcher/FileWatcher.cs
@@ -160,11 +160,14 @@ internal class FileWatcher(ILogger logger, EnvironmentOptions environmentOptions
     }
 
     /// <summary>
-    /// Reduces the number of watched directories by finding the longest common path prefix.
-    /// This minimizes the number of FileSystemWatcher instances to a single watcher on the
-    /// common ancestor directory with includeSubdirectories. Extra file change events from
-    /// unwatched sibling directories are filtered by DirectoryWatcher's filename matching.
+    /// Reduces the number of watched directories by finding the longest common path prefix
+    /// and grouping by immediate children under that ancestor. If the ancestor has few children
+    /// (≤ <see cref="MaxChildWatchers"/>), we create one watcher per child to avoid watching
+    /// unrelated sibling directories (e.g. artifacts/, .packages/). Otherwise, we fall back
+    /// to a single watcher on the ancestor.
     /// </summary>
+    internal const int MaxChildWatchers = 5;
+
     internal static List<string> ConsolidateDirectories(List<string> directories)
     {
         if (directories.Count <= 1)
@@ -173,7 +176,33 @@ internal class FileWatcher(ILogger logger, EnvironmentOptions environmentOptions
         }
 
         var commonRoot = GetLongestCommonPath(directories);
-        return commonRoot != null ? [commonRoot] : directories;
+        if (commonRoot == null)
+        {
+            return directories;
+        }
+
+        // Group directories by their immediate child under the common ancestor.
+        var children = new HashSet<string>(PathUtilities.OSSpecificPathComparer);
+        foreach (var dir in directories)
+        {
+            var relative = dir.Substring(commonRoot.Length).TrimEnd(Path.DirectorySeparatorChar);
+            if (relative.Length == 0)
+            {
+                // One of the directories IS the common ancestor - just watch it.
+                return [commonRoot];
+            }
+
+            var separatorIndex = relative.IndexOf(Path.DirectorySeparatorChar);
+            var immediateChild = separatorIndex >= 0 ? relative.Substring(0, separatorIndex) : relative;
+            children.Add(PathUtilities.EnsureTrailingSlash(Path.Join(commonRoot, immediateChild)));
+        }
+
+        if (children.Count <= MaxChildWatchers)
+        {
+            return children.ToList();
+        }
+
+        return [commonRoot];
     }
 
     internal static string? GetLongestCommonPath(List<string> paths)

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -155,6 +155,73 @@ public class FileWatcherTests(ITestOutputHelper output)
         AssertEx.SequenceEqual([$"{dirA}: []"], Inspect(watcher.DirectoryWatchers));
     }
 
+    [Fact]
+    public void ConsolidateDirectories_FindsCommonAncestor()
+    {
+        string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
+        var dirs = new List<string>
+        {
+            Path.Join(root, "src", "A") + Path.DirectorySeparatorChar,
+            Path.Join(root, "src", "A", "sub") + Path.DirectorySeparatorChar,
+        };
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        AssertEx.SequenceEqual([Path.Join(root, "src", "A") + Path.DirectorySeparatorChar], result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_ConsolidatesSiblingsToParent()
+    {
+        string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
+        var dirs = new List<string>
+        {
+            Path.Join(root, "src", "A") + Path.DirectorySeparatorChar,
+            Path.Join(root, "src", "B") + Path.DirectorySeparatorChar,
+            Path.Join(root, "src", "C") + Path.DirectorySeparatorChar,
+        };
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        AssertEx.SequenceEqual([Path.Join(root, "src") + Path.DirectorySeparatorChar], result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_LargeProjectStructure()
+    {
+        string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
+        var dirs = new List<string>();
+
+        for (int i = 0; i < 200; i++)
+        {
+            dirs.Add(Path.Join(root, "Submodule", $"Project{i}") + Path.DirectorySeparatorChar);
+        }
+
+        for (int i = 0; i < 10; i++)
+        {
+            dirs.Add(Path.Join(root, $"Service{i}") + Path.DirectorySeparatorChar);
+        }
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        AssertEx.SequenceEqual([root], result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_SingleDirectory()
+    {
+        var dirs = new List<string> { "/some/path/" };
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_Empty()
+    {
+        var result = FileWatcher.ConsolidateDirectories([]);
+        Assert.Empty(result);
+    }
+
     [Theory]
     [CombinatorialData]
     public async Task NewFile(bool usePolling)

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -167,23 +167,47 @@ public class FileWatcherTests(ITestOutputHelper output)
 
         var result = FileWatcher.ConsolidateDirectories(dirs);
 
+        // Both are under src/A, which is a single immediate child under src/ — returns src/A/
         AssertEx.SequenceEqual([Path.Join(root, "src", "A") + Path.DirectorySeparatorChar], result);
     }
 
     [Fact]
-    public void ConsolidateDirectories_ConsolidatesSiblingsToParent()
+    public void ConsolidateDirectories_FewChildrenWatchesPerChild()
     {
         string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
         var dirs = new List<string>
         {
             Path.Join(root, "src", "A") + Path.DirectorySeparatorChar,
             Path.Join(root, "src", "B") + Path.DirectorySeparatorChar,
-            Path.Join(root, "src", "C") + Path.DirectorySeparatorChar,
+            Path.Join(root, "test", "C") + Path.DirectorySeparatorChar,
         };
 
         var result = FileWatcher.ConsolidateDirectories(dirs);
 
-        AssertEx.SequenceEqual([Path.Join(root, "src") + Path.DirectorySeparatorChar], result);
+        // Common ancestor is root. 2 immediate children (src/, test/) ≤ 5 — watch per child.
+        result.Sort(StringComparer.Ordinal);
+        AssertEx.SequenceEqual(
+        [
+            Path.Join(root, "src") + Path.DirectorySeparatorChar,
+            Path.Join(root, "test") + Path.DirectorySeparatorChar,
+        ], result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_ManyChildrenWatchesAncestor()
+    {
+        string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
+        var dirs = new List<string>();
+
+        for (int i = 0; i < 10; i++)
+        {
+            dirs.Add(Path.Join(root, $"Service{i}") + Path.DirectorySeparatorChar);
+        }
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        // 10 immediate children > 5 - falls back to ancestor.
+        AssertEx.SequenceEqual([root], result);
     }
 
     [Fact]
@@ -204,6 +228,23 @@ public class FileWatcherTests(ITestOutputHelper output)
 
         var result = FileWatcher.ConsolidateDirectories(dirs);
 
+        // 11 immediate children (Submodule/ + Service0-9) > 5 - falls back to ancestor.
+        AssertEx.SequenceEqual([root], result);
+    }
+
+    [Fact]
+    public void ConsolidateDirectories_DirectoryIsAncestor()
+    {
+        string root = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "repo") + Path.DirectorySeparatorChar;
+        var dirs = new List<string>
+        {
+            root,
+            Path.Join(root, "src", "A") + Path.DirectorySeparatorChar,
+        };
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        // One directory IS the ancestor - just watch it.
         AssertEx.SequenceEqual([root], result);
     }
 

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -249,6 +249,22 @@ public class FileWatcherTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void ConsolidateDirectories_NoCommonAncestorBeyondRoot()
+    {
+        // Simulates watching files under completely different root paths (e.g. /private/tmp/... and /Users/...). Should not consolidate since the only common prefix is the filesystem root.
+        var dirs = new List<string>
+        {
+            "/private/tmp/project/src/",
+            "/Users/someone/Library/dotnet/cache/",
+        };
+
+        var result = FileWatcher.ConsolidateDirectories(dirs);
+
+        
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
     public void ConsolidateDirectories_SingleDirectory()
     {
         var dirs = new List<string> { "/some/path/" };


### PR DESCRIPTION
 ## Summary
  - Prevent stack overflow in `EventBasedDirectoryWatcher` when `StartRaisingEvents` synchronously fires `Error`,
  causing infinite recursion in the error handler
- Consolidate watched directories on macOS to reduce FileSystemWatcher instances, lowering the chance of triggering the recursive error handler. Uses common-ancestor heuristic: if ≤5 immediate children under the ancestor, watch per child (avoids unrelated dirs like `artifacts/`); otherwise fall back to single ancestor watcher

As flagged in #53754 and discussed with @tmat [here](https://github.com/ma225tq/sdk/commit/62e1c32465bb3a5479851af5f96873d28797f16a)