### PR TITLE
Address TODOs in MTP pipe protocol handlers (#50630)

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2657,6 +2657,16 @@ Proceed?</value>
     <value>Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.</value>
     <comment>{Locked="ExecutionId"}</comment>
   </data>
+  <data name="DotnetTestMissingHandshakeProtocolVersions" xml:space="preserve">
+    <value>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</value>
+  </data>
+  <data name="DotnetTestMissingRequiredMessageProperty" xml:space="preserve">
+    <value>The required property '{0}' was not provided in the message of type '{1}'.</value>
+  </data>
+  <data name="RunAsyncCalledMoreThanOnce" xml:space="preserve">
+    <value>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</value>
+    <comment>{Locked="TestApplication.RunAsync"}</comment>
+  </data>
   <data name="ErrorColon" xml:space="preserve">
     <value>error:</value>
   </data>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2661,7 +2661,16 @@ Proceed?</value>
     <value>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</value>
   </data>
   <data name="DotnetTestMissingRequiredMessageProperty" xml:space="preserve">
-    <value>The required property '{0}' was not provided in the message of type '{1}'.</value>
+    <value>The required property '{0}' was missing or empty in the message of type '{1}'.</value>
+  </data>
+  <data name="DotnetTestDuplicateHandshakeOnConnection" xml:space="preserve">
+    <value>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</value>
+  </data>
+  <data name="UnknownSessionEventType" xml:space="preserve">
+    <value>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</value>
+  </data>
+  <data name="UnexpectedMessageWithoutTestHostHandshake" xml:space="preserve">
+    <value>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</value>
   </data>
   <data name="RunAsyncCalledMoreThanOnce" xml:space="preserve">
     <value>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</value>

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -321,7 +321,7 @@ internal sealed class TestApplication(
     private static string GetSupportedProtocolVersion(HandshakeMessage handshakeMessage)
     {
         if (!handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersions) ||
-            protocolVersions is null)
+            string.IsNullOrWhiteSpace(protocolVersions))
         {
             // The handshake didn't advertise any supported protocol versions. Return empty so the
             // handler can surface a dedicated "missing protocol versions" failure to the user via

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -33,6 +33,8 @@ internal sealed class TestApplication(
     private readonly List<NamedPipeServer> _testAppPipeConnections = [];
     private readonly Dictionary<NamedPipeServer, HandshakeMessage> _handshakes = new();
 
+    private int _hasRun;
+
     public TestModule Module { get; } = module;
     public TestOptions TestOptions { get; } = testOptions;
 
@@ -40,8 +42,11 @@ internal sealed class TestApplication(
 
     public async Task<int> RunAsync()
     {
-        // TODO: RunAsync is probably expected to be executed exactly once on each TestApplication instance.
-        // Consider throwing an exception if it's called more than once.
+        if (Interlocked.Exchange(ref _hasRun, 1) != 0)
+        {
+            throw new InvalidOperationException(CliCommandStrings.RunAsyncCalledMoreThanOnce);
+        }
+
         var processStartInfo = CreateProcessStartInfo();
 
         var cancellationTokenSource = new CancellationTokenSource();
@@ -312,8 +317,9 @@ internal sealed class TestApplication(
         if (!handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersions) ||
             protocolVersions is null)
         {
-            // It's not expected we hit this.
-            // TODO: Maybe we should fail more hard?
+            // The handshake didn't advertise any supported protocol versions. Return empty so the
+            // handler can surface a dedicated "missing protocol versions" failure to the user via
+            // 'HandshakeFailure' (rather than throwing here, which would route to 'FailFast').
             return string.Empty;
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -257,10 +257,16 @@ internal sealed class TestApplication(
                 switch (request)
                 {
                     case HandshakeMessage handshakeMessage:
-                        _handshakes.Add(server, handshakeMessage);
+                        if (!_handshakes.TryAdd(server, handshakeMessage))
+                        {
+                            throw new InvalidOperationException(CliCommandStrings.DotnetTestDuplicateHandshakeOnConnection);
+                        }
                         string negotiatedVersion = GetSupportedProtocolVersion(handshakeMessage);
-                        OnHandshakeMessage(handshakeMessage, negotiatedVersion.Length > 0);
-                        return Task.FromResult((IResponse)CreateHandshakeMessage(negotiatedVersion));
+                        // If the handler rejects the handshake (unsupported version, missing required
+                        // properties, mismatching info, ...) respond with an empty negotiated version so
+                        // Microsoft.Testing.Platform stops sending further messages on this connection.
+                        bool handshakeAccepted = OnHandshakeMessage(handshakeMessage, negotiatedVersion.Length > 0);
+                        return Task.FromResult((IResponse)CreateHandshakeMessage(handshakeAccepted ? negotiatedVersion : string.Empty));
 
                     case CommandLineOptionMessages commandLineOptionMessages:
                         OnCommandLineOptionMessages(commandLineOptionMessages);
@@ -347,7 +353,7 @@ internal sealed class TestApplication(
             { HandshakeMessagePropertyNames.SupportedProtocolVersions, version }
         });
 
-    public void OnHandshakeMessage(HandshakeMessage handshakeMessage, bool gotSupportedVersion)
+    public bool OnHandshakeMessage(HandshakeMessage handshakeMessage, bool gotSupportedVersion)
         => _handler.OnHandshakeReceived(handshakeMessage, gotSupportedVersion);
 
     private void OnCommandLineOptionMessages(CommandLineOptionMessages commandLineOptionMessages)

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -30,24 +30,25 @@ internal sealed class TestApplicationHandler
 
         if (!gotSupportedVersion)
         {
+            string failureMessage = handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? supportedProtocolVersions) && supportedProtocolVersions is not null
+                ? string.Format(CliCommandStrings.DotnetTestIncompatibleHandshakeVersion, supportedProtocolVersions, ProtocolConstants.SupportedVersions)
+                : string.Format(CliCommandStrings.DotnetTestMissingHandshakeProtocolVersions, ProtocolConstants.SupportedVersions);
+
             _output.HandshakeFailure(
                 _module.TargetPath,
                 string.Empty,
                 ExitCode.GenericFailure,
-                string.Format(
-                    CliCommandStrings.DotnetTestIncompatibleHandshakeVersion,
-                    handshakeMessage.Properties[HandshakeMessagePropertyNames.SupportedProtocolVersions],
-                    ProtocolConstants.SupportedVersions),
+                failureMessage,
                 string.Empty);
 
-            // Protocol version is not supported.
+            // Protocol version is not supported (or wasn't advertised at all).
             // We don't attempt to do anything else.
             return;
         }
 
-        var executionId = handshakeMessage.Properties[HandshakeMessagePropertyNames.ExecutionId];
-        var arch = handshakeMessage.Properties[HandshakeMessagePropertyNames.Architecture]?.ToLower();
-        var tfm = TargetFrameworkParser.GetShortTargetFramework(handshakeMessage.Properties[HandshakeMessagePropertyNames.Framework]);
+        var executionId = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.ExecutionId);
+        var arch = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Architecture).ToLower();
+        var tfm = TargetFrameworkParser.GetShortTargetFramework(GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Framework));
         var currentHandshakeInfo = (tfm, arch, executionId);
 
         if (!_handshakeInfo.HasValue)
@@ -59,7 +60,7 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.MismatchingHandshakeInfo, currentHandshakeInfo, _handshakeInfo.Value));
         }
 
