### PR TITLE
Don't crash the CLI parser when global.json is unreadable

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
@@ -31,16 +31,31 @@ internal abstract partial class TestCommandDefinition : Command
     }
 
     public static TestCommandDefinition Create()
+        => Create(Environment.CurrentDirectory);
+
+    internal static TestCommandDefinition Create(string startDirectory)
     {
-        string? globalJsonPath = GetGlobalJsonPath(Environment.CurrentDirectory);
-        if (!File.Exists(globalJsonPath))
+        string? globalJsonPath = GetGlobalJsonPath(startDirectory);
+        if (globalJsonPath is null)
         {
             return new VSTest();
         }
 
-        string jsonText = File.ReadAllText(globalJsonPath);
-
-        var globalJson = JsonSerializer.Deserialize(jsonText, GlobalJsonSerializerContext.Default.GlobalJsonModel);
+        GlobalJsonModel? globalJson;
+        try
+        {
+            string jsonText = File.ReadAllText(globalJsonPath);
+            globalJson = JsonSerializer.Deserialize(jsonText, GlobalJsonSerializerContext.Default.GlobalJsonModel);
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            // The global.json file is unreadable or malformed (for example, empty or mid-edit). This
+            // method is invoked very early during CLI parser construction, so throwing here would
+            // bring down ALL commands (including `dotnet --version`). Fall back to the default
+            // runner; if the user actually runs `dotnet test`, the test command itself will surface
+            // a clearer error when it tries to load the configuration.
+            return new VSTest();
+        }
 
         var name = globalJson?.Test?.RunnerName;
 

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -132,5 +132,78 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             settingsCount.Should().Be(0);
             TestCommand.ContainsBuiltTestSources(parseResult, settingsCount).Should().Be(expectedContainsBuiltTestSource);
         }
+
+        [Fact]
+        public void Create_WhenGlobalJsonIsEmpty_FallsBackToVSTestInsteadOfThrowing()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(Path.Combine(temp.Path, "global.json"), string.Empty);
+
+            var command = TestCommandDefinition.Create(temp.Path);
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>(
+                "an empty global.json must not crash the CLI parser (regression for https://github.com/dotnet/sdk/issues/52384)");
+        }
+
+        [Fact]
+        public void Create_WhenGlobalJsonIsMalformed_FallsBackToVSTestInsteadOfThrowing()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(Path.Combine(temp.Path, "global.json"), "{ this is not valid json");
+
+            var command = TestCommandDefinition.Create(temp.Path);
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>();
+        }
+
+        [Fact]
+        public void Create_WhenGlobalJsonHasMtpRunner_ReturnsMicrosoftTestingPlatform()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "Microsoft.Testing.Platform" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path);
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>();
+        }
+
+        [Fact]
+        public void Create_WhenGlobalJsonHasUnknownRunner_StillThrowsInvalidOperation()
+        {
+            // The "unknown runner" failure is intentional user-facing feedback for a typo in a
+            // well-formed global.json and is preserved by the fix for #52384 (which only relaxes
+            // the unreadable/malformed cases).
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "definitely-not-a-real-runner" } }""");
+
+            Action act = () => TestCommandDefinition.Create(temp.Path);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        private sealed class TempDirectory : IDisposable
+        {
+            public string Path { get; } = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "TestCommandDefinitionTests_" + Guid.NewGuid().ToString("N"));
+
+            public TempDirectory() => Directory.CreateDirectory(Path);
+
+            public void Dispose()
+            {
+                try
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+                catch
+                {
+                    // best-effort cleanup
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #52384.

If `global.json` is empty, mid-edit, or otherwise unreadable, the .NET CLI is fully unusable — even `dotnet --version` crashes — because `TestCommandDefinition.Create()` runs eagerly when the root `dotnet` command tree is constructed.

Reproducer:
```
mkdir repro && cd repro
echo > global.json
dotnet --version
# System.TypeInitializationException: The type initializer for 'Microsoft.DotNet.Cli.Parser' threw an exception.
#  ---> ... ---> System.Text.Json.JsonException: The input does not contain any JSON tokens.
```

## Fix

`TestCommandDefinition.Create` now catches `JsonException`, `IOException` and `UnauthorizedAccessException` when reading/parsing `global.json` and falls back to the default VSTest runner — exactly the same behavior as when no `global.json` exists in the directory hierarchy. The intentional `InvalidOperationException` for an unknown but well-formed runner name is preserved.

To make this testable without changing the test process's current directory (and racing with other tests that depend on cwd), the core logic was extracted to an internal overload that takes the starting directory: `internal static TestCommandDefinition Create(string startDirectory)`.

## Design notes

### Why silent fallback to VSTest rather than a warning?
`Create()` runs at startup for **every** CLI command, including `dotnet --version`, `dotnet build`, `dotnet --help`, etc. Emitting a warning here would pollute every command's output whenever `global.json` is mid-edit. The user who runs `dotnet test` is the only one who actually cares about the test runner selection; today that surface already prints clearer errors via the test command pipeline when it tries to actually use the configuration.

### Why preserve the unknown-runner `InvalidOperationException`?
A well-formed `global.json` with an unknown runner name is a genuine user typo that we want to flag loudly. It would be nicer to defer this error to the point where the user actually runs `dotnet test`, but that requires non-trivial refactoring of the command-tree construction. Out of scope for this fix.

### Alternatives considered
- **Lazy stub command that throws on invocation.** Cleaner long-term, but invasive — would require shaping `MicrosoftTestingPlatform` and `VSTest` to be lazy too, plus careful handling of help / completion / parsing. Not worth the surface area for a regression of this kind.
- **Catch only `JsonException`.** Rejected — `File.ReadAllText` can also throw `IOException` (file lock during editor save) or `UnauthorizedAccessException` (permissions). All three indicate a transient / fixable user-side issue, and none should bring down the entire CLI.

### Tests
4 new tests under `TestCommandDefinitionTests`:
- Empty `global.json` → fall back to `VSTest`.
- Malformed JSON → fall back to `VSTest`.
- Valid `global.json` with `runner: "Microsoft.Testing.Platform"` → returns `MicrosoftTestingPlatform`.
- Valid `global.json` with an unknown runner → still throws `InvalidOperationException` (intentional behavior preserved).

All tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
