### PR TITLE
Allow some duplicate #: directives

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -269,8 +269,8 @@ We do not limit these directives to appear only in entry point files because it 
 
 Duplicate directives are handled according to the MSBuild construct they represent.
 For `#:sdk`, `#:property`, and `#:package`, directives are considered duplicate if their kind and name are equal case-insensitively.
-If the duplicate has the same value, it is ignored.
-If the duplicate has a different value, it is an error (which might be relaxed in the future with smarter deduplication,
+If the duplicate has the same unevaluated value (before any MSBuild variable expansion), it is ignored.
+If the duplicate has a different unevaluated value, it is an error (which might be relaxed in the future with smarter deduplication,
 for example, properties could be concatenated via `;`, more specific package versions could override less specific ones.)
 For `#:project`, `#:ref`, `#:include`, and `#:exclude`, duplicates are allowed and translated to the corresponding MSBuild items.
 Any resulting item behavior, including warnings for duplicate `Compile` items, is left to MSBuild and the compiler.

--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -267,12 +267,14 @@ We do not limit these directives to appear only in entry point files because it 
 - which also makes it possible to share it independently or symlink it to multiple script folders,
 - and it's similar to `global using`s which users usually put into a single file but don't have to.
 
-We disallow duplicate `#:` directives (except `#:project` and `#:ref`) to allow us to design some deduplication mechanism in the future.
-Specifically, directives are considered duplicate if their type and name (case insensitive) are equal.
-`#:project` and `#:ref` duplicates are allowed because MSBuild allows duplicate `<ProjectReference />` items.
-Later with deduplication, separate "self-contained" utilities could reference overlapping sets of packages
-even if they end up in the same compilation.
-For example, properties could be concatenated via `;`, more specific package versions could override less specific ones.
+Duplicate directives are handled according to the MSBuild construct they represent.
+For `#:sdk`, `#:property`, and `#:package`, directives are considered duplicate if their kind and name are equal case-insensitively.
+If the duplicate has the same value, it is ignored.
+If the duplicate has a different value, it is an error (which might be relaxed in the future with smarter deduplication,
+for example, properties could be concatenated via `;`, more specific package versions could override less specific ones.)
+For `#:project`, `#:ref`, `#:include`, and `#:exclude`, duplicates are allowed and translated to the corresponding MSBuild items.
+Any resulting item behavior, including warnings for duplicate `Compile` items, is left to MSBuild and the compiler.
+Directive deduplication allows separate "self-contained" utilities to e.g. reference overlapping sets of packages even if they end up in the same compilation.
 
 During [grow up](#grow-up), `#:` directives are removed from the `.cs` files and turned into elements in the converted `.csproj` file.
 For project-based programs, `#:` directives are an error (reported by Roslyn when it's told it is in "project-based" mode).

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -885,7 +885,7 @@ internal struct DirectiveDeduplicator
     private Dictionary<CSharpDirective.Named, CSharpDirective.Named>? _seen;
 
     /// <summary>
-    /// Checks <paramref name="directive"/> for duplication and reports an error if a different value was already seen.
+    /// Checks <paramref name="directive"/> for duplication and reports an error if a different unevaluated value was already seen.
     /// </summary>
     /// <returns><see langword="false"/> if a duplicate directive was already seen and this directive should be skipped.</returns>
     public bool CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError)
@@ -921,6 +921,8 @@ internal struct DirectiveDeduplicator
     private static bool HasSameValue(CSharpDirective.Named existingDirective, CSharpDirective.Named directive)
     {
         Debug.Assert(NamedDirectiveComparer.Instance.Equals(existingDirective, directive));
+        Debug.Assert(existingDirective is CSharpDirective.Sdk or CSharpDirective.Property or CSharpDirective.Package);
+        Debug.Assert(directive is CSharpDirective.Sdk or CSharpDirective.Property or CSharpDirective.Package);
 
         return (existingDirective, directive) switch
         {

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -875,38 +875,63 @@ internal abstract class CSharpDirective(in CSharpDirective.ParseInfo info)
 
 /// <summary>
 /// Detects duplicate directives (by type and case-insensitive name)
-/// and reports errors via the provided <see cref="ErrorReporter"/>.
+/// and reports errors via the provided <see cref="ErrorReporter"/> when their values differ.
 /// </summary>
 /// <remarks>
-/// <c>#:project</c> and <c>#:ref</c> duplicates are allowed (MSBuild can handle multiple <c>ProjectReference</c>s).
+/// <c>#:project</c>, <c>#:ref</c>, <c>#:include</c>, and <c>#:exclude</c> duplicates are allowed (MSBuild can handle them).
 /// </remarks>
 internal struct DirectiveDeduplicator
 {
     private Dictionary<CSharpDirective.Named, CSharpDirective.Named>? _seen;
 
     /// <summary>
-    /// Checks <paramref name="directive"/> for duplication and reports an error if it was already seen.
+    /// Checks <paramref name="directive"/> for duplication and reports an error if a different value was already seen.
     /// </summary>
-    public void CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError)
+    /// <returns><see langword="false"/> if a duplicate directive was already seen and this directive should be skipped.</returns>
+    public bool CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError)
     {
-        // Duplicate #:project and #:ref directives are allowed (MSBuild can handle that).
-        if (directive is CSharpDirective.Project or CSharpDirective.Ref)
+        if (directive is CSharpDirective.Project or CSharpDirective.Ref or CSharpDirective.IncludeOrExclude)
         {
-            return;
+            return true;
         }
 
         _seen ??= new(NamedDirectiveComparer.Instance);
 
         if (_seen.TryGetValue(directive, out var existingDirective))
         {
+            if (HasSameValue(existingDirective, directive))
+            {
+                return false;
+            }
+
             var typeAndName = $"#:{existingDirective.KindToString()} {existingDirective.Name}";
             reportError(directive.Info.SourceFile.Text, directive.Info.SourceFile.Path, directive.Info.Span,
                 string.Format(FileBasedProgramsResources.DuplicateDirective, typeAndName));
+
+            return false;
         }
         else
         {
             _seen.Add(directive, directive);
         }
+
+        return true;
+    }
+
+    private static bool HasSameValue(CSharpDirective.Named existingDirective, CSharpDirective.Named directive)
+    {
+        Debug.Assert(NamedDirectiveComparer.Instance.Equals(existingDirective, directive));
+
+        return (existingDirective, directive) switch
+        {
+            (CSharpDirective.Sdk existing, CSharpDirective.Sdk current) =>
+                string.Equals(existing.Version, current.Version, StringComparison.Ordinal),
+            (CSharpDirective.Property existing, CSharpDirective.Property current) =>
+                string.Equals(existing.Value, current.Value, StringComparison.Ordinal),
+            (CSharpDirective.Package existing, CSharpDirective.Package current) =>
+                string.Equals(existing.Version, current.Version, StringComparison.Ordinal),
+            _ => false,
+        };
     }
 }
 

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -159,7 +159,7 @@ internal static class FileLevelDirectiveHelpers
                 {
                     if (checkDuplicates)
                     {
-                        deduplicator.CheckDirective(directive, errorReporter);
+                        deduplicator.CheckDirective(directive, errorReporter, shouldKeep: out _);
                     }
 
                     builder?.Add(directive);
@@ -887,12 +887,13 @@ internal struct DirectiveDeduplicator
     /// <summary>
     /// Checks <paramref name="directive"/> for duplication and reports an error if a different unevaluated value was already seen.
     /// </summary>
-    /// <returns><see langword="false"/> if a duplicate directive was already seen and this directive should be skipped.</returns>
-    public bool CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError)
+    /// <param name="shouldKeep"><see langword="false"/> if a duplicate directive was already seen and this directive should be skipped.</param>
+    public void CheckDirective(CSharpDirective.Named directive, ErrorReporter reportError, out bool shouldKeep)
     {
         if (directive is CSharpDirective.Project or CSharpDirective.Ref or CSharpDirective.IncludeOrExclude)
         {
-            return true;
+            shouldKeep = true;
+            return;
         }
 
         _seen ??= new(NamedDirectiveComparer.Instance);
@@ -901,21 +902,23 @@ internal struct DirectiveDeduplicator
         {
             if (HasSameValue(existingDirective, directive))
             {
-                return false;
+                shouldKeep = false;
+                return;
             }
 
             var typeAndName = $"#:{existingDirective.KindToString()} {existingDirective.Name}";
             reportError(directive.Info.SourceFile.Text, directive.Info.SourceFile.Path, directive.Info.Span,
                 string.Format(FileBasedProgramsResources.DuplicateDirective, typeAndName));
 
-            return false;
+            shouldKeep = false;
+            return;
         }
         else
         {
             _seen.Add(directive, directive);
         }
 
-        return true;
+        shouldKeep = true;
     }
 
     private static bool HasSameValue(CSharpDirective.Named existingDirective, CSharpDirective.Named directive)

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
@@ -90,7 +90,7 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Version.init -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang.Shebang(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info) -> void
 Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator
-Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.CheckDirective(Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named! directive, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError) -> void
+Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.CheckDirective(Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named! directive, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError) -> bool
 Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.DirectiveDeduplicator() -> void
 Microsoft.DotNet.FileBasedPrograms.ErrorReporter
 Microsoft.DotNet.FileBasedPrograms.ErrorReporters

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/InternalAPI.Unshipped.txt
@@ -90,7 +90,7 @@ Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Sdk.Version.init -> void
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang
 Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Shebang.Shebang(in Microsoft.DotNet.FileBasedPrograms.CSharpDirective.ParseInfo info) -> void
 Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator
-Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.CheckDirective(Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named! directive, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError) -> bool
+Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.CheckDirective(Microsoft.DotNet.FileBasedPrograms.CSharpDirective.Named! directive, Microsoft.DotNet.FileBasedPrograms.ErrorReporter! reportError, out bool shouldKeep) -> void
 Microsoft.DotNet.FileBasedPrograms.DirectiveDeduplicator.DirectiveDeduplicator() -> void
 Microsoft.DotNet.FileBasedPrograms.ErrorReporter
 Microsoft.DotNet.FileBasedPrograms.ErrorReporters

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -342,9 +342,13 @@ public sealed class VirtualProjectBuilder
                     continue;
                 }
 
-                if (directive is CSharpDirective.Named named && !deduplicator.CheckDirective(named, reportError))
+                if (directive is CSharpDirective.Named named)
                 {
-                    continue;
+                    deduplicator.CheckDirective(named, reportError, out bool shouldKeep);
+                    if (!shouldKeep)
+                    {
+                        continue;
+                    }
                 }
 
                 deduplicatedFileEvaluatedDirectiveBuilder.Add(directive);
@@ -414,10 +418,14 @@ public sealed class VirtualProjectBuilder
 
             foreach (var directive in directives)
             {
-                if (directive is CSharpDirective.Sdk sdk && !deduplicator.CheckDirective(sdk, reportError))
+                if (directive is CSharpDirective.Sdk sdk)
                 {
-                    changed = true;
-                    continue;
+                    deduplicator.CheckDirective(sdk, reportError, out bool shouldKeep);
+                    if (!shouldKeep)
+                    {
+                        changed = true;
+                        continue;
+                    }
                 }
 
                 builder.Add(directive);

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -331,7 +331,8 @@ public sealed class VirtualProjectBuilder
             // Evaluate directives, e.g., determine item types for #:include/#:exclude from their file extension.
             var fileEvaluatedDirectives = EvaluateDirectives(project, directivesForEvaluation, reportError);
 
-            // Detect duplicate directives across all files on evaluated directives.
+            // Detect duplicate directives across all files on evaluated directives. EvaluateDirectives only expands
+            // #:project, #:ref, #:include, and #:exclude; #:property and #:package values are still unevaluated here.
             var deduplicatedFileEvaluatedDirectiveBuilder = ImmutableArray.CreateBuilder<CSharpDirective>(fileEvaluatedDirectives.Length);
             foreach (var directive in fileEvaluatedDirectives)
             {
@@ -399,6 +400,8 @@ public sealed class VirtualProjectBuilder
             return false;
         }
 
+        // #:sdk directives become Sdk.props/Sdk.targets imports when creating the temporary project used for
+        // directive evaluation, so identical duplicates must be removed before that project is created.
         ImmutableArray<CSharpDirective> DeduplicateSdkDirectives(ImmutableArray<CSharpDirective> directives)
         {
             if (!directives.Any(static directive => directive is CSharpDirective.Sdk))

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -124,7 +124,7 @@ public sealed class VirtualProjectBuilder
         var sourceFile = SourceFile.Load(sourceFilePath);
         var directives = FileLevelDirectiveHelpers.FindDirectives(sourceFile, reportAllErrors: false, ErrorReporters.IgnoringReporter);
 
-        // Return the first value. Duplicate directives are not supported.
+        // Return the first value. Conflicting duplicate directives are not supported.
         return directives.OfType<CSharpDirective.Property>()
             .FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase))?.Value;
     }
