### PR TITLE
Fix CS0103: Add missing using for CommandLoggingContext

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
 using Xunit.Sdk;


### PR DESCRIPTION
Adds `using Microsoft.DotNet.Cli.Utils;` to `RunFileTestBase.cs` to fix the CS0103 compiler error for `CommandLoggingContext`.

It looks like this build error was caused by two PRs conflicting with each other - https://github.com/dotnet/sdk/pull/53960 and https://github.com/dotnet/sdk/pull/53884