### PR TITLE
Migrate process framework references

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs
@@ -26,6 +26,14 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
         private Func<string, bool>? _directoryExistOverride;
 
         public static WorkloadResolver Create(IWorkloadManifestProvider manifestProvider, string dotnetRootPath, string sdkVersion, string? userProfileDir)
+            => Create(manifestProvider, dotnetRootPath, sdkVersion, userProfileDir, Environment.GetEnvironmentVariable);
+
+        /// <summary>
+        /// Same as <see cref="Create(IWorkloadManifestProvider, string, string, string?)"/> but reads environment
+        /// variables via the supplied delegate. Use this from MSBuild tasks to route reads through TaskEnvironment
+        /// so concurrent tasks observe their own per-task environment snapshot.
+        /// </summary>
+        public static WorkloadResolver Create(IWorkloadManifestProvider manifestProvider, string dotnetRootPath, string sdkVersion, string? userProfileDir, Func<string, string?> getEnvironmentVariable)
         {
             string runtimeIdentifierChainPath = Path.Combine(dotnetRootPath, "sdk", sdkVersion, "NETCoreSdkRuntimeIdentifierChain.txt");
             string[] currentRuntimeIdentifiers = File.Exists(runtimeIdentifierChainPath) ?
@@ -42,7 +50,7 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
                 workloadRootPaths = [ new(dotnetRootPath, true) ];
             }
 
