### PR TITLE
Tighten stale issue and PR thresholds

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/stale@v9 # https://github.com/actions/stale/blob/v9/README.md
         with:
           ascending: true # Process the oldest issues first
-          stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'Stale'. It will be closed if no further activity occurs within 30 more days. Any new comment will remove the label."
+          stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'Stale'. It will be closed if no further activity occurs within 14 more days. Any new comment will remove the label."
           stale-pr-message: "Due to lack of recent activity, this PR has been labeled as 'Stale'. It will be closed if no further activity occurs within 7 more days. Any new comment will remove the label."
-          days-before-issue-stale: 1827 # ~5 years
-          days-before-issue-close: 30
-          days-before-pr-stale: 180 # 6 months
+          days-before-issue-stale: 1644 # ~4.5 years
+          days-before-issue-close: 14
+          days-before-pr-stale: 120 # ~4 months
           days-before-pr-close: 7
           operations-per-run: 4000


### PR DESCRIPTION
## Summary

Reduce the stale thresholds as a first step toward more aggressive cleanup of inactive issues and PRs.

## Changes

| Threshold | Before | After |
|-----------|--------|-------|
| Issues stale after | 5 years (1827 days) | 4.5 years (1644 days) |
| Days before stale issue closed | 30 days | 14 days |
| PRs stale after | 6 months (180 days) | 4 months (120 days) |
| Days before stale PR closed | 7 days | 7 days (unchanged) |

## Plan

This is the first step in a gradual tightening. In approximately one month, we plan to ratchet these down further to 4 years for issues and 2 months for PRs.

Related to https://github.com/dotnet/sdk/issues/54044.