### PR TITLE
Add DOTNET_TEST_RUNNER environment variable to select the test runner

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
@@ -14,6 +14,7 @@ internal abstract partial class TestCommandDefinition : Command
     private const string Link = "https://aka.ms/dotnet-test";
     private const string VSTestRunnerName = "VSTest";
     private const string MicrosoftTestingPlatformRunnerName = "Microsoft.Testing.Platform";
+    private const string TestRunnerEnvironmentVariableName = "DOTNET_TEST_RUNNER";
 
     public readonly TargetPlatformOptions TargetPlatformOptions = new(CommandDefinitionStrings.TestRuntimeOptionDescription);
 
@@ -31,35 +32,45 @@ internal abstract partial class TestCommandDefinition : Command
     }
 
     public static TestCommandDefinition Create()
-        => Create(Environment.CurrentDirectory);
+        => Create(Environment.CurrentDirectory, Environment.GetEnvironmentVariable(TestRunnerEnvironmentVariableName));
 
     internal static TestCommandDefinition Create(string startDirectory)
+        => Create(startDirectory, Environment.GetEnvironmentVariable(TestRunnerEnvironmentVariableName));
+
+    internal static TestCommandDefinition Create(string startDirectory, string? testRunnerEnvironmentValue)
     {
-        string? globalJsonPath = GetGlobalJsonPath(startDirectory);
-        if (globalJsonPath is null)
+        // The DOTNET_TEST_RUNNER environment variable lets users pick a runner without editing
+        // (or carrying multiple) global.json files. When set to a recognized value it takes
+        // precedence over the global.json `test.runner` setting.
+        //
+        // The runner name is resolved during CLI parser construction, which runs for *every*
+        // dotnet invocation (e.g. `dotnet --version`, `dotnet build`), so an unrecognized env
+        // var value must not crash unrelated commands. Unknown/whitespace values silently fall
+        // back to the global.json lookup; an unknown value in global.json itself remains a
+        // hard error because that file is explicit, in-repo configuration the user can fix.
+        string? trimmedEnvValue = testRunnerEnvironmentValue?.Trim();
+        if (!string.IsNullOrEmpty(trimmedEnvValue) && TryResolveRunner(trimmedEnvValue) is { } runnerFromEnv)
+        {
+            return runnerFromEnv;
+        }
+
+        string? globalJsonRunnerName = TryGetRunnerNameFromGlobalJson(startDirectory);
+        if (globalJsonRunnerName is null || globalJsonRunnerName.Equals(VSTestRunnerName, StringComparison.OrdinalIgnoreCase))
         {
             return new VSTest();
         }
 
-        GlobalJsonModel? globalJson;
-        try
+        if (globalJsonRunnerName.Equals(MicrosoftTestingPlatformRunnerName, StringComparison.OrdinalIgnoreCase))
         {
-            string jsonText = File.ReadAllText(globalJsonPath);
-            globalJson = JsonSerializer.Deserialize(jsonText, GlobalJsonSerializerContext.Default.GlobalJsonModel);
-        }
-        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
-        {
-            // The global.json file is unreadable or malformed (for example, empty or mid-edit). This
-            // method is invoked very early during CLI parser construction, so throwing here would
-            // bring down ALL commands (including `dotnet --version`). Fall back to the default
-            // runner; if the user actually runs `dotnet test`, the test command itself will surface
-            // a clearer error when it tries to load the configuration.
-            return new VSTest();
+            return new MicrosoftTestingPlatform();
         }
 
-        var name = globalJson?.Test?.RunnerName;
+        throw new InvalidOperationException(string.Format(CommandDefinitionStrings.CmdUnsupportedTestRunnerDescription, globalJsonRunnerName));
+    }
 
-        if (name is null || name.Equals(VSTestRunnerName, StringComparison.OrdinalIgnoreCase))
+    private static TestCommandDefinition? TryResolveRunner(string name)
+    {
+        if (name.Equals(VSTestRunnerName, StringComparison.OrdinalIgnoreCase))
         {
             return new VSTest();
         }
@@ -69,7 +80,32 @@ internal abstract partial class TestCommandDefinition : Command
             return new MicrosoftTestingPlatform();
         }
 
-        throw new InvalidOperationException(string.Format(CommandDefinitionStrings.CmdUnsupportedTestRunnerDescription, name));
+        return null;
+    }
+
+    private static string? TryGetRunnerNameFromGlobalJson(string startDirectory)
+    {
+        string? globalJsonPath = GetGlobalJsonPath(startDirectory);
+        if (globalJsonPath is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            string jsonText = File.ReadAllText(globalJsonPath);
+            GlobalJsonModel? globalJson = JsonSerializer.Deserialize(jsonText, GlobalJsonSerializerContext.Default.GlobalJsonModel);
+            return globalJson?.Test?.RunnerName;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            // The global.json file is unreadable or malformed (for example, empty or mid-edit). This
+            // method is invoked very early during CLI parser construction, so throwing here would
+            // bring down ALL commands (including `dotnet --version`). Fall back to the default
+            // runner; if the user actually runs `dotnet test`, the test command itself will surface
+            // a clearer error when it tries to load the configuration.
+            return null;
+        }
     }
 
     private static string? GetGlobalJsonPath(string? startDir)

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.cs
@@ -55,17 +55,13 @@ internal abstract partial class TestCommandDefinition : Command
         }
 
         string? globalJsonRunnerName = TryGetRunnerNameFromGlobalJson(startDirectory);
