### PR TITLE
Fix parallel-build race condition on RunnableProjects DLL

### DIFF
--- a/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -37,4 +37,21 @@
     <InternalsVisibleTo Include="Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests" Key="$(TemplateEnginePublicKey)" />
   </ItemGroup>
 
+  <!-- Copy the nupkg to TestPackagesDir so integration tests can consume it.
+       This replaces the BuildTestPackages.targets entry that re-packed this project
+       with different global properties, which caused a parallel-build race condition
+       on referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll).
+       Guard with IsCrossTargetingBuild so this runs only once in the outer build of a
+       multi-targeting project, avoiding concurrent copies per inner TFM build. -->
+  <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
+          Condition="'$(TestLayoutDir)' != '' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
+    <PropertyGroup>
+      <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(_TestPackagesDir)" Condition="!Exists('$(_TestPackagesDir)')" />
+    <Copy SourceFiles="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg"
+          DestinationFolder="$(_TestPackagesDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -159,15 +159,11 @@
         <ProjectName>Microsoft.Net.Sdk.Compilers.Toolset.csproj</ProjectName>
         <Version>$(Version)</Version>
       </BaseTestPackageProject>
-      <!-- Microsoft.TemplateEngine.Authoring.Tasks is excluded here because it has
-           GeneratePackageOnBuild=true and is in the solution. Packing it again with
-           different global properties causes a parallel-build race condition on the
-           obj/ output DLL. The project copies its nupkg to TestPackagesDir itself. -->
-      <BaseTestPackageProject Include="src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery">
-        <Name>Microsoft.TemplateSearch.TemplateDiscovery</Name>
-        <ProjectName>Microsoft.TemplateSearch.TemplateDiscovery.csproj</ProjectName>
-        <Version>$(Version)</Version>
-      </BaseTestPackageProject>
+      <!-- Microsoft.TemplateEngine.Authoring.Tasks and Microsoft.TemplateSearch.TemplateDiscovery
+           are excluded here because they are in the solution. Packing them again with
+           different global properties (PackageOutputPath, Version) causes a parallel-build
+           race condition on referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll).
+           Both projects copy their nupkg to TestPackagesDir themselves. -->
       <BaseTestPackageProject Include="src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task">
         <Name>Microsoft.DotNet.ApiCompat.Task</Name>
         <ProjectName>Microsoft.DotNet.ApiCompat.Task.csproj</ProjectName>

--- a/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -160,7 +160,7 @@
         <Version>$(Version)</Version>
       </BaseTestPackageProject>
       <!-- Microsoft.TemplateEngine.Authoring.Tasks and Microsoft.TemplateSearch.TemplateDiscovery
-           are excluded here because they are in the solution. Packing them again with
+           are excluded here because they are already packed elsewhere. Packing them again with
            different global properties (PackageOutputPath, Version) causes a parallel-build
            race condition on referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll).
            Both projects copy their nupkg to TestPackagesDir themselves. -->


### PR DESCRIPTION
BuildTestPackages.targets invoked Pack on TemplateSearch.TemplateDiscovery with different global properties (PackageOutputPath, Version), creating a second MSBuild node that cascades to RunnableProjects via ProjectReference. Two concurrent compilations of the same project then contend for the same obj/ output DLL, causing MSB3026 (promoted to error by TreatWarningsAsErrors).

Fix: Remove TemplateSearch.TemplateDiscovery from BuildTestPackages.targets and instead copy the nupkg (already produced via the solution's Pack target) to TestPackagesDir in a post-pack target within the csproj itself.

This is the same pattern used for Authoring.Tasks in commit 38643199bce.