### PR TITLE
Update get-dotnetup scripts to use aka.ms download links

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -22,82 +22,13 @@ function InitializeCustomSDKToolset {
 
     # The following shared frameworks are only needed for testing.
     # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
-    # dotnetup is only built when test runtimes are needed (it's the install tool).
     if ($env:DOTNET_INSTALL_TEST_RUNTIMES -ne 'false') {
-        # Build dotnetup if not already present (needs SDK to be installed first)
-        EnsureDotnetupBuilt
-
         InstallDotNetSharedFrameworks "6.0", "7.0", "8.0", "9.0", "10.0"
     }
 
     CreateBuildEnvScripts
     CreateVSShortcut
     InstallNuget
-}
-
-function EnsureDotnetupBuilt {
-    $dotnetupExe = Join-Path $PSScriptRoot "dotnetup\dotnetup.exe"
-    $shouldBuild = !(Test-Path $dotnetupExe)
-
-    if (-not $shouldBuild) {
-        # eng\dotnetup is an ignored bootstrap artifact, so it can survive branch
-        # switches and fall behind the current checkout. Rebuild it if either:
-        # 1. the current HEAD commit is newer than the bootstrap executable, or
-        # 2. there are local uncommitted changes with newer timestamps.
-        $bootstrapWriteTime = (Get-Item $dotnetupExe).LastWriteTimeUtc
-        $latestRepoChangeTime = [DateTime]::MinValue
-
-        if (Get-Command git -ErrorAction SilentlyContinue) {
-            try {
-                $headCommitTimestamp = (& git -C $RepoRoot log -1 --format=%ct HEAD 2>$null).Trim()
-                if ($LASTEXITCODE -eq 0 -and $headCommitTimestamp -match '^\d+$') {
-                    $latestRepoChangeTime = [DateTimeOffset]::FromUnixTimeSeconds([int64]$headCommitTimestamp).UtcDateTime
-                }
-
-                $changedFiles = @()
-                $changedFiles += (& git -C $RepoRoot diff --name-only --relative HEAD 2>$null)
-                $changedFiles += (& git -C $RepoRoot ls-files --others --exclude-standard 2>$null)
-
-                foreach ($relativePath in ($changedFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique)) {
-                    $fullPath = Join-Path $RepoRoot $relativePath
-                    if (Test-Path $fullPath -PathType Leaf) {
-                        $writeTime = (Get-Item $fullPath).LastWriteTimeUtc
-                        if ($writeTime -gt $latestRepoChangeTime) {
-                            $latestRepoChangeTime = $writeTime
-                        }
-                    }
-                }
-            }
-            catch {
-                # Best-effort freshness check — if git metadata is unavailable,
-                # fall back to using the existing bootstrap binary.
-            }
-        }
-
-        $shouldBuild = $latestRepoChangeTime -gt $bootstrapWriteTime
-    }
-
-    if ($shouldBuild) {
-        Write-Host "Building dotnetup..."
-        $dotnetupProject = Join-Path $RepoRoot "src\Installer\dotnetup\dotnetup.csproj"
-        $dotnetupOutDir = Join-Path $PSScriptRoot "dotnetup"
-
-        # Determine RID based on architecture
-        $rid = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
-            "win-arm64"
-        }
-        else {
-            "win-x64"
-        }
-
-        & (Join-Path $env:DOTNET_INSTALL_DIR 'dotnet.exe') publish $dotnetupProject -c Release -r $rid -o $dotnetupOutDir
-
-        if ($lastExitCode -ne 0) {
-            throw "Failed to build dotnetup (exit code '$lastExitCode')."
-        }
-
-        Write-Host "dotnetup built successfully"
-    }
 }
 
 function InstallNuGet {
@@ -189,7 +120,11 @@ function CreateVSShortcut() {
 
 function InstallDotNetSharedFrameworks([string[]]$versions) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
-    $dotnetupExe = Join-Path $PSScriptRoot "dotnetup\dotnetup.exe"
+    $dotnetupDir = Join-Path $PSScriptRoot "dotnetup"
+    $dotnetupExe = Join-Path $dotnetupDir "dotnetup.exe"
+
+    # Acquire the latest dotnetup daily build using the in-repo install script.
+    & (Join-Path $RepoRoot "scripts\get-dotnetup.ps1") -InstallDir $dotnetupDir
 
     # Let dotnetup handle checking if versions are already installed
     & $dotnetupExe runtime install @versions --install-path $dotnetRoot --no-progress --set-default-install false --untracked --interactive false

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -120,17 +120,26 @@ function CreateVSShortcut() {
 
 function InstallDotNetSharedFrameworks([string[]]$versions) {
     $dotnetRoot = $env:DOTNET_INSTALL_DIR
+
+    # Skip if every requested framework is already on disk.
+    $versionsToInstall = @($versions | Where-Object {
+        -not (Test-Path -PathType Container `
+              (Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$_"))
+    })
+    if ($versionsToInstall.Count -eq 0) {
+        return
+    }
+
     $dotnetupDir = Join-Path $PSScriptRoot "dotnetup"
     $dotnetupExe = Join-Path $dotnetupDir "dotnetup.exe"
 
     # Acquire the latest dotnetup daily build using the in-repo install script.
     & (Join-Path $RepoRoot "scripts\get-dotnetup.ps1") -InstallDir $dotnetupDir
 
-    # Let dotnetup handle checking if versions are already installed
-    & $dotnetupExe runtime install @versions --install-path $dotnetRoot --no-progress --set-default-install false --untracked --interactive false
+    & $dotnetupExe runtime install @versionsToInstall --install-path $dotnetRoot --no-progress --set-default-install false --untracked --interactive false
 
     if ($lastExitCode -ne 0) {
-        throw "Failed to install shared frameworks ($($versions -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode')."
+        throw "Failed to install shared frameworks ($($versionsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode')."
     }
 }
 

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -55,11 +55,12 @@ function InstallDotNetSharedFrameworks {
   local dotnetup_exe="$dotnetup_dir/dotnetup"
 
   # Acquire the latest dotnetup daily build using the in-repo install script.
-  "$repo_root/scripts/get-dotnetup.sh" --install-dir "$dotnetup_dir"
-  local install_exitcode=$?
-  if [[ $install_exitcode != 0 ]]; then
-    echo "Failed to acquire dotnetup (exit code '$install_exitcode')."
-    ExitWithExitCode $install_exitcode
+  # build.sh runs under `set -e`, so we have to invoke the script in a way that
+  # doesn't trigger errexit; otherwise the script's non-zero exit aborts the
+  # whole build before our diagnostic error message can fire.
+  if ! "$repo_root/scripts/get-dotnetup.sh" --install-dir "$dotnetup_dir"; then
+    echo "Failed to acquire dotnetup."
+    ExitWithExitCode 1
   fi
 
   "$dotnetup_exe" runtime install "${versions_to_install[@]}" --install-path "$dotnet_root" --no-progress --set-default-install false --untracked --interactive false

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -27,104 +27,11 @@ function InitializeCustomSDKToolset {
 
   # The following shared frameworks are only needed for testing.
   # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
-  # dotnetup is only built when test runtimes are needed (it's the install tool).
   if [[ "${DOTNET_INSTALL_TEST_RUNTIMES:-true}" != "false" ]]; then
-    # Build dotnetup if not already present (needs SDK to be installed first)
-    EnsureDotnetupBuilt
     InstallDotNetSharedFrameworks "6.0.0" "7.0.0" "8.0.0" "9.0.0" "10.0.0"
   fi
 
   CreateBuildEnvScript
-}
-
-# Gets a file's last-modified time as a Unix timestamp.
-function GetFileTimestamp {
-  local path="$1"
-  if [[ "$(uname)" == "Darwin" ]]; then
-    stat -f "%m" "$path"
-  else
-    stat -c "%Y" "$path"
-  fi
-}
-
-# Builds dotnetup if the executable is missing or stale
-function EnsureDotnetupBuilt {
-  local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local dotnetup_dir="$script_dir/dotnetup"
-  local dotnetup_exe="$dotnetup_dir/dotnetup"
-  local should_build=false
-
-  if [[ ! -f "$dotnetup_exe" ]]; then
-    should_build=true
-  else
-    # eng/dotnetup is an ignored bootstrap artifact, so it can survive branch
-    # switches and fall behind the current checkout. Rebuild it if either:
-    # 1. the current HEAD commit is newer than the bootstrap executable, or
-    # 2. there are local uncommitted changes with newer timestamps.
-    local bootstrap_ts
-    bootstrap_ts=$(GetFileTimestamp "$dotnetup_exe")
-    local latest_repo_change_ts=0
-
-    if command -v git &> /dev/null && git -C "$repo_root" rev-parse --is-inside-work-tree &> /dev/null; then
-      local head_commit_ts
-      head_commit_ts=$(git -C "$repo_root" log -1 --format=%ct HEAD 2>/dev/null || echo 0)
-      if [[ "$head_commit_ts" =~ ^[0-9]+$ ]]; then
-        latest_repo_change_ts=$head_commit_ts
-      fi
-
-      while IFS= read -r relative_path; do
-        [[ -z "$relative_path" ]] && continue
-        local full_path="$repo_root/$relative_path"
-        if [[ -f "$full_path" ]]; then
-          local file_ts
-          file_ts=$(GetFileTimestamp "$full_path")
-          if (( file_ts > latest_repo_change_ts )); then
-            latest_repo_change_ts=$file_ts
-          fi
-        fi
-      done < <(
-        {
-          git -C "$repo_root" diff --name-only --relative HEAD 2>/dev/null
-          git -C "$repo_root" ls-files --others --exclude-standard 2>/dev/null
-        } | sort -u
-      )
-    fi
-
-    if (( latest_repo_change_ts > bootstrap_ts )); then
-      should_build=true
-    fi
-  fi
-
-  if [[ "$should_build" == true ]]; then
-    echo "Building dotnetup..."
-    local dotnetup_project="$repo_root/src/Installer/dotnetup/dotnetup.csproj"
-    mkdir -p "$dotnetup_dir"
-
-    # Determine RID based on OS
-    local rid
-    if [[ "$(uname)" == "Darwin" ]]; then
-      if [[ "$(uname -m)" == "arm64" ]]; then
-        rid="osx-arm64"
-      else
-        rid="osx-x64"
-      fi
-    else
-      if [[ "$(uname -m)" == "aarch64" ]]; then
-        rid="linux-arm64"
-      else
-        rid="linux-x64"
-      fi
-    fi
-
-    "$DOTNET_INSTALL_DIR/dotnet" publish "$dotnetup_project" -c Release -r "$rid" -o "$dotnetup_dir"
-
-    if [[ $? -ne 0 ]]; then
-      echo "Failed to build dotnetup."
-      ExitWithExitCode 1
-    fi
-
-    echo "dotnetup built successfully"
-  fi
 }
 
 # Installs additional shared frameworks for testing purposes (batched, concurrent)
@@ -144,7 +51,16 @@ function InstallDotNetSharedFrameworks {
   fi
 
   local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  local dotnetup_exe="$script_dir/dotnetup/dotnetup"
+  local dotnetup_dir="$script_dir/dotnetup"
+  local dotnetup_exe="$dotnetup_dir/dotnetup"
+
+  # Acquire the latest dotnetup daily build using the in-repo install script.
+  "$repo_root/scripts/get-dotnetup.sh" --install-dir "$dotnetup_dir"
+  local install_exitcode=$?
+  if [[ $install_exitcode != 0 ]]; then
+    echo "Failed to acquire dotnetup (exit code '$install_exitcode')."
+    ExitWithExitCode $install_exitcode
+  fi
 
   "$dotnetup_exe" runtime install "${versions_to_install[@]}" --install-path "$dotnet_root" --no-progress --set-default-install false --untracked --interactive false
   local lastexitcode=$?

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -1,48 +1,42 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Downloads the latest dotnetup binary from the dotnetup CI pipeline and installs it locally.
+    Downloads the latest dotnetup daily build and installs it locally.
 
 .DESCRIPTION
-    Uses the Azure CLI (az) to query the dotnetup CI pipeline in dnceng/internal,
-    download the platform-appropriate artifact, and install it to a local directory.
+    Downloads dotnetup from the public aka.ms shortlinks (e.g.
+    https://aka.ms/dotnet/dotnetup/daily/dotnetup-win-x64.exe), verifies the
+    SHA-512 checksum, and installs the binary to a local directory.
 
-    You must have the Azure CLI installed with the azure-devops extension, and be
-    logged in with 'az login' with access to the dnceng/internal project.
+    No Azure DevOps credentials are required.
 
 .PARAMETER InstallDir
     Directory to install dotnetup into. Defaults to ~/.dotnetup.
 
-.PARAMETER Branch
-    The branch to get the latest build from. Defaults to 'release/dnup'.
+.PARAMETER Quality
+    Build quality to install. Defaults to 'daily'.
 
 .PARAMETER RuntimeId
     Override automatic OS/architecture detection with an explicit RID
     (e.g. win-x64, linux-arm64, osx-arm64, linux-musl-x64).
 
 .EXAMPLE
-    # Ensure you're logged in, then run:
-    az login
     ./get-dotnetup.ps1
 
 .EXAMPLE
-    # Override RID and install directory:
     ./get-dotnetup.ps1 -RuntimeId linux-musl-x64 -InstallDir /opt/dotnetup
 #>
 [CmdletBinding()]
 param(
     [string]$InstallDir = (Join-Path $HOME ".dotnetup"),
-    [string]$Branch = "release/dnup",
+    [string]$Quality = "daily",
     [string]$RuntimeId
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-
-$AzdoOrg = "https://dev.azure.com/dnceng"
-$AzdoProject = "internal"
-$PipelineId = 1544
+$BaseUrl = "https://aka.ms/dotnet/dotnetup/$Quality"
 
 function Get-RuntimeId {
     if ($RuntimeId) {
@@ -112,103 +106,59 @@ Then re-run this script with 'pwsh' instead of 'powershell'.
 "@
 }
 
-# Check for Azure CLI
-if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
-    throw @"
-Azure CLI (az) is required but was not found on PATH.
-Install it from: https://aka.ms/install-az-cli
-
-After installing, log in with:
-    az login
-"@
-}
-
-# Check for the azure-devops extension
-$extList = az extension show --name azure-devops 2>&1
-if ($LASTEXITCODE -ne 0) {
-    throw @"
-The 'azure-devops' Azure CLI extension is required but is not installed.
-Install it with:
-    az extension add --name azure-devops
-"@
-}
-
 $rid = Get-RuntimeId
 Write-Host "Detected runtime: $rid" -ForegroundColor Cyan
 
-# Get latest successful build for the specified branch
-Write-Host "Querying for latest successful build on $Branch..." -ForegroundColor Cyan
-
-$runsJson = az pipelines runs list `
-    --pipeline-ids $PipelineId `
-    --branch $Branch `
-    --status completed `
-    --query-order FinishTimeDesc `
-    --top 10 `
-    --org $AzdoOrg `
-    --project $AzdoProject `
-    --query "[?result=='succeeded' || result=='partiallySucceeded'] | [0].id" `
-    --output tsv
-
-if ($LASTEXITCODE -ne 0) {
-    throw @"
-Failed to query pipeline runs. Ensure you are logged in and have access to dnceng/internal:
-
-    az login
-    az devops configure --defaults organization=$AzdoOrg project=$AzdoProject
-
-Error: $runsJson
-"@
-}
-
-$runId = ($runsJson | Out-String).Trim()
-if (-not $runId) {
-    throw "No successful builds found for pipeline $PipelineId on branch $Branch."
-}
-
-$buildUrl = "$AzdoOrg/$AzdoProject/_build/results?buildId=$runId"
-Write-Host "Found build $runId" -ForegroundColor Green
-Write-Host "  $buildUrl" -ForegroundColor DarkGray
-
-# Download the artifact
-$artifactName = "dotnetup-standalone-$rid"
-Write-Host "Downloading artifact '$artifactName'..." -ForegroundColor Cyan
+$binaryName = if ($rid -like "win-*") { "dotnetup.exe" } else { "dotnetup" }
+$fileName = if ($rid -like "win-*") { "dotnetup-$rid.exe" } else { "dotnetup-$rid" }
+$downloadUrl = "$BaseUrl/$fileName"
+$checksumUrl = "$downloadUrl.sha512"
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "dotnetup-install-$([System.IO.Path]::GetRandomFileName())"
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
 try {
-    az pipelines runs artifact download `
-        --artifact-name $artifactName `
-        --path $tempDir `
-        --run-id $runId `
-        --org $AzdoOrg `
-        --project $AzdoProject 2>&1
+    $tempBinary = Join-Path $tempDir $fileName
 
-    if ($LASTEXITCODE -ne 0) {
+    Write-Host "Downloading $downloadUrl" -ForegroundColor Cyan
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempBinary -UseBasicParsing
+    }
+    catch {
         throw @"
-Failed to download artifact '$artifactName' for run $runId.
+Failed to download dotnetup from $downloadUrl
 Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64
-Use -RuntimeId to specify the correct RID.
+Use -RuntimeId to specify the correct RID, or -Quality to select a different build quality.
+
+Error: $($_.Exception.Message)
 "@
     }
 
-    # Find the binary in the downloaded contents
-    $binaryName = if ($rid -like "win-*") { "dotnetup.exe" } else { "dotnetup" }
-    $foundBinary = Get-ChildItem -Path $tempDir -Recurse -Filter $binaryName | Select-Object -First 1
-    if (-not $foundBinary) {
-        throw "Could not find '$binaryName' in the downloaded artifact. Contents: $(Get-ChildItem -Path $tempDir -Recurse | Select-Object -ExpandProperty FullName)"
+    Write-Host "Verifying SHA-512 checksum..." -ForegroundColor Cyan
+    $tempChecksum = Join-Path $tempDir "$fileName.sha512"
+    try {
+        Invoke-WebRequest -Uri $checksumUrl -OutFile $tempChecksum -UseBasicParsing
+    }
+    catch {
+        throw "Failed to download checksum from $checksumUrl.`nError: $($_.Exception.Message)"
     }
 
-    # Install just the binary
+    $expected = ((Get-Content $tempChecksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+    $actual = (Get-FileHash -Path $tempBinary -Algorithm SHA512).Hash.ToLowerInvariant()
+    if ($expected -ne $actual) {
+        throw "Checksum mismatch.`n  Expected: $expected`n  Actual:   $actual"
+    }
+    Write-Host "Checksum verified." -ForegroundColor Green
+
+    # Install just the binary (renamed to plain dotnetup[.exe])
     Write-Host "Installing to $InstallDir..." -ForegroundColor Cyan
     if (-not (Test-Path $InstallDir)) {
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
     }
 
-    Copy-Item -Path $foundBinary.FullName -Destination $InstallDir -Force
-
-    # Verify the binary is present
     $installedBinary = Join-Path $InstallDir $binaryName
+    Copy-Item -Path $tempBinary -Destination $installedBinary -Force
+
     if (-not (Test-Path $installedBinary)) {
         throw "Installation failed: '$installedBinary' not found after copy."
     }

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -113,9 +113,31 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
     $tempBinary = Join-Path $tempDir $fileName
 
+    function Invoke-WithRetry {
+        param([scriptblock]$ScriptBlock, [string]$ActionDescription, [int]$MaxAttempts = 3)
+        $attempt = 1
+        while ($true) {
+            try {
+                & $ScriptBlock
+                return
+            }
+            catch {
+                if ($attempt -ge $MaxAttempts) {
+                    throw "${ActionDescription} failed after $MaxAttempts attempts.`nError: $($_.Exception.Message)"
+                }
+                $delay = [Math]::Pow(2, $attempt)
+                Write-Host "${ActionDescription} failed (attempt $attempt of $MaxAttempts): $($_.Exception.Message). Retrying in $delay seconds..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $delay
+                $attempt++
+            }
+        }
+    }
+
     Write-Host "Downloading $downloadUrl" -ForegroundColor Cyan
     try {
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempBinary -UseBasicParsing
+        Invoke-WithRetry -ActionDescription "Download from $downloadUrl" -ScriptBlock {
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $tempBinary -UseBasicParsing
+        }
     }
     catch {
         throw @"
@@ -129,11 +151,8 @@ Error: $($_.Exception.Message)
 
     Write-Host "Verifying SHA-512 checksum..." -ForegroundColor Cyan
     $tempChecksum = Join-Path $tempDir "$fileName.sha512"
-    try {
+    Invoke-WithRetry -ActionDescription "Download checksum from $checksumUrl" -ScriptBlock {
         Invoke-WebRequest -Uri $checksumUrl -OutFile $tempChecksum -UseBasicParsing
-    }
-    catch {
-        throw "Failed to download checksum from $checksumUrl.`nError: $($_.Exception.Message)"
     }
 
     $expected = ((Get-Content $tempChecksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -8,8 +8,6 @@
     https://aka.ms/dotnet/dotnetup/daily/dotnetup-win-x64.exe), verifies the
     SHA-512 checksum, and installs the binary to a local directory.
 
-    No Azure DevOps credentials are required.
-
 .PARAMETER InstallDir
     Directory to install dotnetup into. Defaults to ~/.dotnetup.
 
@@ -43,14 +41,20 @@ function Get-RuntimeId {
         return $RuntimeId
     }
 
+    # Use RuntimeInformation so this works on both Windows PowerShell 5.1
+    # and PowerShell Core ($IsWindows/$IsMacOS/$IsLinux only exist on Core).
+
     # Detect OS
-    if ($IsWindows -or ($env:OS -eq "Windows_NT")) {
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::Windows)) {
         $os = "win"
     }
-    elseif ($IsMacOS) {
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::OSX)) {
         $os = "osx"
     }
-    elseif ($IsLinux) {
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::Linux)) {
         $os = "linux"
 
         # Detect musl vs glibc
@@ -94,17 +98,6 @@ function Get-RuntimeId {
 }
 
 # --- Main ---
-
-# Windows PowerShell (5.x) is not supported; require PowerShell 6+ (pwsh).
-# The 'PSEdition' property is only present on 5+, so usage on 4 and below will be null,
-# so we check that the version isn't Core instead of "version is Desktop"
-if ($PSVersionTable.PSEdition -ne "Core") {
-    throw @"
-This script requires PowerShell Core (pwsh) and cannot run on Windows PowerShell 5.x.
-Install PowerShell Core from: https://aka.ms/install-powershell
-Then re-run this script with 'pwsh' instead of 'powershell'.
-"@
-}
 
 $rid = Get-RuntimeId
 Write-Host "Detected runtime: $rid" -ForegroundColor Cyan

--- a/scripts/get-dotnetup.sh
+++ b/scripts/get-dotnetup.sh
@@ -1,26 +1,24 @@
 #!/usr/bin/env bash
 # get-dotnetup.sh
 #
-# Downloads the latest dotnetup binary from the dotnetup CI pipeline and installs it locally.
+# Downloads the latest dotnetup daily build and installs it locally.
 #
-# Uses the Azure CLI (az) with the azure-devops extension for all Azure DevOps interactions.
-# You must be logged in with 'az login' and have access to the dnceng/internal project.
+# Downloads dotnetup from the public aka.ms shortlinks (e.g.
+# https://aka.ms/dotnet/dotnetup/daily/dotnetup-linux-x64), verifies the
+# SHA-512 checksum, and installs the binary to a local directory.
 #
 # Usage:
 #   ./get-dotnetup.sh
 #   ./get-dotnetup.sh --install-dir /opt/dotnetup
 #   ./get-dotnetup.sh --runtime-id linux-musl-x64
-#   ./get-dotnetup.sh --branch release/dnup
+#   ./get-dotnetup.sh --quality daily
 
 set -euo pipefail
 
 # --- Defaults ---
 INSTALL_DIR="$HOME/.dotnetup"
-BRANCH="release/dnup"
+QUALITY="daily"
 RUNTIME_ID=""
-AZDO_ORG="https://dev.azure.com/dnceng"
-AZDO_PROJECT="internal"
-PIPELINE_ID=1544
 
 # --- Colors (disabled if not a terminal) ---
 if [ -t 1 ]; then
@@ -44,30 +42,24 @@ gray()  { printf "${GRAY}%s${NC}\n" "$*"; }
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --install-dir)  INSTALL_DIR="$2"; shift 2 ;;
-        --branch)       BRANCH="$2"; shift 2 ;;
+        --quality)      QUALITY="$2"; shift 2 ;;
         --runtime-id)   RUNTIME_ID="$2"; shift 2 ;;
         --help|-h)
             cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Downloads the latest dotnetup binary from CI and installs it locally.
-Requires the Azure CLI (az) with the azure-devops extension for authentication
-and artifact download. Log in with 'az login' first.
+Downloads the latest dotnetup daily build from aka.ms and installs it locally.
 
 Options:
   --install-dir DIR     Installation directory (default: ~/.dotnetup)
-  --branch BRANCH       Branch to get the latest build from (default: release/dnup)
+  --quality QUALITY     Build quality (default: daily)
   --runtime-id RID      Override OS/architecture detection (e.g. linux-musl-x64, osx-arm64)
   --help, -h            Show this help message
 
-Prerequisites:
-  Azure CLI (az)        https://aka.ms/install-az-cli
-  azure-devops ext      az extension add --name azure-devops
-
 Examples:
-  az login
   ./get-dotnetup.sh
   ./get-dotnetup.sh --runtime-id linux-musl-x64
+  ./get-dotnetup.sh --install-dir /opt/dotnetup
 EOF
             exit 0
             ;;
@@ -79,83 +71,28 @@ EOF
     esac
 done
 
+BASE_URL="https://aka.ms/dotnet/dotnetup/${QUALITY}"
+
 # --- Check prerequisites ---
-if ! command -v az &>/dev/null; then
-    err "Azure CLI (az) is required but was not found on PATH."
-    err "Install it from: https://aka.ms/install-az-cli"
-    err ""
-    err "After installing, log in with:"
-    err "  az login"
+if command -v curl &>/dev/null; then
+    DOWNLOADER="curl"
+elif command -v wget &>/dev/null; then
+    DOWNLOADER="wget"
+else
+    err "Neither 'curl' nor 'wget' was found on PATH. One of them is required to download dotnetup."
     exit 1
 fi
 
-# Detect Windows az.cmd/az.bat/az.exe being invoked from WSL via inherited PATH.
-# The Windows Azure CLI emits CRLF line endings and Windows-style paths, which
-# corrupts captured output (e.g. trailing \r on RUN_ID) and breaks artifact
-# downloads (paths with backslash separators). Reject early with a clear error.
-AZ_PATH="$(command -v az)"
-case "$AZ_PATH" in
-    *.cmd|*.bat|*.exe)
-        err "Detected Windows Azure CLI at: $AZ_PATH"
-        err ""
-        err "This script must be run with the native Linux Azure CLI."
-        err "On WSL, install it inside your distribution with:"
-        err "  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash"
-        err ""
-        err "Then log in with:"
-        err "  az login"
-        exit 1
-        ;;
-esac
-
-if ! az extension show --name azure-devops &>/dev/null; then
-    err "The 'azure-devops' Azure CLI extension is required but is not installed."
-    err "Install it with:"
-    err "  az extension add --name azure-devops"
-    exit 1
-fi
-
-# --- Detect runtime ID ---
-detect_rid() {
-    if [ -n "$RUNTIME_ID" ]; then
-        echo "$RUNTIME_ID"
-        return
+download() {
+    local url="$1" out="$2"
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl --fail --silent --show-error --location --retry 3 --output "$out" "$url"
+    else
+        wget --quiet --tries=3 --output-document="$out" "$url"
     fi
-
-    local os arch
-
-    # Detect OS
-    case "$(uname -s)" in
-        Linux)
-            # Detect musl vs glibc
-            if is_musl; then
-                os="linux-musl"
-            else
-                os="linux"
-            fi
-            ;;
-        Darwin)
-            os="osx"
-            ;;
-        *)
-            err "Unsupported OS: $(uname -s). Use --runtime-id to specify a RID manually."
-            exit 1
-            ;;
-    esac
-
-    # Detect architecture
-    case "$(uname -m)" in
-        x86_64|amd64)   arch="x64" ;;
-        aarch64|arm64)   arch="arm64" ;;
-        *)
-            err "Unsupported architecture: $(uname -m). Use --runtime-id to specify a RID manually."
-            exit 1
-            ;;
-    esac
-
-    echo "${os}-${arch}"
 }
 
