### PR TITLE
Fix internal feed auth in unofficial CI pipeline

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -75,7 +75,7 @@ jobs:
             filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            Token: $(System.AccessToken)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - powershell: eng\common\build.ps1
@@ -266,7 +266,7 @@ jobs:
             filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            Token: $(System.AccessToken)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - powershell: eng\common\build.ps1
@@ -411,7 +411,7 @@ jobs:
             filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            Token: $(System.AccessToken)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
       - ${{ if contains(parameters.agentOs, 'Windows_NT') }}:
         - powershell: eng\common\build.ps1

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -234,6 +234,8 @@ public class NETFramework
                 TargetFrameworks = "net462",
             };
 
+            project.AdditionalProperties["NuGetAudit"] = "false";
+
             project.SourceFiles[project.Name + ".cs"] = $@"
 using System;
 public static class {project.Name}

--- a/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -823,6 +823,7 @@ namespace Microsoft.NET.Build.Tests
                 TargetFrameworks = targetFrameworkVersion
             };
             libraryProject.AdditionalProperties["NoWarn"] = "NETSDK1138";
+            libraryProject.AdditionalProperties["NuGetAudit"] = "false";
             libraryProject.SourceFiles["Class.cs"] = @"
 public class LibraryClass{}
 ";
@@ -833,6 +834,7 @@ public class LibraryClass{}
                 TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
                 IsExe = true
             };
+            testProject.AdditionalProperties["NuGetAudit"] = "false";
 
             testProject.ReferencedProjects.Add(libraryProject);
             testProject.SourceFiles["Program.cs"] = @"


### PR DESCRIPTION
## Summary

The unofficial CI pipeline (1472) does not have the `AzureDevOps-Artifact-Feeds-Pats` variable group linked, causing `` to resolve to a literal string instead of a PAT. This results in **401 Unauthorized** errors when Helix test machines try to access internal NuGet feeds (e.g. `dotnet8-internal`).

## Changes

### eng/build.yml
Use `` instead of `` for the feed credential token. `System.AccessToken` is always available in any AzDO pipeline — no variable group required. The build service identity already has read access to the internal feeds.

### Test fixes
Disable NuGet audit (`NuGetAudit=false`) in two tests that intentionally reference old vulnerable packages for conflict resolution testing:
- `It_resolves_assembly_conflicts_with_a_NETFramework_library` — System.Net.Http 4.3.0, System.Text.RegularExpressions 4.3.0
- `CheckTargetFrameworkDisplayName` — Microsoft.NETCore.App 2.1.0

The NU1903 vulnerability warnings were causing assertion failures.

## Validation

Verified on internal ADO PR build — all tests pass with these changes.