### PR TITLE
Allow explicitly skipping crossgen

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -37,10 +37,9 @@ if ($pack) {
   $arguments += " -pack /p:SkipBuildingInstallers=false"
   if (-not $skipCrossgen) { $arguments += " /p:SkipUsingCrossgen=false" }
   if (-not $skipInstallers) { $arguments += " /p:SkipBuildingInstallers=false" }
+} else {
+  $arguments += " /p:SkipUsingCrossgen=true /p:SkipBuildingInstallers=true"
 }
-
-if ($skipCrossgen) { $arguments += " /p:SkipUsingCrossgen=true" }
-if ($skipInstallers) { $arguments += " /p:SkipBuildingInstallers=true" }
 
 if ($properties) { $arguments += " " + ($properties -join " ") }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -34,7 +34,7 @@ if ($arch) { $arguments += " /p:TargetArchitecture=$arch" }
 
 if ($test) { $arguments += " -test" }
 if ($pack) {
-  $arguments += " -pack /p:SkipBuildingInstallers=false"
+  $arguments += " -pack"
   if (-not $skipCrossgen) { $arguments += " /p:SkipUsingCrossgen=false" }
   if (-not $skipInstallers) { $arguments += " /p:SkipBuildingInstallers=false" }
 } else {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -34,15 +34,13 @@ if ($arch) { $arguments += " /p:TargetArchitecture=$arch" }
 
 if ($test) { $arguments += " -test" }
 if ($pack) {
-  $arguments += " -pack /p:SkipUsingCrossgen=false /p:SkipBuildingInstallers=false"
-} else {
-  if ($skipCrossgen -or -not $pack) {
-    $arguments += " /p:SkipUsingCrossgen=true"
-  }
-  if ($skipInstallers -or -not $pack) {
-    $arguments += " /p:SkipBuildingInstallers=true"
-  }
+  $arguments += " -pack /p:SkipBuildingInstallers=false"
+  if (-not $skipCrossgen) { $arguments += " /p:SkipUsingCrossgen=false" }
+  if (-not $skipInstallers) { $arguments += " /p:SkipBuildingInstallers=false" }
 }
+
+if ($skipCrossgen) { $arguments += " /p:SkipUsingCrossgen=true" }
+if ($skipInstallers) { $arguments += " /p:SkipBuildingInstallers=true" }
 
 if ($properties) { $arguments += " " + ($properties -join " ") }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -24,6 +24,7 @@ while [[ $# > 0 ]]; do
     -pack) skip_crossgen=false; skip_installers=false; arguments+=(-pack) ;;
     -test|-t) arguments+=(-test) ;;
     -configuration|-c) arguments+=(-configuration "$2"); shift ;;
+    -skipcrossgen) skip_crossgen=true ;;
     *) arguments+=("$1") ;;
   esac
   shift

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -13,7 +13,8 @@ ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 arguments=(--restore --build)
 target_os=""
 target_arch=""
-skip_crossgen=true
+pack=false
+skip_crossgen=""
 skip_installers=true
 
 while [[ $# > 0 ]]; do
@@ -21,7 +22,7 @@ while [[ $# > 0 ]]; do
   case "$opt" in
     -os) target_os="$2"; shift ;;
     -arch|-a) target_arch="$2"; shift ;;
-    -pack) skip_crossgen=false; skip_installers=false; arguments+=(-pack) ;;
+    -pack) pack=true; skip_installers=false; arguments+=(-pack) ;;
     -test|-t) arguments+=(-test) ;;
     -configuration|-c) arguments+=(-configuration "$2"); shift ;;
     -skipcrossgen) skip_crossgen=true ;;
@@ -29,6 +30,13 @@ while [[ $# > 0 ]]; do
   esac
   shift
 done
+
+if [ "$pack" = true ] && [ -z "$skip_crossgen" ]; then
+  skip_crossgen=false
+fi
+if [ -z "$skip_crossgen" ]; then
+  skip_crossgen=true
+fi
 
 if [ -n "$target_os" ]; then
   arguments+=("/p:TargetOS=$target_os")


### PR DESCRIPTION
Add a `-skipCrossgen` option to `build.sh`, similar to the option in `build.ps1`.

This allows the user to both enable `-pack` and skip Crossgen.