### PR TITLE
File-based apps: handle conversion of custom included item types

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -274,7 +274,8 @@ Later with deduplication, separate "self-contained" utilities could reference ov
 even if they end up in the same compilation.
 For example, properties could be concatenated via `;`, more specific package versions could override less specific ones.
 
-During [grow up](#grow-up), `#:` directives are removed from the `.cs` files and turned into elements in the converted `.csproj` file.
+During [grow up](#grow-up), `#:` directives are removed from the `.cs` files and turned into elements in the converted `.csproj` file when needed.
+Files included with `#:include` are copied into the converted project directory; if an included file is not picked up by the converted project's defaults, the corresponding project item is also written explicitly into an `<ItemGroup>` in the converted project.
 For project-based programs, `#:` directives are an error (reported by Roslyn when it's told it is in "project-based" mode).
 `#!` directives are also removed during grow up, although we could consider to have an option to preserve them
 (since they might still be valid after grow up, depending on which program they are actually specifying to "interpret" the file, i.e., it might not be `dotnet run` at all).

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -395,7 +395,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     }
                 }
 
-                yield return new IncludedItem(item.ItemType, itemFullPath, itemRelativePath);
+                bool allowConversionToExplicitItem = string.Equals(
+                    item.GetMetadataValue(VirtualProjectBuilder.AllowConversionToExplicitItemMetadataName),
+                    bool.TrueString,
+                    StringComparison.OrdinalIgnoreCase);
+
+                yield return new IncludedItem(item.ItemType, itemFullPath, itemRelativePath, allowConversionToExplicitItem);
             }
         }
 
@@ -409,6 +414,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             // items such as Compile/None/Content naturally. Explicitly write only copied items that are
             // missing from that evaluation, plus the entry point when Compile defaults do not include it.
             var candidateItems = includeItems
+                .Where(static item => item.AllowConversionToExplicitItem)
                 .Select(item => (item.ItemType, item.RelativePath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
                 .Distinct()
                 .ToArray();
@@ -563,7 +569,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
         ImmutableArray<CSharpDirective> EvaluatedDirectives,
         ImmutableArray<IncludedItem> IncludeItems);
 
-    private readonly record struct IncludedItem(string ItemType, string FullPath, string RelativePath);
+    private readonly record struct IncludedItem(string ItemType, string FullPath, string RelativePath, bool AllowConversionToExplicitItem);
 
     private readonly record struct ProjectItemKey(string ItemType, string FullPath);
 

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -170,8 +170,10 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     projectFile,
                     sourceDirectory,
                     outputDirectory,
+                    targetFile,
+                    fileBuilder.EntryPointSourceFile,
                     includeItems,
-                    fileDirectives).ToImmutableArray();
+                    fileDirectives);
                 if (!explicitProjectItemDirectives.IsEmpty)
                 {
                     WriteProjectFile(projectFile, projectDirectives, explicitProjectItemDirectives);
@@ -403,26 +405,23 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
         }
 
