### PR TITLE
Fix broken run-file test RefDirective_Duplicate

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -572,6 +572,7 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
             }
             """);
 
+        // Duplicate #:ref directives are allowed (MSBuild can handle that).
         File.WriteAllText(filePath, """
             #:ref lib.cs
             #:ref lib.cs
@@ -581,8 +582,8 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
         new DotnetCommand(Log, "run", relativeFilePath)
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
-            .Should().Fail()
-            .And.HaveStdErrContaining(DirectiveError(filePath, 2, FileBasedProgramsResources.DuplicateDirective, "#:ref lib.cs"));
+            .Should().Pass()
+            .And.HaveStdOut("Hello!");
 
         File.WriteAllText(filePath, """
             #:ref lib.cs
@@ -590,7 +591,6 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
             Console.WriteLine(MyLib.Greeter.Greet());
             """);
 
-        // https://github.com/dotnet/sdk/issues/51139: we should detect the duplicate ref
         new DotnetCommand(Log, "run", relativeFilePath)
             .WithWorkingDirectory(testInstance.Path)
             .Execute()
@@ -603,7 +603,6 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
             Console.WriteLine(MyLib.Greeter.Greet());
             """);
 
-        // https://github.com/dotnet/sdk/issues/51139: we should detect the duplicate ref
         new DotnetCommand(Log, "run", relativeFilePath)
             .WithWorkingDirectory(testInstance.Path)
             .Execute()


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/54144.