### PR TITLE
Add `dotnet test` device selection support for MAUI

### DIFF
--- a/documentation/specs/dotnet-run-for-maui.md
+++ b/documentation/specs/dotnet-run-for-maui.md
@@ -1,4 +1,4 @@
-# `dotnet run` for .NET MAUI Scenarios
+# `dotnet run` and `dotnet test` for .NET MAUI Scenarios
 
 The current state of `dotnet run` for .NET MAUI projects is summarized
 by this issue from 2021:
@@ -104,14 +104,57 @@ devices`, or `xcrun devicectl list devices`._
   `$(RunCommand)` and `$(RunArguments)` using the value supplied by
   `-p:Device`.
 
-## New `dotnet run` Command-line Switches
+## `dotnet test` Behavior
+
+`dotnet test` on a multi-targeted project already runs tests for all
+target frameworks. This is existing behavior which differs from `dotnet
+run`, which previously errored when multiple `$(TargetFrameworks)` were
+present and `-f` was not supplied.
+
+For .NET MAUI projects, `dotnet test` extends this behavior with
+device selection:
+
+* **No `$(TargetFramework)` prompt by default** — unlike `dotnet run`,
+  `dotnet test` does _not_ prompt for a target framework. It iterates
+  over all `$(TargetFrameworks)` as it does today.
+
+* **Device prompt per target framework** — for each target framework
+  that provides a `ComputeAvailableDevices` MSBuild target (e.g.,
+  `net11.0-android`, `net11.0-ios`), the user is prompted to select a
+  device. This means a project targeting both Android and iOS may
+  prompt twice.
+
+  * In non-interactive mode, this will error with a friendly message
+    suggesting the `--device` switch, same as `dotnet run`.
+
+* **`--device` forces a `$(TargetFramework)` prompt** — if `--device`
+  is passed, the user _must_ be prompted to select a single
+  `$(TargetFramework)`, because the device identifier is
+  platform-specific and the SDK cannot determine which target framework
+  it applies to.
+
+  * In non-interactive mode with `--device` but no `-f`, this will
+    error suggesting to supply `-f`.
+
+* **`-f` works as normal** — passing `-f` limits the test run to a
+  single target framework. If that framework provides
+  `ComputeAvailableDevices`, the user may be prompted for a device.
+
+* **`--list-devices`** works the same as with `dotnet run`.
+
+* **`-e` / `--environment`** — `dotnet test` already supports `-e` to
+  pass environment variables to the test process. This existing
+  behavior is unchanged.
+
+## New Command-line Switches
 
 So far, it feels like no new subcommand is needed. In interactive
 mode, `dotnet run` will now prompt to select a `$(TargetFramework)`
 for all multi-targeted projects. Platform-specific projects like
-Android, iOS, etc. will prompt for device selection.
+Android, iOS, etc. will prompt for device selection. `dotnet test`
+shares the `--list-devices` and `--device` switches described below.
 
-`dotnet run --list-devices` will:
+`dotnet run --list-devices` (or `dotnet test --list-devices`) will:
 
 * Prompt for `$(TargetFramework)` for multi-targeted projects just
   like when `--list-devices` is omitted.

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -124,6 +124,12 @@ internal abstract partial class TestCommandDefinition
             Description = CommandDefinitionStrings.CommandOptionNoLaunchProfileArgumentsDescription
         };
 
+        public readonly Option<string> DeviceOption = new("--device")
+        {
+            Description = CommandDefinitionStrings.CommandOptionDeviceDescription,
+            HelpName = CommandDefinitionStrings.CommandOptionDeviceHelpName
+        };
+
         public readonly Option<string> ArtifactsPathOption = CommonOptions.CreateArtifactsPathOption();
 
         public const string BuildTargetName = "_MTPBuild";
@@ -159,6 +165,7 @@ internal abstract partial class TestCommandDefinition
             Options.Add(ListTestsOption);
             Options.Add(NoLaunchProfileOption);
             Options.Add(NoLaunchProfileArgumentsOption);
+            Options.Add(DeviceOption);
             Options.Add(MTPTargetOption);
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -69,11 +69,11 @@ internal static class MSBuildUtility
 
         using var collection = new ProjectCollection(globalProperties, loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
         var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
-        ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = GetProjectsProperties(collection, evaluationContext, projectPaths, buildOptions);
+        var (projects, deviceBuildExitCode) = GetProjectsProperties(collection, evaluationContext, projectPaths, buildOptions);
         logger?.ReallyShutdown();
         collection.UnloadAllProjects();
 
-        return (projects, buildExitCode);
+        return (projects, deviceBuildExitCode != 0 ? deviceBuildExitCode : buildExitCode);
     }
 
     public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) GetProjectsFromProject(string projectFilePath, BuildOptions buildOptions)
@@ -332,7 +332,7 @@ internal static class MSBuildUtility
         return new RestoringCommand(parsedMSBuildArgs, buildOptions.HasNoRestore).Execute();
     }
 
-    private static ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> GetProjectsProperties(
+    private static (ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) GetProjectsProperties(
         ProjectCollection projectCollection,
         EvaluationContext evaluationContext,
         IEnumerable<(string ProjectFilePath, string? Configuration, string? Platform)> projects,
@@ -345,17 +345,19 @@ internal static class MSBuildUtility
         // (BuildManager.DefaultBuildManager), which is a process-wide singleton and cannot run concurrently.
         foreach (var project in projects)
         {
-            var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions);
+            var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions, projectCollection, evaluationContext);
 
             if (devicesByTfm is not null)
             {
                 var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm);
-                if (exitCode == 0)
+                if (exitCode != 0)
                 {
-                    foreach (var module in modules)
-                    {
-                        allProjects.Add(module);
-                    }
+                    return (allProjects, exitCode);
+                }
+
+                foreach (var module in modules)
+                {
+                    allProjects.Add(module);
                 }
             }
             else
@@ -379,6 +381,6 @@ internal static class MSBuildUtility
                 }
             });
 
-        return allProjects;
+        return (allProjects, 0);
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -78,6 +78,15 @@ internal static class MSBuildUtility
 
     public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) GetProjectsFromProject(string projectFilePath, BuildOptions buildOptions)
     {
+        // Pre-build device selection: evaluate the project to select devices BEFORE building,
+        // so that device-provided RuntimeIdentifiers are included in the build.
+        var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(projectFilePath, buildOptions);
+
+        if (devicesByTfm is not null)
+        {
+            return BuildPerTfmWithDevices(projectFilePath, buildOptions, devicesByTfm);
+        }
+
         int buildExitCode = BuildOrRestoreProjectOrSolution(projectFilePath, buildOptions);
 
         if (buildExitCode != 0)
@@ -95,6 +104,74 @@ internal static class MSBuildUtility
         logger?.ReallyShutdown();
         collection.UnloadAllProjects();
         return (projects, buildExitCode);
+    }
+
+    /// <summary>
+    /// Builds each TFM separately with its selected device/RuntimeIdentifier injected, then
+    /// evaluates each to get test modules. This ensures device-provided RIDs are part of the build.
+    /// </summary>
+    private static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) BuildPerTfmWithDevices(
+        string projectFilePath,
+        BuildOptions buildOptions,
+        Dictionary<string, (string? Device, string? RuntimeIdentifier)> devicesByTfm)
+    {
+        var allModules = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
+
+        foreach (var (tfm, (device, rid)) in devicesByTfm)
+        {
+            var perTfmArgs = buildOptions.MSBuildArgs;
+            if (!string.IsNullOrEmpty(tfm))
+            {
+                perTfmArgs = perTfmArgs.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
+            }
+
+            if (device is not null)
+            {
+                perTfmArgs = perTfmArgs.Append($"-p:Device={device}");
+            }
+
+            if (!string.IsNullOrEmpty(rid))
+            {
+                perTfmArgs = perTfmArgs.Append($"-p:RuntimeIdentifier={rid}");
+            }
+
+            var perTfmBuildOptions = buildOptions with
+            {
+                MSBuildArgs = perTfmArgs,
+                Device = device,
+                DeviceSelectionDone = true,
+            };
+
+            int exitCode = BuildOrRestoreProjectOrSolution(projectFilePath, perTfmBuildOptions);
+            if (exitCode != 0)
+            {
+                return (Array.Empty<ParallelizableTestModuleGroupWithSequentialInnerModules>(), exitCode);
+            }
+
+            FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. perTfmBuildOptions.MSBuildArgs], dotnetTestVerb);
+
+            var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+                perTfmBuildOptions.MSBuildArgs,
+                CommonOptions.CreatePropertyOption(),
+                CommonOptions.CreateRestorePropertyOption(),
+                CommonOptions.CreateMSBuildTargetOption(),
+                CommonOptions.CreateVerbosityOption(),
+                CommonOptions.CreateNoLogoOption());
+
+            using var collection = new ProjectCollection(
+                globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs),
+                logger is null ? null : [logger],
+                toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+            var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+            IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> modules = SolutionAndProjectUtility.GetProjectProperties(
+                projectFilePath, collection, evaluationContext, perTfmBuildOptions, configuration: null, platform: null);
+            logger?.ReallyShutdown();
+            collection.UnloadAllProjects();
+
+            allModules.AddRange(modules);
+        }
+
+        return (allModules, 0);
     }
 
     public static BuildOptions GetBuildOptions(ParseResult parseResult)

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -138,6 +138,16 @@ internal static class MSBuildUtility
                 perTfmArgs = perTfmArgs.Append($"-p:RuntimeIdentifier={rid}");
             }
 
+            if (!string.IsNullOrEmpty(configuration))
+            {
+                perTfmArgs = perTfmArgs.Append($"-p:Configuration={configuration}");
+            }
+
+            if (!string.IsNullOrEmpty(platform))
+            {
+                perTfmArgs = perTfmArgs.Append($"-p:Platform={platform}");
+            }
+
             var perTfmBuildOptions = buildOptions with
             {
                 MSBuildArgs = perTfmArgs,

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -80,11 +80,11 @@ internal static class MSBuildUtility
     {
         // Pre-build device selection: evaluate the project to select devices BEFORE building,
         // so that device-provided RuntimeIdentifiers are included in the build.
-        var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(projectFilePath, buildOptions);
+        var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(projectFilePath, buildOptions);
 
-        if (devicesByTfm is not null)
+        if (deviceSelection is not null)
         {
-            return BuildPerTfmWithDevices(projectFilePath, buildOptions, devicesByTfm);
+            return BuildPerTfmWithDevices(projectFilePath, buildOptions, deviceSelection);
         }
 
         int buildExitCode = BuildOrRestoreProjectOrSolution(projectFilePath, buildOptions);
@@ -113,14 +113,13 @@ internal static class MSBuildUtility
     private static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) BuildPerTfmWithDevices(
         string projectFilePath,
         BuildOptions buildOptions,
-        Dictionary<string, (string? Device, string? RuntimeIdentifier)> devicesByTfm,
+        SolutionAndProjectUtility.DeviceSelectionResult deviceSelection,
         string? configuration = null,
         string? platform = null)
     {
-        var allModules = new List<TestModule>();
-        bool testTfmsInParallel = true;
+        var allGroups = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
 
-        foreach (var (tfm, (device, rid)) in devicesByTfm)
+        foreach (var (tfm, (device, rid)) in deviceSelection.DevicesByTfm)
         {
             var perTfmArgs = buildOptions.MSBuildArgs;
             if (!string.IsNullOrEmpty(tfm))
@@ -162,13 +161,7 @@ internal static class MSBuildUtility
 
             FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. perTfmBuildOptions.MSBuildArgs], dotnetTestVerb);
 
-            var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-                perTfmBuildOptions.MSBuildArgs,
-                CommonOptions.CreatePropertyOption(),
-                CommonOptions.CreateRestorePropertyOption(),
-                CommonOptions.CreateMSBuildTargetOption(),
-                CommonOptions.CreateVerbosityOption(),
-                CommonOptions.CreateNoLogoOption());
+            var msbuildArgs = SolutionAndProjectUtility.AnalyzeStandardTestMSBuildArgs(perTfmBuildOptions.MSBuildArgs);
 
             using var collection = new ProjectCollection(
                 globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs),
@@ -179,46 +172,31 @@ internal static class MSBuildUtility
                 projectFilePath, collection, evaluationContext, perTfmBuildOptions, configuration, platform);
             logger?.ReallyShutdown();
 
-            // Read TestTfmsInParallel from the first TFM evaluation
-            if (allModules.Count == 0)
+            allGroups.AddRange(modules);
+        }
+
+        // When TestTfmsInParallel is false, merge all modules into one sequential group
+        if (!deviceSelection.TestTfmsInParallel && allGroups.Count > 1)
+        {
+            var allModules = new List<TestModule>();
+            foreach (var group in allGroups)
             {
-                var projectInstance = SolutionAndProjectUtility.EvaluateProject(collection, evaluationContext, projectFilePath, tfm, configuration, platform);
-                if (bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.TestTfmsInParallel), out bool parsed) ||
-                    bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.BuildInParallel), out parsed))
+                if (group.Modules is not null)
                 {
-                    testTfmsInParallel = parsed;
+                    allModules.AddRange(group.Modules);
+                }
+                else if (group.Module is not null)
+                {
+                    allModules.Add(group.Module);
                 }
             }
 
-            collection.UnloadAllProjects();
-
-            foreach (var moduleGroup in modules)
-            {
-                if (moduleGroup.Modules is not null)
-                {
-                    allModules.AddRange(moduleGroup.Modules);
-                }
-                else if (moduleGroup.Module is not null)
-                {
-                    allModules.Add(moduleGroup.Module);
-                }
-            }
-        }
-
-        // Respect TestTfmsInParallel: group all modules into one sequential group if disabled
-        List<ParallelizableTestModuleGroupWithSequentialInnerModules> result;
-        if (testTfmsInParallel)
-        {
-            result = allModules.Select(m => new ParallelizableTestModuleGroupWithSequentialInnerModules(m)).ToList();
-        }
-        else
-        {
-            result = allModules.Count > 0
+            return (allModules.Count > 0
                 ? [new ParallelizableTestModuleGroupWithSequentialInnerModules(allModules)]
-                : [];
+                : [], 0);
         }
 
-        return (result, 0);
+        return (allGroups, 0);
     }
 
     public static BuildOptions GetBuildOptions(ParseResult parseResult)
@@ -393,11 +371,11 @@ internal static class MSBuildUtility
         // (BuildManager.DefaultBuildManager), which is a process-wide singleton and cannot run concurrently.
         foreach (var project in projects)
         {
-            var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions, projectCollection, evaluationContext);
+            var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions, projectCollection, evaluationContext);
 
-            if (devicesByTfm is not null)
+            if (deviceSelection is not null)
             {
-                var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm, project.Configuration, project.Platform);
+                var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, deviceSelection, project.Configuration, project.Platform);
                 if (exitCode != 0)
                 {
                     return (allProjects, exitCode);

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -139,7 +139,6 @@ internal static class MSBuildUtility
             {
                 MSBuildArgs = perTfmArgs,
                 Device = device,
-                DeviceSelectionDone = true,
             };
 
             int exitCode = BuildOrRestoreProjectOrSolution(projectFilePath, perTfmBuildOptions);
@@ -348,10 +347,28 @@ internal static class MSBuildUtility
             new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
             (project) =>
             {
-                IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, project.Configuration, project.Platform);
-                foreach (var projectMetadata in projectsMetadata)
+                // Device selection for this project (same path used by GetProjectsFromProject).
+                // For solutions, the solution build already ran, so the per-TFM rebuild is incremental.
+                var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions);
+
+                if (devicesByTfm is not null)
                 {
-                    allProjects.Add(projectMetadata);
+                    var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm);
+                    if (exitCode == 0)
+                    {
+                        foreach (var module in modules)
+                        {
+                            allProjects.Add(module);
+                        }
+                    }
+                }
+                else
+                {
+                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, project.Configuration, project.Platform);
+                    foreach (var projectMetadata in projectsMetadata)
+                    {
+                        allProjects.Add(projectMetadata);
+                    }
                 }
             });
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -151,7 +151,8 @@ internal static class MSBuildUtility
             parseResult.GetValue(definition.NoLaunchProfileOption),
             parseResult.GetValue(definition.NoLaunchProfileArgumentsOption),
             otherArgs,
-            msbuildArgs);
+            msbuildArgs,
+            Device: parseResult.GetValue(definition.DeviceOption));
     }
 
     private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(List<string> otherArgs)

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -113,9 +113,12 @@ internal static class MSBuildUtility
     private static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) BuildPerTfmWithDevices(
         string projectFilePath,
         BuildOptions buildOptions,
-        Dictionary<string, (string? Device, string? RuntimeIdentifier)> devicesByTfm)
+        Dictionary<string, (string? Device, string? RuntimeIdentifier)> devicesByTfm,
+        string? configuration = null,
+        string? platform = null)
     {
-        var allModules = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
+        var allModules = new List<TestModule>();
+        bool testTfmsInParallel = true;
 
         foreach (var (tfm, (device, rid)) in devicesByTfm)
         {
@@ -163,14 +166,49 @@ internal static class MSBuildUtility
                 toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
             var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
             IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> modules = SolutionAndProjectUtility.GetProjectProperties(
-                projectFilePath, collection, evaluationContext, perTfmBuildOptions, configuration: null, platform: null);
+                projectFilePath, collection, evaluationContext, perTfmBuildOptions, configuration, platform);
             logger?.ReallyShutdown();
+
+            // Read TestTfmsInParallel from the first TFM evaluation
+            if (allModules.Count == 0)
+            {
+                var projectInstance = SolutionAndProjectUtility.EvaluateProject(collection, evaluationContext, projectFilePath, tfm, configuration, platform);
+                if (bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.TestTfmsInParallel), out bool parsed) ||
+                    bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.BuildInParallel), out parsed))
+                {
+                    testTfmsInParallel = parsed;
+                }
+            }
+
             collection.UnloadAllProjects();
 
-            allModules.AddRange(modules);
+            foreach (var moduleGroup in modules)
+            {
+                if (moduleGroup.Modules is not null)
+                {
+                    allModules.AddRange(moduleGroup.Modules);
+                }
+                else if (moduleGroup.Module is not null)
+                {
+                    allModules.Add(moduleGroup.Module);
+                }
+            }
         }
 
-        return (allModules, 0);
+        // Respect TestTfmsInParallel: group all modules into one sequential group if disabled
+        List<ParallelizableTestModuleGroupWithSequentialInnerModules> result;
+        if (testTfmsInParallel)
+        {
+            result = allModules.Select(m => new ParallelizableTestModuleGroupWithSequentialInnerModules(m)).ToList();
+        }
+        else
+        {
+            result = allModules.Count > 0
+                ? [new ParallelizableTestModuleGroupWithSequentialInnerModules(allModules)]
+                : [];
+        }
+
+        return (result, 0);
     }
 
     public static BuildOptions GetBuildOptions(ParseResult parseResult)
@@ -349,7 +387,7 @@ internal static class MSBuildUtility
 
             if (devicesByTfm is not null)
             {
-                var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm);
+                var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm, project.Configuration, project.Platform);
                 if (exitCode != 0)
                 {
                     return (allProjects, exitCode);

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -339,36 +339,43 @@ internal static class MSBuildUtility
         BuildOptions buildOptions)
     {
         var allProjects = new ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules>();
+        var nonDeviceProjects = new List<(string ProjectFilePath, string? Configuration, string? Platform)>();
 
+        // Phase 1: Handle device projects sequentially. Per-TFM builds use in-process MSBuild
+        // (BuildManager.DefaultBuildManager), which is a process-wide singleton and cannot run concurrently.
+        foreach (var project in projects)
+        {
+            var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions);
+
+            if (devicesByTfm is not null)
+            {
+                var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm);
+                if (exitCode == 0)
+                {
+                    foreach (var module in modules)
+                    {
+                        allProjects.Add(module);
+                    }
+                }
+            }
+            else
+            {
+                nonDeviceProjects.Add(project);
+            }
+        }
+
+        // Phase 2: Handle non-device projects in parallel (existing behavior).
         Parallel.ForEach(
-            projects,
+            nonDeviceProjects,
             // We don't use --max-parallel-test-modules here.
             // If user wants to limit the test applications run in parallel, we don't want to punish them and force the evaluation to also be limited.
             new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
             (project) =>
             {
-                // Device selection for this project (same path used by GetProjectsFromProject).
-                // For solutions, the solution build already ran, so the per-TFM rebuild is incremental.
-                var devicesByTfm = SolutionAndProjectUtility.SelectDevicesBeforeBuild(project.ProjectFilePath, buildOptions);
-
-                if (devicesByTfm is not null)
+                IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, project.Configuration, project.Platform);
+                foreach (var projectMetadata in projectsMetadata)
                 {
-                    var (modules, exitCode) = BuildPerTfmWithDevices(project.ProjectFilePath, buildOptions, devicesByTfm);
-                    if (exitCode == 0)
-                    {
-                        foreach (var module in modules)
-                        {
-                            allProjects.Add(module);
-                        }
-                    }
-                }
-                else
-                {
-                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, project.Configuration, project.Platform);
-                    foreach (var projectMetadata in projectsMetadata)
-                    {
-                        allProjects.Add(projectMetadata);
-                    }
+                    allProjects.Add(projectMetadata);
                 }
             });
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.CommandLine;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Run;
@@ -171,11 +170,9 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
             // Evaluate the project to get TargetFrameworks
             using var collection = new ProjectCollection(globalProperties);
-            var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
             var projectInstance = ProjectInstance.FromFile(projectPath, new ProjectOptions
             {
                 GlobalProperties = globalProperties,
-                EvaluationContext = evaluationContext,
                 ProjectCollection = collection,
             });
 
@@ -203,18 +200,16 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 {
                     buildOptions = buildOptions with
                     {
-                        MSBuildArgs = buildOptions.MSBuildArgs.Append($"-p:{ProjectProperties.TargetFramework}={selectedFramework}")
+                        MSBuildArgs = [.. buildOptions.MSBuildArgs, $"-p:{ProjectProperties.TargetFramework}={selectedFramework}"]
                     };
                 }
             }
-
-            collection.UnloadAllProjects();
         }
 
         // Add Device to MSBuild args so the build and evaluation see it
         return buildOptions with
         {
-            MSBuildArgs = buildOptions.MSBuildArgs.Append($"-p:Device={buildOptions.Device}")
+            MSBuildArgs = [.. buildOptions.MSBuildArgs, $"-p:Device={buildOptions.Device}"]
         };
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -3,10 +3,16 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Telemetry;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -18,6 +24,13 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
         ValidationUtility.ValidateMutuallyExclusiveOptions(parseResult, buildOptions.PathOptions);
+
+        // When --device is specified, force single target framework selection because
+        // a device is platform-specific and we need to know which TFM was intended.
+        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
+        {
+            buildOptions = HandleDeviceWithTargetFrameworkSelection(buildOptions);
+        }
 
         ITestHandler testHandler = buildOptions.PathOptions.TestModules is { } testModules
             ? new TestModulesFilterHandler(testModules, parseResult)
@@ -120,5 +133,88 @@ internal partial class MicrosoftTestingPlatformTestCommand
         if (degreeOfParallelism <= 0)
             degreeOfParallelism = Environment.ProcessorCount;
         return degreeOfParallelism;
+    }
+
+    /// <summary>
+    /// When --device is specified, we need to ensure a single target framework is selected
+    /// because a device is platform-specific. If -f/--framework wasn't provided, this method
+    /// evaluates the project to get TargetFrameworks and prompts for selection.
+    /// The selected device is also added to MSBuild args so the build sees it.
+    /// </summary>
+    private static BuildOptions HandleDeviceWithTargetFrameworkSelection(BuildOptions buildOptions)
+    {
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+            buildOptions.MSBuildArgs,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
+        var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
+
+        // Check if TargetFramework is already specified via -f/--framework or -p:TargetFramework=
+        if (!globalProperties.ContainsKey(ProjectProperties.TargetFramework))
+        {
+            // Need to resolve the project to get TargetFrameworks
+            if (!ValidationUtility.ValidateBuildPathOptions(buildOptions.PathOptions, out var projectPath, out bool isSolution))
+            {
+                throw new GracefulException(CliCommandStrings.CmdTestNoTestProjectsFound);
+            }
+
+            if (isSolution)
+            {
+                // Device selection with solutions requires specifying a project and framework
+                throw new GracefulException(
+                    string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework"));
+            }
+
+            // Evaluate the project to get TargetFrameworks
+            using var collection = new ProjectCollection(globalProperties);
+            var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+            var projectInstance = ProjectInstance.FromFile(projectPath, new ProjectOptions
+            {
+                GlobalProperties = globalProperties,
+                EvaluationContext = evaluationContext,
+                ProjectCollection = collection,
+            });
+
+            var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
+            var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
+
+            // Only prompt if multi-targeted (no single TargetFramework set)
+            if (string.IsNullOrEmpty(targetFramework) && !string.IsNullOrEmpty(targetFrameworks))
+            {
+                var frameworks = targetFrameworks
+                    .Split(CliConstants.SemiColon, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(f => f.Trim())
+                    .Where(f => !string.IsNullOrEmpty(f))
+                    .ToArray();
+
+                bool isInteractive = !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment();
+                if (!RunCommandSelector.TrySelectTargetFramework(frameworks, isInteractive, out string? selectedFramework))
+                {
+                    // Error already written to stderr by TrySelectTargetFramework
+                    throw new GracefulException(
+                        string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework"));
+                }
+
+                if (selectedFramework is not null)
+                {
+                    buildOptions = buildOptions with
+                    {
+                        MSBuildArgs = buildOptions.MSBuildArgs.Append($"-p:{ProjectProperties.TargetFramework}={selectedFramework}")
+                    };
+                }
+            }
+
+            collection.UnloadAllProjects();
+        }
+
+        // Add Device to MSBuild args so the build and evaluation see it
+        return buildOptions with
+        {
+            MSBuildArgs = buildOptions.MSBuildArgs.Append($"-p:Device={buildOptions.Device}")
+        };
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -142,13 +142,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
     /// </summary>
     private static BuildOptions HandleDeviceWithTargetFrameworkSelection(BuildOptions buildOptions)
     {
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-            buildOptions.MSBuildArgs,
-            CommonOptions.CreatePropertyOption(),
-            CommonOptions.CreateRestorePropertyOption(),
-            CommonOptions.CreateMSBuildTargetOption(),
-            CommonOptions.CreateVerbosityOption(),
-            CommonOptions.CreateNoLogoOption());
+        var msbuildArgs = SolutionAndProjectUtility.AnalyzeStandardTestMSBuildArgs(buildOptions.MSBuildArgs);
 
         var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -16,4 +16,5 @@ internal record BuildOptions(
     bool NoLaunchProfileArguments,
     List<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs,
-    string? Device);
+    string? Device,
+    bool DeviceSelectionDone = false);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -16,4 +16,4 @@ internal record BuildOptions(
     bool NoLaunchProfileArguments,
     List<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs,
-    string? Device = null);
+    string? Device);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -15,4 +15,5 @@ internal record BuildOptions(
     bool NoLaunchProfile,
     bool NoLaunchProfileArguments,
     List<string> TestApplicationArguments,
-    IEnumerable<string> MSBuildArgs);
+    IEnumerable<string> MSBuildArgs,
+    string? Device = null);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -16,5 +16,4 @@ internal record BuildOptions(
     bool NoLaunchProfileArguments,
     List<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs,
-    string? Device,
-    bool DeviceSelectionDone = false);
+    string? Device);

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -20,6 +20,18 @@ internal static class SolutionAndProjectUtility
     private static readonly string[] s_computeRunArgumentsTarget = [Constants.ComputeRunArguments];
     private static readonly Lock s_buildLock = new();
 
+    /// <summary>
+    /// Parses MSBuild args with the standard set of test command options.
+    /// </summary>
+    internal static MSBuildArgs AnalyzeStandardTestMSBuildArgs(IEnumerable<string> args) =>
+        MSBuildArgs.AnalyzeMSBuildArguments(
+            args,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
     public static (bool SolutionOrProjectFileFound, string Message) TryGetProjectOrSolutionFilePath(string directory, out string projectOrSolutionFilePath, out bool isSolution)
     {
         projectOrSolutionFilePath = string.Empty;
@@ -154,7 +166,7 @@ internal static class SolutionAndProjectUtility
 
     private static string[] GetProjectFilePaths(string directory) => Directory.GetFiles(directory, CliConstants.ProjectExtensionPattern, SearchOption.TopDirectoryOnly);
 
-    internal static ProjectInstance EvaluateProject(
+    private static ProjectInstance EvaluateProject(
         ProjectCollection collection,
         EvaluationContext evaluationContext,
         string projectFilePath,
@@ -299,11 +311,11 @@ internal static class SolutionAndProjectUtility
 
     /// <summary>
     /// Performs device selection for each TFM BEFORE the build, so that device-provided
-    /// RuntimeIdentifiers are included in the build. Returns a dictionary mapping each TFM
-    /// to its selected device and RuntimeIdentifier, or null if no device selection is needed.
+    /// RuntimeIdentifiers are included in the build. Returns a result with device mappings
+    /// and TestTfmsInParallel setting, or null if no device selection is needed.
     /// When projectCollection/evaluationContext are provided, reuses them to avoid redundant evaluation.
     /// </summary>
-    internal static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuild(
+    internal static DeviceSelectionResult? SelectDevicesBeforeBuild(
         string projectFilePath,
         BuildOptions buildOptions,
         ProjectCollection? projectCollection = null,
@@ -315,13 +327,7 @@ internal static class SolutionAndProjectUtility
             return null;
         }
 
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-            buildOptions.MSBuildArgs,
-            CommonOptions.CreatePropertyOption(),
-            CommonOptions.CreateRestorePropertyOption(),
-            CommonOptions.CreateMSBuildTargetOption(),
-            CommonOptions.CreateVerbosityOption(),
-            CommonOptions.CreateNoLogoOption());
+        var msbuildArgs = AnalyzeStandardTestMSBuildArgs(buildOptions.MSBuildArgs);
 
         var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
 
@@ -352,6 +358,14 @@ internal static class SolutionAndProjectUtility
         var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
         var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
 
+        // Read TestTfmsInParallel from the initial evaluation so callers don't need to re-evaluate
+        bool testTfmsInParallel = true;
+        if (bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.TestTfmsInParallel), out bool parsed) ||
+            bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.BuildInParallel), out parsed))
+        {
+            testTfmsInParallel = parsed;
+        }
+
         bool isInteractive = !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment();
 
         IEnumerable<string> frameworks;
@@ -368,15 +382,21 @@ internal static class SolutionAndProjectUtility
                 .Where(f => !string.IsNullOrEmpty(f));
         }
 
-        var result = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
+        var devicesByTfm = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
         foreach (var framework in frameworks)
         {
             var (device, rid) = SelectDeviceForTfm(projectFilePath, buildOptions, framework, isInteractive);
-            result[framework] = (device, rid);
+            devicesByTfm[framework] = (device, rid);
         }
 
-        return result.Values.Any(v => v.Device is not null) ? result : null;
+        return devicesByTfm.Values.Any(v => v.Device is not null)
+            ? new DeviceSelectionResult(devicesByTfm, testTfmsInParallel)
+            : null;
     }
+
+    internal sealed record DeviceSelectionResult(
+        Dictionary<string, (string? Device, string? RuntimeIdentifier)> DevicesByTfm,
+        bool TestTfmsInParallel);
 
     /// <summary>
     /// Selects a device for a specific TFM using RunCommandSelector.
@@ -394,13 +414,7 @@ internal static class SolutionAndProjectUtility
             msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
         }
 
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-            msbuildArgsToAppend,
-            CommonOptions.CreatePropertyOption(),
-            CommonOptions.CreateRestorePropertyOption(),
-            CommonOptions.CreateMSBuildTargetOption(),
-            CommonOptions.CreateVerbosityOption(),
-            CommonOptions.CreateNoLogoOption());
+        var msbuildArgs = AnalyzeStandardTestMSBuildArgs(msbuildArgsToAppend);
 
         using var selector = new RunCommandSelector(
             projectFilePath,

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -154,7 +154,7 @@ internal static class SolutionAndProjectUtility
 
     private static string[] GetProjectFilePaths(string directory) => Directory.GetFiles(directory, CliConstants.ProjectExtensionPattern, SearchOption.TopDirectoryOnly);
 
-    private static ProjectInstance EvaluateProject(
+    internal static ProjectInstance EvaluateProject(
         ProjectCollection collection,
         EvaluationContext evaluationContext,
         string projectFilePath,
@@ -451,7 +451,7 @@ internal static class SolutionAndProjectUtility
         {
             if (!selector.TrySelectDevice(
                 listDevices: false,
-                noRestore: buildOptions.HasNoRestore,
+                noRestore: buildOptions.HasNoRestore || buildOptions.HasNoBuild,
                 out var selectedDevice,
                 out var runtimeIdentifier,
                 out _))

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.ProjectTools;
@@ -236,6 +238,8 @@ internal static class SolutionAndProjectUtility
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
+            TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
+
             if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
             {
                 projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -264,6 +268,8 @@ internal static class SolutionAndProjectUtility
                     projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
+                    TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
+
                     if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
                         projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -277,6 +283,8 @@ internal static class SolutionAndProjectUtility
                 {
                     projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
+
+                    TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
 
                     if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
@@ -293,6 +301,70 @@ internal static class SolutionAndProjectUtility
         }
 
         return projects;
+    }
+
+    /// <summary>
+    /// Selects a device for the given project instance if the project supports device selection
+    /// (has a ComputeAvailableDevices target) and no device was pre-specified via --device.
+    /// When --device is specified, the device is already set as an MSBuild property via the build args.
+    /// </summary>
+    private static void TrySelectDeviceForProject(ProjectInstance projectInstance, string projectFilePath, BuildOptions buildOptions)
+    {
+        // If --device was specified, the device is already in MSBuild args from HandleDeviceWithTargetFrameworkSelection
+        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
+        {
+            return;
+        }
+
+        // Check if this project supports device selection
+        if (!projectInstance.Targets.ContainsKey(Constants.ComputeAvailableDevices))
+        {
+            return;
+        }
+
+        // Create a RunCommandSelector for this project/TFM to handle device selection.
+        // Build/restore was already done by dotnet test, so we use noRestore: true.
+        var tfm = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
+        var msbuildArgsToAppend = buildOptions.MSBuildArgs;
+        if (!string.IsNullOrEmpty(tfm))
+        {
+            msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
+        }
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+            msbuildArgsToAppend,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
+        using var selector = new RunCommandSelector(
+            projectFilePath,
+            !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment(),
+            msbuildArgs,
+            ImmutableDictionary<string, string>.Empty);
+
+        if (!selector.TrySelectDevice(
+            listDevices: false,
+            noRestore: true,
+            out var selectedDevice,
+            out var runtimeIdentifier,
+            out _))
+        {
+            // Device selection failed - error already written to stderr by TrySelectDevice
+            throw new GracefulException(
+                string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+        }
+
+        if (selectedDevice is not null)
+        {
+            projectInstance.SetProperty("Device", selectedDevice);
+            if (!string.IsNullOrEmpty(runtimeIdentifier))
+            {
+                projectInstance.SetProperty("RuntimeIdentifier", runtimeIdentifier);
+            }
+        }
     }
 
     private static TestModule? GetModuleFromProject(ProjectInstance project, BuildOptions buildOptions)

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -304,14 +304,134 @@ internal static class SolutionAndProjectUtility
     }
 
     /// <summary>
+    /// Performs device selection for each TFM BEFORE the build, so that device-provided
+    /// RuntimeIdentifiers are included in the build. Returns a dictionary mapping each TFM
+    /// to its selected device and RuntimeIdentifier, or null if no device selection is needed.
+    /// </summary>
+    internal static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuild(
+        string projectFilePath,
+        BuildOptions buildOptions)
+    {
+        // --device is already handled by HandleDeviceWithTargetFrameworkSelection
+        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
+        {
+            return null;
+        }
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+            buildOptions.MSBuildArgs,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
+        var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
+
+        using var collection = new ProjectCollection(globalProperties);
+        var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+        var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions
+        {
+            GlobalProperties = globalProperties,
+            EvaluationContext = evaluationContext,
+            ProjectCollection = collection,
+        });
+
+        // If the project doesn't support device selection, skip entirely
+        if (!projectInstance.Targets.ContainsKey(Constants.ComputeAvailableDevices))
+        {
+            collection.UnloadAllProjects();
+            return null;
+        }
+
+        var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
+        var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
+
+        bool isInteractive = !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment();
+
+        IEnumerable<string> frameworks;
+        if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
+        {
+            // Single TFM (either explicit or via -f/--framework)
+            frameworks = [targetFramework ?? string.Empty];
+        }
+        else
+        {
+            frameworks = targetFrameworks
+                .Split(CliConstants.SemiColon, StringSplitOptions.RemoveEmptyEntries)
+                .Select(f => f.Trim())
+                .Where(f => !string.IsNullOrEmpty(f));
+        }
+
+        var result = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
+        foreach (var framework in frameworks)
+        {
+            var (device, rid) = SelectDeviceForTfm(projectFilePath, buildOptions, framework, isInteractive);
+            result[framework] = (device, rid);
+        }
+
+        collection.UnloadAllProjects();
+        return result.Values.Any(v => v.Device is not null) ? result : null;
+    }
+
+    /// <summary>
+    /// Selects a device for a specific TFM using RunCommandSelector.
+    /// Returns (null, null) if no device support or no devices available for this TFM.
+    /// </summary>
+    private static (string? device, string? runtimeIdentifier) SelectDeviceForTfm(
+        string projectFilePath,
+        BuildOptions buildOptions,
+        string? tfm,
+        bool isInteractive)
+    {
+        var msbuildArgsToAppend = buildOptions.MSBuildArgs;
+        if (!string.IsNullOrEmpty(tfm))
+        {
+            msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
+        }
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+            msbuildArgsToAppend,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
+        using var selector = new RunCommandSelector(
+            projectFilePath,
+            isInteractive,
+            msbuildArgs,
+            ImmutableDictionary<string, string>.Empty);
+
+        lock (s_buildLock)
+        {
+            if (!selector.TrySelectDevice(
+                listDevices: false,
+                noRestore: buildOptions.HasNoRestore,
+                out var selectedDevice,
+                out var runtimeIdentifier,
+                out _))
+            {
+                throw new GracefulException(
+                    string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+            }
+
+            return (selectedDevice, runtimeIdentifier);
+        }
+    }
+
+    /// <summary>
     /// Selects a device for the given project instance if the project supports device selection
     /// (has a ComputeAvailableDevices target) and no device was pre-specified via --device.
     /// When --device is specified, the device is already set as an MSBuild property via the build args.
+    /// For the project path, device selection is done pre-build via SelectDevicesBeforeBuild;
+    /// this method is the fallback for the solution path where pre-build selection isn't done.
     /// </summary>
     private static void TrySelectDeviceForProject(ProjectInstance projectInstance, string projectFilePath, BuildOptions buildOptions)
     {
-        // If --device was specified, the device is already in MSBuild args from HandleDeviceWithTargetFrameworkSelection
-        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
+        // If --device was specified or device selection was already done pre-build
+        if (!string.IsNullOrWhiteSpace(buildOptions.Device) || buildOptions.DeviceSelectionDone)
         {
             return;
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -330,17 +330,61 @@ internal static class SolutionAndProjectUtility
 
         using var collection = new ProjectCollection(globalProperties);
         var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+
+        return SelectDevicesBeforeBuildCore(projectFilePath, buildOptions, collection, evaluationContext);
+    }
+
+    /// <summary>
+    /// Overload that accepts a pre-existing ProjectCollection/EvaluationContext to avoid
+    /// redundant project evaluation in the solution path.
+    /// </summary>
+    internal static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuild(
+        string projectFilePath,
+        BuildOptions buildOptions,
+        ProjectCollection projectCollection,
+        EvaluationContext evaluationContext)
+    {
+        // --device is already handled by HandleDeviceWithTargetFrameworkSelection
+        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
+        {
+            return null;
+        }
+
+        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
+            buildOptions.MSBuildArgs,
+            CommonOptions.CreatePropertyOption(),
+            CommonOptions.CreateRestorePropertyOption(),
+            CommonOptions.CreateMSBuildTargetOption(),
+            CommonOptions.CreateVerbosityOption(),
+            CommonOptions.CreateNoLogoOption());
+
+        var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
+
+        // If Device is already set via -p:Device=..., skip device selection
+        if (globalProperties.TryGetValue("Device", out var deviceProp) && !string.IsNullOrWhiteSpace(deviceProp))
+        {
+            return null;
+        }
+
+        return SelectDevicesBeforeBuildCore(projectFilePath, buildOptions, projectCollection, evaluationContext);
+    }
+
+    private static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuildCore(
+        string projectFilePath,
+        BuildOptions buildOptions,
+        ProjectCollection projectCollection,
+        EvaluationContext evaluationContext)
+    {
         var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions
         {
-            GlobalProperties = globalProperties,
+            GlobalProperties = projectCollection.GlobalProperties,
             EvaluationContext = evaluationContext,
-            ProjectCollection = collection,
+            ProjectCollection = projectCollection,
         });
 
         // If the project doesn't support device selection, skip entirely
         if (!projectInstance.Targets.ContainsKey(Constants.ComputeAvailableDevices))
         {
-            collection.UnloadAllProjects();
             return null;
         }
 
@@ -370,7 +414,6 @@ internal static class SolutionAndProjectUtility
             result[framework] = (device, rid);
         }
 
-        collection.UnloadAllProjects();
         return result.Values.Any(v => v.Device is not null) ? result : null;
     }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -301,10 +301,13 @@ internal static class SolutionAndProjectUtility
     /// Performs device selection for each TFM BEFORE the build, so that device-provided
     /// RuntimeIdentifiers are included in the build. Returns a dictionary mapping each TFM
     /// to its selected device and RuntimeIdentifier, or null if no device selection is needed.
+    /// When projectCollection/evaluationContext are provided, reuses them to avoid redundant evaluation.
     /// </summary>
     internal static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuild(
         string projectFilePath,
-        BuildOptions buildOptions)
+        BuildOptions buildOptions,
+        ProjectCollection? projectCollection = null,
+        EvaluationContext? evaluationContext = null)
     {
         // --device is already handled by HandleDeviceWithTargetFrameworkSelection
         if (!string.IsNullOrWhiteSpace(buildOptions.Device))
@@ -328,58 +331,16 @@ internal static class SolutionAndProjectUtility
             return null;
         }
 
-        using var collection = new ProjectCollection(globalProperties);
-        var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+        // Create a ProjectCollection if one wasn't provided
+        using var ownedCollection = projectCollection is null ? new ProjectCollection(globalProperties) : null;
+        var collection = projectCollection ?? ownedCollection!;
+        evaluationContext ??= EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 
-        return SelectDevicesBeforeBuildCore(projectFilePath, buildOptions, collection, evaluationContext);
-    }
-
-    /// <summary>
-    /// Overload that accepts a pre-existing ProjectCollection/EvaluationContext to avoid
-    /// redundant project evaluation in the solution path.
-    /// </summary>
-    internal static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuild(
-        string projectFilePath,
-        BuildOptions buildOptions,
-        ProjectCollection projectCollection,
-        EvaluationContext evaluationContext)
-    {
-        // --device is already handled by HandleDeviceWithTargetFrameworkSelection
-        if (!string.IsNullOrWhiteSpace(buildOptions.Device))
-        {
-            return null;
-        }
-
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-            buildOptions.MSBuildArgs,
-            CommonOptions.CreatePropertyOption(),
-            CommonOptions.CreateRestorePropertyOption(),
-            CommonOptions.CreateMSBuildTargetOption(),
-            CommonOptions.CreateVerbosityOption(),
-            CommonOptions.CreateNoLogoOption());
-
-        var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
-
-        // If Device is already set via -p:Device=..., skip device selection
-        if (globalProperties.TryGetValue("Device", out var deviceProp) && !string.IsNullOrWhiteSpace(deviceProp))
-        {
-            return null;
-        }
-
-        return SelectDevicesBeforeBuildCore(projectFilePath, buildOptions, projectCollection, evaluationContext);
-    }
-
-    private static Dictionary<string, (string? Device, string? RuntimeIdentifier)>? SelectDevicesBeforeBuildCore(
-        string projectFilePath,
-        BuildOptions buildOptions,
-        ProjectCollection projectCollection,
-        EvaluationContext evaluationContext)
-    {
         var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions
         {
-            GlobalProperties = projectCollection.GlobalProperties,
+            GlobalProperties = collection.GlobalProperties,
             EvaluationContext = evaluationContext,
-            ProjectCollection = projectCollection,
+            ProjectCollection = collection,
         });
 
         // If the project doesn't support device selection, skip entirely

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -238,8 +238,6 @@ internal static class SolutionAndProjectUtility
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
-            TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
-
             if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
             {
                 projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -268,8 +266,6 @@ internal static class SolutionAndProjectUtility
                     projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
-                    TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
-
                     if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
                         projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -283,8 +279,6 @@ internal static class SolutionAndProjectUtility
                 {
                     projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
-
-                    TrySelectDeviceForProject(projectInstance, projectFilePath, buildOptions);
 
                     if (GetModuleFromProject(projectInstance, buildOptions) is { } module)
                     {
@@ -418,81 +412,6 @@ internal static class SolutionAndProjectUtility
             }
 
             return (selectedDevice, runtimeIdentifier);
-        }
-    }
-
-    /// <summary>
-    /// Selects a device for the given project instance if the project supports device selection
-    /// (has a ComputeAvailableDevices target) and no device was pre-specified via --device.
-    /// When --device is specified, the device is already set as an MSBuild property via the build args.
-    /// For the project path, device selection is done pre-build via SelectDevicesBeforeBuild;
-    /// this method is the fallback for the solution path where pre-build selection isn't done.
-    /// </summary>
-    private static void TrySelectDeviceForProject(ProjectInstance projectInstance, string projectFilePath, BuildOptions buildOptions)
-    {
-        // If --device was specified or device selection was already done pre-build
-        if (!string.IsNullOrWhiteSpace(buildOptions.Device) || buildOptions.DeviceSelectionDone)
-        {
-            return;
-        }
-
-        // Check if this project supports device selection
-        if (!projectInstance.Targets.ContainsKey(Constants.ComputeAvailableDevices))
-        {
-            return;
-        }
-
-        // Create a RunCommandSelector for this project/TFM to handle device selection.
-        // Build/restore was already done by dotnet test, so we use noRestore: true.
-        // Lock is required because TrySelectDevice calls projectInstance.Build() which uses
-        // BuildManager.DefaultBuildManager (a process-wide singleton that cannot run concurrent builds).
-        // The lock also serializes interactive Spectre.Console prompts when a solution has multiple
-        // MAUI projects evaluated in parallel.
-        var tfm = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
-        var msbuildArgsToAppend = buildOptions.MSBuildArgs;
-        if (!string.IsNullOrEmpty(tfm))
-        {
-            msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
-        }
-
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(
-            msbuildArgsToAppend,
-            CommonOptions.CreatePropertyOption(),
-            CommonOptions.CreateRestorePropertyOption(),
-            CommonOptions.CreateMSBuildTargetOption(),
-            CommonOptions.CreateVerbosityOption(),
-            CommonOptions.CreateNoLogoOption());
-
-        using var selector = new RunCommandSelector(
-            projectFilePath,
-            !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment(),
-            msbuildArgs,
-            ImmutableDictionary<string, string>.Empty);
-
-        string? selectedDevice;
-        string? runtimeIdentifier;
-        lock (s_buildLock)
-        {
-            if (!selector.TrySelectDevice(
-                listDevices: false,
-                noRestore: true,
-                out selectedDevice,
-                out runtimeIdentifier,
-                out _))
-            {
-                // Device selection failed - error already written to stderr by TrySelectDevice
-                throw new GracefulException(
-                    string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
-            }
-        }
-
-        if (selectedDevice is not null)
-        {
-            projectInstance.SetProperty("Device", selectedDevice);
-            if (!string.IsNullOrEmpty(runtimeIdentifier))
-            {
-                projectInstance.SetProperty("RuntimeIdentifier", runtimeIdentifier);
-            }
         }
     }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -322,6 +322,12 @@ internal static class SolutionAndProjectUtility
 
         var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
 
+        // If Device is already set via -p:Device=..., skip device selection
+        if (globalProperties.TryGetValue("Device", out var deviceProp) && !string.IsNullOrWhiteSpace(deviceProp))
+        {
+            return null;
+        }
+
         using var collection = new ProjectCollection(globalProperties);
         var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
         var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -324,6 +324,10 @@ internal static class SolutionAndProjectUtility
 
         // Create a RunCommandSelector for this project/TFM to handle device selection.
         // Build/restore was already done by dotnet test, so we use noRestore: true.
+        // Lock is required because TrySelectDevice calls projectInstance.Build() which uses
+        // BuildManager.DefaultBuildManager (a process-wide singleton that cannot run concurrent builds).
+        // The lock also serializes interactive Spectre.Console prompts when a solution has multiple
+        // MAUI projects evaluated in parallel.
         var tfm = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
         var msbuildArgsToAppend = buildOptions.MSBuildArgs;
         if (!string.IsNullOrEmpty(tfm))
@@ -345,16 +349,21 @@ internal static class SolutionAndProjectUtility
             msbuildArgs,
             ImmutableDictionary<string, string>.Empty);
 
-        if (!selector.TrySelectDevice(
-            listDevices: false,
-            noRestore: true,
-            out var selectedDevice,
-            out var runtimeIdentifier,
-            out _))
+        string? selectedDevice;
+        string? runtimeIdentifier;
+        lock (s_buildLock)
         {
-            // Device selection failed - error already written to stderr by TrySelectDevice
-            throw new GracefulException(
-                string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+            if (!selector.TrySelectDevice(
+                listDevices: false,
+                noRestore: true,
+                out selectedDevice,
+                out runtimeIdentifier,
+                out _))
+            {
+                // Device selection failed - error already written to stderr by TrySelectDevice
+                throw new GracefulException(
+                    string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+            }
         }
 
         if (selectedDevice is not null)

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -25,7 +25,7 @@
   <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
     <!-- If SingleDevice property is set, return only one device -->
     <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' == 'true'">
-      <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+      <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" />
     </ItemGroup>
     <!-- Otherwise return multiple devices based on target framework -->
     <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' != 'net9.0'">
@@ -33,7 +33,7 @@
       <Devices Include="test-device-2" Description="Test Device 2" Type="Device" Status="Online" />
     </ItemGroup>
     <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' == 'net9.0'">
-      <Devices Include="test-device-downlevel-1" Description="Test Device Downlevel 1" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+      <Devices Include="test-device-downlevel-1" Description="Test Device Downlevel 1" Type="Emulator" Status="Online" />
       <Devices Include="test-device-downlevel-2" Description="Test Device Downlevel 2" Type="Simulator" Status="Booted" />
     </ItemGroup>
   </Target>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9.0;$(CurrentTargetFramework)</TargetFrameworks>
+    <!-- Disable default items to avoid glob expansion failures on macOS with long paths.
+         See https://github.com/dotnet/msbuild/issues/12546 -->
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+  </ItemGroup>
+
+  <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
+    <!-- If SingleDevice property is set, return only one device -->
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' == 'true'">
+      <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+    </ItemGroup>
+    <!-- Otherwise return multiple devices based on target framework -->
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' != 'net9.0'">
+      <Devices Include="test-device-1" Description="Test Device 1" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+      <Devices Include="test-device-2" Description="Test Device 2" Type="Device" Status="Online" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' == 'net9.0'">
+      <Devices Include="test-device-downlevel-1" Description="Test Device Downlevel 1" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+      <Devices Include="test-device-downlevel-2" Description="Test Device Downlevel 2" Type="Simulator" Status="Booted" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestAdapter);
+
+    public string Version => "2.0.0";
+
+    public string DisplayName => nameof(DummyTestAdapter);
+
+    public string Description => nameof(DummyTestAdapter);
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Type[] DataTypesProduced => new[] {
+        typeof(TestNodeUpdateMessage)
+    };
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Test0",
+            DisplayName = "Test0",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+        }));
+
+        context.Complete();
+    }
+}

--- a/test/TestAssets/TestProjects/DotnetTestDevices/global.json
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands;
+
+namespace Microsoft.DotNet.Cli.Test.Tests;
+
+/// <summary>
+/// Integration tests for device selection in dotnet test
+/// </summary>
+public class GivenDotnetTestSelectsDevice : SdkTest
+{
+    public GivenDotnetTestSelectsDevice(ITestOutputHelper log) : base(log)
+    {
+    }
+
+    [Fact]
+    public void ItFailsInNonInteractiveMode_WhenMultipleDevicesAvailableAndNoneSpecified()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework);
+
+        result.Should().Fail()
+            .And.HaveStdErrContaining(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+    }
+
+    [Theory]
+    [InlineData("test-device-1")]
+    [InlineData("test-device-2")]
+    public void ItRunsTestsWithSpecifiedDevice(string deviceId)
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", identifier: deviceId)
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework, "--device", deviceId);
+
+        result.Should().Pass();
+    }
+
+    [Fact]
+    public void ItAutoSelectsSingleDevice()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        // In test/CI environments, IsInteractive defaults to false (stdout is redirected),
+        // so single device should be auto-selected without prompting.
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework, "-p:SingleDevice=true");
+
+        result.Should().Pass();
+    }
+
+    [Fact]
+    public void ItPromptsForTargetFrameworkWhenDeviceIsSpecifiedWithoutFramework_InNonInteractiveMode()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--device", "test-device-1");
+
+        // Should fail because non-interactive mode can't prompt for TF
+        result.Should().Fail()
+            .And.HaveStdErrContaining(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyFramework, "--framework"));
+    }
+
+    [Fact]
+    public void ItRunsWithDeviceAndFramework()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework, "--device", "test-device-1");
+
+        result.Should().Pass();
+    }
+
+    [Fact]
+    public void ItDoesNotPromptForDeviceWhenComputeAvailableDevicesTargetDoesNotExist()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithTests")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute();
+
+        // Should pass without any device prompting
+        result.Should().Pass();
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -117,4 +117,77 @@ public class GivenDotnetTestSelectsDevice : SdkTest
 
         result.Should().Pass();
     }
+
+    [Fact]
+    public void ItRunsDeviceProjectsInSolution()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", "SolutionDeviceTest")
+            .WithSource();
+
+        // Create two project subdirectories from the copied asset
+        var project1Dir = Path.Combine(testInstance.Path, "Project1");
+        var project2Dir = Path.Combine(testInstance.Path, "Project2");
+        Directory.CreateDirectory(project1Dir);
+        Directory.CreateDirectory(project2Dir);
+
+        foreach (var dir in new[] { project1Dir, project2Dir })
+        {
+            File.Copy(Path.Combine(testInstance.Path, "Program.cs"), Path.Combine(dir, "Program.cs"));
+            File.Copy(
+                Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"),
+                Path.Combine(dir, Path.GetFileName(dir) + ".csproj"));
+        }
+
+        File.Delete(Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"));
+        File.Delete(Path.Combine(testInstance.Path, "Program.cs"));
+
+        File.WriteAllText(Path.Combine(testInstance.Path, "TestSolution.slnx"),
+            """
+            <Solution>
+              <Project Path="Project1\Project1.csproj" />
+              <Project Path="Project2\Project2.csproj" />
+            </Solution>
+            """);
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--solution", "TestSolution.slnx", "-p:SingleDevice=true");
+
+        result.Should().Pass();
+    }
+
+    [Fact]
+    public void ItAcceptsDeviceViaMSBuildProperty()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        // Pass Device via -p:Device= instead of --device
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework, "-p:Device=test-device-1");
+
+        result.Should().Pass();
+    }
+
+    [Fact]
+    public void ItShowsBuildErrorWhenBuildFailsAfterDeviceSelection()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        // Inject a compile error after device selection would succeed
+        var programPath = Path.Combine(testInstance.Path, "Program.cs");
+        File.AppendAllText(programPath, "\nclass Broken { int x = \"not an int\"; }");
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--framework", ToolsetInfo.CurrentTargetFramework, "-p:SingleDevice=true");
+
+        // Should fail with a build error, NOT a device selection error
+        result.Should().Fail();
+        result.StdErr.Should().NotContain(
+            string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
+    }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -101,4 +101,20 @@ public class GivenDotnetTestSelectsDevice : SdkTest
         // Should pass without any device prompting
         result.Should().Pass();
     }
+
+    [Fact]
+    public void ItAutoSelectsSingleDevicePerTfm()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        // Run without -f to test all TFMs. SingleDevice=true means one device per TFM
+        // is auto-selected. Device selection happens BEFORE the build so that any
+        // device-provided RuntimeIdentifier is included in the build output.
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("-p:SingleDevice=true");
+
+        result.Should().Pass();
+    }
 }

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -40,6 +40,7 @@ Options:
   --list-tests <list-tests>                       List the discovered tests instead of running the tests.
   --no-launch-profile                             Do not attempt to use launchSettings.json or [app].run.json to configure the application. [default: False]
   --no-launch-profile-arguments                   Do not use arguments specified in launch profile to run the application. [default: False]
+  --device <DEVICE>                               The device identifier to use for running the application.
   -?, -h, --help                                  Show command line help.
 
 Waiting for options and extensions...


### PR DESCRIPTION
## Summary

Adds `--device` option to `dotnet test` (MTP path) for .NET MAUI projects, enabling per-target-framework device selection.

## Behavior

- **Default**: `dotnet test` iterates all target frameworks without prompting (existing behavior unchanged)
- **Per-TFM device prompting**: For each TFM, if `ComputeAvailableDevices` target exists, uses `RunCommandSelector` to handle device selection (auto-select single device, error in non-interactive mode with multiple devices)
- **`--device`**: When specified without `-f`, forces a target framework prompt since devices are platform-specific
- **Non-interactive**: Errors with a helpful message when prompting would be required but stdin is redirected / CI. Interactive mode is auto-detected (same logic as `dotnet run`).

## Changes

- `TestCommandDefinition.MicrosoftTestingPlatform.cs` - Added `DeviceOption`
- `Options.cs` / `MSBuildUtility.cs` - `Device` on `BuildOptions`
- `MicrosoftTestingPlatformTestCommand.cs` - `HandleDeviceWithTargetFrameworkSelection()` for `--device` + TF selection
- `SolutionAndProjectUtility.cs` - `TrySelectDeviceForProject()` called per-TFM before running tests
- `dotnet-run-for-maui.md` - Updated spec with `dotnet test` behavior section
- `MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt` - Updated snapshot for new `--device` option

## Tests

7 integration tests in `GivenDotnetTestSelectsDevice` covering:
- Non-interactive failure with multiple devices
- Specified device (2 variants)
- Auto-select single device
- TF prompt with `--device` in non-interactive mode
- Combined `-f` + `--device`
- Projects without `ComputeAvailableDevices` target