### PR TITLE
Pass Android target OS to Crossgen2

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -210,12 +210,13 @@ namespace Microsoft.NET.Build.Tasks
             string portablePlatform = NuGetUtils.GetBestMatchingRid(
                     runtimeGraph,
                     _targetRuntimeIdentifier,
-                    ["linux", "osx", "win", "ios", "iossimulator", "tvos", "tvossimulator", "maccatalyst", "freebsd", "openbsd", "illumos", "solaris", "haiku"],
+                    ["linux", "android", "osx", "win", "ios", "iossimulator", "tvos", "tvossimulator", "maccatalyst", "freebsd", "openbsd", "illumos", "solaris", "haiku"],
                     out _);
 
             targetOS = portablePlatform switch
             {
                 "linux" => "linux",
+                "android" => "android",
                 "osx" => "osx",
                 "win" => "windows",
                 "ios" => "ios",


### PR DESCRIPTION
Mirrors the ResolveReadyToRunCompilers change from dotnet/runtime#127578 for the SDK copy of the task.

Android RIDs now resolve to Crossgen2 TargetOS=android instead of falling through to the Linux/Bionic match, allowing runtime Crossgen2 target normalization to select Android-specific ARM ABI handling.