### PR TITLE
Sign and notarize dotnetup binaries on macOS legs

### DIFF
--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -239,6 +239,7 @@ extends:
               publishTaskPrefix: 1ES.
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             populateInternalRuntimeVariables: true
+            enableMicrobuildForMacAndLinux: true
             timeoutInMinutes: 90
             linuxJobParameterSets:
             # Cross-build containers set ROOTFS_DIR; pass /p:SysRoot and /p:LinkerFlavor=lld
@@ -248,6 +249,7 @@ extends:
               targetArchitecture: x64
               runtimeIdentifier: linux-x64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               osProperties: /p:SysRoot=$ROOTFS_DIR /p:LinkerFlavor=lld
@@ -258,6 +260,7 @@ extends:
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               osProperties: /p:SysRoot=$ROOTFS_DIR /p:LinkerFlavor=lld
@@ -268,6 +271,7 @@ extends:
               targetArchitecture: x64
               runtimeIdentifier: linux-musl-x64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               osProperties: /p:SysRoot=$ROOTFS_DIR /p:LinkerFlavor=lld /p:OSName=linux-musl
@@ -279,6 +283,7 @@ extends:
               targetArchitecture: arm64
               runtimeIdentifier: linux-musl-arm64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               osProperties: /p:SysRoot=$ROOTFS_DIR /p:LinkerFlavor=lld /p:OSName=linux-musl
@@ -298,12 +303,14 @@ extends:
               publishTaskPrefix: 1ES.
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             populateInternalRuntimeVariables: true
+            enableMicrobuildForMacAndLinux: true
             timeoutInMinutes: 90
             macOSJobParameterSets:
             - categoryName: Dotnetup
               targetArchitecture: x64
               runtimeIdentifier: osx-x64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               enableDefaultArtifacts: true
@@ -312,6 +319,7 @@ extends:
               targetArchitecture: arm64
               runtimeIdentifier: osx-arm64
               publishArgument: $(_publishArgument)
+              signArgument: $(_signArgument)
               officialBuildProperties: $(_officialBuildProperties) /p:PublishBinariesAndBadge=false
               projectsArgument: /p:Projects=$(Build.SourcesDirectory)/dotnetup.slnf
               enableDefaultArtifacts: true

--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -45,7 +45,7 @@ variables:
 - name: _publishArgument
   value: -publish
 - name: _signArgument
-  value: -sign /p:SignCoreSdk=true
+  value: -sign
 - name: _TeamName
   value: DotNet-Cli
 # MicroBuildSigningPlugin@4 on non-Windows agents requires a pipeline variable

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -35,6 +35,7 @@ parameters:
   projectsArgument: ''
   ### ARCADE ###
   preSteps: []
+  enableMicrobuildForMacAndLinux: false
 
 jobs:
 - template: /eng/common/${{ parameters.oneESCompat.templateFolderName }}/job/job.yml
@@ -51,6 +52,7 @@ jobs:
     helixRepo: dotnet/sdk
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableMicrobuild: true
+    enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
     enablePublishBuildAssets: true
     enableTelemetry: true
     enablePublishUsingPipelines: true
@@ -135,6 +137,12 @@ jobs:
           BuildConfig: $(buildConfiguration)
           OPENSSL_ENABLE_SHA1_SIGNATURES: 1
           MSBUILDALWAYSRETRY: true
+          # Required by the MicroBuild signing plugin to acquire a federated
+          # token for ESRP. AzDO exposes System.AccessToken automatically to
+          # script processes on Windows agents but not on Linux/macOS, so the
+          # SignFiles task fails with "Access token is not available" without
+          # this env var.
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     ############### TESTING ###############
     - ${{ if eq(parameters.runTests, true) }}:


### PR DESCRIPTION
I regressed MacOS signing when we switched to the standard Arcade build infrastructure (#54337).  This should fix that.

Test pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2985287&view=results

**Copilot description of changes:**

Three changes are required for in-build signing to actually run on the non-Windows dotnetup matrix legs:

1. Add signArgument: $(_signArgument) to every Linux and macOS matrix entry in .vsts-dnup-ci.yml so the standard Arcade -sign /p:SignCoreSdk=true step is passed to build.sh on those agents. Without it, build.sh skips the signing target entirely and the FileSignInfo entries in eng/Signing.props for dotnetup-<rid> (MicrosoftDotNet500 on Windows, MacDeveloperHardenWithNotarization on macOS) never get matched.

2. Add enableMicrobuildForMacAndLinux: true to the Linux and macOS sdk-job-matrix.yml invocations in .vsts-dnup-ci.yml (plumbed through sdk-build.yml as an opt-in parameter, defaulting to false to preserve main SDK behavior). The default 'Install MicroBuild plugin' step in eng/common/core-templates/steps/install-microbuild.yml is gated on Windows agents only; the separate Mac/Linux install step is gated on this additional parameter. Without it the MicroBuild ESRP plugin is never installed on the Mac agents and -sign falls back to local codesign with no credentials.

3. Export SYSTEM_ACCESSTOKEN to the non-Windows build script's environment in sdk-build.yml. The MicroBuild SignFiles task uses ESRP with federated workload identity, which needs $(System.AccessToken) to acquire the federated token. AzDO exposes System.AccessToken automatically to script processes on Windows agents but not on Linux/macOS, so without this the sign step fails with 'Access token is not available' inside ESRPCliDll.GetFederatedTokenData(). The old bespoke dotnetup-executables.yml had this env var set explicitly on its signing script.

This was a regression introduced by the pipeline rewrite in bfae6cd29e, which intentionally omitted signArgument on non-Windows legs on the assumption that 'in-build Microsoft cert signing isn't available on those agents.' That assumption is correct for the main SDK's .vsts-ci.yml (which uses post-build signing pipeline 750) but wrong for dotnetup, where PostBuildSign=false forces in-build signing.