### PR TITLE
Preserve "notnull" and "allows ref struct" constraints in GenAPI

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Transactions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -37,7 +36,8 @@ namespace Microsoft.DotNet.GenAPI
                         }
                         return typeDeclaration
                             .WithBaseList(syntaxGenerator.GetBaseTypeList(type, symbolFilter))
-                            .WithMembers(new SyntaxList<MemberDeclarationSyntax>());
+                            .WithMembers(new SyntaxList<MemberDeclarationSyntax>())
+                            .AddNotNullConstraints(type.TypeParameters);
 
                     case TypeKind.Enum:
                         EnumDeclarationSyntax enumDeclaration = (EnumDeclarationSyntax)syntaxGenerator.Declaration(symbol);
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.GenAPI
 
             try
             {
-                return syntaxGenerator.Declaration(symbol);
+                return syntaxGenerator.Declaration(symbol).AddNotNullConstraints(symbol);
             }
             catch (ArgumentException ex)
             {
@@ -139,5 +139,73 @@ namespace Microsoft.DotNet.GenAPI
                 SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(baseTypes)) :
                 null;
         }
+
+        private static SyntaxNode AddNotNullConstraints(this SyntaxNode declaration, ISymbol symbol) =>
+            symbol switch
+            {
+                INamedTypeSymbol namedType => declaration.AddNotNullConstraints(namedType.TypeParameters),
+                IMethodSymbol method when !method.IsOverride && method.ExplicitInterfaceImplementations.IsEmpty =>
+                    declaration.AddNotNullConstraints(method.TypeParameters),
+                _ => declaration
+            };
+
+        private static SyntaxNode AddNotNullConstraints(this SyntaxNode declaration, IEnumerable<ITypeParameterSymbol> typeParameters)
+        {
+            ITypeParameterSymbol[] notNullTypeParameters = typeParameters
+                .Where(typeParameter => typeParameter.HasNotNullConstraint)
+                .ToArray();
+
+            if (notNullTypeParameters.Length == 0)
+            {
+                return declaration;
+            }
+
+            return declaration switch
+            {
+                TypeDeclarationSyntax typeDeclaration => typeDeclaration.WithConstraintClauses(
+                    AddNotNullConstraintClauses(typeDeclaration.ConstraintClauses, notNullTypeParameters)),
+                DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.WithConstraintClauses(
+                    AddNotNullConstraintClauses(delegateDeclaration.ConstraintClauses, notNullTypeParameters)),
+                MethodDeclarationSyntax methodDeclaration => methodDeclaration.WithConstraintClauses(
+                    AddNotNullConstraintClauses(methodDeclaration.ConstraintClauses, notNullTypeParameters)),
+                _ => declaration
+            };
+        }
+
+        private static SyntaxList<TypeParameterConstraintClauseSyntax> AddNotNullConstraintClauses(
+            SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
+            IEnumerable<ITypeParameterSymbol> typeParameters)
+        {
+            foreach (ITypeParameterSymbol typeParameter in typeParameters)
+            {
+                TypeParameterConstraintClauseSyntax? constraintClause = constraintClauses
+                    .FirstOrDefault(clause => clause.Name.Identifier.ValueText == typeParameter.Name);
+
+                if (constraintClause is null)
+                {
+                    constraintClauses = constraintClauses.Add(CreateNotNullConstraintClause(typeParameter.Name));
+                }
+                else if (!constraintClause.Constraints.Any(IsNotNullConstraint))
+                {
+                    TypeParameterConstraintClauseSyntax updatedConstraintClause = constraintClause.WithConstraints(
+                        constraintClause.Constraints.Insert(0, CreateNotNullConstraint()));
+                    constraintClauses = constraintClauses.Replace(constraintClause, updatedConstraintClause);
+                }
+            }
+
+            return constraintClauses;
+        }
+
+        private static TypeParameterConstraintClauseSyntax CreateNotNullConstraintClause(string typeParameterName) =>
+            SyntaxFactory.TypeParameterConstraintClause(SyntaxFactory.IdentifierName(typeParameterName))
+                .WithConstraints(SyntaxFactory.SingletonSeparatedList(CreateNotNullConstraint()));
+
+        private static TypeParameterConstraintSyntax CreateNotNullConstraint() =>
+            SyntaxFactory.TypeConstraint(SyntaxFactory.IdentifierName("notnull"));
+
+        private static bool IsNotNullConstraint(TypeParameterConstraintSyntax constraint) =>
+            constraint is TypeConstraintSyntax typeConstraint &&
+            typeConstraint.Type is IdentifierNameSyntax identifierName &&
+            identifierName.Identifier.ValueText == "notnull";
     }
 }

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.GenAPI
                         return typeDeclaration
                             .WithBaseList(syntaxGenerator.GetBaseTypeList(type, symbolFilter))
                             .WithMembers(new SyntaxList<MemberDeclarationSyntax>())
