### PR TITLE
[release/10.0.3xx] Fix --environment variables not applied to test process without launch profile

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -146,17 +146,17 @@ internal sealed class TestApplication(
                 processStartInfo.Environment[entry.Key] = entry.Value;
             }
 
-            // Env variables specified on command line override those specified in launch profile:
-            foreach (var (name, value) in TestOptions.EnvironmentVariables)
-            {
-                processStartInfo.Environment[name] = value;
-            }
-
             if (!_buildOptions.NoLaunchProfileArguments &&
                 !string.IsNullOrEmpty(Module.LaunchSettings.CommandLineArgs))
             {
                 processStartInfo.Arguments = $"{processStartInfo.Arguments} {Module.LaunchSettings.CommandLineArgs}";
             }
+        }
+
+        // Env variables specified on command line override those specified in launch profile:
+        foreach (var (name, value) in TestOptions.EnvironmentVariables)
+        {
+            processStartInfo.Environment[name] = value;
         }
 
         if (Module.DotnetRootArchVariableName is not null)


### PR DESCRIPTION
Backport of #53306 to `release/10.0.3xx`. See #54428 for details and customer impact analysis.

Fixes #54323 (on `release/10.0.3xx`).