### PR TITLE
Dotnetup: Support daily channels

### DIFF
--- a/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
+++ b/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md
@@ -222,14 +222,14 @@ For a specific prerelease version that isn't in the release manifest:
 The `UpdateChannel` class gains awareness of the `-daily` suffix:
 
 ```csharp
-// New properties
+// New API
 public bool IsDaily => Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
     || Name.EndsWith("-daily", StringComparison.OrdinalIgnoreCase);
-public string BaseChannel => IsDaily
-    ? Name.Equals("daily", StringComparison.OrdinalIgnoreCase)
-        ? "daily"  // bare "daily" is its own base — resolved separately via major+1 probing
-        : Name.Substring(0, Name.LastIndexOf('-'))
-    : Name;
+
+// Helper for the scoped-daily case — bare "daily" is handled separately
+// (resolved via major+1 probing in DailyChannelResolver).
+public static string StripDailySuffix(string scopedDailyChannelName)
+    => scopedDailyChannelName.Substring(0, scopedDailyChannelName.Length - "-daily".Length);
 ```
 
 The `Matches()` method for daily channels matches any version that would match the base channel.
@@ -337,7 +337,7 @@ is needed. We just need the blob-feed download path:
 **Goal**: `dotnetup sdk install 10.0-daily` resolves and installs the latest daily build.
 
 Builds on Phase 1's blob-feed download path by adding version discovery:
-- Extend `UpdateChannel` with `IsDaily` / `BaseChannel` properties for `...-daily` suffix parsing
+- Extend `UpdateChannel` with an `IsDaily` predicate and a `StripDailySuffix` helper for `...-daily` parsing
 - Add `IsValidChannelFormat()` support for `...-daily` channels and bare `daily` (add `daily`
   to the known channel keyword set alongside `latest`, `preview`, `lts`)
 - Extend `ChannelVersionResolver.Resolve()` to detect daily channels and query the aka.ms

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/BlobFeedUrlBuilder.cs
@@ -61,20 +61,24 @@ internal static class BlobFeedUrlBuilder
     };
 
     /// <summary>
+    /// Component → archive filename prefix used in both blob feed paths and
+    /// aka.ms shortlinks (e.g. <c>dotnet-sdk</c>, <c>dotnet-runtime</c>).
+    /// </summary>
+    public static string GetArchivePrefix(InstallComponent component) => component switch
+    {
+        InstallComponent.SDK => "dotnet-sdk",
+        InstallComponent.Runtime => "dotnet-runtime",
+        InstallComponent.ASPNETCore => "aspnetcore-runtime",
+        InstallComponent.WindowsDesktop => "windowsdesktop-runtime",
+        _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unsupported install component"),
+    };
+
+    /// <summary>
     /// Archive filename, e.g. "dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip".
     /// </summary>
     public static string GetArchiveFileName(InstallComponent component, ReleaseVersion version, string rid, string extension)
     {
-        string prefix = component switch
-        {
-            InstallComponent.SDK => "dotnet-sdk",
-            InstallComponent.Runtime => "dotnet-runtime",
-            InstallComponent.ASPNETCore => "aspnetcore-runtime",
-            InstallComponent.WindowsDesktop => "windowsdesktop-runtime",
-            _ => throw new ArgumentOutOfRangeException(nameof(component), component, "Unsupported install component"),
-        };
-
-        return $"{prefix}-{version}-{rid}{extension}";
+        return $"{GetArchivePrefix(component)}-{version}-{rid}{extension}";
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -94,15 +94,15 @@ internal class ChannelVersionResolver
 
     }
 
-    public ReleaseVersion? Resolve(DotnetInstallRequest installRequest)
+    public ReleaseVersion? Resolve(UpdateChannel channel, InstallComponent component, InstallArchitecture architecture)
     {
-        if (installRequest.Channel.IsDaily)
+        if (channel.IsDaily)
         {
             _dailyChannelResolver ??= new DailyChannelResolver(_releaseManifest);
-            return _dailyChannelResolver.Resolve(installRequest.Channel, installRequest.InstallRoot.Architecture);
+            return _dailyChannelResolver.Resolve(channel, architecture);
         }
 
-        return GetLatestVersionForChannel(installRequest.Channel, installRequest.Component);
+        return GetLatestVersionForChannel(channel, component);
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -108,23 +108,27 @@ internal class ChannelVersionResolver
             return true;
         }
 
-        // For "<version>-daily" channels, validate the version prefix as a partial
-        // version. Daily applies only to partial versions (major / major.minor /
-        // feature band) — fully-qualified versions like "10.0.103-daily" are rejected
-        // because there's no such thing as "the daily 10.0.103" (a specific patch is
-        // already specific).
-        if (channel.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase))
+        // The only two forms that include a '-' are:
+        //   * "<partial-version>-daily" (e.g. "10.0-daily", "10.0.1xx-daily").
+        //     Daily only applies to partial versions; "10.0.103-daily" is rejected
+        //     because a specific patch is already specific.
+        //   * a fully-qualified version with a prerelease tag (e.g. "10.0.100-preview.1.32640").
+        //     The prerelease tag is opaque; we only validate the numeric prefix.
+        var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
+        if (dashIndex >= 0)
         {
-            var partialVersion = channel.Substring(0, channel.Length - DailySuffix.Length);
-            if (string.IsNullOrEmpty(partialVersion))
+            var versionPart = channel.Substring(0, dashIndex);
+            var suffix = channel.Substring(dashIndex);
+
+            if (suffix.Equals(DailySuffix, StringComparison.OrdinalIgnoreCase))
             {
-                return false;
+                return !string.IsNullOrEmpty(versionPart) && IsValidPartialVersion(versionPart);
             }
 
-            return IsValidPartialVersion(partialVersion);
+            return IsValidNumericVersion(versionPart);
         }
 
-        return IsValidPartialVersion(channel) || IsValidFullyQualifiedVersion(channel);
+        return IsValidPartialVersion(channel) || IsValidNumericVersion(channel);
     }
 
     /// <summary>
@@ -172,23 +176,6 @@ internal class ChannelVersionResolver
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Validates a fully-qualified version: either a numeric <c>major[.minor[.patch[.rev]]]</c>
-    /// (e.g. <c>10.0.103</c>) or such a version with a prerelease tag (e.g.
-    /// <c>10.0.100-preview.1.32640</c>).
-    /// </summary>
-    private static bool IsValidFullyQualifiedVersion(string channel)
-    {
-        var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
-        if (dashIndex < 0)
-        {
-            return IsValidNumericVersion(channel);
-        }
-
-        var versionPart = channel.Substring(0, dashIndex);
-        return IsValidNumericVersion(versionPart);
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -24,9 +24,20 @@ internal class ChannelVersionResolver
     public const string LtsChannel = "lts";
 
     /// <summary>
+    /// Channel keyword for the latest daily build (latest major version).
+    /// </summary>
+    public const string DailyChannel = "daily";
+
+    /// <summary>
+    /// Suffix that turns any version scope channel into a daily-build channel
+    /// (e.g. <c>10.0-daily</c>, <c>10.0.1xx-daily</c>).
+    /// </summary>
+    public const string DailySuffix = "-daily";
+
+    /// <summary>
     /// Known channel keywords that are always valid.
     /// </summary>
-    public static readonly IReadOnlyList<string> KnownChannelKeywords = [LatestChannel, PreviewChannel, LtsChannel];
+    public static readonly IReadOnlyList<string> KnownChannelKeywords = [LatestChannel, PreviewChannel, LtsChannel, DailyChannel];
 
     /// <summary>
     /// Maximum reasonable major version number. .NET versions are currently single-digit;
@@ -35,6 +46,7 @@ internal class ChannelVersionResolver
     internal const int MaxReasonableMajorVersion = 99;
 
     private readonly ReleaseManifest _releaseManifest = new();
+    private DailyChannelResolver? _dailyChannelResolver;
 
     public ChannelVersionResolver()
     {
@@ -44,6 +56,12 @@ internal class ChannelVersionResolver
     public ChannelVersionResolver(ReleaseManifest releaseManifest)
     {
         _releaseManifest = releaseManifest;
+    }
+
+    public ChannelVersionResolver(ReleaseManifest releaseManifest, DailyChannelResolver dailyChannelResolver)
+    {
+        _releaseManifest = releaseManifest;
+        _dailyChannelResolver = dailyChannelResolver;
     }
 
     public IEnumerable<string> GetSupportedChannels(bool includeFeatureBands = true)
@@ -78,6 +96,12 @@ internal class ChannelVersionResolver
 
     public ReleaseVersion? Resolve(DotnetInstallRequest installRequest)
     {
+        if (installRequest.Channel.IsDaily)
+        {
+            _dailyChannelResolver ??= new DailyChannelResolver(_releaseManifest);
+            return _dailyChannelResolver.Resolve(installRequest.Channel, installRequest.InstallRoot.Architecture);
+        }
+
         return GetLatestVersionForChannel(installRequest.Channel, installRequest.Component);
     }
 
@@ -94,20 +118,40 @@ internal class ChannelVersionResolver
             return false;
         }
 
-        // Known keywords are always valid
+        // Known keywords are always valid (includes bare "daily").
         if (KnownChannelKeywords.Any(k => string.Equals(k, channel, StringComparison.OrdinalIgnoreCase)))
         {
             return true;
         }
 
-        // Check for prerelease suffix (e.g., "10.0.100-preview.1.32640")
-        var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
-        var hasPrerelease = dashIndex >= 0;
-        var versionPart = hasPrerelease ? channel.Substring(0, dashIndex) : channel;
+        // For "<scope>-daily" channels, validate the scope as a version-like
+        // string. Daily applies only to scopes (major / major.minor / feature
+        // band) — fully specified versions like "10.0.103-daily" are rejected
+        // because there's no such thing as "the daily 10.0.103" (a specific
+        // patch is already specific).
+        if (channel.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var scope = channel.Substring(0, channel.Length - DailySuffix.Length);
+            if (string.IsNullOrEmpty(scope))
+            {
+                return false;
+            }
 
-        // Try to parse as a version-like string
-        var parts = versionPart.Split('.');
-        if (parts.Length is 0 or > 4)
+            return IsValidScopeFormat(scope);
+        }
+
+        return IsValidScopeFormat(channel) || IsValidPrereleaseVersion(channel);
+    }
+
+    /// <summary>
+    /// Validates a version-scope channel string: bare major (e.g. <c>10</c>),
+    /// major.minor (e.g. <c>10.0</c>), or feature band (e.g. <c>10.0.1xx</c>).
+    /// Rejects fully-specified versions and prerelease tags.
+    /// </summary>
+    private static bool IsValidScopeFormat(string scope)
+    {
+        var parts = scope.Split('.');
+        if (parts.Length is 0 or > 3)
         {
             return false;
         }
@@ -127,35 +171,68 @@ internal class ChannelVersionResolver
             }
         }
 
