### PR TITLE
Fix the internal 8.0 builds to correctly use the internal feeds to install the workloads

### DIFF
--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -97,10 +97,15 @@
     <!-- Pass the credential provider plugin path to the subprocess so it can authenticate
          with internal NuGet feeds. DOTNET_CLI_HOME redirection causes NuGet to look for
          plugins in the wrong location (artifacts/tmp/ instead of the user profile). -->
+    <PropertyGroup>
+      <_UserHome Condition="'$(USERPROFILE)' != ''">$(USERPROFILE)</_UserHome>
+      <_UserHome Condition="'$(_UserHome)' == ''">$(HOME)</_UserHome>
+      <_CredentialProviderPath>$(_UserHome)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.dll</_CredentialProviderPath>
+    </PropertyGroup>
     <ItemGroup>
       <_OverlaySdkEnvVars Include="DOTNET_CLI_HOME=$(ArtifactsTmpDir)" />
-      <_OverlaySdkEnvVars Condition="Exists('$(USERPROFILE)\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll')"
-                          Include="NUGET_PLUGIN_PATHS=$(USERPROFILE)\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll" />
+      <_OverlaySdkEnvVars Condition="Exists('$(_CredentialProviderPath)')"
+                          Include="NUGET_PLUGIN_PATHS=$(_CredentialProviderPath)" />
     </ItemGroup>
 
     <!-- Install a coherent set of workload manifests -->

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -93,10 +93,20 @@
     <Exec Command="$(RedistLayoutPath)dotnet new"
           EnvironmentVariables="DOTNET_CLI_HOME=$(ArtifactsTmpDir)" />
 
+
+    <!-- Pass the credential provider plugin path to the subprocess so it can authenticate
+         with internal NuGet feeds. DOTNET_CLI_HOME redirection causes NuGet to look for
+         plugins in the wrong location (artifacts/tmp/ instead of the user profile). -->
+    <ItemGroup>
+      <_OverlaySdkEnvVars Include="DOTNET_CLI_HOME=$(ArtifactsTmpDir)" />
+      <_OverlaySdkEnvVars Condition="Exists('$(USERPROFILE)\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll')"
+                          Include="NUGET_PLUGIN_PATHS=$(USERPROFILE)\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll" />
+    </ItemGroup>
+
     <!-- Install a coherent set of workload manifests -->
     <Exec Condition="Exists('$(RedistLayoutPath)TestRollback.json')"
-          Command="$(RedistLayoutPath)dotnet workload update --from-rollback-file $(RedistLayoutPath)TestRollback.json"
-          EnvironmentVariables="DOTNET_CLI_HOME=$(ArtifactsTmpDir)"/>
+          Command="$(RedistLayoutPath)dotnet workload update --from-rollback-file $(RedistLayoutPath)TestRollback.json --configfile $(RepoRoot)NuGet.config"
+          EnvironmentVariables="@(_OverlaySdkEnvVars)"/>
 
     <ItemGroup>
       <MonoToolchainCurrentWorkloadManifests Include="$(RedistLayoutPath)\sdk-manifests\$(MonoWorkloadFeatureBand)\microsoft.net.workload.mono.toolchain.current\*\WorkloadManifest.targets" />


### PR DESCRIPTION
Fixes #54237 

We were getting 401 errors from the feeds when installing the test workloads. After going through the binlog with copilot, this is the solution and this looks right to me.

Test build below is passing the main SDK build on all legs.

https://dev.azure.com/dnceng/internal/_build/results?buildId=2970684&view=logs&j=7a30c6f6-6636-503e-7c63-a02a61cefc9a&t=c608e0de-ddda-52f2-bd6a-8e56778f44b6