### PR TITLE
Enable packaging of dotnet-aot

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -539,13 +539,15 @@
       <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
 
       <_DotnetAotPublishDir>$(ArtifactsBinDir)dotnet-aot-redist\$(Configuration)\$(SdkTargetFramework)\$(TargetRid)\publish\</_DotnetAotPublishDir>
+      <!-- Use separate intermediate directory to avoid restore conflicts with main build -->
+      <_DotnetAotIntermediateDir>$(ArtifactsObjDir)dotnet-aot-redist\$(Configuration)\$(TargetRid)\</_DotnetAotIntermediateDir>
     </PropertyGroup>
 
     <!-- Restore and publish the dotnet-aot project as a NativeAOT shared library -->
     <MSBuild
       Targets="Restore;Publish"
       Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);IntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -525,10 +525,11 @@
     them entirely in native code, falling back to the managed dotnet.dll for other commands.
     The output is placed next to dotnet.dll so it's packaged with the SDK.
 
-    Only runs for RIDs where NativeAOT is supported (Windows, Linux, macOS).
+    Only runs for native builds (TargetRid == HostRid) on supported platforms.
+    Cross-compilation is not supported as NativeAOT requires native toolchain for target platform.
   -->
   <Target Name="PublishDotnetAot"
-          Condition="$(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx'))">
+          Condition="'$(TargetRid)' == '$(HostRid)' and ($(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx')))">
     <PropertyGroup>
       <!-- Define platform-specific native library naming -->
       <_DotnetAotNativeLibPrefix Condition="'$(OSName)' != 'win'">lib</_DotnetAotNativeLibPrefix>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -519,14 +519,62 @@
     <Copy SourceFiles="@(NativeRestoredAppHostNETCore)" DestinationFolder="$(AppHostTemplatePath)" SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Publish the dotnet-aot NativeAOT shared library.
+    This provides fast CLI startup for simple commands (e.g. version, info) by handling
+    them entirely in native code, falling back to the managed dotnet.dll for other commands.
+    The output is placed next to dotnet.dll so it's packaged with the SDK.
+
+    Only runs for RIDs where NativeAOT is supported (Windows, Linux, macOS).
+  -->
+  <Target Name="PublishDotnetAot"
+          Condition="$(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx'))">
+    <PropertyGroup>
+      <!-- Define platform-specific native library naming -->
+      <_DotnetAotNativeLibPrefix Condition="'$(OSName)' != 'win'">lib</_DotnetAotNativeLibPrefix>
+      <_DotnetAotNativeLibExtension Condition="'$(OSName)' == 'win'">.dll</_DotnetAotNativeLibExtension>
+      <_DotnetAotNativeLibExtension Condition="'$(OSName)' == 'osx'">.dylib</_DotnetAotNativeLibExtension>
+      <_DotnetAotNativeLibExtension Condition="'$(_DotnetAotNativeLibExtension)' == ''">.so</_DotnetAotNativeLibExtension>
+      <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
+
+      <_DotnetAotPublishDir>$(ArtifactsBinDir)dotnet-aot-redist\$(Configuration)\$(SdkTargetFramework)\$(TargetRid)\publish\</_DotnetAotPublishDir>
+    </PropertyGroup>
+
+    <!-- Restore and publish the dotnet-aot project as a NativeAOT shared library -->
+    <MSBuild
+      Targets="Restore;Publish"
+      Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
+
+    <!-- Verify the native library was produced -->
+    <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"
+           Text="dotnet-aot native library not found at '$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)'. NativeAOT publish may have failed for RID '$(TargetRid)'." />
+
+    <!-- Copy the native library to the SDK output directory -->
+    <Copy
+      SourceFiles="$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)"
+      DestinationFolder="$(OutputPath)"
+      SkipUnchangedFiles="true" />
+  </Target>
+
   <Target Name="ChmodPublishDir"
           DependsOnTargets="GenerateCliRuntimeConfigurationFiles;CreateMSBuildAppHost"
           Condition="'$(OSName)' != 'win'">
