### PR TITLE
[release/10.0.4xx] Fix --environment variables not applied to test process without launch profile

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -146,17 +146,17 @@ internal sealed class TestApplication(
                 processStartInfo.Environment[entry.Key] = entry.Value;
             }
 
-            // Env variables specified on command line override those specified in launch profile:
-            foreach (var (name, value) in TestOptions.EnvironmentVariables)
-            {
-                processStartInfo.Environment[name] = value;
-            }
-
             if (!_buildOptions.NoLaunchProfileArguments &&
                 !string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {
                 processStartInfo.Arguments = $"{processStartInfo.Arguments} {Module.LaunchSettings.CommandLineArgs}";
             }
+        }
+
+        // Env variables specified on command line override those specified in launch profile:
+        foreach (var (name, value) in TestOptions.EnvironmentVariables)
+        {
+            processStartInfo.Environment[name] = value;
         }
 
         if (Module.DotnetRootArchVariableName is not null)


### PR DESCRIPTION
Backport of #53306 to `release/10.0.4xx`.

## Customer Impact

Tests run via `dotnet test -e NAME=VALUE` / `dotnet test --environment NAME=VALUE` with the Microsoft.Testing.Platform runner do not see those environment variables when the test project has no `launchSettings.json`. The CLI accepts and silently drops them. Reported in #54323.

## Regression?

No — the option was added in #50810 (10.0.2xx); it never worked without a launch profile.

## Risk

Very low. Single-file change moving 6 lines out of an `if` block so the command-line override loop runs unconditionally (matching `dotnet run` behavior in `RunCommand.SetEnvironmentVariables`).

## Testing

Verified the bug reproduces on 10.0.204 with a project lacking `launchSettings.json` and `xunit.v3.core.mtp-v2`. With the fix applied (validated on `main`), `-e` vars reach the test process.

Fixes #54323 (on `release/10.0.4xx`).