### PR TITLE
Add missing Microsoft.McpServer.ProjectTemplates.11.0 dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -491,6 +491,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>547c640d5626b2976499cb3433abc741a63d67c5</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.McpServer.ProjectTemplates.11.0" Version="11.0.0-preview.5.26261.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>547c640d5626b2976499cb3433abc741a63d67c5</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.5.26261.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>547c640d5626b2976499cb3433abc741a63d67c5</Sha>


### PR DESCRIPTION
This was missed in https://github.com/dotnet/sdk/pull/54132/