### PR TITLE
CA2025: Do not report on sync .GetAwaiter.GetResult()

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasks.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasks.cs
@@ -190,6 +190,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             return op.GetAncestor<IAwaitOperation>(OperationKind.Await) is not null ||
                 op.Parent is IInvocationOperation { TargetMethod.Name: "Wait" } or
+                IInvocationOperation { TargetMethod.Name: "GetAwaiter", Parent: IInvocationOperation { TargetMethod.Name: "GetResult" } } or
                 IPropertyReferenceOperation { Property.Name: "Result" };
         }
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
@@ -443,6 +443,44 @@ End Class
 ");
         }
 
+        [Fact]
+        public async Task TaskGetAwaiterWithoutAwaiting_DiagnosticAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    public static void D()
+    {
+        var ms = new MemoryStream();
+        var res = DoAsync(ms).GetAwaiter();
+        ms.Dispose();
+    }
+
+    public static Task<string> DoAsync(Stream s) => Task.FromResult(string.Empty);
+}
+");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System.IO
+Imports System.Threading.Tasks
+
+Public Class C
+    Public Shared Sub D()
+        Dim ms = New MemoryStream()
+        Dim res = DoAsync(ms).GetAwaiter()
+        ms.Dispose()
+    End Sub
+
+    Public Shared Function DoAsync(ByVal s As Stream) As Task(Of String)
+        Return Task.FromResult(String.Empty)
+    End Function
+End Class
+");
+        }
+
         #endregion Diagnostic
 
         #region No Diagnostic

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
@@ -600,6 +600,44 @@ End Class
         }
 
         [Fact]
+        public async Task TaskResultReceivedFromAwaiterSynchronously_NoDiagnosticAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    public static void D()
+    {
+        var ms = new MemoryStream();
+        var res = DoAsync(ms).GetAwaiter().GetResult();
+        ms.Dispose();
+    }
+
+    public static Task<string> DoAsync(Stream s) => Task.FromResult(string.Empty);
+}
+");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System.IO
+Imports System.Threading.Tasks
+
+Public Class C
+    Public Shared Sub D()
+        Dim ms = New MemoryStream()
+        Dim res = DoAsync(ms).GetAwaiter().GetResult()
+        ms.Dispose()
+    End Sub
+
+    Public Shared Function DoAsync(ByVal s As Stream) As Task(Of String)
+        Return Task.FromResult(String.Empty)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
         public async Task AwaitedElsewhereBeforeDispose_NoDiagnosticAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotPassDisposablesIntoUnawaitedTasksTests.cs
@@ -455,7 +455,7 @@ public class C
     public static void D()
     {
         var ms = new MemoryStream();
-        var res = DoAsync(ms).GetAwaiter();
+        var res = DoAsync({|CA2025:ms|}).GetAwaiter();
         ms.Dispose();
     }
 
@@ -470,7 +470,7 @@ Imports System.Threading.Tasks
 Public Class C
     Public Shared Sub D()
         Dim ms = New MemoryStream()
-        Dim res = DoAsync(ms).GetAwaiter()
+        Dim res = DoAsync({|CA2025:ms|}s).GetAwaiter()
         ms.Dispose()
     End Sub
 


### PR DESCRIPTION
Fixes #51761 
* Add `GetAwaiter().GetResult()` invocations on `Task` as a valid pattern for CA2025, thus not reporting the diagnostic
* Adds unit test coverage for the positive case: Usage of `Task.GetAwaiter().GetResult()` does not trigger the diagnostic.
* Adds unit test coverage for the negative case: Usage of `Task.GetAwaiter()` triggers the diagnostic, because the returned `TaskAwaiter` isn't used to actually used to await the `Task`