@@ -320,23 +320,36 @@ public sealed class VirtualProjectBuilder
 
         do
         {
+            var directivesForEvaluation = DeduplicateSdkDirectives(directives);
+
             // Create a project with properties from #:property directives so they can be expanded inside EvaluateDirectives.
             (project, projectRootElement) = CreateProjectInstanceNoEvaluation(
                 projectCollection,
-                [.. evaluatedDirectiveBuilder, .. directives],
+                [.. evaluatedDirectiveBuilder, .. directivesForEvaluation],
                 addGlobalProperties);
 
             // Evaluate directives, e.g., determine item types for #:include/#:exclude from their file extension.
-            var fileEvaluatedDirectives = EvaluateDirectives(project, directives, reportError);
+            var fileEvaluatedDirectives = EvaluateDirectives(project, directivesForEvaluation, reportError);
 
             // Detect duplicate directives across all files on evaluated directives.
+            var deduplicatedFileEvaluatedDirectiveBuilder = ImmutableArray.CreateBuilder<CSharpDirective>(fileEvaluatedDirectives.Length);
             foreach (var directive in fileEvaluatedDirectives)
             {
-                if (directive is CSharpDirective.Named named)
+                if (directive is CSharpDirective.Sdk)
                 {
-                    deduplicator.CheckDirective(named, reportError);
+                    deduplicatedFileEvaluatedDirectiveBuilder.Add(directive);
+                    continue;
                 }
+
+                if (directive is CSharpDirective.Named named && !deduplicator.CheckDirective(named, reportError))
+                {
+                    continue;
+                }
+
+                deduplicatedFileEvaluatedDirectiveBuilder.Add(directive);
             }
+
+            fileEvaluatedDirectives = deduplicatedFileEvaluatedDirectiveBuilder.DrainToImmutable();
 
             evaluatedDirectiveBuilder.AddRange(fileEvaluatedDirectives);
 
@@ -384,6 +397,30 @@ public sealed class VirtualProjectBuilder
             }
 
             return false;
