### PR TITLE
[wasm] HotReload script consolidation

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
+++ b/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
@@ -1,8 +1,23 @@
 let isHotReloadEnabled = false;
+let refreshConfig = null;
 
 export async function onRuntimeConfigLoaded(config) {
-    // If we have 'aspnetcore-browser-refresh', configure mono runtime for HotReload.
-    if (config.debugLevel !== 0 && globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']")) {
+    // Try to fetch browser-refresh config to determine if hot reload is available.
+    // This replaces the previous approach of detecting an injected <script> tag.
+    try {
+        const configResponse = await fetch('/_framework/browser-refresh-config');
+        if (configResponse.ok) {
+            refreshConfig = await configResponse.json();
+        }
+    } catch {
+        // Config endpoint not available — hot reload middleware may not be loaded.
+    }
+
+    // Enable hot reload if either the config endpoint responded or the injected script tag is present (hosted scenario fallback).
+    const hasConfigEndpoint = refreshConfig && refreshConfig.webSocketUrls;
+    const hasInjectedScript = globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']");
+
+    if (config.debugLevel !== 0 && (hasConfigEndpoint || hasInjectedScript)) {
         isHotReloadEnabled = true;
 
         if (!config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]) {
@@ -21,16 +36,15 @@ export async function onRuntimeReady({ getAssemblyExports }) {
     if (!isHotReloadEnabled) {
         return;
     }
-    
+
     const exports = await getAssemblyExports("Microsoft.DotNet.HotReload.WebAssembly.Browser");
     await exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.InitializeAsync(document.baseURI);
 
     if (!window.Blazor) {
         window.Blazor = {};
-
-        if (!window.Blazor._internal) {
-            window.Blazor._internal = {};
-        }
+    }
+    if (!window.Blazor._internal) {
+        window.Blazor._internal = {};
     }
 
     window.Blazor._internal.applyHotReloadDeltas = (deltas, loggingLevel) => {
@@ -41,4 +55,334 @@ export async function onRuntimeReady({ getAssemblyExports }) {
     window.Blazor._internal.getApplyUpdateCapabilities = () => {
         return exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.GetApplyUpdateCapabilities() ?? '';
     };
+
+    // Establish WebSocket connection for hot reload communication.
+    // Only attempt if we have config from the endpoint. In hosted scenarios where
+    // config fetch failed, the injected script (WebSocketScriptInjection.js) handles the connection.
+    if (refreshConfig && refreshConfig.webSocketUrls) {
+        await initializeBrowserRefreshConnection();
+    }
+}
+
+// ---- Browser refresh / hot reload WebSocket communication ----
+// Ported from WebSocketScriptInjection.js
+
+const hotReloadActiveKey = '_dotnet_watch_hot_reload_active';
+const scriptInjectedSentinel = '_dotnet_watch_ws_injected';
+
+async function initializeBrowserRefreshConnection() {
+    // Prevent double-connection if the injected script has already connected
+    if (window.hasOwnProperty(scriptInjectedSentinel)) {
+        return;
+    }
+    // Claim the sentinel early to prevent races with the injected script.
+    // If connection fails, we clear it so the injected script can take over.
+    window[scriptInjectedSentinel] = true;
+
+    const webSocketUrls = refreshConfig.webSocketUrls.split(',');
+    const sharedSecret = await getSecret(refreshConfig.serverKey);
+    let connection;
+    for (const url of webSocketUrls) {
+        try {
+            connection = await getWebSocket(url, sharedSecret);
+            break;
+        } catch (ex) {
+            console.debug(ex);
+        }
+    }
+    if (!connection) {
+        console.debug('Unable to establish a connection to the browser refresh server.');
+        // Clear sentinel so the injected script can still connect as fallback
+        delete window[scriptInjectedSentinel];
+        return;
+    }
+
+    let waiting = false;
+
+    connection.onmessage = function (message) {
+        const payload = JSON.parse(message.data);
+        const action = {
+            'Reload': () => reload(),
+            'Wait': () => wait(),
+            'UpdateStaticFile': () => updateStaticFile(payload.path),
+            'ApplyManagedCodeUpdates': () => applyManagedCodeUpdates(connection, sharedSecret, payload.sharedSecret, payload.updateId, payload.deltas, payload.responseLoggingLevel),
+            'ReportDiagnostics': () => reportDiagnostics(payload.diagnostics),
+            'GetApplyUpdateCapabilities': () => getApplyUpdateCapabilities(connection),
+            'RefreshBrowser': () => refreshBrowser()
+        };
+
+        if (payload.type && action.hasOwnProperty(payload.type)) {
+            action[payload.type]();
+        } else {
+            console.error('Unknown payload:', message.data);
+        }
+    };
+
+    connection.onerror = function (event) { console.debug('dotnet-watch reload socket error.', event); };
+    connection.onclose = function () { console.debug('dotnet-watch reload socket closed.'); };
+    connection.onopen = function () { console.debug('dotnet-watch reload socket connected.'); };
+
+    function wait() {
+        console.debug('Waiting for application to rebuild.');
+        if (waiting) {
+            return;
+        }
+        waiting = true;
+        const glyphs = ['☱', '☲', '☴'];
+        const title = document.title;
+        let i = 0;
+        setInterval(function () { document.title = glyphs[i++ % glyphs.length] + ' ' + title; }, 240);
+    }
+}
+
+function updateStaticFile(path) {
+    if (path && path.endsWith('.css')) {
+        updateCssByPath(path);
+    } else {
+        console.debug(`File change detected to file ${path}. Reloading page...`);
+        location.reload();
+    }
+}
+
+async function updateCssByPath(path) {
+    const styleElement = document.querySelector(`link[href^="${path}"]`) ||
+        document.querySelector(`link[href^="${document.baseURI}${path}"]`);
+
+    // Receive a Clear-site-data header.
+    await fetch('/_framework/clear-browser-cache');
+
+    if (!styleElement || !styleElement.parentNode) {
+        console.debug('Unable to find a stylesheet to update. Updating all local css files.');
+        updateAllLocalCss();
+    }
+
+    updateCssElement(styleElement);
+}
+
+function updateAllLocalCss() {
+    [...document.querySelectorAll('link')]
+        .filter(l => l.baseURI === document.baseURI)
+        .forEach(e => updateCssElement(e));
+}
+
+function updateCssElement(styleElement) {
+    if (!styleElement || styleElement.loading) {
+        return;
+    }
+
+    const newElement = styleElement.cloneNode();
+    const href = styleElement.href;
+    newElement.href = href.split('?', 1)[0] + `?nonce=${Date.now()}`;
+
+    styleElement.loading = true;
+    newElement.loading = true;
+    newElement.addEventListener('load', function () {
+        newElement.loading = false;
+        styleElement.remove();
+    });
+
+    styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
+}
+
+function getMessageAndStack(error) {
+    const message = error.message || '<unknown error>';
+    let messageAndStack = error.stack || message;
+    if (!messageAndStack.includes(message)) {
+        messageAndStack = message + "\n" + messageAndStack;
+    }
+    return messageAndStack;
+}
+
+function getApplyUpdateCapabilities(connection) {
+    let applyUpdateCapabilities;
+    try {
+        applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
+    } catch (error) {
+        applyUpdateCapabilities = "!" + getMessageAndStack(error);
+    }
+    connection.send(applyUpdateCapabilities);
+}
+
+function applyDeltas_legacy(deltas) {
+    let apply = window.Blazor?._internal?.applyHotReload;
+    if (apply) {
+        deltas.forEach(d => {
+            if (apply.length == 5) {
+                apply(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta, d.updatedTypes);
+            } else {
+                apply(d.moduleId, d.metadataDelta, d.ilDelta, d.pdbDelta);
+            }
+        });
+    }
+}
+
+async function applyManagedCodeUpdates(connection, sharedSecret, serverSecret, updateId, deltas, responseLoggingLevel) {
+    if (sharedSecret && (serverSecret != sharedSecret.encodedSharedSecret)) {
+        throw 'Unable to validate the server. Rejecting apply-update payload.';
+    }
+
+    console.debug('Applying managed code updates.');
+
+    const AgentMessageSeverity_Error = 2;
+    let applyError = undefined;
+    let log = [];
+
+    try {
+        let applyDeltas = window.Blazor?._internal?.applyHotReloadDeltas;
+        if (applyDeltas) {
+            let wasmDeltas = deltas.map(delta => ({
+                "moduleId": delta.moduleId,
+                "metadataDelta": delta.metadataDelta,
+                "ilDelta": delta.ilDelta,
+                "pdbDelta": delta.pdbDelta,
+                "updatedTypes": delta.updatedTypes,
+            }));
+            log = applyDeltas(wasmDeltas, responseLoggingLevel);
+        } else {
+            applyDeltas_legacy(deltas);
+        }
+    } catch (error) {
+        console.warn(error);
+        applyError = error;
+        log.push({ "message": getMessageAndStack(error), "severity": AgentMessageSeverity_Error });
+    }
+
+    try {
+        let body = JSON.stringify({ "id": updateId, "deltas": deltas });
+        await fetch('/_framework/blazor-hotreload', { method: 'post', headers: { 'content-type': 'application/json' }, body: body });
+    } catch (error) {
+        console.warn(error);
+        applyError = error;
+        log.push({ "message": getMessageAndStack(error), "severity": AgentMessageSeverity_Error });
+    }
+
+    connection.send(JSON.stringify({ "success": !applyError, "log": log }));
+
+    if (!applyError) {
+        displayChangesAppliedToast();
+    }
+}
+
+function reportDiagnostics(diagnostics) {
+    console.debug('Reporting Hot Reload diagnostics.');
+
+    document.querySelectorAll('#dotnet-compile-error').forEach(el => el.remove());
+
+    if (diagnostics.length == 0) {
+        return;
+    }
+
+    const el = document.body.appendChild(document.createElement('div'));
+    el.id = 'dotnet-compile-error';
+    el.setAttribute('style', 'z-index:1000000; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black; overflow: scroll;');
+    diagnostics.forEach(error => {
+        const item = el.appendChild(document.createElement('div'));
+        item.setAttribute('style', 'border: 2px solid red; padding: 8px; background-color: #faa;');
+        const message = item.appendChild(document.createElement('div'));
+        message.setAttribute('style', 'font-weight: bold');
+        message.textContent = error.Message;
+        item.appendChild(document.createElement('div')).textContent = error;
+    });
+}
+
+function displayChangesAppliedToast() {
+    document.querySelectorAll('#dotnet-compile-error').forEach(el => el.remove());
+    if (document.querySelector('#dotnet-hotreload-toast')) {
+        return;
+    }
+    if (!window[hotReloadActiveKey]) {
+        return;
+    }
+    const el = document.createElement('div');
+    el.id = 'dotnet-hotreload-toast';
+    el.innerHTML = "<svg style=\"filter: drop-shadow(0px 2px 1px rgb(0 0 0 / 0.4));\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 500 500\"><style><![CDATA[#hotreloaded-ellipse1 {animation: hotreloaded-ellipse1_c_o 1800ms linear 1 normal forwards}@keyframes hotreloaded-ellipse1_c_o { 0% {opacity: 0} 16.666667% {opacity: 1} 72.222222% {opacity: 1} 90% {opacity: 0} 100% {opacity: 0}} #hotreloaded-path1 {animation-name: hotreloaded-path1__m, hotreloaded-path1_c_o;animation-duration: 1800ms;animation-delay:100ms;animation-fill-mode: forwards;animation-timing-function: linear;animation-direction: normal;animation-iteration-count: 1;}@keyframes hotreloaded-path1__m { 0% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')} 16.666667% {d: path('M126.151214,288.396852L126.151214,288.396852L126.151214,288.396852')} 22.222222% {d: path('M126.151214,288.396852L196.625037,350.661591L196.625037,350.661591');animation-timing-function: cubic-bezier(0.42,0,0.58,1)} 33.333333% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')} 100% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')}}@keyframes hotreloaded-path1_c_o { 0% {opacity: 0} 16.666667% {opacity: 0} 22.222222% {opacity: 1} 72.222222% {opacity: 1} 90% {opacity: 0} 100% {opacity: 0}}]]></style><ellipse id=\"hotreloaded-ellipse1\" rx=\"212.808853\" ry=\"205.404598\" transform=\"matrix(0.982102 0 0 1.017504 251 238)\" opacity=\"0\" fill=\"rgb(120,120,120)\"/><path id=\"hotreloaded-path1\" d=\"M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242\" transform=\"matrix(1 0 0 1 27.527732 -26.589916)\" opacity=\"0\" fill=\"none\" stroke=\"rgb(255,255,255)\" stroke-width=\"40\" stroke-linecap=\"round\"/></svg>";
+    el.setAttribute('style', 'z-index: 1000000; width: 48px; height: 48px; position:fixed; top:5px; left: 5px');
+    document.body.appendChild(el);
+    window[hotReloadActiveKey] = false;
+    setTimeout(() => el.remove(), 2000);
+}
+
+function refreshBrowser() {
+    if (window.Blazor) {
+        window[hotReloadActiveKey] = true;
+        if (window.Blazor?._internal?.hotReloadApplied) {
+            console.debug('Refreshing browser: WASM.');
+            Blazor._internal.hotReloadApplied();
+        } else {
+            console.debug('Refreshing browser.');
+            displayChangesAppliedToast();
+        }
+    } else {
+        console.debug('Refreshing browser: Reloading.');
+        location.reload();
+    }
+}
+
+function reload() {
+    console.debug('Reloading.');
+    location.reload();
+}
+
+async function getSecret(serverKeyString) {
+    if (!serverKeyString || !window.crypto || !window.crypto.subtle) {
+        return null;
+    }
+
+    const secretBytes = window.crypto.getRandomValues(new Uint8Array(32));
+
+    const binaryServerKey = str2ab(atob(serverKeyString));
+    const serverKey = await window.crypto.subtle.importKey('spki', binaryServerKey, { name: "RSA-OAEP", hash: "SHA-256" }, false, ['encrypt']);
+    const encrypted = await window.crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, secretBytes);
+    return {
+        encryptedSharedSecret: btoa(String.fromCharCode(...new Uint8Array(encrypted))),
+        encodedSharedSecret: btoa(String.fromCharCode(...secretBytes)),
+    };
+
+    function str2ab(str) {
+        const buf = new ArrayBuffer(str.length);
+        const bufView = new Uint8Array(buf);
+        for (let i = 0, strLen = str.length; i < strLen; i++) {
+            bufView[i] = str.charCodeAt(i);
+        }
+        return buf;
+    }
+}
+
+function getWebSocket(url, sharedSecret) {
+    return new Promise((resolve, reject) => {
+        const encryptedSecret = sharedSecret && sharedSecret.encryptedSharedSecret;
+        const protocol = encryptedSecret ? encodeURIComponent(encryptedSecret) : [];
+        const webSocket = new WebSocket(url, protocol);
+        let opened = false;
+
+        function onOpen() {
+            opened = true;
+            clearEventListeners();
+            resolve(webSocket);
+        }
+
+        function onClose(event) {
+            if (opened) {
+                return;
+            }
+            let error = 'WebSocket failed to connect.';
+            if (event instanceof ErrorEvent) {
+                error = event.error;
+            }
+            clearEventListeners();
+            reject(error);
+        }
+
+        function clearEventListeners() {
+            webSocket.removeEventListener('open', onOpen);
+            webSocket.removeEventListener('close', onClose);
+        }
+
+        webSocket.addEventListener('open', onOpen);
+        webSocket.addEventListener('close', onClose);
+        if (window.Blazor?.removeEventListener && window.Blazor?.addEventListener) {
+            webSocket.addEventListener('close', () => window.Blazor?.removeEventListener('enhancedload', displayChangesAppliedToast));
+            window.Blazor?.addEventListener('enhancedload', displayChangesAppliedToast);
+        }
+    });
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/MiddlewareEnvironmentVariables.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/MiddlewareEnvironmentVariables.cs
@@ -40,4 +40,10 @@ internal static class MiddlewareEnvironmentVariables
     /// Variable used to set the logging level of the middleware logger.
     /// </summary>
     public const string LoggingLevel = "Logging__LogLevel__Microsoft.AspNetCore.Watch";
+
+    /// <summary>
+    /// When set to "true", the middleware will skip injecting the browser refresh script tag into HTML responses.
+    /// Used for .NET 11+ WASM apps where lib.module.js handles the WebSocket connection directly.
+    /// </summary>
+    public const string SuppressScriptInjection = "ASPNETCORE_AUTO_RELOAD_SUPPRESS_SCRIPT_INJECTION";
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.Watch;
 
 namespace Microsoft.DotNet.HotReload;
 
@@ -79,7 +80,12 @@ internal sealed class WebAssemblyHotReloadClient(
 
     public override void ConfigureLaunchEnvironment(IDictionary<string, string> environmentBuilder)
     {
-        // the environment is configued via browser refesh server
+        // For .NET 11+ WASM apps, lib.module.js handles the WebSocket connection directly,
+        // so the middleware can skip injecting the browser refresh script tag into HTML responses.
+        if (projectTargetFrameworkVersion >= Versions.Version11_0)
+        {
+            environmentBuilder[MiddlewareEnvironmentVariables.SuppressScriptInjection] = "true";
+        }
     }
 
     public override void InitiateConnection(CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -12,7 +12,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.DotNet.Watch;
 
 namespace Microsoft.DotNet.HotReload;
 
@@ -82,7 +81,7 @@ internal sealed class WebAssemblyHotReloadClient(
     {
         // For .NET 11+ WASM apps, lib.module.js handles the WebSocket connection directly,
         // so the middleware can skip injecting the browser refresh script tag into HTML responses.
-        if (projectTargetFrameworkVersion >= Versions.Version11_0)
+        if (projectTargetFrameworkVersion >= new Version(11, 0))
         {
             environmentBuilder[MiddlewareEnvironmentVariables.SuppressScriptInjection] = "true";
         }

--- a/src/Dotnet.Watch/Watch/Utilities/Versions.cs
+++ b/src/Dotnet.Watch/Watch/Utilities/Versions.cs
@@ -7,4 +7,5 @@ internal static class Versions
 {
     public static readonly Version Version3_1 = new(3, 1);
     public static readonly Version Version6_0 = new(6, 0);
+    public static readonly Version Version11_0 = new(11, 0);
 }

--- a/src/Dotnet.Watch/Web.Middleware/ApplicationPaths.cs
+++ b/src/Dotnet.Watch/Web.Middleware/ApplicationPaths.cs
@@ -39,4 +39,11 @@ internal static class ApplicationPaths
     /// </summary>
     /// <value>/_framework/blazor-hotreload.js</value>
     public static PathString BlazorHotReloadJS { get; } = FrameworkRoot + "/blazor-hotreload.js";
+
+    /// <summary>
+    /// Returns JSON configuration for browser refresh (WebSocket endpoint URL and server key).
+    /// Used by lib.module.js to establish WebSocket connection without script injection.
+    /// </summary>
+    /// <value><c>/_framework/browser-refresh-config</c></value>
+    public static PathString BrowserRefreshConfig { get; } = FrameworkRoot + "/browser-refresh-config";
 }

--- a/src/Dotnet.Watch/Web.Middleware/BrowserRefreshMiddleware.cs
+++ b/src/Dotnet.Watch/Web.Middleware/BrowserRefreshMiddleware.cs
@@ -23,6 +23,8 @@ public sealed class BrowserRefreshMiddleware
     private readonly ILogger<BrowserRefreshMiddleware> _logger;
     private string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
     private string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
+    private bool _suppressScriptInjection = string.Equals(
+        Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_SUPPRESS_SCRIPT_INJECTION"), "true", StringComparison.OrdinalIgnoreCase);
 
     public BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger)
     {
@@ -42,7 +44,7 @@ public sealed class BrowserRefreshMiddleware
             AttachWebAssemblyHeaders(context);
             await _next(context);
         }
-        else if (IsBrowserDocumentRequest(context))
+        else if (!_suppressScriptInjection && IsBrowserDocumentRequest(context))
         {
             // Use a custom StreamWrapper to rewrite output on Write/WriteAsync
             using var responseStreamWrapper = new ResponseStreamWrapper(context, _logger);
@@ -214,6 +216,11 @@ public sealed class BrowserRefreshMiddleware
     {
         _dotnetModifiableAssemblies = dotnetModifiableAssemblies;
         _aspnetcoreBrowserTools = aspnetcoreBrowserTools;
+    }
+
+    internal void Test_SetSuppressScriptInjection(bool suppress)
+    {
+        _suppressScriptInjection = suppress;
     }
 
     internal static class Log

--- a/src/Dotnet.Watch/Web.Middleware/HostingStartup.cs
+++ b/src/Dotnet.Watch/Web.Middleware/HostingStartup.cs
@@ -33,7 +33,8 @@ internal sealed class HostingStartup : IHostingStartup, IStartupFilter
                         (path.StartsWithSegments(ApplicationPaths.ClearSiteData) ||
                         path.StartsWithSegments(ApplicationPaths.BlazorHotReloadMiddleware) ||
                         path.StartsWithSegments(ApplicationPaths.BrowserRefreshJS) ||
-                        path.StartsWithSegments(ApplicationPaths.BlazorHotReloadJS));
+                        path.StartsWithSegments(ApplicationPaths.BlazorHotReloadJS) ||
+                        path.StartsWithSegments(ApplicationPaths.BrowserRefreshConfig));
                 },
                 static app =>
                 {
@@ -53,6 +54,19 @@ internal sealed class HostingStartup : IHostingStartup, IStartupFilter
                     // backwards compat only:
                     app.Map(ApplicationPaths.BlazorHotReloadJS,
                         static app => app.UseMiddleware<BrowserScriptMiddleware>(ApplicationPaths.BlazorHotReloadJS, BrowserScriptMiddleware.GetBlazorHotReloadJS()));
+
+                    app.Map(ApplicationPaths.BrowserRefreshConfig, static app => app.Run(context =>
+                    {
+                        var endpoint = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT") ?? string.Empty;
+                        var serverKey = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY") ?? string.Empty;
+
+                        context.Response.Headers["Cache-Control"] = "no-store";
+                        context.Response.Headers["Content-Type"] = "application/json; charset=utf-8";
+
+                        var json = "{\"webSocketUrls\":\"" + endpoint.Replace("\"", "\\\"") + "\",\"serverKey\":\"" + serverKey.Replace("\"", "\\\"") + "\"}";
+                        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+                        return context.Response.Body.WriteAsync(bytes, 0, bytes.Length, context.RequestAborted);
+                    }));
                 });
 
             app.UseMiddleware<BrowserRefreshMiddleware>();

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
@@ -603,6 +603,42 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             Assert.DoesNotContain("<script src=\"/_framework/aspnetcore-browser-refresh.js\"></script>", responseContent);
         }
 
+        [Fact]
+        public async Task InvokeAsync_DoesNotAddScript_WhenScriptInjectionIsSuppressed()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+            var context = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Method = "GET",
+                    Headers = { ["Accept"] = "text/html" },
+                },
+                Response =
+                {
+                    Body = stream
+                },
+            };
+
+            var middleware = new BrowserRefreshMiddleware(async (context) =>
+            {
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "text/html";
+                await context.Response.WriteAsync("<html><body><h1>Test</h1></body></html>");
+            }, NullLogger<BrowserRefreshMiddleware>.Instance);
+
+            middleware.Test_SetSuppressScriptInjection(true);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            var responseContent = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.DoesNotContain("<script src=\"/_framework/aspnetcore-browser-refresh.js\"></script>", responseContent);
+            Assert.Contains("<body>", responseContent);
+        }
+
         private async Task<string> TestBrowserRefreshMiddleware(int statusCode, string contentType, string content, bool includeHtmlWrapper = true)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
@@ -110,6 +110,62 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
         }
 
         [Fact]
+        public async Task GetBrowserRefreshConfigWorks()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT", "ws://localhost:5000");
+            Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY", "testkey123");
+            try
+            {
+                var requestDelegate = GetRequestDelegate();
+                var context = new DefaultHttpContext();
+                context.Request.Path = "/_framework/browser-refresh-config";
+                var responseBody = new MemoryStream();
+                context.Response.Body = responseBody;
+
+                // Act
+                await requestDelegate(context);
+
+                // Assert
+                Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+                Assert.Equal("no-store", context.Response.Headers["Cache-Control"]);
+                Assert.Equal("application/json; charset=utf-8", context.Response.Headers["Content-Type"]);
+
+                var json = Encoding.UTF8.GetString(responseBody.ToArray());
+                Assert.Contains("\"webSocketUrls\":\"ws://localhost:5000\"", json);
+                Assert.Contains("\"serverKey\":\"testkey123\"", json);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT", null);
+                Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY", null);
+            }
+        }
+
+        [Fact]
+        public async Task GetBrowserRefreshConfigWorks_WhenEnvVarsNotSet()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_KEY", null);
+
+            var requestDelegate = GetRequestDelegate();
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/_framework/browser-refresh-config";
+            var responseBody = new MemoryStream();
+            context.Response.Body = responseBody;
+
+            // Act
+            await requestDelegate(context);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+            var json = Encoding.UTF8.GetString(responseBody.ToArray());
+            Assert.Contains("\"webSocketUrls\":\"\"", json);
+            Assert.Contains("\"serverKey\":\"\"", json);
+        }
+
+        [Fact]
         public async Task GetUnknownUrlWorks()
         {
             // Arrange


### PR DESCRIPTION
## Summary

Consolidates hot reload WebSocket communication for Blazor WebAssembly by embedding the logic from `WebSocketScriptInjection.js` directly into the WASM `lib.module.js` JavaScript initializer. This eliminates the need for `ScriptInjectingStream` to inject a `<script>` tag into HTML responses for .NET 11+ WASM apps.

### Changes

**New config endpoint** (`/_framework/browser-refresh-config`)
- Returns JSON `{webSocketUrls, serverKey}` read from existing middleware env vars
- Allows `lib.module.js` to discover WebSocket connection parameters without script injection

**Embed WebSocket logic into `lib.module.js`**
- Ported all handlers from `WebSocketScriptInjection.js`: reload, wait, CSS updates, managed code updates, diagnostics, capabilities, browser refresh, toast notifications
- Fetches config endpoint in `onRuntimeConfigLoaded`; establishes WebSocket in `onRuntimeReady`
- Maintains backward compatibility: falls back to detecting injected script tag for hosted scenarios

**Disable script injection for .NET 11+ WASM**
- New `ASPNETCORE_AUTO_RELOAD_SUPPRESS_SCRIPT_INJECTION` env var
- `WebAssemblyHotReloadClient` sets it when project TFM >= 11.0
- `BrowserRefreshMiddleware` skips HTML response interception when set
- Avoids the overhead of `ScriptInjectingStream` for WASM apps

### Backward compatibility
- `ScriptInjectingStream.cs` and `WebSocketScriptInjection.js` remain untouched for non-WASM and pre-.NET 11 scenarios
- Sentinel-based double-connection prevention (`_dotnet_watch_ws_injected`) ensures only one WebSocket connection when both mechanisms are present
- If config endpoint fetch fails, `lib.module.js` still enables Blazor hooks via injected script tag detection

### Testing
- 3 new unit tests for the config endpoint and script injection suppression
- All 113 existing middleware tests pass