### PR TITLE
Forward terminal logger arguments to MSBuild during `dotnet test`

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -103,10 +103,25 @@ internal static class MSBuildUtility
 
         LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
 
+        // Terminal logger arguments (e.g. --tl:off, -terminalLogger:auto, -tlp:default=true)
+        // should be forwarded to MSBuild during the build phase rather than being passed to
+        // the test application as it doesn't recognize them. See https://github.com/dotnet/sdk/issues/52229.
+        var terminalLoggerArgs = new List<string>();
+        for (int i = otherArgs.Count - 1; i >= 0; i--)
+        {
+            if (LoggerUtility.IsTerminalLoggerArgument(otherArgs[i]))
+            {
+                terminalLoggerArgs.Add(otherArgs[i]);
+                otherArgs.RemoveAt(i);
+            }
+        }
+        terminalLoggerArgs.Reverse();
+
         var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(definition)
-            .Concat(binLogArgs);
+            .Concat(binLogArgs)
+            .Concat(terminalLoggerArgs);
 
         string? resultsDirectory = parseResult.GetValue(definition.ResultsDirectoryOption);
         if (resultsDirectory is not null)

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -85,6 +85,49 @@ internal static class LoggerUtility
             || arg.StartsWith("--binaryLogger:", comp) || arg.Equals("--binaryLogger", comp)
             || arg.StartsWith("-bl:", comp) || arg.Equals("-bl", comp);
     }
