### PR TITLE
Fix `dotnetup` telemetry to match old data format following `data-x-migration` new `Lens` `Router` deleting data

### DIFF
--- a/src/Installer/Directory.Build.props
+++ b/src/Installer/Directory.Build.props
@@ -7,8 +7,13 @@
        Loading the repo-level D.B.props causes the Arcade SDK to be loaded, which computes load-bearing properties from this value -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <!-- Shared version for dotnetup CLI and Microsoft.Dotnet.Installation library -->
-    <DotnetupVersionPrefix>0.1.3</DotnetupVersionPrefix>
+    <!-- Shared version for dotnetup CLI and Microsoft.Dotnet.Installation library.
+         Bumped 0.1.3 -> 0.1.4 to mark the recovery point after the May 14 prod-data
+         outage. Use this as a `dotnetup.version startswith "0.1.4"` filter on
+         dashboards to separate post-mitigation data (per-emit EventId from SpanId,
+         see DotnetupTelemetry.EmitCompletionLog) from the 0.1.3 stream whose
+         constant EventId=0 was being collapsed by upstream dedup. -->
+    <DotnetupVersionPrefix>0.1.4</DotnetupVersionPrefix>
     <DotnetupPreReleaseVersionLabel>preview</DotnetupPreReleaseVersionLabel>
   </PropertyGroup>
 

--- a/src/Installer/dotnetup.Library/Telemetry/DotnetupTelemetry.cs
+++ b/src/Installer/dotnetup.Library/Telemetry/DotnetupTelemetry.cs
@@ -501,11 +501,7 @@ public sealed class DotnetupTelemetry : IDisposable
         var state = BuildCompletionState(eventName, activity, elapsedMs);
         var formattedMessage = $"dotnetup/{eventName}";
 
-        //  EventId.Id is int (32 bits) and ActivitySpanId is 64 bits.
-        //  Thus, the lower 32 bits of the 64-bit SpanId are used for the EventId.Id.
-        Span<byte> spanIdBytes = stackalloc byte[8];
-        activity.SpanId.CopyTo(spanIdBytes);
-        var eventIdInt = BitConverter.ToInt32(spanIdBytes);
+        var eventIdInt = DeriveEventIdFromSpanId(activity);
 
         _logger.Log(
             LogLevel.Information,
@@ -514,6 +510,17 @@ public sealed class DotnetupTelemetry : IDisposable
             state,
             exception: null,
             formatter: (_, _) => formattedMessage);
+    }
+
+    /// <summary>
+    /// Derives a unique <see cref="EventId"/> integer from the lower 32 bits of an
+    /// <see cref="Activity"/>'s <see cref="Activity.SpanId"/>.
+    /// </summary>
+    internal static int DeriveEventIdFromSpanId(Activity activity)
+    {
+        Span<byte> spanIdBytes = stackalloc byte[8];
+        activity.SpanId.CopyTo(spanIdBytes);
+        return BitConverter.ToInt32(spanIdBytes);
     }
 
     /// <summary>

--- a/src/Installer/dotnetup.Library/Telemetry/DotnetupTelemetry.cs
+++ b/src/Installer/dotnetup.Library/Telemetry/DotnetupTelemetry.cs
@@ -500,9 +500,17 @@ public sealed class DotnetupTelemetry : IDisposable
         var elapsedMs = (DateTime.UtcNow - activity.StartTimeUtc).TotalMilliseconds;
         var state = BuildCompletionState(eventName, activity, elapsedMs);
         var formattedMessage = $"dotnetup/{eventName}";
+
+        //  EventId.Id is int (32 bits) and ActivitySpanId is 64 bits.
+        //  Thus, the lower 32 bits of the 64-bit SpanId are used for the EventId.Id.
+        Span<byte> spanIdBytes = stackalloc byte[8];
+        activity.SpanId.CopyTo(spanIdBytes);
+        var eventIdInt = BitConverter.ToInt32(spanIdBytes);
+
         _logger.Log(
             LogLevel.Information,
-            new EventId(0, formattedMessage),
+            // each event must have a unique id otherwise the new 'router' lens service added by devdiv data on 5/15/2026 will try to dedupe it and 'drop' the data
+            new EventId(eventIdInt, formattedMessage),
             state,
             exception: null,
             formatter: (_, _) => formattedMessage);