-        var hostType = handshakeMessage.Properties[HandshakeMessagePropertyNames.HostType];
+        var hostType = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.HostType);
         // https://github.com/microsoft/testfx/blob/2a9a353ec2bb4ce403f72e8ba1f29e01e7cf1fd4/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs#L87-L97
         if (hostType == "TestHost")
         {
@@ -67,10 +68,23 @@ internal sealed class TestApplicationHandler
             // AssemblyRunStarted counts "retry count", and writes to terminal "(Try <number-of-try>) Running tests from <assembly>"
             // So, we want to call it only for test host, and not for test host controller (or orchestrator, if in future it will handshake as well)
             // Calling it for both test host and test host controllers means we will count retries incorrectly, and will messages twice.
-            var instanceId = handshakeMessage.Properties[HandshakeMessagePropertyNames.InstanceId];
+            var instanceId = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.InstanceId);
             var handshakeInfo = _handshakeInfo.Value;
             _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId);
         }
+    }
+
+    private static string GetRequiredHandshakeProperty(HandshakeMessage handshakeMessage, byte propertyId)
+    {
+        if (!handshakeMessage.Properties.TryGetValue(propertyId, out string? value) || value is null)
+        {
+            throw new InvalidOperationException(string.Format(
+                CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
+                GetHandshakePropertyName(propertyId),
+                nameof(HandshakeMessage)));
+        }
+
+        return value;
     }
 
     private static string GetHandshakePropertyName(byte propertyId) =>
@@ -192,11 +206,18 @@ internal sealed class TestApplicationHandler
         var handshakeInfo = _handshakeInfo.Value;
         foreach (var artifact in fileArtifactMessages.FileArtifacts)
         {
+            if (string.IsNullOrEmpty(artifact.FullPath))
+            {
+                throw new InvalidOperationException(string.Format(
+                    CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
+                    nameof(FileArtifactMessage.FullPath),
+                    nameof(FileArtifactMessage)));
+            }
+
             _output.ArtifactAdded(
                 outOfProcess: false,
                 _module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId,
-                // TODO: Revise null suppression here.
-                artifact.TestDisplayName, artifact.FullPath!);
+                artifact.TestDisplayName, artifact.FullPath);
         }
     }
 
@@ -206,7 +227,10 @@ internal sealed class TestApplicationHandler
         {
             LogSessionEvent(sessionEvent);
 
-            // TODO: Validate if we should get this message in help mode or not.
+            if (_options.IsHelp)
+            {
+                throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageInHelpMode, nameof(TestSessionEvent)));
+            }
 
             if (!_handshakeInfo.HasValue)
             {
@@ -219,13 +243,21 @@ internal sealed class TestApplicationHandler
                 throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, sessionEvent.ExecutionId, nameof(TestSessionEvent), _handshakeInfo.Value.ExecutionId));
             }
 
+            if (string.IsNullOrEmpty(sessionEvent.SessionUid))
+            {
+                throw new InvalidOperationException(string.Format(
+                    CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
+                    nameof(TestSessionEvent.SessionUid),
+                    nameof(TestSessionEvent)));
+            }
+
             if (sessionEvent.SessionType == SessionEventTypes.TestSessionStart)
             {
-                IncreaseTestSessionStart(sessionEvent.SessionUid!);
+                IncreaseTestSessionStart(sessionEvent.SessionUid);
             }
             else if (sessionEvent.SessionType == SessionEventTypes.TestSessionEnd)
             {
-                var (testSessionStartCount, testSessionEndCount) = IncreaseTestSessionEnd(sessionEvent.SessionUid!);
+                var (testSessionStartCount, testSessionEndCount) = IncreaseTestSessionEnd(sessionEvent.SessionUid);
                 if (testSessionEndCount > testSessionStartCount)
                 {
                     throw new InvalidOperationException(CliCommandStrings.UnexpectedTestSessionEnd);

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -36,7 +36,7 @@ internal sealed class TestApplicationHandler
 
         if (!gotSupportedVersion)
         {
-            string failureMessage = handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? supportedProtocolVersions) && !string.IsNullOrEmpty(supportedProtocolVersions)
+            string failureMessage = handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? supportedProtocolVersions) && !string.IsNullOrWhiteSpace(supportedProtocolVersions)
                 ? string.Format(CliCommandStrings.DotnetTestIncompatibleHandshakeVersion, supportedProtocolVersions, ProtocolConstants.SupportedVersions)
                 : string.Format(CliCommandStrings.DotnetTestMissingHandshakeProtocolVersions, ProtocolConstants.SupportedVersions);
 
@@ -57,7 +57,7 @@ internal sealed class TestApplicationHandler
             return false;
         }
 