-        IEnumerable<CSharpDirective.IncludeOrExclude> FindExplicitProjectItemDirectives(
+        ImmutableArray<CSharpDirective.IncludeOrExclude> FindExplicitProjectItemDirectives(
             string projectFile,
             string sourceDirectory,
             string outputDirectory,
+            string entryPointOutputPath,
+            SourceFile entryPointSourceFile,
             List<(string ItemType, string FullPath, string RelativePath)> includeItems,
             ImmutableArray<CSharpDirective> directives)
         {
             // The converted project is evaluated after files are copied so SDK defaults can pick up
             // items such as Compile/None/Content naturally. Keep only the #:include directives whose
-            // copied items are missing from that evaluation so the project writer doesn't infer item
-            // types from mapping again.
+            // copied items are missing from that evaluation, plus the entry point when Compile defaults
+            // do not include it, so the project writer doesn't infer item types from mapping again.
             var candidateItems = includeItems
                 .Select(item => (item.ItemType, item.RelativePath, SourceFullPath: item.FullPath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
                 .Distinct()
                 .ToArray();
-
-            if (candidateItems.Length == 0)
-            {
-                yield break;
-            }
 
             using var outputProjectCollection = new ProjectCollection();
             var outputProject = ProjectInstance.FromFile(projectFile, new ProjectOptions
@@ -432,7 +431,11 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
 
             var itemComparer = new ProjectItemComparer();
             var automaticallyIncludedItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
-            foreach (var itemType in candidateItems.Select(static item => item.ItemType).Distinct(StringComparer.OrdinalIgnoreCase))
+            var itemTypes = candidateItems
+                .Select(static item => item.ItemType)
+                .Append("Compile")
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+            foreach (var itemType in itemTypes)
             {
                 foreach (var item in outputProject.GetItems(itemType))
                 {
@@ -442,6 +445,16 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
 
             var addedExplicitItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
+
+            var entryPointOutputFullPath = Path.GetFullPath(entryPointOutputPath);
+            var explicitProjectItemDirectives = ImmutableArray.CreateBuilder<CSharpDirective.IncludeOrExclude>();
+            if (!automaticallyIncludedItems.Contains(("Compile", entryPointOutputFullPath)))
+            {
+                var directiveName = Path.GetRelativePath(outputDirectory, entryPointOutputFullPath);
+                explicitProjectItemDirectives.Add(CreateIncludeDirective(entryPointSourceFile, directiveName, "Compile"));
+                addedExplicitItems.Add(("Compile", entryPointOutputFullPath));
+            }
+
             foreach (var directive in directives.OfType<CSharpDirective.IncludeOrExclude>())
             {
                 if (directive.Kind != CSharpDirective.IncludeOrExcludeKind.Include || directive.ItemType is null)
@@ -466,14 +479,33 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
 
                 if (TryGetOutputDirectiveName(directive, sourceDirectory, outputDirectory, missingItems, out var directiveName))
                 {
-                    yield return directive.WithName(directiveName);
+                    explicitProjectItemDirectives.Add(directive.WithName(directiveName));
                     continue;
                 }
 
                 foreach (var item in missingItems)
                 {
-                    yield return directive.WithName(item.RelativePath);
+                    explicitProjectItemDirectives.Add(directive.WithName(item.RelativePath));
                 }
+            }
+
+            return explicitProjectItemDirectives.ToImmutable();
+
+            static CSharpDirective.IncludeOrExclude CreateIncludeDirective(SourceFile sourceFile, string name, string itemType)
+            {
+                return new CSharpDirective.IncludeOrExclude(new CSharpDirective.ParseInfo
+                {
+                    SourceFile = sourceFile,
+                    Span = default,
+                    LeadingWhiteSpace = default,
+                    TrailingWhiteSpace = default,
+                })
+                {
+                    OriginalName = name,
+                    Name = name,
+                    Kind = CSharpDirective.IncludeOrExcludeKind.Include,
+                    ItemType = itemType,
+                };
             }
 
             static bool DirectiveIncludesItem(CSharpDirective.IncludeOrExclude directive, string sourceDirectory, string itemFullPath)

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.CommandLine;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -12,7 +11,6 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Spectre.Console;
 
 namespace Microsoft.DotNet.Cli.Commands.Project.Convert;
@@ -166,17 +164,14 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 var projectDirectives = UpdateDirectives(fileDirectives, sourceDirectory, outputDirectory);
                 WriteProjectFile(projectFile, projectDirectives);
 
-                var explicitProjectItemDirectives = FindExplicitProjectItemDirectives(
+                var explicitProjectItems = FindExplicitProjectItems(
                     projectFile,
-                    sourceDirectory,
                     outputDirectory,
                     targetFile,
-                    fileBuilder.EntryPointSourceFile,
-                    includeItems,
-                    fileDirectives);
-                if (!explicitProjectItemDirectives.IsEmpty)
+                    includeItems);
+                if (!explicitProjectItems.IsEmpty)
                 {
-                    WriteProjectFile(projectFile, projectDirectives, explicitProjectItemDirectives);
+                    WriteProjectFile(projectFile, projectDirectives, explicitProjectItems);
                 }
             }
 
@@ -185,7 +180,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             void WriteProjectFile(
                 string projectFile,
                 ImmutableArray<CSharpDirective> projectDirectives,
-                ImmutableArray<CSharpDirective.IncludeOrExclude> explicitProjectItemDirectives = default)
+                ImmutableArray<(string ItemType, string Include)> explicitProjectItems = default)
             {
                 using var stream = File.Open(projectFile, FileMode.Create, FileAccess.Write);
                 using var writer = new StreamWriter(stream, Encoding.UTF8);
@@ -195,7 +190,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     GetDefaultProperties(fileProjectInstance),
                     isVirtualProject: false,
                     userSecretsId: isEntryPointFile ? DetermineUserSecretsId(fileProjectInstance) : null,
-                    explicitProjectItemDirectives: explicitProjectItemDirectives);
+                    explicitProjectItems: explicitProjectItems);
             }
         }
 
@@ -405,21 +400,17 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
         }
 
-        ImmutableArray<CSharpDirective.IncludeOrExclude> FindExplicitProjectItemDirectives(
+        ImmutableArray<(string ItemType, string Include)> FindExplicitProjectItems(
             string projectFile,
-            string sourceDirectory,
             string outputDirectory,
             string entryPointOutputPath,
-            SourceFile entryPointSourceFile,
-            List<(string ItemType, string FullPath, string RelativePath)> includeItems,
-            ImmutableArray<CSharpDirective> directives)
+            List<(string ItemType, string FullPath, string RelativePath)> includeItems)
         {
             // The converted project is evaluated after files are copied so SDK defaults can pick up
-            // items such as Compile/None/Content naturally. Keep only the #:include directives whose
-            // copied items are missing from that evaluation, plus the entry point when Compile defaults
-            // do not include it, so the project writer doesn't infer item types from mapping again.
+            // items such as Compile/None/Content naturally. Explicitly write only copied items that are
+            // missing from that evaluation, plus the entry point when Compile defaults do not include it.
             var candidateItems = includeItems
-                .Select(item => (item.ItemType, item.RelativePath, SourceFullPath: item.FullPath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
+                .Select(item => (item.ItemType, item.RelativePath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
                 .Distinct()
                 .ToArray();
 
@@ -445,123 +436,26 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
 
             var addedExplicitItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
+            var explicitProjectItems = ImmutableArray.CreateBuilder<(string ItemType, string Include)>();
 
             var entryPointOutputFullPath = Path.GetFullPath(entryPointOutputPath);
-            var explicitProjectItemDirectives = ImmutableArray.CreateBuilder<CSharpDirective.IncludeOrExclude>();
-            if (!automaticallyIncludedItems.Contains(("Compile", entryPointOutputFullPath)))
+            AddExplicitProjectItem("Compile", entryPointOutputFullPath, Path.GetRelativePath(outputDirectory, entryPointOutputFullPath));
+
+            foreach (var item in candidateItems)
             {
-                var directiveName = Path.GetRelativePath(outputDirectory, entryPointOutputFullPath);
-                explicitProjectItemDirectives.Add(CreateIncludeDirective(entryPointSourceFile, directiveName, "Compile"));
-                addedExplicitItems.Add(("Compile", entryPointOutputFullPath));
+                AddExplicitProjectItem(item.ItemType, item.OutputFullPath, item.RelativePath);
             }
 
-            foreach (var directive in directives.OfType<CSharpDirective.IncludeOrExclude>())
+            return explicitProjectItems.ToImmutable();
+
+            void AddExplicitProjectItem(string itemType, string fullPath, string include)
             {
-                if (directive.Kind != CSharpDirective.IncludeOrExcludeKind.Include || directive.ItemType is null)
+                var itemKey = (itemType, fullPath);
+                if (!automaticallyIncludedItems.Contains(itemKey) && addedExplicitItems.Add(itemKey))
                 {
-                    continue;
-                }
-
-                var missingItems = candidateItems
-                    .Where(item => string.Equals(item.ItemType, directive.ItemType, StringComparison.OrdinalIgnoreCase) &&
-                        DirectiveIncludesItem(directive, sourceDirectory, item.SourceFullPath))
-                    .Where(item =>
-                    {
-                        var itemKey = (item.ItemType, item.OutputFullPath);
-                        return !automaticallyIncludedItems.Contains(itemKey) && addedExplicitItems.Add(itemKey);
-                    })
-                    .ToArray();
-
-                if (missingItems.Length == 0)
-                {
-                    continue;
-                }
-
-                if (TryGetOutputDirectiveName(directive, sourceDirectory, outputDirectory, missingItems, out var directiveName))
-                {
-                    explicitProjectItemDirectives.Add(directive.WithName(directiveName));
-                    continue;
-                }
-
-                foreach (var item in missingItems)
-                {
-                    explicitProjectItemDirectives.Add(directive.WithName(item.RelativePath));
+                    explicitProjectItems.Add((itemType, include));
                 }
             }
-
-            return explicitProjectItemDirectives.ToImmutable();
-
-            static CSharpDirective.IncludeOrExclude CreateIncludeDirective(SourceFile sourceFile, string name, string itemType)
-            {
-                return new CSharpDirective.IncludeOrExclude(new CSharpDirective.ParseInfo
-                {
-                    SourceFile = sourceFile,
-                    Span = default,
-                    LeadingWhiteSpace = default,
-                    TrailingWhiteSpace = default,
-                })
-                {
-                    OriginalName = name,
-                    Name = name,
-                    Kind = CSharpDirective.IncludeOrExcludeKind.Include,
-                    ItemType = itemType,
-                };
-            }
-
-            static bool DirectiveIncludesItem(CSharpDirective.IncludeOrExclude directive, string sourceDirectory, string itemFullPath)
-            {
-                if (!HasWildcards(directive.Name))
-                {
-                    return string.Equals(Path.GetFullPath(directive.Name), itemFullPath, StringComparison.OrdinalIgnoreCase);
-                }
-
-                if (!IsInDirectory(directive.Name, sourceDirectory))
-                {
-                    return false;
-                }
-
-                var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
-                matcher.AddInclude(NormalizePath(Path.GetRelativePath(sourceDirectory, directive.Name)));
-                return matcher.Match(NormalizePath(Path.GetRelativePath(sourceDirectory, itemFullPath))).HasMatches;
-            }
-
-            static bool TryGetOutputDirectiveName(
-                CSharpDirective.IncludeOrExclude directive,
-                string sourceDirectory,
-                string outputDirectory,
-                (string ItemType, string RelativePath, string SourceFullPath, string OutputFullPath)[] missingItems,
-                [NotNullWhen(true)] out string? directiveName)
-            {
-                // Like project/ref conversion, rewrite paths to be relative to the converted output shape.
-                // Files under the source directory keep the same relative path after being copied; files
-                // copied from outside the source directory are placed at the output root.
-                if (IsInDirectory(directive.Name, sourceDirectory))
-                {
-                    var outputPath = Path.Combine(outputDirectory, Path.GetRelativePath(sourceDirectory, directive.Name));
-                    directiveName = Path.GetRelativePath(outputDirectory, outputPath);
-                    return true;
-                }
-
-                if (missingItems.Length == 1)
-                {
-                    directiveName = Path.GetRelativePath(outputDirectory, missingItems[0].OutputFullPath);
-                    return true;
-                }
-
-                directiveName = null;
-                return false;
-            }
-
-            static bool HasWildcards(string path) => path.Contains('*') || path.Contains('?');
-
-            static bool IsInDirectory(string path, string directory)
-            {
-                var fullPath = Path.GetFullPath(path);
-                var fullDirectory = PathUtilities.EnsureTrailingSlash(Path.GetFullPath(directory));
-                return fullPath.StartsWith(fullDirectory, StringComparison.OrdinalIgnoreCase);
-            }
-
-            static string NormalizePath(string path) => path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
         }
 
         string? DetermineUserSecretsId(ProjectInstance projectInstance)

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -395,12 +395,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     }
                 }
 
-                bool allowConversionToExplicitItem = string.Equals(
-                    item.GetMetadataValue(VirtualProjectBuilder.AllowConversionToExplicitItemMetadataName),
+                bool fromIncludeDirective = string.Equals(
+                    item.GetMetadataValue(VirtualProjectBuilder.FromIncludeDirectiveMetadataName),
                     bool.TrueString,
                     StringComparison.OrdinalIgnoreCase);
 
-                yield return new IncludedItem(item.ItemType, itemFullPath, itemRelativePath, allowConversionToExplicitItem);
+                yield return new IncludedItem(item.ItemType, itemFullPath, itemRelativePath, fromIncludeDirective);
             }
         }
 
@@ -414,7 +414,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             // items such as Compile/None/Content naturally. Explicitly write only copied items that are
             // missing from that evaluation, plus the entry point when Compile defaults do not include it.
             var candidateItems = includeItems
-                .Where(static item => item.AllowConversionToExplicitItem)
+                .Where(static item => item.FromIncludeDirective)
                 .Select(item => (item.ItemType, item.RelativePath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
                 .Distinct()
                 .ToArray();
@@ -569,7 +569,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
         ImmutableArray<CSharpDirective> EvaluatedDirectives,
         ImmutableArray<IncludedItem> IncludeItems);
 
-    private readonly record struct IncludedItem(string ItemType, string FullPath, string RelativePath, bool AllowConversionToExplicitItem);
+    private readonly record struct IncludedItem(string ItemType, string FullPath, string RelativePath, bool FromIncludeDirective);
 
     private readonly record struct ProjectItemKey(string ItemType, string FullPath);
 

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -72,11 +72,11 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 new HashSet<string>(StringComparer.OrdinalIgnoreCase), usedFolderNames);
         }
 
-        var (_, _, _, includeItems) = ConvertFile(file, entryPointOutputDir, isEntryPointFile: true);
+        var convertedEntryPoint = ConvertFile(file, entryPointOutputDir, isEntryPointFile: true);
 
         // Convert referenced files (#:ref directives) into library projects.
         var convertedRefFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var refIncludeItems = new List<(string ItemType, string FullPath, string RelativePath)>();
+        var refIncludeItems = new List<IncludedItem>();
         ConvertReferencedFiles(evaluatedDirectives, Path.GetDirectoryName(file)!);
 
         // Handle deletion of source files if requested.
@@ -87,7 +87,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             DeleteFile(file);
 
             // Delete all included items (e.g., via #:include directives and default items)
-            foreach (var item in includeItems)
+            foreach (var item in convertedEntryPoint.IncludeItems)
             {
                 DeleteFile(item.FullPath);
             }
@@ -106,8 +106,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
 
         return 0;
 
-        (VirtualProjectBuilder builder, ProjectInstance projectInstance, ImmutableArray<CSharpDirective> evaluatedDirectives, List<(string ItemType, string FullPath, string RelativePath)> includeItems)
-            ConvertFile(string sourceFile, string outputDirectory, bool isEntryPointFile)
+        ConvertedFile ConvertFile(string sourceFile, string outputDirectory, bool isEntryPointFile)
         {
             var sourceDirectory = Path.GetDirectoryName(sourceFile)!;
 
@@ -135,7 +134,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
 
             // Find other items to copy over, e.g., default Content items like JSON files in Web apps.
-            var includeItems = FindIncludedItems(fileBuilder, fileProjectInstance, sourceFile).ToList();
+            var includeItems = FindIncludedItems(fileBuilder, fileProjectInstance, sourceFile).ToImmutableArray();
 
             CreateDirectory(outputDirectory);
 
@@ -175,12 +174,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 }
             }
 
