### PR TITLE
Disallow duplicate directives across `#:include`d files too

### DIFF
--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -36,7 +36,7 @@ internal static class FileLevelDirectiveHelpers
     /// The latter is useful for <c>dotnet run file.cs</c> where if there are app directives after the first token,
     /// compiler reports <see cref="ErrorCode.ERR_PPIgnoredFollowsToken"/> anyway, so we speed up success scenarios by not parsing the whole file up front in the SDK CLI.
     /// </param>
-    public static ImmutableArray<CSharpDirective> FindDirectives(SourceFile sourceFile, bool reportAllErrors, ErrorReporter errorReporter)
+    public static ImmutableArray<CSharpDirective> FindDirectives(SourceFile sourceFile, bool reportAllErrors, ErrorReporter errorReporter, bool checkDuplicates = true)
     {
         var builder = ImmutableArray.CreateBuilder<CSharpDirective>();
         var tokenizer = CreateTokenizer(sourceFile.Text);
@@ -44,7 +44,7 @@ internal static class FileLevelDirectiveHelpers
         var result = tokenizer.ParseLeadingTrivia();
         var triviaList = result.Token.LeadingTrivia;
 
-        FindLeadingDirectives(sourceFile, triviaList, errorReporter, builder);
+        FindLeadingDirectives(sourceFile, triviaList, errorReporter, builder, checkDuplicates);
 
         // In conversion mode, we want to report errors for any invalid directives in the rest of the file
         // so users don't end up with invalid directives in the converted project.
@@ -86,7 +86,8 @@ internal static class FileLevelDirectiveHelpers
         SourceFile sourceFile,
         SyntaxTriviaList triviaList,
         ErrorReporter errorReporter,
-        ImmutableArray<CSharpDirective>.Builder? builder)
+        ImmutableArray<CSharpDirective>.Builder? builder,
+        bool checkDuplicates = true)
     {
         var deduplicator = new DirectiveDeduplicator();
         TextSpan previousWhiteSpaceSpan = default;
@@ -156,7 +157,10 @@ internal static class FileLevelDirectiveHelpers
 
                 if (CSharpDirective.Parse(context) is { } directive)
                 {
-                    deduplicator.CheckDirective(directive, errorReporter);
+                    if (checkDuplicates)
+                    {
+                        deduplicator.CheckDirective(directive, errorReporter);
+                    }
 
                     builder?.Add(directive);
                 }
@@ -901,21 +905,6 @@ internal struct DirectiveDeduplicator
         {
             _seen.Add(directive, directive);
         }
-    }
-
-    /// <summary>
-    /// Adds <paramref name="directive"/> to the set of seen directives without reporting errors.
-    /// Used to seed the deduplicator with directives that were already checked elsewhere.
-    /// </summary>
-    public void AddDirective(CSharpDirective.Named directive)
-    {
-        if (directive is CSharpDirective.Project or CSharpDirective.Ref)
-        {
-            return;
-        }
-
-        _seen ??= new(NamedDirectiveComparer.Instance);
-        _seen.TryAdd(directive, directive);
     }
 }
 

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -88,7 +88,7 @@ internal static class FileLevelDirectiveHelpers
         ErrorReporter errorReporter,
         ImmutableArray<CSharpDirective>.Builder? builder)
     {
-        var deduplicated = new Dictionary<CSharpDirective.Named, CSharpDirective.Named>(NamedDirectiveComparer.Instance);
+        var deduplicator = new DirectiveDeduplicator();
         TextSpan previousWhiteSpaceSpan = default;
 
         for (var index = 0; index < triviaList.Count; index++)
@@ -156,20 +156,7 @@ internal static class FileLevelDirectiveHelpers
 
                 if (CSharpDirective.Parse(context) is { } directive)
                 {
-                    // Duplicate #:project and #:ref directives are allowed (MSBuild can handle that).
-                    if (directive is not (CSharpDirective.Project or CSharpDirective.Ref))
-                    {
-                        // If the directive is already present, report an error.
-                        if (deduplicated.TryGetValue(directive, out var existingDirective))
-                        {
-                            var typeAndName = $"#:{existingDirective.GetType().Name.ToLowerInvariant()} {existingDirective.Name}";
-                            context.ReportError(directive.Info.Span, string.Format(FileBasedProgramsResources.DuplicateDirective, typeAndName));
-                        }
-                        else
-                        {
-                            deduplicated.Add(directive, directive);
-                        }
-                    }
+                    deduplicator.CheckDirective(directive, errorReporter);
 
                     builder?.Add(directive);
                 }
@@ -877,6 +864,58 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
             void ReportError(string message)
                 => errorReporter(sourceFile.Text, sourceFile.Path, default, message);
         }
