### PR TITLE
Add task to remove blocked audit sources from NuGet.config

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks
+{
+    /// <summary>
+    /// Removes blocked entries from the auditSources section of a NuGet.config file.
+    /// Audit sources can reach out to the internet at restore time which may not be available in CI builds.
+    /// </summary>
+    public class RemoveBlockedAuditSourcesFromNuGetConfig : Task
+    {
+        private static readonly string[] BlockedAuditSources = [ "nuget.org" ];
+
+        [Required]
+        public required string NuGetConfigFile { get; set; }
+
+        public override bool Execute()
+        {
+            string xml = File.ReadAllText(NuGetConfigFile);
+            string newLineChars = FileUtilities.DetectNewLineChars(xml);
+            XDocument d = XDocument.Parse(xml);
+
+            XElement? auditSourcesElement = d.Root?.Descendants().FirstOrDefault(e => e.Name == "auditSources");
+            if (auditSourcesElement == null)
+            {
+                return true;
+            }
+
+            foreach (string url in BlockedAuditSources)
+            {
+                auditSourcesElement.Descendants("add")
+                    .FirstOrDefault(e => e.Attribute("value")?.Value?.Contains(url, StringComparison.OrdinalIgnoreCase) == true)
+                    ?.Remove();
+            }
+
+            using (var w = XmlWriter.Create(NuGetConfigFile, new XmlWriterSettings { NewLineChars = newLineChars, Indent = true }))
+            {
+                d.Save(w);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
@@ -9,6 +9,8 @@ using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+#nullable enable
+
 namespace Microsoft.DotNet.UnifiedBuild.Tasks
 {
     /// <summary>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -124,6 +124,7 @@
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.AddSourceToNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.RemoveInternetSourcesFromNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.RemoveBlockedAuditSourcesFromNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.UpdateNuGetConfigPackageSourcesMappings" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="UpdateNuGetConfig"
           DependsOnTargets="CopyNuGetConfig;GetRepositoryReferenceInfo"
@@ -175,6 +176,10 @@
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
       KeepFeedPrefixes="@(KeepFeedPrefixes)"
       Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+    
+    <RemoveBlockedAuditSourcesFromNuGetConfig
+      NuGetConfigFile="$(NuGetConfigFile)"
+      Condition="'$(RemoveBlockedAuditSources)' == 'true'" />
 
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(PrebuiltNuGetSourceName)"

--- a/src/SourceBuild/content/repo-projects/nuget-client.proj
+++ b/src/SourceBuild/content/repo-projects/nuget-client.proj
@@ -12,6 +12,8 @@
     <BuildArgs>$(BuildArgs) /p:GenerateResourceUsePreserializedResources=true</BuildArgs>
     <!-- Avoid passing -dotnetEngine msbuild switch, which nuget doesn't recognize. -->
     <ForceDotNetMSBuildEngine>false</ForceDotNetMSBuildEngine>
+    <!-- Remove nuget.org from auditSources to avoid reaching the internet during CI builds. -->
+    <RemoveBlockedAuditSources>true</RemoveBlockedAuditSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/xdt.proj
+++ b/src/SourceBuild/content/repo-projects/xdt.proj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <!-- Remove nuget.org from auditSources to avoid reaching the internet during CI builds. -->
+    <RemoveBlockedAuditSources>true</RemoveBlockedAuditSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/5607

Resolves this error:

```
    /vmr/artifacts/source-built-sdks/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj : error NU1905: Warning As Error: Audit source 'nuget.org' did not provide any vulnerability data.
    /vmr/artifacts/source-built-sdks/Microsoft.DotNet.Arcade.Sdk/tools/Tools.proj : error NU1900: Warning As Error: Error occurred while getting package vulnerability data: Unable to load the service index for source https://api.nuget.org/v3/index.json.
        0 Warning(s)
```

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974899&view=logs&j=609589e2-4f74-5576-cdb7-914bcaea778b&t=8309e960-3e55-5314-da53-c9e47ab6c0d0)