### PR TITLE
Drop netstandard2.0 support from template engine

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,6 @@
     <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
     <AzureMonitorOpenTelemetryExporterPackageVersion>1.4.0</AzureMonitorOpenTelemetryExporterPackageVersion>
     <OpenTelemetryVersion>1.12.0</OpenTelemetryVersion>
-    <NugetNetStandardCompatibleVersion>6.13.2</NugetNetStandardCompatibleVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="MicroBuild.Core version">

--- a/src/TemplateEngine/Directory.Build.props
+++ b/src/TemplateEngine/Directory.Build.props
@@ -8,14 +8,6 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419;0649</NoWarn>
 
-    <!--
-      TemplateEngine projects target netstandard2.0 and pin NuGet packages to an older
-      netstandard-compatible version via VersionOverride. Disable transitive pinning so
-      transitive NuGet deps also resolve to the older version instead of being pulled up
-      to the repo-wide 7.x by CentralPackageTransitivePinningEnabled.
-    -->
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-
     <!-- TemplateEngine assembly signing -->
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <TemplateEnginePublicKey>0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb</TemplateEnginePublicKey>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Contracts for extending Template Engine</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Contracts for extending Microsoft.TemplateEngine.Core</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Helper package for adding Template Engine to consuming applications</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
@@ -30,13 +30,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <!--
-      This project targets netstandard2.0, but the latest NuGet packages used by the rest of the SDK
-      have dropped netstandard support. VersionOverride pins these to an older netstandard-compatible version.
-    -->
-    <PackageReference Include="NuGet.Configuration" VersionOverride="$(NugetNetStandardCompatibleVersion)" />
-    <PackageReference Include="NuGet.Credentials" VersionOverride="$(NugetNetStandardCompatibleVersion)" />
-    <PackageReference Include="NuGet.Protocol" VersionOverride="$(NugetNetStandardCompatibleVersion)" />
+    <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Credentials" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 

--- a/src/TemplateEngine/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Helper package for adding Template Engine to IDEs</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>An extension for Template Engine that allows projects that still run to be used as templates</Description>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Components used by all Template Engine extensions and consumers</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>

--- a/src/TemplateEngine/Shared/IsExternalInit.cs
+++ b/src/TemplateEngine/Shared/IsExternalInit.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NETSTANDARD || NETFRAMEWORK
+#if NETFRAMEWORK
 
 using System.ComponentModel;
 

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.TemplateLocalizer.Core/Microsoft.TemplateEngine.TemplateLocalizer.Core.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.TemplateLocalizer.Core/Microsoft.TemplateEngine.TemplateLocalizer.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent);netstandard2.0;$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>The core API for Template Localizer tool.</Description>
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## Summary

Drop `netstandard2.0` from all template engine project `TargetFrameworks`. This is a **breaking change** for .NET 11.

## Motivation

NuGet dropped netstandard support starting with version 7.0. `Microsoft.TemplateEngine.Edge` depends on NuGet packages (`NuGet.Configuration`, `NuGet.Credentials`, `NuGet.Protocol`), which made it increasingly difficult to maintain netstandard2.0 compatibility — the project had to pin these packages to older versions via `VersionOverride` using `NugetNetStandardCompatibleVersion`, and disable `CentralPackageTransitivePinningEnabled` to prevent transitive deps from being pulled up to the repo-wide 7.x versions.

After discussion with @baronfel, we agreed to make this breaking change in .NET 11.

## Changes

- **8 csproj files**: Removed `netstandard2.0` from `TargetFrameworks` (Abstractions, Core, Core.Contracts, Edge, IDE, Orchestrator.RunnableProjects, Utils, TemplateLocalizer.Core)
- **Edge.csproj**: Removed `VersionOverride="$(NugetNetStandardCompatibleVersion)"` from NuGet package references and associated comment
- **eng/Versions.props**: Removed `NugetNetStandardCompatibleVersion` property (no longer needed)
- **Directory.Build.props**: Removed `CentralPackageTransitivePinningEnabled=false` workaround and associated comment
- **IsExternalInit.cs**: Simplified polyfill guard from `#if NETSTANDARD || NETFRAMEWORK` to `#if NETFRAMEWORK`

## Remaining targets

All 8 projects now target: `$(NetMinimum)`, `$(NetCurrent)`, `$(NetFrameworkToolCurrent)`