### PR TITLE
Publish dotnetup assets from the official build (isAssetlessBuild: false)

### DIFF
--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -327,7 +327,7 @@ extends:
           parameters:
             publishUsingPipelines: true
             publishAssetsImmediately: true
-            isAssetlessBuild: true
+            isAssetlessBuild: false
             repositoryAlias: self
             pool:
               name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
We need this flag to actually publish the dotnetup build assets.  The main branch has this set to true because the .NET SDK is published as part of the VMR, but that's not true for dotnetup.