-                            .AddNotNullConstraints(type.TypeParameters);
+                            .AddMissingSpecialConstraints(type.TypeParameters);
 
                     case TypeKind.Enum:
                         EnumDeclarationSyntax enumDeclaration = (EnumDeclarationSyntax)syntaxGenerator.Declaration(symbol);
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.GenAPI
 
             try
             {
-                return syntaxGenerator.Declaration(symbol).AddNotNullConstraints(symbol);
+                return syntaxGenerator.Declaration(symbol).AddMissingSpecialConstraints(symbol);
             }
             catch (ArgumentException ex)
             {
@@ -140,22 +140,22 @@ namespace Microsoft.DotNet.GenAPI
                 null;
         }
 
-        private static SyntaxNode AddNotNullConstraints(this SyntaxNode declaration, ISymbol symbol) =>
+        private static SyntaxNode AddMissingSpecialConstraints(this SyntaxNode declaration, ISymbol symbol) =>
             symbol switch
             {
-                INamedTypeSymbol namedType => declaration.AddNotNullConstraints(namedType.TypeParameters),
+                INamedTypeSymbol namedType => declaration.AddMissingSpecialConstraints(namedType.TypeParameters),
                 IMethodSymbol method when !method.IsOverride && method.ExplicitInterfaceImplementations.IsEmpty =>
-                    declaration.AddNotNullConstraints(method.TypeParameters),
+                    declaration.AddMissingSpecialConstraints(method.TypeParameters),
                 _ => declaration
             };
 
