### PR TITLE
Design document: Installing daily/nightly builds with dotnetup

### DIFF
--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -297,12 +297,15 @@ as channel qualifiers (e.g., `10.0/signed`).
 Changes needed:
 - Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `.../daily` suffix parsing
 - Add `IsValidChannelFormat()` support for `.../daily` channels
-- Create a `DailyBuildVersionResolver` that queries `aka.ms` / `latest.version` files
-- Extend `DotnetArchiveDownloader` with a blob-storage download path that constructs URLs from
-  version strings rather than release manifest entries
-- Add hash fetching from `{url}.sha512` companion files
+- Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms
+  redirect to discover the latest version (the `InstallWorkflow` doesn't need to change —
+  it already calls `Resolve()` and gets back a version)
+- Extend `IArchiveDownloader` / `DotnetArchiveDownloader` to handle versions that aren't in the
+  release manifest — when the channel is daily, construct the download URL from the blob feed
+  and fetch the hash from the `{url}.sha512` companion file instead of the release manifest
+  (the `InstallWorkflow` already calls `DownloadArchiveWithVerification` — it doesn't need
+  to know where the archive comes from)
 - Add host allowlist for blob feed redirect validation
-- Wire daily channel detection through `InstallWorkflow` to use the daily resolver and downloader
 
 ### Phase 2: Specific prerelease version fallback
 

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -50,7 +50,9 @@ dotnetup runtime install 10.0-daily
 When the user provides a fully-specified prerelease version (e.g., `10.0.100-preview.7.25351.1`),
 dotnetup first checks the release manifest, then falls back to the daily build feed. This fallback
 only applies to **prerelease** version strings — stable versions not in the manifest produce an
-error.
+error. This means `global.json` files specifying daily build versions work naturally — dotnetup
+detects the prerelease version and falls back to the daily feed without requiring explicit
+configuration.
 
 ## Background: How daily builds work today
 
@@ -73,12 +75,21 @@ that points directly to the **archive file** (not a version file):
 https://aka.ms/dotnet/{channel}/{quality}/dotnet-sdk-{os}-{arch}.tar.gz
 ```
 
+The same pattern applies to all components, with different archive prefixes:
+- SDK: `dotnet-sdk-{os}-{arch}.{ext}`
+- .NET Runtime: `dotnet-runtime-{os}-{arch}.{ext}`
+- ASP.NET Core: `aspnetcore-runtime-{os}-{arch}.{ext}`
+- Windows Desktop: `windowsdesktop-runtime-{os}-{arch}.{ext}`
+
 This aka.ms link returns a 301 redirect to the actual blob storage URL, which embeds the
 resolved version in the path:
 ```
 https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.tar.gz
+https://ci.dot.net/public/Runtime/{version}/dotnet-runtime-{version}-{os}-{arch}.zip
 ```
 
+Note that runtime versions differ from SDK versions (e.g., SDK `10.0.109` corresponds to
+runtime `10.0.9`), so version extraction from the redirect URL must account for the component.
 The script extracts the version from the redirect URL path. This is the **only** mechanism used
 when `--quality` is specified — there is no fallback to `latest.version` files.
 
@@ -360,42 +371,34 @@ configuration.
 
 ## Open questions
 
-1. **How should `global.json` interact with daily builds?** If a `global.json` specifies a daily
-   build version, should `dotnetup` automatically try the daily feed? Or should it require explicit
-   configuration?
-
-2. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
+1. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
    a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
    this should be treated as an advanced/untrusted mode.
 
-3. **Runtime transport package**: With the VMR, all components version together, so any
+2. **Runtime transport package**: With the VMR, all components version together, so any
    VMR-produced package can serve as the version index. A candidate like
    `Microsoft.NETCore.App.Runtime.{rid}` would work — the specific choice just needs to be
    a package reliably published for every daily build.
 
-4. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
+3. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
    User research / PM input would be valuable here.
 
-5. **Runtime daily builds**: Do daily builds of the runtime follow the same aka.ms URL patterns
-   and blob feed structure as the SDK? The download URLs likely differ (e.g., `dotnet-runtime-`
-   instead of `dotnet-sdk-`), but the version discovery mechanism should be similar.
-
-6. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
+4. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
    redirects? Need to enumerate all legitimate blob storage hosts used by the .NET build
    infrastructure.
 
-7. **Feed retry order**: What is the exact primary/fallback retry order across
+5. **Feed retry order**: What is the exact primary/fallback retry order across
    `builds.dotnet.microsoft.com` and `ci.dot.net/public`? Should we always try primary first,
    or use both in parallel?
 
-8. **Channel separator**: This document uses `-` as the separator (`10.0-daily`). The `-` syntax
+6. **Channel separator**: This document uses `-` as the separator (`10.0-daily`). The `-` syntax
    is simpler and aligns with prerelease version tag conventions. There is no ambiguity with
    version strings because channels use major.minor (2 components) or feature bands with wildcards
    (`10.0.1xx`), while versions always have 3+ numeric components. An alternative is `/`
    (`10.0/daily`), which mirrors URL path structure but may conflict with file path parsing on
    some platforms.
 
-9. **Other quality levels**: The .NET build pipeline has quality levels beyond `daily`:
+7. **Other quality levels**: The .NET build pipeline has quality levels beyond `daily`:
    `daily → signed → validated → preview → ga`. Should dotnetup support `10.0-signed` or
    `10.0-validated` channels? `signed` builds are code-signed but not fully validated —
    they may be useful for users who want pre-release builds with signature verification.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -86,7 +86,7 @@ Is version specific (e.g. "10.0.100-preview.7.25351.1")?
 ### Core principle: daily builds are just channels
 
 Rather than introducing a separate `--quality` flag, daily builds are expressed as **channel names**
-in dotnetup. This keeps the mental model simple: every install is `dnup sdk install <channel>`,
+in dotnetup. This keeps the mental model simple: every install is `dotnetup sdk install <channel>`,
 and daily channels are just another kind of channel alongside `latest`, `preview`, `lts`, etc.
 
 ### Terminology
@@ -129,19 +129,19 @@ with the version scope and optionally narrow it.
 
 ```bash
 # Install the latest daily SDK build
-dnup sdk install daily
+dotnetup sdk install daily
 
 # Install the latest daily SDK for .NET 10.0
-dnup sdk install 10.0/daily
+dotnetup sdk install 10.0/daily
 
 # Install the latest daily SDK for the 10.0.1xx feature band
-dnup sdk install 10.0.1xx/daily
+dotnetup sdk install 10.0.1xx/daily
 
 # Install a specific daily build by its full version string
-dnup sdk install 10.0.100-preview.7.25351.1
+dotnetup sdk install 10.0.100-preview.7.25351.1
 
 # Daily runtime builds follow the same pattern
