### PR TITLE
Add missing DotNetBuild guard to CopyPackageToTestPackagesDir targets

### DIFF
--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
@@ -48,9 +48,11 @@
        This replaces the BuildTestPackages.targets entry that re-packed this project
        with different global properties, which caused a parallel-build race condition.
        Guard with IsCrossTargetingBuild so this runs only once in the outer build of a
-       multi-targeting project, avoiding concurrent copies per inner TFM build. -->
+       multi-targeting project, avoiding concurrent copies per inner TFM build.
+       Skip in VMR/source-build where integration tests don't run and versioning
+       properties may not be available in the outer cross-targeting evaluation. -->
   <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
-          Condition="'$(TestLayoutDir)' != '' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
+          Condition="'$(TestLayoutDir)' != '' and '$(DotNetBuild)' != 'true' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
     <PropertyGroup>
       <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
     </PropertyGroup>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -42,9 +42,11 @@
        with different global properties, which caused a parallel-build race condition
        on referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll).
        Guard with IsCrossTargetingBuild so this runs only once in the outer build of a
-       multi-targeting project, avoiding concurrent copies per inner TFM build. -->
+       multi-targeting project, avoiding concurrent copies per inner TFM build.
+       Skip in VMR/source-build where integration tests don't run and versioning
+       properties may not be available in the outer cross-targeting evaluation. -->
   <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
-          Condition="'$(TestLayoutDir)' != '' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
+          Condition="'$(TestLayoutDir)' != '' and '$(DotNetBuild)' != 'true' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
     <PropertyGroup>
       <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
     </PropertyGroup>


### PR DESCRIPTION
## Problem

PR #54380 added `CopyPackageToTestPackagesDir` targets to both `Authoring.Tasks` and `TemplateDiscovery` csproj files. A subsequent VMR-only fix (`73010df`) added the `$(DotNetBuild) != true` guard to `Authoring.Tasks`, but that fix has not flowed back to SDK main — and `TemplateDiscovery` never received the guard at all.

Without this guard, the targets run during VMR source-build where `PackageId` and `PackageVersion` resolve to empty strings in the outer cross-targeting evaluation, producing:

```
error MSB3030: Could not copy the file "...artifacts/bin/.../Release/..nupkg" because it was not found.
```

This is currently blocking [dotnet/dotnet#6762](https://github.com/dotnet/dotnet/pull/6762) (SDK codeflow to VMR).

## Fix

Add `$(DotNetBuild) != true` guard to the `CopyPackageToTestPackagesDir` target condition in **both** projects, and update XML comments to document the guard:

- `Microsoft.TemplateEngine.Authoring.Tasks.csproj` — port the guard from the VMR fix
- `Microsoft.TemplateSearch.TemplateDiscovery.csproj` — add the missing guard

cc @marcpop @dotnet/dotnet-cli