+# --- Detect runtime ID ---
 is_musl() {
     # Layer 1: Check if getconf reports glibc
     if getconf GNU_LIBC_VERSION &>/dev/null; then
@@ -176,44 +113,53 @@ is_musl() {
     return 1
 }
 
+detect_rid() {
+    if [ -n "$RUNTIME_ID" ]; then
+        echo "$RUNTIME_ID"
+        return
+    fi
+
+    local os arch
+
+    # Detect OS
+    case "$(uname -s)" in
+        Linux)
+            if is_musl; then
+                os="linux-musl"
+            else
+                os="linux"
+            fi
+            ;;
+        Darwin)
+            os="osx"
+            ;;
+        *)
+            err "Unsupported OS: $(uname -s). Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    # Detect architecture
+    case "$(uname -m)" in
+        x86_64|amd64)    arch="x64" ;;
+        aarch64|arm64)   arch="arm64" ;;
+        *)
+            err "Unsupported architecture: $(uname -m). Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
 # --- Main ---
 
 RID=$(detect_rid)
 info "Detected runtime: $RID"
 
-# Get latest successful build for the specified branch
-info "Querying for latest successful build on $BRANCH..."
-
-RUN_ID=$(az pipelines runs list \
-    --pipeline-ids "$PIPELINE_ID" \
-    --branch "$BRANCH" \
-    --status completed \
-    --query-order FinishTimeDesc \
-    --top 10 \
-    --org "$AZDO_ORG" \
-    --project "$AZDO_PROJECT" \
-    --query "[?result=='succeeded' || result=='partiallySucceeded'] | [0].id" \
-    --output tsv) || {
-    err "Failed to query pipeline runs. Ensure you are logged in and have access to dnceng/internal:"
-    err ""
-    err "  az login"
-    err "  az extension add --name azure-devops   # if not already installed"
-    err ""
-    err "Error: $RUN_ID"
-    exit 1
-}
-
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "None" ]; then
-    err "No successful builds found for pipeline $PIPELINE_ID on branch $BRANCH."
-    exit 1
-fi
-
-ok "Found build $RUN_ID"
-gray "  ${AZDO_ORG}/${AZDO_PROJECT}/_build/results?buildId=${RUN_ID}"
-
-# Download the artifact
-ARTIFACT_NAME="dotnetup-standalone-${RID}"
-info "Downloading artifact '$ARTIFACT_NAME'..."
+FILE_NAME="dotnetup-${RID}"
+DOWNLOAD_URL="${BASE_URL}/${FILE_NAME}"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha512"
 
 TEMP_DIR=$(mktemp -d)
 
