### PR TITLE
Migrate GetPackageDirectory

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -41,8 +41,6 @@ namespace Microsoft.NET.Build.Tasks
                 PackageFolders = PackageFolders.Concat(lockFile.PackageFolders.Select(p => p.Path)).ToArray();
             }
 
-            // Resolve package folders relative to the project directory. Empty entries are left
-            // as-is since GetAbsolutePath rejects them.
             string[] absolutePackageFolders = PackageFolders
                 .Select(p => string.IsNullOrEmpty(p) ? p : (string)TaskEnvironment.GetAbsolutePath(p))
                 .ToArray();

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -45,6 +45,15 @@ namespace Microsoft.NET.Build.Tasks
                 .Select(p => string.IsNullOrEmpty(p) ? p : (string)TaskEnvironment.GetAbsolutePath(p))
                 .ToArray();
 
+            var originalByAbsolute = new Dictionary<string, string>(PackageFolders.Length, StringComparer.Ordinal);
+            for (int i = 0; i < PackageFolders.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(absolutePackageFolders[i]))
+                {
+                    originalByAbsolute[absolutePackageFolders[i]] = PackageFolders[i];
+                }
+            }
+
             var packageResolver = NuGetPackageResolver.CreateResolver(absolutePackageFolders);
 
             int index = 0;
@@ -73,14 +82,11 @@ namespace Microsoft.NET.Build.Tasks
 
                 // Restore the caller's original (possibly relative) folder prefix so the
                 // PackageDirectory metadata is unchanged from before absolutization.
-                if (packageRoot != null)
+                if (packageRoot != null
+                    && originalByAbsolute.TryGetValue(packageRoot, out string originalRoot)
+                    && !string.Equals(originalRoot, packageRoot, StringComparison.Ordinal))
                 {
-                    int folderIndex = Array.IndexOf(absolutePackageFolders, packageRoot);
-                    if (folderIndex >= 0
-                        && !string.Equals(PackageFolders[folderIndex], packageRoot, StringComparison.Ordinal))
-                    {
-                        packageDirectory = PackageFolders[folderIndex] + packageDirectory.Substring(packageRoot.Length);
-                    }
+                    packageDirectory = originalRoot + packageDirectory.Substring(packageRoot.Length);
                 }
 
                 var newItem = new TaskItem(item);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -41,18 +41,13 @@ namespace Microsoft.NET.Build.Tasks
                 PackageFolders = PackageFolders.Concat(lockFile.PackageFolders.Select(p => p.Path)).ToArray();
             }
 
-            // Capture the caller's original folder shapes so that absolutization stays internal to
-            // this task and never leaks into the [Output] items' PackageDirectory metadata.
-            string[] originalPackageFolders = PackageFolders;
-
             // NuGetPackageResolver probes the file system for each folder, so paths must be
             // absolutized relative to the project rather than the process working directory.
-            // Null/empty entries are passed through so NuGet's resolver handles them as it did pre-migration.
-            PackageFolders = originalPackageFolders
+            string[] absolutePackageFolders = PackageFolders
                 .Select(p => string.IsNullOrEmpty(p) ? p : (string)TaskEnvironment.GetAbsolutePath(p))
                 .ToArray();
 
-            var packageResolver = NuGetPackageResolver.CreateResolver(PackageFolders);
+            var packageResolver = NuGetPackageResolver.CreateResolver(absolutePackageFolders);
 
             int index = 0;
             var updatedItems = new ITaskItem[Items.Length];
@@ -83,11 +78,11 @@ namespace Microsoft.NET.Build.Tasks
                 // byte-identical to the pre-migration behavior.
                 if (packageRoot != null)
                 {
-                    int folderIndex = Array.IndexOf(PackageFolders, packageRoot);
+                    int folderIndex = Array.IndexOf(absolutePackageFolders, packageRoot);
                     if (folderIndex >= 0
-                        && !string.Equals(originalPackageFolders[folderIndex], packageRoot, StringComparison.Ordinal))
+                        && !string.Equals(PackageFolders[folderIndex], packageRoot, StringComparison.Ordinal))
                     {
-                        packageDirectory = originalPackageFolders[folderIndex] + packageDirectory.Substring(packageRoot.Length);
+                        packageDirectory = PackageFolders[folderIndex] + packageDirectory.Substring(packageRoot.Length);
                     }
                 }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -41,8 +41,8 @@ namespace Microsoft.NET.Build.Tasks
                 PackageFolders = PackageFolders.Concat(lockFile.PackageFolders.Select(p => p.Path)).ToArray();
             }
 