-        if (parts.Length >= 3 && !IsValidPatchPart(parts[2], hasPrerelease))
+        if (parts.Length == 3)
         {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static bool IsValidPatchPart(string patch, bool hasPrerelease)
-    {
-        if (string.IsNullOrEmpty(patch))
-        {
-            return false;
-        }
-
-        // Allow feature band pattern (e.g., "1xx", "101xx"), but NOT with a prerelease suffix.
-        if (patch.EndsWith("xx", StringComparison.OrdinalIgnoreCase))
-        {
-            if (hasPrerelease)
+            // Scope only allows feature band patterns like "1xx", not numeric patches.
+            var patch = parts[2];
+            if (!patch.EndsWith("xx", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
             var prefix = patch.Substring(0, patch.Length - 2);
-            return prefix.Length > 0 && int.TryParse(prefix, out _);
+            if (prefix.Length == 0 || !int.TryParse(prefix, out _))
+            {
+                return false;
+            }
         }
 
-        // Allow fully specified numeric patch (e.g., "103"), optionally with a prerelease suffix.
-        return int.TryParse(patch, out var numericPatch) && numericPatch >= 0;
+        return true;
+    }
+
+    /// <summary>
+    /// Validates a fully-specified prerelease version like <c>10.0.100-preview.1.32640</c>.
+    /// </summary>
+    private static bool IsValidPrereleaseVersion(string channel)
+    {
+        var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
+        if (dashIndex < 0)
+        {
+            // Non-prerelease, non-scope version (e.g. "10.0.103") — historically accepted.
+            return IsValidNonScopeVersion(channel);
+        }
+
+        var versionPart = channel.Substring(0, dashIndex);
+        return IsValidNonScopeVersion(versionPart);
+    }
+
+    /// <summary>
+    /// Validates a numeric major[.minor[.patch]] version (no feature band, no prerelease).
+    /// </summary>
+    private static bool IsValidNonScopeVersion(string version)
+    {
+        var parts = version.Split('.');
+        if (parts.Length is 0 or > 4)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], out var major) || major < 0 || major > MaxReasonableMajorVersion)
+        {
+            return false;
+        }
+
+        if (parts.Length >= 2 && (!int.TryParse(parts[1], out var minor) || minor < 0))
+        {
+            return false;
+        }
+
+        if (parts.Length >= 3 && (!int.TryParse(parts[2], out var patch) || patch < 0))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -275,6 +275,14 @@ internal class ChannelVersionResolver
     /// <returns>Latest fully specified version string, or null if not found</returns>
     public ReleaseVersion? GetLatestVersionForChannel(UpdateChannel channel, InstallComponent component)
     {
+        // Daily channels must be resolved via DailyChannelResolver. Reaching this method with a
+        // daily channel means a caller bypassed Resolve(); refuse rather than silently parsing
+        // "10.0.1xx-daily" as 10.0.x and returning the latest released version.
+        if (channel.IsDaily)
+        {
+            return null;
+        }
+
         if (string.Equals(channel.Name, LtsChannel, StringComparison.OrdinalIgnoreCase))
         {
             var productIndex = _releaseManifest.GetReleasesIndex();

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -29,7 +29,7 @@ internal class ChannelVersionResolver
     public const string DailyChannel = "daily";
 
     /// <summary>
-    /// Suffix that turns any version scope channel into a daily-build channel
+    /// Suffix that turns any partial version channel into a daily-build channel
     /// (e.g. <c>10.0-daily</c>, <c>10.0.1xx-daily</c>).
     /// </summary>
     public const string DailySuffix = "-daily";
@@ -51,11 +51,6 @@ internal class ChannelVersionResolver
     public ChannelVersionResolver()
     {
 
-    }
-
-    public ChannelVersionResolver(ReleaseManifest releaseManifest)
-    {
-        _releaseManifest = releaseManifest;
     }
 
     public ChannelVersionResolver(ReleaseManifest releaseManifest, DailyChannelResolver dailyChannelResolver)
@@ -113,33 +108,33 @@ internal class ChannelVersionResolver
             return true;
         }
 
-        // For "<scope>-daily" channels, validate the scope as a version-like
-        // string. Daily applies only to scopes (major / major.minor / feature
-        // band) — fully specified versions like "10.0.103-daily" are rejected
-        // because there's no such thing as "the daily 10.0.103" (a specific
-        // patch is already specific).
+        // For "<version>-daily" channels, validate the version prefix as a partial
+        // version. Daily applies only to partial versions (major / major.minor /
+        // feature band) — fully-qualified versions like "10.0.103-daily" are rejected
+        // because there's no such thing as "the daily 10.0.103" (a specific patch is
+        // already specific).
         if (channel.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase))
         {
-            var scope = channel.Substring(0, channel.Length - DailySuffix.Length);
-            if (string.IsNullOrEmpty(scope))
+            var partialVersion = channel.Substring(0, channel.Length - DailySuffix.Length);
+            if (string.IsNullOrEmpty(partialVersion))
             {
                 return false;
             }
 
-            return IsValidScopeFormat(scope);
+            return IsValidPartialVersion(partialVersion);
         }
 
-        return IsValidScopeFormat(channel) || IsValidPrereleaseVersion(channel);
+        return IsValidPartialVersion(channel) || IsValidFullyQualifiedVersion(channel);
     }
 
     /// <summary>
-    /// Validates a version-scope channel string: bare major (e.g. <c>10</c>),
+    /// Validates a partial version channel string: bare major (e.g. <c>10</c>),
     /// major.minor (e.g. <c>10.0</c>), or feature band (e.g. <c>10.0.1xx</c>).
-    /// Rejects fully-specified versions and prerelease tags.
+    /// Rejects fully-qualified versions and prerelease tags.
     /// </summary>
-    private static bool IsValidScopeFormat(string scope)
+    private static bool IsValidPartialVersion(string partialVersion)
     {
-        var parts = scope.Split('.');
+        var parts = partialVersion.Split('.');
         if (parts.Length is 0 or > 3)
         {
             return false;
@@ -162,7 +157,7 @@ internal class ChannelVersionResolver
 
         if (parts.Length == 3)
         {
-            // Scope only allows feature band patterns like "1xx", not numeric patches.
+            // A partial version's third part must be a feature band pattern like "1xx", not a numeric patch.
             var patch = parts[2];
             if (!patch.EndsWith("xx", StringComparison.OrdinalIgnoreCase))
             {
@@ -180,28 +175,30 @@ internal class ChannelVersionResolver
     }
 
     /// <summary>
-    /// Validates a fully-specified prerelease version like <c>10.0.100-preview.1.32640</c>.
+    /// Validates a fully-qualified version: either a numeric <c>major[.minor[.patch[.rev]]]</c>
+    /// (e.g. <c>10.0.103</c>) or such a version with a prerelease tag (e.g.
+    /// <c>10.0.100-preview.1.32640</c>).
     /// </summary>
-    private static bool IsValidPrereleaseVersion(string channel)
+    private static bool IsValidFullyQualifiedVersion(string channel)
     {
         var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
         if (dashIndex < 0)
         {
-            // Non-prerelease, non-scope version (e.g. "10.0.103") — historically accepted.
-            return IsValidNonScopeVersion(channel);
+            return IsValidNumericVersion(channel);
         }
 
         var versionPart = channel.Substring(0, dashIndex);
-        return IsValidNonScopeVersion(versionPart);
+        return IsValidNumericVersion(versionPart);
     }
 
     /// <summary>
-    /// Validates a numeric major[.minor[.patch]] version (no feature band, no prerelease).
+    /// Validates a numeric <c>major.minor.patch</c> version (no feature band, no
+    /// prerelease tag, all three parts required).
     /// </summary>
-    private static bool IsValidNonScopeVersion(string version)
+    private static bool IsValidNumericVersion(string version)
     {
         var parts = version.Split('.');
-        if (parts.Length is 0 or > 4)
+        if (parts.Length != 3)
         {
             return false;
         }
@@ -211,12 +208,12 @@ internal class ChannelVersionResolver
             return false;
         }
 
-        if (parts.Length >= 2 && (!int.TryParse(parts[1], out var minor) || minor < 0))
+        if (!int.TryParse(parts[1], out var minor) || minor < 0)
         {
             return false;
         }
 
-        if (parts.Length >= 3 && (!int.TryParse(parts[2], out var patch) || patch < 0))
+        if (!int.TryParse(parts[2], out var patch) || patch < 0)
         {
             return false;
         }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -94,17 +94,6 @@ internal class ChannelVersionResolver
 
     }
 
-    public ReleaseVersion? Resolve(UpdateChannel channel, InstallComponent component, InstallArchitecture architecture)
-    {
-        if (channel.IsDaily)
-        {
-            _dailyChannelResolver ??= new DailyChannelResolver(_releaseManifest);
-            return _dailyChannelResolver.Resolve(channel, architecture);
-        }
-
-        return GetLatestVersionForChannel(channel, component);
-    }
-
     /// <summary>
     /// Checks if a channel string looks like a valid .NET version/channel format.
     /// This is a preliminary validation before attempting resolution.
@@ -270,17 +259,22 @@ internal class ChannelVersionResolver
     /// <summary>
     /// Finds the latest fully specified version for a given channel string (major, major.minor, or feature band).
     /// </summary>
-    /// <param name="channel">Channel string (e.g., "9", "9.0", "9.0.1xx", "9.0.103", "lts", "preview")</param>
+    /// <param name="channel">Channel string (e.g., "9", "9.0", "9.0.1xx", "9.0.103", "lts", "preview", "10.0.1xx-daily")</param>
     /// <param name="component">The component to check (ie SDK or runtime)</param>
+    /// <param name="architecture">
+    /// Architecture to use when resolving daily channels (selects the correct aka.ms RID-suffixed
+    /// link). Optional; defaults to the current process architecture. Ignored for non-daily channels.
+    /// </param>
     /// <returns>Latest fully specified version string, or null if not found</returns>
-    public ReleaseVersion? GetLatestVersionForChannel(UpdateChannel channel, InstallComponent component)
+    public ReleaseVersion? GetLatestVersionForChannel(UpdateChannel channel, InstallComponent component, InstallArchitecture? architecture = null)
     {
-        // Daily channels must be resolved via DailyChannelResolver. Reaching this method with a
-        // daily channel means a caller bypassed Resolve(); refuse rather than silently parsing
-        // "10.0.1xx-daily" as 10.0.x and returning the latest released version.
+        // Daily channels are resolved via aka.ms redirect rather than the release manifest.
         if (channel.IsDaily)
         {
-            return null;
+            _dailyChannelResolver ??= new DailyChannelResolver(_releaseManifest);
+            return _dailyChannelResolver.Resolve(
+                channel,
+                architecture ?? InstallerUtilities.GetDefaultInstallArchitecture());
         }
 
         if (string.Equals(channel.Name, LtsChannel, StringComparison.OrdinalIgnoreCase))

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -271,7 +271,8 @@ internal class ChannelVersionResolver
             _dailyChannelResolver ??= new DailyChannelResolver(_releaseManifest);
             return _dailyChannelResolver.Resolve(
                 channel,
-                architecture ?? InstallerUtilities.GetDefaultInstallArchitecture());
+                architecture ?? InstallerUtilities.GetDefaultInstallArchitecture(),
+                component);
         }
 
         if (string.Equals(channel.Name, LtsChannel, StringComparison.OrdinalIgnoreCase))

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -102,7 +102,7 @@ internal class ChannelVersionResolver
             return false;
         }
 
-        // Known keywords are always valid (includes bare "daily").
+        // Known keywords are always valid
         if (KnownChannelKeywords.Any(k => string.Equals(k, channel, StringComparison.OrdinalIgnoreCase)))
         {
             return true;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -81,7 +81,7 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         // "<M>-daily" → use "<M>.0" as the aka.ms partial version (aka.ms paths use major.minor).
-        string partialVersion = NormalizePartialVersion(channel.BaseChannel);
+        string partialVersion = NormalizePartialVersion(UpdateChannel.StripDailySuffix(channel.Name));
         return TryResolvePartialVersion(partialVersion, archivePrefix, rid, extension);
     }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -120,6 +120,7 @@ internal sealed class DailyChannelResolver : IDisposable
         string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, partialVersion, archivePrefix, rid, extension);
 
         Uri finalUri;
+        string? contentType;
         try
         {
             using var response = _httpClient.GetAsync(akaMsUrl, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
@@ -133,6 +134,7 @@ internal sealed class DailyChannelResolver : IDisposable
                 ?? throw new DotnetInstallException(
                     DotnetInstallErrorCode.NetworkError,
                     $"Could not determine the redirect target for daily channel '{partialVersion}-daily'.");
+            contentType = response.Content.Headers.ContentType?.MediaType;
         }
         catch (HttpRequestException ex)
         {
@@ -142,11 +144,13 @@ internal sealed class DailyChannelResolver : IDisposable
                 ex);
         }
 
-        if (IsAkaMsShortlinkNotFound(finalUri))
+        if (IsAkaMsShortlinkNotFound(finalUri) || IsHtmlContent(contentType))
         {
-            // aka.ms redirects unknown shortlinks to https://www.bing.com/?ref=aka&shorturl=...
-            // Treat that as "no daily build available for this partial version" so callers
-            // (like the bare 'daily' probe of major+1) can fall back to the next candidate.
+            // Two ways aka.ms can tell us "no daily build available":
+            //  * URL pattern: unknown shortlinks redirect to https://www.bing.com/?ref=aka&shorturl=...
+            //  * Content type: the fallback page is text/html rather than a binary archive.
+            // Either signal returns null so callers (like the bare 'daily' probe of
+            // major+1) can fall back to the next candidate.
             return null;
         }
 
