### PR TITLE
Fix TemplateEngine RS0016/RS0041 public API analyzer violations

### DIFF
--- a/src/TemplateEngine/.editorconfig
+++ b/src/TemplateEngine/.editorconfig
@@ -6,6 +6,8 @@
 # flagged as unnecessary for netcoreapp TFMs.
 dotnet_diagnostic.IDE0005.severity = suggestion
 
+dotnet_diagnostic.RS0041.severity = suggestion
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1005.severity = none
 dotnet_diagnostic.SA1101.severity = none

--- a/src/TemplateEngine/Directory.Build.props
+++ b/src/TemplateEngine/Directory.Build.props
@@ -6,11 +6,7 @@
     TemplateEngine-specific build properties.
   -->
   <PropertyGroup>
-    <!--
-      TODO: Update PublicAPI.Shipped/Unshipped.txt files to fix RS0016/RS0041 violations, then remove the suppression. 
-      https://github.com/dotnet/templating/issues/10085
-    -->
-    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419;0649;RS0016;RS0041</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419;0649;</NoWarn>
 
     <!--
       TemplateEngine projects target netstandard2.0 and pin NuGet packages to an older

--- a/src/TemplateEngine/Directory.Build.props
+++ b/src/TemplateEngine/Directory.Build.props
@@ -6,7 +6,7 @@
     TemplateEngine-specific build properties.
   -->
   <PropertyGroup>
-    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419;0649;</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419;0649</NoWarn>
 
     <!--
       TemplateEngine projects target netstandard2.0 and pin NuGet packages to an older

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -6,10 +6,17 @@ Microsoft.TemplateEngine.Abstractions.Installer.UpdateResult.Vulnerabilities.get
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.AdvisoryUris.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.AdvisoryUris.init -> void
+Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.Deconstruct(out int Severity, out System.Collections.Generic.IReadOnlyList<string!>! AdvisoryUris) -> void
+Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.Equals(Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo other) -> bool
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.Severity.get -> int
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.Severity.init -> void
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.VulnerabilityInfo() -> void
 Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.VulnerabilityInfo(int Severity, System.Collections.Generic.IReadOnlyList<string!>! AdvisoryUris) -> void
+override Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.GetHashCode() -> int
+~override Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.Equals(object obj) -> bool
+~override Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.ToString() -> string
+static Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.operator !=(Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo left, Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo right) -> bool
+static Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo.operator ==(Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo left, Microsoft.TemplateEngine.Abstractions.Installer.VulnerabilityInfo right) -> bool
 Microsoft.TemplateEngine.Abstractions.ITemplate.Localization.get -> Microsoft.TemplateEngine.Abstractions.ILocalizationLocator?
 Microsoft.TemplateEngine.Abstractions.ITemplate.TemplateSourceRoot.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!
 Microsoft.TemplateEngine.Abstractions.ITemplateMetadata.PreferDefaultName.get -> bool

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
@@ -33,7 +33,9 @@ Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig.Expand.get -> bool
 Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander
+virtual Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IKeysChangedEventArgs! args) -> void
 Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander
+virtual Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs! args) -> void
 Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig.Encoding.get -> System.Text.Encoding!
 Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig.LineEndings.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie!
 Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig.this[int index].get -> object!

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.ge
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander!
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander!
+virtual Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IKeysChangedEventArgs! args) -> void
+virtual Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs! args) -> void
 Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
 Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken?>!
 Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string?

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -3,8 +3,6 @@ Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.ge
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander!
 Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander!
-virtual Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IKeysChangedEventArgs! args) -> void
-virtual Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander.Invoke(object! sender, Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs! args) -> void
 Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
 Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken?>!
 Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string?

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -119,6 +119,7 @@ Microsoft.TemplateEngine.Core.Expressions.TokenScope<TToken>.IsIndivisible.get -
 Microsoft.TemplateEngine.Core.Expressions.TokenScope<TToken>.IsQuoted.get -> bool
 Microsoft.TemplateEngine.Core.Expressions.TokenScope<TToken>.IsQuoted.set -> void
 Microsoft.TemplateEngine.Core.Expressions.TypeConverterDelegate<T>
+virtual Microsoft.TemplateEngine.Core.Expressions.TypeConverterDelegate<T>.Invoke(object? source, out T result) -> bool
 Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>
 Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.IsFull.get -> bool
 Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.IsIndivisible.get -> bool
@@ -188,6 +189,7 @@ Microsoft.TemplateEngine.Core.Operations.Conditional.WholeLine.get -> bool
 Microsoft.TemplateEngine.Core.Operations.ConditionalTokens
 Microsoft.TemplateEngine.Core.Operations.ConditionalTokens.ConditionalTokens() -> void
 Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator
+virtual Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator.Invoke(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 Microsoft.TemplateEngine.Core.Operations.ExpandVariables
 Microsoft.TemplateEngine.Core.Operations.Include
 Microsoft.TemplateEngine.Core.Operations.InlineMarkupConditional

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/PublicAPI.Unshipped.txt
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/PublicAPI.Unshipped.txt
@@ -4,11 +4,13 @@ Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.IInstantiationResul
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.IInstantiationResult.StdErr.get -> string!
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.IInstantiationResult.StdOut.get -> string!
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.RunInstantiation
+virtual Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.RunInstantiation.Invoke(Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerifierOptions! options) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.IInstantiationResult!>!
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.AddScrubber(Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.ScrubFileByPath! fileScrubber) -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition!
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.AddScrubber(System.Action<System.Text.StringBuilder!>! scrubber, string? extension = null) -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition!
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.ScrubbersDefinition(System.Action<System.Text.StringBuilder!>! scrubber, string? extension = null) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.ScrubFileByPath
+virtual Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.ScrubFileByPath.Invoke(string! relativeFilePath, System.Text.StringBuilder! content) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode.InstallFailed = 106 -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode.InstantiationFailed = 100 -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode
@@ -87,4 +89,5 @@ Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerificationEngine.Execute(M
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerificationEngine.VerificationEngine(Microsoft.Extensions.Logging.ILogger! logger) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerificationEngine.VerificationEngine(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerifyDirectory
+virtual Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerifyDirectory.Invoke(string! contentDirectory, System.Lazy<System.Collections.Generic.IAsyncEnumerable<(string! FilePath, string! ScrubbedContent)>!>! contentFetcher) -> System.Threading.Tasks.Task!
 static readonly Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition.Empty -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.ScrubbersDefinition!


### PR DESCRIPTION
## Summary

After merging the templating repo into the SDK, the RS0016 and RS0041 public API analyzer rules were suppressed via `NoWarn` in `src/TemplateEngine/Directory.Build.props`. This PR removes that suppression and fixes the underlying issues.

## Root Cause

The SDK repo uses **PublicApiAnalyzers v5.7.0** which detects compiler-synthesized members (delegate `Invoke` methods, `record struct` equality/deconstruct members) that the templating repo's **v3.3.4** did not flag. The `PublicAPI.*.txt` files were correct for the old analyzer but incomplete for the new one.

## Changes

- **Directory.Build.props**: Removed RS0016 and RS0041 from `NoWarn`
- **.editorconfig**: Added `dotnet_diagnostic.RS0041.severity = suggestion` (matching the templating repo's `.editorconfig`)
- **PublicAPI files**: Added missing synthesized members:
  - `VulnerabilityInfo` record struct members (Abstractions)
  - Delegate `Invoke` methods (Core.Contracts, Core, Authoring.TemplateVerifier)

contributes to https://github.com/dotnet/templating/issues/10085