### PR TITLE
Fix .gitignore test failure & build error(s)

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -17,6 +17,7 @@ pr:
     - eng
     - build
     - src
+    - template_feed
     - test
     - '*.yml'
     - '*.props'

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -83,7 +83,7 @@
     <PackageReference Include="NuGet.CommandLine.XPlat" />
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.NET.HostModel" />
-    <ProjectReference Include="$(TemplateEngSrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
+    <ProjectReference Include="$(TemplateEngSrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" GlobalPropertiesToRemove="PublishDir" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -528,8 +528,9 @@
     Only runs for native builds (TargetRid == HostRid) on supported platforms.
     Cross-compilation is not supported as NativeAOT requires native toolchain for target platform.
   -->
-  <Target Name="PublishDotnetAot"
-          Condition="'$(TargetRid)' == '$(HostRid)' and ($(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx')))">
+  <!-- <Target Name="PublishDotnetAot"
+          Condition="'$(TargetRid)' == '$(HostRid)' and ($(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx')))"> -->
+  <Target Name="PublishDotnetAot" Condition="false">
     <PropertyGroup>
       <!-- Define platform-specific native library naming -->
       <_DotnetAotNativeLibPrefix Condition="'$(OSName)' != 'win'">lib</_DotnetAotNativeLibPrefix>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -548,7 +548,7 @@
     <MSBuild
       Targets="Restore;Publish"
       Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);TargetFramework=$(SdkTargetFramework);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);IntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);IntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -547,7 +547,7 @@
     <MSBuild
       Targets="Restore;Publish"
       Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);IntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
+      Properties="Configuration=$(Configuration);TargetFramework=$(SdkTargetFramework);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);IntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -394,7 +394,7 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
-# Offical VS Code C# Dev Kit Extension exclusion
+# Official VS Code C# Dev Kit Extension exclusion
 *.lscache
 
 # Local History for Visual Studio Code

--- a/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -394,7 +394,7 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
-# Offical VS Code C# Dev Kit Extension exclusion
+# Official VS Code C# Dev Kit Extension exclusion
 *.lscache
 
 # Local History for Visual Studio Code

--- a/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
+++ b/test/dotnet-new.IntegrationTests/Approvals/AllCommonItemsCreate.-o#dotnet-gitignore-file#-n#item.verified/dotnet-gitignore-file/.gitignore
@@ -394,6 +394,9 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
+# Offical VS Code C# Dev Kit Extension exclusion
+*.lscache
+
 # Local History for Visual Studio Code
 .history/
 


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/53752
Related: https://github.com/dotnet/sdk/pull/54056

## Summary

## Test Failure
The recent PR that added `.lscache` to the .gitignore file. We have a test that runs against the .gitignore file. This test did not run in the PR because CI didn't run in the PR. This PR addresses the test failure and adds the `template_feed` folder as a folder that is monitored for changes so that CI runs appropriately.

## Build Failure 1 (consistent)
For the second PR, it was causing a build error.
```
##[error].dotnet\sdk\11.0.100-preview.3.26170.106\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1047: (NETCORE_ENGINEERING_TELEMETRY=Build) Assets file 'D:\a\_work\1\s\artifacts\obj\dotnet-aot\project.assets.json' doesn't have a target for 'net11.0/win-x64'. Ensure that restore has run and that you have included 'net11.0' in the TargetFrameworks for your project. You may also need to include 'win-x64' in your project's RuntimeIdentifiers.
```
I tried to add `TargetFramework=$(SdkTargetFramework)`, but that did not seem to fix the issue. Instead, I've just set the target to no longer run since it is not critical for any SDK functionality yet.

## Build Failure 2 (inconsistent)
There was an inconsistent build failure happening. 
```
##[error].dotnet/sdk/11.0.100-preview.3.26170.106/Microsoft.Common.CurrentVersion.targets(4917,5): error MSB3894: (NETCORE_ENGINEERING_TELEMETRY=Build) Got System.IO.IOException: The process cannot access the file '/Users/runner/work/1/s/artifacts/obj/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Release/net10.0/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at Microsoft.Build.Tasks.Copy.CopyFileWithLogging(FileState sourceFileState, FileState destinationFileState)
   at Microsoft.Build.Tasks.Copy.DoCopyWithRetries(FileState sourceFileState, FileState destinationFileState, CopyFileWithState copyFile) copying "/Users/runner/work/1/s/artifacts/obj/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Release/net10.0/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll" to "/Users/runner/work/1/s/artifacts/bin/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Release/net10.0/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.dll" and HR is 35
```

Had Copilot take a look. It realized there is a pattern to including projects in the `dotnet.csproj`. The recently migrated TemplateEngine project, `Microsoft.TemplateEngine.Orchestrator.RunnableProjects`, did not follow this pattern. It seems `GlobalPropertiesToRemove="PublishDir"` was missing, so that has been added to the project reference.