### PR TITLE
[dotnet-watch] Clear WebSocket env vars in ClearHotReloadEnvironmentVariables

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent/HotReloadAgent.cs
+++ b/src/Dotnet.Watch/HotReloadAgent/HotReloadAgent.cs
@@ -305,6 +305,8 @@ internal sealed class HotReloadAgent : IDisposable, IHotReloadAgent
         }
 
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadNamedPipeName, null);
+        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadWebSocketEndpoint, null);
+        Environment.SetEnvironmentVariable(AgentEnvironmentVariables.DotNetWatchHotReloadWebSocketKey, null);
         Environment.SetEnvironmentVariable(AgentEnvironmentVariables.HotReloadDeltaClientLogMessages, null);
     }
 


### PR DESCRIPTION
I just noticed this reading the code -- not sure if it actually causes a problem, but should probably be fixed.

`ClearHotReloadEnvironmentVariables` already clears the named pipe env var ($DOTNET_WATCH_HOTRELOAD_NAMEDPIPE_NAME) but does not clear the WebSocket equivalents ($DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT and $DOTNET_WATCH_HOTRELOAD_WEBSOCKET_KEY). Fix parity so WebSocket env vars are also cleared for child processes.