### PR TITLE
Add missing using to fix broken builds

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
 using Xunit.Sdk;


### PR DESCRIPTION
@marcpopMSFT @baronfel ptal

Looks like the build was broken by merging the combination of https://github.com/dotnet/sdk/pull/53884 and https://github.com/dotnet/sdk/pull/53960.