### PR TITLE
CA2028: Avoid redundant Regex.IsMatch before Regex.Match

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.NetCore.Analyzers;
+using Microsoft.NetCore.Analyzers.Runtime;
+
+namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
+{
+    /// <summary>
+    /// C#-specific fixer for <see cref="AvoidRedundantRegexIsMatchBeforeMatch"/>.
+    /// Transforms:
+    /// <code>
+    /// if (Regex.IsMatch(input, pattern))
+    /// {
+    ///     Match m = Regex.Match(input, pattern);
+    ///     // use m
+    /// }
+    /// </code>
+    /// Into:
+    /// <code>
+    /// if (Regex.Match(input, pattern) is { Success: true } m)
+    /// {
+    ///     // use m
+    /// }
+    /// </code>
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public sealed class CSharpAvoidRedundantRegexIsMatchBeforeMatchFixer : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(AvoidRedundantRegexIsMatchBeforeMatch.RuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.FirstOrDefault();
+            if (diagnostic is null)
+            {
+                return;
+            }
+
+            Document doc = context.Document;
+            SyntaxNode root = await doc.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            SemanticModel model = await doc.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            // Require C# 8.0+ for property patterns (is { Success: true } m)
+            if (root.SyntaxTree.Options is CSharpParseOptions parseOptions &&
+                parseOptions.LanguageVersion < LanguageVersion.CSharp8)
+            {
+                return;
+            }
+
+            // Find the IsMatch invocation from the primary diagnostic location.
+            if (root.FindNode(context.Span, getInnermostNodeForTie: true) is not SyntaxNode isMatchNode)
+            {
+                return;
+            }
+
+            // Find the Match invocation from the additional location.
+            if (diagnostic.AdditionalLocations.Count < 1)
+            {
+                return;
+            }
+
+            var matchLocation = diagnostic.AdditionalLocations[0];
+            if (root.FindNode(matchLocation.SourceSpan, getInnermostNodeForTie: true) is not SyntaxNode matchNode)
+            {
+                return;
+            }
+
+            // The Match call must be in a local declaration statement: Match m = Regex.Match(...);
+            // We only handle single-variable declarations.
+            var matchDeclarationStatement = matchNode.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+            if (matchDeclarationStatement is null)
+            {
+                return;
+            }
+
+            var declaration = matchDeclarationStatement.Declaration;
+            if (declaration.Variables.Count != 1)
+            {
+                return;
+            }
+
+            var declarator = declaration.Variables[0];
+            if (declarator.Initializer?.Value is null)
+            {
+                return;
+            }
+
+            // The IsMatch call must be the condition of an if statement.
+            var ifStatement = isMatchNode.FirstAncestorOrSelf<IfStatementSyntax>();
+            if (ifStatement is null)
+            {
+                return;
+            }
+
+            string variableName = declarator.Identifier.ValueText;
+
+            // Only apply fixer when the Match declaration is the first executable statement
+            // in the if body. If there are preceding statements, moving Match into the
+            // condition would change their execution order relative to the Match call.
+            if (ifStatement.Statement is BlockSyntax block)
+            {
+                var firstStatement = block.Statements.FirstOrDefault();
+                if (firstStatement != matchDeclarationStatement)
+                {
+                    return;
+                }
+            }
+
+            // Check for name conflicts: the pattern variable will be scoped to the
+            // entire if statement, including any else branch. If the else branch
+            // declares a variable with the same name, the fix would not compile.
+            if (ifStatement.Else is not null &&
+                HasConflictingDeclaration(ifStatement.Else, variableName))
+            {
+                return;
+            }
+
+            string title = MicrosoftNetCoreAnalyzersResources.AvoidRedundantRegexIsMatchBeforeMatchFix;
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    createChangedDocument: ct => ApplyFixAsync(doc, ifStatement, matchDeclarationStatement, matchNode, variableName, ct),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+
+        private static async Task<Document> ApplyFixAsync(
+            Document document,
+            IfStatementSyntax ifStatement,
+            LocalDeclarationStatementSyntax matchDeclarationStatement,
+            SyntaxNode matchCallNode,
+            string variableName,
+            CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            // Get the Match call expression (the initializer value of the local declaration).
+            var matchCallExpression = matchDeclarationStatement.Declaration.Variables[0].Initializer!.Value;
+
+            // Build: Regex.Match(input, pattern) is { Success: true } m
+            var successPattern = SyntaxFactory.RecursivePattern()
+                .WithPropertyPatternClause(
+                    SyntaxFactory.PropertyPatternClause(
+                        SyntaxFactory.SeparatedList(new[]
+                        {
+                            SyntaxFactory.Subpattern(
+                                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("Success")),
+                                SyntaxFactory.ConstantPattern(
+                                    SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)))
+                        })))
+                .WithDesignation(
+                    SyntaxFactory.SingleVariableDesignation(
+                        SyntaxFactory.Identifier(variableName)))
+                .NormalizeWhitespace();
+
+            var newCondition = SyntaxFactory.IsPatternExpression(
+                matchCallExpression.WithoutTrivia(),
+                successPattern)
+                .WithLeadingTrivia(ifStatement.Condition.GetLeadingTrivia())
+                .WithTrailingTrivia(ifStatement.Condition.GetTrailingTrivia());
+
+            // Replace the if condition
+            editor.ReplaceNode(ifStatement.Condition, newCondition);
+
+            // Remove the Match declaration statement from the if body
+            editor.RemoveNode(matchDeclarationStatement);
+
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Checks whether the given syntax node (typically an else clause) contains any
+        /// variable declarator with the specified name, which would conflict with a
+        /// pattern variable introduced in the if condition.
+        /// </summary>
+        private static bool HasConflictingDeclaration(SyntaxNode node, string variableName)
+        {
+            foreach (var declarator in node.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+            {
+                if (declarator.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -267,9 +267,11 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return;
             }
 
-            // The variable must not be referenced in any statement after the if,
-            // because the pattern variable won't be definitely assigned there.
-            if (IsVariableReferencedAfterIf(parentBlock, ifIndex, variableName))
+            // The variable must not be referenced in any statement after the if
+            // or in the else branch, because the pattern variable won't be
+            // definitely assigned there.
+            if (IsVariableReferencedAfterIf(parentBlock, ifIndex, variableName) ||
+                IsVariableReferencedInElse(ifStatement, variableName))
             {
                 return;
             }
@@ -367,6 +369,20 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             }
 
             return false;
+        }
+
+        private static bool IsVariableReferencedInElse(
+            IfStatementSyntax ifStatement, string variableName)
+        {
+            if (ifStatement.Else is null)
+            {
+                return false;
+            }
+
+            return ifStatement.Else
+                .DescendantNodesAndSelf()
+                .OfType<IdentifierNameSyntax>()
+                .Any(id => id.Identifier.ValueText == variableName);
         }
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -82,14 +82,42 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return;
             }
 
-            // The Match call must be in a local declaration statement: Match m = Regex.Match(...);
-            // We only handle single-variable declarations.
-            var matchDeclarationStatement = matchNode.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
-            if (matchDeclarationStatement is null)
+            // The IsMatch call must be the condition of an if statement.
+            var ifStatement = isMatchNode.FirstAncestorOrSelf<IfStatementSyntax>();
+            if (ifStatement is null)
             {
                 return;
             }
 
+            // Path 1: Match m = Regex.Match(...); — local declaration in if body
+            var matchDeclarationStatement = matchNode.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+            if (matchDeclarationStatement is not null)
+            {
+                TryRegisterDeclarationFix(context, diagnostic, doc, model, ifStatement, matchDeclarationStatement, matchNode);
+                return;
+            }
+
+            // Path 2: m = Regex.Match(...); — assignment to pre-declared variable
+            var assignmentExpression = matchNode.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+            if (assignmentExpression is not null)
+            {
+                TryRegisterAssignmentFix(context, diagnostic, doc, model, ifStatement, assignmentExpression, matchNode);
+            }
+        }
+
+        /// <summary>
+        /// Path 1: The Match result is assigned via a local declaration in the if body:
+        /// <c>Match m = Regex.Match(...);</c>
+        /// </summary>
+        private static void TryRegisterDeclarationFix(
+            CodeFixContext context,
+            Diagnostic diagnostic,
+            Document doc,
+            SemanticModel model,
+            IfStatementSyntax ifStatement,
+            LocalDeclarationStatementSyntax matchDeclarationStatement,
+            SyntaxNode matchNode)
+        {
             var declaration = matchDeclarationStatement.Declaration;
             if (declaration.Variables.Count != 1)
             {
@@ -105,18 +133,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             // Verify the initializer is exactly the Match invocation reported by the analyzer
             // (unwrapping any parentheses/casts). If the Match call is embedded inside a larger
             // expression (e.g., SomeMethod(Regex.Match(...))), the fix would change semantics.
-            SyntaxNode coreInitializer = declarator.Initializer.Value;
-            while (coreInitializer is ParenthesizedExpressionSyntax parenExpr)
-            {
-                coreInitializer = parenExpr.Expression;
-            }
-
-            while (coreInitializer is CastExpressionSyntax castExpr)
-            {
-                coreInitializer = castExpr.Expression;
-            }
-
-            if (!coreInitializer.Span.Equals(matchNode.Span))
+            if (!IsMatchNode(declarator.Initializer.Value, matchNode))
             {
                 return;
             }
@@ -125,21 +142,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             // System.Text.RegularExpressions.Match. If the user wrote a wider type
             // (e.g., Group, Capture, object), the pattern variable would change
             // the static type and could alter overload resolution.
-            if (!declaration.Type.IsVar)
-            {
-                var typeInfo = model.GetTypeInfo(declaration.Type, context.CancellationToken);
-                var matchType = model.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Match");
-                if (typeInfo.Type is null ||
-                    matchType is null ||
-                    !SymbolEqualityComparer.Default.Equals(typeInfo.Type, matchType))
-                {
-                    return;
-                }
-            }
-
-            // The IsMatch call must be the condition of an if statement.
-            var ifStatement = isMatchNode.FirstAncestorOrSelf<IfStatementSyntax>();
-            if (ifStatement is null)
+            if (!IsVarOrMatchType(declaration.Type, model, context.CancellationToken))
             {
                 return;
             }
@@ -158,18 +161,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 }
             }
 
-            // Check for name conflicts: a pattern variable from
-            //   if (expr is { } m)
-            // scopes to the entire enclosing block, not just the if body.
-            // Bail if any else branch or subsequent sibling statement
-            // declares a variable with the same name.
-            if (ifStatement.Else is not null &&
-                HasConflictingName(ifStatement.Else, variableName))
-            {
-                return;
-            }
-
-            if (HasConflictingNameInSubsequentSiblings(ifStatement, variableName))
+            if (!PassesNameConflictChecks(ifStatement, variableName))
             {
                 return;
             }
@@ -178,12 +170,209 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title,
-                    createChangedDocument: ct => ApplyFixAsync(doc, ifStatement, matchDeclarationStatement, variableName, ct),
+                    createChangedDocument: ct => ApplyDeclarationFixAsync(doc, ifStatement, matchDeclarationStatement, variableName, ct),
                     equivalenceKey: title),
                 diagnostic);
         }
 