+
+    private static readonly string[] s_terminalLoggerArgumentNames =
+    [
+        "tl",
+        "terminallogger",
+        "ll",
+        "livelogger",
+        "tlp",
+        "terminalloggerparameters",
+    ];
+
+    private static readonly string[] s_argumentPrefixes = ["--", "-", "/"];
+
+    /// <summary>
+    /// Determines whether the given argument is an MSBuild terminal logger argument
+    /// (e.g. <c>-tl[:value]</c>, <c>--terminalLogger[:value]</c>, <c>-ll[:value]</c>,
+    /// <c>--livelogger[:value]</c>, <c>-tlp:...</c>, or <c>--terminalLoggerParameters:...</c>).
+    /// </summary>
+    internal static bool IsTerminalLoggerArgument(string arg)
+    {
+        const StringComparison comp = StringComparison.OrdinalIgnoreCase;
+        foreach (var prefix in s_argumentPrefixes)
+        {
+            if (!arg.StartsWith(prefix, comp))
+            {
+                continue;
+            }
+
+            var nameAndValue = arg.AsSpan(prefix.Length);
+            int colonIndex = nameAndValue.IndexOf(':');
+            var name = colonIndex < 0 ? nameAndValue : nameAndValue[..colonIndex];
+
+            foreach (var knownName in s_terminalLoggerArgumentNames)
+            {
+                if (name.Equals(knownName.AsSpan(), comp))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }
 
 /// <summary>

--- a/test/dotnet.Tests/LoggerUtilityTests.cs
+++ b/test/dotnet.Tests/LoggerUtilityTests.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests
+{
+    public class LoggerUtilityTests
+    {
+        [Theory]
+        [InlineData("-tl")]
+        [InlineData("--tl")]
+        [InlineData("/tl")]
+        [InlineData("-tl:off")]
+        [InlineData("--tl:off")]
+        [InlineData("/tl:on")]
+        [InlineData("-TL:Off")]
+        [InlineData("-terminallogger")]
+        [InlineData("--terminalLogger")]
+        [InlineData("/terminallogger")]
+        [InlineData("-terminallogger:auto")]
+        [InlineData("--TerminalLogger:on")]
+        [InlineData("-ll")]
+        [InlineData("--ll:off")]
+        [InlineData("/ll")]
+        [InlineData("-livelogger")]
+        [InlineData("--livelogger:off")]
+        [InlineData("-tlp:default=true")]
+        [InlineData("--tlp:default=auto")]
+        [InlineData("/tlp:DISABLENODEDISPLAY")]
+        [InlineData("-terminalloggerparameters:default=true")]
+        [InlineData("--terminalLoggerParameters:default=true")]
+        public void IsTerminalLoggerArgument_RecognizesTerminalLoggerArguments(string arg)
+        {
+            LoggerUtility.IsTerminalLoggerArgument(arg).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("--no-build")]
+        [InlineData("-bl")]
+        [InlineData("--binaryLogger")]
+        [InlineData("-bl:foo.binlog")]
+        [InlineData("-tlapropertythatstartslikethis")]
+        [InlineData("--tlpwithnocolon")]
+        [InlineData("--terminallogger-something")]
+        [InlineData("-llextra")]
+        [InlineData("foo.csproj")]
+        [InlineData("")]
+        public void IsTerminalLoggerArgument_RejectsNonTerminalLoggerArguments(string arg)
+        {
+            LoggerUtility.IsTerminalLoggerArgument(arg).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("--tl:off")]
+        [InlineData("--terminalLogger:auto")]
+        [InlineData("--tlp:default=true")]
+        [InlineData("/tl:off")]
+        [InlineData("/terminalLogger:auto")]
+        [InlineData("/tlp:default=true")]
+        public void GetBuildOptions_ForwardsTerminalLoggerArgsToMSBuild_NotToTestApplication(string terminalLoggerArg)
+        {
+            // Parse a `dotnet test` command line that includes a terminal logger argument
+            // against the MTP test command definition. The argument is unknown to the parser
+            // and lands in UnmatchedTokens.
+            var mtpCommand = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = mtpCommand.Parse(["--no-build", terminalLoggerArg]);
+
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            buildOptions.MSBuildArgs.Should().Contain(terminalLoggerArg,
+                "terminal logger arguments must be forwarded to the underlying MSBuild build invocation (https://github.com/dotnet/sdk/issues/52229).");
+            buildOptions.TestApplicationArguments.Should().NotContain(terminalLoggerArg,
+                "terminal logger arguments must not be passed to the test application, which doesn't recognize them.");
+        }
+
+        [Fact]
+        public void GetBuildOptions_LeavesUnknownArgumentsAsTestApplicationArguments()
+        {
+            var mtpCommand = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = mtpCommand.Parse(["--no-build", "--my-test-arg"]);
+
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            buildOptions.TestApplicationArguments.Should().Contain("--my-test-arg");
+            buildOptions.MSBuildArgs.Should().NotContain("--my-test-arg");
+        }
+
+        [Fact]
+        public void GetBuildOptions_ExtractsTerminalLoggerArgs_BeforePositionalArgumentDetection()
+        {
+            // Regression test: verify that interspersing terminal logger args with positional arguments
+            // (project paths, test modules) and test application arguments doesn't break positional detection
+            // or argument routing. See https://github.com/dotnet/sdk/issues/52229.
+            var mtpCommand = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = mtpCommand.Parse(["--no-build", "--tl:off", "--my-test-arg", "--tlp:default=true"]);
+
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            buildOptions.MSBuildArgs.Should().Contain("--tl:off").And.Contain("--tlp:default=true");
+            buildOptions.MSBuildArgs.Should().NotContain("--my-test-arg");
+            buildOptions.TestApplicationArguments.Should().Contain("--my-test-arg");
+            buildOptions.TestApplicationArguments.Should().NotContain("--tl:off").And.NotContain("--tlp:default=true");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #52229.

## Problem

When running `dotnet test --project Foo.csproj --tl:off` against an MTP-based test project, the `--tl:off` switch is forwarded to the test application instead of to the underlying MSBuild build invocation, causing the test app to fail with `Unknown option '--tl'`.

## Fix

- Added `LoggerUtility.IsTerminalLoggerArgument(string arg)` helper to detect MSBuild terminal-logger switches (`tl`, `terminallogger`, `ll`, `livelogger`, `tlp`, `terminalloggerparameters`) with `-`, `--`, or `/` prefixes and an optional `:value` suffix.
- Updated `MSBuildUtility.GetBuildOptions` to extract terminal-logger arguments from `parseResult.UnmatchedTokens` and route them into `MSBuildArgs` (forwarded to the build phase) instead of leaving them in `TestApplicationArguments`. The extraction happens before positional-argument detection so project-path detection is unaffected. This mirrors the existing handling of `-bl`/`--binaryLogger`.

## Tests

Added `test/dotnet.Tests/LoggerUtilityTests.cs`:
- 22 positive-case unit tests covering all prefix/name/colon variants.
- 10 negative-case unit tests confirming look-alikes (`--terminallogger-something`, `--tlpwithnocolon`, `-llextra`, etc.) are not matched.
- Integration tests exercising `MSBuildUtility.GetBuildOptions` end-to-end against the MTP command definition, verifying terminal-logger args are routed to `MSBuildArgs` and excluded from `TestApplicationArguments`.
- Regression test for interspersed positional / test-app / terminal-logger arguments.

## Notes

- Scope is intentionally narrow (terminal-logger args only). Per design review, broader MSBuild passthrough switches (`-nodereuse`, `-graph`, etc.) were deliberately not included to avoid intercepting legitimate test-app arguments.
- Single-dash forms `-tl:off`, `-terminalLogger:auto`, `-tlp:default=true` are still consumed by System.CommandLine as values for the `-t` short alias of the build target option, so they don't reach unmatched tokens. The user's reported case `--tl:off` works correctly with this fix; `--`/`/` forms are also covered.