### PR TITLE
add ExcludeScopedCssAssets opt-out to keep scoped CSS out of publish

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.5_0.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.5_0.targets
@@ -359,7 +359,7 @@ Integration with static web assets:
   </ItemGroup>
 </Target>
 
-<Target Name="_AddAppBundleToStaticWebAssetsPublishedFiles" BeforeTargets="_StaticWebAssetsComputeFilesToPublish" Condition="'$(DisableScopedCssBundling)' != 'true' and '@(_AllScopedCss)' != ''" DependsOnTargets="_CollectAllScopedCssAssets">
+<Target Name="_AddAppBundleToStaticWebAssetsPublishedFiles" BeforeTargets="_StaticWebAssetsComputeFilesToPublish" Condition="'$(DisableScopedCssBundling)' != 'true' and '$(ExcludeScopedCssAssets)' != 'true' and '@(_AllScopedCss)' != ''" DependsOnTargets="_CollectAllScopedCssAssets">
   <ItemGroup>
     <!-- Manually add the file to the publish flow. See https://github.com/dotnet/aspnetcore/issues/24245 -->
     <_ExternalPublishStaticWebAsset Include="$(_ScopedCssOutputFullPath)" ExcludeFromSingleFile="true">
@@ -373,7 +373,7 @@ Integration with static web assets:
   </ItemGroup>
 </Target>
 
-<Target Name="_AddScopedCssFilesToStaticWebAssetsPublishedFiles" BeforeTargets="_StaticWebAssetsComputeFilesToPublish" Condition="'$(DisableScopedCssBundling)' == 'true' and '@(_ScopedCss)' != ''" DependsOnTargets="_CollectAllScopedCssAssets">
+<Target Name="_AddScopedCssFilesToStaticWebAssetsPublishedFiles" BeforeTargets="_StaticWebAssetsComputeFilesToPublish" Condition="'$(DisableScopedCssBundling)' == 'true' and '$(ExcludeScopedCssAssets)' != 'true' and '@(_ScopedCss)' != ''" DependsOnTargets="_CollectAllScopedCssAssets">
   <ItemGroup>
     <!-- Manually add the scoped css files to the publish flow. See https://github.com/dotnet/aspnetcore/issues/24245 -->
     <_ExternalPublishStaticWebAsset Include="@(_ScopedCssStaticWebAsset)" ExcludeFromSingleFile="true">

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.ScopedCss.targets
@@ -526,4 +526,67 @@ Integration with static web assets:
 
   </Target>
 