-        private static SyntaxNode AddNotNullConstraints(this SyntaxNode declaration, IEnumerable<ITypeParameterSymbol> typeParameters)
+        private static SyntaxNode AddMissingSpecialConstraints(this SyntaxNode declaration, IEnumerable<ITypeParameterSymbol> typeParameters)
         {
-            ITypeParameterSymbol[] notNullTypeParameters = typeParameters
-                .Where(typeParameter => typeParameter.HasNotNullConstraint)
+            ITypeParameterSymbol[] typeParametersWithMissingConstraints = typeParameters
+                .Where(typeParameter => typeParameter.HasNotNullConstraint || typeParameter.AllowsRefLikeType)
                 .ToArray();
 
-            if (notNullTypeParameters.Length == 0)
+            if (typeParametersWithMissingConstraints.Length == 0)
             {
                 return declaration;
             }
@@ -163,16 +163,16 @@ namespace Microsoft.DotNet.GenAPI
             return declaration switch
             {
                 TypeDeclarationSyntax typeDeclaration => typeDeclaration.WithConstraintClauses(
-                    AddNotNullConstraintClauses(typeDeclaration.ConstraintClauses, notNullTypeParameters)),
+                    AddMissingSpecialConstraintClauses(typeDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
                 DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.WithConstraintClauses(
-                    AddNotNullConstraintClauses(delegateDeclaration.ConstraintClauses, notNullTypeParameters)),
+                    AddMissingSpecialConstraintClauses(delegateDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
                 MethodDeclarationSyntax methodDeclaration => methodDeclaration.WithConstraintClauses(
-                    AddNotNullConstraintClauses(methodDeclaration.ConstraintClauses, notNullTypeParameters)),
+                    AddMissingSpecialConstraintClauses(methodDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
                 _ => declaration
             };
         }
 
-        private static SyntaxList<TypeParameterConstraintClauseSyntax> AddNotNullConstraintClauses(
+        private static SyntaxList<TypeParameterConstraintClauseSyntax> AddMissingSpecialConstraintClauses(
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
             IEnumerable<ITypeParameterSymbol> typeParameters)
         {
@@ -183,29 +183,62 @@ namespace Microsoft.DotNet.GenAPI
 
                 if (constraintClause is null)
                 {
-                    constraintClauses = constraintClauses.Add(CreateNotNullConstraintClause(typeParameter.Name));
+                    constraintClauses = constraintClauses.Add(CreateConstraintClause(typeParameter));
+                    continue;
                 }
-                else if (!constraintClause.Constraints.Any(IsNotNullConstraint))
+
+                SeparatedSyntaxList<TypeParameterConstraintSyntax> constraints = constraintClause.Constraints;
+
+                if (typeParameter.HasNotNullConstraint && !constraints.Any(IsNotNullConstraint))
                 {
-                    TypeParameterConstraintClauseSyntax updatedConstraintClause = constraintClause.WithConstraints(
-                        constraintClause.Constraints.Insert(0, CreateNotNullConstraint()));
-                    constraintClauses = constraintClauses.Replace(constraintClause, updatedConstraintClause);
+                    constraints = constraints.Insert(0, CreateNotNullConstraint());
                 }
+
+                if (typeParameter.AllowsRefLikeType && !constraints.Any(IsAllowsRefStructConstraint))
+                {
+                    constraints = constraints.Add(CreateAllowsRefStructConstraint());
+                }
+
+                TypeParameterConstraintClauseSyntax updatedConstraintClause = constraintClause.WithConstraints(constraints);
+                constraintClauses = constraintClauses.Replace(constraintClause, updatedConstraintClause);
             }
 
             return constraintClauses;
         }
 
-        private static TypeParameterConstraintClauseSyntax CreateNotNullConstraintClause(string typeParameterName) =>
-            SyntaxFactory.TypeParameterConstraintClause(SyntaxFactory.IdentifierName(typeParameterName))
-                .WithConstraints(SyntaxFactory.SingletonSeparatedList(CreateNotNullConstraint()));
+        private static TypeParameterConstraintClauseSyntax CreateConstraintClause(ITypeParameterSymbol typeParameter)
+        {
+            SeparatedSyntaxList<TypeParameterConstraintSyntax> constraints = default;
+
+            if (typeParameter.HasNotNullConstraint)
+            {
+                constraints = constraints.Add(CreateNotNullConstraint());
+            }
+
+            if (typeParameter.AllowsRefLikeType)
+            {
+                constraints = constraints.Add(CreateAllowsRefStructConstraint());
+            }
+
+            return SyntaxFactory.TypeParameterConstraintClause(SyntaxFactory.IdentifierName(typeParameter.Name))
+                .WithConstraints(constraints);
+        }
 
         private static TypeParameterConstraintSyntax CreateNotNullConstraint() =>
             SyntaxFactory.TypeConstraint(SyntaxFactory.IdentifierName("notnull"));
+
+        private static TypeParameterConstraintSyntax CreateAllowsRefStructConstraint() =>
+            SyntaxFactory.AllowsConstraintClause(
+                SyntaxFactory.SingletonSeparatedList<AllowsConstraintSyntax>(
+                    SyntaxFactory.RefStructConstraint()));
 
         private static bool IsNotNullConstraint(TypeParameterConstraintSyntax constraint) =>
             constraint is TypeConstraintSyntax typeConstraint &&
             typeConstraint.Type is IdentifierNameSyntax identifierName &&
             identifierName.Identifier.ValueText == "notnull";
+
+        private static bool IsAllowsRefStructConstraint(TypeParameterConstraintSyntax constraint) =>
+            constraint is AllowsConstraintClauseSyntax allowsConstraintClause &&
+            allowsConstraintClause.Constraints.Any(static constraint => constraint is RefStructConstraintSyntax);
     }
 }

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -151,11 +151,9 @@ namespace Microsoft.DotNet.GenAPI
 
         private static SyntaxNode AddMissingSpecialConstraints(this SyntaxNode declaration, IEnumerable<ITypeParameterSymbol> typeParameters)
         {
-            ITypeParameterSymbol[] typeParametersWithMissingConstraints = typeParameters
-                .Where(typeParameter => typeParameter.HasNotNullConstraint || typeParameter.AllowsRefLikeType)
-                .ToArray();
+            ITypeParameterSymbol[] typeParameterArray = typeParameters.ToArray();
 
-            if (typeParametersWithMissingConstraints.Length == 0)
+            if (!typeParameterArray.Any(typeParameter => typeParameter.HasNotNullConstraint || typeParameter.AllowsRefLikeType))
             {
                 return declaration;
             }
@@ -163,27 +161,36 @@ namespace Microsoft.DotNet.GenAPI
             return declaration switch
             {
                 TypeDeclarationSyntax typeDeclaration => typeDeclaration.WithConstraintClauses(
-                    AddMissingSpecialConstraintClauses(typeDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
+                    AddMissingSpecialConstraintClauses(typeDeclaration.ConstraintClauses, typeParameterArray)),
                 DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.WithConstraintClauses(
-                    AddMissingSpecialConstraintClauses(delegateDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
+                    AddMissingSpecialConstraintClauses(delegateDeclaration.ConstraintClauses, typeParameterArray)),
                 MethodDeclarationSyntax methodDeclaration => methodDeclaration.WithConstraintClauses(
-                    AddMissingSpecialConstraintClauses(methodDeclaration.ConstraintClauses, typeParametersWithMissingConstraints)),
+                    AddMissingSpecialConstraintClauses(methodDeclaration.ConstraintClauses, typeParameterArray)),
                 _ => declaration
             };
         }
 
         private static SyntaxList<TypeParameterConstraintClauseSyntax> AddMissingSpecialConstraintClauses(
             SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
-            IEnumerable<ITypeParameterSymbol> typeParameters)
+            ITypeParameterSymbol[] typeParameters)
         {
-            foreach (ITypeParameterSymbol typeParameter in typeParameters)
+            for (int typeParameterIndex = 0; typeParameterIndex < typeParameters.Length; typeParameterIndex++)
             {
+                ITypeParameterSymbol typeParameter = typeParameters[typeParameterIndex];
+
+                if (!typeParameter.HasNotNullConstraint && !typeParameter.AllowsRefLikeType)
+                {
+                    continue;
+                }
+
                 TypeParameterConstraintClauseSyntax? constraintClause = constraintClauses
                     .FirstOrDefault(clause => clause.Name.Identifier.ValueText == typeParameter.Name);
 
                 if (constraintClause is null)
                 {
-                    constraintClauses = constraintClauses.Add(CreateConstraintClause(typeParameter));
+                    constraintClauses = constraintClauses.Insert(
+                        GetConstraintClauseInsertIndex(constraintClauses, typeParameters, typeParameterIndex),
+                        CreateConstraintClause(typeParameter));
                     continue;
                 }
 
@@ -204,6 +211,26 @@ namespace Microsoft.DotNet.GenAPI
             }
 
             return constraintClauses;
+        }
+
+        private static int GetConstraintClauseInsertIndex(
+            SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
+            ITypeParameterSymbol[] typeParameters,
+            int typeParameterIndex)
+        {
+            for (int i = 0; i < constraintClauses.Count; i++)
+            {
+                int constraintTypeParameterIndex = Array.FindIndex(
+                    typeParameters,
+                    typeParameter => typeParameter.Name == constraintClauses[i].Name.Identifier.ValueText);
+
+                if (constraintTypeParameterIndex > typeParameterIndex)
+                {
+                    return i;
+                }
+            }
+
+            return constraintClauses.Count;
         }
 
         private static TypeParameterConstraintClauseSyntax CreateConstraintClause(ITypeParameterSymbol typeParameter)

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -846,6 +846,50 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestAllowsRefStructGenericConstraintGeneration()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public class Potato
+                    {
+                        public T Carrot<T>(T t) where T : allows ref struct
+                        {
+                            return t;
+                        }
+
+                        public T CarrotNotNull<T>(T t) where T : notnull, allows ref struct
+                        {
+                            return t;
+                        }
+                    }
+
+                    public class RefContainer<T> where T : allows ref struct
+                    {
+                    }
+
+                    public delegate void RefHandler<T>(T value) where T : allows ref struct;
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class Potato
+                    {
+                        public T Carrot<T>(T t) where T : allows ref struct { throw null; }
+                        public T CarrotNotNull<T>(T t) where T : notnull, allows ref struct { throw null; }
+                    }
+
+                    public partial class RefContainer<T> where T : allows ref struct
+                    {
+                    }
+
+                    public delegate void RefHandler<T>(T value) where T : allows ref struct;
+                }
+                """);
+        }
+
+        [Fact]
         public void TestPublicMembersGeneration()
         {
             RunTest(original: """

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -796,6 +796,56 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestNotNullGenericConstraintGeneration()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public abstract class Base
+                    {
+                        public abstract void OverrideMethod<T>() where T : notnull;
+                    }
+
+                    public class Derived : Base
+                    {
+                        public override void OverrideMethod<T>() { }
+                    }
+
+                    public class Container<T> where T : notnull, System.IDisposable, new()
+                    {
+                        public void Method<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dict)
+                            where TKey : notnull
+                        {
+                        }
+                    }
+
+                    public delegate void Handler<T>(T value) where T : notnull;
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public abstract partial class Base
+                    {
+                        public abstract void OverrideMethod<T>() where T : notnull;
+                    }
+
+                    public partial class Container<T> where T : notnull, System.IDisposable, new()
+                    {
+                        public void Method<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dict) where TKey : notnull { }
+                    }
+
+                    public partial class Derived : Base
+                    {
+                        public override void OverrideMethod<T>() { }
+                    }
+
+                    public delegate void Handler<T>(T value) where T : notnull;
+                }
+                """);
+        }
+
+        [Fact]
         public void TestPublicMembersGeneration()
         {
             RunTest(original: """