@@ -211,6 +215,15 @@ internal sealed class DailyChannelResolver : IDisposable
         var query = uri.Query;
         return query.Contains("ref=aka", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Treats <c>text/html</c> as "this isn't a daily-build archive". A real
+    /// daily-build redirect terminates on a binary archive (typically served
+    /// as <c>application/octet-stream</c>); HTML responses are the aka.ms
+    /// not-found fallback or any future error page they switch to.
+    /// </summary>
+    public static bool IsHtmlContent(string? mediaType) =>
+        mediaType is not null && mediaType.Equals("text/html", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Extracts the .NET version from a daily-build redirect URL. The path

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
-using System.Runtime.InteropServices;
 using Microsoft.Deployment.DotNet.Releases;
 
 namespace Microsoft.Dotnet.Installation.Internal;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Dotnet.Installation.Internal;
 internal sealed class DailyChannelResolver : IDisposable
 {
     /// <summary>
-    /// aka.ms link template. The <c>{0}</c> placeholder is the channel scope
+    /// aka.ms link template. The <c>{0}</c> placeholder is the channel's partial version
     /// (e.g. <c>10.0</c> or <c>10.0.1xx</c>); the rest identifies the SDK
     /// archive for the current OS/architecture. We always use the SDK archive
     /// for version discovery because VMR-built daily versions share the same
@@ -58,7 +58,7 @@ internal sealed class DailyChannelResolver : IDisposable
 
     /// <summary>
     /// Resolves the latest daily-build version for <paramref name="channel"/>.
-    /// Returns <c>null</c> if no daily build is available for the channel scope.
+    /// Returns <c>null</c> if no daily build is available.
     /// </summary>
     public ReleaseVersion? Resolve(UpdateChannel channel, InstallArchitecture architecture)
     {
@@ -77,33 +77,33 @@ internal sealed class DailyChannelResolver : IDisposable
         {
             int latestMajor = GetLatestManifestMajor();
 
-            ReleaseVersion? candidate = TryResolveScope($"{latestMajor + 1}.0", rid, extension);
+            ReleaseVersion? candidate = TryResolvePartialVersion($"{latestMajor + 1}.0", rid, extension);
             if (candidate != null)
             {
                 return candidate;
             }
 
-            return TryResolveScope($"{latestMajor}.0", rid, extension);
+            return TryResolvePartialVersion($"{latestMajor}.0", rid, extension);
         }
 
-        // "<M>-daily" → use "<M>.0" as the aka.ms scope (aka.ms paths use major.minor).
-        string scope = NormalizeScope(channel.BaseChannel);
-        return TryResolveScope(scope, rid, extension);
+        // "<M>-daily" → use "<M>.0" as the aka.ms partial version (aka.ms paths use major.minor).
+        string partialVersion = NormalizePartialVersion(channel.BaseChannel);
+        return TryResolvePartialVersion(partialVersion, rid, extension);
     }
 
     /// <summary>
-    /// Converts a channel scope into the form expected by aka.ms paths:
+    /// Converts a channel's partial version into the form expected by aka.ms paths:
     /// bare-major <c>10</c> becomes <c>10.0</c>; major.minor and feature-band
-    /// scopes pass through unchanged.
+    /// partial versions pass through unchanged.
     /// </summary>
-    private static string NormalizeScope(string scope)
+    private static string NormalizePartialVersion(string partialVersion)
     {
-        if (int.TryParse(scope, out _))
+        if (int.TryParse(partialVersion, out _))
         {
-            return $"{scope}.0";
+            return $"{partialVersion}.0";
         }
 
-        return scope;
+        return partialVersion;
     }
 
     private int GetLatestManifestMajor()
@@ -121,9 +121,9 @@ internal sealed class DailyChannelResolver : IDisposable
         return latestMajor;
     }
 
-    private ReleaseVersion? TryResolveScope(string scope, string rid, string extension)
+    private ReleaseVersion? TryResolvePartialVersion(string partialVersion, string rid, string extension)
     {
-        string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, scope, rid, extension);
+        string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, partialVersion, rid, extension);
 
         Uri finalUri;
         try
@@ -138,13 +138,13 @@ internal sealed class DailyChannelResolver : IDisposable
             finalUri = response.RequestMessage?.RequestUri
                 ?? throw new DotnetInstallException(
                     DotnetInstallErrorCode.NetworkError,
-                    $"Could not determine the redirect target for daily channel scope '{scope}'.");
+                    $"Could not determine the redirect target for daily channel '{partialVersion}-daily'.");
         }
         catch (HttpRequestException ex)
         {
             throw new DotnetInstallException(
                 DotnetInstallErrorCode.NetworkError,
-                $"Failed to resolve daily channel scope '{scope}' via {akaMsUrl}: {ex.Message}",
+                $"Failed to resolve daily channel '{partialVersion}-daily' via {akaMsUrl}: {ex.Message}",
                 ex);
         }
 
@@ -152,7 +152,7 @@ internal sealed class DailyChannelResolver : IDisposable
         {
             throw new DotnetInstallException(
                 DotnetInstallErrorCode.NetworkError,
-                $"Daily channel '{scope}' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", AllowedRedirectHosts)}).");
+                $"Daily channel '{partialVersion}-daily' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", AllowedRedirectHosts)}).");
         }
 
         var version = ExtractVersionFromUrl(finalUri);

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -178,6 +178,16 @@ internal sealed class DailyChannelResolver : IDisposable
                 $"Could not extract a version from daily channel redirect target '{finalUri}'.");
         }
 
+        // UpdateChannel.Matches restricts daily channels to prerelease versions,
+        // so returning a stable version here would create an installation that
+        // the channel's own matcher disagrees with. Treat a stable redirect
+        // target as "no daily build available for this scope" so the bare 'daily'
+        // probe can fall back to the next candidate.
+        if (string.IsNullOrEmpty(version.Prerelease))
+        {
+            return null;
+        }
+
         return version;
     }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -17,12 +17,13 @@ internal sealed class DailyChannelResolver : IDisposable
 {
     /// <summary>
     /// aka.ms link template. The <c>{0}</c> placeholder is the channel's partial version
-    /// (e.g. <c>10.0</c> or <c>10.0.1xx</c>); the rest identifies the SDK
-    /// archive for the current OS/architecture. We always use the SDK archive
-    /// for version discovery because VMR-built daily versions share the same
-    /// SDK version across components.
+    /// (e.g. <c>10.0</c> or <c>10.0.1xx</c>); <c>{1}</c> is the component-specific
+    /// archive prefix (e.g. <c>dotnet-sdk</c>, <c>dotnet-runtime</c>); <c>{2}</c> is
+    /// the RID; <c>{3}</c> is the platform archive extension. Component matters
+    /// because daily SDK and runtime builds are published at different base versions
+    /// (e.g. SDK 10.0.110 vs Runtime 10.0.10, sharing the same prerelease tag).
     /// </summary>
-    private const string AkaMsTemplate = "https://aka.ms/dotnet/{0}/daily/dotnet-sdk-{1}{2}";
+    private const string AkaMsTemplate = "https://aka.ms/dotnet/{0}/daily/{1}-{2}{3}";
 
     /// <summary>
     /// Hosts that aka.ms is allowed to redirect to. The redirect target tells
@@ -58,7 +59,10 @@ internal sealed class DailyChannelResolver : IDisposable
 
     /// <summary>
     /// Resolves the latest daily-build version for <paramref name="channel"/>.
-    /// Returns <c>null</c> if no daily build is available.
+    /// Returns <c>null</c> if no daily build is available. The version is
+    /// discovered from the aka.ms shortlink for the requested
+    /// <paramref name="component"/>, since daily SDK and runtime builds share
+    /// the same prerelease tag but differ in base version.
     /// </summary>
     public ReleaseVersion? Resolve(UpdateChannel channel, InstallArchitecture architecture, InstallComponent component = InstallComponent.SDK)
     {
@@ -69,6 +73,7 @@ internal sealed class DailyChannelResolver : IDisposable
 
         string rid = DotnetupUtilities.GetRuntimeIdentifier(architecture);
         string extension = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+        string archivePrefix = BlobFeedUrlBuilder.GetArchivePrefix(component);
 
         // Bare "daily": probe major+1 first so we pick up a new major as soon
         // as it starts producing daily builds, before its first GA release
@@ -79,18 +84,18 @@ internal sealed class DailyChannelResolver : IDisposable
         {
             int latestMajor = GetLatestManifestMajor();
 
-            ReleaseVersion? candidate = TryResolvePartialVersion($"{latestMajor + 1}.0", rid, extension);
+            ReleaseVersion? candidate = TryResolvePartialVersion($"{latestMajor + 1}.0", archivePrefix, rid, extension);
             if (candidate != null)
             {
                 return candidate;
             }
 
-            return TryResolvePartialVersion($"{latestMajor}.0", rid, extension);
+            return TryResolvePartialVersion($"{latestMajor}.0", archivePrefix, rid, extension);
         }
 
         // "<M>-daily" → use "<M>.0" as the aka.ms partial version (aka.ms paths use major.minor).
         string partialVersion = NormalizePartialVersion(channel.BaseChannel);
-        return TryResolvePartialVersion(partialVersion, rid, extension);
+        return TryResolvePartialVersion(partialVersion, archivePrefix, rid, extension);
     }
 
     /// <summary>
@@ -123,9 +128,9 @@ internal sealed class DailyChannelResolver : IDisposable
         return latestMajor;
     }
 
-    private ReleaseVersion? TryResolvePartialVersion(string partialVersion, string rid, string extension)
+    private ReleaseVersion? TryResolvePartialVersion(string partialVersion, string archivePrefix, string rid, string extension)
     {
-        string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, partialVersion, rid, extension);
+        string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, partialVersion, archivePrefix, rid, extension);
 
         Uri finalUri;
         try

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Runtime.InteropServices;
 using Microsoft.Deployment.DotNet.Releases;
 
 namespace Microsoft.Dotnet.Installation.Internal;
@@ -59,7 +60,13 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         string rid = DotnetupUtilities.GetRuntimeIdentifier(architecture);
-        string extension = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+        // aka.ms has historically published the daily SDK as .zip for Windows RIDs
+        // and .tar.gz elsewhere. (.tar.gz is now also published for Windows — see PR
+        // #54467 — but .zip is the long-standing format we know is always present
+        // back through older daily channels.) We only need one URL that resolves to
+        // the daily build to extract a version from the redirect target, so pick
+        // the historically-published extension for the platform.
+        string extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".zip" : ".tar.gz";
         string archivePrefix = BlobFeedUrlBuilder.GetArchivePrefix(component);
 
         // Bare "daily": probe major+1 first so we pick up a new major as soon

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -25,19 +25,6 @@ internal sealed class DailyChannelResolver : IDisposable
     /// </summary>
     private const string AkaMsTemplate = "https://aka.ms/dotnet/{0}/daily/{1}-{2}{3}";
 
-    /// <summary>
-    /// Hosts that aka.ms is allowed to redirect to. The redirect target tells
-    /// us where the daily build is actually published; if it points anywhere
-    /// else (e.g. through DNS hijacking or a misconfigured redirect), we
-    /// refuse to trust the URL for version extraction.
-    /// </summary>
-    public static readonly IReadOnlyList<string> AllowedRedirectHosts =
-    [
-        "ci.dot.net",
-        "builds.dotnet.microsoft.com",
-        "dotnetbuilds.azureedge.net",
-    ];
-
     private readonly HttpClient _httpClient;
     private readonly ReleaseManifest _releaseManifest;
     private readonly bool _shouldDisposeHttpClient;
@@ -167,7 +154,7 @@ internal sealed class DailyChannelResolver : IDisposable
         {
             throw new DotnetInstallException(
                 DotnetInstallErrorCode.NetworkError,
-                $"Daily channel '{partialVersion}-daily' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", AllowedRedirectHosts)}).");
+                $"Daily channel '{partialVersion}-daily' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", UrlSanitizer.KnownDownloadDomains)}).");
         }
 
         var version = ExtractVersionFromUrl(finalUri);
@@ -193,7 +180,7 @@ internal sealed class DailyChannelResolver : IDisposable
 
     /// <summary>
     /// Returns true when <paramref name="uri"/> uses HTTPS and points at a
-    /// host on <see cref="AllowedRedirectHosts"/>.
+    /// host on <see cref="UrlSanitizer.KnownDownloadDomains"/>.
     /// </summary>
     public static bool IsAllowedRedirectTarget(Uri uri)
     {
@@ -202,7 +189,7 @@ internal sealed class DailyChannelResolver : IDisposable
             return false;
         }
 