-            return (fileBuilder, fileProjectInstance, fileDirectives, includeItems);
+            return new ConvertedFile(fileDirectives, includeItems);
 
             void WriteProjectFile(
                 string projectFile,
                 ImmutableArray<CSharpDirective> projectDirectives,
-                ImmutableArray<(string ItemType, string Include)> explicitProjectItems = default)
+                ImmutableArray<VirtualProjectBuilder.ExplicitProjectItem> explicitProjectItems = default)
             {
                 using var stream = File.Open(projectFile, FileMode.Create, FileAccess.Write);
                 using var writer = new StreamWriter(stream, Encoding.UTF8);
@@ -234,7 +233,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
         }
 
-        void CopyIncludedItems(List<(string ItemType, string FullPath, string RelativePath)> items, string outputDirectory)
+        void CopyIncludedItems(ImmutableArray<IncludedItem> items, string outputDirectory)
         {
             foreach (var item in items)
             {
@@ -289,12 +288,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 var refDir = Path.GetDirectoryName(refPath)!;
                 var refTargetDirectory = Path.Combine(targetDirectory, refName);
 
-                var (_, _, refEvaluatedDirectives, items) = ConvertFile(refPath, refTargetDirectory, isEntryPointFile: false);
+                var convertedReference = ConvertFile(refPath, refTargetDirectory, isEntryPointFile: false);
 
-                refIncludeItems.AddRange(items);
+                refIncludeItems.AddRange(convertedReference.IncludeItems);
 
                 // Recursively convert referenced files in the referenced file.
-                ConvertReferencedFiles(refEvaluatedDirectives, refDir);
+                ConvertReferencedFiles(convertedReference.EvaluatedDirectives, refDir);
             }
         }
 
@@ -341,7 +340,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
         }
 
-        IEnumerable<(string ItemType, string FullPath, string RelativePath)> FindIncludedItems(
+        IEnumerable<IncludedItem> FindIncludedItems(
             VirtualProjectBuilder fileBuilder, ProjectInstance fileProjectInstance, string sourceFile)
         {
             string sourceFileDirectory = PathUtilities.EnsureTrailingSlash(Path.GetDirectoryName(sourceFile)!);
@@ -396,15 +395,15 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     }
                 }
 
-                yield return (item.ItemType, FullPath: itemFullPath, RelativePath: itemRelativePath);
+                yield return new IncludedItem(item.ItemType, itemFullPath, itemRelativePath);
             }
         }
 