+<!--
+  Opt-out hook for $(ExcludeScopedCssAssets).
+
+  Removes scoped CSS assets (the application bundle, the project bundle, and individual
+  per-component .rz.scp.css files) from the publish output while leaving build/dev
+  serving untouched.
+
+  The target is appended to GenerateStaticWebAssetsPublishManifestDependsOn (in
+  Microsoft.NET.Sdk.StaticWebAssets.targets) so it runs after ResolveAllPublishStaticWebAssets
+  has loaded the assets (including for 'dotnet publish /p:NoBuild=true') but before
+  GenerateStaticWebAssetsPublishManifest materializes _FinalPublishStaticWebAsset from
+  @(StaticWebAsset).
+
+  Items are identified via AssetTraitName="ScopedCss" plus an explicit AssetTraitValue
+  allow-list to avoid removing unrelated assets that may share the trait name in the future.
+-->
+<PropertyGroup Condition="'$(ExcludeScopedCssAssets)' == 'true'">
+  <GenerateStaticWebAssetsPublishManifestDependsOn>
+    $(GenerateStaticWebAssetsPublishManifestDependsOn);
+    _RemoveScopedCssAssetsFromPublish;
+  </GenerateStaticWebAssetsPublishManifestDependsOn>
+</PropertyGroup>
+
+<Target Name="_RemoveScopedCssAssetsFromPublish" Condition="'$(ExcludeScopedCssAssets)' == 'true'">
+  <ItemGroup>
+    <_ScopedCssPrimaryAssetToRemove Include="@(StaticWebAsset)"
+      Condition="'%(StaticWebAsset.AssetTraitName)' == 'ScopedCss' and
+                 ('%(StaticWebAsset.AssetTraitValue)' == 'ApplicationBundle' or
+                  '%(StaticWebAsset.AssetTraitValue)' == 'ProjectBundle' or
+                  '%(StaticWebAsset.AssetTraitValue)' == 'ScopedCssFile')" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_ScopedCssPrimaryIdentities>;@(_ScopedCssPrimaryAssetToRemove->'%(Identity)', ';');</_ScopedCssPrimaryIdentities>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Compressed (gzip / brotli) alternates from ResolvePublishCompressedStaticWebAssets
+         carry AssetTraitName="Content-Encoding" and link to their primary via RelatedAsset
+         (a full path equal to the primary's Identity). -->
+    <_ScopedCssCompressedAssetToRemove Include="@(StaticWebAsset)"
+      Condition="'%(StaticWebAsset.AssetTraitName)' == 'Content-Encoding' and
+                 '%(StaticWebAsset.RelatedAsset)' != '' and
+                 $(_ScopedCssPrimaryIdentities.Contains(';%(StaticWebAsset.RelatedAsset);'))" />
+
+    <_ScopedCssAssetToRemove Include="@(_ScopedCssPrimaryAssetToRemove);@(_ScopedCssCompressedAssetToRemove)" />
+    <StaticWebAsset Remove="@(_ScopedCssAssetToRemove)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_ScopedCssRemovedIdentities>;@(_ScopedCssAssetToRemove->'%(Identity)', ';');</_ScopedCssRemovedIdentities>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Endpoints don't carry AssetTraitName directly; remove them by matching their
+         AssetFile to the identities of every asset we removed (primary + compressed)
+         to preserve the invariant that every endpoint must point to an existing asset. -->
+    <StaticWebAssetEndpoint Remove="@(StaticWebAssetEndpoint)"
+      Condition="'%(StaticWebAssetEndpoint.AssetFile)' != '' and
+                 $(_ScopedCssRemovedIdentities.Contains(';%(StaticWebAssetEndpoint.AssetFile);'))" />
+  </ItemGroup>
+</Target>
+
 </Project>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ScopedCssIntegrationTests.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ScopedCssIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -300,6 +300,73 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
 
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Index.razor.rz.scp.css")).Should().Exist();
             new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().Exist();
+        }
+
+        [Fact]
+        public void Publish_ExcludesScopedCssBundle_WhenExcludeScopedCssAssetsIsTrue()
+        {
+            var testAsset = "RazorComponentApp";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var publish = CreatePublishCommand(projectDirectory);
+            ExecuteCommand(publish, "/p:ExcludeScopedCssAssets=true").Should().Pass();
+
+            var intermediateOutputPath = Path.Combine(publish.GetBaseIntermediateDirectory().ToString(), "Debug", DefaultTfm);
+            var publishOutputPath = publish.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "bundle", "ComponentApp.styles.css")).Should().Exist();
+
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css.gz")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css.br")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "ComponentApp.styles.css")).Should().NotExist();
+
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "Components", "Pages", "Index.razor.rz.scp.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().NotExist();
+        }
+
+        [Fact]
+        public void Publish_ExcludesIndividualScopedCssFiles_WhenExcludeScopedCssAssetsIsTrue_AndBundlingDisabled()
+        {
+            var testAsset = "RazorComponentApp";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var publish = CreatePublishCommand(projectDirectory);
+            ExecuteCommand(publish, "/p:DisableScopedCssBundling=true", "/p:ExcludeScopedCssAssets=true").Should().Pass();
+
+            var intermediateOutputPath = Path.Combine(publish.GetBaseIntermediateDirectory().ToString(), "Debug", DefaultTfm);
+            var publishOutputPath = publish.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(intermediateOutputPath, "scopedcss", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().Exist();
+
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "ComponentApp.styles.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Index.razor.rz.scp.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Index.razor.rz.scp.css.gz")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Index.razor.rz.scp.css.br")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Counter.razor.rz.scp.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Counter.razor.rz.scp.css.gz")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "Components", "Pages", "Counter.razor.rz.scp.css.br")).Should().NotExist();
+        }
+
+        [Fact]
+        public void Publish_ExcludesScopedCssBundle_WhenExcludeScopedCssAssetsIsTrue_AndNoBuild()
+        {
+            var testAsset = "RazorComponentApp";
+            var projectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+            var build = CreateBuildCommand(projectDirectory);
+            ExecuteCommand(build).Should().Pass();
+
+            var publish = CreatePublishCommand(projectDirectory);
+            ExecuteCommand(publish, "/p:NoBuild=true", "/p:ExcludeScopedCssAssets=true").Should().Pass();
+
+            var publishOutputPath = publish.GetOutputDirectory(DefaultTfm, "Debug").ToString();
+
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css.gz")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "ComponentApp.styles.css.br")).Should().NotExist();
+            new FileInfo(Path.Combine(publishOutputPath, "wwwroot", "_content", "ComponentApp", "ComponentApp.styles.css")).Should().NotExist();
         }
 
         [CoreMSBuildOnlyFact]


### PR DESCRIPTION
fixes dotnet/aspnetcore#41961

adds a new MSBuild property `ExcludeScopedCssAssets` that, when set to `true` excludes CSS-isolation assets from `dotnet publish` while leaving the build/dev pipeline (and runtime serving) untouched. This unblocks projects that bundle their CSS through external tooling (e.g. webpack) and previously h ad to delete the published files

how to use:
```xml
   <PropertyGroup>
     <ExcludeScopedCssAssets>true</ExcludeScopedCssAssets>
   </PropertyGroup>
```

or

```bash
dotnet publish /p:ExcludeScopedCssAssets=true
```

as far as the implementation goes:
- for the legacy part I just added an additional clause to their condition
- for the v2 CSS bundles and per-component files are added as regular `StaticWebAsset` items, so a new target `_RemoveScopedCssAssetsFromPublish` is appended to `GenerateStaticWebAssetsPublishManifestDependsOn` which runs after
 `ResolveAllPublishStaticWebAssets` (so it sees assets loaded from disk in the --no-build path too) and before `GenerateStaticWebAssetsPublishManifest` materializes `_FinalPublishStaticWebAsset` (Disclaimer: I required AI's help to make sure I don't miss anything and it helped me add two more parts: a) an explicit AssetTraitValue allow-list (ApplicationBundle, ProjectBundle, ScopedCssFile) and b) the `endpoint must reference an existing asset` part


fyi: the flag **intentionally only affects publish output** which means build artifacts in obj/.../ are still produced so dev-time serving keeps working