### PR TITLE
Show currently running tests in dotnet test MTP output (#49712)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/TestInProgressMessages.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/TestInProgressMessages.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+internal sealed record TestInProgressMessage(string? Uid, string? DisplayName);
+
+internal sealed record TestInProgressMessages(string? ExecutionId, string? InstanceId, TestInProgressMessage[] InProgressMessages) : IRequest;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -133,3 +133,18 @@ internal static class HandshakeMessageFieldsId
 {
     public const int MessagesSerializerId = 9;
 }
+
+internal static class TestInProgressMessagesFieldsId
+{
+    public const int MessagesSerializerId = 10;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort TestInProgressMessageList = 3;
+}
+
+internal static class TestInProgressMessageFieldsId
+{
+    public const ushort Uid = 1;
+    public const ushort DisplayName = 2;
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
  * FileArtifactMessageSerializer: 7
  * TestSessionEventSerializer: 8
  * HandshakeMessageSerializer: 9
+ * TestInProgressMessagesSerializer: 10
  */
 
 internal static class RegisterSerializers
@@ -31,5 +32,6 @@ internal static class RegisterSerializers
         namedPipeBase.RegisterSerializer(new FileArtifactMessagesSerializer(), typeof(FileArtifactMessages));
         namedPipeBase.RegisterSerializer(new TestSessionEventSerializer(), typeof(TestSessionEvent));
         namedPipeBase.RegisterSerializer(new HandshakeMessageSerializer(), typeof(HandshakeMessage));
+        namedPipeBase.RegisterSerializer(new TestInProgressMessagesSerializer(), typeof(TestInProgressMessages));
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+/*
+|---FieldCount---| 2 bytes
+
+|---ExecutionId Id---| (2 bytes)
+|---ExecutionId Size---| (4 bytes)
+|---ExecutionId Value---| (n bytes)
+
+|---InstanceId Id---| (2 bytes)
+|---InstanceId Size---| (4 bytes)
+|---InstanceId Value---| (n bytes)
+
+|---TestInProgressMessageList Id---| (2 bytes)
+|---TestInProgressMessageList Size---| (4 bytes)
+|---TestInProgressMessageList Value---| (n bytes)
+    |---TestInProgressMessageList Length---| (4 bytes)
+
+    |---TestInProgressMessageList[0] FieldCount---| 2 bytes
+
+    |---TestInProgressMessageList[0].Uid Id---| (2 bytes)
+    |---TestInProgressMessageList[0].Uid Size---| (4 bytes)
+    |---TestInProgressMessageList[0].Uid Value---| (n bytes)
+
+    |---TestInProgressMessageList[0].DisplayName Id---| (2 bytes)
+    |---TestInProgressMessageList[0].DisplayName Size---| (4 bytes)
+    |---TestInProgressMessageList[0].DisplayName Value---| (n bytes)
+*/
+
+internal sealed class TestInProgressMessagesSerializer : BaseSerializer, INamedPipeSerializer
+{
+    public int Id => TestInProgressMessagesFieldsId.MessagesSerializerId;
+
+    public object Deserialize(Stream stream)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+        List<TestInProgressMessage>? inProgressMessages = null;
+
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            int fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case TestInProgressMessagesFieldsId.ExecutionId:
+                    executionId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case TestInProgressMessagesFieldsId.InstanceId:
+                    instanceId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case TestInProgressMessagesFieldsId.TestInProgressMessageList:
+                    inProgressMessages = ReadInProgressMessagesPayload(stream);
+                    break;
+
+                default:
+                    // If we don't recognize the field id, skip the payload corresponding to that field
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
+            }
+        }
+
+        return new TestInProgressMessages(executionId, instanceId, inProgressMessages is null ? [] : [.. inProgressMessages]);
+    }
+
+    private static List<TestInProgressMessage> ReadInProgressMessagesPayload(Stream stream)
+    {
+        List<TestInProgressMessage> inProgressMessages = [];
+
+        int length = ReadInt(stream);
+        for (int i = 0; i < length; i++)
+        {
+            string? uid = null, displayName = null;
+
+            int fieldCount = ReadUShort(stream);
+
+            for (int j = 0; j < fieldCount; j++)
+            {
+                int fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
+                switch (fieldId)
+                {
+                    case TestInProgressMessageFieldsId.Uid:
+                        uid = ReadStringValue(stream, fieldSize);
+                        break;
+
+                    case TestInProgressMessageFieldsId.DisplayName:
+                        displayName = ReadStringValue(stream, fieldSize);
+                        break;
+
+                    default:
+                        SetPosition(stream, stream.Position + fieldSize);
+                        break;
+                }
+            }
+
+            inProgressMessages.Add(new TestInProgressMessage(uid, displayName));
+        }
+
+        return inProgressMessages;
+    }
+
+    public void Serialize(object objectToSerialize, Stream stream)
+    {
+        Debug.Assert(stream.CanSeek, "We expect a seekable stream.");
+
+        var inProgressMessages = (TestInProgressMessages)objectToSerialize;
+
+        WriteUShort(stream, GetFieldCount(inProgressMessages));
+
+        WriteField(stream, TestInProgressMessagesFieldsId.ExecutionId, inProgressMessages.ExecutionId);
+        WriteField(stream, TestInProgressMessagesFieldsId.InstanceId, inProgressMessages.InstanceId);
+        WriteInProgressMessagesPayload(stream, inProgressMessages.InProgressMessages);
+    }
+
+    private static void WriteInProgressMessagesPayload(Stream stream, TestInProgressMessage[]? inProgressMessageList)
+    {
+        if (inProgressMessageList is null || inProgressMessageList.Length == 0)
+        {
+            return;
+        }
+
+        WriteUShort(stream, TestInProgressMessagesFieldsId.TestInProgressMessageList);
+
+        // We will reserve an int (4 bytes)
+        // so that we fill the size later, once we write the payload
+        WriteInt(stream, 0);
+
+        long before = stream.Position;
+        WriteInt(stream, inProgressMessageList.Length);
+        foreach (TestInProgressMessage inProgressMessage in inProgressMessageList)
+        {
+            WriteUShort(stream, GetFieldCount(inProgressMessage));
+
+            WriteField(stream, TestInProgressMessageFieldsId.Uid, inProgressMessage.Uid);
+            WriteField(stream, TestInProgressMessageFieldsId.DisplayName, inProgressMessage.DisplayName);
+        }
+
+        // NOTE: We are able to seek only if we are using a MemoryStream
+        // thus, the seek operation is fast as we are only changing the value of a property
+        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
+    }
+
+    private static ushort GetFieldCount(TestInProgressMessages inProgressMessages) =>
+        (ushort)((inProgressMessages.ExecutionId is null ? 0 : 1) +
+        (inProgressMessages.InstanceId is null ? 0 : 1) +
+        (IsNullOrEmpty(inProgressMessages.InProgressMessages) ? 0 : 1));
+
+    private static ushort GetFieldCount(TestInProgressMessage inProgressMessage) =>
+        (ushort)((inProgressMessage.Uid is null ? 0 : 1) +
+        (inProgressMessage.DisplayName is null ? 0 : 1));
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -94,6 +94,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
         {
             ShowPassedTests = showPassedTests,
             ShowProgress = !noProgress,
+            ShowActiveTests = !noProgress && ansiMode == AnsiMode.AnsiIfPossible,
             AnsiMode = ansiMode,
             ShowAssembly = true,
             ShowAssemblyStartAndComplete = true,

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -409,7 +409,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         if (_options.ShowActiveTests)
         {
-            asm.TestNodeResultsState?.RemoveRunningTestNode(testNodeUid);
+            asm.TestNodeResultsState?.RemoveRunningTestNode(instanceId, testNodeUid);
         }
 
         switch (outcome)
@@ -950,9 +950,13 @@ internal sealed partial class TerminalTestReporter : IDisposable
         };
 
     public void TestInProgress(
+        string assembly,
+        string? targetFramework,
+        string? architecture,
+        string executionId,
+        string instanceId,
         string testNodeUid,
-        string displayName,
-        string executionId)
+        string displayName)
     {
         TestProgressState asm = _assemblies[executionId];
 
@@ -960,7 +964,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             asm.TestNodeResultsState ??= new(Interlocked.Increment(ref _counter));
             asm.TestNodeResultsState.AddRunningTestNode(
-                Interlocked.Increment(ref _counter), testNodeUid, displayName, CreateStopwatch());
+                Interlocked.Increment(ref _counter), instanceId, testNodeUid, displayName, CreateStopwatch());
         }
 
         _terminalWithProgress.UpdateWorker(asm.SlotIndex);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -36,6 +36,14 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private readonly TestProgressStateAwareTerminal _terminalWithProgress;
 
