### PR TITLE
Warn when MetadataUpdaterSupport is false in dotnet watch

### DIFF
--- a/src/Dotnet.Watch/Watch/AppModels/HotReloadAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/HotReloadAppModel.cs
@@ -84,6 +84,32 @@ internal abstract partial class HotReloadAppModel()
             return false;
         }
 
+        // MetadataUpdaterSupport is the primary indicator of whether the runtime supports Hot Reload.
+        // It is however not correctly set prior to .NET 11, so we use Optimize and DebugSymbols instead for older frameworks.
+        // See https://github.com/dotnet/runtime/pull/127163
+        if (project.IsNetCoreApp(Versions.Version11_0))
+        {
+            if (!project.ProjectInstance.GetBooleanPropertyValue(PropertyNames.MetadataUpdaterSupport, defaultValue: true))
+            {
+                logger.Log(MessageDescriptor.ProjectDoesNotSupportHotReload_Property, PropertyNames.MetadataUpdaterSupport, "False", PropertyNames.MetadataUpdaterSupport, "True");
+                return false;
+            }
+        }
+        else
+        {
+            if (project.ProjectInstance.GetBooleanPropertyValue(PropertyNames.Optimize))
+            {
+                logger.Log(MessageDescriptor.ProjectDoesNotSupportHotReload_Property, PropertyNames.Optimize, "True", PropertyNames.Optimize, "False");
+                return false;
+            }
+
+            if (!project.ProjectInstance.GetBooleanPropertyValue(PropertyNames.DebugSymbols))
+            {
+                logger.Log(MessageDescriptor.ProjectDoesNotSupportHotReload_Property, PropertyNames.DebugSymbols, "False", PropertyNames.DebugSymbols, "True");
+                return false;
+            }
+        }
+
         return true;
     }
 }

--- a/src/Dotnet.Watch/Watch/Build/BuildNames.cs
+++ b/src/Dotnet.Watch/Watch/Build/BuildNames.cs
@@ -24,6 +24,9 @@ internal static class PropertyNames
     public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
     public const string NonExistentFile = nameof(NonExistentFile);
     public const string StartupHookSupport = nameof(StartupHookSupport);
+    public const string MetadataUpdaterSupport = nameof(MetadataUpdaterSupport);
+    public const string Optimize = nameof(Optimize);
+    public const string DebugSymbols = nameof(DebugSymbols);
     public const string PublishTrimmed = nameof(PublishTrimmed);
     public const string PublishAot = nameof(PublishAot);
 }

--- a/src/Dotnet.Watch/Watch/Utilities/Versions.cs
+++ b/src/Dotnet.Watch/Watch/Utilities/Versions.cs
@@ -7,4 +7,5 @@ internal static class Versions
 {
     public static readonly Version Version3_1 = new(3, 1);
     public static readonly Version Version6_0 = new(6, 0);
+    public static readonly Version Version11_0 = new(11, 0);
 }

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
@@ -11,8 +11,19 @@ public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logge
     [InlineData("PublishAot", "True")]
     [InlineData("PublishTrimmed", "True")]
     [InlineData("StartupHookSupport", "False")]
+    [InlineData("Optimize", "True")]
+    [InlineData("MetadataUpdaterSupport", "False")]
     public async Task ChangeFileInAotProject(string propertyName, string propertyValue)
     {
+        var tfvParsed = Version.Parse(ToolsetInfo.CurrentTargetFrameworkVersion);
+        var isNet11OrNewer = tfvParsed.Major >= 11;
+
+        // Optimize check only applies to < .NET 11; MetadataUpdaterSupport only to >= .NET 11.
+        if (propertyName == "Optimize" && isNet11OrNewer)
+            return;
+        if (propertyName == "MetadataUpdaterSupport" && !isNet11OrNewer)
+            return;
+
         var projectDisplay = $"WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})";
 
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: $"{propertyName};{propertyValue}")
@@ -28,7 +39,14 @@ public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logge
 
         App.Start(testAsset, ["--non-interactive"]);
 
-        var message = MessageDescriptor.ProjectDoesNotSupportHotReload_Property.GetMessage((propertyName, propertyValue, PropertyNames.StartupHookSupport, "True"));
+        // The warning message suggests which property to set to fix the issue.
+        var (suggestedProperty, suggestedValue) = propertyName switch
+        {
+            "Optimize" => (PropertyNames.Optimize, "False"),
+            "MetadataUpdaterSupport" => (PropertyNames.MetadataUpdaterSupport, "True"),
+            _ => (PropertyNames.StartupHookSupport, "True"),
+        };
+        var message = MessageDescriptor.ProjectDoesNotSupportHotReload_Property.GetMessage((propertyName, propertyValue, suggestedProperty, suggestedValue));
         await App.WaitForOutputLineContaining($"[{projectDisplay}] {message}");
         await App.WaitForOutputLineContaining(MessageDescriptor.WaitingForChanges);
         App.Process.ClearOutput();


### PR DESCRIPTION
Warn when project configuration disables Hot Reload in `dotnet watch`, matching the checks that VS uses in [dotnet-project-system PR 738329](https://devdiv.visualstudio.com/DevDiv/_git/dotnet-project-system/pullrequest/738329).

### Background

Previously, `dotnet watch` only checked `StartupHookSupport` (and `PublishAot`/`PublishTrimmed` which imply it). It did not warn when the runtime's `MetadataUpdater.IsSupported` would be `false`, leading to confusing behavior — e.g. running `dotnet watch` in a non-Debug configuration would silently fail to apply Hot Reload updates.

### Changes

**TFM >= .NET 11** — check `MetadataUpdaterSupport`. This property is now [correctly set by the runtime](https://github.com/dotnet/runtime/pull/127163) starting in .NET 11.

**TFM < .NET 11** — check `Optimize == false` and `DebugSymbols == true`, since `MetadataUpdaterSupport` was not reliably set for older frameworks. This matches what VS does.

### Files changed

- **`Versions.cs`** — Added `Version11_0` constant
- **`BuildNames.cs`** — Added `MetadataUpdaterSupport`, `Optimize`, `DebugSymbols` constants
- **`HotReloadAppModel.cs`** — Added TFM-gated checks with link to runtime PR
- **`SourceFileUpdateTests.HotReloadNotSupported.cs`** — Replaced `MetadataUpdaterSupport=False` test case with `Optimize=True` (test TFM is `net10.0`, so the `< 11` path is exercised)