### PR TITLE
Update the dnx script to use the newest SDK

### DIFF
--- a/src/Layout/redist/dnx
+++ b/src/Layout/redist/dnx
@@ -4,7 +4,7 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 
 DOTNET="$(dirname "$0")/dotnet"
-SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+SDK_VERSION=$(DOTNET_MULTILEVEL_LOOKUP=0 "$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
 SDK_PATH="$(dirname "$0")/sdk/$SDK_VERSION/dotnet.dll"
 
-"$DOTNET" exec "$SDK_PATH" tool exec "$@"
+DOTNET_MULTILEVEL_LOOKUP=0 "$DOTNET" exec "$SDK_PATH" tool exec "$@"

--- a/src/Layout/redist/dnx
+++ b/src/Layout/redist/dnx
@@ -4,7 +4,7 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 
 DOTNET="$(dirname "$0")/dotnet"
-SDK_VERSION=$(DOTNET_MULTILEVEL_LOOKUP=0 "$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
 SDK_PATH="$(dirname "$0")/sdk/$SDK_VERSION/dotnet.dll"
 
-DOTNET_MULTILEVEL_LOOKUP=0 "$DOTNET" exec "$SDK_PATH" tool exec "$@"
+"$DOTNET" exec "$SDK_PATH" tool exec "$@"

--- a/src/Layout/redist/dnx
+++ b/src/Layout/redist/dnx
@@ -3,4 +3,8 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-"$(dirname "$0")/dotnet" dnx "$@"
+DOTNET="$(dirname "$0")/dotnet"
+SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
+SDK_PATH="$(dirname "$0")/sdk/$SDK_VERSION/dotnet.dll"
+
+"$DOTNET" exec "$SDK_PATH" tool exec "$@"

--- a/src/Layout/redist/dnx
+++ b/src/Layout/redist/dnx
@@ -7,4 +7,4 @@ DOTNET="$(dirname "$0")/dotnet"
 SDK_VERSION=$("$DOTNET" --list-sdks | tail -1 | cut -d' ' -f1)
 SDK_PATH="$(dirname "$0")/sdk/$SDK_VERSION/dotnet.dll"
 
-"$DOTNET" exec "$SDK_PATH" tool exec "$@"
+"$DOTNET" exec "$SDK_PATH" dnx "$@"

--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -2,4 +2,16 @@
 :: The .NET Foundation licenses this file to you under the MIT license.
 
 @echo off
-"%~dp0dotnet.exe" dnx %*
+setlocal
+
+set "DOTNET=%~dp0dotnet.exe"
+
+for /f "tokens=1" %%i in ('"%DOTNET%" --list-sdks') do (
+    set "SDK_VERSION=%%i"
+)
+
+set "SDK_PATH=%~dp0sdk\%SDK_VERSION%\dotnet.dll"
+
+"%DOTNET%" exec "%SDK_PATH%" tool exec %*
+
+endlocal

--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -12,6 +12,6 @@ for /f "tokens=1" %%i in ('"%DOTNET%" --list-sdks') do (
 
 set "SDK_PATH=%~dp0sdk\%SDK_VERSION%\dotnet.dll"
 
-"%DOTNET%" exec "%SDK_PATH%" tool exec %*
+"%DOTNET%" exec "%SDK_PATH%" dnx %*
 
 endlocal

--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -4,6 +4,7 @@
 @echo off
 setlocal
 
+set "DOTNET_MULTILEVEL_LOOKUP=0"
 set "DOTNET=%~dp0dotnet.exe"
 
 for /f "tokens=1" %%i in ('"%DOTNET%" --list-sdks') do (

--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -4,7 +4,6 @@
 @echo off
 setlocal
 
-set "DOTNET_MULTILEVEL_LOOKUP=0"
 set "DOTNET=%~dp0dotnet.exe"
 
 for /f "tokens=1" %%i in ('"%DOTNET%" --list-sdks') do (

--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -2,7 +2,7 @@
 :: The .NET Foundation licenses this file to you under the MIT license.
 
 @echo off
-setlocal
+setlocal enableextensions
 
 set "DOTNET=%~dp0dotnet.exe"
 


### PR DESCRIPTION
The dnx scripts worked by invoking `dotnet dnx`. This creates issues in folders where a global.json has pinned a version of the SDK which does not support the `dnx` command.

We change the behavior of the scripts to use `dotnet--list-sdks` to get the list of installed SDKs. We then take the last entry, which should be the latest as the list is sorted. We then directly execute that version of the dotnet.dll. This allows the dnx script to script to work despite any global.json.

Resolves https://github.com/dotnet/sdk/issues/51085