+        }
+
+        ImmutableArray<CSharpDirective> DeduplicateSdkDirectives(ImmutableArray<CSharpDirective> directives)
+        {
+            if (!directives.Any(static directive => directive is CSharpDirective.Sdk))
+            {
+                return directives;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<CSharpDirective>(directives.Length);
+            var changed = false;
+
+            foreach (var directive in directives)
+            {
+                if (directive is CSharpDirective.Sdk sdk && !deduplicator.CheckDirective(sdk, reportError))
+                {
+                    changed = true;
+                    continue;
+                }
+
+                builder.Add(directive);
+            }
+
+            return changed ? builder.DrainToImmutable() : directives;
         }
 
         (ProjectInstance, ProjectRootElement) CreateProjectInstanceNoEvaluation(

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -2252,6 +2252,47 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void Directives_IdenticalDuplicate()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        VerifyConversion(
+            baseDirectory: testInstance.Path,
+            inputCSharp: """
+                #:sdk Microsoft.NET.Sdk
+                #:sdk Microsoft.NET.Sdk
+                #:package Package@1.0
+                #:package Package@1.0
+                #:property Prop=1
+                #:property Prop=1
+                Console.Write();
+                """,
+            expectedProject: $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                    <Prop>1</Prop>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Package" Version="1.0" />
+                  </ItemGroup>
+
+                </Project>
+
+                """,
+            expectedCSharp: """
+                Console.Write();
+                """,
+            evaluateDirectives: true);
+    }
+
+    [Fact]
     public void Directives_Duplicate()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();
@@ -2272,6 +2313,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             inputCSharp: """
                 #:sdk Name
                 #:sdk Name@X
+                #:sdk Name@Y
                 #:sdk Name
                 #:sdk Name2
                 """,
@@ -2287,6 +2329,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             inputCSharp: """
                 #:package Name
                 #:package Name@X
+                #:package Name@Y
                 #:package Name
                 #:package Name2
                 """,

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -2293,6 +2293,76 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void Directives_Duplicate_UsesUnevaluatedValues()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        VerifyConversion(
+            baseDirectory: testInstance.Path,
+            inputCSharp: """
+                #:property A=a
+                #:property B=b
+                #:property B=b
+                #:property C=a
+                #:property C=$(A)
+                #:property D=$(A)
+                #:property D=$(A)
+                Console.Write();
+                """,
+            expectedProject: null,
+            expectedCSharp: """
+                Console.Write();
+                """,
+            expectedErrors:
+            [
+                (5, string.Format(FileBasedProgramsResources.DuplicateDirective, "#:property C")),
+            ],
+            evaluateDirectives: true);
+    }
+
+    [Fact]
+    public void Directives_Duplicate_EvaluatedProjectDirectivesAreAllowed()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Lib.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk" />
+            """);
+
+        VerifyConversion(
+            baseDirectory: testInstance.Path,
+            inputCSharp: """
+                #:property LibraryProject=Lib.csproj
+                #:project Lib.csproj
+                #:project $(LibraryProject)
+                Console.Write();
+                """,
+            expectedProject: $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                    <LibraryProject>Lib.csproj</LibraryProject>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <ProjectReference Include="Lib.csproj" />
+                    <ProjectReference Include="Lib.csproj" />
+                  </ItemGroup>
+
+                </Project>
+
+                """,
+            expectedCSharp: """
+                Console.Write();
+                """,
+            evaluateDirectives: true);
+    }
+
+    [Fact]
     public void Directives_Duplicate()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1683,17 +1683,108 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
     }
 
     /// <summary>
-    /// Duplicate directives across <c>#:include</c>'d files should be reported as errors.
-    /// Note: <c>#:project</c> and <c>#:ref</c> duplicates are allowed
-    /// (tested by <see cref="ProjectReference_Duplicate"/> and <see cref="RefDirective_DuplicateRefFromIncludedFiles"/>).
+    /// Identical duplicate directives across <c>#:include</c>'d files should be allowed.
     /// </summary>
     [Theory]
     [InlineData("package")]
     [InlineData("property")]
     [InlineData("sdk")]
-    [InlineData("include")]
     [InlineData("exclude")]
-    public void IncludeDirective_DuplicateDirectives(string directiveKind)
+    public void IncludeDirective_IdenticalDuplicateDirectives(string directiveKind)
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var programPath = Path.Join(testInstance.Path, "Program.cs");
+        var utilPath = Path.Join(testInstance.Path, "Util.cs");
+
+        string programDirective;
+        string utilDirective;
+
+        switch (directiveKind)
+        {
+            case "package":
+                programDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
+                utilDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
+                break;
+            case "property":
+                programDirective = "#:property MyProp=Value";
+                utilDirective = "#:property MyProp=Value";
+                break;
+            case "sdk":
+                programDirective = "#:sdk Microsoft.NET.Sdk";
+                utilDirective = "#:sdk Microsoft.NET.Sdk";
+                break;
+            case "exclude":
+                programDirective = "#:exclude Helper.cs";
+                utilDirective = "#:exclude Helper.cs";
+                break;
+            default:
+                throw new ArgumentException($"Unsupported directive kind '{directiveKind}'.", nameof(directiveKind));
+        }
+
+        File.WriteAllText(programPath, $"""
+            #!/usr/bin/env dotnet
+            #:include Util.cs
+            {programDirective}
+            Console.WriteLine("Hello");
+            """);
+
+        File.WriteAllText(utilPath, $$"""
+            {{utilDirective}}
+            static class Util { }
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello");
+    }
+
+    [Fact]
+    public void IncludeDirective_IdenticalDuplicateIncludeDirectivesAreAllowed()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var programPath = Path.Join(testInstance.Path, "Program.cs");
+        var utilPath = Path.Join(testInstance.Path, "Util.cs");
+
+        File.WriteAllText(programPath, """
+            #!/usr/bin/env dotnet
+            #:include Util.cs
+            #:include Helper.cs
+            Console.WriteLine("Hello");
+            """);
+
+        File.WriteAllText(utilPath, """
+            #:include Helper.cs
+            static class Util { }
+            """);
+
+        var helperPath = Path.Join(testInstance.Path, "Helper.cs");
+        File.WriteAllText(helperPath, """
+            static class Helper { }
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            // warning CS2002: Source file 'Helper.cs' specified multiple times
+            .And.HaveStdOutContaining("warning CS2002")
+            .And.HaveStdOutContaining(helperPath)
+            .And.HaveStdOutContaining("Hello");
+    }
+
+    /// <summary>
+    /// Conflicting duplicate directives across <c>#:include</c>'d files should be reported as errors.
+    /// Note: <c>#:project</c>, <c>#:ref</c>, <c>#:include</c>, and <c>#:exclude</c> duplicates are allowed.
+    /// </summary>
+    [Theory]
+    [InlineData("package")]
+    [InlineData("property")]
+    [InlineData("sdk")]
+    public void IncludeDirective_ConflictingDuplicateDirectives(string directiveKind)
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();
 
@@ -1708,7 +1799,7 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
         {
             case "package":
                 programDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
-                utilDirective = "#:package System.CommandLine@2.0.0-beta4.22272.1";
+                utilDirective = "#:package System.CommandLine@2.0.0-beta4.22537.1";
                 duplicateTypeAndName = "#:package System.CommandLine";
                 break;
             case "property":
@@ -1721,22 +1812,12 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
                 utilDirective = "#:sdk Microsoft.NET.Sdk@9.0.0";
                 duplicateTypeAndName = "#:sdk Microsoft.NET.Sdk";
                 break;
-            case "include":
-                File.WriteAllText(Path.Join(testInstance.Path, "Helper.cs"), "static class Helper { }");
-                programDirective = "#:include Helper.cs";
-                utilDirective = "#:include Helper.cs";
-                duplicateTypeAndName = $"#:include {Path.Join(testInstance.Path, "Helper.cs")}";
-                break;
-            case "exclude":
-                programDirective = "#:exclude Helper.cs";
-                utilDirective = "#:exclude Helper.cs";
-                duplicateTypeAndName = $"#:exclude {Path.Join(testInstance.Path, "Helper.cs")}";
-                break;
             default:
                 throw new ArgumentException($"Unsupported directive kind '{directiveKind}'.", nameof(directiveKind));
         }
 
         File.WriteAllText(programPath, $"""
+            #!/usr/bin/env dotnet
             #:include Util.cs
             {programDirective}
             Console.WriteLine("Hello");

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1834,4 +1834,29 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
             .Should().Fail()
             .And.HaveStdErrContaining(DirectiveError(utilPath, 1, FileBasedProgramsResources.DuplicateDirective, duplicateTypeAndName));
     }
+
+    [Fact]
+    public void IncludeDirective_IncludeAndExcludeSamePathAreAllowed()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        var programPath = Path.Join(testInstance.Path, "Program.cs");
+
+        File.WriteAllText(programPath, """
+            #!/usr/bin/env dotnet
+            #:include Helper.cs
+            #:exclude Helper.cs
+            Console.WriteLine("Hello");
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Helper.cs"), """
+            #error This file should not be compiled.
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut("Hello");
+    }
 }


### PR DESCRIPTION
Related to https://github.com/dotnet/sdk/pull/54101#discussion_r3153578018, https://github.com/dotnet/sdk/issues/54080, https://github.com/dotnet/sdk/issues/54090.

The motivation is allowing duplicate directives in files which can be `#:include`d by multiple entry-points, so the `#:include`d file can be self-contained and specify all the properties/packages/etc it needs and if multiple `#:include`d files need the same directive, that should be allowed.

- Allow `#:sdk`, `#:property`, `#:package` directives to be duplicated if their values are the same. They are deduplicated before being converted to the virtual project.
- Allow `#:include`, `#:exclude` to be duplicated. They are passed as-is; leaving the duplicate handling to MSBuild (sometimes it's a warning that can be suppressed, like for .cs files, other times it's probably allowed).
- (Previously we already allowed `#:ref` and `#:project` to be duplicated; MSBuild can handle that.)