-        if (globalJsonRunnerName is null || globalJsonRunnerName.Equals(VSTestRunnerName, StringComparison.OrdinalIgnoreCase))
+        if (globalJsonRunnerName is null)
         {
             return new VSTest();
         }
 
-        if (globalJsonRunnerName.Equals(MicrosoftTestingPlatformRunnerName, StringComparison.OrdinalIgnoreCase))
-        {
-            return new MicrosoftTestingPlatform();
-        }
-
-        throw new InvalidOperationException(string.Format(CommandDefinitionStrings.CmdUnsupportedTestRunnerDescription, globalJsonRunnerName));
+        return TryResolveRunner(globalJsonRunnerName)
+            ?? throw new InvalidOperationException(string.Format(CommandDefinitionStrings.CmdUnsupportedTestRunnerDescription, globalJsonRunnerName));
     }
 
     private static TestCommandDefinition? TryResolveRunner(string name)

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -205,7 +205,156 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             Action act = () => TestCommandDefinition.Create(temp.Path);
 
-            act.Should().Throw<InvalidOperationException>();
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*definitely-not-a-real-runner*");
+        }
+
+        [Fact]
+        public void Create_WhenEnvironmentVariableIsMtp_ReturnsMicrosoftTestingPlatform()
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, "Microsoft.Testing.Platform");
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>(
+                "DOTNET_TEST_RUNNER=Microsoft.Testing.Platform should select MTP without requiring a global.json (#51505).");
+        }
+
+        [Fact]
+        public void Create_WhenEnvironmentVariableIsVSTest_ReturnsVSTest()
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, "VSTest");
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>();
+        }
+
+        [Fact]
+        public void Create_EnvironmentVariableMatchIsCaseInsensitive()
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, "microsoft.testing.platform");
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>();
+        }
+
+        [Theory]
+        [InlineData(" VSTest ")]
+        [InlineData("\tVSTest\n")]
+        public void Create_TrimsWhitespaceAroundEnvironmentVariableValue_VSTest(string envValue)
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, envValue);
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>(
+                "shell/editor mishaps that surround the env var with whitespace must not silently change the selected runner.");
+        }
+
+        [Theory]
+        [InlineData(" Microsoft.Testing.Platform ")]
+        [InlineData("\tMicrosoft.Testing.Platform\n")]
+        public void Create_TrimsWhitespaceAroundEnvironmentVariableValue_MTP(string envValue)
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, envValue);
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>();
+        }
+
+        [Fact]
+        public void Create_EnvironmentVariableTakesPrecedenceOverGlobalJson_MtpOverridesVSTest()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "VSTest" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path, "Microsoft.Testing.Platform");
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>(
+                "DOTNET_TEST_RUNNER should override the runner configured in global.json (#51505).");
+        }
+
+        [Fact]
+        public void Create_EnvironmentVariableTakesPrecedenceOverGlobalJson_VSTestOverridesMtp()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "Microsoft.Testing.Platform" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path, "VSTest");
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>(
+                "DOTNET_TEST_RUNNER should override the runner configured in global.json (#51505).");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Create_WhenEnvironmentVariableIsEmptyOrWhitespace_FallsBackToGlobalJson(string? envValue)
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "Microsoft.Testing.Platform" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path, envValue);
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>(
+                "an unset or whitespace-only DOTNET_TEST_RUNNER must not block the global.json runner from being honored.");
+        }
+
+        [Fact]
+        public void Create_WhenEnvironmentVariableIsUnknown_FallsBackToGlobalJson()
+        {
+            // An unrecognized DOTNET_TEST_RUNNER value must NOT throw — TestCommandDefinition.Create
+            // is invoked during CLI parser construction (i.e. for every `dotnet ...` invocation,
+            // including `dotnet --version` and `dotnet build`). A stale or mistyped env var that
+            // a user inadvertently left set must not crash every command on the box.
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "Microsoft.Testing.Platform" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path, "definitely-not-a-real-runner");
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>(
+                "an unrecognized env var value should be ignored so the global.json runner still wins.");
+        }
+
+        [Fact]
+        public void Create_WhenEnvironmentVariableIsUnknownAndNoGlobalJson_DefaultsToVSTest()
+        {
+            using var temp = new TempDirectory();
+
+            var command = TestCommandDefinition.Create(temp.Path, "definitely-not-a-real-runner");
+
+            command.Should().BeOfType<TestCommandDefinition.VSTest>(
+                "with no other configuration, an unrecognized env var value should fall back to the default runner instead of crashing the CLI.");
+        }
+
+        [Fact]
+        public void Create_ValidEnvironmentVariableShieldsInvalidGlobalJson()
+        {
+            // When DOTNET_TEST_RUNNER is set to a recognized runner, it must take precedence
+            // and prevent the throw that would otherwise come from an invalid global.json
+            // runner name. This is the key escape hatch: a user with a broken global.json can
+            // unblock themselves by setting the env var instead of editing the repo config.
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "global.json"),
+                """{ "test": { "runner": "definitely-not-a-real-runner" } }""");
+
+            var command = TestCommandDefinition.Create(temp.Path, "Microsoft.Testing.Platform");
+
+            command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>(
+                "a valid DOTNET_TEST_RUNNER should shield users from an unsupported runner name in global.json.");
         }
 
         private sealed class TempDirectory : IDisposable

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             using var temp = new TempDirectory();
             File.WriteAllText(Path.Combine(temp.Path, "global.json"), string.Empty);
 
