### PR TITLE
[dotnet watch] Enable CA2007 (ConfigureAwait) for startup hook assembly

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.Host/.editorconfig
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/.editorconfig
@@ -4,3 +4,7 @@
 # The directive needs to be included since all sources in a source package are considered generated code
 # when referenced from a project via package reference.
 dotnet_diagnostic.IDE0240.severity = none
+
+# CA2007: This assembly runs inside the user's app process where a SynchronizationContext may be present.
+# Missing ConfigureAwait(false) can cause deadlocks (e.g. iOS UIKitSynchronizationContext).
+dotnet_diagnostic.CA2007.severity = error

--- a/src/Dotnet.Watch/HotReloadAgent.Host/NamedPipeTransport.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/NamedPipeTransport.cs
@@ -34,8 +34,8 @@ internal sealed class NamedPipeTransport(string pipeName, Action<string> log, in
             }
         }
 
-        await _pipeClient.WriteAsync((byte)response.Type, cancellationToken);
-        await response.WriteAsync(_pipeClient, cancellationToken);
+        await _pipeClient.WriteAsync((byte)response.Type, cancellationToken).ConfigureAwait(false);
+        await response.WriteAsync(_pipeClient, cancellationToken).ConfigureAwait(false);
     }
 
     public override ValueTask<RequestStream> ReceiveAsync(CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
@@ -84,7 +84,7 @@ internal sealed class StartupHook
                 {
                     try
                     {
-                        await listener.SendResponseAsync(new HotReloadExceptionCreatedNotification(code, message), CancellationToken.None);
+                        await listener.SendResponseAsync(new HotReloadExceptionCreatedNotification(code, message), CancellationToken.None).ConfigureAwait(false);
                     }
                     catch
                     {


### PR DESCRIPTION
Enable CA2007 as an error in the `HotReloadAgent.Host` `.editorconfig` and add `ConfigureAwait(false)` to awaits in the startup hook assembly. This assembly runs inside the user's app process where a `SynchronizationContext` may be present (e.g. `UIKitSynchronizationContext` on iOS), so missing `ConfigureAwait(false)` can cause deadlocks.

Context: https://github.com/dotnet/sdk/pull/54023#issuecomment-4311009586