### PR TITLE
Fix PublishDotnetAot: remove BaseIntermediateOutputPath propagation

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -534,26 +534,23 @@
       <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
 
       <_DotnetAotPublishDir>$(ArtifactsBinDir)dotnet-aot-redist\$(Configuration)\$(SdkTargetFramework)\$(TargetRid)\publish\</_DotnetAotPublishDir>
-      <!-- Use separate intermediate directory to avoid restore conflicts with main build -->
-      <_DotnetAotIntermediateDir>$(ArtifactsObjDir)dotnet-aot-redist\$(Configuration)\$(TargetRid)\</_DotnetAotIntermediateDir>
     </PropertyGroup>
 
     <!--
       In CI, Arcade's centralized NuGet restore runs via NuGet.targets and does not include
       RuntimeIdentifier, so the assets file lacks the RID-specific target (NETSDK1047).
       Restore here with RuntimeIdentifiers (plural) to add the RID target to the assets file.
-      BaseIntermediateOutputPath controls where project.assets.json is written.
     -->
     <MSBuild
       Targets="Restore"
       Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);RuntimeIdentifiers=$(TargetRid);BaseIntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
+      Properties="Configuration=$(Configuration);RuntimeIdentifiers=$(TargetRid)" />
 
     <!-- Publish the dotnet-aot project as a NativeAOT shared library -->
     <MSBuild
       Targets="Publish"
       Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir);BaseIntermediateOutputPath=$(_DotnetAotIntermediateDir)" />
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"


### PR DESCRIPTION
## Fix main CI break (build 2965123)

PR #54114 re-enabled the \PublishDotnetAot\ target but passed \BaseIntermediateOutputPath\ as a global property to the MSBuild invocations. This propagated to all transitive ProjectReferences (\Cli.Utils\, \NativeWrapper\, \CoreUtils\), causing their \project.assets.json\ files to collide in a shared directory.

### CI Errors Fixed
- **CS0234**: \Microsoft.Deployment.DotNet.Releases\ namespace not found (Windows)
- **MSB9008**: \CoreUtils\ project not found (macOS)  
- **MSB4006**: Circular dependency in \ResolveProjectReferences\ (macOS)

### Root Cause
\BaseIntermediateOutputPath\ is a global property that flows to all project references. When all projects share the same intermediate directory, their \project.assets.json\ files overwrite each other, breaking package resolution.

### Fix
Remove \BaseIntermediateOutputPath\ from the MSBuild Restore/Publish properties. The separate Restore call with \RuntimeIdentifiers\ (plural) — which is the NETSDK1047 fix from #54114 — works correctly using default \obj/\ directories. Each project keeps its own assets file, and the RID-specific restore target is added properly.

### Validation
- Reproduced locally: \dotnet publish\ **with** \BaseIntermediateOutputPath\ → CS0234 errors
- Confirmed fix: \dotnet publish\ **without** it → NativeAOT build succeeds  
- Full \uild.cmd\ passes including \dotnet-aot\ NativeAOT compilation