### PR TITLE
Disable PathEndsWithSlashOrBackslash test

### DIFF
--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
@@ -732,7 +732,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/sdk/issues/54209")]
         // Even count of slash/backslash
         [InlineData("--output", "\\\\")]
         [InlineData("--output", "\\\\\\\\")]


### PR DESCRIPTION
The test `PathEndsWithSlashOrBackslash` exhibits consistent failure across multiple branches, blocking PRs. Disabling until the root cause is investigated by @dotnet/dotnet-testing-admin.

Fixes https://github.com/dotnet/sdk/issues/54209