### PR TITLE
allow SB SDKs to emit otel telemetry like MS-built SDKs do

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -81,6 +81,8 @@
     <DefineConstants Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(DefineConstants),CI_BUILD</DefineConstants>
     <DefineConstants Condition="'$(OfficialBuilder)' == 'Microsoft'">$(DefineConstants),MICROSOFT_ENABLE_TELEMETRY</DefineConstants>
     <DefineConstants Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(DefineConstants),DOT_NET_BUILD_FROM_SOURCE</DefineConstants>
+    <!-- The Azure Monitor OTel Exporter is not yet onboarded to source build, so we need to conditionally compile the code that references it. -->
+    <DefineConstants Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(DefineConstants),MICROSOFT_ENABLE_TELEMETRY_AZURE_MONITOR</DefineConstants>
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryDotnetContribVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryDotnetContribPackageVersion)" />
     <!-- roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryDotnetContribVersion)" />
     <!-- roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,8 +60,8 @@
     <!-- When updating MicrosoftVisualStudioSolutionPersistenceVersion make sure to sync with dotnet/msbuild, dotnet/source-build-externals and NuGet/NuGet.Client -->
     <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
     <AzureMonitorOpenTelemetryExporterPackageVersion>1.4.0</AzureMonitorOpenTelemetryExporterPackageVersion>
-    <OpenTelemetryDotnetVersion>1.15.1</OpenTelemetryDotnetVersion>
-    <OpenTelemetryDotnetContribVersion>1.15.1</OpenTelemetryDotnetContribVersion>
+    <OpenTelemetryDotnetPackageVersion>1.15.1</OpenTelemetryDotnetPackageVersion>
+    <OpenTelemetryDotnetContribPackageVersion>1.15.1</OpenTelemetryDotnetContribPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="MicroBuild.Core version">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,8 @@
     <!-- When updating MicrosoftVisualStudioSolutionPersistenceVersion make sure to sync with dotnet/msbuild, dotnet/source-build-externals and NuGet/NuGet.Client -->
     <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
     <AzureMonitorOpenTelemetryExporterPackageVersion>1.4.0</AzureMonitorOpenTelemetryExporterPackageVersion>
-    <OpenTelemetryVersion>1.12.0</OpenTelemetryVersion>
+    <OpenTelemetryDotnetVersion>1.15.1</OpenTelemetryDotnetVersion>
+    <OpenTelemetryDotnetContribVersion>1.15.1</OpenTelemetryDotnetContribVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="MicroBuild.Core version">

--- a/src/Cli/dotnet/Telemetry/TelemetryClient.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryClient.cs
@@ -6,14 +6,14 @@ using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 
-#if TARGET_WINDOWS
+#if MICROSOFT_ENABLE_TELEMETRY_AZURE_MONITOR
 using Azure.Monitor.OpenTelemetry.Exporter;
+#endif
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-#endif
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
@@ -22,22 +22,22 @@ public class TelemetryClient : ITelemetryClient
     private static FrozenDictionary<string, string?> s_commonProperties = [];
     private Task? _trackEventTask;
 
-#if TARGET_WINDOWS
     private static readonly MeterProviderBuilder s_metricsProviderBuilder;
     private static MeterProvider? s_metricsProvider;
     private static readonly TracerProviderBuilder s_tracerProviderBuilder;
     private static TracerProvider? s_tracerProvider;
     private static readonly List<Activity> s_activities = [];
 
+#if MICROSOFT_ENABLE_TELEMETRY_AZURE_MONITOR
     private static readonly string s_connectionString = "InstrumentationKey=74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
     private static readonly string s_defaultStorageDirectory = Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath, "TelemetryStorageService");
     // Note: The TelemetryClient instance constructor takes in an environment provider. These fields don't use that currently.
     private static readonly string? s_environmentStoragePath = Env.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_STORAGE_PATH);
+#endif
     private static readonly string? s_diskLogPath = Env.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_LOG_PATH);
     private static readonly bool s_disableTraceExport = Env.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT);
     private static readonly bool s_enableOtlpExporter = Env.GetEnvironmentVariableAsBool(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER);
     private static readonly int s_flushTimeoutMs = 200;
