### PR TITLE
Duplicate language-agnostic NetAnalyzers.dll into cs/ and vb/ folders

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Directory.Build.targets
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Directory.Build.targets
@@ -54,13 +54,28 @@
     <PropertyGroup>
       <PackAsAnalyzerPath>analyzers/dotnet</PackAsAnalyzerPath>
       <PackAsAnalyzerPath Condition="'$(AnalyzerRoslynVersion)' != ''">$(PackAsAnalyzerPath)/roslyn$(AnalyzerRoslynVersion)</PackAsAnalyzerPath>
-      <PackAsAnalyzerPath Condition="'$(AnalyzerLanguage)' != ''">$(PackAsAnalyzerPath)/$(AnalyzerLanguage)</PackAsAnalyzerPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackAsAnalyzerFile Include="@(_BuildOutputInPackage)" />
-      <PackAsAnalyzerFile Include="@(_TargetPathsToSymbols)" IsSymbol="true" />
-      <PackAsAnalyzerFile PackagePath="$(PackAsAnalyzerPath)/%(TargetPath)" />
+      <_PackAsAnalyzerAssembly Include="@(_BuildOutputInPackage)" />
+      <_PackAsAnalyzerAssembly Include="@(_TargetPathsToSymbols)" IsSymbol="true" />
+    </ItemGroup>
+
+    <!-- Language-specific analyzers go under analyzers/dotnet/<lang>/. -->
+    <ItemGroup Condition="'$(AnalyzerLanguage)' != ''">
+      <PackAsAnalyzerFile Include="@(_PackAsAnalyzerAssembly)"
+                          PackagePath="$(PackAsAnalyzerPath)/$(AnalyzerLanguage)/%(_PackAsAnalyzerAssembly.TargetPath)" />
+    </ItemGroup>
+
+    <!-- Language-agnostic analyzers (no AnalyzerLanguage) are duplicated into every language
+         folder so each language-specific analyzer sits alongside the agnostic assembly it
+         depends on. Roslyn requires an analyzer and its dependencies to live in the same
+         directory; see https://github.com/dotnet/sdk/issues/54350. -->
+    <ItemGroup Condition="'$(AnalyzerLanguage)' == ''">
+      <PackAsAnalyzerFile Include="@(_PackAsAnalyzerAssembly)"
+                          PackagePath="$(PackAsAnalyzerPath)/cs/%(_PackAsAnalyzerAssembly.TargetPath)" />
+      <PackAsAnalyzerFile Include="@(_PackAsAnalyzerAssembly)"
+                          PackagePath="$(PackAsAnalyzerPath)/vb/%(_PackAsAnalyzerAssembly.TargetPath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
When NetAnalyzers was integrated into the SDK build, the new GetPackAsAnalyzerFiles target started placing the language-agnostic Microsoft.CodeAnalysis.NetAnalyzers.dll flat under analyzers/dotnet/ while the C#/VB-specific assemblies live in analyzers/dotnet/cs/ and analyzers/dotnet/vb/. Roslyn requires an analyzer and its dependencies to live in the same directory, so the language-specific analyzers fail to load when consumed via the NuGet package.

The pre-10.0.100 layout produced by the old GenerateAnalyzerNuspec tool duplicated the agnostic assembly into both cs/ and vb/ folders. Restore that behavior so each language-specific analyzer sits next to its agnostic dependency.

Fixes https://github.com/dotnet/sdk/issues/54350.