-        return AllowedRedirectHosts.Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
+        return UrlSanitizer.KnownDownloadDomains.Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.Deployment.DotNet.Releases;
+
+namespace Microsoft.Dotnet.Installation.Internal;
+
+/// <summary>
+/// Resolves daily-build channels (e.g. <c>10.0-daily</c>, <c>daily</c>) to a
+/// concrete <see cref="ReleaseVersion"/> by querying the aka.ms redirect for
+/// the latest daily SDK archive and extracting the version from the redirect
+/// target URL. The resolved version is then handed to the existing blob-feed
+/// download path for the actual install.
+/// </summary>
+internal sealed class DailyChannelResolver : IDisposable
+{
+    /// <summary>
+    /// aka.ms link template. The <c>{0}</c> placeholder is the channel scope
+    /// (e.g. <c>10.0</c> or <c>10.0.1xx</c>); the rest identifies the SDK
+    /// archive for the current OS/architecture. We always use the SDK archive
+    /// for version discovery because VMR-built daily versions share the same
+    /// SDK version across components.
+    /// </summary>
+    private const string AkaMsTemplate = "https://aka.ms/dotnet/{0}/daily/dotnet-sdk-{1}{2}";
+
+    /// <summary>
+    /// Hosts that aka.ms is allowed to redirect to. The redirect target tells
+    /// us where the daily build is actually published; if it points anywhere
+    /// else (e.g. through DNS hijacking or a misconfigured redirect), we
+    /// refuse to trust the URL for version extraction.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AllowedRedirectHosts =
+    [
+        "ci.dot.net",
+        "builds.dotnet.microsoft.com",
+        "dotnetbuilds.azureedge.net",
+    ];
+
+    private readonly HttpClient _httpClient;
+    private readonly ReleaseManifest _releaseManifest;
+    private readonly bool _shouldDisposeHttpClient;
+
+    public DailyChannelResolver(ReleaseManifest? releaseManifest = null, HttpClient? httpClient = null)
+    {
+        _releaseManifest = releaseManifest ?? new ReleaseManifest();
+        if (httpClient == null)
+        {
+            _httpClient = CreateDefaultHttpClient();
+            _shouldDisposeHttpClient = true;
+        }
+        else
+        {
+            _httpClient = httpClient;
+            _shouldDisposeHttpClient = false;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the latest daily-build version for <paramref name="channel"/>.
+    /// Returns <c>null</c> if no daily build is available for the channel scope.
+    /// </summary>
+    public ReleaseVersion? Resolve(UpdateChannel channel, InstallArchitecture architecture)
+    {
+        if (!channel.IsDaily)
+        {
+            throw new ArgumentException($"Channel '{channel.Name}' is not a daily channel.", nameof(channel));
+        }
+
+        string rid = DotnetupUtilities.GetRuntimeIdentifier(architecture);
+        string extension = DotnetupUtilities.GetArchiveFileExtensionForPlatform();
+
+        // Bare "daily": probe major+1 first so we pick up a new major as soon
+        // as it starts producing daily builds, before its first GA release
+        // updates the manifest.
+        if (channel.Name.Equals(ChannelVersionResolver.DailyChannel, StringComparison.OrdinalIgnoreCase))
+        {
+            int latestMajor = GetLatestManifestMajor();
+
+            ReleaseVersion? candidate = TryResolveScope($"{latestMajor + 1}.0", rid, extension);
+            if (candidate != null)
+            {
+                return candidate;
+            }
+
+            return TryResolveScope($"{latestMajor}.0", rid, extension);
+        }
+
+        // "<M>-daily" → use "<M>.0" as the aka.ms scope (aka.ms paths use major.minor).
+        string scope = NormalizeScope(channel.BaseChannel);
+        return TryResolveScope(scope, rid, extension);
+    }
+
+    /// <summary>
+    /// Converts a channel scope into the form expected by aka.ms paths:
+    /// bare-major <c>10</c> becomes <c>10.0</c>; major.minor and feature-band
+    /// scopes pass through unchanged.
+    /// </summary>
+    private static string NormalizeScope(string scope)
+    {
+        if (int.TryParse(scope, out _))
+        {
+            return $"{scope}.0";
+        }
+
+        return scope;
+    }
+
+    private int GetLatestManifestMajor()
+    {
+        var index = _releaseManifest.GetReleasesIndex();
+        int latestMajor = 0;
+        foreach (var product in index)
+        {
+            if (int.TryParse(product.ProductVersion.Split('.')[0], out var major) && major > latestMajor)
+            {
+                latestMajor = major;
+            }
+        }
+
+        return latestMajor;
+    }
+
+    private ReleaseVersion? TryResolveScope(string scope, string rid, string extension)
+    {
+        string akaMsUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, AkaMsTemplate, scope, rid, extension);
+
+        Uri finalUri;
+        try
+        {
+            using var response = _httpClient.GetAsync(akaMsUrl, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            finalUri = response.RequestMessage?.RequestUri
+                ?? throw new DotnetInstallException(
+                    DotnetInstallErrorCode.NetworkError,
+                    $"Could not determine the redirect target for daily channel scope '{scope}'.");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.NetworkError,
+                $"Failed to resolve daily channel scope '{scope}' via {akaMsUrl}: {ex.Message}",
+                ex);
+        }
+
+        if (!IsAllowedRedirectTarget(finalUri))
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.NetworkError,
+                $"Daily channel '{scope}' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", AllowedRedirectHosts)}).");
+        }
+
+        var version = ExtractVersionFromUrl(finalUri);
+        if (version == null)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.NetworkError,
+                $"Could not extract a version from daily channel redirect target '{finalUri}'.");
+        }
+
+        return version;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="uri"/> uses HTTPS and points at a
+    /// host on <see cref="AllowedRedirectHosts"/>.
+    /// </summary>
+    public static bool IsAllowedRedirectTarget(Uri uri)
+    {
+        if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return AllowedRedirectHosts.Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Extracts the .NET version from a daily-build redirect URL. The path
+    /// segments include the version (e.g. <c>.../Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-...</c>);
+    /// we return the first segment that parses as a <see cref="ReleaseVersion"/>.
+    /// </summary>
+    public static ReleaseVersion? ExtractVersionFromUrl(Uri uri)
+    {
+        foreach (var segment in uri.Segments)
+        {
+            var trimmed = segment.Trim('/');
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (ReleaseVersion.TryParse(trimmed, out var version))
+            {
+                return version;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// HttpClient configured to follow redirects (so we can read the final
+    /// <see cref="HttpResponseMessage.RequestMessage"/> URI after aka.ms
+    /// resolves).
+    /// </summary>
+    private static HttpClient CreateDefaultHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            UseProxy = true,
+            UseDefaultCredentials = true,
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 10,
+        };
+
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromMinutes(2),
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_shouldDisposeHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+    }
+}

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -146,13 +146,6 @@ internal sealed class DailyChannelResolver : IDisposable
             return null;
         }
 
