### PR TITLE
Use exact name matching in VSTest TerminalLoggerDetector.TryFind

### DIFF
--- a/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
@@ -522,9 +522,11 @@ public class TerminalLoggerDetector
 
     internal static Switch? TryFind(IReadOnlyList<string> unmatchedTokens, params string[] names)
     {
-        // Order matters: check "--" before "-" so that "--tl:off" is matched as the long form
-        // rather than as a malformed short form, and use exact name matching (not StartsWith)
-        // so that e.g. "-tlp:default=true" is not incorrectly returned when searching for "tl".
+        // Two orderings matter here:
+        //   * Use exact name matching (not StartsWith) so that e.g. "-tlp:default=true" is not
+        //     incorrectly returned when searching for "tl".
+        //   * Check "--" before "-" so that if both "-tl" and "--tl" variants appear in the
+        //     same token list, the long form wins.
         foreach (string prefix in new[] { "--", "-", "/" })
         {
             foreach (var name in names)

--- a/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/TestCommand.cs
@@ -520,30 +520,46 @@ public class TerminalLoggerDetector
         }
     }
 
-    private static Switch? TryFind(IReadOnlyList<string> unmatchedTokens, params string[] names)
+    internal static Switch? TryFind(IReadOnlyList<string> unmatchedTokens, params string[] names)
     {
-        foreach (string prefix in new string[] { "-", "--", "/" })
+        // Order matters: check "--" before "-" so that "--tl:off" is matched as the long form
+        // rather than as a malformed short form, and use exact name matching (not StartsWith)
+        // so that e.g. "-tlp:default=true" is not incorrectly returned when searching for "tl".
+        foreach (string prefix in new[] { "--", "-", "/" })
         {
             foreach (var name in names)
             {
-                var found = unmatchedTokens.FirstOrDefault(t => t.StartsWith(prefix + name, StringComparison.OrdinalIgnoreCase));
-                if (found != null)
+                foreach (var token in unmatchedTokens)
                 {
-                    var param = found.Substring(prefix.Length);
-                    if (!param.Contains(":"))
+                    if (TryMatchExact(token, prefix, name, out string? value))
                     {
-                        return new Switch(param, null);
-                    }
-                    else
-                    {
-                        var parts = param.Split(":", 2);
-                        return new Switch(parts[0], parts[1]);
+                        return new Switch(name, value);
                     }
                 }
             }
         }
 
         return null;
+
+        static bool TryMatchExact(string token, string prefix, string name, out string? value)
+        {
+            value = null;
+            if (!token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var rest = token.AsSpan(prefix.Length);
+            int colonIndex = rest.IndexOf(':');
+            var tokenName = colonIndex < 0 ? rest : rest[..colonIndex];
+            if (!tokenName.Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            value = colonIndex < 0 ? null : rest[(colonIndex + 1)..].ToString();
+            return true;
+        }
     }
 
     internal static class NativeMethods
@@ -691,7 +707,7 @@ public class TerminalLoggerDetector
             => !string.IsNullOrEmpty(termType) && TerminalsRegexes.Any(regex => regex.IsMatch(termType));
     }
 
-    private record class Switch(string Name, string? Value);
+    internal record class Switch(string Name, string? Value);
 }
 
 public enum TerminalLoggerMode

