### PR TITLE
Add --strip-il-bodies crossgen2 arg for Apple mobile RIDs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -23,6 +23,7 @@ namespace Microsoft.NET.Build.Tasks
         public bool ShowCompilerWarnings { get; set; }
         public bool UseCrossgen2 { get; set; }
         public string Crossgen2ExtraCommandLineArgs { get; set; }
+        public string Crossgen2CompositeExtraCommandLineArgs { get; set; }
         public ITaskItem[] Crossgen2PgoFiles { get; set; }
         public string Crossgen2ContainerFormat { get; set; }
 
@@ -357,6 +358,17 @@ namespace Microsoft.NET.Build.Tasks
             if (!string.IsNullOrEmpty(Crossgen2ExtraCommandLineArgs))
             {
                 foreach (string extraArg in Crossgen2ExtraCommandLineArgs.Split([';'], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    result.AppendLine(extraArg);
+                }
+            }
+
+            // Arguments that are only valid for full composite builds (e.g. --strip-il-bodies).
+            // These arguments will not be applied to any assemblies that have been excluded from the composite image.
+            if (_createCompositeImage && !_partialCompile
+                && !string.IsNullOrEmpty(Crossgen2CompositeExtraCommandLineArgs))
+            {
+                foreach (string extraArg in Crossgen2CompositeExtraCommandLineArgs.Split([';'], StringSplitOptions.RemoveEmptyEntries))
                 {
                     result.AppendLine(extraArg);
                 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -35,17 +35,26 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">false</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('osx-'))">false</PublishReadyToRunEmitSymbols>
 
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('ios-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvos-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
 
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('ios-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvos-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
-    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' != 'false' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
+
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripILBodies>
+
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -469,6 +478,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ReadyToRunNativeObjectOutputs Include="@(_ReadyToRunFilesToPublish->WithMetadataValue('RequiresNativeLink', 'true'))" />
       <_ReadyToRunNativeObjectOutputs OutputPath="%(Identity)" />
     </ItemGroup>
+
+    <PropertyGroup Condition="'$(PublishReadyToRunStripILBodies)' == 'true' and '$(PublishReadyToRunComposite)' == 'true' and '@(PublishReadyToRunPartialAssemblies)' == '' and '@(PublishReadyToRunCompositeExclusions)' == ''">
+      <PublishReadyToRunCrossgen2CompositeExtraArgs>$(PublishReadyToRunCrossgen2CompositeExtraArgs);--strip-il-bodies</PublishReadyToRunCrossgen2CompositeExtraArgs>
+    </PropertyGroup>
   </Target>
 
   <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="ResolveReadyToRunCompilers" AssemblyFile="$(CrossGenTasksPath)" />
@@ -505,6 +518,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                            Crossgen2PgoFiles="@(_ReadyToRunPgoFiles)"
                            Crossgen2ContainerFormat="$(PublishReadyToRunContainerFormat)"
                            Crossgen2ExtraCommandLineArgs="$(PublishReadyToRunCrossgen2ExtraArgs)"
+                           Crossgen2CompositeExtraCommandLineArgs="$(PublishReadyToRunCrossgen2CompositeExtraArgs)"
                            ImplementationAssemblyReferences="@(_ReadyToRunAssembliesToReference)"
                            ShowCompilerWarnings="$(PublishReadyToRunShowWarnings)"
                            CompilationEntry="@(_ReadyToRunCompileList)"


### PR DESCRIPTION
## Description

Mirror the changes from https://github.com/dotnet/runtime/pull/125647.

For Apple mobile RIDs (`ios-`, `tvos-`, `iossimulator-`, `tvossimulator-`, `maccatalyst-`), pass `--strip-il-bodies` to crossgen2 by default via `PublishReadyToRunCrossgen2CompositeExtraArgs` when composite R2R is enabled (`PublishReadyToRunComposite=true`), controllable via the `PublishReadyToRunStripILBodies` MSBuild property. The composite gate is required because crossgen2 only accepts `--strip-il-bodies` in composite mode.

This re-applies #53947 (reverted in #54135) with the MSB4099 fix.

## New behavior

The `PublishReadyToRunStripInliningInfo`, `PublishReadyToRunStripDebugInfo`, and `PublishReadyToRunStripILBodies` properties are now real opt-in toggles: each defaults to `true` only on the five Apple-mobile RIDs but can be set explicitly to `true` on any RID (e.g. `osx-arm64`) to take effect, instead of being silently ignored as before.

## MSB4099 fix

The original PR placed the property assignments inside the import-time `<PropertyGroup>` at the top of `Microsoft.NET.CrossGen.targets`. Two of the conditions referenced items:

```
'@(PublishReadyToRunPartialAssemblies)' == '' and '@(PublishReadyToRunCompositeExclusions)' == ''
```

MSBuild forbids item-list references in property conditions evaluated at import time, raising `MSB4099: A reference to an item list at position N is not allowed in this condition`. This blocked any project that imported the targets when an Apple-mobile RID was set, surfacing in CI as a `WasmAoTPublishIntegrationTest.AoT_Publish_WithExistingWebConfig_Works` failure.

The fix moves the `<PublishReadyToRunCrossgen2CompositeExtraArgs>` computation into the body of the existing `_PrepareForReadyToRunCompilation` target, where item references are evaluated at target execution time. The gating semantics from #53947 are preserved exactly:

- `PublishReadyToRunStripILBodies != 'false'`
- `PublishReadyToRunComposite == 'true'`
- `@(PublishReadyToRunPartialAssemblies)` is empty
- `@(PublishReadyToRunCompositeExclusions)` is empty
- RID is one of `ios-`, `tvos-`, `iossimulator-`, `tvossimulator-`, `maccatalyst-`

The `_PrepareForReadyToRunCompilation` target is non-batched and runs before `_CreateR2RImages` via `DependsOnTargets`, so the property is computed exactly once and available when the `RunReadyToRunCompiler` task is invoked.

cc @jkoritzinsky @MichaelSimons