-        if (!IsAllowedRedirectTarget(finalUri))
-        {
-            throw new DotnetInstallException(
-                DotnetInstallErrorCode.NetworkError,
-                $"Daily channel '{partialVersion}-daily' redirected to disallowed host '{finalUri.Host}' (expected one of: {string.Join(", ", UrlSanitizer.KnownDownloadDomains)}).");
-        }
-
         var version = ExtractVersionFromUrl(finalUri);
         if (version == null)
         {
@@ -172,20 +165,6 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         return version;
-    }
-
-    /// <summary>
-    /// Returns true when <paramref name="uri"/> uses HTTPS and points at a
-    /// host on <see cref="UrlSanitizer.KnownDownloadDomains"/>.
-    /// </summary>
-    public static bool IsAllowedRedirectTarget(Uri uri)
-    {
-        if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return UrlSanitizer.KnownDownloadDomains.Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -102,17 +102,15 @@ internal sealed class DailyChannelResolver : IDisposable
 
     private int GetLatestManifestMajor()
     {
-        var index = _releaseManifest.GetReleasesIndex();
-        int latestMajor = 0;
-        foreach (var product in index)
+        // The manifest is designed so that the first product is always the latest major
+        // (same assumption ChannelVersionResolver.GetLatestVersionForMajorOrMajorMinor relies on).
+        var first = _releaseManifest.GetReleasesIndex().FirstOrDefault();
+        if (first != null && int.TryParse(first.ProductVersion.Split('.')[0], out var major))
         {
-            if (int.TryParse(product.ProductVersion.Split('.')[0], out var major) && major > latestMajor)
-            {
-                latestMajor = major;
-            }
+            return major;
         }
 
-        return latestMajor;
+        return 0;
     }
 
     private ReleaseVersion? TryResolvePartialVersion(string partialVersion, string archivePrefix, string rid, string extension)

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -60,7 +60,7 @@ internal sealed class DailyChannelResolver : IDisposable
     /// Resolves the latest daily-build version for <paramref name="channel"/>.
     /// Returns <c>null</c> if no daily build is available.
     /// </summary>
-    public ReleaseVersion? Resolve(UpdateChannel channel, InstallArchitecture architecture)
+    public ReleaseVersion? Resolve(UpdateChannel channel, InstallArchitecture architecture, InstallComponent component = InstallComponent.SDK)
     {
         if (!channel.IsDaily)
         {

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -104,13 +104,7 @@ internal sealed class DailyChannelResolver : IDisposable
     {
         // The manifest is designed so that the first product is always the latest major
         // (same assumption ChannelVersionResolver.GetLatestVersionForMajorOrMajorMinor relies on).
-        var first = _releaseManifest.GetReleasesIndex().FirstOrDefault();
-        if (first != null && int.TryParse(first.ProductVersion.Split('.')[0], out var major))
-        {
-            return major;
-        }
-
-        return 0;
+        return _releaseManifest.GetReleasesIndex().FirstOrDefault()?.LatestReleaseVersion?.Major ?? 0;
     }
 
     private ReleaseVersion? TryResolvePartialVersion(string partialVersion, string archivePrefix, string rid, string extension)

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -72,7 +72,9 @@ internal sealed class DailyChannelResolver : IDisposable
 
         // Bare "daily": probe major+1 first so we pick up a new major as soon
         // as it starts producing daily builds, before its first GA release
-        // updates the manifest.
+        // updates the manifest. TryResolvePartialVersion returns null when
+        // aka.ms doesn't have a link for the requested major, so the fallback
+        // to the manifest's highest major runs as designed.
         if (channel.Name.Equals(ChannelVersionResolver.DailyChannel, StringComparison.OrdinalIgnoreCase))
         {
             int latestMajor = GetLatestManifestMajor();
@@ -148,6 +150,14 @@ internal sealed class DailyChannelResolver : IDisposable
                 ex);
         }
 
+        if (IsAkaMsShortlinkNotFound(finalUri))
+        {
+            // aka.ms redirects unknown shortlinks to https://www.bing.com/?ref=aka&shorturl=...
+            // Treat that as "no daily build available for this partial version" so callers
+            // (like the bare 'daily' probe of major+1) can fall back to the next candidate.
+            return null;
+        }
+
         if (!IsAllowedRedirectTarget(finalUri))
         {
             throw new DotnetInstallException(
@@ -178,6 +188,26 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         return AllowedRedirectHosts.Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Detects the aka.ms "shortlink not found" redirect: when an aka.ms URL
+    /// has no registered target, the service redirects to a Bing landing page
+    /// of the form <c>https://www.bing.com/?ref=aka&amp;shorturl=&lt;original-path&gt;</c>.
+    /// The <c>ref=aka</c> query parameter is the unambiguous marker that the
+    /// redirect originated from aka.ms's not-found fallback (rather than a
+    /// legitimate redirect chain that happens to terminate on bing.com).
+    /// </summary>
+    public static bool IsAkaMsShortlinkNotFound(Uri uri)
+    {
+        if (!uri.Host.Equals("www.bing.com", StringComparison.OrdinalIgnoreCase)
+            && !uri.Host.Equals("bing.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var query = uri.Query;
+        return query.Contains("ref=aka", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -295,17 +295,15 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
         DotnetInstallRequest installRequest,
         ReleaseVersion resolvedVersion)
     {
-        if (string.IsNullOrEmpty(resolvedVersion.Prerelease))
-        {
-            return false;
-        }
-
+        // DailyChannelResolver only returns prerelease versions, so we don't
+        // need to re-check the resolved version's prerelease label here.
         if (installRequest.Channel.IsDaily)
         {
             return true;
         }
 
-        if (!installRequest.Channel.IsFullySpecifiedVersion())
+        if (string.IsNullOrEmpty(resolvedVersion.Prerelease)
+            || !installRequest.Channel.IsFullySpecifiedVersion())
         {
             return false;
         }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveDownloader.cs
@@ -286,19 +286,26 @@ internal class DotnetArchiveDownloader : IArchiveDownloader
     /// Returns true if a manifest miss should fall back to the blob feed.
     /// We only fall back when the user gave us an exact prerelease version
     /// (e.g. <c>10.0.100-preview.4.25216.37</c>) and the manifest doesn't yet
-    /// know about it. Stable versions and named channels (e.g. "preview") are
-    /// served only from the manifest so that real misses surface as errors.
+    /// know about it, OR when the channel is a daily channel (where the
+    /// resolved version always points at a blob-feed-only build). Stable
+    /// versions and named channels (e.g. "preview") are served only from the
+    /// manifest so that real misses surface as errors.
     /// </summary>
     private static bool ShouldFallbackToBlobFeed(
         DotnetInstallRequest installRequest,
         ReleaseVersion resolvedVersion)
     {
-        if (!installRequest.Channel.IsFullySpecifiedVersion())
+        if (string.IsNullOrEmpty(resolvedVersion.Prerelease))
         {
             return false;
         }
 
-        if (string.IsNullOrEmpty(resolvedVersion.Prerelease))
+        if (installRequest.Channel.IsDaily)
+        {
+            return true;
+        }
+
+        if (!installRequest.Channel.IsFullySpecifiedVersion())
         {
             return false;
         }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -115,9 +115,9 @@ internal class UpdateChannel
         }
 
         // Named channels (lts, latest, preview, daily)
-        if (TryMatchNamedChannel(version, out var namedMatch))
+        if (TryMatchNamedChannel(version, out var versionMatchesChannel))
         {
-            return namedMatch;
+            return versionMatchesChannel;
         }
 
         // Major version match (e.g., "10" matches "10.0.103")
@@ -144,12 +144,24 @@ internal class UpdateChannel
         return MatchesMajorMinorOrFeatureBand(version);
     }
 
-    private bool TryMatchNamedChannel(ReleaseVersion version, out bool result)
+    /// <summary>
+    /// Returns whether this channel is one of the recognized keyword channels
+    /// (<c>lts</c>, <c>latest</c>, <c>preview</c>, <c>daily</c>). When it is,
+    /// <paramref name="versionMatchesChannel"/> is set to whether <paramref name="version"/>
+    /// satisfies that keyword's rules; when it isn't, this returns
+    /// <c>false</c> so the caller can keep trying other match strategies.
+    /// </summary>
+    /// <remarks>
+    /// The double-bool shape follows the standard <c>TryXxx</c> pattern: the
+    /// return value answers "did the keyword path apply?" and
+    /// <paramref name="versionMatchesChannel"/> carries the actual match decision when it did.
+    /// </remarks>
+    private bool TryMatchNamedChannel(ReleaseVersion version, out bool versionMatchesChannel)
     {
         if (Name.Equals("lts", StringComparison.OrdinalIgnoreCase))
         {
             // LTS releases are even major versions and must be stable releases.
-            result = version.Major % 2 == 0 && IsStableRelease(version);
+            versionMatchesChannel = version.Major % 2 == 0 && IsStableRelease(version);
             return true;
         }
 
@@ -158,24 +170,24 @@ internal class UpdateChannel
         // matches so existing preview specs can keep a GA SDK when no preview exists yet.
         if (Name.Equals("latest", StringComparison.OrdinalIgnoreCase))
         {
-            result = IsStableRelease(version);
+            versionMatchesChannel = IsStableRelease(version);
             return true;
         }
 
         if (Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
         {
-            result = true;
+            versionMatchesChannel = true;
             return true;
         }
 
         // Bare "daily" matches any prerelease version; stable releases are not daily builds.
         if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
         {
-            result = !IsStableRelease(version);
+            versionMatchesChannel = !IsStableRelease(version);
             return true;
         }
 
-        result = false;
+        versionMatchesChannel = false;
         return false;
     }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Dotnet.Installation.Internal;
 
 internal class UpdateChannel
 {
+    private const string DailySuffix = "-daily";
+    private const string DailyKeyword = "daily";
+
     public string Name { get; }
 
     private static bool IsStableRelease(ReleaseVersion version) => string.IsNullOrEmpty(version.Prerelease);
@@ -19,6 +22,39 @@ internal class UpdateChannel
     public bool IsFullySpecifiedVersion()
     {
         return ReleaseVersion.TryParse(Name, out _);
+    }
+
+    /// <summary>
+    /// True if this channel refers to a daily build — either bare <c>daily</c>
+    /// or a scope with a <c>-daily</c> suffix (e.g. <c>10.0-daily</c>,
+    /// <c>10.0.1xx-daily</c>).
+    /// </summary>
+    public bool IsDaily =>
+        Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase) ||
+        Name.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// For daily channels, the version scope without the <c>-daily</c> suffix
+    /// (e.g. <c>10.0-daily</c> → <c>10.0</c>). Bare <c>daily</c> returns
+    /// <c>"daily"</c> — it has no explicit scope and is resolved separately.
+    /// For non-daily channels, returns the channel name unchanged.
+    /// </summary>
+    public string BaseChannel
+    {
+        get
+        {
+            if (!IsDaily)
+            {
+                return Name;
+            }
+
+            if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return DailyKeyword;
+            }
+
+            return Name.Substring(0, Name.Length - DailySuffix.Length);
+        }
     }
 
     /// <summary>
@@ -71,30 +107,31 @@ internal class UpdateChannel
             return false;
         }
 
+        // Daily channels match the same versions their base channel would.
+        // Bare "daily" matches any version; "10.0-daily" matches any 10.0.x;
+        // "10.0.1xx-daily" matches any 10.0.1xx version. The "kind of build"
+        // distinction (daily vs released) is reflected in how versions are
+        // resolved and tracked, not in which versions Matches() accepts.
+        if (IsDaily)
+        {
+            if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return new UpdateChannel(BaseChannel).Matches(version);
+        }
+
         // Exact version match
         if (string.Equals(version.ToString(), Name, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        // Named channels
-        if (Name.Equals("lts", StringComparison.OrdinalIgnoreCase))
+        // Named channels (lts, latest, preview)
+        if (TryMatchNamedChannel(version, out var namedMatch))
         {
-            // LTS releases are even major versions and must be stable releases.
-            return version.Major % 2 == 0 && IsStableRelease(version);
-        }
-
-        // "latest" should only match stable releases so a preview SDK doesn't satisfy the
-        // stable channel during garbage collection. "preview" continues to allow stable
-        // matches so existing preview specs can keep a GA SDK when no preview exists yet.
-        if (Name.Equals("latest", StringComparison.OrdinalIgnoreCase))
-        {
-            return IsStableRelease(version);
-        }
-
-        if (Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
+            return namedMatch;
         }
 
         // Major version match (e.g., "10" matches "10.0.103")
@@ -103,6 +140,39 @@ internal class UpdateChannel
             return version.Major == major;
         }
 
+        return MatchesMajorMinorOrFeatureBand(version);
+    }
+
+    private bool TryMatchNamedChannel(ReleaseVersion version, out bool result)
+    {
+        if (Name.Equals("lts", StringComparison.OrdinalIgnoreCase))
+        {
+            // LTS releases are even major versions and must be stable releases.
+            result = version.Major % 2 == 0 && IsStableRelease(version);
+            return true;
+        }
+
+        // "latest" should only match stable releases so a preview SDK doesn't satisfy the
+        // stable channel during garbage collection. "preview" continues to allow stable
+        // matches so existing preview specs can keep a GA SDK when no preview exists yet.
+        if (Name.Equals("latest", StringComparison.OrdinalIgnoreCase))
+        {
+            result = IsStableRelease(version);
+            return true;
+        }
+
+        if (Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
+        {
+            result = true;
+            return true;
+        }
+
+        result = false;
+        return false;
+    }
+
+    private bool MatchesMajorMinorOrFeatureBand(ReleaseVersion version)
+    {
         var parts = Name.Split('.');
 
         // Major.Minor match (e.g., "10.0" matches "10.0.103")

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -107,13 +107,18 @@ internal class UpdateChannel
             return false;
         }
 
-        // Daily channels match the same versions their base channel would.
-        // Bare "daily" matches any version; "10.0-daily" matches any 10.0.x;
-        // "10.0.1xx-daily" matches any 10.0.1xx version. The "kind of build"
-        // distinction (daily vs released) is reflected in how versions are
-        // resolved and tracked, not in which versions Matches() accepts.
+        // Daily channels match the same versions their base channel would, but
+        // restricted to prerelease versions. A stable release is not a daily
+        // build, even if its version falls inside the base scope; rejecting it
+        // here keeps the channel's "what satisfies me?" answer coherent for GC
+        // and reporting.
         if (IsDaily)
         {
+            if (IsStableRelease(version))
+            {
+                return false;
+            }
+
             if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
             {
                 return true;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -34,28 +34,14 @@ internal class UpdateChannel
         Name.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
-    /// For daily channels, the version scope without the <c>-daily</c> suffix
-    /// (e.g. <c>10.0-daily</c> → <c>10.0</c>). Bare <c>daily</c> returns
-    /// <c>"daily"</c> — it has no explicit scope and is resolved separately.
-    /// For non-daily channels, returns the channel name unchanged.
+    /// Strips the <c>-daily</c> suffix from a channel name (e.g. <c>"10.0-daily"</c>
+    /// → <c>"10.0"</c>). Returns the input unchanged if it doesn't end with
+    /// <c>-daily</c>.
     /// </summary>
-    public string BaseChannel
-    {
-        get
-        {
-            if (!IsDaily)
-            {
-                return Name;
-            }
-
-            if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
-            {
-                return DailyKeyword;
-            }
-
-            return Name.Substring(0, Name.Length - DailySuffix.Length);
-        }
-    }
+    public static string StripDailySuffix(string channelName)
+        => channelName.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase)
+            ? channelName.Substring(0, channelName.Length - DailySuffix.Length)
+            : channelName;
 
     /// <summary>
     /// Checks if the channel string looks like an SDK version or feature band pattern rather than a runtime version.
@@ -138,7 +124,7 @@ internal class UpdateChannel
                 return false;
             }
 
-            return new UpdateChannel(BaseChannel).Matches(version);
+            return new UpdateChannel(StripDailySuffix(Name)).Matches(version);
         }
 
         return MatchesMajorMinorOrFeatureBand(version);

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -97,8 +97,9 @@ internal class UpdateChannel
 
     /// <summary>
     /// Checks if the given version matches this channel pattern.
-    /// Supports exact versions, named channels (latest, lts, preview),
-    /// major-only, major.minor, and feature band patterns.
+    /// Supports exact versions, named channels (latest, lts, preview, daily),
+    /// major-only, major.minor, and feature band patterns (each of these may
+    /// also carry a <c>-daily</c> suffix to narrow the match to prerelease versions).
     /// </summary>
     public bool Matches(ReleaseVersion version)
     {
@@ -107,33 +108,13 @@ internal class UpdateChannel
             return false;
         }
 
-        // Daily channels match the same versions their base channel would, but
-        // restricted to prerelease versions. A stable release is not a daily
-        // build, even if its version falls inside the base scope; rejecting it
-        // here keeps the channel's "what satisfies me?" answer coherent for GC
-        // and reporting.
-        if (IsDaily)
-        {
-            if (IsStableRelease(version))
-            {
-                return false;
-            }
-
-            if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return new UpdateChannel(BaseChannel).Matches(version);
-        }
-
         // Exact version match
         if (string.Equals(version.ToString(), Name, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        // Named channels (lts, latest, preview)
+        // Named channels (lts, latest, preview, daily)
         if (TryMatchNamedChannel(version, out var namedMatch))
         {
             return namedMatch;
@@ -143,6 +124,21 @@ internal class UpdateChannel
         if (int.TryParse(Name, out var major))
         {
             return version.Major == major;
+        }
+
+        // Scoped daily channels (e.g. "10.0-daily", "10.0.1xx-daily") match the
+        // same versions their base scope would, but restricted to prerelease
+        // versions. A stable release is not a daily build, even if its version
+        // falls inside the base scope; rejecting it here keeps the channel's
+        // "what satisfies me?" answer coherent for GC and reporting.
+        if (IsDaily)
+        {
+            if (IsStableRelease(version))
+            {
+                return false;
+            }
+
+            return new UpdateChannel(BaseChannel).Matches(version);
         }
 
         return MatchesMajorMinorOrFeatureBand(version);
@@ -169,6 +165,13 @@ internal class UpdateChannel
         if (Name.Equals("preview", StringComparison.OrdinalIgnoreCase))
         {
             result = true;
+            return true;
+        }
+
+        // Bare "daily" matches any prerelease version; stable releases are not daily builds.
+        if (Name.Equals(DailyKeyword, StringComparison.OrdinalIgnoreCase))
+        {
+            result = !IsStableRelease(version);
             return true;
         }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UrlSanitizer.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UrlSanitizer.cs
@@ -23,7 +23,8 @@ public static class UrlSanitizer
         "builds.dotnet.microsoft.com",
         "ci.dot.net",
         "dotnetcli.blob.core.windows.net",
-        "dotnetcli.azureedge.net"  // Legacy CDN, may still be referenced
+        "dotnetcli.azureedge.net",   // Legacy CDN, may still be referenced
+        "dotnetbuilds.azureedge.net" // Daily-build CDN aka.ms can redirect to
     ];
 
     /// <summary>

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -144,7 +144,7 @@ internal class InstallWorkflow
                 Verbosity = _command.Verbosity
             });
 
-        var resolvedVersion = _command.ChannelVersionResolver.Resolve(request);
+        var resolvedVersion = _command.ChannelVersionResolver.Resolve(request.Channel, request.Component, request.InstallRoot.Architecture);
 
         if (resolvedVersion is null)
         {

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -144,7 +144,7 @@ internal class InstallWorkflow
                 Verbosity = _command.Verbosity
             });
 
-        var resolvedVersion = _command.ChannelVersionResolver.Resolve(request.Channel, request.Component, request.InstallRoot.Architecture);
+        var resolvedVersion = _command.ChannelVersionResolver.GetLatestVersionForChannel(request.Channel, request.Component, request.InstallRoot.Architecture);
 
         if (resolvedVersion is null)
         {

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -118,6 +118,18 @@ internal class InstallWorkflow
 
         var (channel, isFromGlobalJson) = ResolveChannel(component, explicitChannel, globalJson);
 
+        // Validate the channel format before any network calls so bogus inputs (e.g. "preview-daily",
+        // "100-daily", typos) fail fast with a clean InvalidChannel error instead of bubbling up as
+        // a 404 from the release manifest or aka.ms redirect.
+        if (!ChannelVersionResolver.IsValidChannelFormat(channel))
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.InvalidChannel,
+                $"'{channel}' is not a recognized .NET version or channel for {component.GetDisplayName()}. "
+                + "Use a channel like 'latest', 'lts', 'preview', a version scope like '10.0' or '10.0.1xx', "
+                + "a daily-build scope like '10.0-daily' or '10.0.1xx-daily', or a fully-qualified version like '10.0.103'.");
+        }
+
         var request = new DotnetInstallRequest(
             installRoot,
             new UpdateChannel(channel),

--- a/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
@@ -162,7 +162,15 @@ internal class UpdateWorkflow
             return false;
         }
 
-        var latestVersion = _channelVersionResolver.GetLatestVersionForChannel(channel, spec.Component);
+        // Route through Resolve() so daily channels reach DailyChannelResolver instead
+        // of falling through to the release-manifest path (which would parse "10.0.1xx-daily"
+        // as 10.0.x and silently install the latest released version).
+        var resolveRequest = new DotnetInstallRequest(
+            installRoot,
+            channel,
+            spec.Component,
+            new InstallRequestOptions { ManifestPath = manifestPath, Verbosity = verbosity });
+        var latestVersion = _channelVersionResolver.Resolve(resolveRequest);
         string displayName = spec.Component.GetDisplayName();
         if (latestVersion is null)
         {

--- a/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
@@ -165,12 +165,7 @@ internal class UpdateWorkflow
         // Route through Resolve() so daily channels reach DailyChannelResolver instead
         // of falling through to the release-manifest path (which would parse "10.0.1xx-daily"
         // as 10.0.x and silently install the latest released version).
-        var resolveRequest = new DotnetInstallRequest(
-            installRoot,
-            channel,
-            spec.Component,
-            new InstallRequestOptions { ManifestPath = manifestPath, Verbosity = verbosity });
-        var latestVersion = _channelVersionResolver.Resolve(resolveRequest);
+        var latestVersion = _channelVersionResolver.Resolve(channel, spec.Component, installRoot.Architecture);
         string displayName = spec.Component.GetDisplayName();
         if (latestVersion is null)
         {

--- a/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
@@ -162,10 +162,8 @@ internal class UpdateWorkflow
             return false;
         }
 
-        // Route through Resolve() so daily channels reach DailyChannelResolver instead
-        // of falling through to the release-manifest path (which would parse "10.0.1xx-daily"
-        // as 10.0.x and silently install the latest released version).
-        var latestVersion = _channelVersionResolver.Resolve(channel, spec.Component, installRoot.Architecture);
+        // Pass architecture so daily channels can be resolved via DailyChannelResolver.
+        var latestVersion = _channelVersionResolver.GetLatestVersionForChannel(channel, spec.Component, installRoot.Architecture);
         string displayName = spec.Component.GetDisplayName();
         if (latestVersion is null)
         {

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Dotnet.Installation;
 using Microsoft.Dotnet.Installation.Internal;
 using Xunit;
@@ -189,6 +194,84 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
             var channels = resolver.GetSupportedChannels().ToList();
 
             Assert.Contains(channels, c => c.EndsWith("xx"));
+        }
+
+        [Fact]
+        public void GetLatestVersionForChannel_DailyChannel_ReturnsNull()
+        {
+            // Daily channels must go through DailyChannelResolver via Resolve(); reaching
+            // GetLatestVersionForChannel with a daily channel means a caller bypassed routing.
+            // We refuse rather than silently returning the latest released version (which is
+            // what the manifest path would do for "10.0.1xx-daily" parsing).
+            var resolver = new ChannelVersionResolver();
+
+            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("10.0.1xx-daily"), InstallComponent.SDK));
+            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("10.0-daily"), InstallComponent.SDK));
+            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("daily"), InstallComponent.SDK));
+        }
+
+        [Fact]
+        public void Resolve_DailyChannel_RoutesThroughDailyChannelResolver()
+        {
+            // Wiring test: Resolve() for a daily channel must invoke DailyChannelResolver,
+            // not the release-manifest path. We prove this by stubbing the aka.ms redirect
+            // target — if the daily resolver isn't called, the returned version won't match
+            // the redirect URL we set up.
+            const string redirectTarget =
+                "https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip";
+
+            using var handler = new StubRedirectHandler(new Dictionary<string, string>
+            {
+                ["https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-"] = redirectTarget,
+            });
+            using var httpClient = new HttpClient(handler);
+            using var dailyResolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+            var resolver = new ChannelVersionResolver(new ReleaseManifest(), dailyResolver);
+
+            var request = new DotnetInstallRequest(
+                new DotnetInstallRoot("C:/dotnet", InstallArchitecture.x64),
+                new UpdateChannel("10.0.1xx-daily"),
+                InstallComponent.SDK,
+                new InstallRequestOptions());
+
+            var version = resolver.Resolve(request);
+
+            Assert.NotNull(version);
+            Assert.Equal("10.0.100-preview.4.25216.37", version!.ToString());
+        }
+
+        /// <summary>
+        /// Maps URL prefixes to redirect target URLs, emulating the post-redirect state of
+        /// HttpClient after aka.ms redirects to the actual blob storage location.
+        /// </summary>
+        private sealed class StubRedirectHandler : HttpMessageHandler
+        {
+            private readonly Dictionary<string, string> _redirectMap;
+
+            public StubRedirectHandler(Dictionary<string, string> redirectMap)
+            {
+                _redirectMap = redirectMap;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                string url = request.RequestUri!.ToString();
+
+                foreach (var (prefix, target) in _redirectMap)
+                {
+                    if (url.StartsWith(prefix, StringComparison.Ordinal))
+                    {
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(string.Empty),
+                            RequestMessage = new HttpRequestMessage(HttpMethod.Get, target),
+                        });
+                    }
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request });
+            }
         }
 
         #region UpdateChannel.IsSdkVersionOrFeatureBand Tests

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -99,6 +99,29 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
             );
         }
 
