### PR TITLE
Fix xUnit1051 build errors in CA1033 tests

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypesTests.cs
@@ -423,7 +423,7 @@ public class ImplementsGeneralThree : IGeneral
                     object IGeneral.DoSomething() { return null; }
                 }
                 """,
-                LanguageVersion.CSharp8).RunAsync();
+                LanguageVersion.CSharp8).RunAsync(TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -468,7 +468,7 @@ public class ImplementsGeneralThree : IGeneral
                     string Name => "name";
                 }
                 """,
-                LanguageVersion.CSharp8).RunAsync();
+                LanguageVersion.CSharp8).RunAsync(TestContext.Current.CancellationToken);
         }
 
         #endregion


### PR DESCRIPTION
This PR fixes xUnit1051 build errors introduced by #50339.

## Problem

The two test methods added in #50339 call `.RunAsync()` without passing a `CancellationToken`, which violates [xUnit1051](https://xunit.net/xunit.analyzers/rules/xUnit1051) and causes build failures.

## Fix

Pass `TestContext.Current.CancellationToken` to both `.RunAsync()` calls in:
- `CA1033InterfaceWithDefaultImplementationsCSharpAsync`
- `CA1033InterfaceWithExpressionBodiedDefaultImplementationsCSharpAsync`