-        var arch = architecture!.ToLower();
+        var arch = architecture!.ToLowerInvariant();
         var tfm = TargetFrameworkParser.GetShortTargetFramework(framework);
         var currentHandshakeInfo = (tfm, arch, executionId!);
 
@@ -103,7 +103,7 @@ internal sealed class TestApplicationHandler
 
     private static bool TryGetRequiredHandshakeProperty(HandshakeMessage handshakeMessage, byte propertyId, out string? value, out string? failureMessage)
     {
-        if (handshakeMessage.Properties.TryGetValue(propertyId, out value) && !string.IsNullOrEmpty(value))
+        if (handshakeMessage.Properties.TryGetValue(propertyId, out value) && !string.IsNullOrWhiteSpace(value))
         {
             failureMessage = null;
             return true;
@@ -118,7 +118,7 @@ internal sealed class TestApplicationHandler
 
     private static string ValidateRequiredMessageProperty(string? value, string propertyName, string messageTypeName)
     {
-        if (string.IsNullOrEmpty(value))
+        if (string.IsNullOrWhiteSpace(value))
         {
             throw new InvalidOperationException(string.Format(
                 CliCommandStrings.DotnetTestMissingRequiredMessageProperty,

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -24,32 +24,51 @@ internal sealed class TestApplicationHandler
         _options = options;
     }
 
-    internal void OnHandshakeReceived(HandshakeMessage handshakeMessage, bool gotSupportedVersion)
+    /// <summary>
+    /// Validates the handshake message and updates handler state. Returns <see langword="true"/> if the
+    /// handshake was accepted, or <see langword="false"/> if it should be rejected (in which case the
+    /// caller should return a failed handshake response to Microsoft.Testing.Platform so it stops
+    /// sending further messages).
+    /// </summary>
+    internal bool OnHandshakeReceived(HandshakeMessage handshakeMessage, bool gotSupportedVersion)
     {
         LogHandshake(handshakeMessage);
 
         if (!gotSupportedVersion)
         {
-            string failureMessage = handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? supportedProtocolVersions) && supportedProtocolVersions is not null
+            string failureMessage = handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? supportedProtocolVersions) && !string.IsNullOrEmpty(supportedProtocolVersions)
                 ? string.Format(CliCommandStrings.DotnetTestIncompatibleHandshakeVersion, supportedProtocolVersions, ProtocolConstants.SupportedVersions)
                 : string.Format(CliCommandStrings.DotnetTestMissingHandshakeProtocolVersions, ProtocolConstants.SupportedVersions);
 
-            _output.HandshakeFailure(
-                _module.TargetPath,
-                string.Empty,
-                ExitCode.GenericFailure,
-                failureMessage,
-                string.Empty);
-
-            // Protocol version is not supported (or wasn't advertised at all).
-            // We don't attempt to do anything else.
-            return;
+            ReportHandshakeFailure(failureMessage);
+            return false;
         }
 
-        var executionId = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.ExecutionId);
-        var arch = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Architecture).ToLower();
-        var tfm = TargetFrameworkParser.GetShortTargetFramework(GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Framework));
-        var currentHandshakeInfo = (tfm, arch, executionId);
+        // Validate all required handshake properties up-front. Missing values are reported via the
+        // structured 'HandshakeFailure' path (consistent with how unsupported versions are reported)
+        // and the caller rejects the handshake at the protocol level so MTP does not keep sending
+        // further messages that would then fail validation in other handlers.
+        if (!TryGetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.ExecutionId, out string? executionId, out string? validationError) ||
+            !TryGetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Architecture, out string? architecture, out validationError) ||
+            !TryGetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.Framework, out string? framework, out validationError) ||
+            !TryGetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.HostType, out string? hostType, out validationError))
+        {
+            ReportHandshakeFailure(validationError!);
+            return false;
+        }
+
+        var arch = architecture!.ToLower();
+        var tfm = TargetFrameworkParser.GetShortTargetFramework(framework);
+        var currentHandshakeInfo = (tfm, arch, executionId!);
+
+        // https://github.com/microsoft/testfx/blob/2a9a353ec2bb4ce403f72e8ba1f29e01e7cf1fd4/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs#L87-L97
+        string? instanceId = null;
+        if (hostType == "TestHost"
+            && !TryGetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.InstanceId, out instanceId, out validationError))
+        {
+            ReportHandshakeFailure(validationError!);
+            return false;
+        }
 
         if (!_handshakeInfo.HasValue)
         {
@@ -57,31 +76,54 @@ internal sealed class TestApplicationHandler
         }
         else if (_handshakeInfo.Value != currentHandshakeInfo)
         {
-            throw new InvalidOperationException(string.Format(CliCommandStrings.MismatchingHandshakeInfo, currentHandshakeInfo, _handshakeInfo.Value));
+            ReportHandshakeFailure(string.Format(CliCommandStrings.MismatchingHandshakeInfo, currentHandshakeInfo, _handshakeInfo.Value));
+            return false;
         }
 