+    }
+}
+
+/// <summary>
+/// Detects duplicate directives (by type and case-insensitive name)
+/// and reports errors via the provided <see cref="ErrorReporter"/>.
+/// </summary>
+/// <remarks>
+/// <c>#:project</c> and <c>#:ref</c> duplicates are allowed (MSBuild can handle multiple <c>ProjectReference</c>s).
+/// </remarks>
+internal struct DirectiveDeduplicator
+{
+    private Dictionary<CSharpDirective.Named, CSharpDirective.Named>? _seen;
+
+    /// <summary>
+    /// Checks <paramref name="directive"/> for duplication and reports an error if it was already seen.
+    /// </summary>
+    public void CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError)
+    {
+        // Duplicate #:project and #:ref directives are allowed (MSBuild can handle that).
+        if (directive is CSharpDirective.Project or CSharpDirective.Ref)
+        {
+            return;
+        }
+
+        _seen ??= new(NamedDirectiveComparer.Instance);
+
+        if (_seen.TryGetValue(directive, out var existingDirective))
+        {
+            var typeAndName = $"#:{existingDirective.GetType().Name.ToLowerInvariant()} {existingDirective.Name}";
+            reportError(directive.Info.SourceFile.Text, directive.Info.SourceFile.Path, directive.Info.Span,
+                string.Format(FileBasedProgramsResources.DuplicateDirective, typeAndName));
+        }
+        else
+        {
+            _seen.Add(directive, directive);
+        }
+    }
+
+    /// <summary>
+    /// Adds <paramref name="directive"/> to the set of seen directives without reporting errors.
+    /// Used to seed the deduplicator with directives that were already checked elsewhere.
+    /// </summary>
+    public void AddDirective(CSharpDirective.Named directive)
+    {
+        if (directive is CSharpDirective.Project or CSharpDirective.Ref)
+        {
+            return;
+        }
+
+        _seen ??= new(NamedDirectiveComparer.Instance);
+        _seen.TryAdd(directive, directive);
     }
 }
 

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -364,6 +364,8 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
 
     public abstract override string ToString();
 
+    public virtual string KindToString() => GetType().Name.ToLowerInvariant();
+
     /// <summary>
     /// <c>#!</c> directive.
     /// </summary>
@@ -800,7 +802,7 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
             };
         }
 