-dnup runtime install 10.0/daily
+dotnetup runtime install 10.0/daily
 ```
 
 #### Specific version fallback
@@ -234,10 +234,10 @@ reads install specs.
 ### Update behavior
 
 **Daily channel installs support updates**, just like any other tracked channel. Running
-`dnup sdk update` will re-resolve the `10.0/daily` channel against the blob feed and install
+`dotnetup sdk update` will re-resolve the `10.0/daily` channel against the blob feed and install
 a newer version if available.
 
-**Specific-version daily installs** (e.g., `dnup sdk install 10.0.100-preview.7.25351.1`)
+**Specific-version daily installs** (e.g., `dotnetup sdk install 10.0.100-preview.7.25351.1`)
 are point-in-time snapshots. They record the exact version as the channel, so there's nothing
 to "update to" — same as installing a specific released version today.
 
@@ -254,7 +254,7 @@ Mitigations:
   (`builds.dotnet.microsoft.com`, `ci.dot.net`). Redirects to unexpected hosts should be rejected.
 - **TLS-only**: All feed communication must be over HTTPS.
 - **Transparency**: dotnetup should clearly indicate when an install came from a daily build feed
-  rather than the release manifest (e.g., in `dnup list` output and installation messages).
+  rather than the release manifest (e.g., in `dotnetup list` output and installation messages).
 - **Future**: If independent signature verification is added (e.g., verifying the Authenticode
   signature on the extracted binaries), this would strengthen the trust model for daily builds.
 
@@ -292,7 +292,7 @@ as channel qualifiers (e.g., `10.0/signed`).
 
 ### Phase 1: Daily channel parsing and blob-feed download
 
-**Goal**: `dnup sdk install 10.0/daily` resolves and installs the latest daily build.
+**Goal**: `dotnetup sdk install 10.0/daily` resolves and installs the latest daily build.
 
 Changes needed:
 - Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `.../daily` suffix parsing
@@ -309,7 +309,7 @@ Changes needed:
 
 ### Phase 2: Specific prerelease version fallback
 
-**Goal**: `dnup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
+**Goal**: `dotnetup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
 
 Changes needed:
 - Modify `InstallWorkflow.ResolveSpec()` to fall back to blob storage when the release manifest
@@ -330,7 +330,7 @@ The feasibility depends on what listing/enumeration APIs are available from the 
 ## Open questions
 
 1. **How should `global.json` interact with daily builds?** If a `global.json` specifies a daily
-   build version, should `dnup` automatically try the daily feed? Or should it require explicit
+   build version, should `dotnetup` automatically try the daily feed? Or should it require explicit
    configuration?
 
 2. **Should there be a `--feed` override?** For internal scenarios, users might want to point at

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -290,30 +290,30 @@ as channel qualifiers (e.g., `10.0/signed`).
 
 ## Implementation phases
 
-### Phase 1: Daily channel parsing and blob-feed download
+### Phase 1: Specific prerelease version install from blob feed
+
+**Goal**: `dotnetup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
+
+This is the simplest starting point — the user provides the exact version, so no version discovery
+is needed. We just need the blob-feed download path:
+- Extend `IArchiveDownloader` / `DotnetArchiveDownloader` to handle versions that aren't in the
+  release manifest — construct the download URL from the blob feed and fetch the hash from the
+  `{url}.sha512` companion file (`InstallWorkflow` already calls `DownloadArchiveWithVerification`
+  — it doesn't need to know where the archive comes from)
+- Add host allowlist for blob feed redirect validation
+- Modify version resolution to fall back to blob storage when the release manifest doesn't
+  contain the requested prerelease version
+
+### Phase 2: Daily channel parsing and latest version resolution
 
 **Goal**: `dotnetup sdk install 10.0/daily` resolves and installs the latest daily build.
 
-Changes needed:
+Builds on Phase 1's blob-feed download path by adding version discovery:
 - Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `.../daily` suffix parsing
 - Add `IsValidChannelFormat()` support for `.../daily` channels
 - Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms
   redirect to discover the latest version (the `InstallWorkflow` doesn't need to change —
   it already calls `Resolve()` and gets back a version)
-- Extend `IArchiveDownloader` / `DotnetArchiveDownloader` to handle versions that aren't in the
-  release manifest — when the channel is daily, construct the download URL from the blob feed
-  and fetch the hash from the `{url}.sha512` companion file instead of the release manifest
-  (the `InstallWorkflow` already calls `DownloadArchiveWithVerification` — it doesn't need
-  to know where the archive comes from)
-- Add host allowlist for blob feed redirect validation
-
-### Phase 2: Specific prerelease version fallback
-
-**Goal**: `dotnetup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
-
-Changes needed:
-- Modify `InstallWorkflow.ResolveSpec()` to fall back to blob storage when the release manifest
-  doesn't contain the requested prerelease version (non-daily channel, prerelease tag present)
 - Reuse the blob-feed download path from Phase 1
 
 ### Phase 3: List and browse daily builds

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -325,7 +325,16 @@ SDK build, a `Microsoft.NET.Sdk` transport package is published with a version m
 version. This package isn't meant for direct consumption — it's an internal transport mechanism —
 but it provides a reliable index of available daily builds.
 
-- Query the NuGet V3 feed for available versions of `Microsoft.NET.Sdk` (for SDK daily builds)
+The feed URLs are calculated from the major version, not read from `NuGet.config`. The pattern is:
+```
+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet{major}-transport/nuget/v3/index.json
+```
+For example, to list .NET 11 daily builds, dotnetup queries the `dotnet11-transport` feed. These
+are public feeds (no authentication required). dotnetup uses the NuGet V3 protocol directly to
+enumerate package versions — it does not shell out to `dotnet nuget` or read project NuGet
+configuration.
+
+- Query the transport feed for available versions of `Microsoft.NET.Sdk` (for SDK daily builds)
 - For runtime daily builds, use a runtime transport package such as
   `Microsoft.NETCore.App.Runtime.{rid}`. With the VMR, all components version together, so any
   VMR-produced package can serve as the version index for a given daily build.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -326,8 +326,9 @@ version. This package isn't meant for direct consumption — it's an internal tr
 but it provides a reliable index of available daily builds.
 
 - Query the NuGet V3 feed for available versions of `Microsoft.NET.Sdk` (for SDK daily builds)
-- For runtime daily builds, use a different transport package (TBD — need to identify the right
-  package name per runtime component)
+- For runtime daily builds, use a runtime transport package such as
+  `Microsoft.NETCore.App.Runtime.{rid}`. With the VMR, all components version together, so any
+  VMR-produced package can serve as the version index for a given daily build.
 - Filter versions to the requested channel scope (e.g., `10.0/daily` → versions matching `10.0.*`)
 - Present available versions in a list, sorted by date/version
 - In interactive mode, offer a picker to select and install a specific daily version
@@ -342,9 +343,10 @@ but it provides a reliable index of available daily builds.
    a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
    this should be treated as an advanced/untrusted mode.
 
-3. **Runtime transport package**: For SDK daily builds, `Microsoft.NET.Sdk` is the transport
-   package to query for available versions. What is the equivalent package for runtime components
-   (e.g., `Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`)?
+3. **Runtime transport package**: With the VMR, all components version together, so any
+   VMR-produced package can serve as the version index. A candidate like
+   `Microsoft.NETCore.App.Runtime.{rid}` would work — the specific choice just needs to be
+   a package reliably published for every daily build.
 
 4. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
    User research / PM input would be valuable here.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -27,32 +27,52 @@ The `dotnet-install.sh` and `dotnet-install.ps1` scripts use a **quality + chann
 - **Channel**: A version band like `10.0`, `10.0.1xx`, `STS`, `LTS`, or a specific version
 - **Quality**: One of `daily`, `preview`, or `ga` (default)
 
-Quality combined with channel constructs a discovery URL:
+### Version discovery: two mechanisms
+
+The scripts use **two different mechanisms** for discovering versions, tried in order:
+
+#### 1. aka.ms redirect (primary, when quality is specified)
+
+When `--quality` is provided and the version is `latest`, the script constructs an aka.ms URL
+that points directly to the **archive file** (not a version file):
 ```
-https://aka.ms/dotnet/{channel}/{quality}/sdk-productVersion.txt
+https://aka.ms/dotnet/{channel}/{quality}/dotnet-sdk-{os}-{arch}.tar.gz
 ```
 
-This aka.ms redirect resolves to a blob on the primary build feed. The resolved version is then used
-to construct the download URL:
+This aka.ms link returns a 301 redirect to the actual blob storage URL, which embeds the
+resolved version in the path:
 ```
-{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.tar.gz
+https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.tar.gz
 ```
 
-### Build feeds
+The script extracts the version from the redirect URL path. This is the **only** mechanism used
+when `--quality` is specified — there is no fallback to `latest.version` files.
 
-Two feeds serve daily builds:
-1. **Primary**: `https://builds.dotnet.microsoft.com/dotnet`
-2. **Fallback**: `https://ci.dot.net/public`
+#### 2. `latest.version` file (legacy fallback, no quality)
 
-### Version discovery
-
-For a given channel and quality, the scripts fetch a `latest.version` file:
+When `--quality` is NOT specified, the script falls back to fetching a version file from the feed:
 ```
 {feed}/Sdk/{channel}/latest.version
 ```
 
-This file contains a single line with the latest version string for that channel
-(e.g., `10.0.100-preview.7.25351.1`).
+This file contains the latest version string. The script then constructs the download URL from
+the resolved version. This mechanism iterates over two feeds:
+1. **Primary**: `https://builds.dotnet.microsoft.com/dotnet`
+2. **Fallback**: `https://ci.dot.net/public`
+
+#### Decision logic
+
+```
+Is version "latest" AND quality specified?
+    → aka.ms redirect (direct to archive, version extracted from redirect URL)
+    → If quality specified and aka.ms fails, ERROR (no fallback)
+
+Is version "latest" AND no quality?
+    → latest.version file from feeds (legacy path)
+
+Is version specific (e.g. "10.0.100-preview.7.25351.1")?
+    → Use version directly, construct download URL from feed
+```
 
 ### Key constraints in the current model
 
@@ -156,11 +176,16 @@ User provides: channel
   └──────────────┘  └──────────────────────┘
 ```
 
-For daily channels, version resolution queries the build feed:
+For daily channels, version resolution uses the aka.ms redirect:
 1. Parse the channel: `10.0/daily` → base channel `10.0`, quality `daily`
-2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/sdk-productVersion.txt`
-3. Follow the redirect to get the latest version string
-4. Construct the download URL: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
+2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/dotnet-sdk-{os}-{arch}.tar.gz`
+3. Follow the redirect (301) to get the actual blob storage URL
+4. Extract the version from the redirect URL path
+5. Use the redirect URL directly as the download URL
+
+This matches how the `dotnet-install` scripts work — the aka.ms link resolves directly to the
+archive, and the version is parsed from the redirect target. No separate version-file fetch is
+needed.
 
 For a specific prerelease version that isn't in the release manifest:
 1. Construct the download URL directly from the version string

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -63,151 +63,155 @@ This file contains a single line with the latest version string for that channel
 
 ## Proposed design
 
+### Core principle: daily builds are just channels
+
+Rather than introducing a separate `--quality` flag, daily builds are expressed as **channel names**
+in dotnetup. This keeps the mental model simple: every install is `dnup sdk install <channel>`,
+and daily channels are just another kind of channel alongside `latest`, `preview`, `lts`, etc.
+
 ### Terminology
 
-We propose using **"daily"** as the primary term, matching the existing `dotnet-install` scripts'
-`--quality daily` parameter. The GitHub issue uses "nightly" which is more familiar to users of
-other ecosystems (Rust, Python, etc.), but aligning with the existing .NET infrastructure reduces
-confusion and implementation complexity.
+We use **"daily"** as the channel keyword, matching the existing `dotnet-install` scripts'
+quality level. The GitHub issue uses "nightly" which is more familiar in other ecosystems
+(Rust, Python), but "daily" aligns with the existing .NET build infrastructure.
 
 Alternative names considered:
-- **"nightly"**: More familiar to the broader developer community; could be used as a user-facing
-  alias even if the underlying quality is "daily"
-- **"prerelease"**: Too broad — preview releases are also pre-release but come from the release manifest
+- **"nightly"**: More community-friendly; could be added as an alias
 - **"ci"**: Accurate but less user-friendly
+- **"preview"**: Already used for official preview releases from the release manifest
 
-**Recommendation**: Use "daily" in the implementation and documentation to match `dotnet-install`.
-If user research indicates "nightly" resonates better, we can add it as an alias later.
+**Recommendation**: Use "daily" as the primary name. Consider "nightly" as an alias if user
+research shows it resonates better.
 
-### CLI syntax
+### Channel syntax
 
-#### Installing the latest daily build for a channel
+Daily channels follow the pattern `daily[/{version-scope}]`:
+
+| Channel | Meaning |
+|---------|---------|
+| `daily` | Latest daily build (latest major version) |
+| `daily/10.0` | Latest daily build for .NET 10.0 |
+| `daily/10.0.1xx` | Latest daily build for the 10.0.1xx feature band |
+
+This extends the existing channel vocabulary naturally:
+
+| Existing channels | Daily channels |
+|-------------------|---------------|
+| `latest` | `daily` |
+| `preview` | (already in release manifest) |
+| `lts` | (not applicable — daily builds aren't LTS) |
+| `10.0` | `daily/10.0` |
+| `10.0.1xx` | `daily/10.0.1xx` |
+
+### CLI examples
 
 ```bash
+# Install the latest daily SDK build
+dnup sdk install daily
+
 # Install the latest daily SDK for .NET 10.0
-dnup sdk install 10.0 --quality daily
+dnup sdk install daily/10.0
 
 # Install the latest daily SDK for the 10.0.1xx feature band
-dnup sdk install 10.0.1xx --quality daily
+dnup sdk install daily/10.0.1xx
 
-# Short form (if we want to support it)
-dnup sdk install daily/10.0
-```
-
-The `--quality` flag mirrors `dotnet-install`'s terminology and is the recommended approach.
-It composes naturally with the existing channel argument.
-
-The `daily/{channel}` short form is convenient but introduces a new syntax pattern. It could
-be supported as sugar that expands to `--quality daily`.
-
-#### Installing a specific daily build version
-
-```bash
 # Install a specific daily build by its full version string
 dnup sdk install 10.0.100-preview.7.25351.1
+
+# Daily runtime builds follow the same pattern
+dnup runtime install daily/10.0
 ```
 
-When the user provides a fully-specified version with a prerelease tag, dotnetup should:
+#### Specific version fallback
+
+When the user provides a fully-specified version with a prerelease tag (e.g.,
+`10.0.100-preview.7.25351.1`), dotnetup should:
 1. First, check the release manifest (it may be an officially published preview)
 2. If not found in the release manifest, attempt to download from the daily build feed
-
-This fallback behavior means users don't need to know whether a version is "released" or "daily" —
-they just provide the version string and dotnetup figures out where to get it.
 
 **Important constraint**: blob-feed fallback should only be attempted for **prerelease** version
 strings (versions containing a `-` prerelease tag). Stable version strings like `10.0.100` that
 aren't in the release manifest should produce a clear "version not found" error rather than probing
 blob storage — this avoids confusing behavior for typos like `10.0.999`.
 
-If `--quality daily` is explicitly provided alongside an exact version, that is an error
-(quality is only meaningful for "latest" resolution, matching the `dotnet-install` script behavior).
-
-#### Runtime installs
-
-```bash
-# Daily runtime builds follow the same pattern
-dnup runtime install 10.0 --quality daily
-```
-
 ### Version resolution
 
-A new resolution path is needed alongside the existing `ChannelVersionResolver`:
-
 ```
-User provides: channel + quality
-                    │
-                    ▼
-        ┌───────────────────────┐
-        │  Is quality specified? │
-        └───────┬───────┬───────┘
-                │       │
-            No  │       │  Yes (daily/preview)
-                ▼       ▼
-    ┌──────────────┐  ┌──────────────────────┐
-    │ Release       │  │ Daily build feed     │
-    │ manifest      │  │ (aka.ms / blob)      │
-    │ (existing)    │  │                      │
-    └──────────────┘  └──────────────────────┘
+User provides: channel
+        │
+        ▼
+  ┌─────────────────────┐
+  │ Is it a daily/...   │
+  │ channel?            │
+  └───────┬───────┬─────┘
+          │       │
+      No  │       │  Yes
+          ▼       ▼
+  ┌──────────────┐  ┌──────────────────────┐
+  │ Release       │  │ Daily build feed     │
+  │ manifest      │  │ (aka.ms / blob)      │
+  │ (existing)    │  │                      │
+  └──────────────┘  └──────────────────────┘
 ```
 
-For daily builds, version resolution queries the build feed:
-1. Construct the aka.ms URL: `https://aka.ms/dotnet/{channel}/{quality}/sdk-productVersion.txt`
-2. Follow the redirect to get the `latest.version` file content
-3. Parse the version string
+For daily channels, version resolution queries the build feed:
+1. Parse the channel: `daily/10.0` → base channel `10.0`, quality `daily`
+2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/sdk-productVersion.txt`
+3. Follow the redirect to get the latest version string
 4. Construct the download URL: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
 
 For a specific prerelease version that isn't in the release manifest:
-1. Construct the download URL directly: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
+1. Construct the download URL directly from the version string
 2. Verify the archive exists (HEAD request or attempt download)
 3. Fetch the hash from `{url}.sha512` for verification
 
+### Channel parsing in `UpdateChannel`
+
+The `UpdateChannel` class gains awareness of the `daily/` prefix:
+
+```csharp
+// New properties
+public bool IsDaily => Name.StartsWith("daily", StringComparison.OrdinalIgnoreCase);
+public string BaseChannel => IsDaily
+    ? Name.Contains('/') ? Name.Substring(Name.IndexOf('/') + 1) : "latest"
+    : Name;
+```
+
+The `Matches()` method for daily channels matches any version that would match the base channel.
+For example, `daily/10.0` matches any `10.0.x` version, just like `10.0` does today. The
+difference is only in how versions are **resolved** (blob feed vs release manifest) and
+**tracked** (daily install specs vs release install specs).
+
 ### Manifest tracking
 
-Daily builds need to be tracked in the dotnetup manifest so that:
-- `dnup list` shows them
-- `dnup remove` can remove them
-- The garbage collector knows about them
-
-A daily install should be recorded with enough information to identify its source:
+Daily builds are tracked in the dotnetup manifest just like any other channel:
 
 ```json
 {
-  "channel": "10.0",
-  "quality": "daily",
+  "channel": "daily/10.0",
   "version": "10.0.100-preview.7.25351.1",
-  "component": "sdk",
-  "feedKind": "daily-build"
+  "component": "sdk"
 }
 ```
 
-The `quality` and `feedKind` fields distinguish daily installs from release-manifest installs.
-(Note: the existing `InstallSource` field means something different — it tracks whether the
-install was triggered explicitly by the user vs. by `global.json`. We use `feedKind` to avoid
-naming confusion.)
+Because the channel name itself encodes the daily nature, no additional `quality` or `feedKind`
+fields are needed. The GC, update, and list logic can use the existing `channel` field to
+determine resolution behavior:
+- Channel starts with `daily/`? → resolve from blob feed
+- Otherwise → resolve from release manifest
 
-This distinction is important because:
-- The same version string might not exist in the release manifest
-- Update/GC logic must distinguish `{channel: "10.0", quality: "daily"}` from `{channel: "10.0"}`
-  (stable) — otherwise daily installs would be garbage-collected by stable channel rules
-- The download source is different
+This keeps the manifest schema unchanged and avoids needing to update every piece of code that
+reads install specs.
 
 ### Update behavior
 
-**Daily builds should not auto-update by default.** The issue author confirms this assumption:
-> "I assume we don't update specific nightlies."
+**Daily channel installs support updates**, just like any other tracked channel. Running
+`dnup sdk update` will re-resolve the `daily/10.0` channel against the blob feed and install
+a newer version if available.
 
-However, we should support explicit updates:
-```bash
-# Explicitly update to the latest daily for the tracked channel
-dnup sdk update --quality daily
-```
-
-When a user has an install spec like `{channel: "10.0", quality: "daily"}`, running `dnup sdk update`
-with `--quality daily` would resolve the latest daily for 10.0 and install it if newer.
-
-Install specs for daily builds should be recorded only when the user installs via channel + quality
-(not when they install a specific version). A specific-version daily install is a point-in-time
-snapshot and shouldn't imply ongoing tracking.
+**Specific-version daily installs** (e.g., `dnup sdk install 10.0.100-preview.7.25351.1`)
+are point-in-time snapshots. They record the exact version as the channel, so there's nothing
+to "update to" — same as installing a specific released version today.
 
 ### Security and trust model
 
@@ -243,43 +247,30 @@ No additional signature verification infrastructure is needed for daily builds.
 
 ## Implementation phases
 
-### Phase 1: Data model and source identity
+### Phase 1: Daily channel parsing and blob-feed download
 
-**Goal**: Introduce the concept of build quality and feed kind into the request/manifest/spec model.
-
-Changes needed:
-- Add `Quality` property to `InstallRequestOptions` (enum: `Ga`, `Preview`, `Daily`)
-- Add `FeedKind` property to install spec recording (enum: `ReleaseManifest`, `DailyBuild`)
-- Update `UpdateChannel` identity: a channel + quality pair must be distinct from the same channel
-  without quality, so update/remove/GC logic doesn't confuse daily and stable installs
-- Update manifest serialization to persist `quality` and `feedKind`
-- Update `dnup list` output to surface daily-build provenance
-
-### Phase 2: Install a specific daily build version
-
-**Goal**: `dnup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
+**Goal**: `dnup sdk install daily/10.0` resolves and installs the latest daily build.
 
 Changes needed:
+- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `daily/...` prefix parsing
+- Add `IsValidChannelFormat()` support for `daily/...` channels
+- Create a `DailyBuildVersionResolver` that queries `aka.ms` / `latest.version` files
 - Extend `DotnetArchiveDownloader` with a blob-storage download path that constructs URLs from
   version strings rather than release manifest entries
 - Add hash fetching from `{url}.sha512` companion files
 - Add host allowlist for blob feed redirect validation
-- Modify `InstallWorkflow.ResolveSpec()` to fall back to blob storage when the release manifest
-  doesn't contain the requested prerelease version
-- Track the install in the manifest with `feedKind: "daily-build"`
+- Wire daily channel detection through `InstallWorkflow` to use the daily resolver and downloader
 
-### Phase 3: Install latest daily for a channel
+### Phase 2: Specific prerelease version fallback
 
-**Goal**: `dnup sdk install 10.0 --quality daily` resolves and installs the latest daily build.
+**Goal**: `dnup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
 
 Changes needed:
-- Add `--quality` option to install commands (validate: incompatible with exact versions, `lts`, `sts`)
-- Create a `DailyBuildVersionResolver` (or extend `ChannelVersionResolver`) that queries
-  `aka.ms` / `latest.version` files
-- Wire quality through the install workflow
-- Record install spec with quality so updates can re-resolve from the daily feed
+- Modify `InstallWorkflow.ResolveSpec()` to fall back to blob storage when the release manifest
+  doesn't contain the requested prerelease version (non-daily channel, prerelease tag present)
+- Reuse the blob-feed download path from Phase 1
 
-### Phase 4: List and browse daily builds
+### Phase 3: List and browse daily builds
 
 **Goal**: Users can discover what daily builds are available.
 
@@ -292,37 +283,31 @@ The feasibility depends on what listing/enumeration APIs are available from the 
 
 ## Open questions
 
-1. **Should `dnup sdk install 10.0 --quality preview` also be supported?** The `dotnet-install`
-   scripts support `--quality preview` to get the latest preview build. This would be a natural
-   extension.
-
-2. **How should `global.json` interact with daily builds?** If a `global.json` specifies a daily
+1. **How should `global.json` interact with daily builds?** If a `global.json` specifies a daily
    build version, should `dnup` automatically try the daily feed? Or should it require explicit
    configuration?
 
-3. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
+2. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
    a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
    this should be treated as an advanced/untrusted mode.
 
-4. **What about listing daily builds (Phase 4)?** The blob storage doesn't have a natural listing
+3. **What about listing daily builds (Phase 3)?** The blob storage doesn't have a natural listing
    API. We may need to rely on version ranges or a separate index. This needs investigation.
 
-5. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
+4. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
    User research / PM input would be valuable here.
 
-6. **Runtime daily builds**: Do daily builds of the runtime follow the same feed structure?
+5. **Runtime daily builds**: Do daily builds of the runtime follow the same feed structure?
    Need to verify the URL patterns for runtime vs SDK daily downloads.
 
-7. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
+6. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
    redirects? Need to enumerate all legitimate blob storage hosts used by the .NET build
    infrastructure.
 
-8. **Feed retry order**: What is the exact primary/fallback retry order across
+7. **Feed retry order**: What is the exact primary/fallback retry order across
    `builds.dotnet.microsoft.com` and `ci.dot.net/public`? Should we always try primary first,
    or use both in parallel?
 
-9. **Invalid combinations**: What validation and error messages do we want for invalid combos
-   like `--quality daily` with `lts`, `sts`, or a fully specified version?
-
-10. **Distinguishing tracked channels**: How do we surface the difference between tracked `10.0`
-    (stable) vs tracked `10.0 --quality daily` in `dnup list`, `dnup remove`, and other commands?
+8. **Channel separator**: Is `daily/10.0` the best syntax? Alternatives include `daily:10.0`,
+   `daily-10.0`, or `10.0-daily`. The `/` syntax reads naturally ("daily builds of 10.0") but
+   may conflict with file path parsing on some platforms.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -320,12 +320,17 @@ Builds on Phase 1's blob-feed download path by adding version discovery:
 
 **Goal**: Users can discover what daily builds are available.
 
-This phase is more exploratory. Options include:
-- Querying the blob storage for available versions (may require an index endpoint)
-- Listing recent builds from the aka.ms redirects
-- An interactive picker in the TUI showing recent daily versions for a channel
+The approach is to query the NuGet package feed where daily builds are published. For each daily
+SDK build, a `Microsoft.NET.Sdk` transport package is published with a version matching the SDK
+version. This package isn't meant for direct consumption — it's an internal transport mechanism —
+but it provides a reliable index of available daily builds.
 
-The feasibility depends on what listing/enumeration APIs are available from the build feeds.
+- Query the NuGet V3 feed for available versions of `Microsoft.NET.Sdk` (for SDK daily builds)
+- For runtime daily builds, use a different transport package (TBD — need to identify the right
+  package name per runtime component)
+- Filter versions to the requested channel scope (e.g., `10.0/daily` → versions matching `10.0.*`)
+- Present available versions in a list, sorted by date/version
+- In interactive mode, offer a picker to select and install a specific daily version
 
 ## Open questions
 
@@ -337,14 +342,16 @@ The feasibility depends on what listing/enumeration APIs are available from the 
    a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
    this should be treated as an advanced/untrusted mode.
 
-3. **What about listing daily builds (Phase 3)?** The blob storage doesn't have a natural listing
-   API. We may need to rely on version ranges or a separate index. This needs investigation.
+3. **Runtime transport package**: For SDK daily builds, `Microsoft.NET.Sdk` is the transport
+   package to query for available versions. What is the equivalent package for runtime components
+   (e.g., `Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`)?
 
 4. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
    User research / PM input would be valuable here.
 
-5. **Runtime daily builds**: Do daily builds of the runtime follow the same feed structure?
-   Need to verify the URL patterns for runtime vs SDK daily downloads.
+5. **Runtime daily builds**: Do daily builds of the runtime follow the same aka.ms URL patterns
+   and blob feed structure as the SDK? The download URLs likely differ (e.g., `dotnet-runtime-`
+   instead of `dotnet-sdk-`), but the version discovery mechanism should be similar.
 
 6. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
    redirects? Need to enumerate all legitimate blob storage hosts used by the .NET build

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -269,9 +269,24 @@ companion file instead of from the release manifest.
 
 ### Archive signatures
 
-Daily build archives are signed with the same Authenticode/codesign signatures as release builds
-(the signing happens in the build pipeline). The archive-level verification (SHA-512) is the same.
-No additional signature verification infrastructure is needed for daily builds.
+Daily build archives are **not** Authenticode-signed. The .NET build pipeline has a quality
+progression: `daily → signed → validated → preview → ga`. Code signing happens at the "signed"
+quality level and above. Daily builds are the lowest quality — they are produced by CI on every
+commit or daily schedule and have not passed through the signing gate.
+
+This means:
+- Windows `.exe` installers and binaries inside daily archives may not pass Authenticode trust checks
+- macOS archives may not be codesigned/notarized
+- Users installing daily builds are trusting the feed and SHA-512 hash only
+
+dotnetup should clearly communicate this to users when installing from daily channels:
+```
+⚠ Daily builds are not code-signed. Only the SHA-512 hash is verified.
+```
+
+If users need signed pre-release builds, they should use the `signed` quality level instead.
+This raises the question of whether dotnetup should also support `signed` and `validated`
+as channel qualifiers (e.g., `10.0/signed`).
 
 ## Implementation phases
 
@@ -340,3 +355,8 @@ The feasibility depends on what listing/enumeration APIs are available from the 
    `10.0-daily`. The `/` syntax reads naturally ("10.0 slash daily") and mirrors URL path
    structure, but may conflict with file path parsing on some platforms. The `-` syntax is
    simpler but could be confused with prerelease version tags.
+
+9. **Other quality levels**: The .NET build pipeline has quality levels beyond `daily`:
+   `daily → signed → validated → preview → ga`. Should dotnetup support `10.0/signed` or
+   `10.0/validated` channels? `signed` builds are code-signed but not fully validated —
+   they may be useful for users who want pre-release builds with signature verification.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -18,6 +18,40 @@ from `builds.dotnet.microsoft.com`. dotnetup should provide a first-class experi
 
 See: https://github.com/dotnet/sdk/issues/51097
 
+## Proposed user experience
+
+Daily builds are expressed as **channel names** — no new flags or modes needed. The mental model
+is simple: every install is `dotnetup sdk install <channel>`, and daily channels are just another
+kind of channel alongside `latest`, `preview`, `lts`, etc.
+
+```bash
+# Install the latest daily SDK build
+dotnetup sdk install daily
+
+# Install the latest daily SDK for .NET 10.0
+dotnetup sdk install 10.0-daily
+
+# Install the latest daily SDK for the 10.0.1xx feature band
+dotnetup sdk install 10.0.1xx-daily
+
+# Install a specific daily build by its full version string
+dotnetup sdk install 10.0.100-preview.7.25351.1
+
+# Daily runtime builds follow the same pattern
+dotnetup runtime install 10.0-daily
+```
+
+| Channel | Meaning |
+|---------|---------|
+| `daily` | Latest daily build (latest major version) |
+| `10.0-daily` | Latest daily build for .NET 10.0 |
+| `10.0.1xx-daily` | Latest daily build for the 10.0.1xx feature band |
+
+When the user provides a fully-specified prerelease version (e.g., `10.0.100-preview.7.25351.1`),
+dotnetup first checks the release manifest, then falls back to the daily build feed. This fallback
+only applies to **prerelease** version strings — stable versions not in the manifest produce an
+error.
+
 ## Background: How daily builds work today
 
 ### dotnet-install script model
@@ -105,13 +139,7 @@ research shows it resonates better.
 
 ### Channel syntax
 
-Daily channels use a `-daily` suffix: `{version-scope}-daily`:
-
-| Channel | Meaning |
-|---------|---------|
-| `daily` | Latest daily build (latest major version — see below) |
-| `10.0-daily` | Latest daily build for .NET 10.0 |
-| `10.0.1xx-daily` | Latest daily build for the 10.0.1xx feature band |
+Daily channels use a `-daily` suffix: `{version-scope}-daily`.
 
 This reads naturally as "10.0, daily" — the version scope comes first (what you want),
 then the qualifier (what kind of build). It mirrors how existing channels work: you start
@@ -141,37 +169,6 @@ an explicit version scope (`10.0-daily`), the major version is extracted directl
 | `lts` | (not applicable — daily builds aren't LTS) |
 | `10.0` | `10.0-daily` |
 | `10.0.1xx` | `10.0.1xx-daily` |
-
-### CLI examples
-
-```bash
-# Install the latest daily SDK build
-dotnetup sdk install daily
-
-# Install the latest daily SDK for .NET 10.0
-dotnetup sdk install 10.0-daily
-
-# Install the latest daily SDK for the 10.0.1xx feature band
-dotnetup sdk install 10.0.1xx-daily
-
-# Install a specific daily build by its full version string
-dotnetup sdk install 10.0.100-preview.7.25351.1
-
-# Daily runtime builds follow the same pattern
-dotnetup runtime install 10.0-daily
-```
-
-#### Specific version fallback
-
-When the user provides a fully-specified version with a prerelease tag (e.g.,
-`10.0.100-preview.7.25351.1`), dotnetup should:
-1. First, check the release manifest (it may be an officially published preview)
-2. If not found in the release manifest, attempt to download from the daily build feed
-
-**Important constraint**: blob-feed fallback should only be attempted for **prerelease** version
-strings (versions containing a `-` prerelease tag). Stable version strings like `10.0.100` that
-aren't in the release manifest should produce a clear "version not found" error rather than probing
-blob storage — this avoids confusing behavior for typos like `10.0.999`.
 
 ### Version resolution
 

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -105,13 +105,13 @@ research shows it resonates better.
 
 ### Channel syntax
 
-Daily channels use a suffix pattern `{version-scope}/daily` or `{version-scope}-daily`:
+Daily channels use a `-daily` suffix: `{version-scope}-daily`:
 
 | Channel | Meaning |
 |---------|---------|
 | `daily` | Latest daily build (latest major version — see below) |
-| `10.0/daily` | Latest daily build for .NET 10.0 |
-| `10.0.1xx/daily` | Latest daily build for the 10.0.1xx feature band |
+| `10.0-daily` | Latest daily build for .NET 10.0 |
+| `10.0.1xx-daily` | Latest daily build for the 10.0.1xx feature band |
 
 This reads naturally as "10.0, daily" — the version scope comes first (what you want),
 then the qualifier (what kind of build). It mirrors how existing channels work: you start
@@ -132,15 +132,15 @@ daily builds (but hasn't shipped a release yet), dotnetup automatically picks it
 version ships its first release, the manifest updates and the +1 probe moves to the next version.
 
 The same logic applies to feed selection for version listing (Phase 3). When the channel includes
-an explicit version scope (`10.0/daily`), the major version is extracted directly.
+an explicit version scope (`10.0-daily`), the major version is extracted directly.
 
 | Existing channels | Daily channels |
 |-------------------|---------------|
 | `latest` | `daily` |
 | `preview` | (already in release manifest) |
 | `lts` | (not applicable — daily builds aren't LTS) |
-| `10.0` | `10.0/daily` |
-| `10.0.1xx` | `10.0.1xx/daily` |
+| `10.0` | `10.0-daily` |
+| `10.0.1xx` | `10.0.1xx-daily` |
 
 ### CLI examples
 
@@ -149,16 +149,16 @@ an explicit version scope (`10.0/daily`), the major version is extracted directl
 dotnetup sdk install daily
 
 # Install the latest daily SDK for .NET 10.0
-dotnetup sdk install 10.0/daily
+dotnetup sdk install 10.0-daily
 
 # Install the latest daily SDK for the 10.0.1xx feature band
-dotnetup sdk install 10.0.1xx/daily
+dotnetup sdk install 10.0.1xx-daily
 
 # Install a specific daily build by its full version string
 dotnetup sdk install 10.0.100-preview.7.25351.1
 
 # Daily runtime builds follow the same pattern
-dotnetup runtime install 10.0/daily
+dotnetup runtime install 10.0-daily
 ```
 
 #### Specific version fallback
@@ -180,7 +180,7 @@ User provides: channel
         │
         ▼
   ┌─────────────────────┐
-  │ Is it a .../daily    │
+  │ Is it a ...-daily    │
   │ channel?            │
   └───────┬───────┬─────┘
           │       │
@@ -194,8 +194,8 @@ User provides: channel
 ```
 
 For daily channels, version resolution uses the aka.ms redirect:
-1. Parse the channel: `10.0/daily` → base channel `10.0`, quality `daily`
-2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/dotnet-sdk-{os}-{arch}.tar.gz`
+1. Parse the channel: `10.0-daily` → base channel `10.0`, quality `daily`
+2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0-daily/dotnet-sdk-{os}-{arch}.tar.gz`
 3. Follow the redirect (301) to get the actual blob storage URL
 4. Extract the version from the redirect URL path
 5. Use the redirect URL directly as the download URL
@@ -211,19 +211,21 @@ For a specific prerelease version that isn't in the release manifest:
 
 ### Channel parsing in `UpdateChannel`
 
-The `UpdateChannel` class gains awareness of the `/daily` suffix:
+The `UpdateChannel` class gains awareness of the `-daily` suffix:
 
 ```csharp
 // New properties
 public bool IsDaily => Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
-    || Name.EndsWith("/daily", StringComparison.OrdinalIgnoreCase);
+    || Name.EndsWith("-daily", StringComparison.OrdinalIgnoreCase);
 public string BaseChannel => IsDaily
-    ? Name.Contains('/') ? Name.Substring(0, Name.LastIndexOf('/')) : "latest"
+    ? Name.Contains('-') && !Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
+        ? Name.Substring(0, Name.LastIndexOf('-'))
+        : "latest"
     : Name;
 ```
 
 The `Matches()` method for daily channels matches any version that would match the base channel.
-For example, `10.0/daily` matches any `10.0.x` version, just like `10.0` does today. The
+For example, `10.0-daily` matches any `10.0.x` version, just like `10.0` does today. The
 difference is only in how versions are **resolved** (blob feed vs release manifest) and
 **tracked** (daily install specs vs release install specs).
 
@@ -233,7 +235,7 @@ Daily builds are tracked in the dotnetup manifest just like any other channel:
 
 ```json
 {
-  "channel": "10.0/daily",
+  "channel": "10.0-daily",
   "version": "10.0.100-preview.7.25351.1",
   "component": "sdk"
 }
@@ -242,7 +244,7 @@ Daily builds are tracked in the dotnetup manifest just like any other channel:
 Because the channel name itself encodes the daily nature, no additional fields are needed.
 The GC, update, and list logic can use the existing `channel` field to determine resolution
 behavior:
-- Channel ends with `/daily` (or is exactly `daily`)? → resolve from blob feed
+- Channel ends with `-daily` (or is exactly `daily`)? → resolve from blob feed
 - Otherwise → resolve from release manifest
 
 This keeps the manifest schema unchanged and avoids needing to update every piece of code that
@@ -251,7 +253,7 @@ reads install specs.
 ### Update behavior
 
 **Daily channel installs support updates**, just like any other tracked channel. Running
-`dotnetup sdk update` will re-resolve the `10.0/daily` channel against the blob feed and install
+`dotnetup sdk update` will re-resolve the `10.0-daily` channel against the blob feed and install
 a newer version if available.
 
 **Specific-version daily installs** (e.g., `dotnetup sdk install 10.0.100-preview.7.25351.1`)
@@ -323,11 +325,11 @@ is needed. We just need the blob-feed download path:
 
 ### Phase 2: Daily channel parsing and latest version resolution
 
-**Goal**: `dotnetup sdk install 10.0/daily` resolves and installs the latest daily build.
+**Goal**: `dotnetup sdk install 10.0-daily` resolves and installs the latest daily build.
 
 Builds on Phase 1's blob-feed download path by adding version discovery:
-- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `.../daily` suffix parsing
-- Add `IsValidChannelFormat()` support for `.../daily` channels
+- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `...-daily` suffix parsing
+- Add `IsValidChannelFormat()` support for `...-daily` channels
 - Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms
   redirect to discover the latest version (the `InstallWorkflow` doesn't need to change —
   it already calls `Resolve()` and gets back a version)
@@ -355,7 +357,7 @@ configuration.
 - For runtime daily builds, use a runtime transport package such as
   `Microsoft.NETCore.App.Runtime.{rid}`. With the VMR, all components version together, so any
   VMR-produced package can serve as the version index for a given daily build.
-- Filter versions to the requested channel scope (e.g., `10.0/daily` → versions matching `10.0.*`)
+- Filter versions to the requested channel scope (e.g., `10.0-daily` → versions matching `10.0.*`)
 - Present available versions in a list, sorted by date/version
 - In interactive mode, offer a picker to select and install a specific daily version
 
@@ -389,12 +391,14 @@ configuration.
    `builds.dotnet.microsoft.com` and `ci.dot.net/public`? Should we always try primary first,
    or use both in parallel?
 
-8. **Channel separator**: Is `10.0/daily` the best syntax? Alternatives include `10.0:daily`,
-   `10.0-daily`. The `/` syntax reads naturally ("10.0 slash daily") and mirrors URL path
-   structure, but may conflict with file path parsing on some platforms. The `-` syntax is
-   simpler but could be confused with prerelease version tags.
+8. **Channel separator**: This document uses `-` as the separator (`10.0-daily`). The `-` syntax
+   is simpler and aligns with prerelease version tag conventions. There is no ambiguity with
+   version strings because channels use major.minor (2 components) or feature bands with wildcards
+   (`10.0.1xx`), while versions always have 3+ numeric components. An alternative is `/`
+   (`10.0/daily`), which mirrors URL path structure but may conflict with file path parsing on
+   some platforms.
 
 9. **Other quality levels**: The .NET build pipeline has quality levels beyond `daily`:
-   `daily → signed → validated → preview → ga`. Should dotnetup support `10.0/signed` or
-   `10.0/validated` channels? `signed` builds are code-signed but not fully validated —
+   `daily → signed → validated → preview → ga`. Should dotnetup support `10.0-signed` or
+   `10.0-validated` channels? `signed` builds are code-signed but not fully validated —
    they may be useful for users who want pre-release builds with signature verification.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -1,0 +1,328 @@
+# Installing Pre-Release (Daily/Nightly) Builds with dotnetup
+
+## Motivation
+
+dotnetup currently installs .NET SDKs and runtimes from the official release manifest (`releases-index.json`).
+This covers GA, LTS, and preview releases that have been officially published. However, many internal and
+external users need access to **daily builds** — CI-produced builds that have not gone through the full
+release process. These are commonly called "nightly builds" in the community.
+
+Use cases for daily builds include:
+- Testing upcoming features or bug fixes before they ship in a preview or GA release
+- Reproducing issues against the latest source to check if they're already fixed
+- Internal .NET team development workflows
+- CI pipelines that need to validate against the latest .NET bits
+
+Today, users install daily builds via the `dotnet-install` scripts or by manually downloading archives
+from `builds.dotnet.microsoft.com`. dotnetup should provide a first-class experience for this.
+
+See: https://github.com/dotnet/sdk/issues/51097
+
+## Background: How daily builds work today
+
+### dotnet-install script model
+
+The `dotnet-install.sh` and `dotnet-install.ps1` scripts use a **quality + channel** model:
+
+- **Channel**: A version band like `10.0`, `10.0.1xx`, `STS`, `LTS`, or a specific version
+- **Quality**: One of `daily`, `preview`, or `ga` (default)
+
+Quality combined with channel constructs a discovery URL:
+```
+https://aka.ms/dotnet/{channel}/{quality}/sdk-productVersion.txt
+```
+
+This aka.ms redirect resolves to a blob on the primary build feed. The resolved version is then used
+to construct the download URL:
+```
+{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.tar.gz
+```
+
+### Build feeds
+
+Two feeds serve daily builds:
+1. **Primary**: `https://builds.dotnet.microsoft.com/dotnet`
+2. **Fallback**: `https://ci.dot.net/public`
+
+### Version discovery
+
+For a given channel and quality, the scripts fetch a `latest.version` file:
+```
+{feed}/Sdk/{channel}/latest.version
+```
+
+This file contains a single line with the latest version string for that channel
+(e.g., `10.0.100-preview.7.25351.1`).
+
+### Key constraints in the current model
+
+- Quality cannot be combined with a fully-specified version (quality is only meaningful for "latest")
+- Quality is not supported for `LTS` or `STS` meta-channels
+- Daily builds are **not** listed in the release manifest (`releases-index.json`)
+- Hash verification uses `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.tar.gz.sha512`
+
+## Proposed design
+
+### Terminology
+
+We propose using **"daily"** as the primary term, matching the existing `dotnet-install` scripts'
+`--quality daily` parameter. The GitHub issue uses "nightly" which is more familiar to users of
+other ecosystems (Rust, Python, etc.), but aligning with the existing .NET infrastructure reduces
+confusion and implementation complexity.
+
+Alternative names considered:
+- **"nightly"**: More familiar to the broader developer community; could be used as a user-facing
+  alias even if the underlying quality is "daily"
+- **"prerelease"**: Too broad — preview releases are also pre-release but come from the release manifest
+- **"ci"**: Accurate but less user-friendly
+
+**Recommendation**: Use "daily" in the implementation and documentation to match `dotnet-install`.
+If user research indicates "nightly" resonates better, we can add it as an alias later.
+
+### CLI syntax
+
+#### Installing the latest daily build for a channel
+
+```bash
+# Install the latest daily SDK for .NET 10.0
+dnup sdk install 10.0 --quality daily
+
+# Install the latest daily SDK for the 10.0.1xx feature band
+dnup sdk install 10.0.1xx --quality daily
+
+# Short form (if we want to support it)
+dnup sdk install daily/10.0
+```
+
+The `--quality` flag mirrors `dotnet-install`'s terminology and is the recommended approach.
+It composes naturally with the existing channel argument.
+
+The `daily/{channel}` short form is convenient but introduces a new syntax pattern. It could
+be supported as sugar that expands to `--quality daily`.
+
+#### Installing a specific daily build version
+
+```bash
+# Install a specific daily build by its full version string
+dnup sdk install 10.0.100-preview.7.25351.1
+```
+
+When the user provides a fully-specified version with a prerelease tag, dotnetup should:
+1. First, check the release manifest (it may be an officially published preview)
+2. If not found in the release manifest, attempt to download from the daily build feed
+
+This fallback behavior means users don't need to know whether a version is "released" or "daily" —
+they just provide the version string and dotnetup figures out where to get it.
+
+**Important constraint**: blob-feed fallback should only be attempted for **prerelease** version
+strings (versions containing a `-` prerelease tag). Stable version strings like `10.0.100` that
+aren't in the release manifest should produce a clear "version not found" error rather than probing
+blob storage — this avoids confusing behavior for typos like `10.0.999`.
+
+If `--quality daily` is explicitly provided alongside an exact version, that is an error
+(quality is only meaningful for "latest" resolution, matching the `dotnet-install` script behavior).
+
+#### Runtime installs
+
+```bash
+# Daily runtime builds follow the same pattern
+dnup runtime install 10.0 --quality daily
+```
+
+### Version resolution
+
+A new resolution path is needed alongside the existing `ChannelVersionResolver`:
+
+```
+User provides: channel + quality
+                    │
+                    ▼
+        ┌───────────────────────┐
+        │  Is quality specified? │
+        └───────┬───────┬───────┘
+                │       │
+            No  │       │  Yes (daily/preview)
+                ▼       ▼
+    ┌──────────────┐  ┌──────────────────────┐
+    │ Release       │  │ Daily build feed     │
+    │ manifest      │  │ (aka.ms / blob)      │
+    │ (existing)    │  │                      │
+    └──────────────┘  └──────────────────────┘
+```
+
+For daily builds, version resolution queries the build feed:
+1. Construct the aka.ms URL: `https://aka.ms/dotnet/{channel}/{quality}/sdk-productVersion.txt`
+2. Follow the redirect to get the `latest.version` file content
+3. Parse the version string
+4. Construct the download URL: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
+
+For a specific prerelease version that isn't in the release manifest:
+1. Construct the download URL directly: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
+2. Verify the archive exists (HEAD request or attempt download)
+3. Fetch the hash from `{url}.sha512` for verification
+
+### Manifest tracking
+
+Daily builds need to be tracked in the dotnetup manifest so that:
+- `dnup list` shows them
+- `dnup remove` can remove them
+- The garbage collector knows about them
+
+A daily install should be recorded with enough information to identify its source:
+
+```json
+{
+  "channel": "10.0",
+  "quality": "daily",
+  "version": "10.0.100-preview.7.25351.1",
+  "component": "sdk",
+  "feedKind": "daily-build"
+}
+```
+
+The `quality` and `feedKind` fields distinguish daily installs from release-manifest installs.
+(Note: the existing `InstallSource` field means something different — it tracks whether the
+install was triggered explicitly by the user vs. by `global.json`. We use `feedKind` to avoid
+naming confusion.)
+
+This distinction is important because:
+- The same version string might not exist in the release manifest
+- Update/GC logic must distinguish `{channel: "10.0", quality: "daily"}` from `{channel: "10.0"}`
+  (stable) — otherwise daily installs would be garbage-collected by stable channel rules
+- The download source is different
+
+### Update behavior
+
+**Daily builds should not auto-update by default.** The issue author confirms this assumption:
+> "I assume we don't update specific nightlies."
+
+However, we should support explicit updates:
+```bash
+# Explicitly update to the latest daily for the tracked channel
+dnup sdk update --quality daily
+```
+
+When a user has an install spec like `{channel: "10.0", quality: "daily"}`, running `dnup sdk update`
+with `--quality daily` would resolve the latest daily for 10.0 and install it if newer.
+
+Install specs for daily builds should be recorded only when the user installs via channel + quality
+(not when they install a specific version). A specific-version daily install is a point-in-time
+snapshot and shouldn't imply ongoing tracking.
+
+### Security and trust model
+
+Daily builds have a **weaker trust model** than release-manifest installs. For released versions,
+the hash is obtained from the release manifest (an independent metadata source hosted separately
+from the archive). For daily builds, both the archive and the `.sha512` hash file are served from
+the same blob storage feed. This protects against download corruption but not against a
+compromised feed.
+
+Mitigations:
+- **Host allowlist**: aka.ms redirects should only be followed to known, expected blob hosts
+  (`builds.dotnet.microsoft.com`, `ci.dot.net`). Redirects to unexpected hosts should be rejected.
+- **TLS-only**: All feed communication must be over HTTPS.
+- **Transparency**: dotnetup should clearly indicate when an install came from a daily build feed
+  rather than the release manifest (e.g., in `dnup list` output and installation messages).
+- **Future**: If independent signature verification is added (e.g., verifying the Authenticode
+  signature on the extracted binaries), this would strengthen the trust model for daily builds.
+
+If a `--feed` override is added later, it should be treated as an advanced/untrusted mode with
+appropriate warnings.
+
+### Hash verification
+
+Daily build archives have SHA-512 hash files available at `{download-url}.sha512`. The existing
+hash verification in `DotnetArchiveDownloader` can be extended to fetch the hash from this
+companion file instead of from the release manifest.
+
+### Archive signatures
+
+Daily build archives are signed with the same Authenticode/codesign signatures as release builds
+(the signing happens in the build pipeline). The archive-level verification (SHA-512) is the same.
+No additional signature verification infrastructure is needed for daily builds.
+
+## Implementation phases
+
+### Phase 1: Data model and source identity
+
+**Goal**: Introduce the concept of build quality and feed kind into the request/manifest/spec model.
+
+Changes needed:
+- Add `Quality` property to `InstallRequestOptions` (enum: `Ga`, `Preview`, `Daily`)
+- Add `FeedKind` property to install spec recording (enum: `ReleaseManifest`, `DailyBuild`)
+- Update `UpdateChannel` identity: a channel + quality pair must be distinct from the same channel
+  without quality, so update/remove/GC logic doesn't confuse daily and stable installs
+- Update manifest serialization to persist `quality` and `feedKind`
+- Update `dnup list` output to surface daily-build provenance
+
+### Phase 2: Install a specific daily build version
+
+**Goal**: `dnup sdk install 10.0.100-preview.7.25351.1` works for versions not in the release manifest.
+
+Changes needed:
+- Extend `DotnetArchiveDownloader` with a blob-storage download path that constructs URLs from
+  version strings rather than release manifest entries
+- Add hash fetching from `{url}.sha512` companion files
+- Add host allowlist for blob feed redirect validation
+- Modify `InstallWorkflow.ResolveSpec()` to fall back to blob storage when the release manifest
+  doesn't contain the requested prerelease version
+- Track the install in the manifest with `feedKind: "daily-build"`
+
+### Phase 3: Install latest daily for a channel
+
+**Goal**: `dnup sdk install 10.0 --quality daily` resolves and installs the latest daily build.
+
+Changes needed:
+- Add `--quality` option to install commands (validate: incompatible with exact versions, `lts`, `sts`)
+- Create a `DailyBuildVersionResolver` (or extend `ChannelVersionResolver`) that queries
+  `aka.ms` / `latest.version` files
+- Wire quality through the install workflow
+- Record install spec with quality so updates can re-resolve from the daily feed
+
+### Phase 4: List and browse daily builds
+
+**Goal**: Users can discover what daily builds are available.
+
+This phase is more exploratory. Options include:
+- Querying the blob storage for available versions (may require an index endpoint)
+- Listing recent builds from the aka.ms redirects
+- An interactive picker in the TUI showing recent daily versions for a channel
+
+The feasibility depends on what listing/enumeration APIs are available from the build feeds.
+
+## Open questions
+
+1. **Should `dnup sdk install 10.0 --quality preview` also be supported?** The `dotnet-install`
+   scripts support `--quality preview` to get the latest preview build. This would be a natural
+   extension.
+
+2. **How should `global.json` interact with daily builds?** If a `global.json` specifies a daily
+   build version, should `dnup` automatically try the daily feed? Or should it require explicit
+   configuration?
+
+3. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
+   a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
+   this should be treated as an advanced/untrusted mode.
+
+4. **What about listing daily builds (Phase 4)?** The blob storage doesn't have a natural listing
+   API. We may need to rely on version ranges or a separate index. This needs investigation.
+
+5. **Naming**: Should we use "daily" throughout, or offer "nightly" as a user-facing alias?
+   User research / PM input would be valuable here.
+
+6. **Runtime daily builds**: Do daily builds of the runtime follow the same feed structure?
+   Need to verify the URL patterns for runtime vs SDK daily downloads.
+
+7. **Host allowlist / redirect policy**: What is the exact set of allowed hosts for aka.ms
+   redirects? Need to enumerate all legitimate blob storage hosts used by the .NET build
+   infrastructure.
+
+8. **Feed retry order**: What is the exact primary/fallback retry order across
+   `builds.dotnet.microsoft.com` and `ci.dot.net/public`? Should we always try primary first,
+   or use both in parallel?
+
+9. **Invalid combinations**: What validation and error messages do we want for invalid combos
+   like `--quality daily` with `lts`, `sts`, or a fully specified version?
+
+10. **Distinguishing tracked channels**: How do we surface the difference between tracked `10.0`
+    (stable) vs tracked `10.0 --quality daily` in `dnup list`, `dnup remove`, and other commands?

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -192,7 +192,7 @@ User provides: channel
 
 For daily channels, version resolution uses the aka.ms redirect:
 1. Parse the channel: `10.0-daily` → base channel `10.0`, quality `daily`
-2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0-daily/dotnet-sdk-{os}-{arch}.tar.gz`
+2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/dotnet-sdk-{os}-{arch}.tar.gz`
 3. Follow the redirect (301) to get the actual blob storage URL
 4. Extract the version from the redirect URL path
 5. Use the redirect URL directly as the download URL
@@ -215,9 +215,9 @@ The `UpdateChannel` class gains awareness of the `-daily` suffix:
 public bool IsDaily => Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
     || Name.EndsWith("-daily", StringComparison.OrdinalIgnoreCase);
 public string BaseChannel => IsDaily
-    ? Name.Contains('-') && !Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
-        ? Name.Substring(0, Name.LastIndexOf('-'))
-        : "latest"
+    ? Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
+        ? "daily"
+        : Name.Substring(0, Name.LastIndexOf('-'))
     : Name;
 ```
 
@@ -232,15 +232,15 @@ Daily builds are tracked in the dotnetup manifest just like any other channel:
 
 ```json
 {
-  "channel": "10.0-daily",
-  "version": "10.0.100-preview.7.25351.1",
-  "component": "sdk"
+  "component": "sdk",
+  "versionOrChannel": "10.0-daily",
+  "installSource": "explicit"
 }
 ```
 
 Because the channel name itself encodes the daily nature, no additional fields are needed.
-The GC, update, and list logic can use the existing `channel` field to determine resolution
-behavior:
+The GC, update, and list logic can use the existing `versionOrChannel` field to determine
+resolution behavior:
 - Channel ends with `-daily` (or is exactly `daily`)? → resolve from blob feed
 - Otherwise → resolve from release manifest
 
@@ -326,7 +326,7 @@ is needed. We just need the blob-feed download path:
 
 Builds on Phase 1's blob-feed download path by adding version discovery:
 - Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `...-daily` suffix parsing
-- Add `IsValidChannelFormat()` support for `...-daily` channels
+- Add `IsValidChannelFormat()` support for `...-daily` channels and bare `daily`
 - Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms
   redirect to discover the latest version (the `InstallWorkflow` doesn't need to change —
   it already calls `Resolve()` and gets back a version)

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -85,23 +85,25 @@ research shows it resonates better.
 
 ### Channel syntax
 
-Daily channels follow the pattern `daily[/{version-scope}]`:
+Daily channels use a suffix pattern `{version-scope}/daily` or `{version-scope}-daily`:
 
 | Channel | Meaning |
 |---------|---------|
 | `daily` | Latest daily build (latest major version) |
-| `daily/10.0` | Latest daily build for .NET 10.0 |
-| `daily/10.0.1xx` | Latest daily build for the 10.0.1xx feature band |
+| `10.0/daily` | Latest daily build for .NET 10.0 |
+| `10.0.1xx/daily` | Latest daily build for the 10.0.1xx feature band |
 
-This extends the existing channel vocabulary naturally:
+This reads naturally as "10.0, daily" — the version scope comes first (what you want),
+then the qualifier (what kind of build). It mirrors how existing channels work: you start
+with the version scope and optionally narrow it.
 
 | Existing channels | Daily channels |
 |-------------------|---------------|
 | `latest` | `daily` |
 | `preview` | (already in release manifest) |
 | `lts` | (not applicable — daily builds aren't LTS) |
-| `10.0` | `daily/10.0` |
-| `10.0.1xx` | `daily/10.0.1xx` |
+| `10.0` | `10.0/daily` |
+| `10.0.1xx` | `10.0.1xx/daily` |
 
 ### CLI examples
 
@@ -110,16 +112,16 @@ This extends the existing channel vocabulary naturally:
 dnup sdk install daily
 
 # Install the latest daily SDK for .NET 10.0
-dnup sdk install daily/10.0
+dnup sdk install 10.0/daily
 
 # Install the latest daily SDK for the 10.0.1xx feature band
-dnup sdk install daily/10.0.1xx
+dnup sdk install 10.0.1xx/daily
 
 # Install a specific daily build by its full version string
 dnup sdk install 10.0.100-preview.7.25351.1
 
 # Daily runtime builds follow the same pattern
-dnup runtime install daily/10.0
+dnup runtime install 10.0/daily
 ```
 
 #### Specific version fallback
@@ -141,7 +143,7 @@ User provides: channel
         │
         ▼
   ┌─────────────────────┐
-  │ Is it a daily/...   │
+  │ Is it a .../daily    │
   │ channel?            │
   └───────┬───────┬─────┘
           │       │
@@ -155,7 +157,7 @@ User provides: channel
 ```
 
 For daily channels, version resolution queries the build feed:
-1. Parse the channel: `daily/10.0` → base channel `10.0`, quality `daily`
+1. Parse the channel: `10.0/daily` → base channel `10.0`, quality `daily`
 2. Construct the aka.ms URL: `https://aka.ms/dotnet/10.0/daily/sdk-productVersion.txt`
 3. Follow the redirect to get the latest version string
 4. Construct the download URL: `{feed}/Sdk/{version}/dotnet-sdk-{version}-{os}-{arch}.{ext}`
@@ -167,18 +169,19 @@ For a specific prerelease version that isn't in the release manifest:
 
 ### Channel parsing in `UpdateChannel`
 
-The `UpdateChannel` class gains awareness of the `daily/` prefix:
+The `UpdateChannel` class gains awareness of the `/daily` suffix:
 
 ```csharp
 // New properties
-public bool IsDaily => Name.StartsWith("daily", StringComparison.OrdinalIgnoreCase);
+public bool IsDaily => Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
+    || Name.EndsWith("/daily", StringComparison.OrdinalIgnoreCase);
 public string BaseChannel => IsDaily
-    ? Name.Contains('/') ? Name.Substring(Name.IndexOf('/') + 1) : "latest"
+    ? Name.Contains('/') ? Name.Substring(0, Name.LastIndexOf('/')) : "latest"
     : Name;
 ```
 
 The `Matches()` method for daily channels matches any version that would match the base channel.
-For example, `daily/10.0` matches any `10.0.x` version, just like `10.0` does today. The
+For example, `10.0/daily` matches any `10.0.x` version, just like `10.0` does today. The
 difference is only in how versions are **resolved** (blob feed vs release manifest) and
 **tracked** (daily install specs vs release install specs).
 
@@ -188,16 +191,16 @@ Daily builds are tracked in the dotnetup manifest just like any other channel:
 
 ```json
 {
-  "channel": "daily/10.0",
+  "channel": "10.0/daily",
   "version": "10.0.100-preview.7.25351.1",
   "component": "sdk"
 }
 ```
 
-Because the channel name itself encodes the daily nature, no additional `quality` or `feedKind`
-fields are needed. The GC, update, and list logic can use the existing `channel` field to
-determine resolution behavior:
-- Channel starts with `daily/`? → resolve from blob feed
+Because the channel name itself encodes the daily nature, no additional fields are needed.
+The GC, update, and list logic can use the existing `channel` field to determine resolution
+behavior:
+- Channel ends with `/daily` (or is exactly `daily`)? → resolve from blob feed
 - Otherwise → resolve from release manifest
 
 This keeps the manifest schema unchanged and avoids needing to update every piece of code that
@@ -206,7 +209,7 @@ reads install specs.
 ### Update behavior
 
 **Daily channel installs support updates**, just like any other tracked channel. Running
-`dnup sdk update` will re-resolve the `daily/10.0` channel against the blob feed and install
+`dnup sdk update` will re-resolve the `10.0/daily` channel against the blob feed and install
 a newer version if available.
 
 **Specific-version daily installs** (e.g., `dnup sdk install 10.0.100-preview.7.25351.1`)
@@ -249,11 +252,11 @@ No additional signature verification infrastructure is needed for daily builds.
 
 ### Phase 1: Daily channel parsing and blob-feed download
 
-**Goal**: `dnup sdk install daily/10.0` resolves and installs the latest daily build.
+**Goal**: `dnup sdk install 10.0/daily` resolves and installs the latest daily build.
 
 Changes needed:
-- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `daily/...` prefix parsing
-- Add `IsValidChannelFormat()` support for `daily/...` channels
+- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `.../daily` suffix parsing
+- Add `IsValidChannelFormat()` support for `.../daily` channels
 - Create a `DailyBuildVersionResolver` that queries `aka.ms` / `latest.version` files
 - Extend `DotnetArchiveDownloader` with a blob-storage download path that constructs URLs from
   version strings rather than release manifest entries
@@ -308,6 +311,7 @@ The feasibility depends on what listing/enumeration APIs are available from the 
    `builds.dotnet.microsoft.com` and `ci.dot.net/public`? Should we always try primary first,
    or use both in parallel?
 
-8. **Channel separator**: Is `daily/10.0` the best syntax? Alternatives include `daily:10.0`,
-   `daily-10.0`, or `10.0-daily`. The `/` syntax reads naturally ("daily builds of 10.0") but
-   may conflict with file path parsing on some platforms.
+8. **Channel separator**: Is `10.0/daily` the best syntax? Alternatives include `10.0:daily`,
+   `10.0-daily`. The `/` syntax reads naturally ("10.0 slash daily") and mirrors URL path
+   structure, but may conflict with file path parsing on some platforms. The `-` syntax is
+   simpler but could be confused with prerelease version tags.

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -109,13 +109,30 @@ Daily channels use a suffix pattern `{version-scope}/daily` or `{version-scope}-
 
 | Channel | Meaning |
 |---------|---------|
-| `daily` | Latest daily build (latest major version) |
+| `daily` | Latest daily build (latest major version — see below) |
 | `10.0/daily` | Latest daily build for .NET 10.0 |
 | `10.0.1xx/daily` | Latest daily build for the 10.0.1xx feature band |
 
 This reads naturally as "10.0, daily" — the version scope comes first (what you want),
 then the qualifier (what kind of build). It mirrors how existing channels work: you start
 with the version scope and optionally narrow it.
+
+#### Resolving bare `daily` to a major version
+
+When the user specifies `daily` without a version scope, dotnetup needs to determine which major
+version to target. The approach:
+
+1. Look up the latest major version in the release manifest (e.g., 10)
+2. Probe the `dotnet{major+1}-transport` feed (e.g., `dotnet11-transport`) — if it exists and has
+   matching packages, use major+1 as the daily major version
+3. If the major+1 feed doesn't exist or has no packages, fall back to `dotnet{major}-transport`
+
+This ensures `daily` always tracks the bleeding edge. When a new major version starts producing
+daily builds (but hasn't shipped a release yet), dotnetup automatically picks it up. Once that
+version ships its first release, the manifest updates and the +1 probe moves to the next version.
+
+The same logic applies to feed selection for version listing (Phase 3). When the channel includes
+an explicit version scope (`10.0/daily`), the major version is extracted directly.
 
 | Existing channels | Daily channels |
 |-------------------|---------------|

--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -227,7 +227,7 @@ public bool IsDaily => Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
     || Name.EndsWith("-daily", StringComparison.OrdinalIgnoreCase);
 public string BaseChannel => IsDaily
     ? Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
-        ? "daily"
+        ? "daily"  // bare "daily" is its own base — resolved separately via major+1 probing
         : Name.Substring(0, Name.LastIndexOf('-'))
     : Name;
 ```
@@ -311,9 +311,10 @@ dotnetup should clearly communicate this to users when installing from daily cha
 ⚠ Daily builds are not code-signed. Only the SHA-512 hash is verified.
 ```
 
-If users need signed pre-release builds, they should use the `signed` quality level instead.
-This raises the question of whether dotnetup should also support `signed` and `validated`
-as channel qualifiers (e.g., `10.0/signed`).
+When dotnetup adds signing validation in the future, if daily channel builds are not signed, then
+dotnetup will automatically skip the sign check but print out a warning.  If they are typically signed,
+then we will add a `--skip-sign-check` flag (which would only work on daily builds) for installing older
+or otherwise unsigned daily builds.
 
 ## Implementation phases
 
@@ -337,7 +338,8 @@ is needed. We just need the blob-feed download path:
 
 Builds on Phase 1's blob-feed download path by adding version discovery:
 - Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `...-daily` suffix parsing
-- Add `IsValidChannelFormat()` support for `...-daily` channels and bare `daily`
+- Add `IsValidChannelFormat()` support for `...-daily` channels and bare `daily` (add `daily`
+  to the known channel keyword set alongside `latest`, `preview`, `lts`)
 - Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms
   redirect to discover the latest version (the `InstallWorkflow` doesn't need to change —
   it already calls `Resolve()` and gets back a version)
@@ -371,9 +373,9 @@ configuration.
 
 ## Open questions
 
-1. **Should there be a `--feed` override?** For internal scenarios, users might want to point at
-   a different feed URL. The `dotnet-install` scripts support `--azure-feed` for this. If added,
-   this should be treated as an advanced/untrusted mode.
+1. ~~**Should there be a `--feed` override?**~~ **Resolved**: No. For custom feed scenarios,
+   users should construct their own release manifest and point dotnetup at that. This keeps
+   daily build support focused on the well-known .NET infrastructure feeds.
 
 2. **Runtime transport package**: With the VMR, all components version together, so any
    VMR-produced package can serve as the version index. A candidate like
@@ -398,7 +400,14 @@ configuration.
    (`10.0/daily`), which mirrors URL path structure but may conflict with file path parsing on
    some platforms.
 
-7. **Other quality levels**: The .NET build pipeline has quality levels beyond `daily`:
-   `daily → signed → validated → preview → ga`. Should dotnetup support `10.0-signed` or
-   `10.0-validated` channels? `signed` builds are code-signed but not fully validated —
-   they may be useful for users who want pre-release builds with signature verification.
+7. ~~**Other quality levels**~~: **Resolved**: No — we will not support `10.0-signed` or
+   `10.0-validated` channels for this feature. Users who need signed pre-release builds can
+   use the `dotnet-install` scripts with `--quality signed` until/unless demand warrants adding
+   these to dotnetup.
+
+8. **Alternative version discovery via AzDO artifacts**: If the build pipelines are public, we
+   could acquire installer payloads directly from AzDO artifacts rather than relying on aka.ms
+   redirects. This would avoid stale marker files and give access to the build metadata. Worth
+   investigating whether the public SDK build pipeline reliably publishes artifacts that map
+   cleanly to what dotnetup needs (archive + hash). Could be explored as an alternative to
+   aka.ms in Phase 2 or as a fallback when aka.ms redirects fail.


### PR DESCRIPTION
## Summary

Design document for adding daily/nightly build support to dotnetup (SDK issue #51097).

## Key design decisions

- **Daily builds are channels, not a separate `--quality` flag** — `dotnetup sdk install 10.0-daily` uses the same mental model as `dotnetup sdk install latest`
- **Channel syntax**: `{version-scope}-daily` suffix (e.g., `10.0-daily`, `10.0.1xx-daily`, or bare `daily`)
- **Version discovery**: aka.ms redirect for latest daily, blob-feed download with `.sha512` hash verification
- **No changes to InstallWorkflow** — daily logic lives behind existing `ChannelVersionResolver` and `IArchiveDownloader` abstractions
- **Phase ordering**: (1) specific prerelease version install from blob feed, (2) daily channel parsing + latest version resolution, (3) list/browse via NuGet transport package feeds
- **Daily builds are NOT code-signed** — design documents the weaker trust model

## Open questions for review

1. `global.json` interaction with daily builds
2. `--feed` override for internal scenarios
3. Runtime transport package selection (VMR versions together)
4. Naming: `daily` vs `nightly` alias
5. Runtime URL patterns
6. Host allowlist for redirects
7. Feed retry order
8. Channel separator: `-` (current) vs `/`
9. Supporting other quality levels (`signed`, `validated`)

Resolves #51097