### PR TITLE
Fix arm64 macOS CI installing x64 runtimes under Rosetta 2

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -130,6 +130,7 @@ jobs:
           BuildConfig: $(buildConfiguration)
           OPENSSL_ENABLE_SHA1_SIGNATURES: 1
           MSBUILDALWAYSRETRY: true
+          TARGET_ARCHITECTURE: ${{ parameters.targetArchitecture }}
 
     ############### TESTING ###############
     - ${{ if eq(parameters.runTests, true) }}:
@@ -181,6 +182,7 @@ jobs:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             HelixAccessToken: $(HelixApiAccessToken)
             RunAoTTests: ${{ parameters.runAoTTests }}
+            TARGET_ARCHITECTURE: ${{ parameters.targetArchitecture }}
 
     ############### POST ###############
     - ${{ if eq(parameters.publishXunitResults, true) }}:

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -1,3 +1,17 @@
+# Detect native OS architecture, which may differ from the process architecture
+# (e.g., x64 process running on ARM64 Windows via emulation).
+function Get-NativeMachineArchitecture {
+  try {
+    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
+      return "arm64"
+    }
+  } catch {
+    # Fallback for environments where RuntimeInformation is unavailable
+  }
+  return "x64"
+}
+
 function InitializeCustomSDKToolset {
   if ($env:TestFullMSBuild -eq "true") {
      $env:DOTNET_SDK_TEST_MSBUILD_PATH = InitializeVisualStudioMSBuild -install:$true -vsRequirements:$GlobalJson.tools.'vs-opt'
@@ -15,11 +29,13 @@ function InitializeCustomSDKToolset {
   }
 
   $cli = InitializeDotnetCli -install:$true
-  InstallDotNetSharedFramework "6.0.0"
-  InstallDotNetSharedFramework "7.0.0"
-  InstallDotNetSharedFramework "8.0.0"
-  InstallDotNetSharedFramework "9.0.0"
-  InstallDotNetSharedFramework "10.0.0"
+
+  $nativeArch = Get-NativeMachineArchitecture
+  InstallDotNetSharedFramework "6.0.0" $nativeArch
+  InstallDotNetSharedFramework "7.0.0" $nativeArch
+  InstallDotNetSharedFramework "8.0.0" $nativeArch
+  InstallDotNetSharedFramework "9.0.0" $nativeArch
+  InstallDotNetSharedFramework "10.0.0" $nativeArch
 
   CreateBuildEnvScripts
   CreateVSShortcut
@@ -117,13 +133,22 @@ function CreateVSShortcut()
   $shortcut.Save()
 }
 
-function InstallDotNetSharedFramework([string]$version) {
+function InstallDotNetSharedFramework([string]$version, [string]$arch = "") {
   $dotnetRoot = $env:DOTNET_INSTALL_DIR
   $fxDir = Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$version"
 
   if (!(Test-Path $fxDir)) {
     $installScript = GetDotNetInstallScript $dotnetRoot
-    & $installScript -Version $version -InstallDir $dotnetRoot -Runtime "dotnet" -SkipNonVersionedFiles
+    $installArgs = @{
+      Version = $version
+      InstallDir = $dotnetRoot
+      Runtime = "dotnet"
+      SkipNonVersionedFiles = $true
+    }
+    if ($arch) {
+      $installArgs.Architecture = $arch
+    }
+    & $installScript @installArgs
 
     if($lastExitCode -ne 0) {
       throw "Failed to install shared Framework $version to '$dotnetRoot' (exit code '$lastExitCode')."

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -6,6 +6,12 @@ function Get-NativeMachineArchitecture {
     if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
       return "arm64"
     }
+    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::X86) {
+      return "x86"
+    }
+    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm) {
+      return "arm"
+    }
   } catch {
     # Fallback for environments where RuntimeInformation is unavailable
   }

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -10,6 +10,8 @@ function GetNativeMachineArchitecture {
   case "$(uname -m)" in
     arm64|aarch64) echo "arm64" ;;
     amd64|x86_64) echo "x64" ;;
+    armv*l) echo "arm" ;;
+    i[3-6]86) echo "x86" ;;
     *) echo "x64" ;;
   esac
 }

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -40,6 +40,11 @@ function InitializeCustomSDKToolset {
   local native_arch
   native_arch=$(GetNativeMachineArchitecture)
 
+  # Use the pipeline's target architecture for runtime installation when set,
+  # otherwise fall back to the native machine architecture. This handles
+  # cross-compilation scenarios (e.g., x64 build machine targeting arm64).
+  local runtime_arch="${TARGET_ARCHITECTURE:-$native_arch}"
+
   # On macOS arm64 running under Rosetta 2, uname -m reports x86_64 and
   # Arcade installs the x64 SDK. Reinstall with the native architecture so
   # the dotnet host and shared frameworks match the hardware.
@@ -56,11 +61,11 @@ function InitializeCustomSDKToolset {
     done
   fi
 
-  InstallDotNetSharedFramework "6.0.0" "$native_arch"
-  InstallDotNetSharedFramework "7.0.0" "$native_arch"
-  InstallDotNetSharedFramework "8.0.0" "$native_arch"
-  InstallDotNetSharedFramework "9.0.0" "$native_arch"
-  InstallDotNetSharedFramework "10.0.0" "$native_arch"
+  InstallDotNetSharedFramework "6.0.0" "$runtime_arch"
+  InstallDotNetSharedFramework "7.0.0" "$runtime_arch"
+  InstallDotNetSharedFramework "8.0.0" "$runtime_arch"
+  InstallDotNetSharedFramework "9.0.0" "$runtime_arch"
+  InstallDotNetSharedFramework "10.0.0" "$runtime_arch"
 
   CreateBuildEnvScript
 }

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Detect native machine architecture, handling macOS Rosetta 2
+# where uname -m may report x86_64 on arm64 hardware.
+function GetNativeMachineArchitecture {
+  if [[ "$(uname)" == "Darwin" ]] && [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]; then
+    echo "arm64"
+    return
+  fi
+  case "$(uname -m)" in
+    arm64|aarch64) echo "arm64" ;;
+    amd64|x86_64) echo "x64" ;;
+    *) echo "x64" ;;
+  esac
+}
+
 function InitializeCustomSDKToolset {
   if [[ "$restore" != true ]]; then
     return
@@ -21,11 +35,30 @@ function InitializeCustomSDKToolset {
 
   InitializeDotNetCli true
 
-  InstallDotNetSharedFramework "6.0.0"
-  InstallDotNetSharedFramework "7.0.0"
-  InstallDotNetSharedFramework "8.0.0"
-  InstallDotNetSharedFramework "9.0.0"
-  InstallDotNetSharedFramework "10.0.0"
+  local native_arch
+  native_arch=$(GetNativeMachineArchitecture)
+
+  # On macOS arm64 running under Rosetta 2, uname -m reports x86_64 and
+  # Arcade installs the x64 SDK. Reinstall with the native architecture so
+  # the dotnet host and shared frameworks match the hardware.
+  if [[ "$native_arch" == "arm64" ]] && [[ "$(uname -m)" == "x86_64" ]]; then
+    ReadGlobalVersion "dotnet"
+    local dotnet_sdk_version=$_ReadGlobalVersion
+    echo "Native architecture is arm64 but SDK was installed as x64 (Rosetta 2). Reinstalling for arm64..."
+    rm -rf "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version"
+    InstallDotNet "$DOTNET_INSTALL_DIR" "$dotnet_sdk_version" "$native_arch" "sdk" "false" $runtime_source_feed $runtime_source_feed_key
+
+    # Remove any cached x64 test runtimes from previous builds
+    for fx_version in "6.0.0" "7.0.0" "8.0.0" "9.0.0" "10.0.0"; do
+      rm -rf "$DOTNET_INSTALL_DIR/shared/Microsoft.NETCore.App/$fx_version"
+    done
+  fi
+
+  InstallDotNetSharedFramework "6.0.0" "$native_arch"
+  InstallDotNetSharedFramework "7.0.0" "$native_arch"
+  InstallDotNetSharedFramework "8.0.0" "$native_arch"
+  InstallDotNetSharedFramework "9.0.0" "$native_arch"
+  InstallDotNetSharedFramework "10.0.0" "$native_arch"
 
   CreateBuildEnvScript
 }
@@ -33,6 +66,7 @@ function InitializeCustomSDKToolset {
 # Installs additional shared frameworks for testing purposes
 function InstallDotNetSharedFramework {
   local version=$1
+  local arch=${2:-}
   local dotnet_root=$DOTNET_INSTALL_DIR
   local fx_dir="$dotnet_root/shared/Microsoft.NETCore.App/$version"
 
@@ -40,7 +74,12 @@ function InstallDotNetSharedFramework {
     GetDotNetInstallScript "$dotnet_root"
     local install_script=$_GetDotNetInstallScript
 
-    bash "$install_script" --version $version --install-dir "$dotnet_root" --runtime "dotnet" --skip-non-versioned-files
+    local install_args=(--version $version --install-dir "$dotnet_root" --runtime "dotnet" --skip-non-versioned-files)
+    if [[ -n "$arch" ]]; then
+      install_args+=(--architecture "$arch")
+    fi
+
+    bash "$install_script" "${install_args[@]}"
     local lastexitcode=$?
 
     if [[ $lastexitcode != 0 ]]; then

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
         {
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiCompatTool_AssembliesIdentical_ExitsZero()
         {
             string assembly = BuildAsset(nameof(ApiCompatTool_AssembliesIdentical_ExitsZero), forceBreakingChange: false);
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             result.Should().Pass();
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiCompatTool_BreakingChange_ReportsCP0002()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_BreakingChange_ReportsCP0002)}_left", forceBreakingChange: false);
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
                 .And.Contain("Goodbye");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiCompatTool_SuppressionFile_RoundTrip()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_SuppressionFile_RoundTrip)}_left", forceBreakingChange: false);
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             consumeResult.StdOut.Should().NotContain("error CP0002");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiCompatTool_PackageMode_DetectsRemovedApi()
         {
             // Pack the existing PackageValidationTestProject twice to produce two .nupkg files

--- a/test/Microsoft.DotNet.ApiDiff.IntegrationTests/Tool/ApiDiffToolIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.IntegrationTests/Tool/ApiDiffToolIntegrationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ApiDiff.IntegrationTests.Tool
         {
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiDiffTool_NoChanges_ProducesNoMemberDiffs()
         {
             string assembly = BuildAssembly("MyLib", "public class Greeter { public string Hello(string name) => name; }", nameof(ApiDiffTool_NoChanges_ProducesNoMemberDiffs) + "_before");
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ApiDiff.IntegrationTests.Tool
             File.Exists(toc).Should().BeTrue($"the table-of-contents file should be written to {toc}");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiDiffTool_AddedMember_ProducesDiff()
         {
             const string sharedSource =
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ApiDiff.IntegrationTests.Tool
                 "the added member should appear in the diff for MyLib");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiDiffTool_TableOfContentsTitle_ControlsOutputFileName()
         {
             string assembly = BuildAssembly("MyLib", "public class Greeter { public string Hello(string name) => name; }",
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ApiDiff.IntegrationTests.Tool
             File.Exists(toc).Should().BeTrue($"the table-of-contents file should honour --tableOfContentsTitle and be written to {toc}");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void ApiDiffTool_MissingRequiredOption_FailsWithHelpfulError()
         {
             // Omit --output and verify System.CommandLine reports the missing required option

--- a/test/Microsoft.DotNet.GenAPI.IntegrationTests/Tool/GenAPIToolIntegrationTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.IntegrationTests/Tool/GenAPIToolIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.GenAPI.IntegrationTests.Tool
         {
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void GenAPITool_GeneratesSourceForAssembly()
         {
             (string assembly, string outputDirectory) = BuildAndPrepareOutput(nameof(GenAPITool_GeneratesSourceForAssembly));
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.GenAPI.IntegrationTests.Tool
                 .And.NotContain("InternalMultiply");
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void GenAPITool_HeaderFile_IsPrependedToOutput()
         {
             (string assembly, string outputDirectory) = BuildAndPrepareOutput(nameof(GenAPITool_HeaderFile_IsPrependedToOutput));
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.GenAPI.IntegrationTests.Tool
             File.ReadAllText(generated).Should().StartWith(headerLine);
         }
 
-        [PlatformSpecificFact(skipPlatforms: TestPlatforms.OSX, skipArchitecture: Architecture.Arm64, skipReason: "https://github.com/dotnet/sdk/issues/54248")]
+        [Fact] 
         public void GenAPITool_RespectInternals_IncludesInternalMembers()
         {
             (string assembly, string outputDirectory) = BuildAndPrepareOutput(nameof(GenAPITool_RespectInternals_IncludesInternalMembers));


### PR DESCRIPTION
Fixes #54248

On macOS arm64 CI machines, the Azure Pipelines agent may run under Rosetta 2, causing uname -m to report x86_64. This results in x64 SDK and test runtimes being installed instead of arm64.

Add GetNativeMachineArchitecture (bash) / Get-NativeMachineArchitecture (PowerShell) that detects the true hardware architecture using sysctl -n hw.optional.arm64 on macOS, falling back to uname -m elsewhere. Pass the detected architecture explicitly via --architecture to dotnet-install.sh calls.

When Rosetta is detected (native arm64 but uname reports x86_64), reinstall the SDK with arm64 architecture and clean any cached x64 test runtimes before installing the correct arm64 versions.

Fixes #54248