### PR TITLE
Ensure prerequisites of csc-only tests

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
@@ -5,13 +5,35 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Cli.Run.Tests;
 
-public abstract class RunFileTestBase(ITestOutputHelper log) : SdkTest(log)
+public sealed class RunFileTestFixture(IMessageSink sink) : IAsyncLifetime
+{
+    public ValueTask InitializeAsync()
+    {
+        RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
+
+        // Ensure a simple app runs fully with MSBuild before running other csc-only tests
+        // so we have packages like ILLink.Tasks restored and csc-only optimization can kick in.
+        new DotnetCommand(new SharedTestOutputHelper(sink), "run", "-")
+            .WithStandardInput("""
+                Console.WriteLine("Hello");
+                """)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello");
+
+        return default;
+    }
+
+    public ValueTask DisposeAsync() => default;
+}
+
+public abstract class RunFileTestBase(ITestOutputHelper log) : SdkTest(log), IClassFixture<RunFileTestFixture>
 {
     internal static string s_includeExcludeDefaultKnownExtensions
         => field ??= string.Join(", ", CSharpDirective.IncludeOrExclude.DefaultMapping.Select(static e => e.Extension));

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
@@ -140,7 +140,7 @@ public abstract class RunFileTestBase(ITestOutputHelper log) : SdkTest(log)
     /// is created under this directory, and NuGet walks up from the project location to
     /// find config files.
     /// </summary>
-    protected static void CopyNuGetConfigToRunfileDirectory()
+    internal static void CopyNuGetConfigToRunfileDirectory()
     {
         var sourceNuGetConfig = Path.Join(SdkTestContext.Current.TestExecutionDirectory, "NuGet.config");
         var runfileDir = VirtualProjectBuilder.GetTempSubdirectory();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -8,33 +8,10 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
-using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Cli.Run.Tests;
 
-public sealed class RunFileCscOnlyFixture(IMessageSink sink) : IAsyncLifetime
-{
-    public ValueTask InitializeAsync()
-    {
-        RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
-
-        // Ensure a simple app runs fully with MSBuild before running other csc-only tests
-        // so we have packages like ILLink.Tasks restored and csc-only optimization can kick in.
-        new DotnetCommand(new SharedTestOutputHelper(sink), "run", "-")
-            .WithStandardInput("""
-                Console.WriteLine("Hello");
-                """)
-            .Execute()
-            .Should().Pass()
-            .And.HaveStdOut("Hello");
-
-        return default;
-    }
-
-    public ValueTask DisposeAsync() => default;
-}
-
-public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileTestBase(log), IClassFixture<RunFileCscOnlyFixture>
+public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileTestBase(log)
 {
     [Fact]
     public void UpToDate()

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -8,10 +8,33 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Xunit.Sdk;
 
 namespace Microsoft.DotNet.Cli.Run.Tests;
 
-public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileTestBase(log)
+public sealed class RunFileCscOnlyFixture(IMessageSink sink) : IAsyncLifetime
+{
+    public ValueTask InitializeAsync()
+    {
+        RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
+
+        // Ensure a simple app runs fully with MSBuild before running other csc-only tests
+        // so we have packages like ILLink.Tasks restored and csc-only optimization can kick in.
+        new DotnetCommand(new SharedTestOutputHelper(sink), "run", "-")
+            .WithStandardInput("""
+                Console.WriteLine("Hello");
+                """)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello");
+
+        return default;
+    }
+
+    public ValueTask DisposeAsync() => default;
+}
+
+public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileTestBase(log), IClassFixture<RunFileCscOnlyFixture>
 {
     [Fact]
     public void UpToDate()


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/issues/53869 (should fix that issue but I don't want to close it yet since it's flaky, so I would like to see it not appear for a while first).