-        var hostType = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.HostType);
-        // https://github.com/microsoft/testfx/blob/2a9a353ec2bb4ce403f72e8ba1f29e01e7cf1fd4/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs#L87-L97
         if (hostType == "TestHost")
         {
             _receivedTestHostHandshake = true;
             // AssemblyRunStarted counts "retry count", and writes to terminal "(Try <number-of-try>) Running tests from <assembly>"
             // So, we want to call it only for test host, and not for test host controller (or orchestrator, if in future it will handshake as well)
             // Calling it for both test host and test host controllers means we will count retries incorrectly, and will messages twice.
-            var instanceId = GetRequiredHandshakeProperty(handshakeMessage, HandshakeMessagePropertyNames.InstanceId);
             var handshakeInfo = _handshakeInfo.Value;
-            _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId);
+            _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId!);
         }
+
+        return true;
     }
 
-    private static string GetRequiredHandshakeProperty(HandshakeMessage handshakeMessage, byte propertyId)
+    private void ReportHandshakeFailure(string failureMessage) =>
+        _output.HandshakeFailure(
+            _module.TargetPath,
+            string.Empty,
+            ExitCode.GenericFailure,
+            failureMessage,
+            string.Empty);
+
+    private static bool TryGetRequiredHandshakeProperty(HandshakeMessage handshakeMessage, byte propertyId, out string? value, out string? failureMessage)
     {
-        if (!handshakeMessage.Properties.TryGetValue(propertyId, out string? value) || value is null)
+        if (handshakeMessage.Properties.TryGetValue(propertyId, out value) && !string.IsNullOrEmpty(value))
+        {
+            failureMessage = null;
+            return true;
+        }
+
+        failureMessage = string.Format(
+            CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
+            GetHandshakePropertyName(propertyId),
+            nameof(HandshakeMessage));
+        return false;
+    }
+
+    private static string ValidateRequiredMessageProperty(string? value, string propertyName, string messageTypeName)
+    {
+        if (string.IsNullOrEmpty(value))
         {
             throw new InvalidOperationException(string.Format(
                 CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
-                GetHandshakePropertyName(propertyId),
-                nameof(HandshakeMessage)));
+                propertyName,
+                messageTypeName));
         }
 
         return value;
@@ -116,17 +158,29 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(DiscoveredTestMessages)));
         }
 
-        if (discoveredTestMessages.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        if (!_receivedTestHostHandshake)
+        {
+            // The terminal reporter only registers an assembly run when the TestHost handshake completes.
+            // Without it, '_assemblies[executionId]' lookups would throw a non-actionable KeyNotFoundException.
+            throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutTestHostHandshake, nameof(DiscoveredTestMessages)));
+        }
+
+        string executionId = ValidateRequiredMessageProperty(
+            discoveredTestMessages.ExecutionId,
+            nameof(DiscoveredTestMessages.ExecutionId),
+            nameof(DiscoveredTestMessages));
+
+        if (executionId != _handshakeInfo.Value.ExecutionId)
         {
             // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
-            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, discoveredTestMessages.ExecutionId, nameof(DiscoveredTestMessages), _handshakeInfo.Value.ExecutionId));
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, executionId, nameof(DiscoveredTestMessages), _handshakeInfo.Value.ExecutionId));
         }
 
         foreach (var test in discoveredTestMessages.DiscoveredMessages)
         {
             _output.TestDiscovered(_handshakeInfo.Value.ExecutionId,
-                test.DisplayName,
-                test.Uid);
+                ValidateRequiredMessageProperty(test.DisplayName, nameof(DiscoveredTestMessage.DisplayName), nameof(DiscoveredTestMessage)),
+                ValidateRequiredMessageProperty(test.Uid, nameof(DiscoveredTestMessage.Uid), nameof(DiscoveredTestMessage)));
         }
     }
 
@@ -144,19 +198,34 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(TestResultMessages)));
         }
 
-        if (testResultMessage.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        if (!_receivedTestHostHandshake)
+        {
+            throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutTestHostHandshake, nameof(TestResultMessages)));
+        }
+
+        string messageExecutionId = ValidateRequiredMessageProperty(
+            testResultMessage.ExecutionId,
+            nameof(TestResultMessages.ExecutionId),
+            nameof(TestResultMessages));
+
+        if (messageExecutionId != _handshakeInfo.Value.ExecutionId)
         {
             // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
-            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, testResultMessage.ExecutionId, nameof(TestResultMessages), _handshakeInfo.Value.ExecutionId));
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, messageExecutionId, nameof(TestResultMessages), _handshakeInfo.Value.ExecutionId));
         }
 
         var handshakeInfo = _handshakeInfo.Value;