-        private static async Task<Document> ApplyFixAsync(
+        /// <summary>
+        /// Path 2: The Match result is assigned to a pre-declared variable in the if body:
+        /// <c>Match m; if (IsMatch(...)) { m = Regex.Match(...); }</c>
+        /// Transforms to: <c>if (Regex.Match(...) is { Success: true } m) { }</c>
+        /// Only applies when the pre-existing declaration is immediately before the if
+        /// and the variable is not referenced after the if statement.
+        /// </summary>
+        private static void TryRegisterAssignmentFix(
+            CodeFixContext context,
+            Diagnostic diagnostic,
+            Document doc,
+            SemanticModel model,
+            IfStatementSyntax ifStatement,
+            AssignmentExpressionSyntax assignmentExpression,
+            SyntaxNode matchNode)
+        {
+            // The left side must be a simple identifier (the variable being assigned).
+            if (assignmentExpression.Left is not IdentifierNameSyntax identName)
+            {
+                return;
+            }
+
+            // Verify the right side is exactly the Match invocation.
+            if (!IsMatchNode(assignmentExpression.Right, matchNode))
+            {
+                return;
+            }
+
+            // The assignment must be in an expression statement.
+            var assignmentStatement = assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+            if (assignmentStatement is null)
+            {
+                return;
+            }
+
+            // The assignment statement must be the first statement in a block body.
+            if (ifStatement.Statement is not BlockSyntax block ||
+                block.Statements.FirstOrDefault() != assignmentStatement)
+            {
+                return;
+            }
+
+            // The if must be inside a block so we can find the preceding declaration.
+            if (ifStatement.Parent is not BlockSyntax parentBlock)
+            {
+                return;
+            }
+
+            string variableName = identName.Identifier.ValueText;
+
+            // Find the pre-existing declaration of the variable immediately before the if.
+            int ifIndex = parentBlock.Statements.IndexOf(ifStatement);
+            if (ifIndex <= 0)
+            {
+                return;
+            }
+
+            if (parentBlock.Statements[ifIndex - 1] is not LocalDeclarationStatementSyntax preDecl)
+            {
+                return;
+            }
+
+            if (preDecl.Declaration.Variables.Count != 1)
+            {
+                return;
+            }
+
+            var preVar = preDecl.Declaration.Variables[0];
+            if (preVar.Identifier.ValueText != variableName)
+            {
+                return;
+            }
+
+            // The pre-existing declaration must have no initializer, or be initialized to
+            // null/default so removing it doesn't lose meaningful computation.
+            if (preVar.Initializer is not null)
+            {
+                var initValue = preVar.Initializer.Value;
+                if (initValue is not LiteralExpressionSyntax literal ||
+                    (!literal.IsKind(SyntaxKind.NullLiteralExpression) &&
+                     !literal.IsKind(SyntaxKind.DefaultLiteralExpression)))
+                {
+                    return;
+                }
+            }
+
+            // Verify the declared type is 'var' or exactly Match.
+            if (!IsVarOrMatchType(preDecl.Declaration.Type, model, context.CancellationToken))
+            {
+                return;
+            }
+
+            // The variable must not be referenced in any statement after the if,
+            // because the pattern variable won't be definitely assigned there.
+            if (IsVariableReferencedAfterIf(parentBlock, ifIndex, variableName))
+            {
+                return;
+            }
+
+            if (!PassesNameConflictChecks(ifStatement, variableName))
+            {
+                return;
+            }
+
+            string title = MicrosoftNetCoreAnalyzersResources.AvoidRedundantRegexIsMatchBeforeMatchFix;
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    createChangedDocument: ct => ApplyAssignmentFixAsync(doc, ifStatement, preDecl, assignmentStatement, variableName, ct),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+
+        /// <summary>
+        /// Checks whether <paramref name="expression"/> is exactly the Match invocation
+        /// <paramref name="matchNode"/> after unwrapping parentheses and casts.
+        /// </summary>
+        private static bool IsMatchNode(ExpressionSyntax expression, SyntaxNode matchNode)
+        {
+            SyntaxNode core = expression;
+            while (core is ParenthesizedExpressionSyntax parenExpr)
+            {
+                core = parenExpr.Expression;
+            }
+
+            while (core is CastExpressionSyntax castExpr)
+            {
+                core = castExpr.Expression;
+            }
+
+            return core.Span.Equals(matchNode.Span);
+        }
+
+        /// <summary>
+        /// Returns true when the type syntax is <c>var</c> or exactly
+        /// <c>System.Text.RegularExpressions.Match</c>.
+        /// </summary>
+        private static bool IsVarOrMatchType(
+            TypeSyntax typeSyntax, SemanticModel model, CancellationToken cancellationToken)
+        {
+            if (typeSyntax.IsVar)
+            {
+                return true;
+            }
+
+            var typeInfo = model.GetTypeInfo(typeSyntax, cancellationToken);
+            var matchType = model.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Match");
+            return typeInfo.Type is not null &&
+                   matchType is not null &&
+                   SymbolEqualityComparer.Default.Equals(typeInfo.Type, matchType);
+        }
+
+        /// <summary>
+        /// Returns true when the variable name doesn't conflict with bindings in else
+        /// branches or subsequent sibling statements.
+        /// </summary>
+        private static bool PassesNameConflictChecks(
+            IfStatementSyntax ifStatement, string variableName)
+        {
+            if (ifStatement.Else is not null &&
+                HasConflictingName(ifStatement.Else, variableName))
+            {
+                return false;
+            }
+
+            if (HasConflictingNameInSubsequentSiblings(ifStatement, variableName))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the variable is referenced in any statement after
+        /// <paramref name="ifIndex"/> in the parent block.
+        /// </summary>
+        private static bool IsVariableReferencedAfterIf(
+            BlockSyntax parentBlock, int ifIndex, string variableName)
+        {
+            for (int i = ifIndex + 1; i < parentBlock.Statements.Count; i++)
+            {
+                if (parentBlock.Statements[i]
+                    .DescendantNodesAndSelf()
+                    .OfType<IdentifierNameSyntax>()
+                    .Any(id => id.Identifier.ValueText == variableName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Applies the fix for Path 1 (local declaration in if body).
+        /// </summary>
+        private static async Task<Document> ApplyDeclarationFixAsync(
             Document document,
             IfStatementSyntax ifStatement,
             LocalDeclarationStatementSyntax matchDeclarationStatement,
@@ -191,11 +380,44 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
-            // Get the Match call expression (the initializer value of the local declaration).
             var matchCallExpression = matchDeclarationStatement.Declaration.Variables[0].Initializer!.Value;
 
-            // Build: Regex.Match(input, pattern) is { Success: true } m
+            editor.ReplaceNode(ifStatement.Condition, BuildIsPatternCondition(ifStatement, matchCallExpression, variableName));
+            editor.RemoveNode(matchDeclarationStatement);
+
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Applies the fix for Path 2 (assignment to pre-declared variable).
+        /// </summary>
+        private static async Task<Document> ApplyAssignmentFixAsync(
+            Document document,
+            IfStatementSyntax ifStatement,
+            LocalDeclarationStatementSyntax preDeclaration,
+            ExpressionStatementSyntax assignmentStatement,
+            string variableName,
+            CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var assignmentExpr = (AssignmentExpressionSyntax)assignmentStatement.Expression;
+            var matchCallExpression = assignmentExpr.Right;
+
+            editor.ReplaceNode(ifStatement.Condition, BuildIsPatternCondition(ifStatement, matchCallExpression, variableName));
+            editor.RemoveNode(assignmentStatement);
+            editor.RemoveNode(preDeclaration);
+
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Builds: <c>Regex.Match(input, pattern) is { Success: true } m</c>
+        /// </summary>
+        private static IsPatternExpressionSyntax BuildIsPatternCondition(
+            IfStatementSyntax ifStatement,
+            ExpressionSyntax matchCallExpression,
+            string variableName)
+        {
             var successPattern = SyntaxFactory.RecursivePattern()
                 .WithPropertyPatternClause(
                     SyntaxFactory.PropertyPatternClause(
@@ -211,19 +433,11 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                         SyntaxFactory.Identifier(variableName)))
                 .NormalizeWhitespace();
 
-            var newCondition = SyntaxFactory.IsPatternExpression(
+            return SyntaxFactory.IsPatternExpression(
                 matchCallExpression.WithoutTrivia(),
                 successPattern)
                 .WithLeadingTrivia(ifStatement.Condition.GetLeadingTrivia())
                 .WithTrailingTrivia(SyntaxFactory.TriviaList());
-
-            // Replace the if condition
-            editor.ReplaceNode(ifStatement.Condition, newCondition);
-
-            // Remove the Match declaration statement from the if body
-            editor.RemoveNode(matchDeclarationStatement);
-
-            return editor.GetChangedDocument();
         }
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -103,6 +103,20 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return;
             }
 
+            // Only apply fixer when the declared type is 'var' or exactly
+            // System.Text.RegularExpressions.Match. If the user wrote a wider type
+            // (e.g., Group, Capture, object), the pattern variable would change
+            // the static type and could alter overload resolution.
+            if (!declaration.Type.IsVar)
+            {
+                var typeInfo = model.GetTypeInfo(declaration.Type, context.CancellationToken);
+                if (typeInfo.Type is null ||
+                    typeInfo.Type.ToDisplayString() != "System.Text.RegularExpressions.Match")
+                {
+                    return;
+                }
+            }
+
             // The IsMatch call must be the condition of an if statement.
             var ifStatement = isMatchNode.FirstAncestorOrSelf<IfStatementSyntax>();
             if (ifStatement is null)
@@ -124,11 +138,18 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 }
             }
 
-            // Check for name conflicts: the pattern variable will be scoped to the
-            // entire if statement, including any else branch. If the else branch
-            // declares a variable with the same name, the fix would not compile.
+            // Check for name conflicts: a pattern variable from
+            //   if (expr is { } m)
+            // scopes to the entire enclosing block, not just the if body.
+            // Bail if any else branch or subsequent sibling statement
+            // declares a variable with the same name.
             if (ifStatement.Else is not null &&
-                HasConflictingDeclaration(ifStatement.Else, variableName))
+                HasConflictingName(ifStatement.Else, variableName))
+            {
+                return;
+            }
+
+            if (HasConflictingNameInSubsequentSiblings(ifStatement, variableName))
             {
                 return;
             }
@@ -189,14 +210,64 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 
         /// <summary>
         /// Checks whether the given syntax node (typically an else clause) contains any
-        /// variable declarator with the specified name, which would conflict with a
-        /// pattern variable introduced in the if condition.
+        /// variable binding with the specified name — including variable declarators,
+        /// pattern designations (is/switch patterns), out var, foreach, and catch.
         /// </summary>
-        private static bool HasConflictingDeclaration(SyntaxNode node, string variableName)
+        private static bool HasConflictingName(SyntaxNode node, string variableName)
         {
-            foreach (var declarator in node.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+            foreach (var descendant in node.DescendantNodes())
             {
-                if (declarator.Identifier.ValueText == variableName)
+                if (descendant is VariableDeclaratorSyntax declarator &&
+                    declarator.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is SingleVariableDesignationSyntax designation &&
+                    designation.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is ForEachStatementSyntax forEach &&
+                    forEach.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is CatchDeclarationSyntax catchDecl &&
+                    catchDecl.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether any statement after the given if statement in its parent block
+        /// declares a variable with the specified name. Pattern variables from the if
+        /// condition scope to the entire enclosing block, so later declarations conflict.
+        /// </summary>
+        private static bool HasConflictingNameInSubsequentSiblings(
+            IfStatementSyntax ifStatement, string variableName)
+        {
+            if (ifStatement.Parent is not BlockSyntax parentBlock)
+            {
+                return false;
+            }
+
+            bool foundIf = false;
+            foreach (var statement in parentBlock.Statements)
+            {
+                if (statement == ifStatement)
+                {
+                    foundIf = true;
+                    continue;
+                }
+
+                if (foundIf && HasConflictingName(statement, variableName))
                 {
                     return true;
                 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -47,15 +47,10 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var diagnostic = context.Diagnostics.FirstOrDefault();
-            if (diagnostic is null)
-            {
-                return;
-            }
+            var diagnostic = context.Diagnostics[0];
 
             Document doc = context.Document;
             SyntaxNode root = await doc.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            SemanticModel model = await doc.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
 
             // Require C# 8.0+ for property patterns (is { Success: true } m)
             if (root.SyntaxTree.Options is CSharpParseOptions parseOptions &&
@@ -88,6 +83,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             {
                 return;
             }
+
+            SemanticModel model = await doc.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
 
             // Path 1: Match m = Regex.Match(...); — local declaration in if body
             var matchDeclarationStatement = matchNode.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -128,8 +128,10 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             if (!declaration.Type.IsVar)
             {
                 var typeInfo = model.GetTypeInfo(declaration.Type, context.CancellationToken);
+                var matchType = model.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Match");
                 if (typeInfo.Type is null ||
-                    typeInfo.Type.ToDisplayString() != "System.Text.RegularExpressions.Match")
+                    matchType is null ||
+                    !SymbolEqualityComparer.Default.Equals(typeInfo.Type, matchType))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -102,6 +102,25 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return;
             }
 
+            // Verify the initializer is exactly the Match invocation reported by the analyzer
+            // (unwrapping any parentheses/casts). If the Match call is embedded inside a larger
+            // expression (e.g., SomeMethod(Regex.Match(...))), the fix would change semantics.
+            SyntaxNode coreInitializer = declarator.Initializer.Value;
+            while (coreInitializer is ParenthesizedExpressionSyntax parenExpr)
+            {
+                coreInitializer = parenExpr.Expression;
+            }
+
+            while (coreInitializer is CastExpressionSyntax castExpr)
+            {
+                coreInitializer = castExpr.Expression;
+            }
+
+            if (!coreInitializer.Span.Equals(matchNode.Span))
+            {
+                return;
+            }
+
             // Only apply fixer when the declared type is 'var' or exactly
             // System.Text.RegularExpressions.Match. If the user wrote a wider type
             // (e.g., Group, Capture, object), the pattern variable would change

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.NetCore.Analyzers;
 using Microsoft.NetCore.Analyzers.Runtime;
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -268,6 +268,13 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 {
                     return true;
                 }
+
+                // Lambda, anonymous method, and local function parameters
+                if (descendant is ParameterSyntax parameter &&
+                    parameter.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title,
-                    createChangedDocument: ct => ApplyFixAsync(doc, ifStatement, matchDeclarationStatement, matchNode, variableName, ct),
+                    createChangedDocument: ct => ApplyFixAsync(doc, ifStatement, matchDeclarationStatement, variableName, ct),
                     equivalenceKey: title),
                 diagnostic);
         }
@@ -167,12 +167,10 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             Document document,
             IfStatementSyntax ifStatement,
             LocalDeclarationStatementSyntax matchDeclarationStatement,
-            SyntaxNode matchCallNode,
             string variableName,
             CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Get the Match call expression (the initializer value of the local declaration).
             var matchCallExpression = matchDeclarationStatement.Declaration.Variables[0].Initializer!.Value;
@@ -197,7 +195,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 matchCallExpression.WithoutTrivia(),
                 successPattern)
                 .WithLeadingTrivia(ifStatement.Condition.GetLeadingTrivia())
-                .WithTrailingTrivia(ifStatement.Condition.GetTrailingTrivia());
+                .WithTrailingTrivia(SyntaxFactory.TriviaList());
 
             // Replace the if condition
             editor.ReplaceNode(ifStatement.Condition, newCondition);
@@ -235,6 +233,16 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                     return true;
                 }
 
+                // Deconstruction foreach: foreach (var (x, y) in ...)
+                if (descendant is ForEachVariableStatementSyntax forEachVariable &&
+                    forEachVariable.Variable
+                        .DescendantNodesAndSelf()
+                        .OfType<SingleVariableDesignationSyntax>()
+                        .Any(d => d.Identifier.ValueText == variableName))
+                {
+                    return true;
+                }
+
                 if (descendant is CatchDeclarationSyntax catchDecl &&
                     catchDecl.Identifier.ValueText == variableName)
                 {
@@ -249,19 +257,31 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         /// Checks whether any statement after the given if statement in its parent block
         /// declares a variable with the specified name. Pattern variables from the if
         /// condition scope to the entire enclosing block, so later declarations conflict.
+        /// For parent containers other than <see cref="BlockSyntax"/>, conservatively
+        /// assume a conflict because this helper only scans block statements.
         /// </summary>
         private static bool HasConflictingNameInSubsequentSiblings(
             IfStatementSyntax ifStatement, string variableName)
         {
-            if (ifStatement.Parent is not BlockSyntax parentBlock)
+            // Walk up through else-if chains to find the outermost if statement.
+            // Pattern variables scope to the enclosing block, so for an "else if" we
+            // must check siblings after the outermost if in that chain.
+            SyntaxNode current = ifStatement;
+            while (current.Parent is ElseClauseSyntax elseClause &&
+                   elseClause.Parent is IfStatementSyntax parentIf)
             {
-                return false;
+                current = parentIf;
+            }
+
+            if (current.Parent is not BlockSyntax parentBlock)
+            {
+                return true;
             }
 
             bool foundIf = false;
             foreach (var statement in parentBlock.Statements)
             {
-                if (statement == ifStatement)
+                if (statement == current)
                 {
                     foundIf = true;
                     continue;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.NetCore.Analyzers;
 using Microsoft.NetCore.Analyzers.Runtime;
 
@@ -356,10 +357,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         {
             for (int i = ifIndex + 1; i < parentBlock.Statements.Count; i++)
             {
-                if (parentBlock.Statements[i]
-                    .DescendantNodesAndSelf()
-                    .OfType<IdentifierNameSyntax>()
-                    .Any(id => id.Identifier.ValueText == variableName))
+                if (ContainsIdentifierReference(parentBlock.Statements[i], variableName))
                 {
                     return true;
                 }
@@ -376,10 +374,49 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return false;
             }
 
-            return ifStatement.Else
-                .DescendantNodesAndSelf()
-                .OfType<IdentifierNameSyntax>()
-                .Any(id => id.Identifier.ValueText == variableName);
+            return ContainsIdentifierReference(ifStatement.Else, variableName);
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="node"/> contains an identifier that
+        /// could plausibly bind to a local named <paramref name="variableName"/>.
+        /// Excludes identifiers that are syntactically the name of a member access
+        /// (e.g. <c>obj.m</c>) or a qualified name suffix, since those bind to a
+        /// member rather than the local. Conservative — does not consult the
+        /// semantic model, so it can still over-report (e.g. type names, nameof).
+        /// </summary>
+        private static bool ContainsIdentifierReference(SyntaxNode node, string variableName)
+        {
+            foreach (var id in node.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            {
+                if (id.Identifier.ValueText != variableName)
+                {
+                    continue;
+                }
+
+                // Skip `something.m` (right-hand side of a member access) — `m` here is
+                // a member name, not a reference to the local.
+                if (id.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == id)
+                {
+                    continue;
+                }
+
+                // Skip `Foo.m` where `m` is the right-hand side of a qualified name.
+                if (id.Parent is QualifiedNameSyntax qualified && qualified.Right == id)
+                {
+                    continue;
+                }
+
+                // Skip `M(m: value)` — `m` here is a parameter name label, not a reference.
+                if (id.Parent is NameColonSyntax nameColon && nameColon.Name == id)
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -450,7 +487,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 matchCallExpression.WithoutTrivia(),
                 successPattern)
                 .WithLeadingTrivia(ifStatement.Condition.GetLeadingTrivia())
-                .WithTrailingTrivia(SyntaxFactory.TriviaList());
+                .WithTrailingTrivia(SyntaxFactory.TriviaList())
+                .WithAdditionalAnnotations(Formatter.Annotation);
         }
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -548,6 +548,39 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 {
                     return true;
                 }
+
+                // LINQ query range variables. Pattern variables introduced by
+                // `is { ... } m` scope to the enclosing block, so any subsequent
+                // query that already binds the same name would start conflicting.
+                if (descendant is FromClauseSyntax fromClause &&
+                    fromClause.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is LetClauseSyntax letClause &&
+                    letClause.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is JoinClauseSyntax joinClause &&
+                    joinClause.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is JoinIntoClauseSyntax joinIntoClause &&
+                    joinIntoClause.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
+
+                if (descendant is QueryContinuationSyntax queryCont &&
+                    queryCont.Identifier.ValueText == variableName)
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidRedundantRegexIsMatchBeforeMatch.Fixer.cs
@@ -246,14 +246,22 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return;
             }
 
-            // The pre-existing declaration must have no initializer, or be initialized to
-            // null/default so removing it doesn't lose meaningful computation.
+            // The pre-existing declaration must have no initializer, or be initialized
+            // to a constant default expression (`null`, `default`, or `default(T)`) so
+            // removing it doesn't lose meaningful computation.
             if (preVar.Initializer is not null)
             {
                 var initValue = preVar.Initializer.Value;
-                if (initValue is not LiteralExpressionSyntax literal ||
-                    (!literal.IsKind(SyntaxKind.NullLiteralExpression) &&
-                     !literal.IsKind(SyntaxKind.DefaultLiteralExpression)))
+                bool acceptable = initValue switch
+                {
+                    LiteralExpressionSyntax literal =>
+                        literal.IsKind(SyntaxKind.NullLiteralExpression) ||
+                        literal.IsKind(SyntaxKind.DefaultLiteralExpression),
+                    DefaultExpressionSyntax => true,
+                    _ => false,
+                };
+
+                if (!acceptable)
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -2214,6 +2214,18 @@ When Task.Delay is used with Task.WhenAny to implement a timeout, the timer crea
 |CodeFix|False|
 ---
 
+## [CA2028](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2028): Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'
+
+When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.
+
+|Item|Value|
+|-|-|
+|Category|Reliability|
+|Enabled|True|
+|Severity|Info|
+|CodeFix|True|
+---
+
 ## [CA2100](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100): Review SQL queries for security vulnerabilities
 
 SQL queries that directly use user input can be vulnerable to SQL injection attacks. Review this SQL query for potential vulnerabilities, and consider using a parameterized SQL query.

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3950,6 +3950,26 @@
             ]
           }
         },
+        "CA2028": {
+          "id": "CA2028",
+          "shortDescription": "Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'",
+          "fullDescription": "When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.",
+          "defaultLevel": "note",
+          "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2028",
+          "properties": {
+            "category": "Reliability",
+            "isEnabledByDefault": true,
+            "typeName": "AvoidRedundantRegexIsMatchBeforeMatch",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ],
+            "tags": [
+              "Telemetry",
+              "EnabledRuleInAggressiveMode"
+            ]
+          }
+        },
         "CA2100": {
           "id": "CA2100",
           "shortDescription": "Review SQL queries for security vulnerabilities",

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ CA1876 | Performance | Info | DoNotUseAsParallelInForEachLoopAnalyzer, [Document
 CA1877 | Performance | Info | CollapseMultiplePathOperationsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/cA1877)
 CA2026 | Reliability | Info | PreferJsonElementParse, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2026)
 CA2027 | Reliability | Info | DoNotUseNonCancelableTaskDelayWithWhenAny, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2027)
+CA2028 | Reliability | Info | AvoidRedundantRegexIsMatchBeforeMatch, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2028)

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -2087,6 +2087,18 @@ Widening and user defined conversions are not supported with generic types.</val
   <data name="PreferJsonElementParseFix" xml:space="preserve">
     <value>Use 'JsonElement.Parse'</value>
   </data>
+  <data name="AvoidRedundantRegexIsMatchBeforeMatchTitle" xml:space="preserve">
+    <value>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</value>
+  </data>
+  <data name="AvoidRedundantRegexIsMatchBeforeMatchMessage" xml:space="preserve">
+    <value>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</value>
+  </data>
+  <data name="AvoidRedundantRegexIsMatchBeforeMatchDescription" xml:space="preserve">
+    <value>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</value>
+  </data>
+  <data name="AvoidRedundantRegexIsMatchBeforeMatchFix" xml:space="preserve">
+    <value>Use 'Regex.Match' and check 'Success'</value>
+  </data>
   <data name="UseConcreteTypeDescription" xml:space="preserve">
     <value>Using concrete types avoids virtual or interface call overhead and enables inlining.</value>
   </data>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -468,8 +468,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         /// <summary>
         /// Checks whether an operation or any of its descendants writes to any of the
-        /// given symbols (via assignment, compound assignment, or increment/decrement).
-        /// Does not recurse into lambdas or local functions.
+        /// given symbols (via assignment, compound assignment, increment/decrement, or
+        /// ref/out argument passing). Does not recurse into lambdas or local functions.
         /// </summary>
         private static bool ContainsWriteToSymbols(IOperation operation, HashSet<ISymbol> symbols)
         {
@@ -477,6 +477,25 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             if (writtenSymbol is not null && symbols.Contains(writtenSymbol))
             {
                 return true;
+            }
+
+            // Check for ref/out argument passing which can mutate tracked symbols.
+            if (operation is IArgumentOperation argOp &&
+                argOp.Parameter is not null &&
+                argOp.Parameter.RefKind is RefKind.Ref or RefKind.Out)
+            {
+                var argValue = argOp.Value.WalkDownConversion();
+                ISymbol? argSymbol = argValue switch
+                {
+                    ILocalReferenceOperation localRef => localRef.Local,
+                    IParameterReferenceOperation paramRef => paramRef.Parameter,
+                    _ => null
+                };
+
+                if (argSymbol is not null && symbols.Contains(argSymbol))
+                {
+                    return true;
+                }
             }
 
             foreach (var child in operation.Children)

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -328,11 +328,27 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return false;
             }
 
-            for (int i = 0; i < isMatchInvocation.Arguments.Length; i++)
+            // Compare arguments by parameter ordinal rather than array index,
+            // because named arguments may reorder the Arguments array.
+            foreach (IArgumentOperation isMatchArg in isMatchInvocation.Arguments)
             {
-                if (!AreOperandsEquivalent(
-                        isMatchInvocation.Arguments[i].Value,
-                        matchInvocation.Arguments[i].Value))
+                if (isMatchArg.Parameter is null)
+                {
+                    return false;
+                }
+
+                IArgumentOperation? matchArg = null;
+                foreach (IArgumentOperation candidate in matchInvocation.Arguments)
+                {
+                    if (candidate.Parameter?.Ordinal == isMatchArg.Parameter.Ordinal)
+                    {
+                        matchArg = candidate;
+                        break;
+                    }
+                }
+
+                if (matchArg is null ||
+                    !AreOperandsEquivalent(isMatchArg.Value, matchArg.Value))
                 {
                     return false;
                 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -45,29 +44,21 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            context.RegisterCompilationStartAction(compilationContext =>
+            context.RegisterCompilationStartAction(context =>
             {
-                if (!compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTextRegularExpressionsRegex, out var regexType))
+                if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTextRegularExpressionsRegex, out var regexType))
                 {
                     return;
                 }
 
-                var isMatchMembers = regexType.GetMembers("IsMatch");
-                var matchMembers = regexType.GetMembers("Match");
-
-                if (isMatchMembers.IsEmpty || matchMembers.IsEmpty)
+                context.RegisterOperationAction(context =>
                 {
-                    return;
-                }
-
-                compilationContext.RegisterOperationAction(operationContext =>
-                {
-                    var conditional = (IConditionalOperation)operationContext.Operation;
+                    var conditional = (IConditionalOperation)context.Operation;
 
                     // The condition must be a direct call to Regex.IsMatch (not negated).
-                    if (GetUnwrappedInvocation(conditional.Condition) is not IInvocationOperation isMatchInvocation ||
+                    if (UnwrapInvocationFromCondition(conditional.Condition) is not IInvocationOperation isMatchInvocation ||
                         isMatchInvocation.TargetMethod.Name != "IsMatch" ||
-                        !isMatchMembers.Contains(isMatchInvocation.TargetMethod, SymbolEqualityComparer.Default))
+                        !SymbolEqualityComparer.Default.Equals(isMatchInvocation.TargetMethod.ContainingType, regexType))
                     {
                         return;
                     }
@@ -79,7 +70,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     // Search direct children of the WhenTrue block for Regex.Match calls.
                     IInvocationOperation? matchInvocation = FindMatchingMatchCall(
-                        conditional.WhenTrue, isMatchInvocation, matchMembers);
+                        conditional.WhenTrue, isMatchInvocation, regexType);
 
                     if (matchInvocation is null)
                     {
@@ -87,7 +78,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
 
                     // Report diagnostic on the IsMatch call, with additional location on the Match call.
-                    operationContext.ReportDiagnostic(
+                    context.ReportDiagnostic(
                         isMatchInvocation.CreateDiagnostic(
                             Rule,
                             ImmutableArray.Create(matchInvocation.Syntax.GetLocation()),
@@ -97,15 +88,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         }
 
         /// <summary>
-        /// Unwraps parenthesized and conversion operations to get the underlying invocation.
+        /// Unwraps parenthesized and conversion operations from a condition to get the underlying invocation.
         /// </summary>
-        private static IInvocationOperation? GetUnwrappedInvocation(IOperation? operation)
+        private static IInvocationOperation? UnwrapInvocationFromCondition(IOperation operation)
         {
-            if (operation is null)
-            {
-                return null;
-            }
-
             // Walk through parentheses and conversions (e.g., implicit bool conversion)
             operation = operation.WalkDownParentheses().WalkDownConversion();
 
@@ -119,7 +105,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static IInvocationOperation? FindMatchingMatchCall(
             IOperation whenTrue,
             IInvocationOperation isMatchInvocation,
-            ImmutableArray<ISymbol> matchMembers)
+            INamedTypeSymbol regexType)
         {
             // If WhenTrue is not a block, check the single operation directly.
             // Still perform the write check for consistency with the block path —
@@ -133,7 +119,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return null;
                 }
 
-                return TryFindMatchInOperation(whenTrue, isMatchInvocation, matchMembers);
+                return TryFindMatchInOperation(whenTrue, isMatchInvocation, regexType);
             }
 
             // Collect local/parameter symbols referenced by the IsMatch arguments.
@@ -153,7 +139,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 // Look for Match calls in direct children only — don't recurse into
                 // lambdas, local functions, or nested blocks (except expression-level nesting).
-                if (TryFindMatchInOperation(op, isMatchInvocation, matchMembers) is { } found)
+                if (TryFindMatchInOperation(op, isMatchInvocation, regexType) is { } found)
                 {
                     return found;
                 }
@@ -170,7 +156,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static IInvocationOperation? TryFindMatchInOperation(
             IOperation operation,
             IInvocationOperation isMatchInvocation,
-            ImmutableArray<ISymbol> matchMembers)
+            INamedTypeSymbol regexType)
         {
             // Handle variable declaration: Match m = Regex.Match(...)
             if (operation is IVariableDeclarationGroupOperation declGroup)
@@ -180,7 +166,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     // In VB, the initializer is on the declaration (not the declarator).
                     if (declaration.Initializer?.Value is { } declInitValue)
                     {
-                        var found = FindMatchInExpression(declInitValue, isMatchInvocation, matchMembers);
+                        var found = FindMatchInExpression(declInitValue, isMatchInvocation, regexType);
                         if (found is not null)
                         {
                             return found;
@@ -192,7 +178,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         if (declarator.Initializer?.Value is { } initValue)
                         {
-                            var found = FindMatchInExpression(initValue, isMatchInvocation, matchMembers);
+                            var found = FindMatchInExpression(initValue, isMatchInvocation, regexType);
                             if (found is not null)
                             {
                                 return found;
@@ -207,13 +193,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Handle expression statements: Regex.Match(...) or m = Regex.Match(...)
             if (operation is IExpressionStatementOperation exprStatement)
             {
-                return FindMatchInExpression(exprStatement.Operation, isMatchInvocation, matchMembers);
+                return FindMatchInExpression(exprStatement.Operation, isMatchInvocation, regexType);
             }
 
             // Handle return statements: return Regex.Match(...)
             if (operation is IReturnOperation returnOp && returnOp.ReturnedValue is not null)
             {
-                return FindMatchInExpression(returnOp.ReturnedValue, isMatchInvocation, matchMembers);
+                return FindMatchInExpression(returnOp.ReturnedValue, isMatchInvocation, regexType);
             }
 
             return null;
@@ -227,14 +213,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static IInvocationOperation? FindMatchInExpression(
             IOperation expression,
             IInvocationOperation isMatchInvocation,
-            ImmutableArray<ISymbol> matchMembers)
+            INamedTypeSymbol regexType)
         {
             expression = expression.WalkDownParentheses().WalkDownConversion();
 
             // Direct invocation: check if it's a matching Regex.Match call.
             if (expression is IInvocationOperation invocation)
             {
-                if (IsMatchingMatchCall(invocation, isMatchInvocation, matchMembers))
+                if (IsMatchingMatchCall(invocation, isMatchInvocation, regexType))
                 {
                     return invocation;
                 }
@@ -243,7 +229,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // and the instance receiver.
                 if (invocation.Instance is not null)
                 {
-                    var found = FindMatchInExpression(invocation.Instance, isMatchInvocation, matchMembers);
+                    var found = FindMatchInExpression(invocation.Instance, isMatchInvocation, regexType);
                     if (found is not null)
                     {
                         return found;
@@ -252,7 +238,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 foreach (var arg in invocation.Arguments)
                 {
-                    var found = FindMatchInExpression(arg.Value, isMatchInvocation, matchMembers);
+                    var found = FindMatchInExpression(arg.Value, isMatchInvocation, regexType);
                     if (found is not null)
                     {
                         return found;
@@ -267,7 +253,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 if (propRef.Instance is not null)
                 {
-                    var found = FindMatchInExpression(propRef.Instance, isMatchInvocation, matchMembers);
+                    var found = FindMatchInExpression(propRef.Instance, isMatchInvocation, regexType);
                     if (found is not null)
                     {
                         return found;
@@ -278,7 +264,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     foreach (var arg in propRef.Arguments)
                     {
-                        var found = FindMatchInExpression(arg.Value, isMatchInvocation, matchMembers);
+                        var found = FindMatchInExpression(arg.Value, isMatchInvocation, regexType);
                         if (found is not null)
                         {
                             return found;
@@ -292,7 +278,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Array/indexer element access
             if (expression is IArrayElementReferenceOperation arrayRef)
             {
-                var found = FindMatchInExpression(arrayRef.ArrayReference, isMatchInvocation, matchMembers);
+                var found = FindMatchInExpression(arrayRef.ArrayReference, isMatchInvocation, regexType);
                 if (found is not null)
                 {
                     return found;
@@ -300,7 +286,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 foreach (var index in arrayRef.Indices)
                 {
-                    found = FindMatchInExpression(index, isMatchInvocation, matchMembers);
+                    found = FindMatchInExpression(index, isMatchInvocation, regexType);
                     if (found is not null)
                     {
                         return found;
@@ -313,13 +299,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Simple assignment: x = Regex.Match(...)
             if (expression is ISimpleAssignmentOperation assignment)
             {
-                return FindMatchInExpression(assignment.Value, isMatchInvocation, matchMembers);
+                return FindMatchInExpression(assignment.Value, isMatchInvocation, regexType);
             }
 
             // Conditional access: Regex.Match(...)?.Groups
             if (expression is IConditionalAccessOperation condAccess)
             {
-                return FindMatchInExpression(condAccess.Operation, isMatchInvocation, matchMembers);
+                return FindMatchInExpression(condAccess.Operation, isMatchInvocation, regexType);
             }
 
             return null;
@@ -332,11 +318,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static bool IsMatchingMatchCall(
             IInvocationOperation matchInvocation,
             IInvocationOperation isMatchInvocation,
-            ImmutableArray<ISymbol> matchMembers)
+            INamedTypeSymbol regexType)
         {
             // Must be a Regex.Match method
             if (matchInvocation.TargetMethod.Name != "Match" ||
-                !matchMembers.Contains(matchInvocation.TargetMethod, SymbolEqualityComparer.Default))
+                !SymbolEqualityComparer.Default.Equals(matchInvocation.TargetMethod.ContainingType, regexType))
             {
                 return false;
             }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -302,10 +302,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return FindMatchInExpression(assignment.Value, isMatchInvocation, regexType);
             }
 
-            // Conditional access: Regex.Match(...)?.Groups
+            // Conditional access: Regex.Match(...)?.Groups or obj?.Method(Regex.Match(...))
             if (expression is IConditionalAccessOperation condAccess)
             {
-                return FindMatchInExpression(condAccess.Operation, isMatchInvocation, regexType);
+                return FindMatchInExpression(condAccess.Operation, isMatchInvocation, regexType)
+                    ?? FindMatchInExpression(condAccess.WhenNotNull, isMatchInvocation, regexType);
             }
 
             return null;
@@ -592,7 +593,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return null;
             }
 
-            target = target.WalkDownConversion();
+            target = target.WalkDownParentheses().WalkDownConversion();
 
             return target switch
             {
@@ -607,7 +608,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         /// </summary>
         private static bool ContainsTrackedSymbolReference(IOperation operation, HashSet<ISymbol> symbols)
         {
-            var unwrapped = operation.WalkDownConversion();
+            var unwrapped = operation.WalkDownParentheses().WalkDownConversion();
 
             ISymbol? symbol = unwrapped switch
             {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -503,6 +503,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
 
+            // Check for deconstruction assignments: (x, y) = expr
+            // The target tuple elements are written to, but aren't modeled as
+            // individual assignment operations.
+            if (operation is IDeconstructionAssignmentOperation decon &&
+                ContainsTrackedSymbolReference(decon.Target, symbols))
+            {
+                return true;
+            }
+
             foreach (var child in operation.Children)
             {
                 if (child is IAnonymousFunctionOperation or ILocalFunctionOperation)
@@ -529,6 +538,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 ISimpleAssignmentOperation assignment => assignment.Target,
                 ICompoundAssignmentOperation compound => compound.Target,
+                ICoalesceAssignmentOperation coalesce => coalesce.Target,
                 IIncrementOrDecrementOperation incDec => incDec.Target,
                 _ => null
             };
@@ -546,6 +556,36 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 IParameterReferenceOperation paramRef => paramRef.Parameter,
                 _ => null
             };
+        }
+        /// <summary>
+        /// Checks whether an operation tree contains a local or parameter reference
+        /// to any of the tracked symbols. Used for deconstruction assignment targets.
+        /// </summary>
+        private static bool ContainsTrackedSymbolReference(IOperation operation, HashSet<ISymbol> symbols)
+        {
+            var unwrapped = operation.WalkDownConversion();
+
+            ISymbol? symbol = unwrapped switch
+            {
+                ILocalReferenceOperation localRef => localRef.Local,
+                IParameterReferenceOperation paramRef => paramRef.Parameter,
+                _ => null
+            };
+
+            if (symbol is not null && symbols.Contains(symbol))
+            {
+                return true;
+            }
+
+            foreach (var child in unwrapped.Children)
+            {
+                if (ContainsTrackedSymbolReference(child, symbols))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -257,15 +257,49 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Member access: e.g., Regex.Match(...).Groups[1].Value
             if (expression is IPropertyReferenceOperation propRef)
             {
-                return propRef.Instance is not null
-                    ? FindMatchInExpression(propRef.Instance, isMatchInvocation, matchMembers)
-                    : null;
+                if (propRef.Instance is not null)
+                {
+                    var found = FindMatchInExpression(propRef.Instance, isMatchInvocation, matchMembers);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                if (propRef.Property.IsIndexer)
+                {
+                    foreach (var arg in propRef.Arguments)
+                    {
+                        var found = FindMatchInExpression(arg.Value, isMatchInvocation, matchMembers);
+                        if (found is not null)
+                        {
+                            return found;
+                        }
+                    }
+                }
+
+                return null;
             }
 
             // Array/indexer element access
             if (expression is IArrayElementReferenceOperation arrayRef)
             {
-                return FindMatchInExpression(arrayRef.ArrayReference, isMatchInvocation, matchMembers);
+                var found = FindMatchInExpression(arrayRef.ArrayReference, isMatchInvocation, matchMembers);
+                if (found is not null)
+                {
+                    return found;
+                }
+
+                foreach (var index in arrayRef.Indices)
+                {
+                    found = FindMatchInExpression(index, isMatchInvocation, matchMembers);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
             }
 
             // Simple assignment: x = Regex.Match(...)
@@ -391,8 +425,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return left is null && right is null;
             }
 
-            left = left.WalkDownConversion();
-            right = right.WalkDownConversion();
+            left = left.WalkDownParentheses().WalkDownConversion();
+            right = right.WalkDownParentheses().WalkDownConversion();
 
             // Same local variable reference
             if (left is ILocalReferenceOperation leftLocal &&
@@ -467,7 +501,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             static void AddMutableSymbol(IOperation operation, ref HashSet<ISymbol>? symbols)
             {
-                operation = operation.WalkDownConversion();
+                operation = operation.WalkDownParentheses().WalkDownConversion();
 
                 if (operation is ILocalReferenceOperation localRef)
                 {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -1,0 +1,527 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Runtime
+{
+    using static MicrosoftNetCoreAnalyzersResources;
+
+    /// <summary>
+    /// CA2028: Avoid redundant Regex.IsMatch before Regex.Match
+    /// <para>
+    /// Detects the pattern where <c>Regex.IsMatch</c> is used as a condition and then
+    /// <c>Regex.Match</c> is called inside the body with the same arguments, causing
+    /// the regex engine to execute twice. The fix is to call <c>Regex.Match</c> once
+    /// and check <c>Success</c>.
+    /// </para>
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class AvoidRedundantRegexIsMatchBeforeMatch : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA2028";
+
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+            RuleId,
+            CreateLocalizableResourceString(nameof(AvoidRedundantRegexIsMatchBeforeMatchTitle)),
+            CreateLocalizableResourceString(nameof(AvoidRedundantRegexIsMatchBeforeMatchMessage)),
+            DiagnosticCategory.Reliability,
+            RuleLevel.IdeSuggestion,
+            CreateLocalizableResourceString(nameof(AvoidRedundantRegexIsMatchBeforeMatchDescription)),
+            isPortedFxCopRule: false,
+            isDataflowRule: false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                if (!compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTextRegularExpressionsRegex, out var regexType))
+                {
+                    return;
+                }
+
+                var isMatchMembers = regexType.GetMembers("IsMatch");
+                var matchMembers = regexType.GetMembers("Match");
+
+                if (isMatchMembers.IsEmpty || matchMembers.IsEmpty)
+                {
+                    return;
+                }
+
+                compilationContext.RegisterOperationAction(operationContext =>
+                {
+                    var conditional = (IConditionalOperation)operationContext.Operation;
+
+                    // The condition must be a direct call to Regex.IsMatch (not negated).
+                    if (GetUnwrappedInvocation(conditional.Condition) is not IInvocationOperation isMatchInvocation ||
+                        isMatchInvocation.TargetMethod.Name != "IsMatch" ||
+                        !isMatchMembers.Contains(isMatchInvocation.TargetMethod, SymbolEqualityComparer.Default))
+                    {
+                        return;
+                    }
+
+                    if (conditional.WhenTrue is null)
+                    {
+                        return;
+                    }
+
+                    // Search direct children of the WhenTrue block for Regex.Match calls.
+                    IInvocationOperation? matchInvocation = FindMatchingMatchCall(
+                        conditional.WhenTrue, isMatchInvocation, matchMembers);
+
+                    if (matchInvocation is null)
+                    {
+                        return;
+                    }
+
+                    // Report diagnostic on the IsMatch call, with additional location on the Match call.
+                    operationContext.ReportDiagnostic(
+                        isMatchInvocation.CreateDiagnostic(
+                            Rule,
+                            ImmutableArray.Create(matchInvocation.Syntax.GetLocation()),
+                            properties: null));
+                }, OperationKind.Conditional);
+            });
+        }
+
+        /// <summary>
+        /// Unwraps parenthesized/conversion operations to get the underlying invocation.
+        /// </summary>
+        private static IInvocationOperation? GetUnwrappedInvocation(IOperation? operation)
+        {
+            if (operation is null)
+            {
+                return null;
+            }
+
+            // Walk through conversions (e.g., implicit bool conversion)
+            operation = operation.WalkDownConversion();
+
+            return operation as IInvocationOperation;
+        }
+
+        /// <summary>
+        /// Searches the WhenTrue block for a Regex.Match call whose arguments are semantically
+        /// equivalent to the given IsMatch call.
+        /// </summary>
+        private static IInvocationOperation? FindMatchingMatchCall(
+            IOperation whenTrue,
+            IInvocationOperation isMatchInvocation,
+            ImmutableArray<ISymbol> matchMembers)
+        {
+            // If WhenTrue is not a block, check the single operation directly
+            // to avoid allocating a one-element ImmutableArray.
+            if (whenTrue is not IBlockOperation block)
+            {
+                return TryFindMatchInOperation(whenTrue, isMatchInvocation, matchMembers);
+            }
+
+            // Collect local/parameter symbols referenced by the IsMatch arguments.
+            // If any of these are written to before a candidate Match call, the
+            // values may differ and the calls are not truly redundant.
+            HashSet<ISymbol>? trackedSymbols = null;
+            CollectReferencedMutableSymbols(isMatchInvocation, ref trackedSymbols);
+
+            foreach (var op in block.Operations)
+            {
+                // If this statement writes to any tracked symbol, stop searching.
+                // Any Match call in this or later statements could see a different value.
+                if (trackedSymbols is not null && ContainsWriteToSymbols(op, trackedSymbols))
+                {
+                    return null;
+                }
+
+                // Look for Match calls in direct children only — don't recurse into
+                // lambdas, local functions, or nested blocks (except expression-level nesting).
+                if (TryFindMatchInOperation(op, isMatchInvocation, matchMembers) is { } found)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Tries to find a matching Regex.Match invocation within a single statement operation.
+        /// Only looks at expression-level nesting (e.g., within variable declarations, assignments,
+        /// member access chains) — does NOT recurse into nested control flow, lambdas, or local functions.
+        /// </summary>
+        private static IInvocationOperation? TryFindMatchInOperation(
+            IOperation operation,
+            IInvocationOperation isMatchInvocation,
+            ImmutableArray<ISymbol> matchMembers)
+        {
+            // Handle variable declaration: Match m = Regex.Match(...)
+            if (operation is IVariableDeclarationGroupOperation declGroup)
+            {
+                foreach (var declaration in declGroup.Declarations)
+                {
+                    // In VB, the initializer is on the declaration (not the declarator).
+                    if (declaration.Initializer?.Value is { } declInitValue)
+                    {
+                        var found = FindMatchInExpression(declInitValue, isMatchInvocation, matchMembers);
+                        if (found is not null)
+                        {
+                            return found;
+                        }
+                    }
+
+                    // In C#, the initializer is on each declarator.
+                    foreach (var declarator in declaration.Declarators)
+                    {
+                        if (declarator.Initializer?.Value is { } initValue)
+                        {
+                            var found = FindMatchInExpression(initValue, isMatchInvocation, matchMembers);
+                            if (found is not null)
+                            {
+                                return found;
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            // Handle expression statements: Regex.Match(...) or m = Regex.Match(...)
+            if (operation is IExpressionStatementOperation exprStatement)
+            {
+                return FindMatchInExpression(exprStatement.Operation, isMatchInvocation, matchMembers);
+            }
+
+            // Handle return statements: return Regex.Match(...)
+            if (operation is IReturnOperation returnOp && returnOp.ReturnedValue is not null)
+            {
+                return FindMatchInExpression(returnOp.ReturnedValue, isMatchInvocation, matchMembers);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Walks an expression tree looking for a Regex.Match invocation with equivalent arguments.
+        /// Walks into member access, indexer access, invocation arguments, assignment right-hand sides,
+        /// and conversions — but NOT into lambdas, anonymous functions, or nested blocks.
+        /// </summary>
+        private static IInvocationOperation? FindMatchInExpression(
+            IOperation expression,
+            IInvocationOperation isMatchInvocation,
+            ImmutableArray<ISymbol> matchMembers)
+        {
+            expression = expression.WalkDownConversion();
+
+            // Direct invocation: check if it's a matching Regex.Match call.
+            if (expression is IInvocationOperation invocation)
+            {
+                if (IsMatchingMatchCall(invocation, isMatchInvocation, matchMembers))
+                {
+                    return invocation;
+                }
+
+                // Also check arguments of this invocation (e.g., SomeMethod(Regex.Match(...)))
+                // and the instance receiver.
+                if (invocation.Instance is not null)
+                {
+                    var found = FindMatchInExpression(invocation.Instance, isMatchInvocation, matchMembers);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                foreach (var arg in invocation.Arguments)
+                {
+                    var found = FindMatchInExpression(arg.Value, isMatchInvocation, matchMembers);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            }
+
+            // Member access: e.g., Regex.Match(...).Groups[1].Value
+            if (expression is IPropertyReferenceOperation propRef)
+            {
+                return propRef.Instance is not null
+                    ? FindMatchInExpression(propRef.Instance, isMatchInvocation, matchMembers)
+                    : null;
+            }
+
+            // Array/indexer element access
+            if (expression is IArrayElementReferenceOperation arrayRef)
+            {
+                return FindMatchInExpression(arrayRef.ArrayReference, isMatchInvocation, matchMembers);
+            }
+
+            // Simple assignment: x = Regex.Match(...)
+            if (expression is ISimpleAssignmentOperation assignment)
+            {
+                return FindMatchInExpression(assignment.Value, isMatchInvocation, matchMembers);
+            }
+
+            // Conditional access: Regex.Match(...)?.Groups
+            if (expression is IConditionalAccessOperation condAccess)
+            {
+                return FindMatchInExpression(condAccess.Operation, isMatchInvocation, matchMembers);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks whether a given invocation is a Regex.Match call with arguments semantically
+        /// equivalent to the provided IsMatch call.
+        /// </summary>
+        private static bool IsMatchingMatchCall(
+            IInvocationOperation matchInvocation,
+            IInvocationOperation isMatchInvocation,
+            ImmutableArray<ISymbol> matchMembers)
+        {
+            // Must be a Regex.Match method
+            if (matchInvocation.TargetMethod.Name != "Match" ||
+                !matchMembers.Contains(matchInvocation.TargetMethod, SymbolEqualityComparer.Default))
+            {
+                return false;
+            }
+
+            // Both must be static or both instance
+            if (isMatchInvocation.TargetMethod.IsStatic != matchInvocation.TargetMethod.IsStatic)
+            {
+                return false;
+            }
+
+            // For instance methods, verify same receiver
+            if (!isMatchInvocation.TargetMethod.IsStatic)
+            {
+                if (!AreOperandsEquivalent(isMatchInvocation.Instance, matchInvocation.Instance))
+                {
+                    return false;
+                }
+            }
+
+            // Both must have the same parameter types (same overload shape)
+            if (!ParameterTypesMatch(
+                    isMatchInvocation.TargetMethod.Parameters,
+                    matchInvocation.TargetMethod.Parameters))
+            {
+                return false;
+            }
+
+            // All arguments must be semantically equivalent
+            if (isMatchInvocation.Arguments.Length != matchInvocation.Arguments.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < isMatchInvocation.Arguments.Length; i++)
+            {
+                if (!AreOperandsEquivalent(
+                        isMatchInvocation.Arguments[i].Value,
+                        matchInvocation.Arguments[i].Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether two lists of parameters have the same types in the same order.
+        /// </summary>
+        private static bool ParameterTypesMatch(
+            ImmutableArray<IParameterSymbol> left,
+            ImmutableArray<IParameterSymbol> right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(left[i].Type, right[i].Type))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether two operations refer to the same value. Only considers stable
+        /// operand sources: locals, parameters, constants, and readonly fields.
+        /// </summary>
+        private static bool AreOperandsEquivalent(IOperation? left, IOperation? right)
+        {
+            if (left is null || right is null)
+            {
+                return left is null && right is null;
+            }
+
+            left = left.WalkDownConversion();
+            right = right.WalkDownConversion();
+
+            // Same local variable reference
+            if (left is ILocalReferenceOperation leftLocal &&
+                right is ILocalReferenceOperation rightLocal)
+            {
+                return SymbolEqualityComparer.Default.Equals(leftLocal.Local, rightLocal.Local);
+            }
+
+            // Same parameter reference
+            if (left is IParameterReferenceOperation leftParam &&
+                right is IParameterReferenceOperation rightParam)
+            {
+                return SymbolEqualityComparer.Default.Equals(leftParam.Parameter, rightParam.Parameter);
+            }
+
+            // Same constant value
+            if (left.ConstantValue.HasValue && right.ConstantValue.HasValue)
+            {
+                return Equals(left.ConstantValue.Value, right.ConstantValue.Value);
+            }
+
+            // Same instance reference (this/Me)
+            if (left is IInstanceReferenceOperation && right is IInstanceReferenceOperation)
+            {
+                return true;
+            }
+
+            // Same field reference (readonly fields only for safety)
+            if (left is IFieldReferenceOperation leftField &&
+                right is IFieldReferenceOperation rightField)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(leftField.Field, rightField.Field))
+                {
+                    return false;
+                }
+
+                // Only trust readonly/const fields
+                if (!leftField.Field.IsReadOnly && !leftField.Field.IsConst)
+                {
+                    return false;
+                }
+
+                // For instance fields, receivers must also be equivalent
+                if (!leftField.Field.IsStatic)
+                {
+                    return AreOperandsEquivalent(leftField.Instance, rightField.Instance);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Collects all local and parameter symbols directly referenced by the invocation's
+        /// arguments and instance receiver.
+        /// </summary>
+        private static void CollectReferencedMutableSymbols(
+            IInvocationOperation invocation,
+            ref HashSet<ISymbol>? symbols)
+        {
+            foreach (var arg in invocation.Arguments)
+            {
+                AddMutableSymbol(arg.Value, ref symbols);
+            }
+
+            if (invocation.Instance is not null)
+            {
+                AddMutableSymbol(invocation.Instance, ref symbols);
+            }
+
+            static void AddMutableSymbol(IOperation operation, ref HashSet<ISymbol>? symbols)
+            {
+                operation = operation.WalkDownConversion();
+
+                if (operation is ILocalReferenceOperation localRef)
+                {
+                    symbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    symbols.Add(localRef.Local);
+                }
+                else if (operation is IParameterReferenceOperation paramRef)
+                {
+                    symbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    symbols.Add(paramRef.Parameter);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks whether an operation or any of its descendants writes to any of the
+        /// given symbols (via assignment, compound assignment, or increment/decrement).
+        /// Does not recurse into lambdas or local functions.
+        /// </summary>
+        private static bool ContainsWriteToSymbols(IOperation operation, HashSet<ISymbol> symbols)
+        {
+            ISymbol? writtenSymbol = GetWrittenSymbol(operation);
+            if (writtenSymbol is not null && symbols.Contains(writtenSymbol))
+            {
+                return true;
+            }
+
+            foreach (var child in operation.Children)
+            {
+                if (child is IAnonymousFunctionOperation or ILocalFunctionOperation)
+                {
+                    continue;
+                }
+
+                if (ContainsWriteToSymbols(child, symbols))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// If the operation is an assignment or increment/decrement targeting a local or parameter,
+        /// returns that symbol. Otherwise returns null.
+        /// </summary>
+        private static ISymbol? GetWrittenSymbol(IOperation operation)
+        {
+            IOperation? target = operation switch
+            {
+                ISimpleAssignmentOperation assignment => assignment.Target,
+                ICompoundAssignmentOperation compound => compound.Target,
+                IIncrementOrDecrementOperation incDec => incDec.Target,
+                _ => null
+            };
+
+            if (target is null)
+            {
+                return null;
+            }
+
+            target = target.WalkDownConversion();
+
+            return target switch
+            {
+                ILocalReferenceOperation localRef => localRef.Local,
+                IParameterReferenceOperation paramRef => paramRef.Parameter,
+                _ => null
+            };
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -121,10 +121,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             IInvocationOperation isMatchInvocation,
             ImmutableArray<ISymbol> matchMembers)
         {
-            // If WhenTrue is not a block, check the single operation directly
-            // to avoid allocating a one-element ImmutableArray.
+            // If WhenTrue is not a block, check the single operation directly.
+            // Still perform the write check for consistency with the block path —
+            // if the single statement mutates a tracked operand, don't flag it.
             if (whenTrue is not IBlockOperation block)
             {
+                HashSet<ISymbol>? singleTracked = null;
+                CollectReferencedMutableSymbols(isMatchInvocation, ref singleTracked);
+                if (singleTracked is not null && ContainsWriteToSymbols(whenTrue, singleTracked))
+                {
+                    return null;
+                }
+
                 return TryFindMatchInOperation(whenTrue, isMatchInvocation, matchMembers);
             }
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -221,7 +221,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             IInvocationOperation isMatchInvocation,
             ImmutableArray<ISymbol> matchMembers)
         {
-            expression = expression.WalkDownConversion();
+            expression = expression.WalkDownParentheses().WalkDownConversion();
 
             // Direct invocation: check if it's a matching Regex.Match call.
             if (expression is IInvocationOperation invocation)

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -97,7 +97,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         }
 
         /// <summary>
-        /// Unwraps parenthesized/conversion operations to get the underlying invocation.
+        /// Unwraps parenthesized and conversion operations to get the underlying invocation.
         /// </summary>
         private static IInvocationOperation? GetUnwrappedInvocation(IOperation? operation)
         {
@@ -106,8 +106,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return null;
             }
 
-            // Walk through conversions (e.g., implicit bool conversion)
-            operation = operation.WalkDownConversion();
+            // Walk through parentheses and conversions (e.g., implicit bool conversion)
+            operation = operation.WalkDownParentheses().WalkDownConversion();
 
             return operation as IInvocationOperation;
         }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -463,6 +463,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     symbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                     symbols.Add(paramRef.Parameter);
                 }
+                else if (operation is IFieldReferenceOperation fieldRef && fieldRef.Instance is not null)
+                {
+                    // For h.ReadonlyField, track h so that reassignment of h is detected.
+                    AddMutableSymbol(fieldRef.Instance, ref symbols);
+                }
             }
         }
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -359,13 +359,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return null;
             }
 
-            // Simple assignment (used as an expression, e.g. inside an object initializer
-            // member assignment): the value may contain a Match call.
-            if (expression is ISimpleAssignmentOperation simpleAssignment)
-            {
-                return FindMatchInExpression(simpleAssignment.Value, isMatchInvocation, regexType);
-            }
-
             if (expression is IArrayCreationOperation arrayCreation && arrayCreation.Initializer is not null)
             {
                 foreach (var element in arrayCreation.Initializer.ElementValues)

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -343,6 +343,29 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return null;
             }
 
+            // Object/collection initializer: walk the member assignments
+            // (e.g. `new Foo { Bar = Regex.Match(...) }`) and any nested initializers.
+            if (expression is IObjectOrCollectionInitializerOperation initializer)
+            {
+                foreach (var inner in initializer.Initializers)
+                {
+                    var found = FindMatchInExpression(inner, isMatchInvocation, regexType);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            }
+
+            // Simple assignment (used as an expression, e.g. inside an object initializer
+            // member assignment): the value may contain a Match call.
+            if (expression is ISimpleAssignmentOperation simpleAssignment)
+            {
+                return FindMatchInExpression(simpleAssignment.Value, isMatchInvocation, regexType);
+            }
+
             if (expression is IArrayCreationOperation arrayCreation && arrayCreation.Initializer is not null)
             {
                 foreach (var element in arrayCreation.Initializer.ElementValues)
@@ -635,6 +658,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         /// </summary>
         private static bool ContainsWriteToSymbols(IOperation operation, HashSet<ISymbol> symbols)
         {
+            // Local function and lambda bodies are not executed at the declaration
+            // point, so writes inside them are not intervening writes.
+            if (operation is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return false;
+            }
+
             ISymbol? writtenSymbol = GetWrittenSymbol(operation);
             if (writtenSymbol is not null && symbols.Contains(writtenSymbol))
             {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatch.cs
@@ -55,6 +55,16 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     var conditional = (IConditionalOperation)context.Operation;
 
+                    // OperationKind.Conditional fires for both if-statements and ternary
+                    // expressions (`?:` in C#, `If(...)` in VB). Statement-form conditionals
+                    // have a null Type; expression-form conditionals have the result Type.
+                    // Skip expressions — the rest of the analyzer (and the C# fixer) is
+                    // structured around statement-shaped WhenTrue bodies.
+                    if (conditional.Type is not null)
+                    {
+                        return;
+                    }
+
                     // The condition must be a direct call to Regex.IsMatch (not negated).
                     if (UnwrapInvocationFromCondition(conditional.Condition) is not IInvocationOperation isMatchInvocation ||
                         isMatchInvocation.TargetMethod.Name != "IsMatch" ||
@@ -309,6 +319,103 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     ?? FindMatchInExpression(condAccess.WhenNotNull, isMatchInvocation, regexType);
             }
 
+            // Object/collection creation: new Foo(Regex.Match(...)) / new[] { Regex.Match(...) }
+            if (expression is IObjectCreationOperation objCreation)
+            {
+                foreach (var arg in objCreation.Arguments)
+                {
+                    var found = FindMatchInExpression(arg.Value, isMatchInvocation, regexType);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                if (objCreation.Initializer is not null)
+                {
+                    var found = FindMatchInExpression(objCreation.Initializer, isMatchInvocation, regexType);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            }
+
+            if (expression is IArrayCreationOperation arrayCreation && arrayCreation.Initializer is not null)
+            {
+                foreach (var element in arrayCreation.Initializer.ElementValues)
+                {
+                    var found = FindMatchInExpression(element, isMatchInvocation, regexType);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            }
+
+            // Coalesce: Regex.Match(...) ?? defaultMatch
+            if (expression is ICoalesceOperation coalesce)
+            {
+                return FindMatchInExpression(coalesce.Value, isMatchInvocation, regexType)
+                    ?? FindMatchInExpression(coalesce.WhenNull, isMatchInvocation, regexType);
+            }
+
+            // Tuple: (Regex.Match(...), other)
+            if (expression is ITupleOperation tuple)
+            {
+                foreach (var element in tuple.Elements)
+                {
+                    var found = FindMatchInExpression(element, isMatchInvocation, regexType);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            }
+
+            // Interpolated string: $"{Regex.Match(...).Value}"
+            if (expression is IInterpolatedStringOperation interpString)
+            {
+                foreach (var part in interpString.Parts)
+                {
+                    if (part is IInterpolationOperation interpolation)
+                    {
+                        var found = FindMatchInExpression(interpolation.Expression, isMatchInvocation, regexType);
+                        if (found is not null)
+                        {
+                            return found;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            // Binary: Regex.Match(...) != null, x + Regex.Match(...).Length, etc.
+            if (expression is IBinaryOperation binary)
+            {
+                return FindMatchInExpression(binary.LeftOperand, isMatchInvocation, regexType)
+                    ?? FindMatchInExpression(binary.RightOperand, isMatchInvocation, regexType);
+            }
+
+            // Unary: !Regex.Match(...).Success, -Regex.Match(...).Length, etc.
+            if (expression is IUnaryOperation unary)
+            {
+                return FindMatchInExpression(unary.Operand, isMatchInvocation, regexType);
+            }
+
+            // Await: await Task.FromResult(Regex.Match(...))
+            if (expression is IAwaitOperation awaitOp)
+            {
+                return FindMatchInExpression(awaitOp.Operation, isMatchInvocation, regexType);
+            }
+
             return null;
         }
 
@@ -443,10 +550,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return Equals(left.ConstantValue.Value, right.ConstantValue.Value);
             }
 
-            // Same instance reference (this/Me)
-            if (left is IInstanceReferenceOperation && right is IInstanceReferenceOperation)
+            // Same instance reference (this/Me).
+            // Restrict to reference types only: `this` is reassignable inside struct
+            // instance methods (e.g. `this = new S(...)`), so two `this` references
+            // separated by such a write are not necessarily the same value.
+            if (left is IInstanceReferenceOperation leftInstance &&
+                right is IInstanceReferenceOperation rightInstance)
             {
-                return true;
+                return leftInstance.Type is { IsValueType: false } &&
+                       rightInstance.Type is { IsValueType: false };
             }
 
             // Same field reference (readonly fields only for safety)
@@ -534,7 +646,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 argOp.Parameter is not null &&
                 argOp.Parameter.RefKind is RefKind.Ref or RefKind.Out)
             {
-                var argValue = argOp.Value.WalkDownConversion();
+                var argValue = argOp.Value.WalkDownParentheses().WalkDownConversion();
                 ISymbol? argSymbol = argValue switch
                 {
                     ILocalReferenceOperation localRef => localRef.Local,

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Vyhněte se alokacím polí s nulovou délkou</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Když se deserializují nedůvěryhodná data bez SerializationBinderu, který omezí typ objektu v grafu deserializovaných objektů, není metoda {0} bezpečná.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Arrayzuordnungen mit einer Länge von null vermeiden</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Die Methode "{0}" ist unsicher, wenn nicht vertrauenswürdige Daten deserialisiert werden, ohne dass der Typ von Objekten im deserialisierten Objektgraphen durch einen SerializationBinder beschränkt wird.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Evite las asignaciones de matriz de longitud cero</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">El método "{0}" no es seguro cuando se deserializan datos que no son de confianza sin un elemento SerializationBinder para restringir el tipo de objetos en el grafo de objetos deserializado.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Évitez les allocations de tableaux dont la longueur est égale à zéro</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">La méthode '{0}' n'est pas sécurisée durant la désérialisation de données non fiables sans SerializationBinder pour restreindre le type des objets dans le graphe d'objets désérialisé.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Evitare allocazioni di matrice di lunghezza zero</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Il metodo '{0}' non è sicuro quando si deserializzano dati non attendibili senza un elemento SerializationBinder per limitare il tipo di oggetti nel grafico di oggetti deserializzato.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -202,6 +202,26 @@
         <target state="translated">長さ 0 の配列は割り当て不可</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">SerializationBinder なしで信頼されていないデータを逆シリアル化して、逆シリアル化されたオブジェクト グラフ内でオブジェクトの型を制限する場合、メソッド '{0}' は安全ではありません。</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -202,6 +202,26 @@
         <target state="translated">길이가 0인 배열 할당을 사용하면 안 됨</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">역직렬화된 개체 그래프에서 개체 형식을 제한하기 위해 SerializationBinder 없이 신뢰할 수 없는 데이터를 역직렬화하는 경우 '{0}' 메서드는 안전하지 않습니다.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Unikaj alokowania tablic o długości zero</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Metoda „{0}” nie jest bezpieczna podczas deserializowania niezaufanych danych bez użycia elementu SerializationBinder w celu ograniczenia typu obiektów w zdeserializowanym grafie obiektów.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Evite alocações de matriz de comprimento zero</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">O método '{0}' não é seguro durante a desserialização de dados não confiáveis sem um SerializationBinder para restringir o tipo de objetos no grafo de objetos desserializado.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Нежелательность выделения массивов нулевой длины</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Метод "{0}" является небезопасным при десериализации ненадежных данных без использования SerializationBinder для ограничения типа объектов в графе десериализованных объектов.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -202,6 +202,26 @@
         <target state="translated">Sıfır uzunluklu dizi ayırmaları kullanmaktan kaçının</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">Güvenilmeyen veriler, seri durumdan çıkarılmış nesne grafındaki nesnelerin türünü kısıtlamak için SerializationBinder kullanılmadan seri durumdan çıkarılırken '{0}' yöntemi güvenli değildir.</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -202,6 +202,26 @@
         <target state="translated">避免长度为零的数组分配</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">在不使用 SerializationBinder 的情况下对不受信任的数据进行反序列化，以限制反序列化对象图中的对象类型时，方法“{0}”不安全。</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -202,6 +202,26 @@
         <target state="translated">避免長度為零的陣列配置</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchDescription">
+        <source>When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</source>
+        <target state="new">When 'Regex.IsMatch' is used to check for a match and then 'Regex.Match' is called with the same arguments, the regular expression is evaluated twice. Call 'Regex.Match' once and check 'Match.Success' to avoid redundant work.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchFix">
+        <source>Use 'Regex.Match' and check 'Success'</source>
+        <target state="new">Use 'Regex.Match' and check 'Success'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchMessage">
+        <source>Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</source>
+        <target state="new">Redundant call to 'Regex.IsMatch' before 'Regex.Match'. Use 'Regex.Match' and check 'Match.Success' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AvoidRedundantRegexIsMatchBeforeMatchTitle">
+        <source>Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</source>
+        <target state="new">Avoid redundant 'Regex.IsMatch' call before 'Regex.Match'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BinaryFormatterDeserializeMaybeWithoutBinderSetMessage">
         <source>The method '{0}' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.</source>
         <target state="translated">將未受信任的資料還原序列化時，若沒有使用 SerializationBinder 來限制已還原序列化物件圖中的物件類型，方法 '{0}' 就不安全。</target>

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
@@ -18,7 +18,7 @@ Usage: CA1801, CA1806, CA1816, CA2200-CA2209, CA2211-CA2265
 Naming: CA1700-CA1727
 Interoperability: CA1400-CA1422
 Maintainability: CA1500-CA1517
-Reliability: CA9998-CA9999, CA2000-CA2027
+Reliability: CA9998-CA9999, CA2000-CA2028
 Documentation: CA1200-CA1200
 
 # Microsoft CodeAnalysis API rules

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1387,5 +1387,203 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         #endregion
+
+        #region Review round — GPT-5.4 findings
+
+        [Fact]
+        public async Task InterveningRefMutation_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void Normalize(ref string s) { s = s.Trim(); }
+
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            Normalize(ref input);
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task InterveningOutMutation_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    bool TryNormalize(string s, out string result) { result = s.Trim(); return true; }
+
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            TryNormalize(input, out input);
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NameConflictAfterIfStatement_DiagnosticButNoFix()
+        {
+            // The conflicting 'int m' must be in a sibling block so the original
+            // code compiles (sibling scopes may reuse names). After the fixer
+            // transforms the condition to 'is { } m', the pattern variable scopes
+            // to the entire enclosing block, colliding with the later 'm'.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        {
+                            int m = 0; // sibling block — valid now, but would conflict with pattern var
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task NameConflictWithPatternInElse_DiagnosticButNoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, object obj)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else if (obj is int m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task NameConflictWithForeachInElse_DiagnosticButNoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(string input, List<int> items)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else
+                        {
+                            foreach (var m in items) { }
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task DeclaredAsGroupType_DiagnosticButNoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Group g = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task DeclaredAsObjectType_DiagnosticButNoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            object o = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task DeclaredAsExactMatchType_FixOffered()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1515,6 +1515,95 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
+        [Fact]
+        public async Task NamedArgumentsSameOrder_Diagnostic()
+        {
+            // Named arguments in same order as parameters — should still match.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input: input, pattern: @"\d+")|})
+                        {
+                            Match m = Regex.Match(input: input, pattern: @"\d+");
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input: input, pattern: @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task NamedArgumentsReordered_Diagnostic()
+        {
+            // Named arguments reordered between IsMatch and Match — same values, different order.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input: input, pattern: @"\d+")|})
+                        {
+                            Match m = Regex.Match(pattern: @"\d+", input: input);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(pattern: @"\d+", input: input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task NamedArgumentsDifferentValues_NoDiagnostic()
+        {
+            // Named arguments with same names but different values — should NOT match.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, string input2)
+                    {
+                        if (Regex.IsMatch(input: input, pattern: @"\d+"))
+                        {
+                            Match m = Regex.Match(input: input2, pattern: @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
         #endregion
 
         #region Regression tests for mutation and control-flow edge cases

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -943,6 +943,34 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
+        [Fact]
+        public async Task SpanOverloadIsMatch_NoDiagnostic()
+        {
+            // ReadOnlySpan<char> overloads of IsMatch have no corresponding
+            // Match overload returning Match — ParameterTypesMatch rejects.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        ReadOnlySpan<char> span = input.AsSpan();
+                        if (Regex.IsMatch(span, @"\d+"))
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+            }.RunAsync(TestContext.Current.CancellationToken);
+        }
+
         #endregion
 
         #region Diagnostic but no fix

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2310,6 +2310,33 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCodeFixCSharp9Async(source, source);
         }
 
+        [Fact]
+        public async Task PreDeclaredAssignment_UsedInElse_DiagnosticButNoFix()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = null;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                        else
+                        {
+                            System.Console.WriteLine(m);
+                        }
+                    }
+                }
+                """;
+            // Variable referenced in else branch — pattern variable wouldn't be
+            // definitely assigned there, so no fix offered.
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -134,9 +134,47 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
+        public async Task StaticWithOptionsAndTimeout_Flags()
+        {
+            // Timeout overload: all four arguments (input, pattern, options, timeout) must be preserved.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var timeout = TimeSpan.FromSeconds(1);
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase, timeout)|})
+                        {
+                            var m = Regex.Match(input, @"\d+", RegexOptions.IgnoreCase, timeout);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var timeout = TimeSpan.FromSeconds(1);
+                        if (Regex.Match(input, @"\d+", RegexOptions.IgnoreCase, timeout) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
         public async Task MatchUsedInlineWithGroupsAccess_FlagsButNoFix()
         {
-            // Real-world pattern from BiliDuang: regex.Match(x).Groups[1].Value
+            // Real-world pattern: regex.Match(x).Groups[1].Value
             // Analyzer should flag, but fixer shouldn't offer a fix (no local declaration).
             var source = """
                 using System.Text.RegularExpressions;
@@ -403,7 +441,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task DifferentPatterns_NoDiagnostic()
         {
-            // Real-world false positive: microsoft/perfview CommandLineUtilities.cs pattern
+            // Real-world false positive: different IsMatch and Match patterns on same input.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -841,6 +879,70 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
+        [Fact]
+        public async Task ReadonlyFieldReceiverReassigned_NoDiagnostic()
+        {
+            // Receiver is local.ReadonlyField — reassigning the local between IsMatch
+            // and Match means a different field instance, so not redundant.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class Holder
+                {
+                    public readonly Regex Re = new Regex(@"\d+");
+                }
+
+                class C
+                {
+                    Holder GetA() => new Holder();
+                    Holder GetB() => new Holder();
+
+                    void M(string input)
+                    {
+                        Holder h = GetA();
+                        if (h.Re.IsMatch(input))
+                        {
+                            h = GetB();
+                            Match m = h.Re.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task ReadonlyFieldArgumentReassigned_NoDiagnostic()
+        {
+            // Argument is local.ReadonlyField — reassigning the local between
+            // IsMatch and Match means a different field value, so not redundant.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class Holder
+                {
+                    public readonly string Pattern = @"\d+";
+                }
+
+                class C
+                {
+                    Holder GetA() => new Holder();
+                    Holder GetB() => new Holder();
+
+                    void M(string input)
+                    {
+                        Holder h = GetA();
+                        if (Regex.IsMatch(input, h.Pattern))
+                        {
+                            h = GetB();
+                            Match m = Regex.Match(input, h.Pattern);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
         #endregion
 
         #region Diagnostic but no fix
@@ -905,7 +1007,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task RealWorld_MatchUsedForGroupsInline()
         {
-            // Based on BiliDuang Other.cs pattern:
+            // Real-world pattern: inline Groups access on Match result.
             // if (regex.IsMatch(contentype)) { Encoding.GetEncoding(regex.Match(contentype).Groups[1].Value.Trim()); }
             var source = """
                 using System;
@@ -932,7 +1034,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task RealWorld_MultiplePairsWithDifferentPatterns_NoDiagnostic()
         {
-            // Based on OpenLiveWriter pattern: multiple IsMatch/Match pairs but with different patterns.
+            // Real-world pattern: multiple IsMatch/Match pairs but with different patterns.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -958,7 +1060,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task RealWorld_ElseIfChainWithIsMatchThenMatch_Flags()
         {
-            // Based on NTransit FbpParser.cs: else-if chain where each branch
+            // Real-world pattern: else-if chain where each branch
             // does IsMatch then Match with the same pattern.
             // Uses distinct variable names so "fix all" doesn't hit C# pattern
             // variable scoping conflicts.
@@ -1014,8 +1116,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task RealWorld_IsMatchThenMatchInsideLoop_Flags()
         {
-            // Based on autoscreen Program.cs / NTransit FbpParser.cs:
-            // IsMatch/Match pair inside a foreach loop body.
+            // Real-world pattern: IsMatch/Match pair inside a foreach loop body.
             var source = """
                 using System;
                 using System.Text.RegularExpressions;
@@ -1059,7 +1160,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task RealWorld_ConstStringFieldPattern_Flags()
         {
-            // Based on NTransit FbpParser.cs: const string fields used as regex pattern arg.
+            // Real-world pattern: const string fields used as regex pattern arg.
             var source = """
                 using System;
                 using System.Text.RegularExpressions;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1713,6 +1713,93 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
+        [Fact]
+        public async Task ParenthesizedCondition_Diagnostic()
+        {
+            // Parenthesized IsMatch condition: if ((Regex.IsMatch(input, pattern)))
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (({|CA2028:Regex.IsMatch(input, @"\d+")|})  )
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task DeconstructionForeachNameCollision_ElseBranch_DiagnosticNoFix()
+        {
+            // Deconstruction foreach in else branch with conflicting variable name
+            var source = """
+                using System.Text.RegularExpressions;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(string input, List<(string, int)> items)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else
+                        {
+                            foreach (var (m, count) in items) { }
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task NonBlockParent_DiagnosticNoFix()
+        {
+            // If statement whose parent is not a block (e.g., switch section)
+            // — fixer conservatively doesn't offer fix
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, int mode)
+                    {
+                        switch (mode)
+                        {
+                            case 1:
+                                if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                                {
+                                    Match m = Regex.Match(input, @"\d+");
+                                }
+                                break;
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2118,6 +2118,48 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
+        [Fact]
+        public async Task ParenthesizedAssignmentTarget_WriteDetected_NoDiagnostic()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            (input) = "other";
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task ConditionalAccessWhenNotNull_MatchInArgument_Diagnostic()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    string Process(Match m) => m.Value;
+
+                    void M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            var result = this?.Process(Regex.Match(input, @"\d+"));
+                        }
+                    }
+                }
+                """;
+            // No fix for this pattern (conditional access is not a simple local/assignment)
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
         #endregion
 
         #region Pre-declaration assignment pattern tests

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1944,5 +1944,81 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         #endregion
+
+        #region Non-block write and lambda parameter conflict tests
+
+        [Fact]
+        public async Task SingleStatementBody_WriteToTrackedSymbol_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        string result = "";
+                        if (Regex.IsMatch(input, @"\d+"))
+                            result = Regex.Match(input = "other", @"\d+").Value;
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task LambdaParameterConflictsWithMatchVariable_NoFix()
+        {
+            // Fixer should not offer fix because 'm' is used as a lambda parameter in else branch
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else
+                        {
+                            Func<int, int> f = m => m + 1;
+                        }
+                    }
+                }
+                """;
+            // Fix not applicable — lambda parameter 'm' conflicts
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task LocalFunctionParameterConflictsWithMatchVariable_NoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else
+                        {
+                            int F(int m) => m + 1;
+                            _ = F(0);
+                        }
+                    }
+                }
+                """;
+            // Fix not applicable — local function parameter 'm' conflicts
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1,0 +1,1204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.AvoidRedundantRegexIsMatchBeforeMatch,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpAvoidRedundantRegexIsMatchBeforeMatchFixer>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.AvoidRedundantRegexIsMatchBeforeMatch,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
+{
+    public class AvoidRedundantRegexIsMatchBeforeMatchTests
+    {
+        /// <summary>
+        /// Helper for code fix tests — property patterns require C# 8+, but the
+        /// test infrastructure defaults to C# 7.3.
+        /// </summary>
+        private static async Task VerifyCodeFixCSharp9Async(string source, string fixedSource)
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync(TestContext.Current.CancellationToken);
+        }
+
+        #region Diagnostic tests — should flag
+
+        [Fact]
+        public async Task StaticIsMatchThenMatch_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task InstanceIsMatchThenMatch_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if ({|CA2028:regex.IsMatch(input)|})
+                        {
+                            Match m = regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if (regex.Match(input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task StaticWithOptions_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase)|})
+                        {
+                            Match m = Regex.Match(input, @"\d+", RegexOptions.IgnoreCase);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+", RegexOptions.IgnoreCase) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task MatchUsedInlineWithGroupsAccess_FlagsButNoFix()
+        {
+            // Real-world pattern from BiliDuang: regex.Match(x).Groups[1].Value
+            // Analyzer should flag, but fixer shouldn't offer a fix (no local declaration).
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string M(string input)
+                    {
+                        var regex = new Regex(@"charset=(.+)");
+                        if ({|CA2028:regex.IsMatch(input)|})
+                        {
+                            return regex.Match(input).Groups[1].Value;
+                        }
+                        return null;
+                    }
+                }
+                """;
+            // No code fix — Match is used inline, not assigned to a local.
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInExpressionStatement_FlagsButNoFix()
+        {
+            // Match is assigned to an existing variable, not a new declaration.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchWithVarDeclaration_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ReadonlyFieldAsReceiver_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private readonly Regex _regex = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if ({|CA2028:_regex.IsMatch(input)|})
+                        {
+                            Match m = _regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private readonly Regex _regex = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if (_regex.Match(input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ParameterAsInput_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, string pattern)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, pattern)|})
+                        {
+                            Match m = Regex.Match(input, pattern);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, string pattern)
+                    {
+                        if (Regex.Match(input, pattern) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ConstantPatternString_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, "hello")|})
+                        {
+                            Match m = Regex.Match(input, "hello");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchWithOtherStatementsInBody_Flags()
+        {
+            // Match is not the first statement — diagnostic fires but fixer
+            // skips because moving Match into condition changes execution order.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Console.WriteLine("Found a match");
+                            Match m = Regex.Match(input, @"\d+");
+                            Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task InstanceWithStartAtParameter_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if ({|CA2028:regex.IsMatch(input, 0)|})
+                        {
+                            Match m = regex.Match(input, 0);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region No-diagnostic tests — should NOT flag
+
+        [Fact]
+        public async Task DifferentInputVariables_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input1, string input2)
+                    {
+                        if (Regex.IsMatch(input1, @"\d+"))
+                        {
+                            Match m = Regex.Match(input2, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task DifferentPatterns_NoDiagnostic()
+        {
+            // Real-world false positive: microsoft/perfview CommandLineUtilities.cs pattern
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\s"))
+                        {
+                            Match m = Regex.Match(input, @"^(.*?)(\\\\.*)""(.*)");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task DifferentRegexInstances_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex1 = new Regex(@"\d+");
+                        var regex2 = new Regex(@"\d+");
+                        if (regex1.IsMatch(input))
+                        {
+                            Match m = regex2.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task DifferentOptions_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase))
+                        {
+                            Match m = Regex.Match(input, @"\d+", RegexOptions.None);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task StaticIsMatchInstanceMatch_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            Match m = regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NegatedIsMatch_NoDiagnostic()
+        {
+            // Inverted case — explicitly dropped per stephentoub's review.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string M(string input)
+                    {
+                        if (!Regex.IsMatch(input, @"\d+"))
+                        {
+                            return input;
+                        }
+                        Match m = Regex.Match(input, @"\d+");
+                        return m.Value;
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInElseBranch_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                        }
+                        else
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInsideLambda_NoDiagnostic()
+        {
+            // The Match call is inside a lambda — different scope.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            Action a = () =>
+                            {
+                                Match m = Regex.Match(input, @"\d+");
+                            };
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInsideLocalFunction_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            void Local()
+                            {
+                                Match m = Regex.Match(input, @"\d+");
+                            }
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MutableFieldReceiver_NoDiagnostic()
+        {
+            // Non-readonly field — could be reassigned between calls.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private Regex _regex = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if (_regex.IsMatch(input))
+                        {
+                            Match m = _regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MutableFieldAsArgument_NoDiagnostic()
+        {
+            // Field used as argument is not readonly — could be mutated.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private string _input = "hello";
+
+                    void M()
+                    {
+                        if (Regex.IsMatch(_input, @"\d+"))
+                        {
+                            Match m = Regex.Match(_input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task DifferentOverloads_NoDiagnostic()
+        {
+            // IsMatch with 2 args (input, pattern), Match with 3 args (input, pattern, options)
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            Match m = Regex.Match(input, @"\d+", RegexOptions.IgnoreCase);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task PropertyAsArgument_NoDiagnostic()
+        {
+            // Property access is not stable — could have side effects.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string Input { get; set; }
+
+                    void M()
+                    {
+                        if (Regex.IsMatch(Input, @"\d+"))
+                        {
+                            Match m = Regex.Match(Input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MethodCallAsArgument_NoDiagnostic()
+        {
+            // Method call result is not stable.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string GetInput() => "hello";
+
+                    void M()
+                    {
+                        if (Regex.IsMatch(GetInput(), @"\d+"))
+                        {
+                            Match m = Regex.Match(GetInput(), @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchNotInWhenTrue_NoDiagnostic()
+        {
+            // No Match call at all in the if body.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            Console.WriteLine("match found");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NotIsMatchCondition_NoDiagnostic()
+        {
+            // Condition is Regex.Match, not IsMatch.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+").Success)
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInNestedIfBody_NoDiagnostic()
+        {
+            // Match is in a nested if block, not a direct child.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, bool flag)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            if (flag)
+                            {
+                                Match m = Regex.Match(input, @"\d+");
+                            }
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task NoRegexType_NoDiagnostic()
+        {
+            // When Regex type is not available.
+            var source = """
+                class C
+                {
+                    void M(string input)
+                    {
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task InterveningLocalReassignment_NoDiagnostic()
+        {
+            // Local is reassigned between IsMatch and Match — values may differ.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            input = "something else";
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task InterveningParameterReassignment_NoDiagnostic()
+        {
+            // Parameter is reassigned between IsMatch and Match.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        string pattern = @"\d+";
+                        if (Regex.IsMatch(input, pattern))
+                        {
+                            pattern = @"\w+";
+                            Match m = Regex.Match(input, pattern);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task InterveningReceiverReassignment_NoDiagnostic()
+        {
+            // Instance receiver is reassigned between IsMatch and Match.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if (regex.IsMatch(input))
+                        {
+                            regex = new Regex(@"\w+");
+                            Match m = regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region Diagnostic but no fix
+
+        [Fact]
+        public async Task MatchNotFirstStatement_DiagnosticButNoFix()
+        {
+            // Match is not the first statement — diagnostic fires but fixer
+            // skips to avoid changing execution order.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Console.WriteLine("before match");
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            // Verify diagnostic fires but no code fix changes (analyzer-only test).
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task ElseBranchNameConflict_DiagnosticButNoFix()
+        {
+            // Else branch declares a variable with the same name as the Match
+            // variable — fixer would introduce a name conflict.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        else
+                        {
+                            int m = 0;
+                            _ = m;
+                        }
+                    }
+                }
+                """;
+            // Verify diagnostic fires but no code fix changes (analyzer-only test).
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region Real-world pattern variants
+
+        [Fact]
+        public async Task RealWorld_MatchUsedForGroupsInline()
+        {
+            // Based on BiliDuang Other.cs pattern:
+            // if (regex.IsMatch(contentype)) { Encoding.GetEncoding(regex.Match(contentype).Groups[1].Value.Trim()); }
+            var source = """
+                using System;
+                using System.Text;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    Encoding M(string contentType)
+                    {
+                        var regex = new Regex(@"charset=(.+)", RegexOptions.IgnoreCase);
+                        if ({|CA2028:regex.IsMatch(contentType)|})
+                        {
+                            return Encoding.GetEncoding(regex.Match(contentType).Groups[1].Value.Trim());
+                        }
+                        return Encoding.UTF8;
+                    }
+                }
+                """;
+            // No fix — Match is used inline, not assigned to a local declaration.
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task RealWorld_MultiplePairsWithDifferentPatterns_NoDiagnostic()
+        {
+            // Based on OpenLiveWriter pattern: multiple IsMatch/Match pairs but with different patterns.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string chunk)
+                    {
+                        string blocks = "div|p|ul";
+                        if (!Regex.IsMatch(chunk, @"^<\/?" + blocks))
+                        {
+                            if (!Regex.IsMatch(chunk, @"^<" + blocks))
+                            {
+                                // different pattern from the outer IsMatch
+                            }
+                            Match m = Regex.Match(chunk, @"<\/" + blocks + ">$");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region VB tests — analyzer only (no fixer)
+
+        [Fact]
+        public async Task VB_StaticIsMatchThenMatch_Flags()
+        {
+            var source = """
+                Imports System.Text.RegularExpressions
+
+                Class C
+                    Sub M(input As String)
+                        If {|CA2028:Regex.IsMatch(input, "\d+")|} Then
+                            Dim m As Match = Regex.Match(input, "\d+")
+                        End If
+                    End Sub
+                End Class
+                """;
+            await VerifyVB.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task VB_DifferentInputs_NoDiagnostic()
+        {
+            var source = """
+                Imports System.Text.RegularExpressions
+
+                Class C
+                    Sub M(input1 As String, input2 As String)
+                        If Regex.IsMatch(input1, "\d+") Then
+                            Dim m As Match = Regex.Match(input2, "\d+")
+                        End If
+                    End Sub
+                End Class
+                """;
+            await VerifyVB.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region Edge cases
+
+        [Fact]
+        public async Task MultipleMatchCallsInBody_FlagsFirst()
+        {
+            // Only the first matching Match call should be included in the diagnostic.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                            Match m2 = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchReturnedFromIfBody_FlagsButNoFix()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    Match M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            return Regex.Match(input, @"\d+");
+                        }
+                        return null;
+                    }
+                }
+                """;
+            // Analyzer flags, but fixer doesn't handle return statements.
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task MatchInSingleStatementIfBody_Flags()
+        {
+            // No braces around if body.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                            Regex.Match(input, @"\d+");
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task StaticReadonlyFieldReceiver_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private static readonly Regex s_regex = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if ({|CA2028:s_regex.IsMatch(input)|})
+                        {
+                            Match m = s_regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private static readonly Regex s_regex = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if (s_regex.Match(input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ParameterAsRegexReceiver_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(Regex regex, string input)
+                    {
+                        if ({|CA2028:regex.IsMatch(input)|})
+                        {
+                            Match m = regex.Match(input);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(Regex regex, string input)
+                    {
+                        if (regex.Match(input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task IsMatchWithAdditionalConjunction_NoDiagnostic()
+        {
+            // Condition is IsMatch && something — not a simple IsMatch call.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, bool flag)
+                    {
+                        if (Regex.IsMatch(input, @"\d+") && flag)
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task ConstFieldReceiver_Flags()
+        {
+            // const string used for pattern — equivalent.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string Pattern = @"\d+";
+
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, Pattern)|})
+                        {
+                            Match m = Regex.Match(input, Pattern);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string Pattern = @"\d+";
+
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, Pattern) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ReadonlyFieldAsPatternArgument_Flags()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private readonly string _pattern = @"\d+";
+
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch(input, _pattern)|})
+                        {
+                            Match m = Regex.Match(input, _pattern);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    private readonly string _pattern = @"\d+";
+
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, _pattern) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        #endregion
+    }
+}

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             // No code fix — Match is used inline, not assigned to a local.
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]
@@ -866,8 +866,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            // Verify diagnostic fires but no code fix changes (analyzer-only test).
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            // Verify diagnostic fires but fixer does not change the code.
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]
@@ -894,8 +894,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            // Verify diagnostic fires but no code fix changes (analyzer-only test).
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            // Verify diagnostic fires but fixer does not change the code.
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         #endregion
@@ -926,7 +926,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             // No fix — Match is used inline, not assigned to a local declaration.
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]
@@ -953,6 +953,151 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task RealWorld_ElseIfChainWithIsMatchThenMatch_Flags()
+        {
+            // Based on NTransit FbpParser.cs: else-if chain where each branch
+            // does IsMatch then Match with the same pattern.
+            // Uses distinct variable names so "fix all" doesn't hit C# pattern
+            // variable scoping conflicts.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string PATTERN_A = @"^\d+\.\d+$";
+                    const string PATTERN_B = @"^\d+$";
+
+                    void M(string text)
+                    {
+                        if ({|CA2028:Regex.IsMatch(text, PATTERN_A)|})
+                        {
+                            Match ma = Regex.Match(text, PATTERN_A);
+                            Console.WriteLine(ma.Value);
+                        }
+                        else if ({|CA2028:Regex.IsMatch(text, PATTERN_B)|})
+                        {
+                            Match mb = Regex.Match(text, PATTERN_B);
+                            Console.WriteLine(mb.Value);
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string PATTERN_A = @"^\d+\.\d+$";
+                    const string PATTERN_B = @"^\d+$";
+
+                    void M(string text)
+                    {
+                        if (Regex.Match(text, PATTERN_A) is { Success: true } ma)
+                        {
+                            Console.WriteLine(ma.Value);
+                        }
+                        else if (Regex.Match(text, PATTERN_B) is { Success: true } mb)
+                        {
+                            Console.WriteLine(mb.Value);
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task RealWorld_IsMatchThenMatchInsideLoop_Flags()
+        {
+            // Based on autoscreen Program.cs / NTransit FbpParser.cs:
+            // IsMatch/Match pair inside a foreach loop body.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string[] args)
+                    {
+                        foreach (string arg in args)
+                        {
+                            if ({|CA2028:Regex.IsMatch(arg, @"^-config=(.+)$")|})
+                            {
+                                Match m = Regex.Match(arg, @"^-config=(.+)$");
+                                Console.WriteLine(m.Groups[1].Value);
+                            }
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string[] args)
+                    {
+                        foreach (string arg in args)
+                        {
+                            if (Regex.Match(arg, @"^-config=(.+)$") is { Success: true } m)
+                            {
+                                Console.WriteLine(m.Groups[1].Value);
+                            }
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task RealWorld_ConstStringFieldPattern_Flags()
+        {
+            // Based on NTransit FbpParser.cs: const string fields used as regex pattern arg.
+            var source = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string COMPONENT_PATTERN = @"(\w+)\((\w+)\)";
+
+                    void M(string text)
+                    {
+                        if ({|CA2028:Regex.IsMatch(text, COMPONENT_PATTERN)|})
+                        {
+                            Match m = Regex.Match(text, COMPONENT_PATTERN);
+                            string name = m.Groups[1].Value;
+                            string type = m.Groups[2].Value;
+                        }
+                    }
+                }
+                """;
+            var fixedSource = """
+                using System;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    const string COMPONENT_PATTERN = @"(\w+)\((\w+)\)";
+
+                    void M(string text)
+                    {
+                        if (Regex.Match(text, COMPONENT_PATTERN) is { Success: true } m)
+                        {
+                            string name = m.Groups[1].Value;
+                            string type = m.Groups[2].Value;
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
         #endregion
@@ -1053,7 +1198,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             // Analyzer flags, but fixer doesn't handle return statements.
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]
@@ -1072,7 +1217,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCodeFixCSharp9Async(source, source);
         }
 
         [Fact]

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -1517,7 +1517,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         #endregion
 
-        #region Review round — GPT-5.4 findings
+        #region Regression tests for mutation and control-flow edge cases
 
         [Fact]
         public async Task InterveningRefMutation_NoDiagnostic()
@@ -1798,6 +1798,60 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        #endregion
+
+        #region Coalesce and deconstruction write tests
+
+        [Fact]
+        public async Task InterveningCoalesceAssignment_NoDiagnostic()
+        {
+            var source = """
+                #nullable enable
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string? input)
+                    {
+                        if (Regex.IsMatch(input!, @"\d+"))
+                        {
+                            input ??= "default";
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            // ??= and nullable require C# 8+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync(TestContext.Current.CancellationToken);
+        }
+
+        [Fact]
+        public async Task InterveningDeconstructionAssignment_NoDiagnostic()
+        {
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    (string, string) Split(string s) => (s, s);
+
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch(input, @"\d+"))
+                        {
+                            (input, _) = Split(input);
+                            var m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
         #endregion

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -300,7 +300,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, "hello") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
         [Fact]
@@ -346,7 +359,21 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        var regex = new Regex(@"\d+");
+                        if (regex.Match(input, 0) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
         #endregion
@@ -974,6 +1001,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         public async Task MultipleMatchCallsInBody_FlagsFirst()
         {
             // Only the first matching Match call should be included in the diagnostic.
+            // Fixer removes only the first Match declaration.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -989,7 +1017,21 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                            Match m2 = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
         [Fact]

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -76,7 +76,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         var regex = new Regex(@"\d+");
-                        if ({|CA2028:regex.IsMatch(input)|})
+                        if ([|regex.IsMatch(input)|])
                         {
                             Match m = regex.Match(input);
                         }
@@ -110,7 +110,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase)|})
+                        if ([|Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase)|])
                         {
                             Match m = Regex.Match(input, @"\d+", RegexOptions.IgnoreCase);
                         }
@@ -146,7 +146,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         var timeout = TimeSpan.FromSeconds(1);
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase, timeout)|})
+                        if ([|Regex.IsMatch(input, @"\d+", RegexOptions.IgnoreCase, timeout)|])
                         {
                             var m = Regex.Match(input, @"\d+", RegexOptions.IgnoreCase, timeout);
                         }
@@ -184,7 +184,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     string M(string input)
                     {
                         var regex = new Regex(@"charset=(.+)");
-                        if ({|CA2028:regex.IsMatch(input)|})
+                        if ([|regex.IsMatch(input)|])
                         {
                             return regex.Match(input).Groups[1].Value;
                         }
@@ -208,7 +208,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                         }
@@ -241,7 +241,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             var m = Regex.Match(input, @"\d+");
                         }
@@ -276,7 +276,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string input)
                     {
-                        if ({|CA2028:_regex.IsMatch(input)|})
+                        if ([|_regex.IsMatch(input)|])
                         {
                             Match m = _regex.Match(input);
                         }
@@ -311,7 +311,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input, string pattern)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, pattern)|})
+                        if ([|Regex.IsMatch(input, pattern)|])
                         {
                             Match m = Regex.Match(input, pattern);
                         }
@@ -344,7 +344,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, "hello")|})
+                        if ([|Regex.IsMatch(input, "hello")|])
                         {
                             Match m = Regex.Match(input, "hello");
                         }
@@ -380,7 +380,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Console.WriteLine("Found a match");
                             Match m = Regex.Match(input, @"\d+");
@@ -389,7 +389,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -403,7 +403,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         var regex = new Regex(@"\d+");
-                        if ({|CA2028:regex.IsMatch(input, 0)|})
+                        if ([|regex.IsMatch(input, 0)|])
                         {
                             Match m = regex.Match(input, 0);
                         }
@@ -448,7 +448,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -469,7 +469,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -491,7 +491,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -511,7 +511,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -532,7 +532,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -555,7 +555,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -578,7 +578,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -603,7 +603,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -626,7 +626,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -649,7 +649,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -672,7 +672,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -693,7 +693,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -716,7 +716,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -739,7 +739,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -761,7 +761,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -782,7 +782,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -806,7 +806,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -821,7 +821,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -843,7 +843,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -866,7 +866,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -889,7 +889,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -921,7 +921,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -953,7 +953,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1001,7 +1001,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Console.WriteLine("before match");
                             Match m = Regex.Match(input, @"\d+");
@@ -1025,7 +1025,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1060,7 +1060,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     Encoding M(string contentType)
                     {
                         var regex = new Regex(@"charset=(.+)", RegexOptions.IgnoreCase);
-                        if ({|CA2028:regex.IsMatch(contentType)|})
+                        if ([|regex.IsMatch(contentType)|])
                         {
                             return Encoding.GetEncoding(regex.Match(contentType).Groups[1].Value.Trim());
                         }
@@ -1095,7 +1095,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1116,12 +1116,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string text)
                     {
-                        if ({|CA2028:Regex.IsMatch(text, PATTERN_A)|})
+                        if ([|Regex.IsMatch(text, PATTERN_A)|])
                         {
                             Match ma = Regex.Match(text, PATTERN_A);
                             Console.WriteLine(ma.Value);
                         }
-                        else if ({|CA2028:Regex.IsMatch(text, PATTERN_B)|})
+                        else if ([|Regex.IsMatch(text, PATTERN_B)|])
                         {
                             Match mb = Regex.Match(text, PATTERN_B);
                             Console.WriteLine(mb.Value);
@@ -1168,7 +1168,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     {
                         foreach (string arg in args)
                         {
-                            if ({|CA2028:Regex.IsMatch(arg, @"^-config=(.+)$")|})
+                            if ([|Regex.IsMatch(arg, @"^-config=(.+)$")|])
                             {
                                 Match m = Regex.Match(arg, @"^-config=(.+)$");
                                 Console.WriteLine(m.Groups[1].Value);
@@ -1212,7 +1212,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string text)
                     {
-                        if ({|CA2028:Regex.IsMatch(text, COMPONENT_PATTERN)|})
+                        if ([|Regex.IsMatch(text, COMPONENT_PATTERN)|])
                         {
                             Match m = Regex.Match(text, COMPONENT_PATTERN);
                             string name = m.Groups[1].Value;
@@ -1254,13 +1254,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                 Class C
                     Sub M(input As String)
-                        If {|CA2028:Regex.IsMatch(input, "\d+")|} Then
+                        If [|Regex.IsMatch(input, "\d+")|] Then
                             Dim m As Match = Regex.Match(input, "\d+")
                         End If
                     End Sub
                 End Class
                 """;
-            await VerifyVB.VerifyAnalyzerAsync(source);
+            await VerifyVB.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1277,7 +1277,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     End Sub
                 End Class
                 """;
-            await VerifyVB.VerifyAnalyzerAsync(source);
+            await VerifyVB.VerifyCodeFixAsync(source, source);
         }
 
         #endregion
@@ -1296,7 +1296,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                             Match m2 = Regex.Match(input, @"\d+");
@@ -1331,7 +1331,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     Match M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             return Regex.Match(input, @"\d+");
                         }
@@ -1354,7 +1354,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                             Regex.Match(input, @"\d+");
                     }
                 }
@@ -1374,7 +1374,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string input)
                     {
-                        if ({|CA2028:s_regex.IsMatch(input)|})
+                        if ([|s_regex.IsMatch(input)|])
                         {
                             Match m = s_regex.Match(input);
                         }
@@ -1409,7 +1409,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(Regex regex, string input)
                     {
-                        if ({|CA2028:regex.IsMatch(input)|})
+                        if ([|regex.IsMatch(input)|])
                         {
                             Match m = regex.Match(input);
                         }
@@ -1450,7 +1450,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1466,7 +1466,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, Pattern)|})
+                        if ([|Regex.IsMatch(input, Pattern)|])
                         {
                             Match m = Regex.Match(input, Pattern);
                         }
@@ -1503,7 +1503,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, _pattern)|})
+                        if ([|Regex.IsMatch(input, _pattern)|])
                         {
                             Match m = Regex.Match(input, _pattern);
                         }
@@ -1539,7 +1539,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input: input, pattern: @"\d+")|})
+                        if ([|Regex.IsMatch(input: input, pattern: @"\d+")|])
                         {
                             Match m = Regex.Match(input: input, pattern: @"\d+");
                         }
@@ -1573,7 +1573,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input: input, pattern: @"\d+")|})
+                        if ([|Regex.IsMatch(input: input, pattern: @"\d+")|])
                         {
                             Match m = Regex.Match(pattern: @"\d+", input: input);
                         }
@@ -1641,7 +1641,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1664,7 +1664,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1681,7 +1681,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1704,7 +1704,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input, object obj)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1728,7 +1728,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input, List<int> items)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1752,7 +1752,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Group g = Regex.Match(input, @"\d+");
                         }
@@ -1772,7 +1772,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             object o = Regex.Match(input, @"\d+");
                         }
@@ -1792,7 +1792,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1826,7 +1826,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if (({|CA2028:Regex.IsMatch(input, @"\d+")|})  )
+                        if (([|Regex.IsMatch(input, @"\d+")|])  )
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1861,7 +1861,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input, List<(string, int)> items)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -1890,7 +1890,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                         switch (mode)
                         {
                             case 1:
-                                if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                                if ([|Regex.IsMatch(input, @"\d+")|])
                                 {
                                     Match m = Regex.Match(input, @"\d+");
                                 }
@@ -1953,7 +1953,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         #endregion
@@ -1976,7 +1976,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -1991,7 +1991,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -2016,7 +2016,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             Match m = Regex.Match(input, @"\d+");
                         }
@@ -2045,7 +2045,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch((input), (@"\d+"))|})
+                        if ([|Regex.IsMatch((input), (@"\d+"))|])
                         {
                             Match m = Regex.Match((input), (@"\d+"));
                         }
@@ -2076,7 +2076,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 {
                     void M(string input)
                     {
-                        if ({|CA2028:Regex.IsMatch((input), @"\d+")|})
+                        if ([|Regex.IsMatch((input), @"\d+")|])
                         {
                             Match m = Regex.Match(input, (@"\d+"));
                         }
@@ -2115,7 +2115,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         #endregion
@@ -2132,7 +2132,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = null;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);
@@ -2166,7 +2166,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);
@@ -2200,7 +2200,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = default;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);
@@ -2234,7 +2234,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = null;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                         }
@@ -2256,7 +2256,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = Regex.Match("", "");
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);
@@ -2279,7 +2279,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     {
                         Match m = null;
                         int x = 42;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);
@@ -2301,7 +2301,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = null;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                             m = Regex.Match(input, @"\d+");
                     }
                 }
@@ -2320,7 +2320,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     void M(string input)
                     {
                         Match m = null;
-                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        if ([|Regex.IsMatch(input, @"\d+")|])
                         {
                             m = Regex.Match(input, @"\d+");
                             System.Console.WriteLine(m.Value);

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -197,9 +197,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
-        public async Task MatchInExpressionStatement_FlagsButNoFix()
+        public async Task MatchInExpressionStatement_FlagsAndFix()
         {
-            // Match is assigned to an existing variable, not a new declaration.
+            // Match is assigned to an existing variable declared immediately before the if.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -215,7 +215,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                     }
                 }
                 """;
-            await VerifyCodeFixCSharp9Async(source, source);
+            var fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
         [Fact]
@@ -2016,6 +2029,284 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 }
                 """;
             // Fix not applicable — local function parameter 'm' conflicts
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        #endregion
+
+        #region Parenthesized argument tests
+
+        [Fact]
+        public async Task ParenthesizedArguments_MatchesDiagnostic()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch((input), (@"\d+"))|})
+                        {
+                            Match m = Regex.Match((input), (@"\d+"));
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match((input), (@"\d+")) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task MismatchedParentheses_StillMatchesDiagnostic()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ({|CA2028:Regex.IsMatch((input), @"\d+")|})
+                        {
+                            Match m = Regex.Match(input, (@"\d+"));
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, (@"\d+")) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ParenthesizedArgument_InterveningReassignment_NoDiagnostic()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.IsMatch((input), @"\d+"))
+                        {
+                            input = "other";
+                            Match m = Regex.Match((input), @"\d+");
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        #endregion
+
+        #region Pre-declaration assignment pattern tests
+
+        [Fact]
+        public async Task PreDeclaredAssignment_FixRemovesDeclaration()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = null;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_NoInitializer_FixRemovesDeclaration()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_DefaultInitializer_FixRemovesDeclaration()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = default;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_UsedAfterIf_DiagnosticButNoFix()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = null;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                        }
+                        System.Console.WriteLine(m);
+                    }
+                }
+                """;
+            // Diagnostic fires, but fixer cannot apply because m is used after the if.
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_NonNullInitializer_DiagnosticButNoFix()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = Regex.Match("", "");
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            // Diagnostic fires, but fixer doesn't apply because initializer is non-null/default.
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_NotImmediatelyBeforeIf_DiagnosticButNoFix()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = null;
+                        int x = 42;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                        {
+                            m = Regex.Match(input, @"\d+");
+                            System.Console.WriteLine(m.Value);
+                        }
+                    }
+                }
+                """;
+            // Diagnostic fires, but fixer doesn't apply because declaration isn't immediately before if.
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_SingleStatementBody_NoBraces_DiagnosticButNoFix()
+        {
+            string source = """
+                using System.Text.RegularExpressions;
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = null;
+                        if ({|CA2028:Regex.IsMatch(input, @"\d+")|})
+                            m = Regex.Match(input, @"\d+");
+                    }
+                }
+                """;
+            // Diagnostic fires, but fixer requires block body for assignment path.
             await VerifyCodeFixCSharp9Async(source, source);
         }
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -538,7 +538,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task NegatedIsMatch_NoDiagnostic()
         {
-            // Inverted case — explicitly dropped per stephentoub's review.
+            // Inverted form (`!Regex.IsMatch(...)`) is intentionally not handled.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -2381,7 +2381,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         #endregion
 
-        #region Regression tests for krwq review feedback (2026-05-12)
+        #region Additional regression tests
 
         [Fact]
         public async Task TernaryConditional_NoDiagnostic()
@@ -2745,9 +2745,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task MatchInsideObjectInitializer_Diagnostic()
         {
-            // Regression for Copilot review (2026-05-12): Match call inside an
-            // object initializer (`new Foo { Bar = Regex.Match(...) }`) should
-            // be detected by walking IObjectOrCollectionInitializerOperation.
+            // Match call inside an object initializer
+            // (`new Foo { Bar = Regex.Match(...) }`) should be detected by
+            // walking IObjectOrCollectionInitializerOperation.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -2771,11 +2771,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task IntermediateLocalFunctionWithWrite_StillFlags()
         {
-            // Regression for Copilot review (2026-05-12): A local function declared
-            // between IsMatch and Match contains a write to `input`, but its body
-            // is not executed at declaration time, so the analyzer should still
-            // fire. (The fixer may decline due to intermediate statements; we only
-            // assert the diagnostic here.)
+            // A local function declared between IsMatch and Match contains a
+            // write to `input`, but its body is not executed at declaration
+            // time, so the analyzer should still fire. (The fixer may decline
+            // due to intermediate statements; we only assert the diagnostic
+            // here.)
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -2798,9 +2798,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task PreDeclaredAssignment_DefaultTypeExpressionInitializer_FixOffered()
         {
-            // Regression for Copilot review (2026-05-12): `Match m = default(Match);`
-            // is also a constant-default initializer, equivalent to `null` for a
-            // reference type, and should be treated as removable.
+            // `Match m = default(Match);` is a constant-default initializer,
+            // equivalent to `null` for a reference type, and should be treated
+            // as removable by the pre-declared assignment fixer.
             var source = """
                 using System.Text.RegularExpressions;
 
@@ -2835,11 +2835,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task LinqQueryRangeVariableAfterIf_NoFix()
         {
-            // Regression for Copilot review (2026-05-12): a subsequent LINQ query
-            // that already binds `m` (via `from m in ...`) would conflict with a
-            // pattern variable `m` introduced by the fixer (which scopes to the
-            // entire enclosing block). HasConflictingName must include query range
-            // variables, so no fix is offered here.
+            // A subsequent LINQ query that already binds `m` (via
+            // `from m in ...`) would conflict with a pattern variable `m`
+            // introduced by the fixer (which scopes to the entire enclosing
+            // block). HasConflictingName must include query range variables,
+            // so no fix is offered here.
             var source = """
                 using System.Collections.Generic;
                 using System.Linq;

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2795,6 +2795,43 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
+        [Fact]
+        public async Task PreDeclaredAssignment_DefaultTypeExpressionInitializer_FixOffered()
+        {
+            // Regression for Copilot review (2026-05-12): `Match m = default(Match);`
+            // is also a constant-default initializer, equivalent to `null` for a
+            // reference type, and should be treated as removable.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        Match m = default(Match);
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2380,5 +2380,368 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         #endregion
+
+        #region Regression tests for krwq review feedback (2026-05-12)
+
+        [Fact]
+        public async Task TernaryConditional_NoDiagnostic()
+        {
+            // IConditionalOperation also fires for `?:` (and VB `If(...)`),
+            // but the analyzer should only report on if-statements.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string M(string input, string p)
+                    {
+                        return Regex.IsMatch(input, p) ? Regex.Match(input, p).Value : "";
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task VB_TernaryIfExpression_NoDiagnostic()
+        {
+            // VB `If(cond, a, b)` is also IConditionalOperation; analyzer must skip it.
+            var source = """
+                Imports System.Text.RegularExpressions
+
+                Class C
+                    Function M(input As String, p As String) As String
+                        Return If(Regex.IsMatch(input, p), Regex.Match(input, p).Value, "")
+                    End Function
+                End Class
+                """;
+            await VerifyVB.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideObjectCreation_Diagnostic()
+        {
+            // Locks in coverage for IObjectCreationOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class Wrapper { public Wrapper(Match m) { } }
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            var w = new Wrapper(Regex.Match(input, @"\d+"));
+                        }
+                    }
+                }
+                """;
+            // Diagnostic fires; no fix because Match is embedded inside a larger expression.
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideTuple_Diagnostic()
+        {
+            // Locks in coverage for ITupleOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    (Match, int) M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return (Regex.Match(input, @"\d+"), 1);
+                        }
+                        return (null, 0);
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideInterpolatedString_Diagnostic()
+        {
+            // Locks in coverage for IInterpolatedStringOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    string M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return $"{Regex.Match(input, @"\d+").Value}";
+                        }
+                        return "";
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideCoalesce_Diagnostic()
+        {
+            // Locks in coverage for ICoalesceOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    Match M(string input, Match fallback)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return Regex.Match(input, @"\d+") ?? fallback;
+                        }
+                        return fallback;
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideBinaryComparison_Diagnostic()
+        {
+            // Locks in coverage for IBinaryOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    bool M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return Regex.Match(input, @"\d+") != null;
+                        }
+                        return false;
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task MatchInsideUnaryNot_Diagnostic()
+        {
+            // Locks in coverage for IUnaryOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    bool M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return !Regex.Match(input, @"\d+").Success;
+                        }
+                        return false;
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task StructInstanceMethod_ThisReassignedBeforeMatch_NoDiagnostic()
+        {
+            // `this` is reassignable inside a struct's instance methods, so
+            // `r.IsMatch(input)` and a later `r.Match(input)` separated by a
+            // `this = ...` may use different `r` values. Restricting the
+            // IInstanceReferenceOperation equivalence to reference types
+            // suppresses the diagnostic in this case.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                struct S
+                {
+                    public Regex r;
+
+                    public S(Regex regex) { r = regex; }
+
+                    public void M(string input, Regex other)
+                    {
+                        if (r.IsMatch(input))
+                        {
+                            this = new S(other);
+                            Match m = r.Match(input);
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task ClassInstanceMethod_StillFlags()
+        {
+            // Sanity check that the struct-only restriction in Comment 3 didn't
+            // break the common reference-type case.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    readonly Regex r = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if ([|r.IsMatch(input)|])
+                        {
+                            Match m = r.Match(input);
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    readonly Regex r = new Regex(@"\d+");
+
+                    void M(string input)
+                    {
+                        if (r.Match(input) is { Success: true } m)
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_UnrelatedMemberAccessAfter_FixOffered()
+        {
+            // `something.m` after the if is a member access, not a reference to the
+            // local `m`, so the fixer should still be offered.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class Holder { public int m; }
+
+                class C
+                {
+                    void M(string input, Holder something)
+                    {
+                        Match m = null;
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            m = Regex.Match(input, @"\d+");
+                        }
+                        something.m = 1;
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class Holder { public int m; }
+
+                class C
+                {
+                    void M(string input, Holder something)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                        something.m = 1;
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task FixerStripsTrivia_DocumentsBehavior()
+        {
+            // The fixer intentionally clears trailing trivia from the original
+            // condition expression and uses `WithoutTrivia()` on the moved Match
+            // call. This regression test documents the current behavior so that
+            // future formatting changes are caught explicitly.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|]) // end-of-line comment
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m) // end-of-line comment
+                        {
+                        }
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task PreDeclaredAssignment_NamedArgumentLabelMatchesName_FixOffered()
+        {
+            // `m: 1` after the if is a named-argument label, not a reference to the
+            // local `m`, so the fixer should still be offered.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void Helper(int m) { }
+
+                    void M(string input)
+                    {
+                        Match m = null;
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            m = Regex.Match(input, @"\d+");
+                        }
+                        Helper(m: 1);
+                    }
+                }
+                """;
+            string fixedSource = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void Helper(int m) { }
+
+                    void M(string input)
+                    {
+                        if (Regex.Match(input, @"\d+") is { Success: true } m)
+                        {
+                        }
+                        Helper(m: 1);
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, fixedSource);
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2832,6 +2832,34 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
+        [Fact]
+        public async Task LinqQueryRangeVariableAfterIf_NoFix()
+        {
+            // Regression for Copilot review (2026-05-12): a subsequent LINQ query
+            // that already binds `m` (via `from m in ...`) would conflict with a
+            // pattern variable `m` introduced by the fixer (which scopes to the
+            // entire enclosing block). HasConflictingName must include query range
+            // variables, so no fix is offered here.
+            var source = """
+                using System.Collections.Generic;
+                using System.Linq;
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input, IEnumerable<string> items)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            Match m = Regex.Match(input, @"\d+");
+                        }
+                        var q = (from m in items select m).ToList();
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2742,6 +2742,59 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCodeFixCSharp9Async(source, fixedSource);
         }
 
+        [Fact]
+        public async Task MatchInsideObjectInitializer_Diagnostic()
+        {
+            // Regression for Copilot review (2026-05-12): Match call inside an
+            // object initializer (`new Foo { Bar = Regex.Match(...) }`) should
+            // be detected by walking IObjectOrCollectionInitializerOperation.
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class Wrapper { public Match Bar { get; set; } }
+
+                class C
+                {
+                    Wrapper M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            return new Wrapper { Bar = Regex.Match(input, @"\d+") };
+                        }
+                        return null;
+                    }
+                }
+                """;
+            await VerifyCodeFixCSharp9Async(source, source);
+        }
+
+        [Fact]
+        public async Task IntermediateLocalFunctionWithWrite_StillFlags()
+        {
+            // Regression for Copilot review (2026-05-12): A local function declared
+            // between IsMatch and Match contains a write to `input`, but its body
+            // is not executed at declaration time, so the analyzer should still
+            // fire. (The fixer may decline due to intermediate statements; we only
+            // assert the diagnostic here.)
+            var source = """
+                using System.Text.RegularExpressions;
+
+                class C
+                {
+                    void M(string input)
+                    {
+                        if ([|Regex.IsMatch(input, @"\d+")|])
+                        {
+                            void Local() { input = "other"; }
+                            Match m = Regex.Match(input, @"\d+");
+                            Local();
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Implements CA2028: Avoid redundant Regex.IsMatch before Regex.Match.

Closes dotnet/runtime#111239
Supersedes #51214 (abandoned — Copilot was not converging at the time)

## Pattern detected

```csharp
// Before (local declaration)
if (Regex.IsMatch(input, pattern))
{
    Match m = Regex.Match(input, pattern);
    // use m
}

// Before (pre-declared variable)
Match m = null;
if (Regex.IsMatch(input, pattern))
{
    m = Regex.Match(input, pattern);
    // use m
}

// After (both cases)
if (Regex.Match(input, pattern) is { Success: true } m)
{
    // use m
}
```

## What's included

- **Analyzer** (IOperation-based, language-agnostic): registers on `IConditionalOperation`, validates operand equivalence (restricted to stable sources: locals, parameters, constants, readonly/const fields), tracks intervening writes including ref/out argument mutations, and reports diagnostic with additional location on the Match call.
- **C# fixer** with two paths:
  - **Local declaration**: `Match m = Regex.Match(...)` inside the if body — replaces with `is` pattern.
  - **Pre-declared variable assignment**: `Match m = null; if (...) { m = Regex.Match(...); ... }` — removes the declaration and assignment, replaces with `is` pattern. Includes safety checks: variable must not be referenced after the if statement, initializer must be absent/null/default.
- **82 tests** covering: all static/instance overloads (including timeout), diagnostic+fix, diagnostic-only (no fix offered), no-diagnostic, VB smoke tests, real-world patterns found via GitHub code search (else-if chains, foreach loops, const fields), parenthesized arguments, pre-declared variable assignment patterns, edge cases (intervening writes, mutable receivers, property/method arguments, ref/out mutations, readonly-field receiver reassignment, span overloads with Net70 reference assemblies).

## Addresses all feedback from #51214

All 15 review comments from @stephentoub on the abandoned PR are addressed:
- Resource strings don't mention "pattern matching"
- Inverted case (`!IsMatch` guard) intentionally not supported per reviewer guidance — adds too much complexity
- Full intervening-write analysis prevents false positives from variable reassignment
- Instance receiver equivalence validated with same rules as arguments
- No VB fixer (VB analyzer works, fixer is `EmptyCodeFixProvider`)
- No unnecessary wrapper methods; `context.Diagnostics[0]` not inlined because it's used 4x
- Extensive test coverage (82 tests vs ~10 in original)

## Design decisions

- **Rule ID CA2028** — CA2027 is already taken by `DoNotUseNonCancelableTaskDelayWithWhenAny`
- **Category: Reliability**, severity: IdeSuggestion
- Operand equivalence restricted to stable sources — properties, method calls, mutable fields are rejected
- Does not recurse into lambdas, local functions, or nested blocks for Match call search
- `AddMutableSymbol` recurses into `IFieldReferenceOperation.Instance` to handle `obj.ReadonlyField` receiver patterns
- Span overloads (`ReadOnlySpan`) intentionally not flagged — `IsMatch` returns bool but there's no corresponding `Match` overload returning `Match`
- Named arguments matched by `Parameter.Ordinal` (not array index) for correctness
- `WalkDownParentheses()` applied consistently before `WalkDownConversion()` in all operand/symbol tracking paths
