### PR TITLE
Fix stale Known Build Error workflow (CRLF regex bug)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,14 +35,14 @@ jobs:
   # Known Build Error issues with 0 hits for a month get labeled Stale,
   # then actions/stale closes them after 7 days.
   stale-known-build-errors:
-    if: github.repository_owner == 'dotnet' || github.repository_owner == 'MichaelSimons' # Allow fork testing
+    if: github.repository_owner == 'dotnet' # Do not run on forks
 
     runs-on: ubuntu-latest
     steps:
       # Step 1: Label/unlabel based on hit counts
       - uses: actions/github-script@v7
         with:
-           script: |
+          script: |
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
               { owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Stale: Label and Close Issues'
 on:
   schedule:
     - cron: '19 4,16 * * *' # Twice daily at 19 minutes after the hour (random/uncommon time)
+  workflow_dispatch: # Allow manual trigger for testing
 
 env:
   KBE_LABEL: 'Known Build Error'
@@ -34,18 +35,20 @@ jobs:
   # Known Build Error issues with 0 hits for a month get labeled Stale,
   # then actions/stale closes them after 7 days.
   stale-known-build-errors:
-    if: github.repository_owner == 'dotnet' # Do not run on forks
+    if: github.repository_owner == 'dotnet' || github.repository_owner == 'MichaelSimons' # Allow fork testing
 
     runs-on: ubuntu-latest
     steps:
       # Step 1: Label/unlabel based on hit counts
       - uses: actions/github-script@v7
         with:
-          script: |
+           script: |
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
               { owner: context.repo.owner, repo: context.repo.repo,
                 labels: process.env.KBE_LABEL, state: 'open', per_page: 100 });
+
+            console.log(`Found ${issues.length} open issues with '${process.env.KBE_LABEL}' label`);
 
             for (const issue of issues) {
               if (issue.pull_request) continue;
@@ -56,14 +59,19 @@ jobs:
               //         |---|---|---|
               //         |N|N|N|
               const match = issue.body?.match(
-                /\|24-Hour Hit Count\|.*\n\|[-| ]+\n\|(\d+)\|(\d+)\|(\d+)\|/);
-              if (!match) continue;
+                /\|24-Hour Hit Count\|.*\r?\n\|[-| ]+\r?\n\|(\d+)\|(\d+)\|(\d+)\|/);
+              if (!match) {
+                console.log(`  #${issue.number}: no hit count table found`);
+                continue;
+              }
               const monthCount = parseInt(match[3], 10);
+              console.log(`  #${issue.number}: 1-month count = ${monthCount}`);
 
               const hasStale = issue.labels.some(l => l.name === process.env.STALE_LABEL);
 
               if (monthCount === 0 && !hasStale) {
                 // Zero hits for a month: mark as stale
+                console.log(`  #${issue.number}: marking as stale`);
                 await github.rest.issues.addLabels({
                   ...context.repo, issue_number: issue.number,
                   labels: [process.env.STALE_LABEL] });
@@ -74,6 +82,7 @@ jobs:
                     'Add the `' + process.env.KEEP_OPEN_LABEL + '` label to prevent auto-closure.' });
               } else if (monthCount > 0 && hasStale) {
                 // Hits resumed: remove the stale label
+                console.log(`  #${issue.number}: removing stale (hits resumed)`);
                 await github.rest.issues.removeLabel({
                   ...context.repo, issue_number: issue.number,
                   name: process.env.STALE_LABEL }).catch(() => {});


### PR DESCRIPTION
## Problem

The `stale-known-build-errors` job in the stale workflow was silently failing to match any issues. No Known Build Error issues were ever being labeled `stale`, regardless of their hit counts.

## Root Cause

GitHub issue bodies use CRLF line endings (`\r\n`), but the regex used bare `\n` to match line breaks in the hit count table. This caused the regex to never match, so the job would iterate over all issues but skip every one.

## Fix

- **CRLF regex**: Change `\n` to `\r?\n` in the table-matching regex
- **Diagnostic logging**: Add `console.log` statements so future issues are visible in workflow run logs
- **Manual trigger**: Add `workflow_dispatch` to allow on-demand runs for testing/verification

## Validation

Tested on [MichaelSimons/sdk](https://github.com/MichaelSimons/sdk) fork with synthetic test issues:
- Issue with 0 monthly hits → correctly labeled `stale` with comment
- Issue with 12 monthly hits → correctly left alone
- Issue with no hit count table → correctly skipped

Related to https://github.com/dotnet/sdk/pull/54017