-        ImmutableArray<(string ItemType, string Include)> FindExplicitProjectItems(
+        ImmutableArray<VirtualProjectBuilder.ExplicitProjectItem> FindExplicitProjectItems(
             string projectFile,
             string outputDirectory,
             string entryPointOutputPath,
-            List<(string ItemType, string FullPath, string RelativePath)> includeItems)
+            ImmutableArray<IncludedItem> includeItems)
         {
             // The converted project is evaluated after files are copied so SDK defaults can pick up
             // items such as Compile/None/Content naturally. Explicitly write only copied items that are
@@ -420,8 +419,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 ProjectCollection = outputProjectCollection,
             });
 
-            var itemComparer = new ProjectItemComparer();
-            var automaticallyIncludedItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
+            var automaticallyIncludedItems = new HashSet<ProjectItemKey>(ProjectItemComparer.Instance);
             var itemTypes = candidateItems
                 .Select(static item => item.ItemType)
                 .Append("Compile")
@@ -431,12 +429,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 foreach (var item in outputProject.GetItems(itemType))
                 {
                     var fullPath = Path.GetFullPath(item.GetMetadataValue("FullPath"), outputDirectory);
-                    automaticallyIncludedItems.Add((itemType, fullPath));
+                    automaticallyIncludedItems.Add(new ProjectItemKey(itemType, fullPath));
                 }
             }
 
-            var addedExplicitItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
-            var explicitProjectItems = ImmutableArray.CreateBuilder<(string ItemType, string Include)>();
+            var addedExplicitItems = new HashSet<ProjectItemKey>(ProjectItemComparer.Instance);
+            var explicitProjectItems = ImmutableArray.CreateBuilder<VirtualProjectBuilder.ExplicitProjectItem>();
 
             var entryPointOutputFullPath = Path.GetFullPath(entryPointOutputPath);
             AddExplicitProjectItem("Compile", entryPointOutputFullPath, Path.GetRelativePath(outputDirectory, entryPointOutputFullPath));
@@ -450,10 +448,10 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
 
             void AddExplicitProjectItem(string itemType, string fullPath, string include)
             {
-                var itemKey = (itemType, fullPath);
+                var itemKey = new ProjectItemKey(itemType, fullPath);
                 if (!automaticallyIncludedItems.Contains(itemKey) && addedExplicitItems.Add(itemKey))
                 {
-                    explicitProjectItems.Add((itemType, include));
+                    explicitProjectItems.Add(new VirtualProjectBuilder.ExplicitProjectItem(itemType, include));
                 }
             }
         }
@@ -561,15 +559,27 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
         }
     }
 
-    private sealed class ProjectItemComparer : IEqualityComparer<(string ItemType, string FullPath)>
+    private sealed record ConvertedFile(
+        ImmutableArray<CSharpDirective> EvaluatedDirectives,
+        ImmutableArray<IncludedItem> IncludeItems);
+
+    private readonly record struct IncludedItem(string ItemType, string FullPath, string RelativePath);
+
+    private readonly record struct ProjectItemKey(string ItemType, string FullPath);
+
+    private sealed class ProjectItemComparer : IEqualityComparer<ProjectItemKey>
     {
-        public bool Equals((string ItemType, string FullPath) x, (string ItemType, string FullPath) y)
+        public static ProjectItemComparer Instance { get; } = new();
+
+        private ProjectItemComparer() { }
+
+        public bool Equals(ProjectItemKey x, ProjectItemKey y)
         {
             return string.Equals(x.ItemType, y.ItemType, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(x.FullPath, y.FullPath, StringComparison.OrdinalIgnoreCase);
         }
 
-        public int GetHashCode((string ItemType, string FullPath) obj)
+        public int GetHashCode(ProjectItemKey obj)
         {
             return HashCode.Combine(
                 StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ItemType),

--- a/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
+++ b/src/Cli/dotnet/Commands/Project/Convert/ProjectConvertCommand.cs
@@ -4,12 +4,15 @@
 using System.Collections.Immutable;
 using System.CommandLine;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Spectre.Console;
 
 namespace Microsoft.DotNet.Cli.Commands.Project.Convert;
@@ -71,18 +74,12 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 new HashSet<string>(StringComparer.OrdinalIgnoreCase), usedFolderNames);
         }
 
-        ConvertFile(file, entryPointOutputDir, isEntryPointFile: true);
-
-        // Find other items to copy over, e.g., default Content items like JSON files in Web apps.
-        var includeItems = FindIncludedItems(builder, projectInstance, file).ToList();
+        var (_, _, _, includeItems) = ConvertFile(file, entryPointOutputDir, isEntryPointFile: true);
 
         // Convert referenced files (#:ref directives) into library projects.
         var convertedRefFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var refIncludeItems = new List<(string ItemType, string FullPath, string RelativePath)>();
         ConvertReferencedFiles(evaluatedDirectives, Path.GetDirectoryName(file)!);
-
-        // Copy or move over included items.
-        CopyIncludedItems(includeItems, entryPointOutputDir);
 
         // Handle deletion of source files if requested.
         bool shouldDelete = _deleteSource || TryAskForDeleteSource();
@@ -111,7 +108,7 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
 
         return 0;
 
-        (VirtualProjectBuilder builder, ProjectInstance projectInstance, ImmutableArray<CSharpDirective> evaluatedDirectives)
+        (VirtualProjectBuilder builder, ProjectInstance projectInstance, ImmutableArray<CSharpDirective> evaluatedDirectives, List<(string ItemType, string FullPath, string RelativePath)> includeItems)
             ConvertFile(string sourceFile, string outputDirectory, bool isEntryPointFile)
         {
             var sourceDirectory = Path.GetDirectoryName(sourceFile)!;
@@ -139,6 +136,9 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     validateAllDirectives: !_force);
             }
 
+            // Find other items to copy over, e.g., default Content items like JSON files in Web apps.
+            var includeItems = FindIncludedItems(fileBuilder, fileProjectInstance, sourceFile).ToList();
+
             CreateDirectory(outputDirectory);
 
             // Copy the .cs file with directives removed.
@@ -153,6 +153,8 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 VirtualProjectBuildingCommand.RemoveDirectivesFromFile(fileBuilder.EntryPointSourceFile, targetFile);
             }
 
+            CopyIncludedItems(includeItems, outputDirectory);
+
             // Create project file.
             var projectFile = Path.Join(outputDirectory, Path.GetFileNameWithoutExtension(sourceFile) + ".csproj");
             if (_dryRun)