+        string instanceId = ValidateRequiredMessageProperty(
+            testResultMessage.InstanceId,
+            nameof(TestResultMessages.InstanceId),
+            nameof(TestResultMessages));
+
         foreach (var testResult in testResultMessage.SuccessfulTestMessages)
         {
             _output.TestCompleted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId,
-                testResultMessage.InstanceId!,
-                testResult.Uid!,
-                testResult.DisplayName!,
+                instanceId,
+                ValidateRequiredMessageProperty(testResult.Uid, nameof(SuccessfulTestResultMessage.Uid), nameof(SuccessfulTestResultMessage)),
+                ValidateRequiredMessageProperty(testResult.DisplayName, nameof(SuccessfulTestResultMessage.DisplayName), nameof(SuccessfulTestResultMessage)),
                 testResult.Reason,
                 ToOutcome(testResult.State),
                 testResult.Duration.HasValue ? TimeSpan.FromTicks(testResult.Duration.Value) : null,
@@ -169,13 +238,14 @@ internal sealed class TestApplicationHandler
 
         foreach (var testResult in testResultMessage.FailedTestMessages)
         {
-            _output.TestCompleted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, testResultMessage.InstanceId!,
-                testResult.Uid!,
-                testResult.DisplayName!,
+            _output.TestCompleted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId,
+                instanceId,
+                ValidateRequiredMessageProperty(testResult.Uid, nameof(FailedTestResultMessage.Uid), nameof(FailedTestResultMessage)),
+                ValidateRequiredMessageProperty(testResult.DisplayName, nameof(FailedTestResultMessage.DisplayName), nameof(FailedTestResultMessage)),
                 testResult.Reason,
                 ToOutcome(testResult.State),
                 testResult.Duration.HasValue ? TimeSpan.FromTicks(testResult.Duration.Value) : null,
-                exceptions: [.. testResult.Exceptions!.Select(fe => new Terminal.FlatException(fe.ErrorMessage, fe.ErrorType, fe.StackTrace))],
+                exceptions: [.. (testResult.Exceptions ?? []).Select(fe => new Terminal.FlatException(fe.ErrorMessage, fe.ErrorType, fe.StackTrace))],
                 expected: null,
                 actual: null,
                 standardOutput: testResult.StandardOutput,
@@ -197,27 +267,34 @@ internal sealed class TestApplicationHandler
             throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(FileArtifactMessages)));
         }
 
-        if (fileArtifactMessages.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        if (!_receivedTestHostHandshake)
+        {
+            throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutTestHostHandshake, nameof(FileArtifactMessages)));
+        }
+
+        string fileArtifactExecutionId = ValidateRequiredMessageProperty(
+            fileArtifactMessages.ExecutionId,
+            nameof(FileArtifactMessages.ExecutionId),
+            nameof(FileArtifactMessages));
+
+        if (fileArtifactExecutionId != _handshakeInfo.Value.ExecutionId)
         {
             // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
-            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, fileArtifactMessages.ExecutionId, nameof(FileArtifactMessages), _handshakeInfo.Value.ExecutionId));
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, fileArtifactExecutionId, nameof(FileArtifactMessages), _handshakeInfo.Value.ExecutionId));
         }
 
         var handshakeInfo = _handshakeInfo.Value;
         foreach (var artifact in fileArtifactMessages.FileArtifacts)
         {
-            if (string.IsNullOrEmpty(artifact.FullPath))
-            {
-                throw new InvalidOperationException(string.Format(
-                    CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
-                    nameof(FileArtifactMessage.FullPath),
-                    nameof(FileArtifactMessage)));
-            }
+            string fullPath = ValidateRequiredMessageProperty(
+                artifact.FullPath,
+                nameof(FileArtifactMessage.FullPath),
+                nameof(FileArtifactMessage));
 
             _output.ArtifactAdded(
                 outOfProcess: false,
                 _module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId,
-                artifact.TestDisplayName, artifact.FullPath);
+                artifact.TestDisplayName, fullPath);
         }
     }
 
@@ -237,27 +314,37 @@ internal sealed class TestApplicationHandler
                 throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(TestSessionEvent)));
             }
 
-            if (sessionEvent.ExecutionId != _handshakeInfo.Value.ExecutionId)
+            string sessionExecutionId = ValidateRequiredMessageProperty(
+                sessionEvent.ExecutionId,
+                nameof(TestSessionEvent.ExecutionId),
+                nameof(TestSessionEvent));
+
+            if (sessionExecutionId != _handshakeInfo.Value.ExecutionId)
             {
                 // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
-                throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, sessionEvent.ExecutionId, nameof(TestSessionEvent), _handshakeInfo.Value.ExecutionId));
+                throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, sessionExecutionId, nameof(TestSessionEvent), _handshakeInfo.Value.ExecutionId));
             }
 
-            if (string.IsNullOrEmpty(sessionEvent.SessionUid))
+            if (sessionEvent.SessionType is null)
             {
                 throw new InvalidOperationException(string.Format(
                     CliCommandStrings.DotnetTestMissingRequiredMessageProperty,
-                    nameof(TestSessionEvent.SessionUid),
+                    nameof(TestSessionEvent.SessionType),
                     nameof(TestSessionEvent)));
             }
 
+            string sessionUid = ValidateRequiredMessageProperty(
+                sessionEvent.SessionUid,
+                nameof(TestSessionEvent.SessionUid),
+                nameof(TestSessionEvent));
+
             if (sessionEvent.SessionType == SessionEventTypes.TestSessionStart)
             {
-                IncreaseTestSessionStart(sessionEvent.SessionUid);
+                IncreaseTestSessionStart(sessionUid);
             }
             else if (sessionEvent.SessionType == SessionEventTypes.TestSessionEnd)
             {
-                var (testSessionStartCount, testSessionEndCount) = IncreaseTestSessionEnd(sessionEvent.SessionUid);
+                var (testSessionStartCount, testSessionEndCount) = IncreaseTestSessionEnd(sessionUid);
                 if (testSessionEndCount > testSessionStartCount)
                 {
                     throw new InvalidOperationException(CliCommandStrings.UnexpectedTestSessionEnd);
@@ -265,7 +352,7 @@ internal sealed class TestApplicationHandler
             }
             else
             {
-                throw new ArgumentOutOfRangeException(nameof(sessionEvent), $"Unknown session event type: {sessionEvent.SessionType}");
+                throw new InvalidOperationException(string.Format(CliCommandStrings.UnknownSessionEventType, sessionEvent.SessionType));
             }
         }
     }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ příkazu „dotnet tool list“.</target>
         <target state="translated">Zpráva typu {0} byla přijata předtím, než jsme obdrželi jakékoli zprávy metodou handshake, což je neočekávané.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Byla přijata koncová událost testovací relace bez odpovídajícího začátku testovací relace.</target>
