### PR TITLE
Auto-close stale Known Build Error issues with zero monthly hits

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '19 4,16 * * *' # Twice daily at 19 minutes after the hour (random/uncommon time)
 
+env:
+  KBE_LABEL: 'Known Build Error'
+
 permissions:
   actions: write # For managing the operation state cache
   issues: write
@@ -23,4 +26,68 @@ jobs:
           days-before-issue-close: 30
           days-before-pr-stale: 180 # 6 months
           days-before-pr-close: 7
+          exempt-issue-labels: ${{ env.KBE_LABEL }}
           operations-per-run: 4000
+
+  # Known Build Error issues with 0 hits for a month get labeled Stale,
+  # then actions/stale closes them after 7 days.
+  stale-known-build-errors:
+    if: github.repository_owner == 'dotnet' # Do not run on forks
+
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Label/unlabel based on hit counts
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const staleLabel = 'stale';
+
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner: context.repo.owner, repo: context.repo.repo,
+                labels: process.env.KBE_LABEL, state: 'open', per_page: 100 });
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (issue.labels.some(l => l.name === 'keep-open')) continue;
+
+              // Parse the hit count summary table from the issue body.
+              // Format: |24-Hour Hit Count|7-Day Hit Count|1-Month Count|
+              //         |---|---|---|
+              //         |N|N|N|
+              const match = issue.body?.match(
+                /\|24-Hour Hit Count\|.*\n\|[-| ]+\n\|(\d+)\|(\d+)\|(\d+)\|/);
+              if (!match) continue;
+              const monthCount = parseInt(match[3], 10);
+
+              const hasStale = issue.labels.some(l => l.name === staleLabel);
+
+              if (monthCount === 0 && !hasStale) {
+                // Zero hits for a month: mark as stale
+                await github.rest.issues.addLabels({
+                  ...context.repo, issue_number: issue.number,
+                  labels: [staleLabel] });
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number: issue.number,
+                  body: 'This Known Build Error has had **0 hits in the past month** and has been labeled `stale`. ' +
+                    'It will be auto-closed in 7 days if the hit count remains at 0. ' +
+                    'Add the `keep-open` label to prevent auto-closure.' });
+              } else if (monthCount > 0 && hasStale) {
+                // Hits resumed: remove the stale label
+                await github.rest.issues.removeLabel({
+                  ...context.repo, issue_number: issue.number,
+                  name: staleLabel }).catch(() => {});
+              }
+            }
+
+      # Step 2: Close KBE issues that have been Stale for 7+ days
+      - uses: actions/stale@v9
+        with:
+          only-labels: ${{ env.KBE_LABEL }}
+          stale-issue-label: 'stale'
+          close-issue-message: 'Closed automatically — this Known Build Error has had 0 hits for over a month.'
+          days-before-issue-stale: -1 # Don't auto-stale; step 1 handles that
+          days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,8 @@ on:
 
 env:
   KBE_LABEL: 'Known Build Error'
+  STALE_LABEL: 'stale'
+  KEEP_OPEN_LABEL: 'keep-open'
 
 permissions:
   actions: write # For managing the operation state cache