@@ -161,17 +163,38 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
             else
             {
+                var projectDirectives = UpdateDirectives(fileDirectives, sourceDirectory, outputDirectory);
+                WriteProjectFile(projectFile, projectDirectives);
+
+                var explicitProjectItemDirectives = FindExplicitProjectItemDirectives(
+                    projectFile,
+                    sourceDirectory,
+                    outputDirectory,
+                    includeItems,
+                    fileDirectives).ToImmutableArray();
+                if (!explicitProjectItemDirectives.IsEmpty)
+                {
+                    WriteProjectFile(projectFile, projectDirectives, explicitProjectItemDirectives);
+                }
+            }
+
+            return (fileBuilder, fileProjectInstance, fileDirectives, includeItems);
+
+            void WriteProjectFile(
+                string projectFile,
+                ImmutableArray<CSharpDirective> projectDirectives,
+                ImmutableArray<CSharpDirective.IncludeOrExclude> explicitProjectItemDirectives = default)
+            {
                 using var stream = File.Open(projectFile, FileMode.Create, FileAccess.Write);
                 using var writer = new StreamWriter(stream, Encoding.UTF8);
                 VirtualProjectBuilder.WriteProjectFile(
                     writer,
-                    UpdateDirectives(fileDirectives, sourceDirectory, outputDirectory),
+                    projectDirectives,
+                    GetDefaultProperties(fileProjectInstance),
                     isVirtualProject: false,
                     userSecretsId: isEntryPointFile ? DetermineUserSecretsId(fileProjectInstance) : null,
-                    defaultProperties: GetDefaultProperties(fileProjectInstance));
+                    explicitProjectItemDirectives: explicitProjectItemDirectives);
             }
-
-            return (fileBuilder, fileProjectInstance, fileDirectives);
         }
 
         void CreateDirectory(string path)
@@ -269,11 +292,8 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                 var refDir = Path.GetDirectoryName(refPath)!;
                 var refTargetDirectory = Path.Combine(targetDirectory, refName);
 
-                var (refBuilder, refProjectInstance, refEvaluatedDirectives) = ConvertFile(refPath, refTargetDirectory, isEntryPointFile: false);
+                var (_, _, refEvaluatedDirectives, items) = ConvertFile(refPath, refTargetDirectory, isEntryPointFile: false);
 
-                // Copy included items (e.g., default Content items) for the referenced file.
-                var items = FindIncludedItems(refBuilder, refProjectInstance, refPath).ToList();
-                CopyIncludedItems(items, refTargetDirectory);
                 refIncludeItems.AddRange(items);
 
                 // Recursively convert referenced files in the referenced file.
@@ -383,6 +403,135 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
             }
         }
 
+        IEnumerable<CSharpDirective.IncludeOrExclude> FindExplicitProjectItemDirectives(
+            string projectFile,
+            string sourceDirectory,
+            string outputDirectory,
+            List<(string ItemType, string FullPath, string RelativePath)> includeItems,
+            ImmutableArray<CSharpDirective> directives)
+        {
+            // The converted project is evaluated after files are copied so SDK defaults can pick up
+            // items such as Compile/None/Content naturally. Keep only the #:include directives whose
+            // copied items are missing from that evaluation so the project writer doesn't infer item
+            // types from mapping again.
+            var candidateItems = includeItems
+                .Select(item => (item.ItemType, item.RelativePath, SourceFullPath: item.FullPath, OutputFullPath: Path.GetFullPath(Path.Combine(outputDirectory, item.RelativePath))))
+                .Distinct()
+                .ToArray();
+
+            if (candidateItems.Length == 0)
+            {
+                yield break;
+            }
+
+            using var outputProjectCollection = new ProjectCollection();
+            var outputProject = ProjectInstance.FromFile(projectFile, new ProjectOptions
+            {
+                ProjectCollection = outputProjectCollection,
+            });
+
+            var itemComparer = new ProjectItemComparer();
+            var automaticallyIncludedItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
+            foreach (var itemType in candidateItems.Select(static item => item.ItemType).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                foreach (var item in outputProject.GetItems(itemType))
+                {
+                    var fullPath = Path.GetFullPath(item.GetMetadataValue("FullPath"), outputDirectory);
+                    automaticallyIncludedItems.Add((itemType, fullPath));
+                }
+            }
+
+            var addedExplicitItems = new HashSet<(string ItemType, string FullPath)>(itemComparer);
+            foreach (var directive in directives.OfType<CSharpDirective.IncludeOrExclude>())
+            {
+                if (directive.Kind != CSharpDirective.IncludeOrExcludeKind.Include || directive.ItemType is null)
+                {
+                    continue;
+                }
+
+                var missingItems = candidateItems
+                    .Where(item => string.Equals(item.ItemType, directive.ItemType, StringComparison.OrdinalIgnoreCase) &&
+                        DirectiveIncludesItem(directive, sourceDirectory, item.SourceFullPath))
+                    .Where(item =>
+                    {
+                        var itemKey = (item.ItemType, item.OutputFullPath);
+                        return !automaticallyIncludedItems.Contains(itemKey) && addedExplicitItems.Add(itemKey);
+                    })
+                    .ToArray();
+
+                if (missingItems.Length == 0)
+                {
+                    continue;
+                }
+
+                if (TryGetOutputDirectiveName(directive, sourceDirectory, outputDirectory, missingItems, out var directiveName))
+                {
+                    yield return directive.WithName(directiveName);
+                    continue;
+                }
+
+                foreach (var item in missingItems)
+                {
+                    yield return directive.WithName(item.RelativePath);
+                }
+            }
+
+            static bool DirectiveIncludesItem(CSharpDirective.IncludeOrExclude directive, string sourceDirectory, string itemFullPath)
+            {
+                if (!HasWildcards(directive.Name))
+                {
+                    return string.Equals(Path.GetFullPath(directive.Name), itemFullPath, StringComparison.OrdinalIgnoreCase);
+                }
+
+                if (!IsInDirectory(directive.Name, sourceDirectory))
+                {
+                    return false;
+                }
+
+                var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+                matcher.AddInclude(NormalizePath(Path.GetRelativePath(sourceDirectory, directive.Name)));
+                return matcher.Match(NormalizePath(Path.GetRelativePath(sourceDirectory, itemFullPath))).HasMatches;
+            }
+
+            static bool TryGetOutputDirectiveName(
+                CSharpDirective.IncludeOrExclude directive,
+                string sourceDirectory,
+                string outputDirectory,
+                (string ItemType, string RelativePath, string SourceFullPath, string OutputFullPath)[] missingItems,
+                [NotNullWhen(true)] out string? directiveName)
+            {
+                // Like project/ref conversion, rewrite paths to be relative to the converted output shape.
+                // Files under the source directory keep the same relative path after being copied; files
+                // copied from outside the source directory are placed at the output root.
+                if (IsInDirectory(directive.Name, sourceDirectory))
+                {
+                    var outputPath = Path.Combine(outputDirectory, Path.GetRelativePath(sourceDirectory, directive.Name));
+                    directiveName = Path.GetRelativePath(outputDirectory, outputPath);
+                    return true;
+                }
+
+                if (missingItems.Length == 1)
+                {
+                    directiveName = Path.GetRelativePath(outputDirectory, missingItems[0].OutputFullPath);
+                    return true;
+                }
+
+                directiveName = null;
+                return false;
+            }
+
+            static bool HasWildcards(string path) => path.Contains('*') || path.Contains('?');
+
+            static bool IsInDirectory(string path, string directory)
+            {
+                var fullPath = Path.GetFullPath(path);
+                var fullDirectory = PathUtilities.EnsureTrailingSlash(Path.GetFullPath(directory));
+                return fullPath.StartsWith(fullDirectory, StringComparison.OrdinalIgnoreCase);
+            }
+
+            static string NormalizePath(string path) => path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+        }
+
         string? DetermineUserSecretsId(ProjectInstance projectInstance)
         {
             var implicitValue = projectInstance.GetPropertyValue("_ImplicitFileBasedProgramUserSecretsId");
@@ -462,6 +611,11 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     continue;
                 }
 