+        /// <summary>
+        /// Daily-channel resolution against the live aka.ms infrastructure. Probes the
+        /// three forms a user might type. Bare <c>daily</c> tries major+1 first and falls
+        /// back to the manifest's highest major; channel-scoped forms (<c>10.0-daily</c>,
+        /// <c>11.0-daily</c>) target a specific major.minor. If aka.ms isn't redirecting
+        /// for one of these majors (e.g. a fresh major hasn't started producing dailies),
+        /// the version comes back null and the test fails — that's the signal we want.
+        /// </summary>
+        [Theory]
+        [InlineData("daily")]
+        [InlineData("10.0-daily")]
+        [InlineData("11.0-daily")]
+        public void GetLatestVersionForChannel_Daily_ResolvesAgainstLiveAkaMs(string channelName)
+        {
+            var resolver = new ChannelVersionResolver();
+            var version = resolver.GetLatestVersionForChannel(new UpdateChannel(channelName), InstallComponent.SDK);
+
+            Log.WriteLine($"Daily channel '{channelName}' resolved to: {version}");
+
+            Assert.NotNull(version);
+            Assert.False(string.IsNullOrEmpty(version.Prerelease), $"Daily-channel version {version} should have a prerelease tag");
+        }
+
         [Theory]
         [InlineData("latest", true)]
         [InlineData("preview", true)]

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -107,6 +107,12 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("99", true)]  // Max reasonable major
         [InlineData("99.0.100", true)]
         [InlineData("10.0.100-preview.1.32640", true)]  // Full prerelease version
+        [InlineData("daily", true)]
+        [InlineData("DAILY", true)]
+        [InlineData("10-daily", true)]
+        [InlineData("10.0-daily", true)]
+        [InlineData("10.0.1xx-daily", true)]
+        [InlineData("10.0-DAILY", true)]
         public void IsValidChannelFormat_ValidInputs_ReturnsTrue(string channel, bool expected)
         {
             Assert.Equal(expected, ChannelVersionResolver.IsValidChannelFormat(channel));
@@ -124,6 +130,10 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("9.-1.100", false)]  // Negative minor
         [InlineData("10.0.1xxx", false)]  // Invalid wildcard
         [InlineData("10.0.1xx-preview.1", false)]  // Wildcards with prerelease not supported
+        [InlineData("10.0.103-daily", false)]  // Daily applies only to scopes, not specific patches
+        [InlineData("-daily", false)]  // Empty scope before -daily
+        [InlineData("preview-daily", false)]  // Named channels can't take -daily
+        [InlineData("100-daily", false)]  // Major outside reasonable range
         public void IsValidChannelFormat_InvalidInputs_ReturnsFalse(string channel, bool expected)
         {
             Assert.Equal(expected, ChannelVersionResolver.IsValidChannelFormat(channel));

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -229,13 +229,7 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
 
             var resolver = new ChannelVersionResolver(new ReleaseManifest(), dailyResolver);
 
-            var request = new DotnetInstallRequest(
-                new DotnetInstallRoot("C:/dotnet", InstallArchitecture.x64),
-                new UpdateChannel("10.0.1xx-daily"),
-                InstallComponent.SDK,
-                new InstallRequestOptions());
-
-            var version = resolver.Resolve(request);
+            var version = resolver.Resolve(new UpdateChannel("10.0.1xx-daily"), InstallComponent.SDK, InstallArchitecture.x64);
 
             Assert.NotNull(version);
             Assert.Equal("10.0.100-preview.4.25216.37", version!.ToString());

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -197,26 +197,12 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         }
 
         [Fact]