@@ -222,36 +168,47 @@ cleanup() {
 }
 trap cleanup EXIT
 
-az pipelines runs artifact download \
-    --artifact-name "$ARTIFACT_NAME" \
-    --path "$TEMP_DIR" \
-    --run-id "$RUN_ID" \
-    --org "$AZDO_ORG" \
-    --project "$AZDO_PROJECT" 2>&1 || {
-    err "Failed to download artifact '$ARTIFACT_NAME' for run $RUN_ID."
-    err "Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64"
-    err "Use --runtime-id to specify the correct RID."
-    exit 1
-}
+TEMP_BINARY="${TEMP_DIR}/${FILE_NAME}"
 
-# Find the binary in the downloaded contents
-BINARY_PATH=$(find "$TEMP_DIR" -name "dotnetup" -type f | head -1)
-if [ -z "$BINARY_PATH" ]; then
-    err "Could not find 'dotnetup' binary in the downloaded artifact."
-    err "Contents:"
-    find "$TEMP_DIR" -type f | sed 's/^/  /' >&2
+info "Downloading ${DOWNLOAD_URL}"
+if ! download "$DOWNLOAD_URL" "$TEMP_BINARY"; then
+    err "Failed to download dotnetup from $DOWNLOAD_URL"
+    err "Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64"
+    err "Use --runtime-id to specify the correct RID, or --quality to select a different build quality."
     exit 1
 fi
 
