### PR TITLE
dotnetup daily builds (Phase 1): blob feed fallback for fully-specified prerelease versions

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/InstallComponent.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/InstallComponent.cs
@@ -47,19 +47,15 @@ public static class InstallComponentExtensions
 
     /// <summary>
     /// Formats a version string to a fixed display width so progress rows align.
-    /// Short versions like "9.0.312" are left-padded; long versions like
-    /// "11.0.100-preview.2.26159.112" are truncated to "..59.112".
-    /// Target width matches the common format "10.0.201" (8 chars).
+    /// Short versions like "9.0.312" are left-padded to <paramref name="minWidth"/>
+    /// (default 8, matching the common "10.0.201" format). Longer versions are
+    /// returned at their natural width — never truncated. Pass the maximum version
+    /// length across a batch as <paramref name="minWidth"/> to keep all rows aligned.
     /// </summary>
-    public static string FormatVersionForDisplay(string version)
+    public static string FormatVersionForDisplay(string version, int minWidth = 8)
     {
-        const int targetWidth = 8;
-        if (version.Length <= targetWidth)
-        {
-            return version.PadLeft(targetWidth);
-        }
-
-        return ".." + version[^(targetWidth - 2)..];
+        int width = Math.Max(minWidth, version.Length);
+        return version.PadLeft(width);
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Deployment.DotNet.Releases;
+
+namespace Microsoft.Dotnet.Installation.Internal;
+
+/// <summary>
+/// Builds URLs for downloading .NET archives and their SHA-512 checksum files
+/// from the public dotnet blob feeds. Used when a version is not present in the
+/// release manifest (e.g. daily/preview builds).
+/// </summary>
+internal static class BlobFeedUrlBuilder
+{
+    /// <summary>
+    /// Primary blob feed where stable/serviced builds are hosted. Archives and
+    /// their .sha512 companions are co-located at the same path.
+    /// </summary>
+    public const string PrimaryFeedBaseUrl = "https://builds.dotnet.microsoft.com/dotnet";
+
+    /// <summary>
+    /// Fallback blob feed where daily/preview builds are hosted. Archives and
+    /// checksums live on different path roots ("public" vs "public-checksums").
+    /// </summary>
+    public const string FallbackFeedArchiveBaseUrl = "https://ci.dot.net/public";
+    public const string FallbackFeedChecksumBaseUrl = "https://ci.dot.net/public-checksums";
+
+    /// <summary>
+    /// Describes a candidate blob feed location (archive URL + matching .sha512 URL).
+    /// </summary>
+    public readonly record struct BlobFeedLocation(string ArchiveUrl, string ChecksumUrl);
+
+    /// <summary>
+    /// Returns the primary then fallback feed locations to try, in order, for the
+    /// given component/version/RID/extension.
+    /// </summary>
+    public static IEnumerable<BlobFeedLocation> GetFeedLocations(
+        InstallComponent component,
+        ReleaseVersion version,
+        string rid,
+        string extension)
+    {
+        string componentDir = GetComponentDirectory(component);
+        string fileName = GetArchiveFileName(component, version, rid, extension);
+        string versionString = version.ToString();
+
+        // Primary feed: archive + checksum co-located.
+        string primaryDir = $"{PrimaryFeedBaseUrl}/{componentDir}/{versionString}";
+        yield return new BlobFeedLocation(
+            ArchiveUrl: $"{primaryDir}/{fileName}",
+            ChecksumUrl: $"{primaryDir}/{fileName}.sha512");
+
+        // Fallback feed: archive on /public, checksum on /public-checksums.
+        yield return new BlobFeedLocation(
+            ArchiveUrl: $"{FallbackFeedArchiveBaseUrl}/{componentDir}/{versionString}/{fileName}",
+            ChecksumUrl: $"{FallbackFeedChecksumBaseUrl}/{componentDir}/{versionString}/{fileName}.sha512");
+    }
+
+    /// <summary>
+    /// Component → directory segment used in blob feed URLs.
+    /// </summary>
+    public static string GetComponentDirectory(InstallComponent component) => component switch
+    {
+        InstallComponent.SDK => "Sdk",
+        InstallComponent.Runtime => "Runtime",
+        InstallComponent.ASPNETCore => "aspnetcore/Runtime",
+        InstallComponent.WindowsDesktop => "WindowsDesktop",
+        _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unsupported install component"),
+    };
+
+    /// <summary>
+    /// Archive filename, e.g. "dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip".
+    /// </summary>
+    public static string GetArchiveFileName(InstallComponent component, ReleaseVersion version, string rid, string extension)
+    {
+        string prefix = component switch
+        {
+            InstallComponent.SDK => "dotnet-sdk",
+            InstallComponent.Runtime => "dotnet-runtime",
+            InstallComponent.ASPNETCore => "aspnetcore-runtime",
+            InstallComponent.WindowsDesktop => "windowsdesktop-runtime",
+            _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unsupported install component"),
+        };
+
+        return $"{prefix}-{version}-{rid}{extension}";
+    }
+
+    /// <summary>
+    /// Parses the contents of a .sha512 file. Hash files commonly contain just
+    /// the hex hash, optionally followed by whitespace and a filename
+    /// (e.g. coreutils sha512sum format). Returns the lowercase hash.
+    /// </summary>
+    public static string ParseHashFile(string contents)
+    {
+        if (string.IsNullOrWhiteSpace(contents))
+        {
+            throw new FormatException("SHA-512 hash file is empty.");
+        }
+
+        // First whitespace-delimited token is the hex hash.
+        var token = contents.AsSpan().Trim();
+        int firstWhitespace = -1;
+        for (int i = 0; i < token.Length; i++)
+        {
+            if (char.IsWhiteSpace(token[i]))
+            {
+                firstWhitespace = i;
+                break;
+            }
+        }
+
+        var hash = firstWhitespace < 0 ? token : token.Slice(0, firstWhitespace);
+
+        // SHA-512 hex is 128 hex chars.
+        if (hash.Length != 128)
+        {
+            throw new FormatException($"SHA-512 hash file does not contain a 128-character hex hash (got {hash.Length} chars).");
+        }
+
+        for (int i = 0; i < hash.Length; i++)
+        {
+            char c = hash[i];
+            bool isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!isHex)
+            {
+                throw new FormatException("SHA-512 hash file contains non-hex characters.");
+            }
+        }
+
+        return hash.ToString().ToLowerInvariant();
+    }
+}

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
@@ -7,34 +7,33 @@ namespace Microsoft.Dotnet.Installation.Internal;
 
 /// <summary>
 /// Builds URLs for downloading .NET archives and their SHA-512 checksum files
