### PR TITLE
Keep GenAPI event accessors on one line

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;
+using Microsoft.DotNet.GenAPI.SyntaxRewriter;
 
 namespace Microsoft.DotNet.GenAPI;
 
@@ -106,6 +107,8 @@ public sealed class CSharpAssemblyDocumentGenerator
         if (_options.ShouldFormat)
         {
             document = await Formatter.FormatAsync(document, DefineFormattingOptions()).ConfigureAwait(false);
+            SyntaxNode root = await document.GetSyntaxRootAsync().ConfigureAwait(false) ?? throw new InvalidOperationException(Resources.SyntaxNodeNotFound);
+            document = document.WithSyntaxRoot(root.Rewrite(SingleLineStatementCSharpSyntaxRewriter.Singleton));
         }
 
         return document;

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/SingleLineStatementCSharpSyntaxRewriter.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxRewriter/SingleLineStatementCSharpSyntaxRewriter.cs
@@ -108,10 +108,18 @@ namespace Microsoft.DotNet.GenAPI.SyntaxRewriter
                 }
 
                 accessorList = accessorList
-                    .WithOpenBraceToken(accessorList.OpenBraceToken.WithTrailingTrivia())
+                    .WithOpenBraceToken(accessorList.OpenBraceToken.WithLeadingTrivia(SyntaxFactory.Space).WithTrailingTrivia())
                     .WithCloseBraceToken(accessorList.CloseBraceToken.WithLeadingTrivia())
                     .WithAccessors(accessors);
             }
+
+            node = node switch
+            {
+                EventDeclarationSyntax eventDeclaration => eventDeclaration.WithIdentifier(eventDeclaration.Identifier.WithTrailingTrivia()),
+                IndexerDeclarationSyntax indexerDeclaration => indexerDeclaration.WithParameterList(indexerDeclaration.ParameterList.WithTrailingTrivia()),
+                PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.WithIdentifier(propertyDeclaration.Identifier.WithTrailingTrivia()),
+                _ => node
+            };
 
             return node.WithAccessorList(accessorList);
         }

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -36,6 +36,43 @@ namespace Microsoft.DotNet.GenAPI.Tests
             // Empty string is considered a valid header, null causes to use the default CSharpFileBuilder header
             string header = "")
         {
+            string resultedString = GenerateOutput(original, includeInternalSymbols, includeEffectivelyPrivateSymbols,
+                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, assemblyName, header);
+
+            SyntaxTree resultedSyntaxTree = GetSyntaxTree(resultedString);
+            SyntaxTree expectedSyntaxTree = GetSyntaxTree(expected);
+
+            // compare SyntaxTree and not string representation
+            Assert.True(resultedSyntaxTree.IsEquivalentTo(expectedSyntaxTree),
+                $"Expected:\n{expected}\nResulted:\n{resultedString}");
+        }
+
+        private void RunTestAndCompareOutput(string original,
+            string expected,
+            bool includeInternalSymbols = true,
+            bool includeEffectivelyPrivateSymbols = true,
+            bool includeExplicitInterfaceImplementationSymbols = true,
+            bool allowUnsafe = false,
+            string[] excludedAttributeList = null,
+            [CallerMemberName] string assemblyName = "",
+            // Empty string is considered a valid header, null causes to use the default CSharpFileBuilder header
+            string header = "")
+        {
+            string resultedString = GenerateOutput(original, includeInternalSymbols, includeEffectivelyPrivateSymbols,
+                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, assemblyName, header);
+
+            Assert.Equal(expected.ReplaceLineEndings("\n"), resultedString.ReplaceLineEndings("\n"));
+        }
+
+        private static string GenerateOutput(string original,
+            bool includeInternalSymbols,
+            bool includeEffectivelyPrivateSymbols,
+            bool includeExplicitInterfaceImplementationSymbols,
+            bool allowUnsafe,
+            string[] excludedAttributeList,
+            string assemblyName,
+            string header)
+        {
             using StringWriter stringWriter = new();
 
             Mock<ILog> log = new();
@@ -60,17 +97,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
 
             csharpFileBuilder.WriteAssembly(assemblySymbols.First().Value);
 
-            StringBuilder stringBuilder = stringWriter.GetStringBuilder();
-            string resultedString = stringBuilder.ToString();
-
-            stringBuilder.Remove(0, stringBuilder.Length);
-
-            SyntaxTree resultedSyntaxTree = GetSyntaxTree(resultedString);
-            SyntaxTree expectedSyntaxTree = GetSyntaxTree(expected);
-
-            // compare SyntaxTree and not string representation
-            Assert.True(resultedSyntaxTree.IsEquivalentTo(expectedSyntaxTree),
-                $"Expected:\n{expected}\nResulted:\n{resultedString}");
+            return stringWriter.ToString();
         }
 
         [Fact]
@@ -887,6 +914,29 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
                         public abstract event System.EventHandler<bool> TextChanged;
                     }
 
+                    public partial class Events
+                    {
+                        public event System.EventHandler<string> OnNewMessage { add { } remove { } }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public void TestEventGenerationOutput()
+        {
+            RunTestAndCompareOutput(original: """
+                namespace Foo
+                {
+                    public class Events
+                    {
+                        public event System.EventHandler<string> OnNewMessage { add { } remove { } }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
                     public partial class Events
                     {
                         public event System.EventHandler<string> OnNewMessage { add { } remove { } }


### PR DESCRIPTION
## Summary
- Reapply GenAPI's single-line statement/accessor normalization after Roslyn formatting.
- Keep generated custom event accessors in the compact `{ add { } remove { } }` form.
- Add an exact-output GenAPI test for event declarations.

Fixes #48831

## Testing
- `.\.dotnet\dotnet.exe build test\Microsoft.DotNet.GenAPI.Tests\Microsoft.DotNet.GenAPI.Tests.csproj -p:SdkTargetFramework=net10.0 --no-restore`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.GenAPI.Tests\Debug\net10.0\Microsoft.DotNet.GenAPI.Tests.dll -class "Microsoft.DotNet.GenAPI.Tests.CSharpFileBuilderTests"`
- `.\.dotnet\dotnet.exe build test\Microsoft.DotNet.ApiDiff.Tests\Microsoft.DotNet.ApiDiff.Tests.csproj -p:SdkTargetFramework=net10.0 --no-restore`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.ApiDiff.Tests\Debug\net10.0\Microsoft.DotNet.ApiDiff.Tests.dll`