--- a/test/dotnetup.Tests/TelemetryTests.cs
+++ b/test/dotnetup.Tests/TelemetryTests.cs
@@ -708,16 +708,8 @@ public class DotnetupTelemetryTests : IDisposable
             "eventid-test-2", ActivityKind.Internal);
         Assert.NotNull(activity2);
 
-        // Replicate the production EventId derivation logic from EmitCompletionLog.
-        static int DeriveEventId(Activity activity)
-        {
-            Span<byte> spanIdBytes = stackalloc byte[8];
-            activity.SpanId.CopyTo(spanIdBytes);
-            return BitConverter.ToInt32(spanIdBytes);
-        }
-
-        var eventId1 = DeriveEventId(activity1);
-        var eventId2 = DeriveEventId(activity2);
+        var eventId1 = DotnetupTelemetry.DeriveEventIdFromSpanId(activity1);
+        var eventId2 = DotnetupTelemetry.DeriveEventIdFromSpanId(activity2);
 
         // Each activity gets a random SpanId; the derived EventId must not be
         // the old constant zero and must differ between activities.

--- a/test/dotnetup.Tests/TelemetryTests.cs
+++ b/test/dotnetup.Tests/TelemetryTests.cs
@@ -693,6 +693,38 @@ public class DotnetupTelemetryTests : IDisposable
         Assert.Contains("os.type", asDict.Keys);
         Assert.Contains("session.id", asDict.Keys);
     }
+
+    [Fact]
+    public void EmitCompletionLog_EventId_DerivedFromSpanId_IsNonZeroAndUnique()
+    {
+        // Regression: EmitCompletionLog must derive EventId from the Activity's
+        // SpanId so each log emission has a unique EventId. A constant EventId=0
+        // causes the router lens service to deduplicate and drop telemetry rows.
+        using var activity1 = DotnetupTelemetry.CommandSource.StartActivity(
+            "eventid-test-1", ActivityKind.Internal);
+        Assert.NotNull(activity1);
+
+        using var activity2 = DotnetupTelemetry.CommandSource.StartActivity(
+            "eventid-test-2", ActivityKind.Internal);
+        Assert.NotNull(activity2);
+
+        // Replicate the production EventId derivation logic from EmitCompletionLog.
+        static int DeriveEventId(Activity activity)
+        {
+            Span<byte> spanIdBytes = stackalloc byte[8];
+            activity.SpanId.CopyTo(spanIdBytes);
+            return BitConverter.ToInt32(spanIdBytes);
+        }
+
+        var eventId1 = DeriveEventId(activity1);
+        var eventId2 = DeriveEventId(activity2);
+
+        // Each activity gets a random SpanId; the derived EventId must not be
+        // the old constant zero and must differ between activities.
+        Assert.NotEqual(0, eventId1);
+        Assert.NotEqual(0, eventId2);
+        Assert.NotEqual(eventId1, eventId2);
+    }
 }
 
 [Collection("DotnetupEnvironmentMutationTests")]


### PR DESCRIPTION
DevDiv Data added on 5/15 a new 'lens' and 'router' - the lens and router is meant to join together old data before otel migration and data after otel migration, but our data was added after / during the migration and did not have the old format, i.e. containing 'eventId'. The lens tries to dedupe data points and that deletes the data if it does not have a unique event id, to the limited knowledge I have (I am not allowed to see that code or azure resource.)

We now try to generate a unique event id per datum pushed. If we used the event id as the event name then it would try to dedupe and drop everything that was not the first event received within a time frame, I believe.

I determined this when I observed data began flowing back into the unclassified table incorrectly but then got dropped despite being classified, + from reading other internal group chats talking about data being lost, as well as by observing the new 'router' data additions to the lost data.