### PR TITLE
Add source fallback retry logic to NuGet package downloader

### DIFF
--- a/src/Cli/dotnet/CliStrings.resx
+++ b/src/Cli/dotnet/CliStrings.resx
@@ -474,6 +474,9 @@ setx PATH "%PATH%;{0}"
     <value>Failed to validate package signing.
 {0}</value>
   </data>
+  <data name="PackageDownloadFailedFromSource" xml:space="preserve">
+    <value>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</value>
+  </data>
   <data name="FieldCommandsIsMissing" xml:space="preserve">
     <value>Missing 'commands' entry.</value>
   </data>

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -101,20 +101,11 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
     {
         CancellationToken cancellationToken = CancellationToken.None;
 
+        IEnumerable<PackageSource> allSources = LoadNuGetSources(packageId, packageSourceLocation, packageSourceMapping);
+        bool resolvedIncludeUnlisted = includeUnlisted ?? packageVersion is not null;
+
         (var source, var resolvedPackageVersion) = await GetPackageSourceAndVersion(packageId, packageVersion,
-            packageSourceLocation, includePreview, includeUnlisted ?? packageVersion is not null, packageSourceMapping).ConfigureAwait(false);
-
-        FindPackageByIdResource resource = null;
-        SourceRepository repository = GetSourceRepository(source);
-
-        resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken)
-            .ConfigureAwait(false);
-
-        if (resource == null)
-        {
-            throw new NuGetPackageNotFoundException(
-                string.Format(CliStrings.IsNotFoundInNuGetFeeds, packageId, source.Source));
-        }
+            allSources, includePreview, resolvedIncludeUnlisted).ConfigureAwait(false);
 
         var resolvedDownloadFolder = downloadFolder == null || !downloadFolder.HasValue ? _packageInstallDir.Value : downloadFolder.Value.Value;
         if (string.IsNullOrEmpty(resolvedDownloadFolder))
@@ -122,39 +113,115 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
             throw new ArgumentException($"Package download folder must be specified either via {nameof(NuGetPackageDownloader)} constructor or via {nameof(downloadFolder)} method argument.");
         }
         var pathResolver = new VersionFolderPathResolver(resolvedDownloadFolder);
-
         string nupkgPath = pathResolver.GetPackageFilePath(packageId.ToString(), resolvedPackageVersion);
         Directory.CreateDirectory(Path.GetDirectoryName(nupkgPath));
 
-        using FileStream destinationStream = File.Create(nupkgPath);
-        bool success = await ExponentialRetry.ExecuteWithRetryOnFailure(async () => await resource.CopyNupkgToStreamAsync(
-            packageId.ToString(),
-            resolvedPackageVersion,
-            destinationStream,
-            _cacheSettings,
-            _verboseLogger,
-            cancellationToken));
-        destinationStream.Close();
+        HashSet<string> failedSources = new(StringComparer.OrdinalIgnoreCase);
+        Exception firstDownloadException = null;
 
-        if (!success)
+        while (true)
         {
-            throw new NuGetPackageInstallerException(
-                string.Format("Downloading {0} version {1} failed", packageId,
-                    packageVersion.ToNormalizedString()));
+            SourceRepository repository = GetSourceRepository(source);
+            FindPackageByIdResource resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (resource != null)
+            {
+                try
+                {
+                    // Use a fresh file stream for each download attempt to avoid corruption from partial writes
+                    {
+                        await using FileStream destinationStream = File.Create(nupkgPath);
+                        bool success = await ExponentialRetry.ExecuteWithRetryOnFailure(async () => await resource.CopyNupkgToStreamAsync(
+                            packageId.ToString(),
+                            resolvedPackageVersion,
+                            destinationStream,
+                            _cacheSettings,
+                            _verboseLogger,
+                            cancellationToken));
+
+                        if (success)
+                        {
+                            // Signing verification failure should not trigger fallback to another source
+                            try
+                            {
+                                await VerifySigning(nupkgPath, repository);
+                            }
+                            catch (NuGetPackageInstallerException)
+                            {
+                                File.Delete(nupkgPath);
+                                throw;
+                            }
+
+                            return nupkgPath;
+                        }
+                    }
+
+                    // Download returned false — clean up partial file before trying next source
+                    TryDeleteFile(nupkgPath);
+                }
+                catch (Exception ex) when (IsDownloadFailure(ex))
+                {
+                    firstDownloadException ??= ex;
+                    _verboseLogger.LogWarning(string.Format(
+                        CliStrings.PackageDownloadFailedFromSource,
+                        packageId, source.Source, ex.Message));
+                    TryDeleteFile(nupkgPath);
+                }
+            }
+
+            // Mark this source as failed and try to find another source that has the package
+            failedSources.Add(source.Source);
+            var remainingSources = allSources.Where(s => !failedSources.Contains(s.Source));
+
+            if (!remainingSources.Any())
+            {
+                break;
+            }
+
+            try
+            {
+                // Re-resolve using only the remaining sources, pinning to the already-resolved version
+                (source, _) = await GetPackageSourceAndVersion(packageId, resolvedPackageVersion,
+                    remainingSources, includePreview, resolvedIncludeUnlisted).ConfigureAwait(false);
+            }
+            catch (NuGetPackageNotFoundException)
+            {
+                // No remaining source has this package version
+                break;
+            }
         }
 
