### PR TITLE
[dotnet watch] fix deadlock on iOS with `UIKitSynchronizationContext`

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
@@ -54,7 +54,7 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
         {
             try
             {
-                await ReceiveAndApplyUpdatesAsync(initialUpdates: false, cancellationToken);
+                await ReceiveAndApplyUpdatesAsync(initialUpdates: false, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
@@ -72,35 +72,35 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
     {
         agent.Reporter.Report("Writing capabilities: " + agent.Capabilities, AgentMessageSeverity.Verbose);
 
-        await transport.SendAsync(new ClientInitializationResponse(agent.Capabilities), cancellationToken);
+        await transport.SendAsync(new ClientInitializationResponse(agent.Capabilities), cancellationToken).ConfigureAwait(false);
 
         // Apply updates made before this process was launched to avoid executing unupdated versions of the affected modules.
 
         // We should only receive ManagedCodeUpdate when when the debugger isn't attached,
         // otherwise the initialization should send InitialUpdatesCompleted immediately.
         // The debugger itself applies these updates when launching process with the debugger attached.
-        await ReceiveAndApplyUpdatesAsync(initialUpdates: true, cancellationToken);
+        await ReceiveAndApplyUpdatesAsync(initialUpdates: true, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ReceiveAndApplyUpdatesAsync(bool initialUpdates, CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            using var request = await transport.ReceiveAsync(cancellationToken);
+            using var request = await transport.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             if (request.Stream == null)
             {
                 break;
             }
 
-            var payloadType = (RequestType)await request.Stream.ReadByteAsync(cancellationToken);
+            var payloadType = (RequestType)await request.Stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             switch (payloadType)
             {
                 case RequestType.ManagedCodeUpdate:
-                    await ReadAndApplyManagedCodeUpdateAsync(request.Stream, cancellationToken);
+                    await ReadAndApplyManagedCodeUpdateAsync(request.Stream, cancellationToken).ConfigureAwait(false);
                     break;
 
                 case RequestType.StaticAssetUpdate:
-                    await ReadAndApplyStaticAssetUpdateAsync(request.Stream, cancellationToken);
+                    await ReadAndApplyStaticAssetUpdateAsync(request.Stream, cancellationToken).ConfigureAwait(false);
                     break;
 
                 case RequestType.InitialUpdatesCompleted when initialUpdates:
@@ -115,7 +115,7 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
 
     private async ValueTask ReadAndApplyManagedCodeUpdateAsync(Stream stream, CancellationToken cancellationToken)
     {
-        var request = await ManagedCodeUpdateRequest.ReadAsync(stream, cancellationToken);
+        var request = await ManagedCodeUpdateRequest.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
         bool success;
         try
@@ -132,12 +132,12 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
 
         var logEntries = agent.Reporter.GetAndClearLogEntries(request.ResponseLoggingLevel);
 
-        await SendResponseAsync(new UpdateResponse(logEntries, success), cancellationToken);
+        await SendResponseAsync(new UpdateResponse(logEntries, success), cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask ReadAndApplyStaticAssetUpdateAsync(Stream stream, CancellationToken cancellationToken)
     {
-        var request = await StaticAssetUpdateRequest.ReadAsync(stream, cancellationToken);
+        var request = await StaticAssetUpdateRequest.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -153,7 +153,7 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
         // Updating static asset only invokes ContentUpdate metadata update handlers.
         // Failures of these handlers are reported to the log and ignored.
         // Therefore, this request always succeeds.
-        await SendResponseAsync(new UpdateResponse(logEntries, success: true), cancellationToken);
+        await SendResponseAsync(new UpdateResponse(logEntries, success: true), cancellationToken).ConfigureAwait(false);
     }
 
     internal async ValueTask SendResponseAsync<T>(T response, CancellationToken cancellationToken)
@@ -161,8 +161,8 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
     {
         try
         {
-            await _messageToClientLock.WaitAsync(cancellationToken);
-            await transport.SendAsync(response, cancellationToken);
+            await _messageToClientLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await transport.SendAsync(response, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Dotnet.Watch/HotReloadAgent.Host/WebSocketTransport.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/WebSocketTransport.cs
@@ -58,7 +58,7 @@ internal sealed class WebSocketTransport(string serverUrl, string? serverPublicK
                 }
 
                 Log($"Connecting to {serverUrl}...");
-                await _webSocket.ConnectAsync(new Uri(serverUrl), connectCts.Token);
+                await _webSocket.ConnectAsync(new Uri(serverUrl), connectCts.Token).ConfigureAwait(false);
                 Log("Connected.");
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
@@ -71,8 +71,8 @@ internal sealed class WebSocketTransport(string serverUrl, string? serverPublicK
         _sendBuffer ??= new MemoryStream();
         _sendBuffer.SetLength(0);
 
-        await _sendBuffer.WriteAsync((byte)response.Type, cancellationToken);
-        await response.WriteAsync(_sendBuffer, cancellationToken);
+        await _sendBuffer.WriteAsync((byte)response.Type, cancellationToken).ConfigureAwait(false);
+        await response.WriteAsync(_sendBuffer, cancellationToken).ConfigureAwait(false);
 
         Log($"Sending {response.Type} ({_sendBuffer.Length} bytes)");
 
@@ -81,7 +81,7 @@ internal sealed class WebSocketTransport(string serverUrl, string? serverPublicK
             new ArraySegment<byte>(_sendBuffer.GetBuffer(), 0, (int)_sendBuffer.Length),
             WebSocketMessageType.Binary,
             endOfMessage: true,
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     public override async ValueTask<RequestStream> ReceiveAsync(CancellationToken cancellationToken)
@@ -101,7 +101,7 @@ internal sealed class WebSocketTransport(string serverUrl, string? serverPublicK
             WebSocketReceiveResult result;
             do
             {
-                result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+                result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
 
                 if (result.MessageType == WebSocketMessageType.Close)
                 {


### PR DESCRIPTION
On iOS with CoreCLR, `UIKitSynchronizationContext` is installed before startup hooks run. `Listener.Listen()` calls `GetAwaiter().GetResult()` on the main thread, and await continuations try to post back to the blocked UI thread, causing a deadlock. Fix by adding `ConfigureAwait(false)` to awaits in the startup hook's call chain. On Android, just due to startup ordering the `SynchronizationContext` was not set.

I didn't think of a way we could test this easily -- I basically built the dotnet/macios repo and copied dotnet-watch files on top to manually test. An end-to-end test in the dotnet/macios repo might be the best place.

With these changes in place:
```
2026-04-21 14:41:01.681990-0500 heyo[27489:980549] [HotReload] DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT=ws://localhost:61875
2026-04-21 14:41:01.686900-0500 heyo[27489:980549] [HotReload] Connecting to Hot Reload server via WebSocket ws://localhost:61875.
2026-04-21 14:41:01.696114-0500 heyo[27489:980549] [HotReload] Connecting to ws://localhost:61875...
dotnet watch 🔥 [heyo (net11.0-ios)] WebSocket client connected
2026-04-21 14:41:01.754571-0500 heyo[27489:980834] [HotReload] Connected.
2026-04-21 14:41:01.755569-0500 heyo[27489:980834] [HotReload] Sending InitializationResponse (247 bytes)
dotnet watch 🔥 [heyo (net11.0-ios)] Capabilities: 'Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType AddFieldRva AddExplicitInterfaceImplementation'.
2026-04-21 14:41:01.768519-0500 heyo[27489:980834] [HotReload] Received 1 bytes
dotnet watch ⌚ Waiting for changes
dotnet watch ⌚ File change: Update '/Users/jopeppers/src/heyo/SceneDelegate.cs'.
dotnet watch ⌚ File updated: ./SceneDelegate.cs
dotnet watch ⌚ Updating document text of '/Users/jopeppers/src/heyo/SceneDelegate.cs'.
dotnet watch ⌚ Solution after document update: v2
dotnet watch 🔥 Hot reload capabilities: AddExplicitInterfaceImplementation AddFieldRva AddInstanceFieldToExistingType AddMethodToExistingType AddStaticFieldToExistingType Baseline ChangeCustomAttributes GenericAddFieldToExistingType GenericAddMethodToExistingType GenericUpdateMethod NewTypeDefinition UpdateParameters.
dotnet watch 🔥 [heyo (net11.0-ios)] Sending update batch #0
2026-04-21 14:41:13.296225-0500 heyo[27489:980834] [HotReload] Received 5770 bytes
2026-04-21 14:41:13.338366-0500 heyo[27489:980834] [HotReload] Sending UpdateResponse (466 bytes)
dotnet watch 🕵️ [heyo (net11.0-ios)] Writing capabilities: Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType AddFieldRva
dotnet watch 🕵️ [heyo (net11.0-ios)] Applying updates to module 24147f53-599d-4c51-872f-f2073583eddb.
dotnet watch 🕵️ [heyo (net11.0-ios)] Invoking metadata update handlers.
dotnet watch 🕵️ [heyo (net11.0-ios)] System.Reflection.Metadata.RuntimeTypeMetadataUpdateHandler.ClearCache
dotnet watch 🕵️ [heyo (net11.0-ios)] Updates applied.
dotnet watch 🔥 [heyo (net11.0-ios)] Update batch #0 completed.
dotnet watch 🔥 C# and Razor changes applied in 567ms.
```

I can see it working on a net11.0-ios project in an iOS simulator:

<img width="480" height="588" alt="image" src="https://github.com/user-attachments/assets/9e5944ff-db11-4912-ae4d-48b53190b1da" />