-/// from the public dotnet blob feeds. Used when a version is not present in the
-/// release manifest (e.g. daily/preview builds).
+/// from the public dotnet blob feed at ci.dot.net. Used when a version is not
+/// present in the release manifest (e.g. daily/preview builds). Versions that
+/// are served by builds.dotnet.microsoft.com are also listed in the release
+/// manifest, so they don't reach this fallback path.
 /// </summary>
 internal static class BlobFeedUrlBuilder
 {
     /// <summary>
-    /// Primary blob feed where stable/serviced builds are hosted. Archives and
-    /// their .sha512 companions are co-located at the same path.
+    /// Blob feed root for archive downloads (daily/preview builds).
     /// </summary>
-    public const string PrimaryFeedBaseUrl = "https://builds.dotnet.microsoft.com/dotnet";
+    public const string ArchiveBaseUrl = "https://ci.dot.net/public";
 
     /// <summary>
-    /// Fallback blob feed where daily/preview builds are hosted. Archives and
-    /// checksums live on different path roots ("public" vs "public-checksums").
+    /// Blob feed root for SHA-512 checksum files. Hosted on a separate path from
+    /// the archives so that checksums aren't tampered alongside the artifacts.
     /// </summary>
-    public const string FallbackFeedArchiveBaseUrl = "https://ci.dot.net/public";
-    public const string FallbackFeedChecksumBaseUrl = "https://ci.dot.net/public-checksums";
+    public const string ChecksumBaseUrl = "https://ci.dot.net/public-checksums";
 
     /// <summary>
-    /// Describes a candidate blob feed location (archive URL + matching .sha512 URL).
+    /// A candidate blob feed location (archive URL + matching .sha512 URL).
     /// </summary>
     public readonly record struct BlobFeedLocation(string ArchiveUrl, string ChecksumUrl);
 
     /// <summary>
-    /// Returns the primary then fallback feed locations to try, in order, for the
-    /// given component/version/RID/extension.
+    /// Returns the blob feed location for the given component/version/RID/extension.
     /// </summary>
-    public static IEnumerable<BlobFeedLocation> GetFeedLocations(
+    public static BlobFeedLocation GetFeedLocation(
         InstallComponent component,
         ReleaseVersion version,
         string rid,
@@ -44,16 +43,9 @@ internal static class BlobFeedUrlBuilder
         string fileName = GetArchiveFileName(component, version, rid, extension);
         string versionString = version.ToString();
 
-        // Primary feed: archive + checksum co-located.
-        string primaryDir = $"{PrimaryFeedBaseUrl}/{componentDir}/{versionString}";
-        yield return new BlobFeedLocation(
-            ArchiveUrl: $"{primaryDir}/{fileName}",
-            ChecksumUrl: $"{primaryDir}/{fileName}.sha512");
-
-        // Fallback feed: archive on /public, checksum on /public-checksums.
-        yield return new BlobFeedLocation(
-            ArchiveUrl: $"{FallbackFeedArchiveBaseUrl}/{componentDir}/{versionString}/{fileName}",
-            ChecksumUrl: $"{FallbackFeedChecksumBaseUrl}/{componentDir}/{versionString}/{fileName}.sha512");
+        return new BlobFeedLocation(
+            ArchiveUrl: $"{ArchiveBaseUrl}/{componentDir}/{versionString}/{fileName}",
+            ChecksumUrl: $"{ChecksumBaseUrl}/{componentDir}/{versionString}/{fileName}.sha512");
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
@@ -112,7 +112,7 @@ internal static class BlobFeedUrlBuilder
         for (int i = 0; i < hash.Length; i++)
         {
             char c = hash[i];
-            bool isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            bool isHex = c is (>= '0' and <= '9') or (>= 'a' and <= 'f') or (>= 'A' and <= 'F');
             if (!isHex)
             {
                 throw new FormatException("SHA-512 hash file contains non-hex characters.");

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
 using Microsoft.Deployment.DotNet.Releases;
@@ -212,7 +213,17 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
 
     private (string DownloadUrl, string ExpectedHash) ResolveManifestEntry(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
     {
-        var targetFile = _releaseManifest.FindReleaseFile(installRequest, resolvedVersion);
+        ReleaseFile? targetFile;
+        try
+        {
+            targetFile = _releaseManifest.FindReleaseFile(installRequest, resolvedVersion);
+        }
+        catch (DotnetInstallException ex) when (ShouldFallbackToBlobFeed(ex, installRequest, resolvedVersion))
+        {
+            // Manifest doesn't list this version (typical for daily/preview builds).
+            // Fall back to constructed blob feed URLs.
+            return ResolveBlobFeedEntry(installRequest, resolvedVersion);
+        }
 
         if (targetFile == null)
         {
@@ -245,6 +256,104 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
         }
 
         return (downloadUrl, expectedHash);
+    }
+
+    /// <summary>
+    /// Returns true if the manifest miss should fall back to the blob feeds.
+    /// We only fall back when the user gave us an exact prerelease version
+    /// (e.g. <c>10.0.100-preview.4.25216.37</c>) and the manifest doesn't yet
+    /// know about it. Stable versions and named channels (e.g. "preview") are
+    /// served only from the manifest so that real misses surface as errors.
+    /// </summary>
+    private static bool ShouldFallbackToBlobFeed(
+        DotnetInstallException ex,
+        DotnetInstallRequest installRequest,
+        ReleaseVersion resolvedVersion)
+    {
+        if (ex.ErrorCode != DotnetInstallErrorCode.VersionNotFound &&
+            ex.ErrorCode != DotnetInstallErrorCode.ReleaseNotFound)
+        {
+            return false;
+        }
+
+        if (!installRequest.Channel.IsFullySpecifiedVersion())
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(resolvedVersion.Prerelease))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves a download URL + SHA-512 by probing the public dotnet blob feeds
+    /// for the given component/version/RID.
+    /// </summary>
+    private (string DownloadUrl, string ExpectedHash) ResolveBlobFeedEntry(
+        DotnetInstallRequest installRequest,
+        ReleaseVersion resolvedVersion)
+    {
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(installRequest.InstallRoot.Architecture);
+        string extension = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+
+        var attemptedUrls = new List<string>();
+        foreach (var location in BlobFeedUrlBuilder.GetFeedLocations(installRequest.Component, resolvedVersion, rid, extension))
+        {
+            attemptedUrls.Add(location.ChecksumUrl);
+            string? hash = TryGetHashFromUrl(location.ChecksumUrl, resolvedVersion, installRequest.Component);
+            if (hash != null)
+            {
+                return (location.ArchiveUrl, hash);
+            }
+        }
+
+        throw new DotnetInstallException(
+            DotnetInstallErrorCode.VersionNotFound,
+            $"Version {resolvedVersion} for {installRequest.Component} was not found in the release manifest or any known blob feed. Tried: {string.Join(", ", attemptedUrls)}",
+            version: resolvedVersion.ToString(),
+            component: installRequest.Component.ToString());
+    }
+
+    /// <summary>
+    /// Downloads and parses a .sha512 hash file. Returns null if the URL 404s
+    /// (try the next feed). Throws for any other error.
+    /// </summary>
+    private string? TryGetHashFromUrl(string checksumUrl, ReleaseVersion resolvedVersion, InstallComponent component)
+    {
+        try
+        {
+            using var response = _httpClient.GetAsync(checksumUrl).GetAwaiter().GetResult();
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            string contents = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return BlobFeedUrlBuilder.ParseHashFile(contents);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.NetworkError,
+                $"Failed to fetch hash file from {checksumUrl}: {ex.Message}",
+                ex,
+                version: resolvedVersion.ToString(),
+                component: component.ToString());
+        }
+        catch (FormatException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ManifestParseFailed,
+                $"Hash file at {checksumUrl} is malformed: {ex.Message}",
+                ex,
+                version: resolvedVersion.ToString(),
+                component: component.ToString());
+        }
     }
 
     private bool TryServeCachedArchive(string downloadUrl, string expectedHash, string destinationPath, IProgress<DownloadProgress>? progress)

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -213,31 +213,51 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
 
     private (string DownloadUrl, string ExpectedHash) ResolveManifestEntry(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
     {
-        if (!_releaseManifest.TryFindReleaseFile(installRequest, resolvedVersion, out var targetFile))
+        var result = _releaseManifest.TryFindReleaseFile(installRequest, resolvedVersion);
+
+        switch (result.Status)
         {
-            // Manifest doesn't list this version. For fully-specified prerelease
-            // versions, try the public blob feed (typical for daily/preview builds).
-            if (ShouldFallbackToBlobFeed(installRequest, resolvedVersion))
-            {
-                return ResolveBlobFeedEntry(installRequest, resolvedVersion);
-            }
+            case FindReleaseFileStatus.Found:
+                return BuildEntryFromReleaseFile(result.File!, resolvedVersion, installRequest);
 
-            throw new DotnetInstallException(
-                DotnetInstallErrorCode.VersionNotFound,
-                $"No release found for version {resolvedVersion}",
-                version: resolvedVersion.ToString(),
-                component: installRequest.Component.ToString());
+            case FindReleaseFileStatus.NoMatchingFile:
+                throw new DotnetInstallException(
+                    DotnetInstallErrorCode.NoMatchingReleaseFileForPlatform,
+                    $"No matching file found for {installRequest.Component} version {resolvedVersion} on {installRequest.InstallRoot.Architecture}",
+                    version: resolvedVersion.ToString(),
+                    component: installRequest.Component.ToString());
+
+            case FindReleaseFileStatus.ProductNotFound:
+            case FindReleaseFileStatus.ReleaseNotFound:
+                // Manifest doesn't list this version. For fully-specified prerelease
+                // versions, try the public blob feed (typical for daily/preview builds).
+                if (ShouldFallbackToBlobFeed(installRequest, resolvedVersion))
+                {
+                    return ResolveBlobFeedEntry(installRequest, resolvedVersion);
+                }
+
+                throw result.Status == FindReleaseFileStatus.ProductNotFound
+                    ? new DotnetInstallException(
+                        DotnetInstallErrorCode.VersionNotFound,
+                        $"No product found for version {resolvedVersion}",
+                        version: resolvedVersion.ToString(),
+                        component: installRequest.Component.ToString())
+                    : new DotnetInstallException(
+                        DotnetInstallErrorCode.ReleaseNotFound,
+                        $"No release found for version {resolvedVersion}",
+                        version: resolvedVersion.ToString(),
+                        component: installRequest.Component.ToString());
+
+            default:
+                throw new InvalidOperationException($"Unexpected {nameof(FindReleaseFileStatus)}: {result.Status}");
         }
+    }
 
-        if (targetFile == null)
-        {
-            throw new DotnetInstallException(
-                DotnetInstallErrorCode.NoMatchingReleaseFileForPlatform,
-                $"No matching file found for {installRequest.Component} version {resolvedVersion} on {installRequest.InstallRoot.Architecture}",
-                version: resolvedVersion.ToString(),
-                component: installRequest.Component.ToString());
-        }
-
+    private static (string DownloadUrl, string ExpectedHash) BuildEntryFromReleaseFile(
+        ReleaseFile targetFile,
+        ReleaseVersion resolvedVersion,
+        DotnetInstallRequest installRequest)
+    {
         string downloadUrl = targetFile.Address.ToString();
         string expectedHash = targetFile.Hash.ToString();
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -290,7 +290,7 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
     }
 
     /// <summary>
-    /// Resolves a download URL + SHA-512 by probing the public dotnet blob feeds
+    /// Resolves a download URL + SHA-512 by probing the public dotnet blob feed
     /// for the given component/version/RID.
     /// </summary>
     private (string DownloadUrl, string ExpectedHash) ResolveBlobFeedEntry(
@@ -300,20 +300,16 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
         string rid = DotnetupUtilities.GetRuntimeIdentifier(installRequest.InstallRoot.Architecture);
         string extension = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
 
-        var attemptedUrls = new List<string>();
-        foreach (var location in BlobFeedUrlBuilder.GetFeedLocations(installRequest.Component, resolvedVersion, rid, extension))
+        var location = BlobFeedUrlBuilder.GetFeedLocation(installRequest.Component, resolvedVersion, rid, extension);
+        string? hash = TryGetHashFromUrl(location.ChecksumUrl, resolvedVersion, installRequest.Component);
+        if (hash != null)
         {
-            attemptedUrls.Add(location.ChecksumUrl);
-            string? hash = TryGetHashFromUrl(location.ChecksumUrl, resolvedVersion, installRequest.Component);
-            if (hash != null)
-            {
-                return (location.ArchiveUrl, hash);
-            }
+            return (location.ArchiveUrl, hash);
         }
 
         throw new DotnetInstallException(
             DotnetInstallErrorCode.VersionNotFound,
-            $"Version {resolvedVersion} for {installRequest.Component} was not found in the release manifest or any known blob feed. Tried: {string.Join(", ", attemptedUrls)}",
+            $"Version {resolvedVersion} for {installRequest.Component} was not found in the release manifest or blob feed at {location.ChecksumUrl}",
             version: resolvedVersion.ToString(),
             component: installRequest.Component.ToString());
     }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -213,16 +213,20 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
 
     private (string DownloadUrl, string ExpectedHash) ResolveManifestEntry(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
     {
-        ReleaseFile? targetFile;
-        try
+        if (!_releaseManifest.TryFindReleaseFile(installRequest, resolvedVersion, out var targetFile))
         {
-            targetFile = _releaseManifest.FindReleaseFile(installRequest, resolvedVersion);
-        }
-        catch (DotnetInstallException ex) when (ShouldFallbackToBlobFeed(ex, installRequest, resolvedVersion))
-        {
-            // Manifest doesn't list this version (typical for daily/preview builds).
-            // Fall back to constructed blob feed URLs.
-            return ResolveBlobFeedEntry(installRequest, resolvedVersion);
+            // Manifest doesn't list this version. For fully-specified prerelease
+            // versions, try the public blob feed (typical for daily/preview builds).
+            if (ShouldFallbackToBlobFeed(installRequest, resolvedVersion))
+            {
+                return ResolveBlobFeedEntry(installRequest, resolvedVersion);
+            }
+
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.VersionNotFound,
+                $"No release found for version {resolvedVersion}",
+                version: resolvedVersion.ToString(),
+                component: installRequest.Component.ToString());
         }
 
         if (targetFile == null)
@@ -259,23 +263,16 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
     }
 
     /// <summary>
-    /// Returns true if the manifest miss should fall back to the blob feeds.
+    /// Returns true if a manifest miss should fall back to the blob feed.
     /// We only fall back when the user gave us an exact prerelease version
     /// (e.g. <c>10.0.100-preview.4.25216.37</c>) and the manifest doesn't yet
     /// know about it. Stable versions and named channels (e.g. "preview") are
     /// served only from the manifest so that real misses surface as errors.
     /// </summary>
     private static bool ShouldFallbackToBlobFeed(
-        DotnetInstallException ex,
         DotnetInstallRequest installRequest,
         ReleaseVersion resolvedVersion)
     {
-        if (ex.ErrorCode != DotnetInstallErrorCode.VersionNotFound &&
-            ex.ErrorCode != DotnetInstallErrorCode.ReleaseNotFound)
-        {
-            return false;
-        }
-
         if (!installRequest.Channel.IsFullySpecifiedVersion())
         {
             return false;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -333,7 +333,7 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
 
     /// <summary>
     /// Downloads and parses a .sha512 hash file. Returns null if the URL 404s
-    /// (try the next feed). Throws for any other error.
+    /// (the version is not published to the blob feed). Throws for any other error.
     /// </summary>
     private string? TryGetHashFromUrl(string checksumUrl, ReleaseVersion resolvedVersion, InstallComponent component)
     {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -15,6 +15,7 @@ internal class DotnetArchiveExtractor : IDisposable
     private readonly IArchiveDownloader _archiveDownloader;
     private readonly bool _shouldDisposeDownloader;
     private readonly bool _ownsProgressReporter = true;
+    private readonly int _versionDisplayWidth;
     private MuxerHandler? MuxerHandler { get; set; }
     private string? _archivePath;
     private IProgressReporter? _progressReporter;
@@ -31,8 +32,9 @@ internal class DotnetArchiveExtractor : IDisposable
         ReleaseManifest releaseManifest,
         IProgressTarget progressTarget,
         IArchiveDownloader? archiveDownloader = null,
-        string? cacheDirectory = null)
-        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory)
+        string? cacheDirectory = null,
+        int versionDisplayWidth = 0)
+        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, versionDisplayWidth)
     {
         _progressTarget = progressTarget;
     }
@@ -47,8 +49,9 @@ internal class DotnetArchiveExtractor : IDisposable
         ReleaseManifest releaseManifest,
         IProgressReporter sharedReporter,
         IArchiveDownloader? archiveDownloader = null,
-        string? cacheDirectory = null)
-        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory)
+        string? cacheDirectory = null,
+        int versionDisplayWidth = 0)
+        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, versionDisplayWidth)
     {
         _progressReporter = sharedReporter;
         _ownsProgressReporter = false;
@@ -59,10 +62,12 @@ internal class DotnetArchiveExtractor : IDisposable
         ReleaseVersion resolvedVersion,
         ReleaseManifest releaseManifest,
         IArchiveDownloader? archiveDownloader,
-        string? cacheDirectory = null)
+        string? cacheDirectory = null,
+        int versionDisplayWidth = 0)
     {
         _request = request;
         _resolvedVersion = resolvedVersion;
+        _versionDisplayWidth = versionDisplayWidth;
         ScratchDownloadDirectory = Directory.CreateTempSubdirectory().FullName;
 
         if (archiveDownloader != null)
@@ -89,7 +94,7 @@ internal class DotnetArchiveExtractor : IDisposable
     /// </summary>
     private IProgressReporter ProgressReporter => _progressReporter ??= _progressTarget!.CreateProgressReporter();
 
-    private ExtractorProgressTracker ProgressTracker { get => field ??= new ExtractorProgressTracker(ProgressReporter, _request.Component, _resolvedVersion.ToString()); }
+    private ExtractorProgressTracker ProgressTracker { get => field ??= new ExtractorProgressTracker(ProgressReporter, _request.Component, _resolvedVersion.ToString(), _versionDisplayWidth); }
 
     public void Prepare()
     {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -32,28 +32,27 @@ internal class DotnetArchiveExtractor : IDisposable
         ReleaseManifest releaseManifest,
         IProgressTarget progressTarget,
         IArchiveDownloader? archiveDownloader = null,
-        string? cacheDirectory = null,
-        int versionDisplayWidth = 0)
-        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, versionDisplayWidth)
+        string? cacheDirectory = null)
+        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, versionDisplayWidth: resolvedVersion.ToString().Length)
     {
         _progressTarget = progressTarget;
     }
 
     /// <summary>
-    /// Constructor that accepts a shared IProgressReporter, allowing multiple extractors
-    /// to display progress tasks within the same progress widget.
+    /// Constructor for batched installs. The supplied <see cref="InstallBatchContext"/> carries
+    /// the shared progress reporter (so multiple extractors render tasks in the same widget) and
+    /// the batch's version-display width (so progress rows align across differing version lengths).
     /// </summary>
     public DotnetArchiveExtractor(
         DotnetInstallRequest request,
         ReleaseVersion resolvedVersion,
         ReleaseManifest releaseManifest,
-        IProgressReporter sharedReporter,
+        InstallBatchContext batchContext,
         IArchiveDownloader? archiveDownloader = null,
-        string? cacheDirectory = null,
-        int versionDisplayWidth = 0)
-        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, versionDisplayWidth)
+        string? cacheDirectory = null)
+        : this(request, resolvedVersion, releaseManifest, archiveDownloader, cacheDirectory, batchContext.VersionDisplayWidth)
     {
-        _progressReporter = sharedReporter;
+        _progressReporter = batchContext.Reporter;
         _ownsProgressReporter = false;
     }
 
@@ -62,8 +61,8 @@ internal class DotnetArchiveExtractor : IDisposable
         ReleaseVersion resolvedVersion,
         ReleaseManifest releaseManifest,
         IArchiveDownloader? archiveDownloader,
-        string? cacheDirectory = null,
-        int versionDisplayWidth = 0)
+        string? cacheDirectory,
+        int versionDisplayWidth)
     {
         _request = request;
         _resolvedVersion = resolvedVersion;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ExtractorProgressTracker.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ExtractorProgressTracker.cs
@@ -13,12 +13,14 @@ internal sealed class ExtractorProgressTracker
     private readonly IProgressReporter _reporter;
     private readonly InstallComponent _component;
     private readonly string _version;
+    private readonly int _versionDisplayWidth;
 
-    public ExtractorProgressTracker(IProgressReporter reporter, InstallComponent component, string version)
+    public ExtractorProgressTracker(IProgressReporter reporter, InstallComponent component, string version, int versionDisplayWidth = 0)
     {
         _reporter = reporter;
         _component = component;
         _version = version;
+        _versionDisplayWidth = versionDisplayWidth > 0 ? versionDisplayWidth : version.Length;
     }
 
     /// <summary>
@@ -27,7 +29,7 @@ internal sealed class ExtractorProgressTracker
     /// </summary>
     public (IProgress<DownloadProgress> Reporter, IProgressTask Task) BeginDownload()
     {
-        string description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionDownloading, _component, _version);
+        string description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionDownloading, _component, _version, _versionDisplayWidth);
         var task = _reporter.AddTask(description, 100);
         var reporter = new DownloadProgressReporter(task, description);
         return (reporter, task);
@@ -40,7 +42,7 @@ internal sealed class ExtractorProgressTracker
     {
         downloadTask.Value = 100;
         long archiveBytes = new FileInfo(archivePath).Length;
-        string downloadedDesc = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionDownloaded, _component, _version);
+        string downloadedDesc = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionDownloaded, _component, _version, _versionDisplayWidth);
         downloadTask.Description = $"{downloadedDesc} ({ProgressFormatting.FormatMB(archiveBytes)} / {ProgressFormatting.FormatMB(archiveBytes)})";
     }
 
@@ -50,7 +52,7 @@ internal sealed class ExtractorProgressTracker
     /// </summary>
     public IProgressTask BeginExtraction()
     {
-        string description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionInstalling, _component, _version);
+        string description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionInstalling, _component, _version, _versionDisplayWidth);
         // Pad to match the width of "Downloading" rows (which have an MB suffix)
         // so all progress rows stay aligned within the shared Spectre column.
         string paddedDescription = description + new string(' ', ProgressFormatting.DownloadSuffixWidth);
@@ -62,6 +64,6 @@ internal sealed class ExtractorProgressTracker
     /// </summary>
     public void CompleteExtraction(IProgressTask extractionTask)
     {
-        extractionTask.Description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionInstalled, _component, _version);
+        extractionTask.Description = ProgressFormatting.FormatProgressDescription(ProgressFormatting.ActionInstalled, _component, _version, _versionDisplayWidth);
     }
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/InstallBatchContext.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/InstallBatchContext.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Dotnet.Installation.Internal;
+
+/// <summary>
+/// Per-batch context threaded through the install pipeline so that the orchestrator,
+/// downloader/extractor, and progress tracker share the same reporter and column-alignment
+/// metadata without each layer taking them as separate parameters.
+/// </summary>
+/// <param name="Reporter">
+/// Shared progress reporter for all installs in the batch. Lifetime is owned by the caller
+/// that constructed the context.
+/// </param>
+/// <param name="VersionDisplayWidth">
+/// Minimum width for the version column in progress rows — typically the length of the
+/// longest resolved version in the batch — so mixed short/long version rows align vertically.
+/// </param>
+internal sealed record InstallBatchContext(IProgressReporter Reporter, int VersionDisplayWidth);

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
@@ -6,6 +6,36 @@ using Microsoft.Deployment.DotNet.Releases;
 namespace Microsoft.Dotnet.Installation.Internal;
 
 /// <summary>
+/// Outcome of <see cref="ReleaseManifest.TryFindReleaseFile"/>.
+/// </summary>
+internal enum FindReleaseFileStatus
+{
+    /// <summary>The release was found and a matching archive for the platform exists.</summary>
+    Found,
+
+    /// <summary>The release exists in the manifest but has no archive for the requested RID/extension.</summary>
+    NoMatchingFile,
+
+    /// <summary>No product (major.minor) for the version was found in the manifest.</summary>
+    ProductNotFound,
+
+    /// <summary>The product was found, but the specific version is not listed under it.</summary>
+    ReleaseNotFound,
+}
+
+/// <summary>
+/// Result of looking up a release file in the manifest.
+/// </summary>
+internal readonly record struct FindReleaseFileResult(FindReleaseFileStatus Status, ReleaseFile? File)
+{
+    public static FindReleaseFileResult FromFile(ReleaseFile? file) =>
+        new(file is null ? FindReleaseFileStatus.NoMatchingFile : FindReleaseFileStatus.Found, file);
+
+    public static FindReleaseFileResult ProductNotFound { get; } = new(FindReleaseFileStatus.ProductNotFound, null);
+    public static FindReleaseFileResult ReleaseNotFound { get; } = new(FindReleaseFileStatus.ReleaseNotFound, null);
+}
+
+/// <summary>
 /// Handles downloading and parsing .NET release manifests to find the correct installer/archive for a given installation.
 /// </summary>
 internal class ReleaseManifest
@@ -18,21 +48,11 @@ internal class ReleaseManifest
 
     /// <summary>
     /// Attempts to find the appropriate release file for the given installation.
+    /// Returns a <see cref="FindReleaseFileResult"/> indicating whether the
+    /// product/release/file was found. Network and parse failures are still
+    /// thrown as <see cref="DotnetInstallException"/>.
     /// </summary>
-    /// <param name="installRequest">The .NET installation request details.</param>
-    /// <param name="resolvedVersion">The resolved release version to find.</param>
-    /// <param name="file">
-    /// On return: the matching <see cref="ReleaseFile"/> if one was found, or
-    /// <c>null</c> if the release exists in the manifest but has no archive
-    /// matching the requested platform/architecture.
-    /// </param>
-    /// <returns>
-    /// <c>true</c> if the release for <paramref name="resolvedVersion"/> exists in
-    /// the manifest (regardless of whether a matching platform file was found);
-    /// <c>false</c> if the manifest does not list this version. Real failures
-    /// (network/parse errors) are thrown as <see cref="DotnetInstallException"/>.
-    /// </returns>
-    public virtual bool TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion, out ReleaseFile? file)
+    public virtual FindReleaseFileResult TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
     {
         try
         {
@@ -40,17 +60,14 @@ internal class ReleaseManifest
             var product = FindProduct(productCollection, resolvedVersion);
             if (product is null)
             {
-                file = null;
-                return false;
+                return FindReleaseFileResult.ProductNotFound;
             }
             var release = FindRelease(product, resolvedVersion, installRequest.Component);
             if (release is null)
             {
-                file = null;
-                return false;
+                return FindReleaseFileResult.ReleaseNotFound;
             }
-            file = FindMatchingFile(release, installRequest);
-            return true;
+            return FindReleaseFileResult.FromFile(FindMatchingFile(release, installRequest));
         }
         catch (HttpRequestException ex)
         {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
@@ -17,33 +17,40 @@ internal class ReleaseManifest
     }
 
     /// <summary>
-    /// Finds the appropriate release file for the given installation.
+    /// Attempts to find the appropriate release file for the given installation.
     /// </summary>
-    /// <param name="installRequest">The .NET installation request details</param>
-    /// <param name="resolvedVersion">The resolved release version to find</param>
-    /// <returns>The matching ReleaseFile, throws if none are available.</returns>
-    public virtual ReleaseFile? FindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
+    /// <param name="installRequest">The .NET installation request details.</param>
+    /// <param name="resolvedVersion">The resolved release version to find.</param>
+    /// <param name="file">
+    /// On return: the matching <see cref="ReleaseFile"/> if one was found, or
+    /// <c>null</c> if the release exists in the manifest but has no archive
+    /// matching the requested platform/architecture.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the release for <paramref name="resolvedVersion"/> exists in
+    /// the manifest (regardless of whether a matching platform file was found);
+    /// <c>false</c> if the manifest does not list this version. Real failures
+    /// (network/parse errors) are thrown as <see cref="DotnetInstallException"/>.
+    /// </returns>
+    public virtual bool TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion, out ReleaseFile? file)
     {
         try
         {
             var productCollection = GetReleasesIndex();
-            var product = FindProduct(productCollection, resolvedVersion)
-                ?? throw new DotnetInstallException(
-                    DotnetInstallErrorCode.VersionNotFound,
-                    $"No product found for version {resolvedVersion}",
-                    version: resolvedVersion.ToString(),
-                    component: installRequest.Component.ToString());
-            var release = FindRelease(product, resolvedVersion, installRequest.Component)
-                ?? throw new DotnetInstallException(
-                    DotnetInstallErrorCode.ReleaseNotFound,
-                    $"No release found for version {resolvedVersion}. Daily build versions are not yet supported.",
-                    version: resolvedVersion.ToString(),
-                    component: installRequest.Component.ToString());
-            return FindMatchingFile(release, installRequest);
-        }
-        catch (DotnetInstallException)
-        {
-            throw;
+            var product = FindProduct(productCollection, resolvedVersion);
+            if (product is null)
+            {
+                file = null;
+                return false;
+            }
+            var release = FindRelease(product, resolvedVersion, installRequest.Component);
+            if (release is null)
+            {
+                file = null;
+                return false;
+            }
+            file = FindMatchingFile(release, installRequest);
+            return true;
         }
         catch (HttpRequestException ex)
         {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ReleaseManifest.cs
@@ -22,7 +22,7 @@ internal class ReleaseManifest
     /// <param name="installRequest">The .NET installation request details</param>
     /// <param name="resolvedVersion">The resolved release version to find</param>
     /// <returns>The matching ReleaseFile, throws if none are available.</returns>
-    public ReleaseFile? FindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
+    public virtual ReleaseFile? FindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
     {
         try
         {

--- a/src/Installer/Microsoft.Dotnet.Installation/ProgressFormatting.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/ProgressFormatting.cs
@@ -50,7 +50,7 @@ public static class ProgressFormatting
     /// Pass <paramref name="versionMinWidth"/> (typically the longest version length in
     /// the current install batch) to keep mixed short/long versions aligned.
     /// </summary>
-    public static string FormatProgressDescription(string action, InstallComponent component, string version, int versionMinWidth = 8) =>
+    public static string FormatProgressDescription(string action, InstallComponent component, string version, int versionMinWidth) =>
         $"{action.PadRight(s_actionWidth)} {component.GetPaddedDisplayName()} {InstallComponentExtensions.FormatVersionForDisplay(version, versionMinWidth)}";
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/ProgressFormatting.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/ProgressFormatting.cs
@@ -47,9 +47,11 @@ public static class ProgressFormatting
     /// <summary>
     /// Builds a progress-bar description such as "Downloading aspnet (runtime)         9.0.312".
     /// Component names and versions are padded so all rows align vertically.
+    /// Pass <paramref name="versionMinWidth"/> (typically the longest version length in
+    /// the current install batch) to keep mixed short/long versions aligned.
     /// </summary>
-    public static string FormatProgressDescription(string action, InstallComponent component, string version) =>
-        $"{action.PadRight(s_actionWidth)} {component.GetPaddedDisplayName()} {InstallComponentExtensions.FormatVersionForDisplay(version)}";
+    public static string FormatProgressDescription(string action, InstallComponent component, string version, int versionMinWidth = 8) =>
+        $"{action.PadRight(s_actionWidth)} {component.GetPaddedDisplayName()} {InstallComponentExtensions.FormatVersionForDisplay(version, versionMinWidth)}";
 
     /// <summary>
     /// Formats bytes as MB, right-aligned to 8 characters (e.g. "  0.7 MB", "290.4 MB").

--- a/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
@@ -74,6 +74,11 @@ internal class InstallerOrchestratorSingleton
     /// <returns>A batch result containing both successes and per-request failures.</returns>
     public InstallBatchResult InstallMany(IReadOnlyList<ResolvedInstallRequest> requests, IProgressReporter sharedReporter)
     {
+        // Compute a shared version-display width so all rows in this batch align even
+        // when versions differ in length (e.g. stable "10.0.201" + daily "11.0.100-preview.3.26207.106").
+        int versionDisplayWidth = requests.Count == 0
+            ? 0
+            : requests.Max(r => r.ResolvedVersion.ToString().Length);
 
         var results = new List<InstallResult>();
         var failures = new List<InstallFailure>();
@@ -84,7 +89,7 @@ internal class InstallerOrchestratorSingleton
         // overlapping extraction/commit with still-running downloads.
         using var readyQueue = new System.Collections.Concurrent.BlockingCollection<PreparedInstall>();
 
-        var downloadTask = Task.Run(() => PrepareConcurrent(requests, sharedReporter, readyQueue, results, failures, fatalExceptions, installResultCollectionLock));
+        var downloadTask = Task.Run(() => PrepareConcurrent(requests, sharedReporter, readyQueue, results, failures, fatalExceptions, installResultCollectionLock, versionDisplayWidth));
         ConsumeConcurrentPreparedInstallsAndCommit(readyQueue, results, failures, fatalExceptions, installResultCollectionLock);
         downloadTask.Wait();
 
@@ -108,7 +113,8 @@ internal class InstallerOrchestratorSingleton
         List<InstallResult> results,
         List<InstallFailure> failures,
         List<Exception> fatalExceptions,
-        object installResultCollectionLock)
+        object installResultCollectionLock,
+        int versionDisplayWidth)
     {
         const int maxConcurrentDownloads = 3;
 
@@ -118,7 +124,7 @@ internal class InstallerOrchestratorSingleton
             {
                 try
                 {
-                    var prepared = PrepareInstall(request, sharedReporter, out var existingResult);
+                    var prepared = PrepareInstall(request, sharedReporter, out var existingResult, versionDisplayWidth);
                     lock (installResultCollectionLock)
                     {
                         if (prepared is not null)
@@ -226,12 +232,14 @@ internal class InstallerOrchestratorSingleton
     /// <param name="resolvedRequest">The resolved installation request with a concrete version.</param>
     /// <param name="sharedReporter">A shared progress reporter for displaying download progress.</param>
     /// <param name="alreadyInstalledResult">Set when the install is already present; null otherwise.</param>
+    /// <param name="versionDisplayWidth">Optional minimum width for the version column in progress rows. Pass the longest version length in the current batch to keep mixed-version rows aligned. Zero (default) uses the version's own length.</param>
     /// <returns>A PreparedInstall that can be committed later, or null if already installed.</returns>
 #pragma warning disable CA1822
     public PreparedInstall? PrepareInstall(
         ResolvedInstallRequest resolvedRequest,
         IProgressReporter sharedReporter,
-        out InstallResult? alreadyInstalledResult)
+        out InstallResult? alreadyInstalledResult,
+        int versionDisplayWidth = 0)
     {
         alreadyInstalledResult = null;
         var installRequest = resolvedRequest.Request;
@@ -267,7 +275,7 @@ internal class InstallerOrchestratorSingleton
             }
         }
 
-        DotnetArchiveExtractor extractor = new(installRequest, versionToInstall, releaseManifest, sharedReporter, cacheDirectory: DotnetupPaths.DownloadCacheDirectory);
+        DotnetArchiveExtractor extractor = new(installRequest, versionToInstall, releaseManifest, sharedReporter, cacheDirectory: DotnetupPaths.DownloadCacheDirectory, versionDisplayWidth: versionDisplayWidth);
         extractor.Prepare();
 
         return new PreparedInstall(resolvedRequest, install, extractor);

--- a/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
+++ b/src/Installer/dotnetup/InstallerOrchestratorSingleton.cs
@@ -38,7 +38,7 @@ internal class InstallerOrchestratorSingleton
                 // The PreparedInstall is disposed immediately — only the cache side effect matters.
                 // Use NullProgressTarget to avoid any console output from the background predownload.
                 using var reporter = new LazyProgressReporter(new NullProgressTarget());
-                using var prepared = Instance.PrepareInstall(resolvedRequest, reporter, out _);
+                using var prepared = Instance.PrepareInstall(resolvedRequest, new InstallBatchContext(reporter, resolvedRequest.ResolvedVersion.ToString().Length), out _);
             }).ConfigureAwait(false);
         }
         catch
@@ -54,7 +54,7 @@ internal class InstallerOrchestratorSingleton
     {
         IProgressTarget progressTarget = noProgress ? new NonUpdatingProgressTarget() : new SpectreProgressTarget();
         using var reporter = new LazyProgressReporter(progressTarget);
-        using var prepared = PrepareInstall(resolvedRequest, reporter, out var alreadyInstalledResult);
+        using var prepared = PrepareInstall(resolvedRequest, new InstallBatchContext(reporter, resolvedRequest.ResolvedVersion.ToString().Length), out var alreadyInstalledResult);
 
         if (alreadyInstalledResult is not null)
         {
@@ -79,6 +79,7 @@ internal class InstallerOrchestratorSingleton
         int versionDisplayWidth = requests.Count == 0
             ? 0
             : requests.Max(r => r.ResolvedVersion.ToString().Length);
+        var batchContext = new InstallBatchContext(sharedReporter, versionDisplayWidth);
 
         var results = new List<InstallResult>();
         var failures = new List<InstallFailure>();
@@ -89,7 +90,7 @@ internal class InstallerOrchestratorSingleton
         // overlapping extraction/commit with still-running downloads.
         using var readyQueue = new System.Collections.Concurrent.BlockingCollection<PreparedInstall>();
 
-        var downloadTask = Task.Run(() => PrepareConcurrent(requests, sharedReporter, readyQueue, results, failures, fatalExceptions, installResultCollectionLock, versionDisplayWidth));
+        var downloadTask = Task.Run(() => PrepareConcurrent(requests, batchContext, readyQueue, results, failures, fatalExceptions, installResultCollectionLock));
         ConsumeConcurrentPreparedInstallsAndCommit(readyQueue, results, failures, fatalExceptions, installResultCollectionLock);
         downloadTask.Wait();
 
@@ -108,13 +109,12 @@ internal class InstallerOrchestratorSingleton
     /// </summary>
     private void PrepareConcurrent(
         IReadOnlyList<ResolvedInstallRequest> requests,
-        IProgressReporter sharedReporter,
+        InstallBatchContext batchContext,
         System.Collections.Concurrent.BlockingCollection<PreparedInstall> readyQueue,
         List<InstallResult> results,
         List<InstallFailure> failures,
         List<Exception> fatalExceptions,
-        object installResultCollectionLock,
-        int versionDisplayWidth)
+        object installResultCollectionLock)
     {
         const int maxConcurrentDownloads = 3;
 
@@ -124,7 +124,7 @@ internal class InstallerOrchestratorSingleton
             {
                 try
                 {
-                    var prepared = PrepareInstall(request, sharedReporter, out var existingResult, versionDisplayWidth);
+                    var prepared = PrepareInstall(request, batchContext, out var existingResult);
                     lock (installResultCollectionLock)
                     {
                         if (prepared is not null)
@@ -230,16 +230,14 @@ internal class InstallerOrchestratorSingleton
     /// Used for concurrent multi-install scenarios where downloads happen in parallel.
     /// </summary>
     /// <param name="resolvedRequest">The resolved installation request with a concrete version.</param>
-    /// <param name="sharedReporter">A shared progress reporter for displaying download progress.</param>
+    /// <param name="batchContext">Shared per-batch progress reporter and version-column width. For single-install scenarios, pass a context whose width matches the request's version length.</param>
     /// <param name="alreadyInstalledResult">Set when the install is already present; null otherwise.</param>
-    /// <param name="versionDisplayWidth">Optional minimum width for the version column in progress rows. Pass the longest version length in the current batch to keep mixed-version rows aligned. Zero (default) uses the version's own length.</param>
     /// <returns>A PreparedInstall that can be committed later, or null if already installed.</returns>
 #pragma warning disable CA1822
     public PreparedInstall? PrepareInstall(
         ResolvedInstallRequest resolvedRequest,
-        IProgressReporter sharedReporter,
-        out InstallResult? alreadyInstalledResult,
-        int versionDisplayWidth = 0)
+        InstallBatchContext batchContext,
+        out InstallResult? alreadyInstalledResult)
     {
         alreadyInstalledResult = null;
         var installRequest = resolvedRequest.Request;
@@ -275,7 +273,7 @@ internal class InstallerOrchestratorSingleton
             }
         }
 
-        DotnetArchiveExtractor extractor = new(installRequest, versionToInstall, releaseManifest, sharedReporter, cacheDirectory: DotnetupPaths.DownloadCacheDirectory, versionDisplayWidth: versionDisplayWidth);
+        DotnetArchiveExtractor extractor = new(installRequest, versionToInstall, releaseManifest, batchContext, cacheDirectory: DotnetupPaths.DownloadCacheDirectory);
         extractor.Prepare();
 
         return new PreparedInstall(resolvedRequest, install, extractor);

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -352,6 +352,99 @@ Write-Output ""DOTNET_ROOT=$env:DOTNET_ROOT""
         dotnetRootValue.Should().Be(installPath, $"DOTNET_ROOT should be set to the install path for {shell}");
     }
 
+    /// <summary>
+    /// Exercises the blob-feed fallback path for a fully-specified prerelease SDK version
+    /// that isn't published in the release manifest. We discover the current daily-build
+    /// version via aka.ms at test time so the test stays valid as builds roll over on
+    /// ci.dot.net.
+    /// </summary>
+    [Fact]
+    public void SdkInstall_FullySpecifiedPreviewVersion_UsesBlobFeedFallback()
+    {
+        string? previewVersion = TryResolveCurrentDailyPreviewSdkVersion();
+        previewVersion.Should().NotBeNull("a daily preview SDK should be available on one of the probed dev-branch channels");
+
+        Console.WriteLine($"Resolved current daily preview SDK version: {previewVersion}");
+
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
+        var args = DotnetupTestUtilities.BuildSdkArguments(previewVersion!, testEnv.InstallPath, testEnv.ManifestPath);
+        (int exitCode, string output) = DotnetupTestUtilities.RunDotnetupProcess(args, captureOutput: true, workingDirectory: testEnv.TempRoot);
+        exitCode.Should().Be(0, $"dotnetup exited with code {exitCode}. Output:\n{output}");
+
+        // Only assert that an SDK was installed — don't pin the manifest's recorded
+        // version string, because we don't want to couple to the exact form
+        // (prerelease tag, servicing suffix, etc.) preserved through the install pipeline.
+        VerifyManifestContains(testEnv, InstallComponent.SDK);
+    }
+
+    /// <summary>
+    /// Looks up the current daily preview SDK version by following the aka.ms redirect
+    /// for the SDK archive on the channel with the highest major version in the release
+    /// manifest. If that channel doesn't yield a prerelease, probes the next-major
+    /// channel (some windows have a not-yet-listed dev branch above the manifest's
+    /// highest major).
+    /// </summary>
+    private static string? TryResolveCurrentDailyPreviewSdkVersion()
+    {
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(InstallerUtilities.GetDefaultInstallArchitecture());
+        string ext = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+
+        int latestManifestMajor = new ReleaseManifest().GetReleasesIndex()
+            .Select(product =>
+            {
+                var parts = product.ProductVersion.Split('.');
+                return int.TryParse(parts[0], out var major) ? major : 0;
+            })
+            .Max();
+
+        using var handler = new System.Net.Http.HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+        using var http = new System.Net.Http.HttpClient(handler);
+
+        // Probe the dev-branch channel above the manifest's highest major first (handles
+        // the window where the next dev branch is building daily but not yet listed in
+        // the manifest), then fall back to the manifest's highest major (the dev branch
+        // for a not-yet-GA major is already there).
+        foreach (int probeMajor in new[] { latestManifestMajor + 1, latestManifestMajor })
+        {
+            string channel = $"{probeMajor}.0";
+            var akaMsUrl = $"https://aka.ms/dotnet/{channel}/daily/dotnet-sdk-{rid}{ext}";
+            try
+            {
+                using var response = http.GetAsync(akaMsUrl, System.Net.Http.HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+                if (!response.IsSuccessStatusCode)
+                {
+                    continue;
+                }
+
+                var finalUri = response.RequestMessage?.RequestUri;
+                if (finalUri is null)
+                {
+                    continue;
+                }
+
+                // Path looks like .../Sdk/<version>/dotnet-sdk-<version>-<rid>.<ext>.
+                // Pull the first segment that parses as a prerelease ReleaseVersion —
+                // skip stable versions (the channel redirected to a servicing build,
+                // not a daily preview).
+                foreach (var segment in finalUri.Segments)
+                {
+                    var trimmed = segment.Trim('/');
+                    if (ReleaseVersion.TryParse(trimmed, out var parsed)
+                        && !string.IsNullOrEmpty(parsed.Prerelease))
+                    {
+                        return trimmed;
+                    }
+                }
+            }
+            catch (System.Net.Http.HttpRequestException)
+            {
+                // Try the next major.
+            }
+        }
+
+        return null;
+    }
+
     private static void VerifyManifestContains(TestEnvironment testEnv, InstallComponent expectedComponent, Action<Installation>? additionalAssertions = null)
     {
         Directory.Exists(testEnv.InstallPath).Should().BeTrue();

--- a/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
@@ -115,7 +115,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
             [$"https://ci.dot.net/public-checksums/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash + "\n"),
         });
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
         var (url, hash) = InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version));
 
@@ -134,7 +135,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
         const string version = "10.0.100";
         var (handler, history) = BuildHandler(new());
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
         var ex = Assert.Throws<DotnetInstallException>(() =>
             InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version)));
@@ -154,7 +156,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
         const string resolved = "10.0.100-preview.4.25216.37";
         var (handler, history) = BuildHandler(new());
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
         var ex = Assert.Throws<DotnetInstallException>(() =>
             InvokeResolveManifestEntry(downloader, BuildRequest(channel, InstallComponent.SDK), new ReleaseVersion(resolved)));
@@ -174,7 +177,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
         const string resolved = "10.0.100-preview.4.25216.37";
         var (handler, _) = BuildHandler(new());
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.ReleaseNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.ReleaseNotFound);
 
         var ex = Assert.Throws<DotnetInstallException>(() =>
             InvokeResolveManifestEntry(downloader, BuildRequest(channel, InstallComponent.SDK), new ReleaseVersion(resolved)));