@@ -3596,6 +3606,11 @@ příkazu „dotnet tool list“.</target>
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Řádky s nezaprotokolovanými změnami představují změny z jiných akcí než příkazů úloh rozhraní příkazového řádku .NET. Obvykle to představuje aktualizaci sady .NET SDK nebo sady Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Nezobrazovat úvodní nápis ani zprávu o autorských právech</target>
@@ -2632,6 +2642,11 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <source>.NET Run Command</source>
         <target state="translated">Příkaz rozhraní .NET pro spuštění</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ und die zugehörigen Paket-IDs für installierte Tools über den Befehl
         <target state="translated">Eine Nachricht vom Typ „{0}“ wurde empfangen, bevor ein Handshake erfolgte, was unerwartet ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Ein Testsitzungs-Endereignis wurde ohne einen entsprechenden Testsitzungsstart empfangen.</target>
@@ -3596,6 +3606,11 @@ und die zugehörigen Paket-IDs für installierte Tools über den Befehl
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Zeilen mit nicht protokollierten Änderungen stellen Änderungen von anderen Aktionen als .NET CLI-Workloadbefehlen dar. In der Regel stellt dies ein Update für das .NET SDK oder für Visual Studio dar.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Zeigt kein Startbanner und keine Copyrightmeldung an.</target>
@@ -2632,6 +2642,11 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <source>.NET Run Command</source>
         <target state="translated">.NET-Befehl "Run"</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">No mostrar la pancarta de inicio ni el mensaje de copyright.</target>
@@ -2632,6 +2642,11 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <source>.NET Run Command</source>
         <target state="translated">Ejecutar comando de .NET</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ y los identificadores de los paquetes correspondientes a las herramientas instal
         <target state="translated">Se recibió un mensaje de tipo "{0}" antes de recibir cualquier protocolo de enlace, lo cual es inesperado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Se recibió un evento de finalización de sesión de prueba sin un evento de inicio de sesión de prueba correspondiente.</target>
@@ -3596,6 +3606,11 @@ y los identificadores de los paquetes correspondientes a las herramientas instal
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Las filas con cambios sin registrar representan cambios de acciones distintas de los comandos de carga de trabajo de la CLI de .NET. Por lo general, esto representa una actualización del SDK de .NET o de Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">N'affiche pas la bannière de démarrage ni le message de copyright.</target>
@@ -2632,6 +2642,11 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <source>.NET Run Command</source>
         <target state="translated">Commande d'exécution .NET</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ et les ID de package correspondants aux outils installés, utilisez la commande
         <target state="translated">Un message de type « {0} » a été reçu avant tout établissement d’une liaison, ce qui est inattendu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Un événement de fin de session de test a été reçu sans démarrage d’une session de test correspondante.</target>
@@ -3596,6 +3606,11 @@ et les ID de package correspondants aux outils installés, utilisez la commande
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Les lignes avec des modifications non enregistrées représentent les modifications des actions autres que les commandes de charge de travail CLI .NET. Il s’agit généralement d’une mise à jour du Kit de développement logiciel (SDK) .NET ou de Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Evita la visualizzazione del messaggio di avvio o di copyright.</target>
@@ -2632,6 +2642,11 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <source>.NET Run Command</source>
         <target state="translated">Comando esecuzione .NET</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ e gli ID pacchetto corrispondenti per gli strumenti installati usando il comando
         <target state="translated">È stato ricevuto un messaggio di tipo '{0}' prima di ricevere handshake, cosa imprevista.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">È stato ricevuto un evento di fine sessione di test senza un evento di inizio sessione corrispondente.</target>
@@ -3596,6 +3606,11 @@ e gli ID pacchetto corrispondenti per gli strumenti installati usando il comando
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Le righe con modifiche non registrate rappresentano modifiche da azioni diverse dai comandi del carico di lavoro dell'interfaccia della riga di comando .NET. In genere si tratta di un aggiornamento di .NET SDK o di Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ and the corresponding package Ids for installed tools using the command
         <target state="translated">ハンドシェイクを受信する前に、種類 '{0}' のメッセージを受信しましたが、これは想定されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">対応するテスト セッションの開始がないまま、テスト セッション終了イベントを受信しました。</target>
@@ -3596,6 +3606,11 @@ and the corresponding package Ids for installed tools using the command
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">ログに記録されていない変更がある行は、.NET CLI ワークロード コマンド以外のアクションからの変更を表します。通常、これは .NET SDK または Visual Studio の更新を表します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">著作権情報を表示しません。</target>
@@ -2632,6 +2642,11 @@ The default is to publish a framework-dependent application.</source>
         <source>.NET Run Command</source>
         <target state="translated">.NET Run コマンド</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ and the corresponding package Ids for installed tools using the command
         <target state="translated">핸드셰이크를 받기 전에 예기치 않게 '{0}' 형식의 메시지가 수신되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">해당 테스트 세션을 시작하지 않고 테스트 세션 종료 이벤트를 받았습니다.</target>
@@ -3596,6 +3606,11 @@ and the corresponding package Ids for installed tools using the command
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">기록되지 않은 변경 내용이 있는 행은 .NET CLI 워크로드 명령 이외의 작업에서 변경된 사항을 나타냅니다. 이러한 변경 사항은 일반적으로 .NET SDK 또는 Visual Studio에 대한 업데이트를 나타냅니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">시작 배너 또는 저작권 메시지를 표시하지 않습니다.</target>
@@ -2632,6 +2642,11 @@ The default is to publish a framework-dependent application.</source>
         <source>.NET Run Command</source>
         <target state="translated">.NET 실행 명령</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Nie wyświetlaj baneru początkowego ani komunikatu o prawach autorskich.</target>
