### PR TITLE
Don't forward MSBuild terminal-logger args to the test host (fixes #52114, #52229)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -103,10 +103,29 @@ internal static class MSBuildUtility
 
         LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
 
+        // MSBuild terminal-logger switches (e.g. `-tl:off`, `--terminalLogger`, `/tlp:default=off`) are MSBuild-only
+        // and must not be forwarded to the child test host process, which would reject them as unknown options.
+        // See https://github.com/dotnet/sdk/issues/52114 and https://github.com/dotnet/sdk/issues/52229.
+        var terminalLoggerArgs = new List<string>();
+        var nonTerminalLoggerArgs = new List<string>(otherArgs.Count);
+        foreach (var arg in otherArgs)
+        {
+            if (LoggerUtility.IsTerminalLoggerArgument(arg))
+            {
+                terminalLoggerArgs.Add(arg);
+            }
+            else
+            {
+                nonTerminalLoggerArgs.Add(arg);
+            }
+        }
+        otherArgs = nonTerminalLoggerArgs;
+
         var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(definition)
-            .Concat(binLogArgs);
+            .Concat(binLogArgs)
+            .Concat(terminalLoggerArgs);
 
         string? resultsDirectory = parseResult.GetValue(definition.ResultsDirectoryOption);
         if (resultsDirectory is not null)

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -85,6 +85,65 @@ internal static class LoggerUtility
             || arg.StartsWith("--binaryLogger:", comp) || arg.Equals("--binaryLogger", comp)
             || arg.StartsWith("-bl:", comp) || arg.Equals("-bl", comp);
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="arg"/> is an MSBuild
+    /// terminal-logger switch (e.g. <c>-tl</c>, <c>--terminalLogger:off</c>,
+    /// <c>/tlp:default=off</c>, <c>-ll</c>, <c>--livelogger:on</c>).
+    /// </summary>
+    /// <remarks>
+    /// These arguments are intended for the MSBuild build invocation only and must
+    /// not be forwarded to a child test host process, which would reject them with
+    /// "Unknown option '--tl'".
+    /// </remarks>
+    internal static bool IsTerminalLoggerArgument(string arg)
+        => MatchesAnyNamedSwitch(arg, s_terminalLoggerSwitchNames);
+
+    private static readonly string[] s_terminalLoggerSwitchNames =
+    [
+        "tl",
+        "terminalLogger",
+        "ll",
+        "livelogger",
+        "tlp",
+        "terminalLoggerParameters",
+    ];
+
+    private static bool MatchesAnyNamedSwitch(string arg, string[] names)
+    {
+        if (string.IsNullOrEmpty(arg))
+        {
+            return false;
+        }
+
+        const StringComparison comp = StringComparison.OrdinalIgnoreCase;
+        ReadOnlySpan<string> prefixes = ["-", "--", "/"];
+        foreach (var prefix in prefixes)
+        {
+            if (!arg.StartsWith(prefix, comp))
+            {
+                continue;
+            }
+
+            foreach (var name in names)
+            {
+                if (arg.Length == prefix.Length + name.Length
+                    && arg.AsSpan(prefix.Length).Equals(name.AsSpan(), comp))
+                {
+                    return true;
+                }
+
+                if (arg.Length > prefix.Length + name.Length
+                    && arg.AsSpan(prefix.Length, name.Length).Equals(name.AsSpan(), comp)
+                    && (arg[prefix.Length + name.Length] == ':' || arg[prefix.Length + name.Length] == '='))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }
 
 /// <summary>

--- a/test/dotnet.Tests/CommandTests/Test/LoggerUtilityTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/LoggerUtilityTests.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli;
+
+namespace Microsoft.DotNet.Cli.Test.Tests;
+
+public class LoggerUtilityTests
+{
+    [Theory]
+    [InlineData("-tl")]
+    [InlineData("--tl")]
+    [InlineData("/tl")]
+    [InlineData("-tl:on")]
+    [InlineData("-tl:off")]
+    [InlineData("-tl:false")]
+    [InlineData("-tl:true")]
+    [InlineData("-tl:auto")]
+    [InlineData("--tl:off")]
+    [InlineData("/tl:off")]
+    [InlineData("-terminalLogger")]
+    [InlineData("-terminallogger")]
+    [InlineData("--terminalLogger:off")]
+    [InlineData("/terminalLogger:auto")]
+    [InlineData("-ll")]
+    [InlineData("--livelogger:on")]
+    [InlineData("/ll:off")]
+    [InlineData("-tlp")]
+    [InlineData("-tlp:default=off")]
+    [InlineData("--terminalLoggerParameters:default=on")]
+    [InlineData("/tlp:default=auto")]
+    // Older `=` value separator (MSBuild accepts both : and = on long-form switches).
+    [InlineData("--tl=off")]
+    [InlineData("--terminalLogger=auto")]
+    public void IsTerminalLoggerArgument_ReturnsTrue_ForTerminalLoggerSwitches(string arg)
+    {
+        Assert.True(LoggerUtility.IsTerminalLoggerArgument(arg), $"Expected '{arg}' to be classified as a terminal-logger argument.");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-bl")]
+    [InlineData("--binaryLogger")]
+    [InlineData("-tlNoSuchOption")]      // not a bare switch — must not be a substring match
+    [InlineData("--terminalLoggerExtra")] // ditto
+    [InlineData("-tlpzzz")]
+    [InlineData("--show-live-output")]
+    [InlineData("MyProject.csproj")]
+    [InlineData("-p:Foo=Bar")]
+    [InlineData("tl")]                    // missing prefix
+    [InlineData("tl:off")]                // missing prefix
+    [InlineData("---tl")]                 // too many dashes
+    [InlineData("/tlinvalid")]
+    public void IsTerminalLoggerArgument_ReturnsFalse_ForNonTerminalLoggerArguments(string arg)
+    {
+        Assert.False(LoggerUtility.IsTerminalLoggerArgument(arg), $"Expected '{arg}' to NOT be classified as a terminal-logger argument.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #52114 and #52229.

Running `dotnet test` against an MTP test project with an MSBuild terminal-logger switch — for example `dotnet test -tl:off` or `dotnet test --tl:off` — currently:

1. Splits unmatched CLI tokens into "binlog args" → MSBuild, and **everything else** → test application arguments.
2. Forwards the test application arguments to the child test host.
3. The test host doesn't know about `--tl`, fails with `Unknown option '--tl'`, exits with code 5, and prints its entire help output.

So the user sees a wall of noise and the terminal logger remains on during the build.

## Fix

Terminal-logger switches are an MSBuild concern. They are added to the MSBuild argument list (alongside the binlog switches that were already routed there) and removed from the test application argument list.

Changes:

- `LoggerUtility.IsTerminalLoggerArgument` — new internal predicate that recognizes:
  - short names `-tl`, `--tl`, `/tl`, `-ll`, `--ll`, `/ll`, `-tlp`, `--tlp`, `/tlp`
  - long names `terminalLogger`, `livelogger`, `terminalLoggerParameters` with the same three prefixes
  - bare switches and switches with `:value` or `=value` (e.g. `-tl:off`, `--terminalLogger=on`, `/tlp:default=off`)
- `MSBuildUtility.GetBuildOptions` — after `SeparateBinLogArguments`, partitions the remaining unmatched tokens; terminal-logger tokens are concatenated onto the MSBuild argument sequence, the rest stay as test-application arguments.

## Design notes

**Why a dedicated predicate instead of a full MSBuild argument recognizer?**

The bug is reported specifically for terminal-logger switches, and any broader filter would risk silently dropping options the test host legitimately accepts (e.g. `-p:` global properties already flow through MSBuild via `OptionValuesToBeForwarded` and have a different role on the test-app side). A narrow, well-scoped predicate is also easier to reason about, easier to test, and easier to extend if we find additional MSBuild-only switches leaking in the future.

**Why colocate the predicate with the binlog logic in `LoggerUtility`?**

It's the same shape of code — recognize an MSBuild diagnostic-output switch so it can be routed correctly — and it lives next to its closest analog, `IsBinLogArgument`. Putting it on a hypothetical new helper class would only spread the related concepts across files.

**Why match `:` *and* `=` separators?**

MSBuild accepts both forms on long-name switches (e.g. `-bl:foo.binlog` and `-bl=foo.binlog`). Mirroring that here avoids the predicate disagreeing with how the build invocation will actually parse the same token.

**Why exact-match (not `StartsWith`)?**

The pre-existing `TerminalLoggerDetector.TryFind` in the VSTest path uses `StartsWith(prefix + name, ...)`, which would mis-classify e.g. `--terminalLoggerExtra` as a terminal-logger switch. The new predicate requires either an exact name match or an immediate `:` / `=` separator after the name. The included unit tests pin this down.

## Alternatives considered

1. **Filter args in `LoggerUtility.SeparateBinLogArguments` itself.** Rejected because that helper is also used from `RunCommand`, `PublishCommand`, `PackCommand`, and `DotNetCommandFactory`, and the bug is specific to the MTP test path. Changing the shared helper would either need a new overload or risk subtly affecting other commands.
2. **Pre-process `parseResult.UnmatchedTokens` before MTP parsing.** Possible, but the natural seam is already `GetBuildOptions`, which is the function that builds the two argument lists. Moving the partition there keeps the change local and obvious.
3. **Catch unknown options on the test host side and silently ignore `-tl`.** That would mask other genuine "unknown option" mistakes, and would still produce a confusing build experience (terminal logger remains on, which is the user-visible part of the bug).

## Tests

`test/dotnet.Tests/CommandTests/Test/LoggerUtilityTests.cs` — 36 cases covering:
- All combinations of `-` / `--` / `/` prefixes with each of the six terminal-logger names, both bare and with `:value` / `=value` separators.
- Negative cases: empty string, binlog switches, unrelated switches, near-misses (`-tlNoSuchOption`, `--terminalLoggerExtra`, `/tlinvalid`), missing prefix, too-many-dash prefix, positional argument.

All 36 pass locally.
