### PR TITLE
Forward MSBuild build/tasks/details telemetry event

### DIFF
--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -22,6 +22,7 @@ public sealed class MSBuildLogger : INodeLogger
     // These two events are aggregated and sent at the end of the build.
     internal const string TaskFactoryTelemetryAggregatedEventName = "build/tasks/taskfactory";
     internal const string TasksTelemetryAggregatedEventName = "build/tasks";
+    internal const string TasksDetailsTelemetryEventName = "build/tasks/details";
 
     internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
     internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
@@ -204,6 +205,11 @@ public sealed class MSBuildLogger : INodeLogger
             case BuildcheckRuleStatsEventName:
                 TrackEvent(telemetry, $"msbuild/{BuildcheckRuleStatsEventName}", args.Properties,
                     toBeHashed: ["RuleId", "CheckFriendlyName"]
+                );
+                break;
+            case TasksDetailsTelemetryEventName:
+                TrackEvent(telemetry, $"msbuild/{TasksDetailsTelemetryEventName}", args.Properties,
+                    toBeHashed: []
                 );
                 break;
             // Pass through events that don't need special handling

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -215,5 +215,30 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             fakeTelemetry.LogEntry.Properties.Should().NotContainKey("InvalidProperty");
             fakeTelemetry.LogEntry.Properties.Should().NotContainKey("InvalidProperty2");
         }
+
+        [TestMethod]
+        public void ItForwardsTaskDetailsEvent()
+        {
+            var fakeTelemetry = new FakeTelemetry();
+            var telemetryEventArgs = new TelemetryEventArgs
+            {
+                EventName = MSBuildLogger.TasksDetailsTelemetryEventName,
+                Properties = new Dictionary<string, string>
+                {
+                    { "Tasks", "[{\"Name\":\"Copy\",\"ExecutionsCount\":10}]" },
+                    { "TaskCount", "1" },
+                    { "TotalTaskCount", "1" }
+                }
+            };
+
+            MSBuildLogger.FormatAndSend(fakeTelemetry, telemetryEventArgs);
+
+            fakeTelemetry.LogEntry.Should().NotBeNull();
+            fakeTelemetry.LogEntry.EventName.Should().Be($"msbuild/{MSBuildLogger.TasksDetailsTelemetryEventName}");
+            fakeTelemetry.LogEntry.Properties.Keys.Count.Should().Be(3);
+            fakeTelemetry.LogEntry.Properties["Tasks"].Should().Be("[{\"Name\":\"Copy\",\"ExecutionsCount\":10}]");
+            fakeTelemetry.LogEntry.Properties["TaskCount"].Should().Be("1");
+            fakeTelemetry.LogEntry.Properties["TotalTaskCount"].Should().Be("1");
+        }
     }
 }


### PR DESCRIPTION
### Context

Companion to [dotnet/msbuild#13609](https://github.com/dotnet/msbuild/pull/13609), which adds a new per-task telemetry event `build/tasks/details` emitted from `BuildManager`. The MSBuild PR motivates this work: we want richer task-execution data (per-task name, executions count, task host runtime, etc.) so we can use real-world frequency data to drive decisions about which built-in tasks to prioritize / optimize.

The event carries:
- `TaskCount` — number of distinct tasks in the payload (capped at 100).
- `TotalTaskCount` — total number of distinct tasks observed.
- `Tasks` — JSON array of task-detail records (top 100 by `ExecutionsCount`), ready for Kusto `mv-expand`.

### Changes

`src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs`:
- Added `TasksDetailsTelemetryEventName = "build/tasks/details"` constant.
- Added a `case` in `FormatAndSend` that pass-through-forwards the event under the `msbuild/` namespace, with no hashed properties (the payload is already a JSON string with no PII).

Unlike the existing `build/tasks` / `build/tasks/taskfactory` events, this event is **not aggregated client-side** — MSBuild already does the aggregation/capping (top 100, hashed custom-task names) and the SDK just relays it.

### Testing

- New test `ItForwardsTaskDetailsEvent` in `GivenMSBuildLogger` verifies the event is forwarded under the expected name and that all three properties (`Tasks`, `TaskCount`, `TotalTaskCount`) are preserved verbatim.
- All 8 `GivenMSBuildLogger` tests pass locally.

### Rollout

This change is forward-compatible: older MSBuilds simply won't emit the event, and the `case` in `FormatAndSend` is a no-op when the event isn't raised. No env-var gating is needed on the SDK side — gating lives in MSBuild (`MSBUILDTELEMETRYEXCLUDETASKSDETAILS` / `Traits.ExcludeTasksDetailsFromTelemetry`).