@@ -2632,6 +2642,11 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <source>.NET Run Command</source>
         <target state="translated">Uruchamianie polecenia platformy .NET</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ i odpowiednie identyfikatory pakietów zainstalowanych narzędzi można znaleź�
         <target state="translated">Komunikat typu „{0}” został odebrany przed otrzymaniem jakichkolwiek uzgadniań, co jest nieoczekiwane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Odebrano zdarzenie zakończenia sesji testowej bez odpowiedniego uruchomienia sesji testowej.</target>
@@ -3596,6 +3606,11 @@ i odpowiednie identyfikatory pakietów zainstalowanych narzędzi można znaleź�
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Wiersze z niezarejestrowanymi zmianami reprezentują zmiany pochodzące z akcji innych niż polecenia obciążenia interfejsu wiersza polecenia platformy .NET. Zazwyczaj oznacza to aktualizację zestawu .NET SDK lub programu Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Não exibe a faixa de inicialização ou a mensagem de direitos autorais.</target>
@@ -2632,6 +2642,11 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <source>.NET Run Command</source>
         <target state="translated">Comando Run do .NET</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ e as Ids de pacote correspondentes para as ferramentas instaladas usando o coman
         <target state="translated">Uma mensagem do tipo '{0}' foi recebida antes de qualquer handshake, o que é inesperado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Um evento de término de sessão de teste foi recebido sem um início de sessão de teste correspondente.</target>
@@ -3596,6 +3606,11 @@ e as Ids de pacote correspondentes para as ferramentas instaladas usando o coman
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">As linhas com as alterações Não Registradas representam as alterações de ações diferentes dos comandos de carga de trabalho da CLI do .NET. Geralmente, isso representa uma atualização para o SDK do .NET ou para o Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3579,6 +3584,11 @@ and the corresponding package Ids for installed tools using the command
         <target state="translated">Сообщение типа "{0}" получено до получения каких-либо подтверждений, что является неожиданным.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Получено событие завершения тестового сеанса без соответствующего запуска тестового сеанса.</target>
@@ -3597,6 +3607,11 @@ and the corresponding package Ids for installed tools using the command
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Строки с нерегистрируемыми в журнале изменениями представляют изменения из действий, отличных от команд рабочей нагрузки .NET CLI. Обычно это представляет обновление пакета SDK для .NET или Visual Studio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Не отображать начальный баннер или сообщение об авторских правах.</target>
@@ -2632,6 +2642,11 @@ The default is to publish a framework-dependent application.</source>
         <source>.NET Run Command</source>
         <target state="translated">Команда .NET Run</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Başlangıç bandını veya telif hakkı iletisini görüntüleme.</target>
@@ -2632,6 +2642,11 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <source>.NET Run Command</source>
         <target state="translated">.NET Run Komutu</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ karşılık gelen paket kimliklerini bulmak için
         <target state="translated">Herhangi bir el sıkışma almadan önce '{0}' türünde bir mesaj alındı, bu beklenmedik bir durumdur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">Karşılık gelen test oturumu başlangıcı olmadan bir test oturumu bitiş olayı alındı.</target>
@@ -3596,6 +3606,11 @@ karşılık gelen paket kimliklerini bulmak için
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">Kaydedilmemiş değişiklikler içeren satırlar, .NET CLI iş yükü komutları dışındaki eylemlerden kaynaklanan değişiklikleri temsil eder. Bu genellikle .NET SDK'ya veya Visual Studio'ya bir güncelleştirme anlamına gelir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ and the corresponding package Ids for installed tools using the command
         <target state="translated">在我们收到任何握手之前已收到类型为 ‘{0}’ 的消息，这是意外的行为。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">在没有相应的测试会话启动的情况下收到了测试会话结束事件。</target>
@@ -3596,6 +3606,11 @@ and the corresponding package Ids for installed tools using the command
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">具有未记录更改的行表示除 .NET CLI 工作负载命令以外的操作的更改。这通常表示对 .NET SDK 或 Visual Studio 的更新。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">不显示启动版权标志或版权消息。</target>
@@ -2632,6 +2642,11 @@ The default is to publish a framework-dependent application.</source>
         <source>.NET Run Command</source>
         <target state="translated">.NET 运行命令</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -112,6 +112,16 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
+        <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
+        <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetTestMissingRequiredMessageProperty">
+        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">不顯示啟始資訊或著作權訊息。</target>
@@ -2632,6 +2642,11 @@ The default is to publish a framework-dependent application.</source>
         <source>.NET Run Command</source>
         <target state="translated">.NET 執行命令</target>
         <note />
+      </trans-unit>
+      <trans-unit id="RunAsyncCalledMoreThanOnce">
+        <source>'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</source>
+        <target state="new">'TestApplication.RunAsync' was already called on this instance and cannot be invoked more than once.</target>
+        <note>{Locked="TestApplication.RunAsync"}</note>
       </trans-unit>
       <trans-unit id="RunCommandAvailableDevices">
         <source>Available devices:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -112,14 +112,19 @@
         <target state="new">List available devices for running the application.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetTestDuplicateHandshakeOnConnection">
+        <source>Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</source>
+        <target state="new">Received more than one handshake message from Microsoft.Testing.Platform on the same pipe connection.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DotnetTestMissingHandshakeProtocolVersions">
         <source>The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</source>
         <target state="new">The handshake message from Microsoft.Testing.Platform did not provide the supported protocol versions. The SDK supports '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
