### PR TITLE
Enable Control Flow Guard for dotnet-aot project

### DIFF
--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -23,6 +23,12 @@
 
     <!-- Ignore checking for OS API compatibility as we aren't targeting just the Windows platform  -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+
+    <!--
+      Enable control flow guard
+      https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
+    -->
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `dotnet-aot` Native AOT project did not have Control Flow Guard enabled. Enable it by setting `<ControlFlowGuard>Guard</ControlFlowGuard>`, per the Native AOT [security guidance](https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard).