### PR TITLE
Add COPILOT_CLI env var to LLM environment detection

### DIFF
--- a/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
@@ -15,10 +15,10 @@ internal class LLMEnvironmentDetectorForTelemetry : ILLMEnvironmentDetector
         new EnvironmentDetectionRuleWithResult<string>("cursor", new AnyPresentEnvironmentRule("CURSOR_EDITOR", "CURSOR_AI")),
         // Gemini
         new EnvironmentDetectionRuleWithResult<string>("gemini", new BooleanEnvironmentRule("GEMINI_CLI")),
-        // GitHub Copilot (legacy gh extension: GITHUB_COPILOT_CLI_MODE=true; new Copilot CLI: GH_COPILOT_WORKING_DIRECTORY is set)
+        // GitHub Copilot (legacy gh extension: GITHUB_COPILOT_CLI_MODE=true; new Copilot CLI: GH_COPILOT_WORKING_DIRECTORY or COPILOT_CLI is set)
         new EnvironmentDetectionRuleWithResult<string>("copilot", new AnyMatchEnvironmentRule(
             new BooleanEnvironmentRule("GITHUB_COPILOT_CLI_MODE"),
-            new AnyPresentEnvironmentRule("GH_COPILOT_WORKING_DIRECTORY"))),
+            new AnyPresentEnvironmentRule("GH_COPILOT_WORKING_DIRECTORY", "COPILOT_CLI"))),
         // Codex CLI
         new EnvironmentDetectionRuleWithResult<string>("codex", new AnyPresentEnvironmentRule("CODEX_CLI", "CODEX_SANDBOX")),
         // Aider

--- a/test/dotnet.Tests/TelemetryTests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryCommonPropertiesTests.cs
@@ -237,6 +237,7 @@ public class TelemetryCommonPropertiesTests : SdkTest
         { new Dictionary<string, string> { { "GEMINI_CLI", "true" } }, "gemini" },
         { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
         { new Dictionary<string, string> { { "GH_COPILOT_WORKING_DIRECTORY", "/repo" } }, "copilot" },
+        { new Dictionary<string, string> { { "COPILOT_CLI", "1" } }, "copilot" },
         { new Dictionary<string, string> { { "CODEX_CLI", "1" } }, "codex" },
         { new Dictionary<string, string> { { "CODEX_SANDBOX", "1" } }, "codex" },
         { new Dictionary<string, string> { { "OR_APP_NAME", "Aider" } }, "aider" },


### PR DESCRIPTION
The Copilot CLI sets a COPILOT_CLI environment variable, but the telemetry detector was only checking for GITHUB_COPILOT_CLI_MODE and GH_COPILOT_WORKING_DIRECTORY. Add COPILOT_CLI to the AnyPresentEnvironmentRule so the detector correctly identifies Copilot CLI sessions.