-        <source>The required property '{0}' was not provided in the message of type '{1}'.</source>
-        <target state="new">The required property '{0}' was not provided in the message of type '{1}'.</target>
+        <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
+        <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
@@ -3578,6 +3583,11 @@ and the corresponding package Ids for installed tools using the command
         <target state="translated">在收到任何交握之前，我們就接收到類型為 '{0}' 的訊息，這是不預期的情況。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnexpectedMessageWithoutTestHostHandshake">
+        <source>Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</source>
+        <target state="new">Received a message of type '{0}' from Microsoft.Testing.Platform before the TestHost handshake completed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedTestSessionEnd">
         <source>A test session end event was received without a corresponding test session start.</source>
         <target state="translated">收到測試工作階段結束事件，但沒有對應的測試工作階段開始。</target>
@@ -3596,6 +3606,11 @@ and the corresponding package Ids for installed tools using the command
       <trans-unit id="UnknownRecordsInformationalMessage">
         <source>Rows with Unlogged changes represent changes from actions other than .NET CLI workload commands. Usually this represents an update to the .NET SDK or to Visual Studio.</source>
         <target state="translated">具有未記錄變更的列代表變更來自 .NET CLI 工作負載命令以外的動作。這通常代表對 .NET SDK 或 Visual Studio 的更新。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownSessionEventType">
+        <source>Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</source>
+        <target state="new">Received an unknown session event type '{0}' from Microsoft.Testing.Platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateAllOptionDescription">


### PR DESCRIPTION
Fixes #50630.

Addresses the four explicit TODOs in the Microsoft.Testing.Platform pipe protocol implementation, originally called out in #50625's follow-up review, and hardens handshake / message handling end-to-end based on three rounds of expert review.

## TestApplication.cs
- `RunAsync` is guarded with `Interlocked.Exchange` so callers can no longer invoke it more than once on the same instance.
- `OnRequest` rejects a duplicate `HandshakeMessage` arriving on the same pipe connection (`_handshakes.TryAdd`).
- `OnRequest` now propagates the handshake handler's accept/reject decision: when the handler rejects the handshake (unsupported version, missing required properties, mismatching info, ...), it responds with `CreateHandshakeMessage(string.Empty)` so Microsoft.Testing.Platform stops sending further messages on the connection. Without this, the platform would have continued sending discovery / result messages that would have failed later with a `KeyNotFoundException` inside `TerminalTestReporter`.
- Reworded the `GetSupportedProtocolVersion` comment to explain why we return an empty string instead of throwing.

## TestApplicationHandler.cs
### Handshake validation
- `OnHandshakeReceived` no longer throws when required properties (`ExecutionId`, `Architecture`, `Framework`, `HostType`, `InstanceId`) are missing or empty. A new `TryGetRequiredHandshakeProperty` helper routes failures through the structured `HandshakeFailure` path and the method now returns `bool` so `TestApplication.OnRequest` can reject the handshake at the protocol level.
- A missing `SupportedProtocolVersions` value surfaces a distinct `DotnetTestMissingHandshakeProtocolVersions` message (instead of the previous `KeyNotFoundException`).
- Handshake mismatch is now reported via `HandshakeFailure` instead of throwing → `FailFast`.
- `InstanceId` validation runs before `_handshakeInfo` is set so a failed TestHost handshake leaves handler state clean.

### Per-message validation
- Added `ValidateRequiredMessageProperty` helper used to validate required strings in non-handshake messages.
- Validates the top-level `ExecutionId` on every non-handshake message (`DiscoveredTestMessages`, `TestResultMessages`, `FileArtifactMessages`, `TestSessionEvent`) before comparing it to the handshake's `ExecutionId`.
- Validates `DiscoveredTestMessage.Uid` / `DisplayName`, `TestResultMessages.InstanceId` plus each `SuccessfulTestResultMessage`/`FailedTestResultMessage` `Uid` / `DisplayName`, `FileArtifactMessage.FullPath`, `TestSessionEvent.SessionUid` / `SessionType`.
- `testResult.Exceptions` is now null-safe (`?? []`) instead of using the `!` null-suppression operator.
- `OnSessionEventReceived` rejects messages received in help mode and surfaces unknown session event types via a localized `UnknownSessionEventType` error instead of `ArgumentOutOfRangeException`.

### TestHost-handshake guard
- Discovery / result / artifact handlers reject messages received before the `TestHost` handshake completes. Without this, a non-TestHost-only handshake could let those messages reach `TerminalTestReporter` and throw `KeyNotFoundException` on `_assemblies[executionId]` (the reporter only registers an assembly via `AssemblyRunStarted` for `HostType == "TestHost"`).

## Resources
Added to `CliCommandStrings.resx`:
- `DotnetTestMissingHandshakeProtocolVersions`
- `DotnetTestMissingRequiredMessageProperty` (worded "missing or empty in the message of type '{1}'")
- `DotnetTestDuplicateHandshakeOnConnection`
- `UnknownSessionEventType`
- `UnexpectedMessageWithoutTestHostHandshake`
- `RunAsyncCalledMoreThanOnce`

`.xlf` files were auto-regenerated by the build (`state="new"`).

## Verification
- Build: 0 warnings, 0 errors.
- Targeted regression test `GivenDotnetTestRunsConsoleAppWithoutHandshake.RunConsoleAppDoesNothing_ShouldReturnCorrectExitCode` passes (Debug + Release).

## Out of scope (deliberately deferred)
- Dedicated unit tests for `TestApplicationHandler` / pipe protocol handling — no existing test infrastructure for this layer and adding it would significantly broaden this PR. Tracked as a follow-up.
- `ToOutcome` still throws `ArgumentOutOfRangeException` for unknown states (lower-impact; can be addressed in a follow-up).
- Unrelated TODOs outside the pipe-protocol layer (`MicrosoftTestingPlatformTestCommand`, `SolutionAndProjectUtility`, `Terminal/*`).