-#endif
 
     public static string? CurrentSessionId { get; private set; } = null;
     public static bool DisabledForTests
@@ -60,7 +60,6 @@ public class TelemetryClient : ITelemetryClient
 
     static TelemetryClient()
     {
-#if TARGET_WINDOWS
         s_metricsProviderBuilder = Sdk.CreateMeterProviderBuilder()
             .ConfigureResource(r => { r.AddService("dotnet-cli", serviceVersion: Product.Version); })
             .AddMeter(Activities.Source.Name)
@@ -86,6 +85,7 @@ public class TelemetryClient : ITelemetryClient
             s_tracerProviderBuilder.AddInMemoryExporter(s_activities);
         }
 
+#if MICROSOFT_ENABLE_TELEMETRY_AZURE_MONITOR
         if (!s_disableTraceExport)
         {
             var storageDirectory = string.IsNullOrWhiteSpace(s_environmentStoragePath) ? s_defaultStorageDirectory : s_environmentStoragePath;
@@ -123,7 +123,6 @@ public class TelemetryClient : ITelemetryClient
             return;
         }
 
-#if TARGET_WINDOWS
         if (s_metricsProvider is null || s_tracerProvider is null)
         {
             // Create a new OTel meter and tracer provider.
@@ -131,7 +130,6 @@ public class TelemetryClient : ITelemetryClient
             s_metricsProvider ??= s_metricsProviderBuilder.Build();
             s_tracerProvider ??= s_tracerProviderBuilder.Build();
         }
-#endif
 
         CurrentSessionId ??= !string.IsNullOrEmpty(sessionId) ? sessionId : Guid.NewGuid().ToString();
         s_commonProperties = new TelemetryCommonProperties().GetTelemetryCommonProperties(CurrentSessionId);
@@ -156,18 +154,14 @@ public class TelemetryClient : ITelemetryClient
         }
 
         ActivityContext? parentContext = null;
-#if TARGET_WINDOWS
         // Use the propagator to extract the parent activity context and kind.
         // For some reason, this isn't set by the OTel SDK like docs say it should be.
         Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator([new TraceContextPropagator(), new BaggagePropagator()]));
         parentContext = Propagators.DefaultTextMapPropagator.Extract(default, carrierMap, GetValueFromCarrier).ActivityContext;
-#endif
         return parentContext;
 
-#if TARGET_WINDOWS
         static IEnumerable<string>? GetValueFromCarrier(Dictionary<string, IEnumerable<string>?> carrier, string key) =>
             carrier.TryGetValue(key, out var value) ? value : null;
-#endif
     }
 
     private static ActivityKind GetActivityKind(ActivityContext? parentActivityContext) =>
@@ -175,20 +169,16 @@ public class TelemetryClient : ITelemetryClient
 
     public static void FlushProviders()
     {
-#if TARGET_WINDOWS
         s_tracerProvider?.ForceFlush(s_flushTimeoutMs);
         s_metricsProvider?.ForceFlush(s_flushTimeoutMs);
-#endif
     }
 
     public static void WriteLogIfNecessary()
     {
-#if TARGET_WINDOWS
         if (!string.IsNullOrWhiteSpace(s_diskLogPath) && s_activities.Any())
         {
             TelemetryDiskLogger.WriteLog(s_diskLogPath, s_activities);
         }
-#endif
     }
 
     public void TrackEvent(string eventName, IDictionary<string, string?>? properties)

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -94,14 +94,16 @@
     <!-- Lift dependency of NETStandard.Library.NETFramework to version produced in SBA. -->
     <PackageReference Include="NETStandard.Library" VersionOverride="$(NETStandardLibraryVersion)" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BuildClient" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+  </ItemGroup>
+
+  <!-- Azure Monitor dependencies aren't part of source build yet - see file://../../../Directory.Build.props#L85 for details -->
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">


### PR DESCRIPTION
Lights up OTel telemetry export for local OTLP usage in source-built SDKs. Doesn't light up Azure Monitor exporting for these SDKs yet due to missing dependencies.