### PR TITLE
Document duration abbreviation localization decision (closes #51079)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
@@ -17,10 +17,10 @@ internal static class HumanReadableDurationFormatter
         }
 
         // Duration abbreviations (d/h/m/s/ms) are intentionally NOT localized:
-        // they are based on SI unit symbols and are kept identical across cultures
-        // to match MSBuild Terminal Logger's behavior and the typical convention
-        // for CLI tools (kubectl, cargo, etc.). This keeps timing output easy to
-        // parse and consistent regardless of the active culture.
+        // they use common time unit abbreviations and are kept identical across
+        // cultures to match MSBuild Terminal Logger's behavior and the typical
+        // convention for CLI tools (kubectl, cargo, etc.). This keeps timing
+        // output easy to parse and consistent regardless of the active culture.
         if (duration.Days > 0)
         {
             terminal.Append($"{duration.Days}d");

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
@@ -16,7 +16,11 @@ internal static class HumanReadableDurationFormatter
             terminal.Append('(');
         }
 
-        // TODO: Do these abbrevations (d for days, h for hours, etc) need to be localized?
+        // Duration abbreviations (d/h/m/s/ms) are intentionally NOT localized:
+        // they are based on SI unit symbols and are kept identical across cultures
+        // to match MSBuild Terminal Logger's behavior and the typical convention
+        // for CLI tools (kubectl, cargo, etc.). This keeps timing output easy to
+        // parse and consistent regardless of the active culture.
         if (duration.Days > 0)
         {
             terminal.Append($"{duration.Days}d");


### PR DESCRIPTION
## Summary

Resolves the open question in `HumanReadableDurationFormatter` (closes #51079) by documenting why duration unit abbreviations (d, h, m, s, ms) are intentionally not localized.

## Fix

- Replace the `TODO: Do these abbrevations need to be localized?` comment with a rationale explaining the decision.

## Design notes

The duration formatter prints values like `(0m 03s 123ms)`. The unit suffixes are SI symbols, not English words, and several considerations weigh against localizing them:

1. **MSBuild Terminal Logger** (which `dotnet test` MTP output mirrors) keeps these abbreviations unlocalized — translating them in `dotnet test` only would create inconsistency between the build summary and the test summary.
2. **Industry convention**: kubectl, cargo, npm, ffmpeg, and most CLI tools keep duration suffixes in SI form across locales. Test output is frequently copied into bug reports / CI logs where consistent symbols matter more than translation.
3. **Machine readability**: keeping `ms`/`s`/`m`/`h`/`d` constant lets log scrapers and CI tools parse durations without needing locale-aware regexes.
4. **Translation cost vs. value**: introducing localized strings here would require all 13 .xlf files to be touched for output that is purely numeric in most cases. The benefit is marginal (the units are already universally recognized).

## Alternatives considered

1. **Localize all units.** Rejected: divergence from MSBuild Terminal Logger, breaks log parsing, high translation overhead for little user benefit.
2. **Localize only `d`/`h`/`m` (the ones that look like English words) and keep `s`/`ms` (SI).** Rejected: introduces inconsistency, still diverges from MSBuild.
3. **Leave the TODO in place.** Rejected: leaving open questions in production code is technical debt; a documented "we chose not to" is better than perpetual ambiguity.

## Tests

No behavior change; comment-only.