-            var command = TestCommandDefinition.Create(temp.Path);
+            var command = TestCommandDefinition.Create(temp.Path, testRunnerEnvironmentValue: null);
 
             command.Should().BeOfType<TestCommandDefinition.VSTest>(
                 "an empty global.json must not crash the CLI parser (regression for https://github.com/dotnet/sdk/issues/52384)");
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             using var temp = new TempDirectory();
             File.WriteAllText(Path.Combine(temp.Path, "global.json"), "{ this is not valid json");
 
-            var command = TestCommandDefinition.Create(temp.Path);
+            var command = TestCommandDefinition.Create(temp.Path, testRunnerEnvironmentValue: null);
 
             command.Should().BeOfType<TestCommandDefinition.VSTest>();
         }
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Path.Combine(temp.Path, "global.json"),
                 """{ "test": { "runner": "Microsoft.Testing.Platform" } }""");
 
-            var command = TestCommandDefinition.Create(temp.Path);
+            var command = TestCommandDefinition.Create(temp.Path, testRunnerEnvironmentValue: null);
 
             command.Should().BeOfType<TestCommandDefinition.MicrosoftTestingPlatform>();
         }
@@ -203,7 +203,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 Path.Combine(temp.Path, "global.json"),
                 """{ "test": { "runner": "definitely-not-a-real-runner" } }""");
 
-            Action act = () => TestCommandDefinition.Create(temp.Path);
+            // Pass an explicit null env value so the test cannot be silently disabled by a
+            // DOTNET_TEST_RUNNER value that happens to be set in the developer/CI environment.
+            Action act = () => TestCommandDefinition.Create(temp.Path, testRunnerEnvironmentValue: null);
 
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*definitely-not-a-real-runner*");


### PR DESCRIPTION
Adds a new ``DOTNET_TEST_RUNNER`` environment variable that lets users select between the VSTest and Microsoft.Testing.Platform (MTP) runners without having to create, swap, or carry multiple ``global.json`` files.

Fixes #51505

## Behavior

| ``DOTNET_TEST_RUNNER`` | ``global.json`` ``test.runner`` | Selected runner |
| --- | --- | --- |
| ``VSTest`` | (any) | VSTest |
| ``Microsoft.Testing.Platform`` | (any) | MTP |
| unset / empty / whitespace | (unset) | VSTest (default) |
| unset / empty / whitespace | ``VSTest`` | VSTest |
| unset / empty / whitespace | ``Microsoft.Testing.Platform`` | MTP |
| unset / empty / whitespace | other | throws (unchanged) |
| unrecognized value | (anything) | falls back to ``global.json`` row above |

- Match is **case-insensitive** and **whitespace-trimmed** (so ``" VSTest "``, ``vstest``, ``microsoft.testing.platform``, etc. work). Short aliases such as ``mtp`` are intentionally **not** recognized — runner names mirror what ``global.json`` accepts so behavior stays consistent between the two configuration paths.
- A **recognized** env var **takes precedence** over ``global.json`` — including shielding the user from a throw if ``global.json`` has an invalid runner name (an explicit escape hatch).
- An **unrecognized** env var value is **silently ignored** and the existing ``global.json`` path is used. This is intentional: ``TestCommandDefinition.Create`` runs during CLI parser construction for *every* ``dotnet ...`` invocation (e.g. ``dotnet --version``, ``dotnet build``), so a stale/typoed env var must not crash every command on the box.
- An unknown runner name in ``global.json`` itself still throws — that file is explicit, in-repo configuration the user can correct.

## Tests

Added 7 test methods (13 cases including ``Theory`` expansions) in ``TestCommandParserTests.cs`` covering:
- env var selecting each runner (with and without ``global.json``)
- case-insensitive matching
- whitespace trimming for both runner names
- env var overriding ``global.json`` in both directions
- empty / whitespace / ``null`` env var falling back to ``global.json``
- unrecognized env var falling back to ``global.json``
- unrecognized env var with no ``global.json`` defaulting to VSTest (no crash)
- valid env var shielding an invalid ``global.json`` from throwing

All ``TestCommandDefinitionTests`` cases (48 total) pass locally.