-        // Delete file if verification fails
+        throw new NuGetPackageInstallerException(
+            string.Format("Downloading {0} version {1} failed", packageId,
+                resolvedPackageVersion.ToNormalizedString()),
+            firstDownloadException);
+    }
+
+    /// <summary>
+    /// Returns true for exceptions that indicate a download/protocol failure from a NuGet source,
+    /// where falling back to another source may succeed. Does not match cancellation, local I/O,
+    /// or signing verification failures.
+    /// </summary>
+    private static bool IsDownloadFailure(Exception ex)
+    {
+        return ex is FatalProtocolException
+            || ex is HttpRequestException;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
         try
         {
-            await VerifySigning(nupkgPath, repository);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
         }
-        catch (NuGetPackageInstallerException)
+        catch
         {
-            File.Delete(nupkgPath);
-            throw;
+            // Best effort cleanup
         }
-
-        return nupkgPath;
     }
 
     private bool VerbosityGreaterThanMinimal() =>
@@ -281,11 +348,19 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
          bool includeUnlisted = false,
          PackageSourceMapping packageSourceMapping = null)
     {
+        IEnumerable<PackageSource> packagesSources = LoadNuGetSources(packageId, packageSourceLocation, packageSourceMapping);
+        return await GetPackageSourceAndVersion(packageId, packageVersion, packagesSources, includePreview, includeUnlisted).ConfigureAwait(false);
+    }
+
+    private async Task<(PackageSource, NuGetVersion)> GetPackageSourceAndVersion(PackageId packageId,
+         NuGetVersion packageVersion,
+         IEnumerable<PackageSource> packagesSources,
+         bool includePreview,
+         bool includeUnlisted)
+    {
         CancellationToken cancellationToken = CancellationToken.None;
 
         IPackageSearchMetadata packageMetadata;
-
-        IEnumerable<PackageSource> packagesSources = LoadNuGetSources(packageId, packageSourceLocation, packageSourceMapping);
         PackageSource source;
 
         if (packageVersion is null)

--- a/src/Cli/dotnet/xlf/CliStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.cs.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Lze zabalit pouze jeden .nuspec soubor najednou.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Nejde zadat --version, pokud argument balíčku již obsahuje verzi.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.de.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Es kann immer nur eine .nuspec-Datei gepackt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">--version kann nicht angegeben werden, wenn das Paketargument bereits eine Version enthält.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.es.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Solo se puede empaquetar un archivo .nuspec a la vez</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">No se puede especificar --version cuando el argumento del paquete ya contiene una versión.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.fr.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Vous ne pouvez empaqueter qu’un seul fichier .nuspec à la fois</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Impossible de spécifier --version lorsque l’argument de package contient déjà une version.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.it.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">È creare un pacchetto di un solo file .nuspec alla volta</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Non è possibile specificare --version se l'argomento del pacchetto contiene già una versione.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ja.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">一度にパックできる .nuspec ファイルは 1 つだけです</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">パッケージ引数が既にバージョンを含んでいる場合は、--version を指定できません。</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ko.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">한 번에 하나의 .nuspec 파일만 압축할 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">패키지 인수에 이미 버전이 포함되어 있을 때는 --version을 지정할 수 없습니다.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pl.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Jednocześnie można spakować tylko jeden plik nuspec</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Nie można określić parametru --version, jeśli argument pakietu zawiera już wersję.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Somente um arquivo .nuspec pode ser empacotado por vez</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Não é possível especificar --version quando o argumento do pacote já contém uma versão.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ru.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Одновременно можно упаковать только один файл .nuspec</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Невозможно указать --version, если аргумент пакета уже содержит версию.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.tr.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Tek seferde yalnızca bir .nuspec dosyası paketlenebilir</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">Paket bağımsız değişkeni zaten bir sürüm içeriyorsa --version belirtilemez.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">一次只能打包一个 .nuspec 文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">当包参数已包含版本时，无法指定 --version。</target>

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
@@ -574,6 +574,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">一次只能封裝一個 .nuspec 檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="PackageDownloadFailedFromSource">
+        <source>Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</source>
+        <target state="new">Failed to download package {0} from source {1}: {2}. Attempting to download from another source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdentityArgumentVersionOptionConflict">
         <source>Cannot specify --version when the package argument already contains a version.</source>
         <target state="translated">當套件引數已包含版本時，無法指定 --version。</target>


### PR DESCRIPTION
When downloading a NuGet package fails from the initially selected source (e.g., an Azure DevOps feed with upstream sources that reports having a package via metadata but returns 401/403 on download), the downloader now retries with remaining sources instead of immediately failing.

This fixes the scenario where parallel feed querying selects a feed that claims to have a package through its upstream configuration, but the user lacks permissions to pull from that upstream. Previously, this resulted in a hard failure even when another configured feed (e.g., nuget.org) could serve the package.

The fix:
- Catches FatalProtocolException and HttpRequestException during download
- Excludes the failed source and re-resolves from remaining sources
- Pins to the already-resolved package version to prevent version drift
- Creates fresh file streams per attempt to avoid partial write corruption
- Does NOT fall back on signing verification failures (security boundary)
- Preserves original exception as inner exception in final failure

Fixes #54141