### PR TITLE
Fix flaky SucceedsWithWarningOnLockedFile test

### DIFF
--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    public class GivenAGetDependsOnNETStandardTask
+    public class GivenAGetDependsOnNETStandardTask(ITestOutputHelper log) : SdkTest(log)
     {
         [Fact]
         public void CanCheckThisAssembly()
@@ -121,10 +121,27 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         [Fact]
         public void SucceedsWithWarningOnLockedFile()
         {
-            var lockedFile = $"{nameof(SucceedsWithWarningOnLockedFile)}.dll";
+            var testDir = TestAssetsManager.CreateTestDirectory();
+            var lockedFile = Path.Combine(testDir.Path, $"{nameof(SucceedsWithWarningOnLockedFile)}.dll");
 
-            try
+            // Create file with exclusive lock (no sharing)
+            using (var fileHandle = new FileStream(lockedFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
+                // Verify the lock is actually held before running the task.
+                // On some CI machines, antimalware or file system filters can
+                // interfere with file locking, causing the test to be unreliable.
+                try
+                {
+                    using var probe = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    Assert.Fail(
+                        "File lock is not being enforced — the probe open should have thrown IOException. " +
+                        "This may indicate antimalware or file system filter interference on this machine.");
+                }
+                catch (IOException)
+                {
+                    // Expected — the lock is working correctly
+                }
+
                 var task = new GetDependsOnNETStandard()
                 {
                     BuildEngine = new MockBuildEngine(),
@@ -132,17 +149,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     References = new[] { new MockTaskItem() { ItemSpec = lockedFile } }
                 };
 
-                // create file with no sharing
-                using (var fileHandle = new FileStream(lockedFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
-                {
-                    task.Execute().Should().BeTrue();
-                    task.DependsOnNETStandard.Should().BeFalse();
-                    ((MockBuildEngine)task.BuildEngine).Warnings.Count.Should().BeGreaterThan(0);
-                }
-            }
-            finally
-            {
-                File.Delete(lockedFile);
+                task.Execute().Should().BeTrue();
+                task.DependsOnNETStandard.Should().BeFalse();
+                ((MockBuildEngine)task.BuildEngine).Warnings.Count.Should().BeGreaterThan(0);
             }
         }
     }

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Reflection;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
@@ -122,17 +123,18 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         public void SucceedsWithWarningOnLockedFile()
         {
             var testDir = TestAssetsManager.CreateTestDirectory();
-            var lockedFile = Path.Combine(testDir.Path, $"{nameof(SucceedsWithWarningOnLockedFile)}.dll");
+            var lockedFileName = $"{nameof(SucceedsWithWarningOnLockedFile)}.dll";
+            var lockedFilePath = Path.Combine(testDir.Path, lockedFileName);
 
             // Create file with exclusive lock (no sharing)
-            using (var fileHandle = new FileStream(lockedFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            using (var fileHandle = new FileStream(lockedFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
                 // Verify the lock is actually held before running the task.
                 // On some CI machines, antimalware or file system filters can
                 // interfere with file locking, causing the test to be unreliable.
                 try
                 {
-                    using var probe = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    using var probe = new FileStream(lockedFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     Assert.Fail(
                         "File lock is not being enforced — the probe open should have thrown IOException. " +
                         "This may indicate antimalware or file system filter interference on this machine.");
@@ -145,8 +147,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 var task = new GetDependsOnNETStandard()
                 {
                     BuildEngine = new MockBuildEngine(),
-                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
-                    References = new[] { new MockTaskItem() { ItemSpec = lockedFile } }
+                    TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(testDir.Path),
+                    References = new[] { new MockTaskItem() { ItemSpec = lockedFileName } }
                 };
 
                 task.Execute().Should().BeTrue();


### PR DESCRIPTION
## Summary

Fixes the intermittent `SucceedsWithWarningOnLockedFile` test failure tracked by #53870.

This test has been failing ~12 times per month on Windows CI (`windows.amd64.vs2026.pre.scout.open`), with the assertion `Warnings.Count == 0` — meaning the expected `IOException` from the file lock was never thrown and no warning was logged by the task.

## Root Cause Analysis

The test created a locked file using a **relative path** (`SucceedsWithWarningOnLockedFile.dll`) resolved against the process working directory. The `GetDependsOnNETStandard` task resolves reference paths via `TaskEnvironment.GetAbsolutePath()`, which combines the path with `ProjectDirectory` (captured from `Directory.GetCurrentDirectory()` at construction time).

When xUnit runs test collections in parallel (4+ threads sharing the same process), the working directory state can become unreliable. If the absolute path resolved by the task differs from where the test actually created the locked file, `File.Exists()` returns `false` and the task skips the file entirely — producing zero warnings instead of the expected `IOException`-triggered warning.

Additionally, on Windows CI machines, antimalware mini-filter drivers (e.g., Windows Defender) can interfere with file locking on newly created `.dll` files, potentially allowing a second file handle to open despite `FileShare.None`.

## Changes

1. **Use absolute paths in an isolated temp directory**: Replace the relative-path file creation with `TestAssetsManager.CreateTestDirectory()`, which creates a unique temp directory with an absolute path. This eliminates any dependency on the process working directory.

2. **Add lock-verification probe**: Before running the task, a probe attempts to open the locked file with `FileAccess.Read`. If the probe succeeds (meaning the exclusive lock is not being enforced), the test fails immediately with a clear diagnostic message rather than proceeding to a misleading `Warnings.Count == 0` failure.

3. **Extend from SdkTest**: The test class now extends `SdkTest` to use standard test infrastructure (`TestAssetsManager`).

Fixes #53870