-        public string KindToString()
+        public override string KindToString()
         {
             return Kind switch
             {
@@ -897,7 +899,7 @@ internal struct DirectiveDeduplicator
 
         if (_seen.TryGetValue(directive, out var existingDirective))
         {
-            var typeAndName = $"#:{existingDirective.GetType().Name.ToLowerInvariant()} {existingDirective.Name}";
+            var typeAndName = $"#:{existingDirective.KindToString()} {existingDirective.Name}";
             reportError(directive.Info.SourceFile.Text, directive.Info.SourceFile.Path, directive.Info.Span,
                 string.Format(FileBasedProgramsResources.DuplicateDirective, typeAndName));
         }

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
@@ -88,6 +88,9 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Version.get -> string?
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Version.init -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang.Shebang(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info) -> void
+Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator
+Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.CheckDirective(Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named! directive, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError) -> void
+Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.DirectiveDeduplicator() -> void
 Microsoft.DotNet.FileBasedPrograms.ErrorReporter
 Microsoft.DotNet.FileBasedPrograms.ErrorReporters
 Microsoft.DotNet.FileBasedPrograms.ExternalHelpers
@@ -153,8 +156,8 @@ static Microsoft.DotNet.FileBasedPrograms.ExternalHelpers.CombineHashCodes(int v
 static Microsoft.DotNet.FileBasedPrograms.ExternalHelpers.GetRelativePath(string! relativeTo, string! path) -> string!
 static Microsoft.DotNet.FileBasedPrograms.ExternalHelpers.IsPathFullyQualified(string! path) -> bool
 static Microsoft.DotNet.FileBasedPrograms.FileLevelDirectiveHelpers.CreateTokenizer(Microsoft.CodeAnalysis.Text.SourceText! text) -> Microsoft.CodeAnalysis.CSharp.SyntaxTokenParser!
-static Microsoft.DotNet.FileBasedPrograms.FileLevelDirectiveHelpers.FindDirectives(Microsoft.DotNet.FileBasedPrograms.SourceFile sourceFile, bool reportAllErrors, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! errorReporter) -> System.Collections.Immutable.ImmutableArray<Microsoft.DotNet.FileBasedPrograms.CSharpDirective!>
-static Microsoft.DotNet.FileBasedPrograms.FileLevelDirectiveHelpers.FindLeadingDirectives(Microsoft.DotNet.FileBasedPrograms.SourceFile sourceFile, Microsoft.CodeAnalysis.SyntaxTriviaList triviaList, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! errorReporter, System.Collections.Immutable.ImmutableArray<Microsoft.DotNet.FileBasedPrograms.CSharpDirective!>.Builder? builder) -> void
+static Microsoft.DotNet.FileBasedPrograms.FileLevelDirectiveHelpers.FindDirectives(Microsoft.DotNet.FileBasedPrograms.SourceFile sourceFile, bool reportAllErrors, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! errorReporter, bool checkDuplicates = true) -> System.Collections.Immutable.ImmutableArray<Microsoft.DotNet.FileBasedPrograms.CSharpDirective!>
+static Microsoft.DotNet.FileBasedPrograms.FileLevelDirectiveHelpers.FindLeadingDirectives(Microsoft.DotNet.FileBasedPrograms.SourceFile sourceFile, Microsoft.CodeAnalysis.SyntaxTriviaList triviaList, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! errorReporter, System.Collections.Immutable.ImmutableArray<Microsoft.DotNet.FileBasedPrograms.CSharpDirective!>.Builder? builder, bool checkDuplicates = true) -> void
 static Microsoft.DotNet.FileBasedPrograms.MSBuildUtilities.ConvertStringToBool(string? parameterValue, bool defaultValue = false) -> bool
 static Microsoft.DotNet.FileBasedPrograms.Patterns.DisallowedNameCharacters.get -> System.Text.RegularExpressions.Regex!
 static Microsoft.DotNet.FileBasedPrograms.Patterns.EscapedCompilerOption.get -> System.Text.RegularExpressions.Regex!

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
@@ -9,7 +9,7 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.ItemType.ini
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.Kind.get -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.Kind.init -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.KindToMSBuildString() -> string!
-Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.KindToString() -> string!
+override Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.KindToString() -> string!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.OriginalName.get -> string!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.OriginalName.init -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude.WithDeterminedItemType(Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError, System.Collections.Immutable.ImmutableArray<(string! Extension, string! ItemType)> mapping) -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExclude!
@@ -18,6 +18,7 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind.Exclude = 1 -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind.Include = 0 -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.IncludeOrExcludeKind
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Info.get -> Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo
+virtual Microsoft.DotNet.FileBasedPrograms.CSharpDirective.KindToString() -> string!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named.Name.get -> string!
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named.Name.init -> void

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -316,6 +316,8 @@ public sealed class VirtualProjectBuilder
         var seenFiles = new HashSet<string>(1, StringComparer.Ordinal) { EntryPointFileFullPath };
         var filesToProcess = new Queue<string>();
         var evaluatedDirectiveBuilder = ImmutableArray.CreateBuilder<CSharpDirective>();
+        var deduplicator = new DirectiveDeduplicator();
+        var isFirstFile = true;
 
         do
         {
@@ -327,6 +329,25 @@ public sealed class VirtualProjectBuilder
 
             // Evaluate directives, e.g., determine item types for #:include/#:exclude from their file extension.
             var fileEvaluatedDirectives = EvaluateDirectives(project, directives, reportError);
+
+            // Detect duplicate directives across files (per-file duplicates are already reported by FindDirectives).
+            foreach (var directive in fileEvaluatedDirectives)
+            {
+                if (directive is CSharpDirective.Named named)
+                {
+                    if (isFirstFile)
+                    {
+                        // Seed the deduplicator — the entry point file's duplicates are already reported by FindDirectives.
+                        deduplicator.AddDirective(named);
+                    }
+                    else
+                    {
+                        deduplicator.CheckDirective(named, reportError);
+                    }
+                }
+            }
+
+            isFirstFile = false;
 
             evaluatedDirectiveBuilder.AddRange(fileEvaluatedDirectives);
 

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -290,7 +290,7 @@ public sealed class VirtualProjectBuilder
 
         if (directives.IsDefault)
         {
-            directives = FileLevelDirectiveHelpers.FindDirectives(EntryPointSourceFile, validateAllDirectives, reportError);
+            directives = FileLevelDirectiveHelpers.FindDirectives(EntryPointSourceFile, validateAllDirectives, reportError, checkDuplicates: false);
         }
 
         (string ProjectFileText, ProjectInstance ProjectInstance, ProjectRootElement ProjectRootElement)? lastProject = null;
@@ -317,7 +317,6 @@ public sealed class VirtualProjectBuilder
         var filesToProcess = new Queue<string>();
         var evaluatedDirectiveBuilder = ImmutableArray.CreateBuilder<CSharpDirective>();
         var deduplicator = new DirectiveDeduplicator();
-        var isFirstFile = true;
 
         do
         {
@@ -330,24 +329,14 @@ public sealed class VirtualProjectBuilder
             // Evaluate directives, e.g., determine item types for #:include/#:exclude from their file extension.
             var fileEvaluatedDirectives = EvaluateDirectives(project, directives, reportError);
 
-            // Detect duplicate directives across files (per-file duplicates are already reported by FindDirectives).
+            // Detect duplicate directives across all files on evaluated directives.
             foreach (var directive in fileEvaluatedDirectives)
             {
                 if (directive is CSharpDirective.Named named)
                 {
-                    if (isFirstFile)
-                    {
-                        // Seed the deduplicator — the entry point file's duplicates are already reported by FindDirectives.
-                        deduplicator.AddDirective(named);
-                    }
-                    else
-                    {
-                        deduplicator.CheckDirective(named, reportError);
-                    }
+                    deduplicator.CheckDirective(named, reportError);
                 }
             }
-
-            isFirstFile = false;
 
             evaluatedDirectiveBuilder.AddRange(fileEvaluatedDirectives);
 
@@ -390,7 +379,7 @@ public sealed class VirtualProjectBuilder
                 }
 
                 var sourceFile = SourceFile.Load(filePath);
-                directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, validateAllDirectives, reportError);
+                directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, validateAllDirectives, reportError, checkDuplicates: false);
                 return true;
             }
 

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -2333,6 +2333,36 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             ]);
     }
 