@@ -191,7 +195,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
         const string version = "10.0.100-preview.4.25216.37";
         var (handler, history) = BuildHandler(new());
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
         var ex = Assert.Throws<DotnetInstallException>(() =>
             InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version)));
@@ -216,7 +221,8 @@ public class DotnetArchiveDownloaderBlobFeedTests
             [$"https://ci.dot.net/public-checksums/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash),
         });
 
-        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+        using var http = new HttpClient(handler);
+        using var downloader = CreateDownloader(http, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
         var (url, hash) = InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.Runtime), new ReleaseVersion(version));
 
@@ -232,10 +238,9 @@ public class DotnetArchiveDownloaderBlobFeedTests
         return new DotnetInstallRequest(root, new UpdateChannel(channel), component, new InstallRequestOptions());
     }
 
-    private static DotnetArchiveDownloader CreateDownloader(HttpMessageHandler handler, DotnetInstallErrorCode manifestThrows)
+    private static DotnetArchiveDownloader CreateDownloader(HttpClient http, DotnetInstallErrorCode manifestThrows)
     {
         var manifest = new ThrowingReleaseManifest(manifestThrows);
-        var http = new HttpClient(handler);
         // Use a per-test cache directory so we don't pollute the user cache.
         var cacheDir = Path.Combine(Path.GetTempPath(), "dotnetup-test-cache-" + Guid.NewGuid().ToString("N"));
         return new DotnetArchiveDownloader(manifest, http, cacheDir);

--- a/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Dotnet.Installation;
+using Microsoft.Dotnet.Installation.Internal;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
+
+/// <summary>
+/// Tests for the blob feed fallback path used when the release manifest does
+/// not list the requested version (e.g. daily/preview builds).
+/// </summary>
+public class DotnetArchiveDownloaderBlobFeedTests
+{
+    private readonly ITestOutputHelper _log;
+
+    public DotnetArchiveDownloaderBlobFeedTests(ITestOutputHelper log)
+    {
+        _log = log;
+    }
+
+    [Theory]
+    [InlineData(InstallComponent.SDK, "Sdk", "dotnet-sdk")]
+    [InlineData(InstallComponent.Runtime, "Runtime", "dotnet-runtime")]
+    [InlineData(InstallComponent.ASPNETCore, "aspnetcore/Runtime", "aspnetcore-runtime")]
+    [InlineData(InstallComponent.WindowsDesktop, "WindowsDesktop", "windowsdesktop-runtime")]
+    public void GetFeedLocations_BuildsExpectedUrls(InstallComponent component, string expectedDir, string expectedPrefix)
+    {
+        var version = new ReleaseVersion("10.0.100-preview.4.25216.37");
+        const string rid = "win-x64";
+        const string ext = ".zip";
+
+        var locations = BlobFeedUrlBuilder.GetFeedLocations(component, version, rid, ext).ToList();
+        locations.Should().HaveCount(2, "should produce primary then fallback locations");
+
+        string expectedFile = $"{expectedPrefix}-10.0.100-preview.4.25216.37-win-x64.zip";
+
+        locations[0].ArchiveUrl.Should().Be(
+            $"https://builds.dotnet.microsoft.com/dotnet/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}");
+        locations[0].ChecksumUrl.Should().Be(
+            $"https://builds.dotnet.microsoft.com/dotnet/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}.sha512");
+
+        locations[1].ArchiveUrl.Should().Be(
+            $"https://ci.dot.net/public/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}");
+        locations[1].ChecksumUrl.Should().Be(
+            $"https://ci.dot.net/public-checksums/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}.sha512");
+    }
+
+    [Fact]
+    public void ParseHashFile_ReturnsHashFromBareHexLine()
+    {
+        string hash = new string('a', 128);
+        BlobFeedUrlBuilder.ParseHashFile(hash).Should().Be(hash);
+    }
+
+    [Fact]
+    public void ParseHashFile_HandlesTrailingWhitespace()
+    {
+        string hash = new string('b', 128);
+        BlobFeedUrlBuilder.ParseHashFile(hash + "\r\n").Should().Be(hash);
+        BlobFeedUrlBuilder.ParseHashFile("  " + hash + "  ").Should().Be(hash);
+    }
+
+    [Fact]
+    public void ParseHashFile_HandlesShasum512Format()
+    {
+        string hash = new string('c', 128);
+        BlobFeedUrlBuilder.ParseHashFile($"{hash}  dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip\n")
+            .Should().Be(hash);
+    }
+
+    [Fact]
+    public void ParseHashFile_LowercasesHash()
+    {
+        string upper = new string('A', 128);
+        string lower = new string('a', 128);
+        BlobFeedUrlBuilder.ParseHashFile(upper).Should().Be(lower);
+    }
+
+    [Fact]
+    public void ParseHashFile_RejectsWrongLength()
+    {
+        Assert.Throws<FormatException>(() => BlobFeedUrlBuilder.ParseHashFile(new string('a', 64)));
+    }
+
+    [Fact]
+    public void ParseHashFile_RejectsNonHex()
+    {
+        // 128 chars including 'g' (not hex)
+        string bad = new string('a', 127) + "g";
+        Assert.Throws<FormatException>(() => BlobFeedUrlBuilder.ParseHashFile(bad));
+    }
+
+    [Fact]
+    public void ParseHashFile_RejectsEmpty()
+    {
+        Assert.Throws<FormatException>(() => BlobFeedUrlBuilder.ParseHashFile(""));
+        Assert.Throws<FormatException>(() => BlobFeedUrlBuilder.ParseHashFile("   \r\n"));
+    }
+
+    /// <summary>
+    /// When the user supplies a fully specified prerelease version that is not
+    /// in the release manifest, the downloader should fall back to the blob feeds.
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_FallsBackToBlobFeed_ForUnknownPrerelease()
+    {
+        const string version = "10.0.100-preview.4.25216.37";
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(InstallArchitecture.x64);
+        string ext = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+        string expectedHash = new string('d', 128);
+        var (handler, history) = BuildHandler(new()
+        {
+            // Primary feed checksum: 404
+            [$"https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
+            // Fallback feed checksum: 200
+            [$"https://ci.dot.net/public-checksums/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash + "\n"),
+        });
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+
+        var (url, hash) = InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version));
+
+        url.Should().Be($"https://ci.dot.net/public/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}");
+        hash.Should().Be(expectedHash);
+        history.Should().HaveCount(2, "should probe primary then fallback");
+    }
+
+    /// <summary>
+    /// Manifest miss for a stable (non-prerelease) version must NOT fall back to
+    /// blob feeds — it's a real error.
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_DoesNotFallback_ForStableVersion()
+    {
+        const string version = "10.0.100";
+        var (handler, history) = BuildHandler(new());
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+
+        var ex = Assert.Throws<DotnetInstallException>(() =>
+            InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version)));
+
+        ex.ErrorCode.Should().Be(DotnetInstallErrorCode.VersionNotFound);
+        history.Should().BeEmpty("blob feeds must not be probed for stable versions");
+    }
+
+    /// <summary>
+    /// When the channel string is not a fully specified version (e.g. "preview"),
+    /// a manifest miss is a real error — don't probe blob feeds.
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_DoesNotFallback_ForNamedChannel()
+    {
+        const string channel = "preview";
+        const string resolved = "10.0.100-preview.4.25216.37";
+        var (handler, history) = BuildHandler(new());
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+
+        var ex = Assert.Throws<DotnetInstallException>(() =>
+            InvokeResolveManifestEntry(downloader, BuildRequest(channel, InstallComponent.SDK), new ReleaseVersion(resolved)));
+
+        ex.ErrorCode.Should().Be(DotnetInstallErrorCode.VersionNotFound);
+        history.Should().BeEmpty("named channel misses must not fall back to blob feeds");
+    }
+
+    /// <summary>
+    /// If both feeds 404 the .sha512 file, surface a clear VersionNotFound error.
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_BothFeeds404_ThrowsVersionNotFound()
+    {
+        const string version = "10.0.100-preview.4.25216.37";
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(InstallArchitecture.x64);
+        string ext = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+        var (handler, history) = BuildHandler(new()
+        {
+            [$"https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
+            [$"https://ci.dot.net/public-checksums/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
+        });
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+
+        var ex = Assert.Throws<DotnetInstallException>(() =>
+            InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.SDK), new ReleaseVersion(version)));
+
+        ex.ErrorCode.Should().Be(DotnetInstallErrorCode.VersionNotFound);
+        ex.Message.Should().Contain(version);
+        history.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Runtime-shaped versions (patch &lt; 100) fall back correctly to the Runtime feed path.
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_FallsBackToRuntimeFeed_ForRuntimeVersion()
+    {
+        const string version = "10.0.0-preview.4.25216.10";
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(InstallArchitecture.x64);
+        string ext = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+        string expectedHash = new string('e', 128);
+        var (handler, _) = BuildHandler(new()
+        {
+            [$"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
+            [$"https://ci.dot.net/public-checksums/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash),
+        });
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
+
+        var (url, hash) = InvokeResolveManifestEntry(downloader, BuildRequest(version, InstallComponent.Runtime), new ReleaseVersion(version));
+
+        url.Should().Be($"https://ci.dot.net/public/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}");
+        hash.Should().Be(expectedHash);
+    }
+
+    // --- Test helpers ---
+
+    private static DotnetInstallRequest BuildRequest(string channel, InstallComponent component)
+    {
+        var root = new DotnetInstallRoot(@"C:\dotnet-test", InstallArchitecture.x64);
+        return new DotnetInstallRequest(root, new UpdateChannel(channel), component, new InstallRequestOptions());
+    }
+
+    private static DotnetArchiveDownloader CreateDownloader(HttpMessageHandler handler, DotnetInstallErrorCode manifestThrows)
+    {
+        var manifest = new ThrowingReleaseManifest(manifestThrows);
+        var http = new HttpClient(handler);
+        // Use a per-test cache directory so we don't pollute the user cache.
+        var cacheDir = Path.Combine(Path.GetTempPath(), "dotnetup-test-cache-" + Guid.NewGuid().ToString("N"));
+        return new DotnetArchiveDownloader(manifest, http, cacheDir);
+    }
+
+    private static (string DownloadUrl, string ExpectedHash) InvokeResolveManifestEntry(
+        DotnetArchiveDownloader downloader,
+        DotnetInstallRequest request,
+        ReleaseVersion resolvedVersion)
+    {
+        var method = typeof(DotnetArchiveDownloader).GetMethod("ResolveManifestEntry",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        method.Should().NotBeNull("ResolveManifestEntry must exist on DotnetArchiveDownloader");
+
+        try
+        {
+            var result = method!.Invoke(downloader, new object[] { request, resolvedVersion });
+            // Tuple comes back as ValueTuple<string, string>; unpack via reflection-friendly cast.
+            var tuple = ((string DownloadUrl, string ExpectedHash))result!;
+            return tuple;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;
+        }
+    }
+
+    private static (RecordingHandler Handler, List<string> History) BuildHandler(Dictionary<string, (HttpStatusCode, string)> responses)
+    {
+        var history = new List<string>();
+        var handler = new RecordingHandler(responses, history);
+        return (handler, history);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, (HttpStatusCode, string)> _responses;
+        private readonly List<string> _history;
+
+        public RecordingHandler(Dictionary<string, (HttpStatusCode, string)> responses, List<string> history)
+        {
+            _responses = responses;
+            _history = history;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.ToString();
+            _history.Add(url);
+
+            if (_responses.TryGetValue(url, out var entry))
+            {
+                var resp = new HttpResponseMessage(entry.Item1)
+                {
+                    Content = new StringContent(entry.Item2, Encoding.UTF8, "text/plain"),
+                };
+                return Task.FromResult(resp);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class ThrowingReleaseManifest : ReleaseManifest
+    {
+        private readonly DotnetInstallErrorCode _code;
+
+        public ThrowingReleaseManifest(DotnetInstallErrorCode code)
+        {
+            _code = code;
+        }
+
+        public override ReleaseFile? FindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
+        {
+            throw new DotnetInstallException(
+                _code,
+                $"Test stub: manifest does not contain {resolvedVersion}",
+                version: resolvedVersion.ToString(),
+                component: installRequest.Component.ToString());
+        }
+    }
+}

--- a/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
@@ -31,25 +31,19 @@ public class DotnetArchiveDownloaderBlobFeedTests
     [InlineData(InstallComponent.Runtime, "Runtime", "dotnet-runtime")]
     [InlineData(InstallComponent.ASPNETCore, "aspnetcore/Runtime", "aspnetcore-runtime")]
     [InlineData(InstallComponent.WindowsDesktop, "WindowsDesktop", "windowsdesktop-runtime")]
-    public void GetFeedLocations_BuildsExpectedUrls(InstallComponent component, string expectedDir, string expectedPrefix)
+    public void GetFeedLocation_BuildsExpectedUrls(InstallComponent component, string expectedDir, string expectedPrefix)
     {
         var version = new ReleaseVersion("10.0.100-preview.4.25216.37");
         const string rid = "win-x64";
         const string ext = ".zip";
 
-        var locations = BlobFeedUrlBuilder.GetFeedLocations(component, version, rid, ext).ToList();
-        locations.Should().HaveCount(2, "should produce primary then fallback locations");
+        var location = BlobFeedUrlBuilder.GetFeedLocation(component, version, rid, ext);
 
         string expectedFile = $"{expectedPrefix}-10.0.100-preview.4.25216.37-win-x64.zip";
 
-        locations[0].ArchiveUrl.Should().Be(
-            $"https://builds.dotnet.microsoft.com/dotnet/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}");
-        locations[0].ChecksumUrl.Should().Be(
-            $"https://builds.dotnet.microsoft.com/dotnet/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}.sha512");
-
-        locations[1].ArchiveUrl.Should().Be(
+        location.ArchiveUrl.Should().Be(
             $"https://ci.dot.net/public/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}");
-        locations[1].ChecksumUrl.Should().Be(
+        location.ChecksumUrl.Should().Be(
             $"https://ci.dot.net/public-checksums/{expectedDir}/10.0.100-preview.4.25216.37/{expectedFile}.sha512");
     }
 
@@ -107,7 +101,7 @@ public class DotnetArchiveDownloaderBlobFeedTests
 
     /// <summary>
     /// When the user supplies a fully specified prerelease version that is not
-    /// in the release manifest, the downloader should fall back to the blob feeds.
+    /// in the release manifest, the downloader should fall back to the blob feed.
     /// </summary>
     [Fact]
     public void ResolveManifestEntry_FallsBackToBlobFeed_ForUnknownPrerelease()
@@ -118,9 +112,6 @@ public class DotnetArchiveDownloaderBlobFeedTests
         string expectedHash = new string('d', 128);
         var (handler, history) = BuildHandler(new()
         {
-            // Primary feed checksum: 404
-            [$"https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
-            // Fallback feed checksum: 200
             [$"https://ci.dot.net/public-checksums/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash + "\n"),
         });
 
@@ -130,7 +121,7 @@ public class DotnetArchiveDownloaderBlobFeedTests
 
         url.Should().Be($"https://ci.dot.net/public/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}");
         hash.Should().Be(expectedHash);
-        history.Should().HaveCount(2, "should probe primary then fallback");
+        history.Should().HaveCount(1, "should probe blob feed once");
     }
 
     /// <summary>
@@ -176,16 +167,10 @@ public class DotnetArchiveDownloaderBlobFeedTests
     /// If both feeds 404 the .sha512 file, surface a clear VersionNotFound error.
     /// </summary>
     [Fact]
-    public void ResolveManifestEntry_BothFeeds404_ThrowsVersionNotFound()
+    public void ResolveManifestEntry_BlobFeed404_ThrowsVersionNotFound()
     {
         const string version = "10.0.100-preview.4.25216.37";
-        string rid = DotnetupUtilities.GetRuntimeIdentifier(InstallArchitecture.x64);
-        string ext = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
-        var (handler, history) = BuildHandler(new()
-        {
-            [$"https://builds.dotnet.microsoft.com/dotnet/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
-            [$"https://ci.dot.net/public-checksums/Sdk/{version}/dotnet-sdk-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
-        });
+        var (handler, history) = BuildHandler(new());
 
         using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.VersionNotFound);
 
@@ -194,7 +179,7 @@ public class DotnetArchiveDownloaderBlobFeedTests
 
         ex.ErrorCode.Should().Be(DotnetInstallErrorCode.VersionNotFound);
         ex.Message.Should().Contain(version);
-        history.Should().HaveCount(2);
+        history.Should().HaveCount(1);
     }
 
     /// <summary>
@@ -209,7 +194,6 @@ public class DotnetArchiveDownloaderBlobFeedTests
         string expectedHash = new string('e', 128);
         var (handler, _) = BuildHandler(new()
         {
-            [$"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.NotFound, ""),
             [$"https://ci.dot.net/public-checksums/Runtime/{version}/dotnet-runtime-{version}-{rid}{ext}.sha512"] = (HttpStatusCode.OK, expectedHash),
         });
 

--- a/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
@@ -289,11 +289,20 @@ public class DotnetArchiveDownloaderBlobFeedTests
             _code = code;
         }
 
-        public override ReleaseFile? FindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
+        public override bool TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion, out ReleaseFile? file)
         {
+            // Existing tests pass VersionNotFound to model "manifest does not have this version".
+            // For that case we now indicate the miss via the bool return rather than throwing.
+            if (_code == DotnetInstallErrorCode.VersionNotFound ||
+                _code == DotnetInstallErrorCode.ReleaseNotFound)
+            {
+                file = null;
+                return false;
+            }
+
             throw new DotnetInstallException(
                 _code,
-                $"Test stub: manifest does not contain {resolvedVersion}",
+                $"Test stub: manifest failure for {resolvedVersion}",
                 version: resolvedVersion.ToString(),
                 component: installRequest.Component.ToString());
         }

--- a/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
+++ b/test/dotnetup.Tests/DotnetArchiveDownloaderBlobFeedTests.cs
@@ -164,6 +164,25 @@ public class DotnetArchiveDownloaderBlobFeedTests
     }
 
     /// <summary>
+    /// When the product is in the manifest but the specific release is not, the
+    /// thrown error must surface as ReleaseNotFound (distinct from VersionNotFound).
+    /// </summary>
+    [Fact]
+    public void ResolveManifestEntry_ReleaseNotFound_PreservedDistinctlyFromVersionNotFound()
+    {
+        const string channel = "preview";
+        const string resolved = "10.0.100-preview.4.25216.37";
+        var (handler, _) = BuildHandler(new());
+
+        using var downloader = CreateDownloader(handler, manifestThrows: DotnetInstallErrorCode.ReleaseNotFound);
+
+        var ex = Assert.Throws<DotnetInstallException>(() =>
+            InvokeResolveManifestEntry(downloader, BuildRequest(channel, InstallComponent.SDK), new ReleaseVersion(resolved)));
+
+        ex.ErrorCode.Should().Be(DotnetInstallErrorCode.ReleaseNotFound);
+    }
+
+    /// <summary>
     /// If both feeds 404 the .sha512 file, surface a clear VersionNotFound error.
     /// </summary>
     [Fact]
@@ -289,22 +308,18 @@ public class DotnetArchiveDownloaderBlobFeedTests
             _code = code;
         }
 
-        public override bool TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion, out ReleaseFile? file)
+        public override FindReleaseFileResult TryFindReleaseFile(DotnetInstallRequest installRequest, ReleaseVersion resolvedVersion)
         {
-            // Existing tests pass VersionNotFound to model "manifest does not have this version".
-            // For that case we now indicate the miss via the bool return rather than throwing.
-            if (_code == DotnetInstallErrorCode.VersionNotFound ||
-                _code == DotnetInstallErrorCode.ReleaseNotFound)
+            return _code switch
             {
-                file = null;
-                return false;
-            }
-
-            throw new DotnetInstallException(
-                _code,
-                $"Test stub: manifest failure for {resolvedVersion}",
-                version: resolvedVersion.ToString(),
-                component: installRequest.Component.ToString());
+                DotnetInstallErrorCode.VersionNotFound => FindReleaseFileResult.ProductNotFound,
+                DotnetInstallErrorCode.ReleaseNotFound => FindReleaseFileResult.ReleaseNotFound,
+                _ => throw new DotnetInstallException(
+                    _code,
+                    $"Test stub: manifest failure for {resolvedVersion}",
+                    version: resolvedVersion.ToString(),
+                    component: installRequest.Component.ToString()),
+            };
         }
     }
 }


### PR DESCRIPTION
Phase 1 of the [Installing daily/nightly builds with dotnetup](https://github.com/dotnet/sdk/blob/release/dnup/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md) design.

## What this enables

Users can pass a fully-specified prerelease version (e.g. `11.0.100-preview.3.26207.106`) to `dotnetup install`, and dotnetup will fall back to the public `ci.dot.net` blob feed when the version is not yet published to the release manifest.

## Scope of Phase 1

- **Blob feed fallback only when needed.** Stable versions and named channels (e.g. `preview`) still resolve from the manifest only, so real misses surface as `VersionNotFound` rather than silently going to the blob feed.
- **No new channel syntax.** Channel parsing (e.g. `10.0-daily`) and "latest daily" resolution are deferred to Phase 2.
- **Existence probe via `.sha512`.** The presence of the checksum file is treated as proof the archive is published. This matches how dotnet blob feeds are populated.

## Code changes

- Adds `BlobFeedUrlBuilder` (new) — constructs `ci.dot.net` archive + `.sha512` URLs for a given component / version / RID / archive extension.
- `DotnetArchiveDownloader` — when the manifest doesn't have an entry, decides whether the request is eligible for blob-feed fallback (fully-specified prerelease versions only), probes the `.sha512`, and returns `(archiveUrl, expectedHash)` for the existing download path. Genuine errors (network, parse) are preserved with their original error codes; only 404 on the `.sha512` is treated as "not published".
- `ReleaseManifest` — refactored from throwing on miss to a Try-pattern (`FindReleaseFileResult`) so the fallback path doesn't have to use exceptions for control flow and so original error codes survive.
- `ProgressFormatting` / `InstallComponentExtensions.FormatVersionForDisplay` — no longer truncates long versions like `11.0.100-preview.3.26207.106` to `..07.106`. The version column is sized to the longer of the version's own length or a per-batch minimum, threaded from `InstallerOrchestratorSingleton.InstallMany` through `DotnetArchiveExtractor` → `ExtractorProgressTracker`. Single-install paths default to the version's own length.
- New tests: `DotnetArchiveDownloaderBlobFeedTests` covers the eligibility rules, hash fetch, hash parse failure, network failure, and verifies that genuine errors aren't masked as `VersionNotFound` by the fallback.

## Out of scope (later phases)

- Daily channel syntax (e.g. `10.0-daily`) and "latest daily" resolution (Phase 2).
- Listing/browsing daily builds via NuGet `dotnet{major}-transport` feeds (Phase 3).

## Testing

- Existing `dotnetup.Tests` suite still green (795 passed, 3 skipped).