-        public void GetLatestVersionForChannel_DailyChannel_ReturnsNull()
+        public void GetLatestVersionForChannel_DailyChannel_RoutesThroughDailyChannelResolver()
         {
-            // Daily channels must go through DailyChannelResolver via Resolve(); reaching
-            // GetLatestVersionForChannel with a daily channel means a caller bypassed routing.
-            // We refuse rather than silently returning the latest released version (which is
-            // what the manifest path would do for "10.0.1xx-daily" parsing).
-            var resolver = new ChannelVersionResolver();
-
-            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("10.0.1xx-daily"), InstallComponent.SDK));
-            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("10.0-daily"), InstallComponent.SDK));
-            Assert.Null(resolver.GetLatestVersionForChannel(new UpdateChannel("daily"), InstallComponent.SDK));
-        }
-
-        [Fact]
-        public void Resolve_DailyChannel_RoutesThroughDailyChannelResolver()
-        {
-            // Wiring test: Resolve() for a daily channel must invoke DailyChannelResolver,
-            // not the release-manifest path. We prove this by stubbing the aka.ms redirect
-            // target — if the daily resolver isn't called, the returned version won't match
-            // the redirect URL we set up.
+            // Wiring test: GetLatestVersionForChannel for a daily channel must invoke
+            // DailyChannelResolver, not the release-manifest path. We prove this by stubbing
+            // the aka.ms redirect target — if the daily resolver isn't called, the returned
+            // version won't match the redirect URL we set up.
             const string redirectTarget =
                 "https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip";
 
@@ -229,7 +215,7 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
 
             var resolver = new ChannelVersionResolver(new ReleaseManifest(), dailyResolver);
 
-            var version = resolver.Resolve(new UpdateChannel("10.0.1xx-daily"), InstallComponent.SDK, InstallArchitecture.x64);
+            var version = resolver.GetLatestVersionForChannel(new UpdateChannel("10.0.1xx-daily"), InstallComponent.SDK, InstallArchitecture.x64);
 
             Assert.NotNull(version);
             Assert.Equal("10.0.100-preview.4.25216.37", version!.ToString());

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -137,6 +137,45 @@ public class DailyChannelResolverTests
             resolver.Resolve(new UpdateChannel("10.0"), InstallArchitecture.x64));
     }
 
+    [Fact]
+    public void Resolve_HtmlContentResponse_ReturnsNull()
+    {
+        // If aka.ms changes its not-found fallback to a host other than bing.com (so
+        // IsAkaMsShortlinkNotFound's URL pattern misses) but still returns HTML, the
+        // Content-Type check should still treat the response as "no daily build available".
+        // We point the redirect at an allowed host (ci.dot.net) so IsAllowedRedirectTarget
+        // doesn't intercept first, and label the response as text/html.
+        const string prefix = "https://aka.ms/dotnet/10.0/daily/dotnet-sdk-";
+        using var handler = new RedirectHandler(
+            new Dictionary<string, string>
+            {
+                [prefix] = "https://ci.dot.net/public/maintenance.html",
+            },
+            new Dictionary<string, string>
+            {
+                [prefix] = "text/html",
+            });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0-daily"), InstallArchitecture.x64);
+
+        version.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("text/html", true)]
+    [InlineData("text/HTML", true)] // case-insensitive
+    [InlineData("application/octet-stream", false)]
+    [InlineData("application/zip", false)]
+    [InlineData("application/x-gzip", false)]
+    [InlineData(null, false)] // missing Content-Type header — let other checks decide
+    [InlineData("", false)]
+    public void IsHtmlContent_RecognizesHtmlMediaType(string? mediaType, bool expected)
+    {
+        DailyChannelResolver.IsHtmlContent(mediaType).Should().Be(expected);
+    }
+
     [Theory]
     [InlineData("https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip", true)]
     [InlineData("https://builds.dotnet.microsoft.com/sdk/10.0.100-preview.4.25216.37/dotnet-sdk.zip", true)]