+    [Fact]
+    public void Directives_Duplicate_AcrossIncludedFiles()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var programPath = Path.Join(testInstance.Path, "Program.cs");
+        var utilPath = Path.Join(testInstance.Path, "Util.cs");
+
+        File.WriteAllText(utilPath, """
+            #:package SomePackage@1.0
+            #:property MyProp=Value2
+            static class Util { }
+            """);
+
+        VerifyConversion(
+            inputCSharp: """
+                #:include Util.cs
+                #:package SomePackage@2.0
+                #:property MyProp=Value1
+                Console.WriteLine();
+                """,
+            expectedProject: null,
+            expectedCSharp: """
+                Console.WriteLine();
+                """,
+            filePath: programPath,
+            expectedErrors: [(utilPath, 1, string.Format(FileBasedProgramsResources.DuplicateDirective, "#:package SomePackage")),
+                (utilPath, 2, string.Format(FileBasedProgramsResources.DuplicateDirective, "#:property MyProp"))],
+            evaluateDirectives: true);
+    }
+
     [Fact] // https://github.com/dotnet/sdk/issues/49797
     public void Directives_VersionedSdkFirst()
     {
@@ -2431,6 +2461,23 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     {
         filePath ??= GetProgramPath(baseDirectory);
 
+        VerifyConversion(
+            inputCSharp,
+            expectedProject,
+            expectedCSharp,
+            filePath,
+            expectedErrors?.Select(e => (filePath, e.LineNumber, e.Message)),
+            evaluateDirectives);
+    }
+
+    private static void VerifyConversion(
+        string inputCSharp,
+        string? expectedProject,
+        string? expectedCSharp,
+        string filePath,
+        IEnumerable<(string FilePath, int LineNumber, string Message)>? expectedErrors,
+        bool evaluateDirectives)
+    {
         Convert(
             inputCSharp,
             out var actualProject,
@@ -2452,8 +2499,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         }
         else
         {
-            Assert.All(actualDiagnostics, d => { Assert.Equal(filePath, d.Location.Path); });
-            actualDiagnostics.Select(d => (d.Location.Span.Start.Line + 1, d.Message)).Should().BeEquivalentTo(expectedErrors);
+            actualDiagnostics.Select(d => (d.Location.Path, d.Location.Span.Start.Line + 1, d.Message)).Should().BeEquivalentTo(expectedErrors);
         }
     }
 

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1681,4 +1681,55 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
             MySecret=MyValue (JsonConfigurationProvider for 'secrets.json' (Optional))
             """);
     }
+
+    /// <summary>
+    /// Duplicate directives across <c>#:include</c>'d files should be reported as errors.
+    /// </summary>
+    [Theory]
+    [InlineData("package")]
+    [InlineData("property")]
+    public void IncludeDirective_DuplicateDirectives(string directiveKind)
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var programPath = Path.Join(testInstance.Path, "Program.cs");
+        var utilPath = Path.Join(testInstance.Path, "Util.cs");
+
+        string programDirective;
+        string utilDirective;
+        string duplicateTypeAndName;
+
+        switch (directiveKind)
+        {
+            case "package":
+                programDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
+                utilDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
+                duplicateTypeAndName = "#:package System.CommandLine";
+                break;
+            case "property":
+                programDirective = "#:property MyProp=Value1";
+                utilDirective = "#:property MyProp=Value2";
+                duplicateTypeAndName = "#:property MyProp";
+                break;
+            default:
+                throw new ArgumentException(directiveKind);
+        }
+
+        File.WriteAllText(programPath, $"""
+            #:include Util.cs
+            {programDirective}
+            Console.WriteLine("Hello");
+            """);
+
+        File.WriteAllText(utilPath, $$"""
+            {{utilDirective}}
+            static class Util { }
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            .And.HaveStdErrContaining(DirectiveError(utilPath, 1, FileBasedProgramsResources.DuplicateDirective, duplicateTypeAndName));
+    }
 }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1712,7 +1712,7 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
                 duplicateTypeAndName = "#:property MyProp";
                 break;
             default:
-                throw new ArgumentException(directiveKind);
+                throw new ArgumentException($"Unsupported directive kind '{directiveKind}'.", nameof(directiveKind));
         }
 
         File.WriteAllText(programPath, $"""

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1684,10 +1684,15 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
 
     /// <summary>
     /// Duplicate directives across <c>#:include</c>'d files should be reported as errors.
+    /// Note: <c>#:project</c> and <c>#:ref</c> duplicates are allowed
+    /// (tested by <see cref="ProjectReference_Duplicate"/> and <see cref="RefDirective_DuplicateRefFromIncludedFiles"/>).
     /// </summary>
     [Theory]
     [InlineData("package")]
     [InlineData("property")]
+    [InlineData("sdk")]
+    [InlineData("include")]
+    [InlineData("exclude")]
     public void IncludeDirective_DuplicateDirectives(string directiveKind)
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();
@@ -1710,6 +1715,22 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
                 programDirective = "#:property MyProp=Value1";
                 utilDirective = "#:property MyProp=Value2";
                 duplicateTypeAndName = "#:property MyProp";
+                break;
+            case "sdk":
+                programDirective = "#:sdk Microsoft.NET.Sdk";
+                utilDirective = "#:sdk Microsoft.NET.Sdk@9.0.0";
+                duplicateTypeAndName = "#:sdk Microsoft.NET.Sdk";
+                break;
+            case "include":
+                File.WriteAllText(Path.Join(testInstance.Path, "Helper.cs"), "static class Helper { }");
+                programDirective = "#:include Helper.cs";
+                utilDirective = "#:include Helper.cs";
+                duplicateTypeAndName = $"#:include {Path.Join(testInstance.Path, "Helper.cs")}";
+                break;
+            case "exclude":
+                programDirective = "#:exclude Helper.cs";
+                utilDirective = "#:exclude Helper.cs";
+                duplicateTypeAndName = $"#:exclude {Path.Join(testInstance.Path, "Helper.cs")}";
                 break;
             default:
                 throw new ArgumentException($"Unsupported directive kind '{directiveKind}'.", nameof(directiveKind));


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/issues/54090.