### PR TITLE
[release/11.0.1xx-preview5] Add 'mcpserver' project template as bundled template

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -58,6 +58,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetSignToolPackageVersion>11.0.0-beta.26261.101</MicrosoftDotNetSignToolPackageVersion>
     <MicrosoftDotNetWebItemTemplates110PackageVersion>11.0.0-preview.5.26261.101</MicrosoftDotNetWebItemTemplates110PackageVersion>
     <MicrosoftDotNetWebProjectTemplates110PackageVersion>11.0.0-preview.5.26261.101</MicrosoftDotNetWebProjectTemplates110PackageVersion>
+    <MicrosoftMcpServerProjectTemplates110PackageVersion>11.0.0-preview.5.26261.101</MicrosoftMcpServerProjectTemplates110PackageVersion>
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>11.0.0-preview.5.26261.101</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>11.0.0-preview.5.26261.101</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.26261.101</MicrosoftDotNetXliffTasksPackageVersion>
@@ -193,6 +194,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetSignToolVersion>$(MicrosoftDotNetSignToolPackageVersion)</MicrosoftDotNetSignToolVersion>
     <MicrosoftDotNetWebItemTemplates110Version>$(MicrosoftDotNetWebItemTemplates110PackageVersion)</MicrosoftDotNetWebItemTemplates110Version>
     <MicrosoftDotNetWebProjectTemplates110Version>$(MicrosoftDotNetWebProjectTemplates110PackageVersion)</MicrosoftDotNetWebProjectTemplates110Version>
+    <MicrosoftMcpServerProjectTemplates110Version>$(MicrosoftMcpServerProjectTemplates110PackageVersion)</MicrosoftMcpServerProjectTemplates110Version>
     <MicrosoftDotnetWinFormsProjectTemplatesVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplatesVersion>
     <MicrosoftDotNetWpfProjectTemplatesVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplatesVersion>
     <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksPackageVersion)</MicrosoftDotNetXliffTasksVersion>

--- a/src/Layout/redist/targets/BundledTemplates.targets
+++ b/src/Layout/redist/targets/BundledTemplates.targets
@@ -8,6 +8,7 @@
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates.11.0" PackageVersion="$(MicrosoftDotNetWebItemTemplates110PackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.11.0" PackageVersion="$(MicrosoftDotNetWebProjectTemplates110PackageVersion)" UseVersionForTemplateInstallPath="true" />
+    <BundledTemplate Include="Microsoft.McpServer.ProjectTemplates.11.0" PackageVersion="$(MicrosoftMcpServerProjectTemplates110PackageVersion)" />
     <BundledTemplate Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplatesPackageVersion)" />
   </ItemGroup>

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Linux.verified.txt
@@ -12,6 +12,7 @@ gitattributes
 gitignore
 globaljson
 grpc
+mcpserver
 mstest
 mstest-class
 mstest-playwright

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.OSX.verified.txt
@@ -12,6 +12,7 @@ gitattributes
 gitignore
 globaljson
 grpc
+mcpserver
 mstest
 mstest-class
 mstest-playwright

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewCompleteTests.CanDoTabCompletion.Windows.verified.txt
@@ -12,6 +12,7 @@ gitattributes
 gitignore
 globaljson
 grpc
+mcpserver
 mstest
 mstest-class
 mstest-playwright

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Linux.verified.txt
@@ -12,6 +12,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.OSX.verified.txt
@@ -12,6 +12,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenLegacyCommandIsUsed_common.Windows.verified.txt
@@ -12,6 +12,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Linux.verified.txt
@@ -9,6 +9,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.OSX.verified.txt
@@ -9,6 +9,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
+++ b/test/dotnet-new.IntegrationTests/Approvals/DotnetNewListTests.BasicTest_WhenListCommandIsUsed.Windows.verified.txt
@@ -9,6 +9,7 @@ dotnet
 Dotnet
 EditorConfig
 global.json
+MCP
 MSBuild
 MSTest
 MVC

--- a/test/dotnet-new.IntegrationTests/McpServerTemplateTests.cs
+++ b/test/dotnet-new.IntegrationTests/McpServerTemplateTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.Cli.New.IntegrationTests
+{
+    public class McpServerTemplateTests : BaseIntegrationTest, IClassFixture<McpServerTemplateFixture>
+    {
+        private readonly McpServerTemplateFixture _fixture;
+        private readonly ITestOutputHelper _log;
+
+        public McpServerTemplateTests(McpServerTemplateFixture fixture, ITestOutputHelper log) : base(log)
+        {
+            _fixture = fixture;
+            _log = log;
+        }
+
+        [Theory]
+        [InlineData("mcpserver_local", "mcpserver", "--transport", "local")]
+        [InlineData("mcpserver_remote", "mcpserver", "--transport", "remote")]
+        [InlineData("mcpserver_local_no_selfcontained", "mcpserver", "--transport", "local", "--self-contained", "false")]
+        [InlineData("mcpserver_remote_no_selfcontained", "mcpserver", "--transport", "remote", "--self-contained", "false")]
+        [InlineData("mcpserver_local_aot", "mcpserver", "--transport", "local", "--aot", "true")]
+        [InlineData("mcpserver_remote_aot", "mcpserver", "--transport", "remote", "--aot", "true")]
+        public void AllMcpServerProjectsRestoreAndBuild(string testName, params string[] args)
+        {
+            string workingDir = Path.Combine(_fixture.BaseWorkingDirectory, testName);
+            Directory.CreateDirectory(workingDir);
+
+            new DotnetNewCommand(_log, args)
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr();
+
+            new DotnetRestoreCommand(_log)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr();
+
+            new DotnetBuildCommand(_log)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr();
+
+            Directory.Delete(workingDir, true);
+        }
+    }
+
+    public sealed class McpServerTemplateFixture : SharedHomeDirectory
+    {
+        public McpServerTemplateFixture(IMessageSink messageSink) : base(messageSink)
+        {
+            BaseWorkingDirectory = Utilities.CreateTemporaryFolder(nameof(McpServerTemplateTests));
+        }
+
+        internal string BaseWorkingDirectory { get; private set; }
+    }
+}


### PR DESCRIPTION
Backport of #54132 from main into release/11.0.1xx-preview5

This template was merged into 11.0.1xx-preview4 via dotnet/dotnet#6361, but we hit delays getting it merged into main due to template snapshot tests and the macOS CI queues. This is a clean cherry-pick from #54132.