@@ -1502,7 +1552,7 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
             expected: """
                 namespace Foo
                 {
-                    public partial struct Bar<T>
+                    public partial struct Bar<T> where T : notnull
                     {
                         private System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<T>> _field;
                         private object _dummy;
@@ -1529,7 +1579,7 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
             expected: """
                 namespace Foo
                 {
-                    public readonly partial struct Bar<T>
+                    public readonly partial struct Bar<T> where T : notnull
                     {
                         private readonly System.Collections.Generic.List<Bar<T>> _Baz_k__BackingField;
                         private readonly object _dummy;

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -846,6 +846,67 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestNotNullConstraintClauseOrdering()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public class OrderedContainer<T, U> where T : notnull where U : new()
+                    {
+                        public void OrderedMethod<TMethod, UMethod>() where TMethod : notnull where UMethod : new()
+                        {
+                        }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class OrderedContainer<T, U> where T : notnull where U : new()
+                    {
+                        public void OrderedMethod<TMethod, UMethod>() where TMethod : notnull where UMethod : new() { }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public void TestExplicitInterfaceImplementationNotNullConstraint()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public interface IGeneric
+                    {
+                        void Method<T>(T value) where T : notnull;
+                    }
+
+                    public class ExplicitGeneric : IGeneric
+                    {
+                        void IGeneric.Method<T>(T value)
+                        {
+                        }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class ExplicitGeneric : IGeneric
+                    {
+                        void IGeneric.Method<T>(T value) { }
+                    }
+
+                    public partial interface IGeneric
+                    {
+                        void Method<T>(T value)
+                            where T : notnull;
+                    }
+                }
+                """);
+        }
+
+        [Fact]
         public void TestAllowsRefStructGenericConstraintGeneration()
         {
             RunTest(original: """


### PR DESCRIPTION
Fixes #54450.
Fixes #47113.

## Summary
- Preserve `notnull` generic constraints when GenAPI generates C# declarations from metadata.
- Preserve `allows ref struct` generic constraints and keep them last in generated constraint lists.
- Cover generic types, methods, delegates, and existing struct dummy-field baselines.
- Avoid emitting invalid inherited constraints on overrides and explicit interface implementations.

## Testing
- `.\.dotnet\dotnet.exe build test\Microsoft.DotNet.GenAPI.Tests\Microsoft.DotNet.GenAPI.Tests.csproj -p:SdkTargetFramework=net10.0 --no-restore`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.GenAPI.Tests\Debug\net10.0\Microsoft.DotNet.GenAPI.Tests.dll -method "*TestAllowsRefStructGenericConstraintGeneration*" -method "*TestNotNullGenericConstraintGeneration*" -method "*TestSynthesizePrivateFieldsForNestedGenericTypes*" -method "*TestSynthesizePrivateFieldsAngleBrackets*"`