### PR TITLE
Remove xunit.v3.assert PackageVersion to fix CPM NU1009 conflict

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -146,7 +146,7 @@
     <PackageVersion Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.2.4" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
-    <PackageVersion Include="xunit.v3.assert" Version="$(XUnitV3Version)" Condition="'$(IsTestProject)' != 'true'" />
+
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Test.Utilities/Test.Utilities.csproj
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Test.Utilities/Test.Utilities.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" />
     <PackageReference Include="System.ComponentModel.Composition" />
-    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
     <PackageReference Include="Xunit.Combinatorial" />
   </ItemGroup>
 

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.XunitV3" />
-    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 

--- a/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
     <PackageReference Include="xunit.v3.extensibility.core" />
     <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
+++ b/test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.IO.Hashing" />
-    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
     <PackageReference Include="xunit.v3.extensibility.core" />
     <PackageReference Include="AwesomeAssertions" />
 


### PR DESCRIPTION
## Problem

The `xunit.v3.assert` `PackageVersion` entry in `Directory.Packages.props` uses a `Condition` to try to separate test vs non-test resolution:

```xml
<PackageVersion Include="xunit.v3.assert" Version="$(XUnitV3Version)" Condition="'$(IsTestProject)' != 'true'" />
```

However, `eng/XUnitV3/XUnitV3.targets` also declares `xunit.v3.assert` as `IsImplicitlyDefined="true"` for test projects. NuGet CPM validation **does not honor MSBuild conditions** on `PackageVersion` items, so this produces NU1009 errors in VMR builds where stricter CPM enforcement is active.

This was detected by the VMR-wide CPM validation test in [dotnet/dotnet#5581](https://github.com/dotnet/dotnet/pull/5581).

## Fix

Follow the pattern used by `dotnet/msbuild` — use `VersionOverride` on individual non-test projects instead of a conditional `PackageVersion`:

- **Remove** the `PackageVersion Include="xunit.v3.assert"` entry from `Directory.Packages.props`
- **Add** `VersionOverride="$(XUnitV3Version)"` to the 4 projects that reference `xunit.v3.assert` without getting it implicitly:
  - `Microsoft.TemplateEngine.Authoring.TemplateVerifier`
  - `Microsoft.TemplateSearch.TemplateDiscovery`
  - `Test.Utilities` (test utility, `IsTestProject` not set to `true`)
  - `Microsoft.NET.TestFramework` (test framework, explicitly sets `IsTestProject=false`)

## Context

- Related: dotnet/sdk#43604 (NU1009 with CPM)
- Related: dotnet/sdk#52914 (xUnit v2→v3 migration)
- The same `Condition` pattern also exists in `dotnet/winforms` — a similar fix will be needed there.

cc @dotnet/dotnet-cli @marcpop