-            var packRootEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
+            var packRootEnvironmentVariable = getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
             if (!string.IsNullOrEmpty(packRootEnvironmentVariable))
             {
                 workloadRootPaths = packRootEnvironmentVariable.Split(Path.PathSeparator).Select(path => new WorkloadRootPath(path, false)).Concat(workloadRootPaths).ToArray();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -20,8 +20,11 @@ namespace Microsoft.NET.Build.Tasks
     /// targeting packs which provide the reference assemblies, and creates RuntimeFramework
     /// items, which are written to the runtimeconfig file
     /// </summary>
-    public class ProcessFrameworkReferences : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class ProcessFrameworkReferences : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         public string? TargetFrameworkIdentifier { get; set; }
 
         [Required]
@@ -1112,7 +1115,7 @@ namespace Microsoft.NET.Build.Tasks
         {
             IEnumerable<string> GetPackFolders()
             {
-                var packRootEnvironmentVariable = Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
+                var packRootEnvironmentVariable = TaskEnvironment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_PACK_ROOTS);
                 if (!string.IsNullOrEmpty(packRootEnvironmentVariable))
                 {
                     foreach (var packRoot in packRootEnvironmentVariable.Split(Path.PathSeparator))
@@ -1124,7 +1127,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (!string.IsNullOrEmpty(NetCoreRoot) && !string.IsNullOrEmpty(NETCoreSdkVersion))
                 {
                     if (WorkloadFileBasedInstall.IsUserLocal(NetCoreRoot, NETCoreSdkVersion) &&
-                        new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath() is { } userProfileDir)
+                        new CliFolderPathCalculatorCore(TaskEnvironment.GetEnvironmentVariable).GetDotnetUserProfileFolderPath() is { } userProfileDir)
                     {
                         yield return Path.Combine(userProfileDir, "packs");
                     }
@@ -1139,7 +1142,8 @@ namespace Microsoft.NET.Build.Tasks
             foreach (var packFolder in GetPackFolders())
             {
                 string packPath = Path.Combine(packFolder, packName, packVersion);
-                if (Directory.Exists(packPath))
+                AbsolutePath absolutePackPath = TaskEnvironment.GetAbsolutePath(packPath);
+                if (Directory.Exists(absolutePackPath))
                 {
                     return packPath;
                 }
@@ -1177,14 +1181,17 @@ namespace Microsoft.NET.Build.Tasks
         {
             return new(() =>
         {
-                string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
+                //  Route env reads through TaskEnvironment so concurrent tasks observe their own per-task snapshot.
+                Func<string, string?> getEnvironmentVariable = TaskEnvironment.GetEnvironmentVariable;
+                string? userProfileDir = new CliFolderPathCalculatorCore(getEnvironmentVariable).GetDotnetUserProfileFolderPath();
 
-                //  When running MSBuild tasks, the current directory is always the project directory, so we can use that as the
-                //  starting point to search for global.json
-                string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory);
+            //  When running MSBuild tasks, the project directory is the appropriate starting point to search for global.json.
+            //  Use TaskEnvironment to resolve it safely under multithreaded execution (process cwd is unsafe).
+            string projectDirectory = TaskEnvironment.ProjectDirectory;
+            string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(projectDirectory);
 
-                var manifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, userProfileDir, globalJsonPath);
-                return WorkloadResolver.Create(manifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir);
+                var manifestProvider = new SdkDirectoryWorkloadManifestProvider(NetCoreRoot, NETCoreSdkVersion, getEnvironmentVariable, userProfileDir, globalJsonPath);
+                return WorkloadResolver.Create(manifestProvider, NetCoreRoot, NETCoreSdkVersion, userProfileDir, getEnvironmentVariable);
         });
         }
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAProcessFrameworkReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAProcessFrameworkReferencesMultiThreading.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAProcessFrameworkReferencesMultiThreading
+    {
+        private const string MinimalRuntimeGraph = """
+            {
+                "runtimes": {
+                    "any": { "#import": ["base"] },
+                    "base": { "#import": [] }
+                }
+            }
+            """;
+
+        // Migration concern: GetPackPath calls Directory.Exists. Under multithreaded execution
+        // the process CWD is not the project directory, so a relative TargetingPackRoot must be
+        // resolved via TaskEnvironment. The metadata emitted to MSBuild must still be the
+        // original (relative) form — absolutization must not leak into outputs (Sin 1).
+        [Fact]
+        public void It_resolves_relative_TargetingPackRoot_and_keeps_metadata_in_original_form()
+        {
+            using var env = new TaskTestEnvironment();
+
+            const string packageId = "Microsoft.NETCore.App.Ref";
+            const string version = "5.0.0";
+            const string relativeRoot = "packs";
+
+            // Place the targeting pack on disk under the project directory.
+            env.CreateProjectDirectory(Path.Combine(relativeRoot, packageId, version));
+
+            var runtimeGraphPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPath, MinimalRuntimeGraph);
+
+            try
+            {
+                var task = new ProcessFrameworkReferences
+                {
+                    BuildEngine = new MockNeverCacheBuildEngine4(),
+                    TaskEnvironment = env.TaskEnvironment,
+                    TargetFrameworkIdentifier = ".NETCoreApp",
+                    TargetFrameworkVersion = "5.0",
+                    RuntimeGraphPath = runtimeGraphPath,
+                    NETCoreSdkRuntimeIdentifier = "win-x64",
+                    EnableTargetingPackDownload = true,
+                    TargetingPackRoot = relativeRoot,
+                    FrameworkReferences = new[]
+                    {
+                        new MockTaskItem(packageId, new Dictionary<string, string>())
+                    },
+                    KnownFrameworkReferences = new[] { CreateKnownTargetingPack(packageId, version) },
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
+                var pack = task.TargetingPacks[0];
+
+                // Resolution succeeded despite the process CWD pointing at SpawnDirectory ⇒
+                // Directory.Exists was evaluated against ProjectDirectory via TaskEnvironment.
+                // Metadata must be the original relative form, not an absolutized leak.
+                var expectedRelativePath = Path.Combine(relativeRoot, packageId, version);
+                pack.GetMetadata(MetadataKeys.Path).Should().Be(expectedRelativePath);
+                pack.GetMetadata(MetadataKeys.PackageDirectory).Should().Be(expectedRelativePath);
+            }
+            finally
+            {
+                try { File.Delete(runtimeGraphPath); } catch { }
+            }
+        }
+
+        // Migration concern: GetPackFolders reads DOTNETSDK_WORKLOAD_PACK_ROOTS. Under
+        // multithreaded execution this must be read from the TaskEnvironment snapshot, not the
+        // live process environment. The snapshot value below is independent of process state.
+        [Fact]
+        public void It_reads_workload_pack_roots_from_TaskEnvironment_snapshot()
+        {
+            using var env = new TaskTestEnvironment();
+
+            const string packageId = "Microsoft.NETCore.App.Ref";
+            const string version = "5.0.0";
+            const string envRootName = "customRoot";
+
+            // Pack lives only under the env-var-supplied root, never under TargetingPackRoot.
+            env.CreateProjectDirectory(Path.Combine(envRootName, "packs", packageId, version));
+
+            var envRootAbsolute = Path.Combine(env.ProjectDirectory, envRootName);
+            var snapshot = new Dictionary<string, string>
+            {
+                { "DOTNETSDK_WORKLOAD_PACK_ROOTS", envRootAbsolute }
+            };
+            var taskEnv = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(env.ProjectDirectory, snapshot);
+
+            var runtimeGraphPath = Path.GetTempFileName();
+            File.WriteAllText(runtimeGraphPath, MinimalRuntimeGraph);
+
+            try
+            {
+                var task = new ProcessFrameworkReferences
+                {
+                    BuildEngine = new MockNeverCacheBuildEngine4(),
+                    TaskEnvironment = taskEnv,
+                    TargetFrameworkIdentifier = ".NETCoreApp",
+                    TargetFrameworkVersion = "5.0",
+                    RuntimeGraphPath = runtimeGraphPath,
+                    NETCoreSdkRuntimeIdentifier = "win-x64",
+                    EnableTargetingPackDownload = false, // resolution must come from env var, not download fallback
+                    // TargetingPackRoot intentionally unset — only the env var can drive resolution.
+                    FrameworkReferences = new[]
+                    {
+                        new MockTaskItem(packageId, new Dictionary<string, string>())
+                    },
+                    KnownFrameworkReferences = new[] { CreateKnownTargetingPack(packageId, version) },
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.TargetingPacks.Should().NotBeNull().And.HaveCount(1);
+                var pack = task.TargetingPacks[0];
+
+                // Resolution succeeded ⇒ env var was read from the TaskEnvironment snapshot.
+                // Metadata is the original Path.Combine(envVar, "packs", id, version) form.
+                var expectedPath = Path.Combine(envRootAbsolute, "packs", packageId, version);
+                pack.GetMetadata(MetadataKeys.Path).Should().Be(expectedPath);
+                pack.GetMetadata(MetadataKeys.PackageDirectory).Should().Be(expectedPath);
+            }
+            finally
+            {
+                try { File.Delete(runtimeGraphPath); } catch { }
+            }
+        }
+
+        private static MockTaskItem CreateKnownTargetingPack(string packageId, string version)
+        {
+            return new MockTaskItem(packageId, new Dictionary<string, string>
+            {
+                { "TargetFramework", "net5.0" },
+                { "RuntimeFrameworkName", packageId },
+                { "DefaultRuntimeFrameworkVersion", version },
+                { "LatestRuntimeFrameworkVersion", version },
+                { "TargetingPackName", packageId },
+                { "TargetingPackVersion", version },
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes: dotnet/msbuild#13869

## Summary
Migrates `ProcessFrameworkReferences` to MSBuild's multithreaded task model so it can run safely under the MT host without depending on process-global state.

## Changes

### `src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs`
- Added `[MSBuildMultiThreadableTask]` and `IMultiThreadableTask` implementation.
- Added `TaskEnvironment` property with `TaskEnvironment.Fallback` default for non-MT hosts.
- `GetPackPath`: reads `WORKLOAD_PACK_ROOTS` via `TaskEnvironment.GetEnvironmentVariable`; constructs `CliFolderPathCalculatorCore` with the delegate-based ctor; uses `TaskEnvironment.GetAbsolutePath(packPath)` for local `Directory.Exists` probes while preserving the original `packPath` string in emitted metadata.
- `LazyCreateWorkloadResolver`: routes env reads through `TaskEnvironment.GetEnvironmentVariable`, anchors `global.json` discovery at `TaskEnvironment.ProjectDirectory`, and uses the internal 5-arg `SdkDirectoryWorkloadManifestProvider` ctor.

### `src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/WorkloadResolver.cs`
- Added a delegate-based `Create(IWorkloadManifestProvider, string, string, string?, Func<string, string?>)` overload that reads `WORKLOAD_PACK_ROOTS` via the supplied getter.
- The existing public `Create(...)` overload is preserved as a one-line forwarder to `Environment.GetEnvironmentVariable` — **no behavior change for any existing caller** (CLI workload commands, `TemplateLocator`, `CachingWorkloadResolver`, MSBuild SDK resolver, tests).

### `test/Microsoft.NET.Build.Tasks.Tests/GivenAProcessFrameworkReferencesMultiThreading.cs`
- New sin-based MT tests:
  - Verifies relative `TargetingPackRoot` is resolved against `TaskEnvironment.ProjectDirectory` for local probing while metadata stays in original form.
  - Verifies `WORKLOAD_PACK_ROOTS` is read from the `TaskEnvironment` snapshot, not the process env.

## Why the WorkloadResolver overload is in this PR
The overload exists solely to let `ProcessFrameworkReferences` route `WORKLOAD_PACK_ROOTS` through its `TaskEnvironment` snapshot. Without it, the migrated task would still fall through to a process-env read in `WorkloadResolver`, which under the MT host can return the wrong value for concurrent task instances. Splitting it into a separate PR would ship a half-migration with the bug still present, so the two changes belong together.

## Verification
- Built locally; no warnings or errors introduced.
- Validated with the thread-safe task analyzer from `dotnet/msbuild`: real ambient-state hazards (`WORKLOAD_PACK_ROOTS` env read, `global.json` CWD anchoring) are eliminated. Remaining analyzer findings on this file are transitive and resolve to rooted-path file I/O via the workload resolver chain (workload manifests, install state, workload sets, `global.json` reader) — safe by construction because all inputs are absolute paths derived from task parameters or `SpecialFolder.UserProfile`.
- New MT tests added; existing `ProcessFrameworkReferences` tests unaffected.

## Compatibility
- No public API removed or changed.
- New public property (`TaskEnvironment`) on the task — standard MT-task pattern.
- New `WorkloadResolver.Create` overload is strictly additive.
- Emitted item metadata is unchanged.