### PR TITLE
Fix dotnet-watch Hot Reload deadlock on platforms with a startup SynchronizationContext

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
@@ -34,8 +34,13 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
 
         try
         {
-            // block execution of the app until initial updates are applied:
-            InitializeAsync(cancellationToken).GetAwaiter().GetResult();
+            // block execution of the app until initial updates are applied.
+            // Run on the thread pool (Task.Run) so that awaits inside InitializeAsync
+            // do not capture the calling thread's SynchronizationContext. Otherwise,
+            // on platforms where the startup-hook thread has a sync context (e.g. iOS,
+            // Android), the synchronous wait below would deadlock when an awaited
+            // continuation tries to resume on the same blocked thread.
+            Task.Run(() => InitializeAsync(cancellationToken), cancellationToken).GetAwaiter().GetResult();
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Description

This PR wraps the applier bootstrap in `Listener.Listen` in `Task.Run(...)` so that the awaits inside `InitializeAsync` resume on the threadpool instead of the startup-hook thread. The previous code did a synchronous `InitializeAsync(ct).GetAwaiter().GetResult()` directly on the startup thread. On platforms whose .NET startup-hook thread carries a `SynchronizationContext` (iOS Mono and CoreCLR, Android Mono and CoreCLR), the `await` inside `WebSocketTransport.ConnectAsync` captures that SC for its continuation, and the synchronous wait blocks the only thread that could resume it.

With this fix, end-to-end `dotnet watch` Hot Reload works across mobile on CoreCLR and Mono.