-            // NuGetPackageResolver probes the file system for each folder, so paths must be
-            // absolutized relative to the project rather than the process working directory.
+            // Resolve package folders relative to the project directory. Empty entries are left
+            // as-is since GetAbsolutePath rejects them.
             string[] absolutePackageFolders = PackageFolders
                 .Select(p => string.IsNullOrEmpty(p) ? p : (string)TaskEnvironment.GetAbsolutePath(p))
                 .ToArray();
@@ -73,9 +73,8 @@ namespace Microsoft.NET.Build.Tasks
                     continue;
                 }
 
-                // If the resolver matched against a folder we absolutized, rewrite the result to use
-                // the caller's original (possibly relative) prefix so PackageDirectory metadata is
-                // byte-identical to the pre-migration behavior.
+                // Restore the caller's original (possibly relative) folder prefix so the
+                // PackageDirectory metadata is unchanged from before absolutization.
                 if (packageRoot != null)
                 {
                     int folderIndex = Array.IndexOf(absolutePackageFolders, packageRoot);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackageDirectory.cs
@@ -11,8 +11,11 @@ namespace Microsoft.NET.Build.Tasks
 {
     //  Locates the root NuGet package directory for each of the input items that has PackageName and PackageVersion,
     //  but not PackageDirectory metadata specified
-    public class GetPackageDirectory : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GetPackageDirectory : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         public ITaskItem[] Items { get; set; } = Array.Empty<ITaskItem>();
 
         public string[] PackageFolders { get; set; } = Array.Empty<string>();
@@ -32,10 +35,22 @@ namespace Microsoft.NET.Build.Tasks
 
             if (!string.IsNullOrEmpty(AssetsFileWithAdditionalPackageFolders))
             {
+                AbsolutePath assetsFilePath = TaskEnvironment.GetAbsolutePath(AssetsFileWithAdditionalPackageFolders);
                 var lockFileCache = new LockFileCache(this);
-                var lockFile = lockFileCache.GetLockFile(AssetsFileWithAdditionalPackageFolders);
+                var lockFile = lockFileCache.GetLockFile(assetsFilePath);
                 PackageFolders = PackageFolders.Concat(lockFile.PackageFolders.Select(p => p.Path)).ToArray();
             }
+
+            // Capture the caller's original folder shapes so that absolutization stays internal to
+            // this task and never leaks into the [Output] items' PackageDirectory metadata.
+            string[] originalPackageFolders = PackageFolders;
+
+            // NuGetPackageResolver probes the file system for each folder, so paths must be
+            // absolutized relative to the project rather than the process working directory.
+            // Null/empty entries are passed through so NuGet's resolver handles them as it did pre-migration.
+            PackageFolders = originalPackageFolders
+                .Select(p => string.IsNullOrEmpty(p) ? p : (string)TaskEnvironment.GetAbsolutePath(p))
+                .ToArray();
 
             var packageResolver = NuGetPackageResolver.CreateResolver(PackageFolders);
 
@@ -55,12 +70,25 @@ namespace Microsoft.NET.Build.Tasks
                 }
 
                 var parsedPackageVersion = NuGetVersion.Parse(packageVersion);
-                string packageDirectory = packageResolver.GetPackageDirectory(packageName, parsedPackageVersion);
+                string packageDirectory = packageResolver.GetPackageDirectory(packageName, parsedPackageVersion, out string packageRoot);
 
                 if (packageDirectory == null)
                 {
                     updatedItems[index++] = item;
                     continue;
+                }
+
+                // If the resolver matched against a folder we absolutized, rewrite the result to use
+                // the caller's original (possibly relative) prefix so PackageDirectory metadata is
+                // byte-identical to the pre-migration behavior.
+                if (packageRoot != null)
+                {
+                    int folderIndex = Array.IndexOf(PackageFolders, packageRoot);
+                    if (folderIndex >= 0
+                        && !string.Equals(originalPackageFolders[folderIndex], packageRoot, StringComparison.Ordinal))
+                    {
+                        packageDirectory = originalPackageFolders[folderIndex] + packageDirectory.Substring(packageRoot.Length);
+                    }
                 }
 
                 var newItem = new TaskItem(item);

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAGetPackageDirectoryMultiThreading
+    {
+        // Sin 1 (Output property contamination): when the caller passes a relative PackageFolders
+        // entry, the migration must NOT leak the TaskEnvironment-absolutized form into the
+        // [Output] items' PackageDirectory metadata.
+        [Fact]
+        public void PackageDirectoryMetadata_PreservesRelativeFolderShape_WhenInputIsRelative()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "gpd-rel-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var absolutePackagesDir = Path.Combine(projectDir, "packages");
+                CreateFakeNuGetPackage(absolutePackagesDir, "Newtonsoft.Json", "13.0.1");
+
+                var item = new TaskItem("Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageId, "Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageVersion, "13.0.1");
+
+                var task = new GetPackageDirectory
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    Items = new ITaskItem[] { item },
+                    // Relative folder — would have produced relative metadata pre-migration.
+                    PackageFolders = new[] { "packages" }
+                };
+
+                task.Execute().Should().BeTrue("task should locate the package via the absolutized folder");
+
+                task.Output.Should().HaveCount(1);
+                var resolved = task.Output[0].GetMetadata(MetadataKeys.PackageDirectory);
+
+                resolved.Should().NotBeNullOrEmpty("a package directory should be resolved");
+                Path.IsPathRooted(resolved).Should().BeFalse(
+                    "PackageDirectory must preserve the caller's relative shape; absolutization must not leak into [Output]");
+                resolved.Should().StartWith("packages",
+                    "the original relative prefix should be substituted back into the result");
+                resolved.Should().NotStartWith(projectDir,
+                    "TaskEnvironment.ProjectDirectory must not leak into PackageDirectory metadata");
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+            }
+        }
+
+        // Sin 6 (Exception type change): the Option-A pass-through for empty PackageFolders
+        // entries must keep GetAbsolutePath from throwing ArgumentException. Specifically: an
+        // empty user-package-folder is tolerated by NuGet's VersionFolderPathResolver (it stores
+        // the empty string and probes harmlessly fail), so the task must still reach NuGet and
+        // resolve packages from the remaining (valid) fallback folders.
+        [Fact]
+        public void EmptyPackageFolderEntry_DoesNotThrow_AndValidFallbackResolves()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "gpd-empty-" + Guid.NewGuid().ToString("N"));
+            var packagesDir = Path.Combine(Path.GetTempPath(), "gpd-empty-pkgs-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                CreateFakeNuGetPackage(packagesDir, "Newtonsoft.Json", "13.0.1");
+
+                var item = new TaskItem("Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageId, "Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageVersion, "13.0.1");
+
+                var task = new GetPackageDirectory
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    Items = new ITaskItem[] { item },
+                    // Empty user folder + valid absolute fallback. Without Option-A pass-through,
+                    // GetAbsolutePath("") would throw ArgumentException and the task would never
+                    // reach NuGet. With pass-through, NuGet's VersionFolderPathResolver tolerates
+                    // the empty user folder and the absolute fallback still resolves the package.
+                    PackageFolders = new[] { string.Empty, packagesDir }
+                };
+
+                Action act = () => task.Execute();
+
+                act.Should().NotThrow("empty PackageFolders entries must pass through GetAbsolutePath without raising ArgumentException");
+                task.Output.Should().HaveCount(1);
+                task.Output[0].GetMetadata(MetadataKeys.PackageDirectory)
+                    .Should().StartWith(packagesDir, "the valid fallback folder should still resolve the package");
+            }
+            finally
+            {
+                try { Directory.Delete(projectDir, true); } catch { }
+                try { Directory.Delete(packagesDir, true); } catch { }
+            }
+        }
+
+        // Happy-path regression guard: when all PackageFolders are already absolute (the realistic
+        // production case), the migration must produce the same absolute PackageDirectory metadata
+        // it would have pre-migration, and must NOT root anything against TaskEnvironment.ProjectDirectory.
+        [Fact]
+        public void AbsolutePackageFolders_ProduceAbsoluteMetadata_AndDoNotLeakProjectDirectory()
+        {
+            var packagesDir = Path.Combine(Path.GetTempPath(), "gpd-abs-pkgs-" + Guid.NewGuid().ToString("N"));
+            var unrelatedDir = Path.Combine(Path.GetTempPath(), "gpd-abs-unrelated-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(unrelatedDir);
+            try
+            {
+                CreateFakeNuGetPackage(packagesDir, "Newtonsoft.Json", "13.0.1");
+
+                var item = new TaskItem("Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageId, "Newtonsoft.Json");
+                item.SetMetadata(MetadataKeys.NuGetPackageVersion, "13.0.1");
+
+                var task = new GetPackageDirectory
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    // TaskEnvironment points at a completely unrelated directory; its ProjectDirectory
+                    // must not appear anywhere in the output.
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(unrelatedDir),
+                    Items = new ITaskItem[] { item },
+                    PackageFolders = new[] { packagesDir }
+                };
+
+                task.Execute().Should().BeTrue();
+
+                task.Output.Should().HaveCount(1);
+                var resolved = task.Output[0].GetMetadata(MetadataKeys.PackageDirectory);
+
+                resolved.Should().StartWith(packagesDir,
+                    "PackageDirectory should reflect NuGet's resolved install path under the supplied folder");
+                resolved.Should().NotContain(unrelatedDir,
+                    "TaskEnvironment.ProjectDirectory must never appear in PackageDirectory metadata");
+            }
+            finally
+            {
+                try { Directory.Delete(packagesDir, true); } catch { }
+                try { Directory.Delete(unrelatedDir, true); } catch { }
+            }
+        }
+
+        // Creates the minimum on-disk layout FallbackPackagePathResolver requires to find a package:
+        //   {root}/{id-lower}/{version}/{id-lower}.{version}.nupkg.sha512
+        //   {root}/{id-lower}/{version}/{id-lower}.nuspec
+        private static void CreateFakeNuGetPackage(string root, string id, string version)
+        {
+            var idLower = id.ToLowerInvariant();
+            var pkgDir = Path.Combine(root, idLower, version);
+            Directory.CreateDirectory(pkgDir);
+
+            File.WriteAllText(
+                Path.Combine(pkgDir, $"{idLower}.{version}.nupkg.sha512"),
+                "abc123");
+            File.WriteAllText(
+                Path.Combine(pkgDir, $"{idLower}.nuspec"),
+                $"<package><metadata><id>{id}</id><version>{version}</version></metadata></package>");
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -36,7 +36,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     BuildEngine = new MockBuildEngine(),
                     TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
                     Items = new ITaskItem[] { item },
-                    // Relative folder — would have produced relative metadata pre-migration.
+                    // Production folders are usually absolute; this test deliberately uses a relative
+                    // one to verify a relative input still yields relative PackageDirectory metadata.
                     PackageFolders = new[] { relativeFolder }
                 };
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -10,15 +10,21 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     {
         // Sin 1 (Output property contamination): when the caller passes a relative PackageFolders
         // entry, the migration must NOT leak the TaskEnvironment-absolutized form into the
-        // [Output] items' PackageDirectory metadata.
-        [Fact]
-        public void PackageDirectoryMetadata_PreservesRelativeFolderShape_WhenInputIsRelative()
+        // [Output] items' PackageDirectory metadata. The relative prefix is substituted back into
+        // NuGet's absolutized result via string surgery, so this exercises that surgery across a
+        // range of folder shapes (nested, forward slashes, trailing separators).
+        [Theory]
+        [InlineData("packages")]               // flat relative folder
+        [InlineData("nested/packages")]        // nested with forward slash
+        [InlineData("a/b/c/packages")]         // deeply nested
+        [InlineData("packages/")]              // trailing separator
+        public void PackageDirectoryMetadata_PreservesRelativeFolderShape_WhenInputIsRelative(string relativeFolder)
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "gpd-rel-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(projectDir);
             try
             {
-                var absolutePackagesDir = Path.Combine(projectDir, "packages");
+                var absolutePackagesDir = Path.Combine(projectDir, relativeFolder);
                 CreateFakeNuGetPackage(absolutePackagesDir, "Newtonsoft.Json", "13.0.1");
 
                 var item = new TaskItem("Newtonsoft.Json");
@@ -31,7 +37,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
                     Items = new ITaskItem[] { item },
                     // Relative folder — would have produced relative metadata pre-migration.
-                    PackageFolders = new[] { "packages" }
+                    PackageFolders = new[] { relativeFolder }
                 };
 
                 task.Execute().Should().BeTrue("task should locate the package via the absolutized folder");
@@ -42,10 +48,18 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 resolved.Should().NotBeNullOrEmpty("a package directory should be resolved");
                 Path.IsPathRooted(resolved).Should().BeFalse(
                     "PackageDirectory must preserve the caller's relative shape; absolutization must not leak into [Output]");
-                resolved.Should().StartWith("packages",
+                resolved.Should().StartWith(relativeFolder,
                     "the original relative prefix should be substituted back into the result");
-                resolved.Should().NotStartWith(projectDir,
+                resolved.Should().NotContain(projectDir,
                     "TaskEnvironment.ProjectDirectory must not leak into PackageDirectory metadata");
+
+                // Strongest check on the string surgery: re-rooting the returned relative path at the
+                // project directory must point at the exact location NuGet resolved the package to,
+                // regardless of separator/nesting differences in the substituted prefix.
+                Path.GetFullPath(Path.Combine(projectDir, resolved))
+                    .Should().Be(
+                        Path.GetFullPath(Path.Combine(absolutePackagesDir, "newtonsoft.json", "13.0.1")),
+                        "the rewritten relative path must resolve to the same physical package directory NuGet found");
             }
             finally
             {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -8,7 +8,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     public class GivenAGetPackageDirectoryMultiThreading
     {
-        // Sin 1 (Output property contamination): when the caller passes a relative PackageFolders
+        // When the caller passes a relative PackageFolders
         // entry, the migration must NOT leak the TaskEnvironment-absolutized form into the
         // [Output] items' PackageDirectory metadata. The relative prefix is substituted back into
         // NuGet's absolutized result via string surgery, so this exercises that surgery across a
@@ -68,7 +68,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        // Sin 6 (Exception type change): the Option-A pass-through for empty PackageFolders
+        // The Option-A pass-through for empty PackageFolders
         // entries must keep GetAbsolutePath from throwing ArgumentException. Specifically: an
         // empty user-package-folder is tolerated by NuGet's VersionFolderPathResolver (it stores
         // the empty string and probes harmlessly fail), so the task must still reach NuGet and


### PR DESCRIPTION
Fixes dotnet/msbuild#13868


Adds `[MSBuildMultiThreadableTask]` + `IMultiThreadableTask` and routes path
inputs through `TaskEnvironment` so the task works under MSBuild's worker-thread
model (CWD ≠ project dir).

### Changes
- Absolutize `AssetsFileWithAdditionalPackageFolders` before `LockFileCache.GetLockFile`
  (mirrors `CheckForTargetInAssetsFile`).
- Absolutize each `PackageFolders` entry before `NuGetPackageResolver.CreateResolver`.
  Null/empty entries pass through so NuGet's existing validation fires (no new
  `ArgumentException` from `GetAbsolutePath("")`).
- Capture caller's original folder shapes and substitute them back into the
  `PackageDirectory` output metadata via the `out packageRoot` overload — keeps
  `[Output]` byte-identical to pre-migration (no Sin 1).

### Compatibility
All 6 sins reviewed; none triggered. Two intentional drifts:
- `Strings.AssetsFilePathNotRooted` is now unreachable from this caller (path is
  always rooted before the check). No tests depend on it.
- Under multithreaded MSBuild with a relative `PackageFolders`, the resolver
  previously returned `null` (CWD probe failed); now it correctly finds the
  package and the original-prefix substitution restores the caller's shape.
  This is the point of the migration.

### Tests
New: `test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs`
- `PackageDirectoryMetadata_PreservesRelativeFolderShape_WhenInputIsRelative` — Sin 1
- `EmptyPackageFolderEntry_DoesNotThrow_AndValidFallbackResolves` — Sin 6
- `AbsolutePackageFolders_ProduceAbsoluteMetadata_AndDoNotLeakProjectDirectory` — happy-path regression