### PR TITLE
Fix SDK diff tests azure-devops extension install failure

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -29,7 +29,7 @@ jobs:
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
   steps:
   - script: |
-      # Allow implicit installation of the Azure DevOps extension to use dnceng feed
+      # Pre-install the Azure DevOps extension using the dnceng PyPI feed for dependency resolution under network isolation
       az extension add --name azure-devops \
         --pip-extra-index-urls https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-pypi/pypi/simple/
       

--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -29,6 +29,10 @@ jobs:
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
   steps:
   - script: |
+      # Allow implicit installation of the Azure DevOps extension to use dnceng feed
+      az extension add --name azure-devops \
+        --pip-extra-index-urls https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-pypi/pypi/simple/
+      
       dotnet_dotnet_build='${{ replace(parameters.dotnetDotnetRunId, ' ', '') }}'
 
       if [[ -z "$dotnet_dotnet_build" ]]; then


### PR DESCRIPTION
The sdk-diff-tests pipeline's 'Find associated builds' step was failing because the az CLI's azure-devops extension could not be installed. The extension was being implicitly installed on first use via az CLI's dynamic install feature, which invokes pip to download the extension and its dependencies. However, pip was unable to download the 'distro' dependency (required by azure-devops 1.0.3) because the 1ES pipeline template's network isolation blocks outbound connections to pypi.org.

Fix this by explicitly installing the azure-devops extension with --pip-extra-index-urls pointing to the dnceng internal PyPI feed (dotnet-public-pypi), which is accessible within network isolation.