--- a/test/dotnet.Tests/CommandTests/Test/TerminalLoggerDetectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalLoggerDetectorTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace Microsoft.DotNet.Cli.Test.Tests
+{
+    public class TerminalLoggerDetectorTests
+    {
+        [Theory]
+        [InlineData(new[] { "-tl" }, "tl", null)]
+        [InlineData(new[] { "-tl:on" }, "tl", "on")]
+        [InlineData(new[] { "--tl:off" }, "tl", "off")]
+        [InlineData(new[] { "/tl:auto" }, "tl", "auto")]
+        [InlineData(new[] { "-TL:OFF" }, "tl", "OFF")]
+        [InlineData(new[] { "-terminallogger:on" }, "terminalLogger", "on")]
+        [InlineData(new[] { "--TerminalLogger:auto" }, "terminalLogger", "auto")]
+        [InlineData(new[] { "-ll:off" }, "ll", "off")]
+        [InlineData(new[] { "--livelogger:on" }, "livelogger", "on")]
+        public void TryFind_RecognizesTerminalLoggerSwitches(string[] tokens, string expectedName, string? expectedValue)
+        {
+            var result = TerminalLoggerDetector.TryFind(tokens, "tl", "terminalLogger", "ll", "livelogger");
+
+            result.Should().NotBeNull();
+            result!.Name.Should().Be(expectedName);
+            result.Value.Should().Be(expectedValue);
+        }
+
+        [Theory]
+        [InlineData("-tlp:default=true")]
+        [InlineData("--tlp:default=auto")]
+        [InlineData("/tlp:DISABLENODEDISPLAY")]
+        [InlineData("-tlpwithnocolon")]
+        [InlineData("-tlasm")]
+        [InlineData("--llextra")]
+        public void TryFind_DoesNotMatchTlpOrLookalikesWhenSearchingForTl(string token)
+        {
+            // Regression: before the fix, TryFind used StartsWith and would incorrectly match
+            // "-tlp:default=true" (and other look-alikes that share a prefix with the searched
+            // names) when searching for "tl", returning a Switch with a misleading name/value
+            // that downstream callers interpreted as an invalid terminal logger argument.
+            var result = TerminalLoggerDetector.TryFind([token], "tl", "terminalLogger", "ll", "livelogger");
+
+            result.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(new[] { "-tlp:default=true" }, "tlp", "default=true")]
+        [InlineData(new[] { "--terminalLoggerParameters:default=auto" }, "terminalLoggerParameters", "default=auto")]
+        [InlineData(new[] { "/TLP:DISABLENODEDISPLAY" }, "tlp", "DISABLENODEDISPLAY")]
+        public void TryFind_RecognizesTerminalLoggerParametersSwitches(string[] tokens, string expectedName, string? expectedValue)
+        {
+            var result = TerminalLoggerDetector.TryFind(tokens, "tlp", "terminalLoggerParameters");
+
+            result.Should().NotBeNull();
+            result!.Name.Should().Be(expectedName);
+            result.Value.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void TryFind_PrefersLongFormOverShortFormWhenBothPresent()
+        {
+            // Iteration order checks "--" before "-" so the long form wins when both are present.
+            var result = TerminalLoggerDetector.TryFind(["-tl:on", "--tl:off"], "tl", "terminalLogger", "ll", "livelogger");
+
+            result.Should().NotBeNull();
+            result!.Name.Should().Be("tl");
+            result.Value.Should().Be("off");
+        }
+
+        [Fact]
+        public void TryFind_ReturnsNullWhenNoMatch()
+        {
+            var result = TerminalLoggerDetector.TryFind(["--no-build", "-bl", "foo.csproj"], "tl", "terminalLogger");
+
+            result.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #54310 addressing review feedback.

## Bug

VSTest's TerminalLoggerDetector.TryFind matched argument names with StartsWith, so a query for `tl` would incorrectly match `-tlp:default=true` and return `Switch(""tlp"", ""default=true"")`. `TryFromCommandLine` then treated `default=true` as the terminal logger value, which failed parsing and yielded `TerminalLoggerMode.Invalid` for an otherwise valid `-tlp` argument.

## Fix

- Match the switch name exactly: the substring before `:` must equal one of the requested names. This prevents tlp / lookalike collisions while still supporting the optional `:value` suffix.
- Reorder prefix iteration to `--` before `-` so the long form wins when both forms appear in the same command line.
- Make `TryFind` and the `Switch` record `internal` so the logic can be unit-tested directly via the existing `InternalsVisibleTo` on `dotnet.Tests`.

Both existing callers (`FindDefaultValue` and `TryFromCommandLine`) consume only `Switch.Value`, so returning the canonical name from the `names` parameter (rather than the raw token text) is a no-op in production code.

## Tests

New `TerminalLoggerDetectorTests` covers:
- Positive recognition across `-` / `--` / `/` prefixes, with and without values, case-insensitive.
- Regression: `-tlp:default=true`, `-tlpwithnocolon`, `-tlasm`, `--llextra` are not matched when searching for `tl` / `ll`.
- `tlp` / `terminalLoggerParameters` recognition.
- Long-form preference when both `-tl` and `--tl` are present.
- No-match case returns `null`.

All 20 generated test cases pass locally.

cc @baronfel