@@ -40,8 +42,6 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const staleLabel = 'stale';
-
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
               { owner: context.repo.owner, repo: context.repo.repo,
@@ -49,7 +49,7 @@ jobs:
 
             for (const issue of issues) {
               if (issue.pull_request) continue;
-              if (issue.labels.some(l => l.name === 'keep-open')) continue;
+              if (issue.labels.some(l => l.name === process.env.KEEP_OPEN_LABEL)) continue;
 
               // Parse the hit count summary table from the issue body.
               // Format: |24-Hour Hit Count|7-Day Hit Count|1-Month Count|
@@ -60,23 +60,23 @@ jobs:
               if (!match) continue;
               const monthCount = parseInt(match[3], 10);
 
-              const hasStale = issue.labels.some(l => l.name === staleLabel);
+              const hasStale = issue.labels.some(l => l.name === process.env.STALE_LABEL);
 
               if (monthCount === 0 && !hasStale) {
                 // Zero hits for a month: mark as stale
                 await github.rest.issues.addLabels({
                   ...context.repo, issue_number: issue.number,
-                  labels: [staleLabel] });
+                  labels: [process.env.STALE_LABEL] });
                 await github.rest.issues.createComment({
                   ...context.repo, issue_number: issue.number,
                   body: 'This Known Build Error has had **0 hits in the past month** and has been labeled `stale`. ' +
                     'It will be auto-closed in 7 days if the hit count remains at 0. ' +
-                    'Add the `keep-open` label to prevent auto-closure.' });
+                    'Add the `' + process.env.KEEP_OPEN_LABEL + '` label to prevent auto-closure.' });
               } else if (monthCount > 0 && hasStale) {
                 // Hits resumed: remove the stale label
                 await github.rest.issues.removeLabel({
                   ...context.repo, issue_number: issue.number,
-                  name: staleLabel }).catch(() => {});
+                  name: process.env.STALE_LABEL }).catch(() => {});
               }
             }
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           only-labels: ${{ env.KBE_LABEL }}
-          stale-issue-label: 'stale'
+          stale-issue-label: ${{ env.STALE_LABEL }}
           close-issue-message: 'Closed automatically — this Known Build Error has had 0 hits for over a month.'
           days-before-issue-stale: -1 # Don't auto-stale; step 1 handles that
           days-before-issue-close: 7


### PR DESCRIPTION
## Summary

Adds automation to the existing stale workflow that closes Known Build Error (KBE) issues that have had **0 hits for over a month**.

## How it works

1. **Step 1 (github-script)**: Scans open KBE issues, parses the hit count table from each issue body. If 1-month count is 0 → adds `stale` label + comment. If hits have resumed on a stale issue → removes `stale` label.

2. **Step 2 (actions/stale)**: Closes KBE issues that have been `stale` for 7+ days.

3. **Existing stale job**: Now exempts KBE issues via `exempt-issue-labels` to avoid conflicts.

## Opting out with `keep-open`

The standard escape hatches don't work here:
- **Removing `stale`** — the automation re-applies it on the next run as long as the 1-month hit count is 0.
- **Removing `Known Build Error`** — changes the issue's meaning; the issue is still a known build error, you just don't want it auto-closed.

Instead, add the **`keep-open`** label to any KBE issue that should remain open despite zero hits. The script skips issues with this label entirely.

## Changes
- `.github/workflows/stale.yml`: Added `stale-known-build-errors` job, added `env.KBE_LABEL` shared variable, added `exempt-issue-labels` to existing stale job.

## Testing
Tested on fork (MichaelSimons/sdk) with `workflow_dispatch` and sample issues. Verified:
- Zero-hit issues get `stale` label and comment
- Active-hit issues are skipped
- Resumed-hit stale issues get `stale` label removed
- Stale issues are closed by actions/stale

## Affected Issues

Once merged, the following issues will be marked as stale and closed:

 - [Package reference alias tests are disabled](https://github.com/dotnet/sdk/issues/39172) (#39172)
 - [.NET Framework build job test failure](https://github.com/dotnet/sdk/issues/40160) (#40160)
 - [ToolInstallCommandTests.WhenRunWithRoot is flaky](https://github.com/dotnet/sdk/issues/42346) (#42346)
 - [Build failure in VMR Vertical Build Windows_x64: Downloading vswhere - Process cannot access sdk.txt because it is being used by another 
process](https://github.com/dotnet/sdk/issues/45809) (#45809)
 - [CanIgnoreTemplateGroupsWithConstraints flaky test failing in CI](https://github.com/dotnet/sdk/issues/46212) (#46212)
 - [dotnet watch - Failure in DeleteSubfolder test with polling](https://github.com/dotnet/sdk/issues/46454) (#46454)
 - [Containers integration tests are flaky when the network fails to load the registry](https://github.com/dotnet/sdk/issues/49502) (#49502)
 - [GenerateBundle Task fails writing to singlefilehost.exe](https://github.com/dotnet/sdk/issues/50784) (#50784)
 - [Tests Failing in Template Engine: Failed to update search cache. (The SSL connection could not be established, see inner 
exception.)](https://github.com/dotnet/sdk/issues/51147) (#51147)
 - [Containers Test Issue: Unknown command docker buildx](https://github.com/dotnet/sdk/issues/51161) (#51161)