+                if (directive is CSharpDirective.IncludeOrExclude)
+                {
+                    continue;
+                }
+
                 result.Add(directive);
             }
 
@@ -478,6 +632,22 @@ internal sealed class ProjectConvertCommand : CommandBase<ProjectConvertCommandD
                     yield return (name, defaultValue);
                 }
             }
+        }
+    }
+
+    private sealed class ProjectItemComparer : IEqualityComparer<(string ItemType, string FullPath)>
+    {
+        public bool Equals((string ItemType, string FullPath) x, (string ItemType, string FullPath) y)
+        {
+            return string.Equals(x.ItemType, y.ItemType, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(x.FullPath, y.FullPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode((string ItemType, string FullPath) obj)
+        {
+            return HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ItemType),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.FullPath));
         }
     }
 

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -20,6 +20,8 @@ public sealed class VirtualProjectBuilder
 {
     internal readonly record struct ExplicitProjectItem(string ItemType, string Include);
 
+    internal const string AllowConversionToExplicitItemMetadataName = "FileBasedProgramsAllowConversionToExplicitItem";
+
     private readonly IEnumerable<(string name, string value)> _defaultProperties;
 
     private (ImmutableArray<CSharpDirective> Original, ImmutableArray<CSharpDirective> Evaluated)? _evaluatedDirectives;
@@ -699,9 +701,18 @@ public sealed class VirtualProjectBuilder
                     continue;
                 }
 
-                writer.WriteLine($"""
-                        <{itemType} {includeOrExclude.KindToMSBuildString()}="{EscapeValue(includeOrExclude.Name)}" />
+                if (includeOrExclude.Kind == CSharpDirective.IncludeOrExcludeKind.Include)
+                {
+                    writer.WriteLine($"""
+                        <{itemType} Include="{EscapeValue(includeOrExclude.Name)}" {AllowConversionToExplicitItemMetadataName}="true" />
                     """);
+                }
+                else
+                {
+                    writer.WriteLine($"""
+                        <{itemType} Remove="{EscapeValue(includeOrExclude.Name)}" />
+                    """);
+                }
             }
 
             writer.WriteLine("""

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -479,7 +479,8 @@ public sealed class VirtualProjectBuilder
         string? entryPointFilePath = null,
         string? artifactsPath = null,
         bool includeRuntimeConfigInformation = true,
-        string? userSecretsId = null)
+        string? userSecretsId = null,
+        ImmutableArray<CSharpDirective.IncludeOrExclude> explicitProjectItemDirectives = default)
     {
         Debug.Assert(userSecretsId == null || !isVirtualProject);
 
@@ -490,7 +491,7 @@ public sealed class VirtualProjectBuilder
         var packageDirectives = directives.OfType<CSharpDirective.Package>();
         var projectDirectives = directives.OfType<CSharpDirective.Project>();
         var refDirectives = directives.OfType<CSharpDirective.Ref>();
-        var includeOrExcludeDirectives = directives.OfType<CSharpDirective.IncludeOrExclude>();
+        var includeOrExcludeDirectives = directives.OfType<CSharpDirective.IncludeOrExclude>().ToArray();
 
         const string defaultSdkName = "Microsoft.NET.Sdk";
         string firstSdkName;
@@ -673,10 +674,10 @@ public sealed class VirtualProjectBuilder
         if (!isVirtualProject)
         {
             // In the real project, files are included by the conversion copying them to the output directory,
-            // hence we don't need to transfer the #:include/#:exclude directives over.
-            processedDirectives += includeOrExcludeDirectives.Count();
+            // hence we don't need to transfer the #:include/#:exclude directives over by default.
+            processedDirectives += includeOrExcludeDirectives.Length;
         }
-        else if (includeOrExcludeDirectives.Any())
+        else if (includeOrExcludeDirectives.Length > 0)
         {
             writer.WriteLine("""
                   <ItemGroup>
@@ -693,6 +694,32 @@ public sealed class VirtualProjectBuilder
                     // Before directives are evaluated, the item type is null.
                     // We still need to create the project (so that we can evaluate $() properties),
                     // but we can skip the items.
+                    continue;
+                }
+
+                writer.WriteLine($"""
+                        <{itemType} {includeOrExclude.KindToMSBuildString()}="{EscapeValue(includeOrExclude.Name)}" />
+                    """);
+            }
+
+            writer.WriteLine("""
+                  </ItemGroup>
+
+                """);
+        }
+
+        if (!explicitProjectItemDirectives.IsDefaultOrEmpty)
+        {
+            writer.WriteLine("""
+                  <ItemGroup>
+                """);
+
+            foreach (var includeOrExclude in explicitProjectItemDirectives)
+            {
+                var itemType = includeOrExclude.ItemType;
+
+                if (itemType == null)
+                {
                     continue;
                 }
 

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.ProjectTools;
 
 public sealed class VirtualProjectBuilder
 {
+    internal readonly record struct ExplicitProjectItem(string ItemType, string Include);
+
     private readonly IEnumerable<(string name, string value)> _defaultProperties;
 
     private (ImmutableArray<CSharpDirective> Original, ImmutableArray<CSharpDirective> Evaluated)? _evaluatedDirectives;
@@ -480,7 +482,7 @@ public sealed class VirtualProjectBuilder
         string? artifactsPath = null,
         bool includeRuntimeConfigInformation = true,
         string? userSecretsId = null,
-        ImmutableArray<(string ItemType, string Include)> explicitProjectItems = default)
+        ImmutableArray<ExplicitProjectItem> explicitProjectItems = default)
     {
         Debug.Assert(userSecretsId == null || !isVirtualProject);
 

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -480,7 +480,7 @@ public sealed class VirtualProjectBuilder
         string? artifactsPath = null,
         bool includeRuntimeConfigInformation = true,
         string? userSecretsId = null,
-        ImmutableArray<CSharpDirective.IncludeOrExclude> explicitProjectItemDirectives = default)
+        ImmutableArray<(string ItemType, string Include)> explicitProjectItems = default)
     {
         Debug.Assert(userSecretsId == null || !isVirtualProject);
 
@@ -708,23 +708,16 @@ public sealed class VirtualProjectBuilder
                 """);
         }
 
-        if (!explicitProjectItemDirectives.IsDefaultOrEmpty)
+        if (!explicitProjectItems.IsDefaultOrEmpty)
         {
             writer.WriteLine("""
                   <ItemGroup>
                 """);
 
-            foreach (var includeOrExclude in explicitProjectItemDirectives)
+            foreach (var (itemType, include) in explicitProjectItems)
             {
-                var itemType = includeOrExclude.ItemType;
-
-                if (itemType == null)
-                {
-                    continue;
-                }
-
                 writer.WriteLine($"""
-                        <{itemType} {includeOrExclude.KindToMSBuildString()}="{EscapeValue(includeOrExclude.Name)}" />
+                        <{itemType} Include="{EscapeValue(include)}" />
                     """);
             }
 

--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -20,7 +20,7 @@ public sealed class VirtualProjectBuilder
 {
     internal readonly record struct ExplicitProjectItem(string ItemType, string Include);
 
-    internal const string AllowConversionToExplicitItemMetadataName = "FileBasedProgramsAllowConversionToExplicitItem";
+    internal const string FromIncludeDirectiveMetadataName = "FileBasedProgramsFromIncludeDirective";
 
     private readonly IEnumerable<(string name, string value)> _defaultProperties;
 
@@ -704,7 +704,7 @@ public sealed class VirtualProjectBuilder
                 if (includeOrExclude.Kind == CSharpDirective.IncludeOrExcludeKind.Include)
                 {
                     writer.WriteLine($"""
-                        <{itemType} Include="{EscapeValue(includeOrExclude.Name)}" {AllowConversionToExplicitItemMetadataName}="true" />
+                        <{itemType} Include="{EscapeValue(includeOrExclude.Name)}" {FromIncludeDirectiveMetadataName}="true" />
                     """);
                 }
                 else

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1875,6 +1875,69 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
     }
 
+    [Fact]
+    public void Directives_IncludeDll_Wildcard()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var libDir = Path.Join(testInstance.Path, "Lib");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(libDir, "LibClass.cs"), """
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Lib.csproj")
+            .WithWorkingDirectory(libDir)
+            .Execute()
+            .Should().Pass();
+
+        File.Copy(
+            Path.Join(libDir, "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Lib.dll"),
+            Path.Join(testInstance.Path, "Lib.dll"));
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #:property FileBasedProgramsItemMapping=.dll=Reference
+            #:include *.dll
+            Console.WriteLine(Lib.LibClass.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from Lib";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Contain("<Reference Include=\"Lib.dll\" />");
+
+        File.Exists(Path.Join(testInstance.Path, "Program", "Lib.dll")).Should().BeTrue();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(Path.Join(testInstance.Path, "Program"))
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
     /// <summary>
     /// If a file is included only via MSBuild code but is not in the mapped conversion item set, conversion won't copy it to the output directory.
     /// </summary>

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1727,6 +1727,69 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void Directives_IncludeCompile_DefaultCompileItemsDisabled()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #!/usr/bin/env dotnet
+            #:property EnableDefaultCompileItems=false
+            #:include Util.cs
+            Console.WriteLine(Util.GetMessage());
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Util.cs"), """
+            static class Util
+            {
+                public static string GetMessage() => "Hello from Util";
+            }
+            """);
+
+        var expectedOutput = "Hello from Util";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Match($"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                    <UserSecretsId>Program-*</UserSecretsId>
+                    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <Compile Include="Program.cs" />
+                    <Compile Include="Util.cs" />
+                  </ItemGroup>
+
+                </Project>
+
+                """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(Path.Join(testInstance.Path, "Program"))
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
+    [Fact]
     public void Directives_IncludeDll()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -2013,7 +2013,7 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     /// <summary>
-    /// If an item added by MSBuild has corresponding FileBasedProgramsItemMapping, conversion copies and writes it to the project file.
+    /// If an item added by MSBuild has corresponding FileBasedProgramsItemMapping, conversion copies it but does not write it to the project file.
     /// </summary>
     [Fact]
     public void Directives_IncludeDll_DirectoryBuildProps_ItemMapping()
@@ -2079,13 +2079,14 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
         var outDir = Path.Join(testInstance.Path, "out");
         File.Exists(Path.Join(outDir, "Lib.dll")).Should().BeTrue();
         File.ReadAllText(Path.Join(outDir, "Program.csproj"))
-            .Should().Contain("<Reference Include=\"Lib.dll\" />");
+            .Should().NotContain("<Reference");
 
         new DotnetCommand(Log, "run")
             .WithWorkingDirectory(outDir)
             .Execute()
-            .Should().Pass()
-            .And.HaveStdOut(expectedOutput);
+            .Should().Fail()
+            // error CS0103: The name 'Lib' does not exist in the current context
+            .And.HaveStdOutContaining("error CS0103");
     }
 
     [Fact]

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1875,6 +1875,156 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
             .And.HaveStdOut(expectedOutput);
     }
 
