### PR TITLE
Skip Helix tests when build step fails

### DIFF
--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -93,7 +93,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
@@ -125,7 +124,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               TestFullMSBuild: 'true'
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -166,7 +164,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -104,7 +104,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)
@@ -136,7 +135,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               TestFullMSBuild: 'true'
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -177,7 +175,6 @@ jobs:
                 /p:_CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
                 $(_InternalRuntimeDownloadArgs)
           displayName: Run Tests in Helix
-          condition: succeededOrFailed()
           env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: $(_HelixApiToken)


### PR DESCRIPTION
Remove 'condition: succeededOrFailed()' from all 'Run Tests in Helix' steps in eng/build.yml and eng/build-pr.yml. Without an explicit condition, Azure Pipelines defaults to 'succeeded()', which skips the test step when the preceding build step fails. This avoids wasting Helix resources on tests that cannot succeed.