### PR TITLE
Fix stale workflow: tighten thresholds and fix KBE close logic

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const CLOSE_AFTER_DAYS = 7;
+            const CLOSE_KBE_AFTER_DAYS = 7;
             const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
               { owner: context.repo.owner, repo: context.repo.repo,
@@ -65,6 +66,7 @@ jobs:
                 console.log(`  #${issue.number}: no hit count table found`);
                 continue;
               }
+
               const monthCount = parseInt(match[3], 10);
               console.log(`  #${issue.number}: 1-month count = ${monthCount}`);
 
@@ -79,7 +81,7 @@ jobs:
                 await github.rest.issues.createComment({
                   ...context.repo, issue_number: issue.number,
                   body: 'This Known Build Error has had **0 hits in the past month** and has been labeled `stale`. ' +
-                    'It will be auto-closed in 7 days if the hit count remains at 0. ' +
+                    'It will be auto-closed in ' + CLOSE_KBE_AFTER_DAYS + ' days if the hit count remains at 0. ' +
                     'Add the `' + process.env.KEEP_OPEN_LABEL + '` label to prevent auto-closure.' });
               } else if (monthCount === 0 && hasStale) {
                 // Still zero hits and already stale: check if it's time to close.
@@ -87,18 +89,22 @@ jobs:
                 // A single page suffices since this workflow applied the label recently.
                 const events = await github.rest.issues.listEvents({
                   ...context.repo, issue_number: issue.number, per_page: 100 });
+
                 const staleLabelEvent = events.data
                   .filter(e => e.event === 'labeled' && e.label?.name === process.env.STALE_LABEL)
                   .pop(); // most recent application
+
                 if (!staleLabelEvent) {
                   console.log(`  #${issue.number}: stale label event not found in last 100 events, skipping`);
                   continue;
                 }
+
                 const labeledAt = new Date(staleLabelEvent.created_at);
                 const daysStale = (Date.now() - labeledAt.getTime()) / MS_PER_DAY;
                 console.log(`  #${issue.number}: stale for ${daysStale.toFixed(1)} days`);
-                if (daysStale >= CLOSE_AFTER_DAYS) {
-                  console.log(`  #${issue.number}: closing (stale for ${CLOSE_AFTER_DAYS}+ days)`);
+
+                if (daysStale >= CLOSE_KBE_AFTER_DAYS) {
+                  console.log(`  #${issue.number}: closing (stale for ${CLOSE_KBE_AFTER_DAYS}+ days)`);
                   await github.rest.issues.createComment({
                     ...context.repo, issue_number: issue.number,
                     body: 'Closed automatically — this Known Build Error has had 0 hits for over a month.' });

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -83,15 +83,15 @@ jobs:
                     'Add the `' + process.env.KEEP_OPEN_LABEL + '` label to prevent auto-closure.' });
               } else if (monthCount === 0 && hasStale) {
                 // Still zero hits and already stale: check if it's time to close.
-                // Find when the stale label was applied by looking at issue timeline events.
-                const events = await github.paginate(
-                  github.rest.issues.listEvents,
-                  { ...context.repo, issue_number: issue.number, per_page: 100 });
-                const staleLabelEvent = events
+                // Fetch recent events to find when the stale label was applied.
+                // A single page suffices since this workflow applied the label recently.
+                const events = await github.rest.issues.listEvents({
+                  ...context.repo, issue_number: issue.number, per_page: 100 });
+                const staleLabelEvent = events.data
                   .filter(e => e.event === 'labeled' && e.label?.name === process.env.STALE_LABEL)
                   .pop(); // most recent application
                 if (!staleLabelEvent) {
-                  console.log(`  #${issue.number}: stale label present but no label event found, skipping`);
+                  console.log(`  #${issue.number}: stale label event not found in last 100 events, skipping`);
                   continue;
                 }
                 const labeledAt = new Date(staleLabelEvent.created_at);

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,24 +25,25 @@ jobs:
           ascending: true # Process the oldest issues first
           stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'Stale'. It will be closed if no further activity occurs within 14 more days. Any new comment will remove the label."
           stale-pr-message: "Due to lack of recent activity, this PR has been labeled as 'Stale'. It will be closed if no further activity occurs within 7 more days. Any new comment will remove the label."
-          days-before-issue-stale: 1644 # ~4.5 years
+          days-before-issue-stale: 1460 # ~4 years
           days-before-issue-close: 14
-          days-before-pr-stale: 120 # ~4 months
+          days-before-pr-stale: 60 # ~2 months
           days-before-pr-close: 7
           exempt-issue-labels: ${{ env.KBE_LABEL }}
           operations-per-run: 4000
 
   # Known Build Error issues with 0 hits for a month get labeled Stale,
-  # then actions/stale closes them after 7 days.
+  # then closed after 7 days if hits remain at 0.
   stale-known-build-errors:
     if: github.repository_owner == 'dotnet' # Do not run on forks
 
     runs-on: ubuntu-latest
     steps:
-      # Step 1: Label/unlabel based on hit counts
       - uses: actions/github-script@v7
         with:
           script: |
+            const CLOSE_AFTER_DAYS = 7;
+            const MS_PER_DAY = 1000 * 60 * 60 * 24;
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
               { owner: context.repo.owner, repo: context.repo.repo,
@@ -80,6 +81,31 @@ jobs:
                   body: 'This Known Build Error has had **0 hits in the past month** and has been labeled `stale`. ' +
                     'It will be auto-closed in 7 days if the hit count remains at 0. ' +
                     'Add the `' + process.env.KEEP_OPEN_LABEL + '` label to prevent auto-closure.' });
