### PR TITLE
Restore NuGet packaging for Microsoft.DotNet.TemplateLocator

### DIFF
--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -6,11 +6,21 @@
          verticals that are built in the first build pass. -->
     <TargetFrameworks Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">$(ResolverTargetFramework)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <IsPackable>true</IsPackable>
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
+    <PackageId>microsoft.dotnet.templateLocator</PackageId>
     <!-- https://github.com/dotnet/sdk/issues/14801 -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'net472'">5.0.100.0</AssemblyVersion>
+    <!--https://github.com/NuGet/Home/issues/3891#issuecomment-377319939-->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
+
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
     <ItemGroup>

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -7,12 +7,11 @@
     <TargetFrameworks Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">$(ResolverTargetFramework)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <IsPackable>true</IsPackable>
+    <IsPackable Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">false</IsPackable>
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
-    <PackageId>microsoft.dotnet.templateLocator</PackageId>
     <!-- https://github.com/dotnet/sdk/issues/14801 -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'net472'">5.0.100.0</AssemblyVersion>
-    <!--https://github.com/NuGet/Home/issues/3891#issuecomment-377319939-->
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
The IsPackable, PackageId, and CopyProjectReferencesToPackage target were accidentally removed in #44428 (2e7615d97c4), which stopped publishing the microsoft.dotnet.templateLocator NuGet package starting with .NET 10. The DevKit team depends on this package.

@ViktorHofer The devkit team actually uses the template locator pack though apparently doesn't update it very frequently. It looks like you removed it from publishing when we were prepping the 10 branches for the VMR. This is copilots attempt to bring that back but not sure if this is the right way to go or if you'd recommend a different direction.

CC @emaf who was asking me about this package offline and how to get a newer version for devkit.

---

## Tactics

### Summary

`IsPackable`, `PackageId`, and the `CopyProjectReferencesToPackage` target were accidentally removed from `Microsoft.DotNet.TemplateLocator.csproj` in PR #44428 (commit 2e7615d97c4) when the `release/10.0.1xx` branch was prepared for the VMR. This caused the `microsoft.dotnet.templateLocator` NuGet package to stop being published starting with .NET 10. The fix restores `IsPackable=true` (conditioned to `false` during DotNetBuild source-build VMR pass 1 to avoid incomplete multi-TFM packages) and restores the `CopyProjectReferencesToPackage` MSBuild target that bundles managed `ProjectReference` outputs into the package. This is appropriate for a servicing release as it restores a capability that existed in 9.0.3xx and is actively consumed by the DevKit team.

### Customer Impact

The Visual Studio DevKit team (and any consumers relying on `microsoft.dotnet.templateLocator` from internal feeds) have been unable to obtain an updated .NET 10 version of the package since the branch was cut. There is no build error for end users of the .NET SDK itself—the impact is limited to teams that consume this NuGet package directly (e.g., for VS template-locator integration). No workaround exists short of manually packing the project or pinning to a .NET 9 version of the package. Affected SDK versions: any .NET 10 release from this branch onwards.

### Regression?

Yes, introduced in #44428 (VMR/source-build branch preparation, commit 2e7615d97c4) when `IsPackable` and the pack-related targets were removed from the project file.

### Testing

- CI was run; a reported BA-G test failure was confirmed by the PR author to be an unrelated corrupted `nuget.config` on the test machine and does not affect test validity.
- Review comments confirmed the `IsPackable` condition (disabling pack during DotNetBuild pass 1) matches source-build requirements, verified by ViktorHofer.
- The `CopyProjectReferencesToPackage` target scope (managed `ProjectReference` outputs only) was confirmed to match the 9.0.3xx behavior; native hostfxr content lives in a separate redist layout package.
- No new automated tests were added (the change is a project-file property/target restoration with no code logic to unit-test).

### Risk

Low. The change is confined to a single `.csproj` file (+9 lines), restores properties and a target that existed verbatim in the previous stable branch (9.0.3xx), and has been reviewed by the VMR/source-build owner (ViktorHofer). The `IsPackable` condition correctly gates packing to avoid VMR pass-1 incomplete-package publish errors. No SDK runtime behavior is affected.

<!-- gh-aw-workflow-id: add-tactics-template-on-comment -->