### PR TITLE
Fix license scan exclusion regex to match ignore patterns at any depth

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -226,7 +226,7 @@ public class LicenseScanTests : TestBase
             string lookaheads = string.Join("", additionalIgnorePatterns.Select(p =>
             {
                 string prefix = p.TrimEnd('*').TrimEnd('/');
-                return $"(?!{Regex.Escape(prefix)}/)";
+                return $"(?!(?:.*/)?{Regex.Escape(prefix)}/)";
             }));
             exclusionRegex += lookaheads;
         }


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/6172