+              } else if (monthCount === 0 && hasStale) {
+                // Still zero hits and already stale: check if it's time to close.
+                // Find when the stale label was applied by looking at issue timeline events.
+                const events = await github.paginate(
+                  github.rest.issues.listEvents,
+                  { ...context.repo, issue_number: issue.number, per_page: 100 });
+                const staleLabelEvent = events
+                  .filter(e => e.event === 'labeled' && e.label?.name === process.env.STALE_LABEL)
+                  .pop(); // most recent application
+                if (!staleLabelEvent) {
+                  console.log(`  #${issue.number}: stale label present but no label event found, skipping`);
+                  continue;
+                }
+                const labeledAt = new Date(staleLabelEvent.created_at);
+                const daysStale = (Date.now() - labeledAt.getTime()) / MS_PER_DAY;
+                console.log(`  #${issue.number}: stale for ${daysStale.toFixed(1)} days`);
+                if (daysStale >= CLOSE_AFTER_DAYS) {
+                  console.log(`  #${issue.number}: closing (stale for ${CLOSE_AFTER_DAYS}+ days)`);
+                  await github.rest.issues.createComment({
+                    ...context.repo, issue_number: issue.number,
+                    body: 'Closed automatically — this Known Build Error has had 0 hits for over a month.' });
+                  await github.rest.issues.update({
+                    ...context.repo, issue_number: issue.number,
+                    state: 'closed', state_reason: 'not_planned' });
+                }
               } else if (monthCount > 0 && hasStale) {
                 // Hits resumed: remove the stale label
                 console.log(`  #${issue.number}: removing stale (hits resumed)`);
@@ -88,15 +114,3 @@ jobs:
                   name: process.env.STALE_LABEL }).catch(() => {});
               }
             }
-
-      # Step 2: Close KBE issues that have been Stale for 7+ days
-      - uses: actions/stale@v9
-        with:
-          only-labels: ${{ env.KBE_LABEL }}
-          stale-issue-label: ${{ env.STALE_LABEL }}
-          close-issue-message: 'Closed automatically — this Known Build Error has had 0 hits for over a month.'
-          days-before-issue-stale: -1 # Don't auto-stale; step 1 handles that
-          days-before-issue-close: 7
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          operations-per-run: 100


### PR DESCRIPTION
## Summary

This PR contains two fixes for the stale issue workflow:

1. **Tighten stale thresholds** — Reduces issue staleness from ~4.5 years to ~4 years, and PR staleness from ~4 months to ~2 months.

2. **Fix Known Build Error (KBE) issues never closing** — The previous implementation had a conflict between its two steps:
   - Step 1 added the `stale` label **and** a comment
   - Step 2 (`actions/stale`) treated that comment as "new activity", removing the `stale` label
   - This created an infinite loop: daily re-labeling + comment, issue never closed

   The fix replaces Step 2 with direct close logic in the github-script that checks when the stale label was applied via issue timeline events and closes after 7 days. This eliminates the dependency on `actions/stale` for KBE closure entirely.

## Validation

Tested on a fork with 4 scenarios:
- ✅ Non-KBE issues are not modified
- ✅ Active KBE issues (with hits) stay open without stale label
- ✅ KBE issues with 0 monthly hits get marked stale (label + comment) but are NOT immediately closed
- ✅ KBE issues that have been stale for the configured duration are closed

Related to https://github.com/dotnet/sdk/pull/54043, and https://github.com/dotnet/sdk/issues/54044
