### PR TITLE
Fix flaky test: retry Directory.Delete for transient testhost.exe locks

### DIFF
--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -249,11 +249,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     Directory.Delete(path, true);
                     return;
                 }
-                catch (UnauthorizedAccessException) when (i < maxRetries - 1)
-                {
-                    Thread.Sleep(100 * (i + 1));
-                }
-                catch (IOException) when (i < maxRetries - 1)
+                catch (Exception ex) when ((ex is UnauthorizedAccessException or IOException) && i < maxRetries - 1)
                 {
                     Thread.Sleep(100 * (i + 1));
                 }

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -133,8 +133,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // After executing dotnet new and before cleaning up
             RecordPackages(outputDirectory);
 
-            Directory.Delete(outputDirectory, true);
-            Directory.Delete(workingDirectory, true);
+            DeleteDirectoryWithRetry(outputDirectory);
+            DeleteDirectoryWithRetry(workingDirectory);
 
         }
 
@@ -170,8 +170,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // After executing dotnet new and before cleaning up
             RecordPackages(outputDirectory);
 
-            Directory.Delete(outputDirectory, true);
-            Directory.Delete(workingDirectory, true);
+            DeleteDirectoryWithRetry(outputDirectory);
+            DeleteDirectoryWithRetry(workingDirectory);
         }
 
         [Theory]
@@ -224,8 +224,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // After executing dotnet new and before cleaning up
             RecordPackages(outputDirectory);
 
-            Directory.Delete(outputDirectory, true);
-            Directory.Delete(workingDirectory, true);
+            DeleteDirectoryWithRetry(outputDirectory);
+            DeleteDirectoryWithRetry(workingDirectory);
         }
 
         private void AddItemToFsproj(string itemName, string outputDirectory, string projectName)
@@ -235,6 +235,29 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             lines.Insert(lines.IndexOf("  <ItemGroup>") + 1, $@"    <Compile Include=""{itemName}.fs""/>");
             File.WriteAllLines(fsproj, lines);
+        }
+
+        /// <summary>
+        /// Retries Directory.Delete to handle transient file locks (e.g. testhost.exe not yet released after dotnet test exits).
+        /// </summary>
+        private static void DeleteDirectoryWithRetry(string path, int maxRetries = 10)
+        {
+            for (int i = 0; i < maxRetries; i++)
+            {
+                try
+                {
+                    Directory.Delete(path, true);
+                    return;
+                }
+                catch (UnauthorizedAccessException) when (i < maxRetries - 1)
+                {
+                    Thread.Sleep(100 * (i + 1));
+                }
+                catch (IOException) when (i < maxRetries - 1)
+                {
+                    Thread.Sleep(100 * (i + 1));
+                }
+            }
         }
 
         private void RecordPackages(string projectDirectory)


### PR DESCRIPTION
ItemTemplate_CanBeInstalledAndTestArePassing (nunit/f#) fails in CI with UnauthorizedAccessException on testhost.exe during Directory.Delete cleanup. This is a Windows race condition where dotnet test has exited but the OS hasn't fully released the testhost.exe file handle yet.

Replace all bare Directory.Delete calls in the three test methods with a new DeleteDirectoryWithRetry helper that retries up to 10 times with linear backoff on UnauthorizedAccessException and IOException.