+    <PropertyGroup>
+      <!-- Recompute native lib name for chmod (same logic as PublishDotnetAot) -->
+      <_DotnetAotNativeLibPrefix Condition="'$(OSName)' != 'win'">lib</_DotnetAotNativeLibPrefix>
+      <_DotnetAotNativeLibExtension Condition="'$(OSName)' == 'osx'">.dylib</_DotnetAotNativeLibExtension>
+      <_DotnetAotNativeLibExtension Condition="'$(_DotnetAotNativeLibExtension)' == ''">.so</_DotnetAotNativeLibExtension>
+      <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
+    </PropertyGroup>
 
     <Exec Command="find $(OutputPath) -type d -exec chmod 755 {} \;" />
     <Exec Command="find $(OutputPath) -type f -exec chmod 644 {} \;" />
     <Exec Command="chmod 755 %(_RoslynAppHost.RootDir)%(_RoslynAppHost.Directory)%(_RoslynAppHost.Filename)" />
     <Exec Command="chmod 755 %(_MSBuildAppHost.RootDir)%(_MSBuildAppHost.Directory)%(_MSBuildAppHost.Filename)" />
+    <!-- Make dotnet-aot native shared library executable (only if it exists for this RID) -->
+    <Exec Command="chmod 755 $(OutputPath)$(_DotnetAotNativeLibName)"
+          Condition="Exists('$(OutputPath)$(_DotnetAotNativeLibName)')" />
   </Target>
 
   <Target Name="DeleteSymbolsFromPublishDir" DependsOnTargets="GenerateCliRuntimeConfigurationFiles">
@@ -574,6 +622,7 @@
                             GeneratePackagePruneData;
                             PublishContainersSdk;
                             GenerateCliRuntimeConfigurationFiles;
+                            PublishDotnetAot;
                             CreateMSBuildAppHost;
                             MakeFscRunnableAndMoveToPublishDir;
                             RemoveFscFilesAfterPublish;

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -558,15 +558,8 @@
   </Target>
 
   <Target Name="ChmodPublishDir"
-          DependsOnTargets="GenerateCliRuntimeConfigurationFiles;CreateMSBuildAppHost"
+          DependsOnTargets="GenerateCliRuntimeConfigurationFiles;CreateMSBuildAppHost;PublishDotnetAot"
           Condition="'$(OSName)' != 'win'">
-    <PropertyGroup>
-      <!-- Recompute native lib name for chmod (same logic as PublishDotnetAot) -->
-      <_DotnetAotNativeLibPrefix Condition="'$(OSName)' != 'win'">lib</_DotnetAotNativeLibPrefix>
-      <_DotnetAotNativeLibExtension Condition="'$(OSName)' == 'osx'">.dylib</_DotnetAotNativeLibExtension>
-      <_DotnetAotNativeLibExtension Condition="'$(_DotnetAotNativeLibExtension)' == ''">.so</_DotnetAotNativeLibExtension>
-      <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
-    </PropertyGroup>
 
     <Exec Command="find $(OutputPath) -type d -exec chmod 755 {} \;" />
     <Exec Command="find $(OutputPath) -type f -exec chmod 644 {} \;" />


### PR DESCRIPTION
This PR adds the dotnet-aot NativeAOT shared library to the SDK packaging pipeline.
 
## Changes
 
- Added `PublishDotnetAot` target in `GenerateLayout.targets` that:
  - Restores and publishes `dotnet-aot.csproj` as a NativeAOT shared library
  - Handles platform-specific naming (Windows: `dotnet-aot.dll`, Linux: `libdotnet-aot.so`, macOS: 
`libdotnet-aot.dylib`)
  - Copies the output to the SDK layout directory alongside `dotnet.dll`
 
- Updated `ChmodPublishDir` target to set executable permissions on the native library for Linux/macOS
 
- Added `PublishDotnetAot` to the `GenerateSdkLayout` target dependency chain
 
## Result
 
The dotnet-aot native library is now packaged with the SDK and will be included in Windows MSI, Linux deb/rpm, and macOS pkg installers.
