### PR TITLE
Add Microsoft.DotNet.ProjectTools.csproj to cli.slnf

### DIFF
--- a/cli.slnf
+++ b/cli.slnf
@@ -5,6 +5,8 @@
       "src\\Dotnet.Watch\\dotnet-watch\\dotnet-watch.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
+      "src\\Cli\\Microsoft.DotNet.FileBasedPrograms\\Microsoft.DotNet.FileBasedPrograms.Package.csproj",
+      "src\\Microsoft.DotNet.ProjectTools\\Microsoft.DotNet.ProjectTools.csproj",
       "test\\dotnet-new.IntegrationTests\\dotnet-new.IntegrationTests.csproj",
       "test\\dotnet-watch.Tests\\dotnet-watch.Tests.csproj",
       "test\\dotnet.Tests\\dotnet.Tests.csproj",

--- a/cli.slnf
+++ b/cli.slnf
@@ -5,7 +5,6 @@
       "src\\Dotnet.Watch\\dotnet-watch\\dotnet-watch.csproj",
       "src\\Cli\\dotnet\\dotnet.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
-      "src\\Cli\\Microsoft.DotNet.FileBasedPrograms\\Microsoft.DotNet.FileBasedPrograms.Package.csproj",
       "src\\Microsoft.DotNet.ProjectTools\\Microsoft.DotNet.ProjectTools.csproj",
       "test\\dotnet-new.IntegrationTests\\dotnet-new.IntegrationTests.csproj",
       "test\\dotnet-watch.Tests\\dotnet-watch.Tests.csproj",


### PR DESCRIPTION
`cli.slnf` seems to be the default solution for vscode. That's great, I think it loads faster. But some common projects which are part of dotnet CLI were not there. Is it fine to add them? @dotnet/dotnet-cli