+    /// <summary>
+    /// Whether to track and render currently running tests. Gated on both the caller-requested
+    /// <see cref="TerminalTestReporterOptions.ShowActiveTests"/> and the effective progress
+    /// capability of the console: if progress cannot actually be rendered (e.g. redirected stdout,
+    /// non-TTY, or ANSI not supported) there is no point allocating per-test running-state.
+    /// </summary>
+    private readonly bool _showActiveTests;
+
     private int _handshakeFailuresCount;
 
     private readonly uint? _originalConsoleMode;
@@ -94,6 +102,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
 
         _terminalWithProgress = new TestProgressStateAwareTerminal(terminal, showProgress);
+        _showActiveTests = _options.ShowActiveTests && showProgress;
     }
 
     public void TestExecutionStarted(DateTimeOffset testStartTime, int workerCount, bool isDiscovery, bool isHelp, bool isRetry)
@@ -407,7 +416,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         TestProgressState asm = _assemblies[executionId];
         var attempt = asm.TryCount;
 
-        if (_options.ShowActiveTests)
+        if (_showActiveTests)
         {
             asm.TestNodeResultsState?.RemoveRunningTestNode(instanceId, testNodeUid);
         }
@@ -960,7 +969,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     {
         TestProgressState asm = _assemblies[executionId];
 
-        if (_options.ShowActiveTests)
+        if (_showActiveTests)
         {
             asm.TestNodeResultsState ??= new(Interlocked.Increment(ref _counter));
             asm.TestNodeResultsState.AddRunningTestNode(

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
@@ -12,12 +12,33 @@ internal sealed class TestNodeResultsState(long id)
 
     private readonly TestDetailState _summaryDetail = new(id, stopwatch: null, text: string.Empty);
     private readonly ConcurrentDictionary<string, TestDetailState> _testNodeProgressStates = new();
+    private readonly ConcurrentDictionary<string, byte> _completed = new();
 
     public int Count => _testNodeProgressStates.Count;
 
-    public void AddRunningTestNode(int id, string uid, string name, IStopwatch stopwatch) => _testNodeProgressStates[uid] = new TestDetailState(id, stopwatch, name);
+    public void AddRunningTestNode(int id, string instanceId, string uid, string name, IStopwatch stopwatch)
+    {
+        string key = MakeKey(instanceId, uid);
 
-    public void RemoveRunningTestNode(string uid) => _testNodeProgressStates.TryRemove(uid, out _);
+        // Guard against stale "in-progress" notifications that arrive after the
+        // test already completed. Without this we could surface a "running"
+        // entry that will never be removed.
+        if (_completed.ContainsKey(key))
+        {
+            return;
+        }
+
+        _testNodeProgressStates[key] = new TestDetailState(id, stopwatch, name);
+    }
+
+    public void RemoveRunningTestNode(string instanceId, string uid)
+    {
+        string key = MakeKey(instanceId, uid);
+        _completed[key] = 0;
+        _testNodeProgressStates.TryRemove(key, out _);
+    }
+
+    private static string MakeKey(string instanceId, string uid) => $"{instanceId}\u0000{uid}";
 
     public IEnumerable<TestDetailState> GetRunningTasks(int maxCount)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -273,6 +273,10 @@ internal sealed class TestApplication(
                         OnFileArtifactMessages(fileArtifactMessages);
                         break;
 
+                    case TestInProgressMessages testInProgressMessages:
+                        OnTestInProgressMessages(testInProgressMessages);
+                        break;
+
                     case TestSessionEvent sessionEvent:
                         OnSessionEvent(sessionEvent);
                         break;
@@ -362,6 +366,9 @@ internal sealed class TestApplication(
 
     private void OnFileArtifactMessages(FileArtifactMessages fileArtifactMessages)
         => _handler.OnFileArtifactsReceived(fileArtifactMessages);
+
+    private void OnTestInProgressMessages(TestInProgressMessages testInProgressMessages)
+        => _handler.OnTestInProgressReceived(testInProgressMessages);
 
     private void OnSessionEvent(TestSessionEvent sessionEvent)
         => _handler.OnSessionEventReceived(sessionEvent);

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -169,6 +169,40 @@ internal sealed class TestApplicationHandler
         }
     }
 
+    internal void OnTestInProgressReceived(TestInProgressMessages testInProgressMessages)
+    {
+        LogTestInProgress(testInProgressMessages);
+
+        if (_options.IsHelp)
+        {
+            throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageInHelpMode, nameof(TestInProgressMessages)));
+        }
+
+        if (!_handshakeInfo.HasValue)
+        {
+            throw new InvalidOperationException(string.Format(CliCommandStrings.UnexpectedMessageWithoutHandshake, nameof(TestInProgressMessages)));
+        }
+
+        if (testInProgressMessages.ExecutionId != _handshakeInfo.Value.ExecutionId)
+        {
+            // Received 'ExecutionId' of value '{0}' for message '{1}' while the 'ExecutionId' received of the handshake message was '{2}'.
+            throw new InvalidOperationException(string.Format(CliCommandStrings.DotnetTestMismatchingExecutionId, testInProgressMessages.ExecutionId, nameof(TestInProgressMessages), _handshakeInfo.Value.ExecutionId));
+        }
+
+        var handshakeInfo = _handshakeInfo.Value;
+        foreach (TestInProgressMessage inProgressMessage in testInProgressMessages.InProgressMessages)
+        {
+            _output.TestInProgress(
+                _module.TargetPath,
+                handshakeInfo.TargetFramework,
+                handshakeInfo.Architecture,
+                handshakeInfo.ExecutionId,
+                testInProgressMessages.InstanceId!,
+                inProgressMessage.Uid!,
+                inProgressMessage.DisplayName!);
+        }
+    }
+
     internal void OnFileArtifactsReceived(FileArtifactMessages fileArtifactMessages)
     {
         LogFileArtifacts(fileArtifactMessages);
@@ -355,6 +389,26 @@ internal sealed class TestApplicationHandler
             logMessageBuilder.AppendLine($"FailedTestResult: {failedTestResult.Uid}, {failedTestResult.DisplayName}, " +
                 $"{failedTestResult.State}, {failedTestResult.Duration}, {failedTestResult.Reason}, {string.Join(", ", (failedTestResult.Exceptions ?? Array.Empty<ExceptionMessage>()).Select(e => $"{e.ErrorMessage}, {e.ErrorType}, {e.StackTrace}"))}" +
                 $"{failedTestResult.StandardOutput}, {failedTestResult.ErrorOutput}, {failedTestResult.SessionUid}");
+        }
+
+        Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());
+    }
+
+    private static void LogTestInProgress(TestInProgressMessages testInProgressMessages)
+    {
+        if (!Logger.TraceEnabled)
+        {
+            return;
+        }
+
+        var logMessageBuilder = new StringBuilder();
+
+        logMessageBuilder.AppendLine($"TestInProgress Execution Id: {testInProgressMessages.ExecutionId}");
+        logMessageBuilder.AppendLine($"TestInProgress Instance Id: {testInProgressMessages.InstanceId}");
+
+        foreach (TestInProgressMessage inProgressMessage in testInProgressMessages.InProgressMessages)
+        {
+            logMessageBuilder.AppendLine($"TestInProgress: {inProgressMessage.Uid}, {inProgressMessage.DisplayName}");
         }
 
         Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());