+    /// <summary>
+    /// If a file is included only via MSBuild code but is not in the mapped conversion item set, conversion won't copy it to the output directory.
+    /// </summary>
+    [Fact]
+    public void Directives_IncludeDll_DirectoryBuildProps_NoMapping()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var srcDir = Path.Join(testInstance.Path, "src");
+        var appDir = Path.Join(srcDir, "app");
+        var libDir = Path.Join(srcDir, "Lib");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(libDir, "LibClass.cs"), """
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Lib.csproj")
+            .WithWorkingDirectory(libDir)
+            .Execute()
+            .Should().Pass();
+
+        var libDllPropsPath = Path.Join("Lib", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Lib.dll");
+
+        File.WriteAllText(Path.Join(srcDir, "Directory.Build.props"), $"""
+            <Project>
+              <ItemGroup>
+                <Reference Include="$(MSBuildThisFileDirectory){libDllPropsPath}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(appDir, "Program.cs"), """
+            Console.WriteLine(Lib.LibClass.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from Lib";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(appDir)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "-o", "../../out")
+            .WithWorkingDirectory(appDir)
+            .Execute()
+            .Should().Pass();
+
+        var outDir = Path.Join(testInstance.Path, "out");
+        File.Exists(Path.Join(outDir, "Lib.dll")).Should().BeFalse();
+        File.ReadAllText(Path.Join(outDir, "Program.csproj"))
+            .Should().NotContain("<Reference");
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(outDir)
+            .Execute()
+            .Should().Fail()
+            // error CS0103: The name 'Lib' does not exist in the current context
+            .And.HaveStdOutContaining("error CS0103");
+    }
+
+    /// <summary>
+    /// If an item added by MSBuild has corresponding FileBasedProgramsItemMapping, conversion copies and writes it to the project file.
+    /// </summary>
+    [Fact]
+    public void Directives_IncludeDll_DirectoryBuildProps_ItemMapping()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var srcDir = Path.Join(testInstance.Path, "src");
+        var appDir = Path.Join(srcDir, "app");
+        var libDir = Path.Join(srcDir, "Lib");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(libDir, "LibClass.cs"), """
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Lib.csproj")
+            .WithWorkingDirectory(libDir)
+            .Execute()
+            .Should().Pass();
+
+        var libDllPropsPath = Path.Join("Lib", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Lib.dll");
+
+        File.WriteAllText(Path.Join(srcDir, "Directory.Build.props"), $"""
+            <Project>
+              <PropertyGroup>
+                <FileBasedProgramsItemMapping>.dll=Reference</FileBasedProgramsItemMapping>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="$(MSBuildThisFileDirectory){libDllPropsPath}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(appDir, "Program.cs"), """
+            Console.WriteLine(Lib.LibClass.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from Lib";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(appDir)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "-o", "../../out")
+            .WithWorkingDirectory(appDir)
+            .Execute()
+            .Should().Pass();
+
+        var outDir = Path.Join(testInstance.Path, "out");
+        File.Exists(Path.Join(outDir, "Lib.dll")).Should().BeTrue();
+        File.ReadAllText(Path.Join(outDir, "Program.csproj"))
+            .Should().Contain("<Reference Include=\"Lib.dll\" />");
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(outDir)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
     [Fact]
     public void Directives_IncludeDll_ViaIncludedFile()
     {

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -1727,6 +1727,244 @@ public sealed class DotnetProjectConvertTests(ITestOutputHelper log) : SdkTest(l
     }
 
     [Fact]
+    public void Directives_IncludeDll()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var libDir = Path.Join(testInstance.Path, "Lib");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(libDir, "LibClass.cs"), """
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Lib.csproj")
+            .WithWorkingDirectory(libDir)
+            .Execute()
+            .Should().Pass();
+
+        var libDllDirectivePath = $"Lib/bin/Debug/{ToolsetInfo.CurrentTargetFramework}/Lib.dll";
+        var libDllProjectPath = Path.Join("Lib", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Lib.dll");
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), $$"""
+            #:property FileBasedProgramsItemMapping=.dll=Reference
+            #:include {{libDllDirectivePath}}
+            Console.WriteLine(Lib.LibClass.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from Lib";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Match($"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                    <UserSecretsId>Program-*</UserSecretsId>
+                    <FileBasedProgramsItemMapping>.dll=Reference</FileBasedProgramsItemMapping>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <Reference Include="{libDllProjectPath}" />
+                  </ItemGroup>
+
+                </Project>
+
+                """);
+
+        new DirectoryInfo(Path.Join(testInstance.Path, "Program"))
+            .EnumerateFileSystemInfos().Select(f => f.Name).Order()
+            .Should().BeEquivalentTo(["Lib", "Program.cs", "Program.csproj"]);
+
+        File.Exists(Path.Join(testInstance.Path, "Program", libDllProjectPath)).Should().BeTrue();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(Path.Join(testInstance.Path, "Program"))
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
+    [Fact]
+    public void Directives_IncludeDll_ViaIncludedFile()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+        var libDir = Path.Join(testInstance.Path, "Lib");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Join(libDir, "Lib.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(libDir, "LibClass.cs"), """
+            namespace Lib;
+            public static class LibClass
+            {
+                public static string GetMessage() => "Hello from Lib";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Lib.csproj")
+            .WithWorkingDirectory(libDir)
+            .Execute()
+            .Should().Pass();
+
+        var libDllDirectivePath = $"Lib/bin/Debug/{ToolsetInfo.CurrentTargetFramework}/Lib.dll";
+        var libDllProjectPath = Path.Join("Lib", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Lib.dll");
+
+        File.WriteAllText(Path.Join(testInstance.Path, "extra.cs"), $$"""
+            #:property FileBasedProgramsItemMapping=.dll=Reference
+            #:include {{libDllDirectivePath}}
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #!/usr/bin/env dotnet
+            #:include extra.cs
+            Console.WriteLine(Lib.LibClass.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from Lib";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        new DotnetCommand(Log, "project", "convert", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(testInstance.Path, "Program", "Program.csproj"))
+            .Should().Contain($"<Reference Include=\"{libDllProjectPath}\" />");
+
+        File.Exists(Path.Join(testInstance.Path, "Program", libDllProjectPath)).Should().BeTrue();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(Path.Join(testInstance.Path, "Program"))
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
+    [Fact]
+    public void Directives_IncludeDll_ViaRef()
+    {
+        var testInstance = _testAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), $"""
+            <Project>
+              <PropertyGroup>
+                <{CSharpDirective.Ref.ExperimentalFileBasedProgramEnableRefDirective}>true</{CSharpDirective.Ref.ExperimentalFileBasedProgramEnableRefDirective}>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var libDir = Path.Join(testInstance.Path, "lib");
+        Directory.CreateDirectory(libDir);
+
+        var dependencyDir = Path.Join(libDir, "Dependency");
+        Directory.CreateDirectory(dependencyDir);
+
+        File.WriteAllText(Path.Join(dependencyDir, "Dependency.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(dependencyDir, "DependencyClass.cs"), """
+            namespace Dependency;
+            public static class DependencyClass
+            {
+                public static string GetMessage() => "Hello from dependency";
+            }
+            """);
+
+        new DotnetCommand(Log, "build", "Dependency.csproj")
+            .WithWorkingDirectory(dependencyDir)
+            .Execute()
+            .Should().Pass();
+
+        var dependencyDllDirectivePath = $"Dependency/bin/Debug/{ToolsetInfo.CurrentTargetFramework}/Dependency.dll";
+        var dependencyDllProjectPath = Path.Join("Dependency", "bin", "Debug", ToolsetInfo.CurrentTargetFramework, "Dependency.dll");
+
+        File.WriteAllText(Path.Join(libDir, "lib.cs"), $$"""
+            #:property OutputType=Library
+            #:property FileBasedProgramsItemMapping=.dll=Reference
+            #:include {{dependencyDllDirectivePath}}
+            namespace MyLib;
+            public static class Wrapper
+            {
+                public static string GetMessage() => Dependency.DependencyClass.GetMessage();
+            }
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #:ref lib/lib.cs
+            Console.WriteLine(MyLib.Wrapper.GetMessage());
+            """);
+
+        var expectedOutput = "Hello from dependency";
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        var outputDirFullPath = Path.Join(testInstance.Path, "Project");
+        new DotnetCommand(Log, "project", "convert", "Program.cs", "-o", outputDirFullPath)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass();
+
+        File.ReadAllText(Path.Join(outputDirFullPath, "lib", "lib.csproj"))
+            .Should().Contain($"<Reference Include=\"{dependencyDllProjectPath}\" />");
+
+        File.Exists(Path.Join(outputDirFullPath, "lib", dependencyDllProjectPath)).Should().BeTrue();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(Path.Join(outputDirFullPath, "Program"))
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
+    [Fact]
     public void Directives_IncludeExclude_FilesCopied()
     {
         var testInstance = _testAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -1474,7 +1474,7 @@ public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileT
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <Compile Include="{bPath}" FileBasedProgramsAllowConversionToExplicitItem="true" />
+                        <Compile Include="{bPath}" FileBasedProgramsFromIncludeDirective="true" />
                       </ItemGroup>
 
                       <ItemGroup>

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -1474,7 +1474,7 @@ public sealed class RunFileTests_CscOnlyAndApi(ITestOutputHelper log) : RunFileT
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <Compile Include="{bPath}" />
+                        <Compile Include="{bPath}" FileBasedProgramsAllowConversionToExplicitItem="true" />
                       </ItemGroup>
 
                       <ItemGroup>

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1600,7 +1600,7 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
 
         Log.WriteLine(actualProject);
 
-        actualProject.Should().Contain("""<Compile Include="B.cs" />""");
+        actualProject.Should().Contain("""<Compile Include="B.cs" FileBasedProgramsAllowConversionToExplicitItem="true" />""");
 
         actualProject.Should().NotContain(".proto");
     }

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -1600,7 +1600,7 @@ public sealed class RunFileTests_Directives(ITestOutputHelper log) : RunFileTest
 
         Log.WriteLine(actualProject);
 
-        actualProject.Should().Contain("""<Compile Include="B.cs" FileBasedProgramsAllowConversionToExplicitItem="true" />""");
+        actualProject.Should().Contain("""<Compile Include="B.cs" FileBasedProgramsFromIncludeDirective="true" />""");
 
         actualProject.Should().NotContain(".proto");
     }


### PR DESCRIPTION
I wanted to change the default item mapping to include `.dll=Reference` (so one could reference DLLs, a common request, by doing `#:include /path/to.dll`) but realized conversion isn't handling custom item types like that properly, because conversion just copies the `#:include`d items and relies on implicit includes like `<Compile Include="**.cs"/>` which are in the SDK (but there is of course no implicit `<Reference Include="**.dll"/>`). This PR should fix that hole in the project conversion (by adding explicit `<{ItemType Include="file.ext"/>` to the converted project when necessary). I will follow up with adding `.dll=Reference` to the default mapping next (that will be a simple change).