### PR TITLE
Fix BuildWorkloadMsis failure by explicitly packing manifests in graph mode

### DIFF
--- a/src/Workloads/VSInsertion/workloads.csproj
+++ b/src/Workloads/VSInsertion/workloads.csproj
@@ -208,6 +208,19 @@
           UseHardlinksIfPossible="true" />
   </Target>
 
+  <!-- In graph build mode (.slnx), the Traversal SDK's Pack target in manifest-packages.csproj
+       is skipped because it has Condition="'$(IsGraphBuild)' != 'true'". The graph scheduler is
+       supposed to dispatch Pack to the child .Manifest.proj projects via ProjectReferenceTargets,
+       but the graph builder does not discover them. Explicitly invoke Pack here without IsGraphBuild
+       so the Traversal SDK's Pack target executes normally. -->
+  <Target Name="_PackManifestPackages"
+          BeforeTargets="BuildWorkloadMsis"
+          Condition="'$(BuildWorkloads)' == 'true' and '$(DotNetBuild)' != 'true' and '$(IsGraphBuild)' == 'true'">
+    <MSBuild Projects="$(RepoRoot)src\Workloads\Manifests\manifest-packages.csproj"
+             Targets="Pack"
+             RemoveProperties="IsGraphBuild" />
+  </Target>
+
   <Target Name="BuildWorkloadMsis"
           Condition="'$(BuildWorkloads)' == 'true' and '$(DownloadWorkloadMsis)' != 'true'">
     <ItemGroup>


### PR DESCRIPTION


The Traversal SDK's Pack target in manifest-packages.csproj has a condition that skips execution when IsGraphBuild=true, relying on the graph scheduler to dispatch Pack to child .Manifest.proj projects via ProjectReferenceTargets. However, the graph builder does not discover these child projects, so the manifest nupkg files are never produced, causing BuildWorkloadMsis to fail with 'Could not find expected manifest packages'.

Add a _PackManifestPackages target that explicitly invokes Pack on manifest-packages.csproj with RemoveProperties=IsGraphBuild so the Traversal SDK's Pack target executes normally. This target only runs in graph build mode; non-graph builds continue to work via the existing ProjectReference.