### PR TITLE
Make a RID-suffixed copy of the dotnetup AOT binary for Arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -75,19 +75,18 @@
   <!--
     Set RelativeBlobPath on the dotnetup AOT binary and on its .sha512 sidecar.
     Arcade's GenerateChecksumsFromArtifacts strips RelativeBlobPath from the parent
-    metadata, so we have to set it explicitly here.
-
-    Without this override, Arcade's AddRelativeBlobPathToBlobArtifacts would assign the
-    Sdk/<version>/ default prefix to both files.
+    metadata, so we have to set it explicitly here. Without this override, Arcade's
+    AddRelativeBlobPathToBlobArtifacts would assign the default Sdk/<version>/ prefix
+    to both files.
   -->
   <Target Name="SetDotnetupBlobPaths"
           DependsOnTargets="GetDotnetupVersion"
           AfterTargets="GenerateChecksumsFromArtifacts"
           BeforeTargets="AddRelativeBlobPathToBlobArtifacts;PublishToAzureDevOpsArtifacts">
     <ItemGroup>
-      <Artifact Condition="'%(Filename)%(Extension)' == 'dotnetup$(_DotnetupNativeExt)'"
+      <Artifact Condition="'%(Filename)%(Extension)' == 'dotnetup-$(TargetRid)$(_DotnetupNativeExt)'"
                 RelativeBlobPath="dotnetup/$(DotnetupVersion)/dotnetup-$(TargetRid)$(_DotnetupNativeExt)" />
-      <Artifact Condition="'%(Filename)%(Extension)' == 'dotnetup$(_DotnetupNativeExt).sha512'"
+      <Artifact Condition="'%(Filename)%(Extension)' == 'dotnetup-$(TargetRid)$(_DotnetupNativeExt).sha512'"
                 RelativeBlobPath="dotnetup/$(DotnetupVersion)/dotnetup-$(TargetRid)$(_DotnetupNativeExt).sha512" />
     </ItemGroup>
   </Target>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -109,18 +109,17 @@
     <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="MSBuild" CertificateName="MacDeveloperHarden" />
 
     <!-- dotnetup native executables (produced by src/Installer/dotnetup/dotnetup.csproj).
-         The on-disk file is named `dotnetup` (Linux/macOS) or `dotnetup.exe` (Windows); the
-         RID-encoded blob name (e.g. dotnetup-win-x64.exe) is set on RelativeBlobPath in
-         eng/Publishing.props, not on the local filename.
 
          Windows: MicrosoftDotNet500 (.NET-specific Authenticode cert). Microsoft400 is
                   internal-EKU and gets blocked by Defender SmartScreen; Microsoft402 (EV)
                   isn't provisioned in our MicroBuild signing plugin's ESRPCerts.
          macOS:   MacDeveloperHardenWithNotarization is a virtual cert mapped via
                   CertificatesSignInfo below to MacDeveloperHarden + Apple notarization. -->
-    <FileSignInfo Condition="'$(OS)' == 'Windows_NT'" Include="dotnetup.exe" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Condition="'$(TargetOS)' == 'osx'"
-                  Include="dotnetup"
+    <FileSignInfo Condition="'$(OS)' == 'Windows_NT' and '$(TargetRid)' != ''"
+                  Include="dotnetup-$(TargetRid).exe"
+                  CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="'$(TargetOS)' == 'osx' and '$(TargetRid)' != ''"
+                  Include="dotnetup-$(TargetRid)"
                   CertificateName="MacDeveloperHardenWithNotarization" />
   </ItemGroup>
 
@@ -189,15 +188,13 @@
     eng/TargetRid.props) for the RID-specific publish directory; the TargetFramework
     segment is wildcarded because $(SdkTargetFramework) / $(NetCurrent) isn't reliably set
     in Publish.proj scope.
-
-    RelativeBlobPath is set in the SetDotnetupBlobPaths target in eng/Publishing.props.
   -->
   <PropertyGroup>
     <_DotnetupNativeExt Condition="'$(TargetRid)' != '' and $(TargetRid.StartsWith('win'))">.exe</_DotnetupNativeExt>
   </PropertyGroup>
   <ItemGroup>
-    <!-- The '*' wildcard is for the TargetFramework, which isn't set when evaluatingn this file. -->
-    <_DotnetupPublishedBinary Include="$(ArtifactsBinDir)dotnetup\$(Configuration)\*\$(TargetRid)\publish\dotnetup$(_DotnetupNativeExt)" />
+    <!-- The '*' wildcard is for the TargetFramework, which isn't set when evaluating this file. -->
+    <_DotnetupPublishedBinary Include="$(ArtifactsBinDir)dotnetup\$(Configuration)\*\$(TargetRid)\publish\dotnetup-$(TargetRid)$(_DotnetupNativeExt)" />
     <Artifact Include="@(_DotnetupPublishedBinary)" Kind="Blob">
       <ChecksumPath>%(FullPath).sha512</ChecksumPath>
     </Artifact>

--- a/src/Installer/dotnetup.Library/Program.cs
+++ b/src/Installer/dotnetup.Library/Program.cs
@@ -10,7 +10,11 @@ using Spectre.Console;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;
 
-internal class DotnetupProgram
+/// <summary>
+/// Entry point class for dotnetup. Invoked by the NativeAOT shim in
+/// src/Installer/dotnetup/Program.cs.
+/// </summary>
+public class DotnetupProgram
 {
     public static int Main(string[] args)
     {

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -79,6 +79,26 @@
           Condition="'$(_PublishWasInvokedDirectly)' != 'true' and '$(_DotnetupSkipPublishOnBuild)' != 'true'" />
 
   <!--
+    Make a RID-suffixed copy of the published binary next to the original. The download
+    surfaces (aka.ms shortlinks, ci.dot.net blobs) ship dotnetup-<rid>[.exe] so each
+    RID's standalone binary has a unique filename in the same blob container, but at
+    runtime dotnetup is invoked by the simple name (dotnetup[.exe]). Scripts that
+    download the RID-suffixed file are expected to rename it back to dotnetup.
+  -->
+  <PropertyGroup>
+    <_DotnetupNativeBinaryExt Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.StartsWith('win'))">.exe</_DotnetupNativeBinaryExt>
+  </PropertyGroup>
+  <Target Name="CreateRidSuffixedDotnetupCopy"
+          AfterTargets="Publish"
+          Condition="'$(RuntimeIdentifier)' != ''"
+          Inputs="$(PublishDir)$(TargetName)$(_DotnetupNativeBinaryExt)"
+          Outputs="$(PublishDir)dotnetup-$(RuntimeIdentifier)$(_DotnetupNativeBinaryExt)">
+    <Copy SourceFiles="$(PublishDir)$(TargetName)$(_DotnetupNativeBinaryExt)"
+          DestinationFiles="$(PublishDir)dotnetup-$(RuntimeIdentifier)$(_DotnetupNativeBinaryExt)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!--
     Lets eng/Publishing.props query the dotnetup SemVer (e.g. 0.1.3-preview.<buildid>) to
     use as the blob-path prefix when registering the NativeAOT binary as a Blob artifact
     for Arcade publishing. Mirrors the ReturnProductVersion pattern on


### PR DESCRIPTION
Previously, we were trying to have a blob filename different from the filename of the artifact that was produced, because for the downloads we need a RID-specific URL (ie ending in dotnetup-<rid>[.exe]).

However, it appears that Arcade doesn't support having the artifact filename differ from the blob filename.  So after publish we make a copy of the dotnetup executable with the RID appended to it, and use that as the Artifact for Arcade.