### PR TITLE
Handle global namespace types in GenAPI

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -350,6 +350,16 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
         }
         else if (parentNode is CompilationUnitSyntax)
         {
+            foreach (BaseTypeDeclarationSyntax typeNode in GetMembersOfType<BaseTypeDeclarationSyntax>(parentNode))
+            {
+                dictionary.TryAdd(GetDocId(typeNode, model), typeNode);
+            }
+
+            foreach (DelegateDeclarationSyntax delegateNode in GetMembersOfType<DelegateDeclarationSyntax>(parentNode))
+            {
+                dictionary.TryAdd(GetDocId(delegateNode, model), delegateNode);
+            }
+
             foreach (BaseNamespaceDeclarationSyntax namespaceNode in parentNode.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>())
             {
                 dictionary.TryAdd(GetDocId(namespaceNode, model), namespaceNode);

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -108,40 +108,41 @@ public sealed class CSharpAssemblyDocumentGenerator
 
     private IEnumerable<SyntaxNode> Visit(INamespaceSymbol namespaceSymbol)
     {
-        IEnumerable<INamedTypeSymbol> typeMembers = namespaceSymbol.GetTypeMembers().Where(_options.SymbolFilter.Include);
-        if (!typeMembers.Any())
-        {
-            yield break;
-        }
-
-        List<SyntaxNode> typeDeclarations = [];
-        foreach (INamedTypeSymbol typeMember in typeMembers.Order())
-        {
-            SyntaxNode typeDeclaration = _syntaxGenerator
-                .DeclarationExt(typeMember, _options.SymbolFilter)
-                .AddMemberAttributes(_syntaxGenerator, typeMember, _options.AttributeSymbolFilter);
-
-            typeDeclaration = Visit(typeDeclaration, typeMember);
-            typeDeclarations.Add(typeDeclaration);
-        }
+        IEnumerable<INamedTypeSymbol> typeMembers = namespaceSymbol.GetTypeMembers()
+            .Where(_options.SymbolFilter.Include)
+            .Order();
 
         if (namespaceSymbol.IsGlobalNamespace)
         {
-            foreach (SyntaxNode typeDeclaration in typeDeclarations)
+            foreach (INamedTypeSymbol typeMember in typeMembers)
             {
-                yield return typeDeclaration;
+                yield return CreateTypeDeclaration(typeMember);
             }
 
             yield break;
         }
 
         SyntaxNode namespaceNode = _syntaxGenerator.NamespaceDeclaration(namespaceSymbol.ToDisplayString());
-        foreach (SyntaxNode typeDeclaration in typeDeclarations)
+        bool hasTypeMembers = false;
+        foreach (INamedTypeSymbol typeMember in typeMembers)
         {
-            namespaceNode = _syntaxGenerator.AddMembers(namespaceNode, typeDeclaration);
+            namespaceNode = _syntaxGenerator.AddMembers(namespaceNode, CreateTypeDeclaration(typeMember));
+            hasTypeMembers = true;
         }
 
-        yield return namespaceNode;
+        if (hasTypeMembers)
+        {
+            yield return namespaceNode;
+        }
+    }
+
+    private SyntaxNode CreateTypeDeclaration(INamedTypeSymbol typeMember)
+    {
+        SyntaxNode typeDeclaration = _syntaxGenerator
+            .DeclarationExt(typeMember, _options.SymbolFilter)
+            .AddMemberAttributes(_syntaxGenerator, typeMember, _options.AttributeSymbolFilter);
+
+        return Visit(typeDeclaration, typeMember);
     }
 
     // Name hiding through inheritance occurs when classes or structs redeclare names that were inherited from base classes. This type of name hiding takes one of the following forms:

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -63,18 +63,13 @@ public sealed class CSharpAssemblyDocumentGenerator
 
         IEnumerable<INamespaceSymbol> namespaceSymbols = EnumerateNamespaces(assemblySymbol).Where(_options.SymbolFilter.Include);
 
-        List<SyntaxNode> namespaceSyntaxNodes = [];
+        List<SyntaxNode> declarationSyntaxNodes = [];
         foreach (INamespaceSymbol namespaceSymbol in namespaceSymbols.Order())
         {
-            SyntaxNode? syntaxNode = Visit(namespaceSymbol);
-
-            if (syntaxNode is not null)
-            {
-                namespaceSyntaxNodes.Add(syntaxNode);
-            }
+            declarationSyntaxNodes.AddRange(Visit(namespaceSymbol));
         }
 
-        SyntaxNode compilationUnit = _syntaxGenerator.CompilationUnit(namespaceSyntaxNodes);
+        SyntaxNode compilationUnit = _syntaxGenerator.CompilationUnit(declarationSyntaxNodes);
 
         if (_options.AdditionalAnnotations.Any())
         {
@@ -111,16 +106,15 @@ public sealed class CSharpAssemblyDocumentGenerator
         return document;
     }
 
-    private SyntaxNode? Visit(INamespaceSymbol namespaceSymbol)
+    private IEnumerable<SyntaxNode> Visit(INamespaceSymbol namespaceSymbol)
     {
-        SyntaxNode namespaceNode = _syntaxGenerator.NamespaceDeclaration(namespaceSymbol.ToDisplayString());
-
         IEnumerable<INamedTypeSymbol> typeMembers = namespaceSymbol.GetTypeMembers().Where(_options.SymbolFilter.Include);
         if (!typeMembers.Any())
         {
-            return null;
+            yield break;
         }
 
+        List<SyntaxNode> typeDeclarations = [];
         foreach (INamedTypeSymbol typeMember in typeMembers.Order())
         {
             SyntaxNode typeDeclaration = _syntaxGenerator
@@ -128,11 +122,26 @@ public sealed class CSharpAssemblyDocumentGenerator
                 .AddMemberAttributes(_syntaxGenerator, typeMember, _options.AttributeSymbolFilter);
 
             typeDeclaration = Visit(typeDeclaration, typeMember);
+            typeDeclarations.Add(typeDeclaration);
+        }
 
+        if (namespaceSymbol.IsGlobalNamespace)
+        {
+            foreach (SyntaxNode typeDeclaration in typeDeclarations)
+            {
+                yield return typeDeclaration;
+            }
+
+            yield break;
+        }
+
+        SyntaxNode namespaceNode = _syntaxGenerator.NamespaceDeclaration(namespaceSymbol.ToDisplayString());
+        foreach (SyntaxNode typeDeclaration in typeDeclarations)
+        {
             namespaceNode = _syntaxGenerator.AddMembers(namespaceNode, typeDeclaration);
         }
 
-        return namespaceNode;
+        yield return namespaceNode;
     }
 
     // Name hiding through inheritance occurs when classes or structs redeclare names that were inherited from base classes. This type of name hiding takes one of the following forms:

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -119,7 +119,7 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         public void TestGlobalNamespaceDeclaration()
         {
             RunTest(original: """
-                public class Class1;
+                public class Class1 { }
                 """,
                 expected: """
                 public partial class Class1

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -116,6 +116,19 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestGlobalNamespaceDeclaration()
+        {
+            RunTest(original: """
+                public class Class1;
+                """,
+                expected: """
+                public partial class Class1
+                {
+                }
+                """);
+        }
+
+        [Fact]
         public void TestNamespaceDeclaration()
         {
             RunTest(original: """


### PR DESCRIPTION
Fixes #52303.

## Summary
- Emit types declared in the global namespace directly into the compilation unit instead of generating `namespace <global namespace>`.
- Keep ordinary namespace generation unchanged.
- Add GenAPI coverage for a public type declared in the global namespace.

## Testing
- `.\.dotnet\dotnet.exe build test\Microsoft.DotNet.GenAPI.Tests\Microsoft.DotNet.GenAPI.Tests.csproj -p:SdkTargetFramework=net10.0 --no-restore`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.GenAPI.Tests\Debug\net10.0\Microsoft.DotNet.GenAPI.Tests.dll -method "*TestGlobalNamespaceDeclaration*" -method "*TestNamespaceDeclaration*"`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.GenAPI.Tests\Debug\net10.0\Microsoft.DotNet.GenAPI.Tests.dll -class "Microsoft.DotNet.GenAPI.Tests.CSharpFileBuilderTests"`
- `.\.dotnet\dotnet.exe build test\Microsoft.DotNet.ApiDiff.Tests\Microsoft.DotNet.ApiDiff.Tests.csproj -p:SdkTargetFramework=net10.0 --no-restore`
- `.\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.ApiDiff.Tests\Debug\net10.0\Microsoft.DotNet.ApiDiff.Tests.dll`