-# Install just the binary
+info "Verifying SHA-512 checksum..."
+TEMP_CHECKSUM="${TEMP_DIR}/${FILE_NAME}.sha512"
+if ! download "$CHECKSUM_URL" "$TEMP_CHECKSUM"; then
+    err "Failed to download checksum from $CHECKSUM_URL"
+    exit 1
+fi
+
+EXPECTED=$(awk '{print tolower($1)}' "$TEMP_CHECKSUM")
+if command -v sha512sum &>/dev/null; then
+    ACTUAL=$(sha512sum "$TEMP_BINARY" | awk '{print tolower($1)}')
+elif command -v shasum &>/dev/null; then
+    ACTUAL=$(shasum -a 512 "$TEMP_BINARY" | awk '{print tolower($1)}')
+else
+    err "Neither 'sha512sum' nor 'shasum' was found on PATH."
+    exit 1
+fi
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+    err "Checksum mismatch."
+    err "  Expected: $EXPECTED"
+    err "  Actual:   $ACTUAL"
+    exit 1
+fi
+ok "Checksum verified."
+
+# Install the binary (renamed to plain 'dotnetup')
 info "Installing to $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR"
-cp "$BINARY_PATH" "$INSTALL_DIR/dotnetup"
-
-# Ensure the binary is executable
+cp "$TEMP_BINARY" "$INSTALL_DIR/dotnetup"
 chmod +x "$INSTALL_DIR/dotnetup"
 
-# Verify
 if [ ! -x "$INSTALL_DIR/dotnetup" ]; then
     err "Installation failed: '$INSTALL_DIR/dotnetup' not found or not executable after copy."
     exit 1


### PR DESCRIPTION
- Update get-dotnetup scripts to use new aka.ms download links for dotnetup.  This means that Azure DevOps credentials and the az CLI are no longer required.
- Also updates get-dotnetup.ps1 script to work with PowerShell 5.1 (so you don't have to have pwsh installed).
- Use those scripts to download a prebuilt version of dotnetup to install the previous runtimes in restore-toolset.  This means we don't have to build dotnetup as part of the initialization anymore.  It means we're using an older previously-built version of dotnetup to install the runtimes instead of building from the code in the repo, but we have tests covering the live code in the repo so we don't lose much in terms of coverage.