### PR TITLE
Remove suggestion for docs-only build analysis bypass in developer guide

### DIFF
--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -228,7 +228,6 @@ infrastructure issues unrelated to the PR.
 Example reasons:
 
 - `/ba-g deadletter` - Helix work item crashed with "DeadLetter" status.
-- `/ba-g docs-only change` - PR did not change any source code.
 - `/ba-g insufficient info in logs` - No good unique pattern in the logs to open a known issue.
 - `/ba-g recently fixed known issue #<number>` - The known issue fix was already merged, but CI ran
   before it.


### PR DESCRIPTION
Related:
- #54359 
- #54148

Build analysis checks no longer need to be bypassed for documentation changes, so this PR removes the recommendation from `developer-guide.md`.