--- a/test/dotnet.Tests/CommandTests/Test/TestInProgressMessagesSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestInProgressMessagesSerializerTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+public class TestInProgressMessagesSerializerTests
+{
+    [Fact]
+    public void RoundTrips_WithPopulatedMessages()
+    {
+        var serializer = new TestInProgressMessagesSerializer();
+        var original = new TestInProgressMessages(
+            ExecutionId: "exec-123",
+            InstanceId: "inst-456",
+            InProgressMessages:
+            [
+                new TestInProgressMessage("uid-1", "DisplayName1"),
+                new TestInProgressMessage("uid-2", "DisplayName2"),
+            ]);
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (TestInProgressMessages)serializer.Deserialize(stream);
+
+        Assert.Equal(original.ExecutionId, deserialized.ExecutionId);
+        Assert.Equal(original.InstanceId, deserialized.InstanceId);
+        Assert.Equal(2, deserialized.InProgressMessages.Length);
+        Assert.Equal("uid-1", deserialized.InProgressMessages[0].Uid);
+        Assert.Equal("DisplayName1", deserialized.InProgressMessages[0].DisplayName);
+        Assert.Equal("uid-2", deserialized.InProgressMessages[1].Uid);
+        Assert.Equal("DisplayName2", deserialized.InProgressMessages[1].DisplayName);
+    }
+
+    [Fact]
+    public void RoundTrips_WithEmptyMessagesList()
+    {
+        var serializer = new TestInProgressMessagesSerializer();
+        var original = new TestInProgressMessages(
+            ExecutionId: "exec-123",
+            InstanceId: "inst-456",
+            InProgressMessages: []);
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (TestInProgressMessages)serializer.Deserialize(stream);
+
+        Assert.Equal(original.ExecutionId, deserialized.ExecutionId);
+        Assert.Equal(original.InstanceId, deserialized.InstanceId);
+        Assert.Empty(deserialized.InProgressMessages);
+    }
+
+    [Fact]
+    public void SerializerId_IsTen()
+    {
+        // The IPC protocol reserves serializer IDs across SDK and MTP.
+        // ID 10 is the contract — keep this assertion to prevent accidental changes.
+        Assert.Equal(10, new TestInProgressMessagesSerializer().Id);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestNodeResultsStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestNodeResultsStateTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+public class TestNodeResultsStateTests
+{
+    [Fact]
+    public void AddRunningTestNode_AfterRemove_IsSuppressed()
+    {
+        // Simulates the stale-add race: the producer may emit an in-progress
+        // notification for a test that already completed. The state must not
+        // resurrect the test in the "running" list.
+        var state = new TestNodeResultsState(id: 1);
+        const string instanceId = "instance-A";
+        const string uid = "Foo";
+
+        state.AddRunningTestNode(id: 100, instanceId, uid, "Foo", new FakeStopwatch());
+        Assert.Equal(1, state.Count);
+
+        state.RemoveRunningTestNode(instanceId, uid);
+        Assert.Equal(0, state.Count);
+
+        // Stale in-progress arriving after completion must be ignored.
+        state.AddRunningTestNode(id: 101, instanceId, uid, "Foo", new FakeStopwatch());
+        Assert.Equal(0, state.Count);
+    }
+
+    [Fact]
+    public void AddRunningTestNode_DifferentInstance_SameUid_NotSuppressed()
+    {
+        // Retries use a new instanceId. A previous instance completing must
+        // not prevent the new instance from showing as running.
+        var state = new TestNodeResultsState(id: 1);
+        const string uid = "Foo";
+
+        state.AddRunningTestNode(id: 100, "instance-A", uid, "Foo", new FakeStopwatch());
+        state.RemoveRunningTestNode("instance-A", uid);
+        Assert.Equal(0, state.Count);
+
+        state.AddRunningTestNode(id: 200, "instance-B", uid, "Foo", new FakeStopwatch());
+        Assert.Equal(1, state.Count);
+    }
+
+    [Fact]
+    public void AddRunningTestNode_DistinctTests_AllTracked()
+    {
+        var state = new TestNodeResultsState(id: 1);
+
+        state.AddRunningTestNode(id: 100, "instance-A", "Test1", "Test1", new FakeStopwatch());
+        state.AddRunningTestNode(id: 101, "instance-A", "Test2", "Test2", new FakeStopwatch());
+        state.AddRunningTestNode(id: 102, "instance-B", "Test1", "Test1", new FakeStopwatch());
+
+        Assert.Equal(3, state.Count);
+    }
+
+    private sealed class FakeStopwatch : IStopwatch
+    {
+        public TimeSpan Elapsed => TimeSpan.Zero;
+
+        public void Start() { }
+
+        public void Stop() { }
+    }
+}


### PR DESCRIPTION
Fixes #49712.

## What

Surfaces currently-running tests in the dotnet test output for projects using Microsoft.Testing.Platform (MTP). The SDK already has all of the rendering machinery for this (`TestProgressState`/`TestNodeResultsState`/`AnsiTerminalTestProgressFrame` — including the `... and X more` trimming), but it was dead code because:

1. The IPC protocol carried no `test started` event for MTP, only `TestResultMessages`.
2. `TerminalTestReporterOptions.ShowActiveTests` was never set.

This PR addresses both.

## Changes

* **New IPC message** — `TestInProgressMessages` model + TLV serializer registered with id `10`. Mirrors `DiscoveredTestMessages`.
* **Dispatch + handler** — `TestApplication.OnRequest` dispatches the new message; `TestApplicationHandler.OnTestInProgressReceived` validates the execution id and forwards each item to the reporter.
* **Reporter** — `TerminalTestReporter.TestInProgress` now takes the same `(assembly, tfm, arch, executionId, instanceId, uid, displayName)` shape as `TestCompleted`.
* **State** — `TestNodeResultsState` keys running tests by `(instanceId, uid)` instead of just `uid`, and tracks a `completed` set so a late in-progress notification can never resurrect a finished test. Retries (which get a new `instanceId`) are surfaced correctly.
* **Default-on** — `ShowActiveTests` is enabled when `AnsiMode == AnsiIfPossible` and progress isn't suppressed (so it stays off in CI, `--no-ansi`, `--no-progress`, and LLM environments).

## Back-compat

The named-pipe protocol is **not** versioned for this change because TLV with unknown-id skip is sufficient:

* **Old SDK + new MTP** — `NamedPipeServer` is constructed with `skipUnknownMessages: true` and `TestApplication.OnRequest` already returns `VoidResponse` for `UnknownMessage`, so the events are dropped silently.
* **New SDK + old MTP** — old MTPs simply never send the message, so the running-tests panel stays empty (which is what users see today).

No protocol version bump is needed.

## Producer-side gating (concern from @nohwnd)

@nohwnd flagged in #49712 that 12 parallel processes flooding `test started` events for fast tests would be noisy. Mitigations in this PR:

* The existing per-assembly `... and X more` trimming in `TestNodeResultsState.GetRunningTasks` already handles bursty cases.
* The stale-add guard means stragglers that arrive after a test result don't pollute the panel.

The companion MTP-side PR is microsoft/testfx#8652, which actually emits the new `TestInProgressMessages` from `DotnetTestDataConsumer` on `InProgressTestNodeStateProperty`. A further producer-side slow-test threshold (e.g. only emit after N ms) could be added there as a follow-up.

## Tests

* `TestInProgressMessagesSerializerTests` — round-trip with populated and empty payloads; pins serializer id to `10`.
* `TestNodeResultsStateTests` — stale-add suppression after completion, retry path (new `instanceId` re-adds), distinct `(instanceId, uid)` keying.

All 6 new tests pass.


