### PR TITLE
Enforce more prereqs in the get-dotnetup helper scripts

### DIFF
--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -39,6 +39,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+
 $AzdoOrg = "https://dev.azure.com/dnceng"
 $AzdoProject = "internal"
 $PipelineId = 1544
@@ -99,6 +100,17 @@ function Get-RuntimeId {
 }
 
 # --- Main ---
+
+# Windows PowerShell (5.x) is not supported; require PowerShell 6+ (pwsh).
+# The 'PSEdition' property is only present on 5+, so usage on 4 and below will be null,
+# so we check that the version isn't Core instead of "version is Desktop"
+if ($PSVersionTable.PSEdition -ne "Core") {
+    throw @"
+This script requires PowerShell 7 (pwsh) and cannot run on Windows PowerShell 5.x.
+Install PowerShell 7 from: https://aka.ms/install-powershell
+Then re-run this script with 'pwsh' instead of 'powershell'.
+"@
+}
 
 # Check for Azure CLI
 if (-not (Get-Command az -ErrorAction SilentlyContinue)) {

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -123,6 +123,16 @@ After installing, log in with:
 "@
 }
 
+# Check for the azure-devops extension
+$extList = az extension show --name azure-devops 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+The 'azure-devops' Azure CLI extension is required but is not installed.
+Install it with:
+    az extension add --name azure-devops
+"@
+}
+
 $rid = Get-RuntimeId
 Write-Host "Detected runtime: $rid" -ForegroundColor Cyan
 

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -106,8 +106,8 @@ function Get-RuntimeId {
 # so we check that the version isn't Core instead of "version is Desktop"
 if ($PSVersionTable.PSEdition -ne "Core") {
     throw @"
-This script requires PowerShell 7 (pwsh) and cannot run on Windows PowerShell 5.x.
-Install PowerShell 7 from: https://aka.ms/install-powershell
+This script requires PowerShell Core (pwsh) and cannot run on Windows PowerShell 5.x.
+Install PowerShell Core from: https://aka.ms/install-powershell
 Then re-run this script with 'pwsh' instead of 'powershell'.
 "@
 }

--- a/scripts/get-dotnetup.sh
+++ b/scripts/get-dotnetup.sh
@@ -89,6 +89,13 @@ if ! command -v az &>/dev/null; then
     exit 1
 fi
 
+if ! az extension show --name azure-devops &>/dev/null; then
+    err "The 'azure-devops' Azure CLI extension is required but is not installed."
+    err "Install it with:"
+    err "  az extension add --name azure-devops"
+    exit 1
+fi
+
 # --- Detect runtime ID ---
 detect_rid() {
     if [ -n "$RUNTIME_ID" ]; then


### PR DESCRIPTION
Detect and throw if Windows Powershell is used, or if the AzDO az CLI extension is missing.