### PR TITLE
add missing CLI projects to cli slnf file

### DIFF
--- a/cli.slnf
+++ b/cli.slnf
@@ -2,17 +2,18 @@
   "solution": {
     "path": "sdk.slnx",
     "projects": [
-      "src\\Dotnet.Watch\\dotnet-watch\\dotnet-watch.csproj",
-      "src\\Cli\\dn\\dn.csproj",
       "src\\Cli\\dn\\dn-native-debug.vcxproj",
+      "src\\Cli\\dn\\dn.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
+      "src\\Cli\\Microsoft.DotNet.Cli.CommandLine\\Microsoft.DotNet.Cli.CommandLine.csproj",
+      "src\\Cli\\Microsoft.DotNet.Cli.Definitions\\Microsoft.DotNet.Cli.Definitions.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
+      "src\\Dotnet.Watch\\dotnet-watch\\dotnet-watch.csproj",
       "test\\dotnet-new.IntegrationTests\\dotnet-new.IntegrationTests.csproj",
       "test\\dotnet-watch.Tests\\dotnet-watch.Tests.csproj",
       "test\\dotnet.Tests\\dotnet.Tests.csproj",
       "test\\Microsoft.DotNet.Cli.Utils.Tests\\Microsoft.DotNet.Cli.Utils.Tests.csproj",
       "test\\Microsoft.NET.TestFramework\\Microsoft.NET.TestFramework.csproj",
-      "src\\Cli\\Microsoft.DotNet.Cli.Definitions\\Microsoft.DotNet.Cli.Definitions.csproj"
     ]
   }
 }


### PR DESCRIPTION
This is a quick PR to add some CLI-relevant projects to the cli.slnf that is used by default for VSCode users. Without this go-to-def/refs doesn't work as well when working on the commands/definitions.