@@ -194,10 +233,12 @@ public class DailyChannelResolverTests
     private sealed class RedirectHandler : HttpMessageHandler
     {
         private readonly Dictionary<string, string> _redirectMap;
+        private readonly Dictionary<string, string>? _contentTypes;
 
-        public RedirectHandler(Dictionary<string, string> redirectMap)
+        public RedirectHandler(Dictionary<string, string> redirectMap, Dictionary<string, string>? contentTypes = null)
         {
             _redirectMap = redirectMap;
+            _contentTypes = contentTypes;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -208,9 +249,14 @@ public class DailyChannelResolverTests
             {
                 if (url.StartsWith(prefix, StringComparison.Ordinal))
                 {
+                    string contentType = (_contentTypes is not null && _contentTypes.TryGetValue(prefix, out var ct))
+                        ? ct
+                        : "application/octet-stream";
+                    var content = new ByteArrayContent(Array.Empty<byte>());
+                    content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
                     var response = new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(string.Empty),
+                        Content = content,
                         // Rewrite the URI on the request to simulate the post-redirect state.
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, target),
                     };

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -102,6 +102,23 @@ public class DailyChannelResolverTests
     }
 
     [Theory]
+    // Real aka.ms not-found redirect shape (observed against https://aka.ms/dotnet/12.0/daily/...):
+    [InlineData("https://www.bing.com/?ref=aka&shorturl=dotnet/12.0/daily/dotnet-sdk-win-x64.zip", true)]
+    [InlineData("https://bing.com/?ref=aka&shorturl=dotnet/12.0/daily/dotnet-sdk-linux-x64.tar.gz", true)]
+    // Case-insensitive host and query.
+    [InlineData("https://WWW.BING.COM/?REF=AKA&shorturl=dotnet/12.0/daily/dotnet-sdk-osx-arm64.tar.gz", true)]
+    // Plain bing.com without the ref=aka marker — could be a real user-facing redirect chain; don't treat as not-found.
+    [InlineData("https://www.bing.com/search?q=dotnet+sdk", false)]
+    [InlineData("https://www.bing.com/", false)]
+    // Legitimate daily-build hosts: never match the not-found pattern.
+    [InlineData("https://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk.zip", false)]
+    [InlineData("https://builds.dotnet.microsoft.com/sdk/10.0.100/dotnet-sdk.zip", false)]
+    public void IsAkaMsShortlinkNotFound_RecognizesBingFallbackPattern(string url, bool expected)
+    {
+        DailyChannelResolver.IsAkaMsShortlinkNotFound(new Uri(url)).Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip", "10.0.100-preview.4.25216.37")]
     [InlineData("https://builds.dotnet.microsoft.com/sdk/9.0.103/dotnet-sdk-9.0.103-win-x64.zip", "9.0.103")]
     [InlineData("https://ci.dot.net/no-version-here/file.zip", null)]

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -48,6 +48,26 @@ public class DailyChannelResolverTests
     }
 
     [Fact]
+    public void Resolve_StableRedirectTarget_ReturnsNull()
+    {
+        // If aka.ms is ever misconfigured to redirect a daily link to a stable
+        // release archive, the resolver should treat that as "no daily build
+        // available" rather than returning a stable version that UpdateChannel.Matches
+        // would refuse to satisfy.
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/10.0/daily/dotnet-sdk-"]
+                = "https://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x64.zip",
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0-daily"), InstallArchitecture.x64);
+
+        version.Should().BeNull();
+    }
+
+    [Fact]
     public void Resolve_ScopedDaily_ExtractsVersionFromRedirectTarget()
     {
         using var handler = new RedirectHandler(new Dictionary<string, string>

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -143,8 +143,6 @@ public class DailyChannelResolverTests
         // If aka.ms changes its not-found fallback to a host other than bing.com (so
         // IsAkaMsShortlinkNotFound's URL pattern misses) but still returns HTML, the
         // Content-Type check should still treat the response as "no daily build available".
-        // We point the redirect at an allowed host (ci.dot.net) so IsAllowedRedirectTarget
-        // doesn't intercept first, and label the response as text/html.
         const string prefix = "https://aka.ms/dotnet/10.0/daily/dotnet-sdk-";
         using var handler = new RedirectHandler(
             new Dictionary<string, string>
@@ -174,17 +172,6 @@ public class DailyChannelResolverTests
     public void IsHtmlContent_RecognizesHtmlMediaType(string? mediaType, bool expected)
     {
         DailyChannelResolver.IsHtmlContent(mediaType).Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData("https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip", true)]
-    [InlineData("https://builds.dotnet.microsoft.com/sdk/10.0.100-preview.4.25216.37/dotnet-sdk.zip", true)]
-    [InlineData("https://dotnetbuilds.azureedge.net/public/Sdk/10.0.100/dotnet-sdk.zip", true)]
-    [InlineData("https://evil.example.com/Sdk/10.0.100-preview.4/dotnet-sdk.zip", false)]
-    [InlineData("http://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk.zip", false)] // HTTP rejected
-    public void IsAllowedRedirectTarget_RecognizesAllowlist(string url, bool expected)
-    {
-        DailyChannelResolver.IsAllowedRedirectTarget(new Uri(url)).Should().Be(expected);
     }
 
     [Theory]

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Dotnet.Installation;
+using Microsoft.Dotnet.Installation.Internal;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
+
+public class DailyChannelResolverTests
+{
+    private const string SampleArchiveUrl =
+        "https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip";
+
+    [Fact]
+    public void Resolve_ScopedDaily_ExtractsVersionFromRedirectTarget()
+    {
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            // Match any aka.ms request that starts with the scope path.
+            ["https://aka.ms/dotnet/10.0/daily/dotnet-sdk-"] = SampleArchiveUrl,
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0-daily"), InstallArchitecture.x64);
+
+        version.Should().NotBeNull();
+        version!.ToString().Should().Be("10.0.100-preview.4.25216.37");
+    }
+
+    [Fact]
+    public void Resolve_BareMajorDaily_NormalizesToMajorMinor()
+    {
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/10.0/daily/dotnet-sdk-"] = SampleArchiveUrl,
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10-daily"), InstallArchitecture.x64);
+
+        version.Should().NotBeNull();
+        version!.ToString().Should().Be("10.0.100-preview.4.25216.37");
+    }
+
+    [Fact]
+    public void Resolve_FeatureBandDaily_PassesScopeThrough()
+    {
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/10.0.1xx/daily/dotnet-sdk-"] = SampleArchiveUrl,
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0.1xx-daily"), InstallArchitecture.x64);
+
+        version.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Resolve_AkaMsReturnsNotFound_ReturnsNull()
+    {
+        // Empty redirect map → handler returns 404 for every request.
+        using var handler = new RedirectHandler(new Dictionary<string, string>());
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0-daily"), InstallArchitecture.x64);
+
+        version.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_NonDailyChannel_Throws()
+    {
+        using var resolver = new DailyChannelResolver();
+
+        Assert.Throws<ArgumentException>(() =>
+            resolver.Resolve(new UpdateChannel("10.0"), InstallArchitecture.x64));
+    }
+
+    [Theory]
+    [InlineData("https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip", true)]
+    [InlineData("https://builds.dotnet.microsoft.com/sdk/10.0.100-preview.4.25216.37/dotnet-sdk.zip", true)]
+    [InlineData("https://dotnetbuilds.azureedge.net/public/Sdk/10.0.100/dotnet-sdk.zip", true)]
+    [InlineData("https://evil.example.com/Sdk/10.0.100-preview.4/dotnet-sdk.zip", false)]
+    [InlineData("http://ci.dot.net/public/Sdk/10.0.100/dotnet-sdk.zip", false)] // HTTP rejected
+    public void IsAllowedRedirectTarget_RecognizesAllowlist(string url, bool expected)
+    {
+        DailyChannelResolver.IsAllowedRedirectTarget(new Uri(url)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip", "10.0.100-preview.4.25216.37")]
+    [InlineData("https://builds.dotnet.microsoft.com/sdk/9.0.103/dotnet-sdk-9.0.103-win-x64.zip", "9.0.103")]
+    [InlineData("https://ci.dot.net/no-version-here/file.zip", null)]
+    public void ExtractVersionFromUrl_FindsFirstParseableSegment(string url, string? expected)
+    {
+        var version = DailyChannelResolver.ExtractVersionFromUrl(new Uri(url));
+
+        if (expected == null)
+        {
+            version.Should().BeNull();
+        }
+        else
+        {
+            version.Should().NotBeNull();
+            version!.ToString().Should().Be(expected);
+        }
+    }
+
+    /// <summary>
+    /// Stub HTTP handler that maps a URL prefix to a final URL. When a request
+    /// comes in matching a prefix, it returns a 200 response whose
+    /// <see cref="HttpResponseMessage.RequestMessage"/> URI is rewritten to
+    /// the final URL — emulating the effect of HttpClient following 30x
+    /// redirects all the way to the blob storage URL.
+    /// </summary>
+    private sealed class RedirectHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _redirectMap;
+
+        public RedirectHandler(Dictionary<string, string> redirectMap)
+        {
+            _redirectMap = redirectMap;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.ToString();
+
+            foreach (var (prefix, target) in _redirectMap)
+            {
+                if (url.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(string.Empty),
+                        // Rewrite the URI on the request to simulate the post-redirect state.
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, target),
+                    };
+                    return Task.FromResult(response);
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -21,6 +21,33 @@ public class DailyChannelResolverTests
         "https://ci.dot.net/public/Sdk/10.0.100-preview.4.25216.37/dotnet-sdk-10.0.100-preview.4.25216.37-win-x64.zip";
 
     [Fact]
+    public void Resolve_RuntimeComponent_ReturnsRuntimeVersionNotSdkVersion()
+    {
+        // Test that we correctly handle differences between SDK and Runtime versions
+        // Daily-channel SDK and runtime builds are published at the same prerelease
+        // tag but DIFFERENT base versions (SDK 10.0.110 vs Runtime 10.0.10, sharing
+        // -servicing.26276.118).
+
+        const string sdkArchiveUrl =
+            "https://ci.dot.net/public/Sdk/10.0.110-servicing.26276.118/dotnet-sdk-10.0.110-win-x64.zip";
+        const string runtimeArchiveUrl =
+            "https://ci.dot.net/public/Runtime/10.0.10-servicing.26276.118/dotnet-runtime-10.0.10-win-x64.zip";
+
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/10.0/daily/dotnet-sdk-"] = sdkArchiveUrl,
+            ["https://aka.ms/dotnet/10.0/daily/dotnet-runtime-"] = runtimeArchiveUrl,
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel("10.0-daily"), InstallArchitecture.x64, InstallComponent.Runtime);
+
+        version.Should().NotBeNull();
+        version!.ToString().Should().Be("10.0.10-servicing.26276.118");
+    }
+
+    [Fact]
     public void Resolve_ScopedDaily_ExtractsVersionFromRedirectTarget()
     {
         using var handler = new RedirectHandler(new Dictionary<string, string>

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -401,6 +401,29 @@ Write-Output ""DOTNET_ROOT=$env:DOTNET_ROOT""
     }
 
     /// <summary>
+    /// Installs the latest daily-channel runtime end-to-end. Same flow as
+    /// <see cref="SdkInstall_DailyChannel"/> but exercises the Runtime component, which
+    /// is published at a different base version than the SDK (e.g. SDK 10.0.110 vs
+    /// Runtime 10.0.10 sharing -servicing.26276.118). This catches the case where
+    /// DailyChannelResolver resolves the SDK version and then tries to download a
+    /// non-existent runtime archive from the blob feed.
+    /// </summary>
+    [Fact]
+    public void RuntimeInstall_DailyChannel()
+    {
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
+        var args = DotnetupTestUtilities.BuildRuntimeArgumentsWithSpec("daily", testEnv.InstallPath, testEnv.ManifestPath);
+        (int exitCode, string output) = DotnetupTestUtilities.RunDotnetupProcess(args, captureOutput: true, workingDirectory: testEnv.TempRoot);
+        exitCode.Should().Be(0, $"dotnetup exited with code {exitCode}. Output:\n{output}");
+
+        VerifyManifestContains(testEnv, InstallComponent.Runtime, install =>
+        {
+            install.Version.Should().NotBeNullOrEmpty();
+            install.Version.Should().Contain("-", "daily-channel installs should resolve to a prerelease version");
+        });
+    }
+
+    /// <summary>
     /// Looks up the current daily preview SDK version by following the aka.ms redirect
     /// for the SDK archive on the channel with the highest major version in the release
     /// manifest. If that channel doesn't yield a prerelease, probes the next-major

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -63,11 +63,9 @@ public class InstallEndToEndTests
 
         var updateChannel = new UpdateChannel(channel);
         var expectedVersion = new ChannelVersionResolver().Resolve(
-            new DotnetInstallRequest(
-                new DotnetInstallRoot(testEnv.InstallPath, InstallerUtilities.GetDefaultInstallArchitecture()),
-                updateChannel,
-                InstallComponent.SDK,
-                new InstallRequestOptions()));
+            updateChannel,
+            InstallComponent.SDK,
+            InstallerUtilities.GetDefaultInstallArchitecture());
 
         expectedVersion.Should().NotBeNull($"Channel {channel} should resolve to a valid version");
         Console.WriteLine($"Channel '{channel}' resolved to version: {expectedVersion}");

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -376,6 +376,31 @@ Write-Output ""DOTNET_ROOT=$env:DOTNET_ROOT""
     }
 
     /// <summary>
+    /// Installs the latest daily-channel SDK end-to-end. Exercises the full path:
+    /// `dotnetup sdk daily` → DailyChannelResolver hits aka.ms to discover the latest
+    /// daily prerelease version → DotnetArchiveDownloader pulls the matching archive
+    /// from the blob feed → install completes and is recorded in the manifest.
+    /// </summary>
+    [Fact]
+    public void SdkInstall_DailyChannel()
+    {
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
+        var args = DotnetupTestUtilities.BuildSdkArguments("daily", testEnv.InstallPath, testEnv.ManifestPath);
+        (int exitCode, string output) = DotnetupTestUtilities.RunDotnetupProcess(args, captureOutput: true, workingDirectory: testEnv.TempRoot);
+        exitCode.Should().Be(0, $"dotnetup exited with code {exitCode}. Output:\n{output}");
+
+        // Like SdkInstall_FullySpecifiedPreviewVersion_UsesBlobFeedFallback, we don't
+        // pin the manifest's recorded version because daily channel resolves to a
+        // rolling prerelease that changes day-to-day.
+        VerifyManifestContains(testEnv, InstallComponent.SDK, install =>
+        {
+            install.Version.Should().NotBeNullOrEmpty();
+            // Daily versions are always prerelease.
+            install.Version.Should().Contain("-", "daily-channel installs should resolve to a prerelease version");
+        });
+    }
+
+    /// <summary>
     /// Looks up the current daily preview SDK version by following the aka.ms redirect
     /// for the SDK archive on the channel with the highest major version in the release
     /// manifest. If that channel doesn't yield a prerelease, probes the next-major

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -62,7 +62,7 @@ public class InstallEndToEndTests
         using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
 
         var updateChannel = new UpdateChannel(channel);
-        var expectedVersion = new ChannelVersionResolver().Resolve(
+        var expectedVersion = new ChannelVersionResolver().GetLatestVersionForChannel(
             updateChannel,
             InstallComponent.SDK,
             InstallerUtilities.GetDefaultInstallArchitecture());

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -26,14 +26,18 @@ public class UpdateChannelTests
     [InlineData("lts", "10.0.100", true)]
     [InlineData("lts", "10.0.100-preview.1", false)]
     [InlineData("lts", "9.0.100", false)]
-    // Daily channels: behave like their base scope for matching.
+    // Daily channels: behave like their base scope, but only for prerelease versions.
+    // A stable release is not a daily build, so it must not satisfy a daily channel.
     [InlineData("daily", "11.0.100-preview.4.25216.37", true)]
-    [InlineData("daily", "9.0.103", true)]
+    [InlineData("daily", "9.0.103", false)]
     [InlineData("10-daily", "10.0.103-preview.1", true)]
+    [InlineData("10-daily", "10.0.103", false)]
     [InlineData("10-daily", "11.0.100", false)]
     [InlineData("10.0-daily", "10.0.103-preview.1", true)]
+    [InlineData("10.0-daily", "10.0.103", false)]
     [InlineData("10.0-daily", "10.1.100", false)]
     [InlineData("10.0.1xx-daily", "10.0.103-preview.1", true)]
+    [InlineData("10.0.1xx-daily", "10.0.103", false)]
     [InlineData("10.0.1xx-daily", "10.0.204-preview.1", false)]
     public void Matches_ReturnsExpectedResult(string channel, string versionString, bool expected)
     {

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -26,11 +26,38 @@ public class UpdateChannelTests
     [InlineData("lts", "10.0.100", true)]
     [InlineData("lts", "10.0.100-preview.1", false)]
     [InlineData("lts", "9.0.100", false)]
+    // Daily channels: behave like their base scope for matching.
+    [InlineData("daily", "11.0.100-preview.4.25216.37", true)]
+    [InlineData("daily", "9.0.103", true)]
+    [InlineData("10-daily", "10.0.103-preview.1", true)]
+    [InlineData("10-daily", "11.0.100", false)]
+    [InlineData("10.0-daily", "10.0.103-preview.1", true)]
+    [InlineData("10.0-daily", "10.1.100", false)]
+    [InlineData("10.0.1xx-daily", "10.0.103-preview.1", true)]
+    [InlineData("10.0.1xx-daily", "10.0.204-preview.1", false)]
     public void Matches_ReturnsExpectedResult(string channel, string versionString, bool expected)
     {
         var updateChannel = new UpdateChannel(channel);
         var version = new ReleaseVersion(versionString);
 
         updateChannel.Matches(version).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("daily", true, "daily")]
+    [InlineData("DAILY", true, "daily")]
+    [InlineData("10-daily", true, "10")]
+    [InlineData("10.0-daily", true, "10.0")]
+    [InlineData("10.0.1xx-daily", true, "10.0.1xx")]
+    [InlineData("10.0-DAILY", true, "10.0")]
+    [InlineData("10.0", false, "10.0")]
+    [InlineData("preview", false, "preview")]
+    [InlineData("10.0.100-preview.1", false, "10.0.100-preview.1")]
+    public void IsDaily_And_BaseChannel_ReturnExpected(string name, bool expectedIsDaily, string expectedBase)
+    {
+        var channel = new UpdateChannel(name);
+
+        channel.IsDaily.Should().Be(expectedIsDaily);
+        channel.BaseChannel.Should().Be(expectedBase);
     }
 }

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -48,20 +48,32 @@ public class UpdateChannelTests
     }
 
     [Theory]
-    [InlineData("daily", true, "daily")]
-    [InlineData("DAILY", true, "daily")]
-    [InlineData("10-daily", true, "10")]
-    [InlineData("10.0-daily", true, "10.0")]
-    [InlineData("10.0.1xx-daily", true, "10.0.1xx")]
-    [InlineData("10.0-DAILY", true, "10.0")]
-    [InlineData("10.0", false, "10.0")]
-    [InlineData("preview", false, "preview")]
-    [InlineData("10.0.100-preview.1", false, "10.0.100-preview.1")]
-    public void IsDaily_And_BaseChannel_ReturnExpected(string name, bool expectedIsDaily, string expectedBase)
+    [InlineData("daily", true)]
+    [InlineData("DAILY", true)]
+    [InlineData("10-daily", true)]
+    [InlineData("10.0-daily", true)]
+    [InlineData("10.0.1xx-daily", true)]
+    [InlineData("10.0-DAILY", true)]
+    [InlineData("10.0", false)]
+    [InlineData("preview", false)]
+    [InlineData("10.0.100-preview.1", false)]
+    public void IsDaily_ReturnsExpected(string name, bool expectedIsDaily)
     {
         var channel = new UpdateChannel(name);
 
         channel.IsDaily.Should().Be(expectedIsDaily);
-        channel.BaseChannel.Should().Be(expectedBase);
+    }
+
+    [Theory]
+    [InlineData("10-daily", "10")]
+    [InlineData("10.0-daily", "10.0")]
+    [InlineData("10.0.1xx-daily", "10.0.1xx")]
+    [InlineData("10.0-DAILY", "10.0")]
+    [InlineData("10.0", "10.0")] // no suffix → returned as-is
+    [InlineData("preview", "preview")]
+    [InlineData("", "")]
+    public void StripDailySuffix_ReturnsScope(string channelName, string expectedScope)
+    {
+        UpdateChannel.StripDailySuffix(channelName).Should().Be(expectedScope);
     }
 }


### PR DESCRIPTION
Supports `daily` channel and channels such as `10.0-daily`.  This is [Phase 2 of the daily build support design](https://github.com/dotnet/sdk/blob/release/dnup/documentation/general/dotnetup/designs/dotnetup-nightly-builds.md#phase-2-daily-channel-parsing-and-latest-version-resolution)

Fixes #54298