### PR TITLE
Replace ubuntu22 VM and Helix images with Azure Linux 3

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -171,7 +171,7 @@ extends:
         parameters:
           pool:
             name: $(DncEngInternalBuildPool)
-            image: 1es-ubuntu-2204
+            image: build.azurelinux.3.amd64
             os: linux
           helixTargetQueue: ubuntu.2204.amd64
           oneESCompat:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -46,7 +46,7 @@ stages:
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        demands: ImageOverride -equals build.azurelinux.3.amd64.open
         os: linux
       helixTargetQueue: ubuntu.2204.amd64.open
 

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -43,11 +43,11 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: $(DncEngPublicBuildPool)
-      image: 1es-ubuntu-2204-open
+      image: build.azurelinux.3.amd64.open
       os: linux
     ${{ else }}:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals 1es-ubuntu-2204
+      demands: ImageOverride -equals build.azurelinux.3.amd64
       os: linux
 
   steps:

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -81,7 +81,7 @@ variables:
   - name: shortStackPoolName
     value: NetCore-Public
   - name: poolImage_Linux
-    value: build.ubuntu.2204.amd64.open
+    value: build.azurelinux.3.amd64.open
   - name: poolImage_LinuxArm64
     value: Mariner-2-Docker-ARM64
   - name: poolName_LinuxArm64
@@ -102,7 +102,7 @@ variables:
     - name: shortStackPoolName
       value: $(DncEngInternalBuildPool)
   - name: poolImage_Linux
-    value: build.ubuntu.2204.amd64
+    value: build.azurelinux.3.amd64
   - name: poolImage_LinuxArm64
     value: build.azurelinux.3.arm64
   - name: poolName_LinuxArm64

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -46,7 +46,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -7,7 +7,7 @@ stages:
     displayName: Tag & Scan
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
 
     steps:

--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -54,7 +54,7 @@ extends:
         options: '--memory=20g'
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     sdl:
       sourceAnalysisPool:
@@ -150,7 +150,7 @@ extends:
         container: licenseScanContainer
         pool:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals 1es-ubuntu-2204
+          demands: ImageOverride -equals build.azurelinux.3.amd64
         timeoutInMinutes: 420
         strategy:
           matrix: $[ dependencies.Setup.outputs['GetMatrix.matrix'] ]
@@ -224,7 +224,7 @@ extends:
         condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))
         pool:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals 1es-ubuntu-2204
+          demands: ImageOverride -equals build.azurelinux.3.amd64
         variables:
         - template: /eng/pipelines/templates/variables/pipelines.yml@self
         steps:


### PR DESCRIPTION
Replace Ubuntu 22.04 VM pool images with Azure Linux 3 equivalents across CI/PR pipelines and source-build infrastructure.

Changes:
- build.ubuntu.2204.amd64.open -> build.azurelinux.3.amd64.open
- build.ubuntu.2204.amd64 -> build.azurelinux.3.amd64
- 1es-ubuntu-2204-open -> build.azurelinux.3.amd64.open
- 1es-ubuntu-2204 -> build.azurelinux.3.amd64

Container images and eng/common (from arcade) are unchanged.

Related to https://github.com/dotnet/source-build/issues/5542