### PR TITLE
CA2028: make struct `this`-reassignment test actually exercise the new check

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidRedundantRegexIsMatchBeforeMatchTests.cs
@@ -2560,12 +2560,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             // `this = ...` may use different `r` values. Restricting the
             // IInstanceReferenceOperation equivalence to reference types
             // suppresses the diagnostic in this case.
+            //
+            // The field must be readonly: a mutable field is already rejected
+            // by the field-equivalence check in AreOperandsEquivalent, so a
+            // non-readonly field here would pass even without the new
+            // IInstanceReferenceOperation restriction.
             var source = """
                 using System.Text.RegularExpressions;
 
                 struct S
                 {
-                    public Regex r;
+                    public readonly Regex r;
 
                     public S(Regex regex) { r = regex; }
 


### PR DESCRIPTION
Per [krwq's post-merge review feedback](https://github.com/dotnet/sdk/pull/54071#discussion_r2185655944) on #54071:

The test `StructInstanceMethod_ThisReassignedBeforeMatch_NoDiagnostic` was intended to lock in the new `IInstanceReferenceOperation` IsValueType restriction (struct `this` is not considered equivalent across `this = ...` reassignment). However, it declared a **non-readonly** `public Regex r;` field, and the existing field-equivalence path in `AreOperandsEquivalent` already rejects non-readonly fields:

```csharp
// Only trust readonly/const fields
if (!leftField.Field.IsReadOnly && !leftField.Field.IsConst)
{
    return false;
}
```

So the test passed regardless of whether the new struct-`this` guard existed — it was a tautology, not a regression test.

## Fix

Make the field `readonly`. With `readonly`, the field-equivalence check permits equivalence, so the test now genuinely depends on the `IInstanceReferenceOperation` IsValueType guard.

(The `this = new S(other);` assignment remains legal inside the struct's instance method even with a readonly field, because `this` itself is being reassigned — not a member of `this`.)

## Verification

- ✅ With the production fix in place: test passes.
- ✅ With the production fix temporarily reverted locally: test **fails** with the expected CA2028 diagnostic, proving the test now exercises the intended behavior.
- ✅ `ClassInstanceMethod_StillFlags` (sibling sanity test) unaffected.

Also adds a comment explaining why `readonly` is required so future readers don't innocently "fix" it back.

cc @krwq
