### PR TITLE
Fix Helix test sharding: parse TestFullMSBuild as boolean

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -152,7 +152,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 msbuildAdditionalSdkResolverFolder = "";
             }
 
-            var scheduler = new AssemblyScheduler(methodLimit: !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TestFullMSBuild")) ? 32 : 16);
+            var isFullMSBuild = string.Equals(Environment.GetEnvironmentVariable("TestFullMSBuild"), "true", StringComparison.OrdinalIgnoreCase);
+            var scheduler = new AssemblyScheduler(methodLimit: isFullMSBuild ? 32 : 16);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath);
 
             var partitionedWorkItem = new List<ITaskItem>();


### PR DESCRIPTION
## Problem

The `AssemblyScheduler` `methodLimit` was determined by checking `string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TestFullMSBuild"))`. The `testFullMSBuild` parameter [defaults to `false`](https://github.com/dotnet/sdk/blob/8b1618b7c32401b2f7eb6f924104b1ff3bd49b1c/eng/pipelines/templates/jobs/sdk-build.yml#L20) for all jobs (Windows, Linux, macOS).

However, only the **Windows-conditional test step** includes `TestFullMSBuild` in its env block ([line 162](https://github.com/dotnet/sdk/blob/8b1618b7c32401b2f7eb6f924104b1ff3bd49b1c/eng/pipelines/templates/jobs/sdk-build.yml#L162)), while the **non-Windows test step** does not set it at all ([lines 168-178](https://github.com/dotnet/sdk/blob/8b1618b7c32401b2f7eb6f924104b1ff3bd49b1c/eng/pipelines/templates/jobs/sdk-build.yml#L168-L178)).

Since `"false"` is a non-empty string, `IsNullOrEmpty` returns `false`, and the code selects `methodLimit=32` on Windows instead of the intended `16`. On Linux/macOS the env var is absent (`null`), so `methodLimit=16` is correctly used.

## Impact

This caused an unintentional asymmetry in Helix work item counts (observed in [build 1387124](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1387124)):
- **Windows TestBuild**: 329 work items (`methodLimit=32`), max item ~16.3m
- **Linux TestBuild**: 514 work items (`methodLimit=16`), max item ~15.9m

Because the Windows Helix pool is critical-path bound (276 agents, most running 1 item each), the larger shards made the longest work item the bottleneck. Fixing this should reduce the Windows Helix wall-clock by ~5-8 minutes.

## Fix

Parse the environment variable as a boolean instead of checking for non-empty. This ensures:
- **TestBuild** jobs (all platforms): `methodLimit=16`
- **FullFramework** job (`TestFullMSBuild=true`): `methodLimit=32` (unchanged)