### PR TITLE
Migrate get packages to prune

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using global::NuGet.Frameworks;
 using global::NuGet.Versioning;
+using Microsoft.Build.Framework;
 using Microsoft.NET.Build.Tasks;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
 
@@ -115,17 +116,18 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
         return frameworkPackages.ToArray();
     }
 
-    public static FrameworkPackages LoadFrameworkPackagesFromPack(Logger log, NuGetFramework framework, string frameworkName, string targetingPackRoot)
+    public static FrameworkPackages LoadFrameworkPackagesFromPack(Logger log, NuGetFramework framework, string frameworkName, AbsolutePath targetingPackRoot)
     {
         if (framework is null || framework.Framework != FrameworkConstants.FrameworkIdentifiers.NetCoreApp)
         {
             return null;
         }
 
-        if (!string.IsNullOrEmpty(targetingPackRoot))
+        if (targetingPackRoot.Value is not null)
         {
             var packsFolder = Path.Combine(targetingPackRoot, frameworkName + ".Ref");
-            log.LogMessage("Looking for targeting packs in {0}", packsFolder);
+            var packsFolderForLog = Path.Combine(targetingPackRoot.OriginalValue, frameworkName + ".Ref");
+            log.LogMessage("Looking for targeting packs in {0}", packsFolderForLog);
             if (Directory.Exists(packsFolder))
             {
                 var packVersionPattern = $"{framework.Version.Major}.{framework.Version.Minor}.*";
@@ -153,12 +155,12 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
                 }
                 else
                 {
-                    log.LogMessage("No package overrides found in {0}", packsFolder);
+                    log.LogMessage("No package overrides found in {0}", packsFolderForLog);
                 }
             }
             else
             {
-                log.LogMessage("Targeting pack folder {0} does not exist", packsFolder);
+                log.LogMessage("Targeting pack folder {0} does not exist", packsFolderForLog);
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
@@ -126,24 +126,24 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
         if (!string.IsNullOrEmpty(targetingPackRoot.Value))
         {
             var packsFolder = Path.Combine(targetingPackRoot, frameworkName + ".Ref");
-            var packsFolderForLog = Path.Combine(targetingPackRoot.OriginalValue, frameworkName + ".Ref");
-            log.LogMessage("Looking for targeting packs in {0}", packsFolderForLog);
+            var originalPacksFolder = Path.Combine(targetingPackRoot.OriginalValue, frameworkName + ".Ref");
+            log.LogMessage("Looking for targeting packs in {0}", originalPacksFolder);
             if (Directory.Exists(packsFolder))
             {
                 var packVersionPattern = $"{framework.Version.Major}.{framework.Version.Minor}.*";
                 var packDirectories = Directory.GetDirectories(packsFolder, packVersionPattern);
-                log.LogMessage("Pack directories found: {0}", string.Join(Environment.NewLine, packDirectories));
-                var packageOverridesFile = packDirectories
-                                                .Select(d => (Overrides: Path.Combine(d, "data", "PackageOverrides.txt"), Version: ParseVersion(Path.GetFileName(d))))
+                log.LogMessage("Pack directories found: {0}", string.Join(Environment.NewLine, packDirectories.Select(d => Path.Combine(originalPacksFolder, Path.GetFileName(d)))));
+                var packageOverrides = packDirectories
+                                                .Select(d => (Overrides: Path.Combine(d, "data", "PackageOverrides.txt"), OriginalOverrides: Path.Combine(originalPacksFolder, Path.GetFileName(d), "data", "PackageOverrides.txt"), Version: ParseVersion(Path.GetFileName(d))))
                                                 .Where(d => File.Exists(d.Overrides))
                                                 .OrderByDescending(d => d.Version)
-                                                .FirstOrDefault().Overrides;
+                                                .FirstOrDefault();
 
-                if (packageOverridesFile is not null)
+                if (packageOverrides.Overrides is not null)
                 {
-                    log.LogMessage("Found package overrides file {0}", packageOverridesFile);
+                    log.LogMessage("Found package overrides file {0}", packageOverrides.OriginalOverrides);
                     // Adapted from https://github.com/dotnet/sdk/blob/c3a8f72c3a5491c693ff8e49e7406136a12c3040/src/Tasks/Common/ConflictResolution/PackageOverride.cs#L52-L68
-                    var packageOverrideLines = File.ReadAllLines(packageOverridesFile);
+                    var packageOverrideLines = File.ReadAllLines(packageOverrides.Overrides);
 
                     var frameworkPackages = new FrameworkPackages(framework, frameworkName);
                     foreach (var packageOverride in PackageOverride.CreateOverriddenPackages(packageOverrideLines))
@@ -155,12 +155,12 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
                 }
                 else
                 {
-                    log.LogMessage("No package overrides found in {0}", packsFolderForLog);
+                    log.LogMessage("No package overrides found in {0}", originalPacksFolder);
                 }
             }
             else
             {
-                log.LogMessage("Targeting pack folder {0} does not exist", packsFolderForLog);
+                log.LogMessage("Targeting pack folder {0} does not exist", originalPacksFolder);
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs
@@ -123,7 +123,7 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
             return null;
         }
 
-        if (targetingPackRoot.Value is not null)
+        if (!string.IsNullOrEmpty(targetingPackRoot.Value))
         {
             var packsFolder = Path.Combine(targetingPackRoot, frameworkName + ".Ref");
             var packsFolderForLog = Path.Combine(targetingPackRoot.OriginalValue, frameworkName + ".Ref");

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -63,12 +63,14 @@ namespace Microsoft.NET.Build.Tasks
             public string TargetFrameworkVersion { get; set; }
             public HashSet<string> FrameworkReferences { get; set; }
             public bool LoadPrunePackageDataFromNearestFramework { get; set; }
+            public bool AllowMissingPrunePackageData { get; set; }
 
             //  The resolved (absolutized) prune package data root and targeting pack roots are part of the cache key.
             //  Otherwise two projects with the same framework values but different resolved roots (for example, the same
             //  project-relative path under different TaskEnvironment.ProjectDirectory values) could incorrectly reuse the
             //  first project's package data from the build-wide cache.
             public string PrunePackageDataRoot { get; set; }
+            //  Targeting pack roots are a search path, so their order can affect which pack is loaded.
             public string[] TargetingPackRoots { get; set; }
 
             public override bool Equals(object obj) => obj is CacheKey key &&
@@ -76,6 +78,7 @@ namespace Microsoft.NET.Build.Tasks
                 TargetFrameworkVersion == key.TargetFrameworkVersion &&
                 FrameworkReferences.SetEquals(key.FrameworkReferences) &&
                 LoadPrunePackageDataFromNearestFramework == key.LoadPrunePackageDataFromNearestFramework &&
+                AllowMissingPrunePackageData == key.AllowMissingPrunePackageData &&
                 PrunePackageDataRoot == key.PrunePackageDataRoot &&
                 TargetingPackRoots.SequenceEqual(key.TargetingPackRoots);
             public override int GetHashCode()
@@ -84,11 +87,12 @@ namespace Microsoft.NET.Build.Tasks
                 var hashCode = new HashCode();
                 hashCode.Add(TargetFrameworkIdentifier);
                 hashCode.Add(TargetFrameworkVersion);
-                foreach (var frameworkReference in FrameworkReferences)
+                foreach (var frameworkReference in FrameworkReferences.OrderBy(r => r, StringComparer.Ordinal))
                 {
                     hashCode.Add(frameworkReference);
                 }
                 hashCode.Add(LoadPrunePackageDataFromNearestFramework);
+                hashCode.Add(AllowMissingPrunePackageData);
                 hashCode.Add(PrunePackageDataRoot);
                 foreach (var targetingPackRoot in TargetingPackRoots)
                 {
@@ -100,11 +104,12 @@ namespace Microsoft.NET.Build.Tasks
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TargetFrameworkIdentifier);
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TargetFrameworkVersion);
 
-                foreach (var frameworkReference in FrameworkReferences)
+                foreach (var frameworkReference in FrameworkReferences.OrderBy(r => r, StringComparer.Ordinal))
                 {
                     hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(frameworkReference);
                 }
                 hashCode = hashCode * -1521134295 + LoadPrunePackageDataFromNearestFramework.GetHashCode();
+                hashCode = hashCode * -1521134295 + AllowMissingPrunePackageData.GetHashCode();
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(PrunePackageDataRoot);
                 foreach (var targetingPackRoot in TargetingPackRoots)
                 {
@@ -153,11 +158,16 @@ namespace Microsoft.NET.Build.Tasks
                 TargetFrameworkVersion = TargetFrameworkVersion,
                 FrameworkReferences = runtimeFrameworks.ToHashSet(),
                 LoadPrunePackageDataFromNearestFramework = LoadPrunePackageDataFromNearestFramework,
+                AllowMissingPrunePackageData = AllowMissingPrunePackageData,
                 PrunePackageDataRoot = prunePackageDataRoot.Value,
                 TargetingPackRoots = targetingPackRoots.Select(r => r.Value).ToArray()
             };
 
-            //  Cache framework package values per build
+            //  Cache framework package values per build.  Under multithreaded execution two instances can pass this
+            //  check and compute concurrently for the same key, but that race is benign: the task object registry is
+            //  thread-safe (last writer wins) and the result is deterministic for a given key, so racing instances
+            //  produce equivalent PackagesToPrune regardless of which registration wins.  The only cost is the
+            //  occasional redundant computation, which we accept rather than serialize all instances on a shared lock.
             var existingResult = BuildEngine4.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.Build);
             if (existingResult != null)
             {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -12,8 +12,11 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    public class GetPackagesToPrune : TaskBase
+    [MSBuildMultiThreadableTask]
+    public class GetPackagesToPrune : TaskBase, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         // Minimum .NET Core version that supports package pruning
         private const int FrameworkReferenceMinVersion = 3;
         
@@ -133,13 +136,19 @@ namespace Microsoft.NET.Build.Tasks
                 PackagesToPrune = (TaskItem[])existingResult;
                 return;
             }
+            AbsolutePath prunePackageDataRoot = TaskEnvironment.GetAbsolutePath(PrunePackageDataRoot);
 
-            PackagesToPrune = LoadPackagesToPrune(key, TargetingPackRoots, PrunePackageDataRoot, Log, AllowMissingPrunePackageData);
+            AbsolutePath[] targetingPackRoots = TargetingPackRoots
+                .Where(r => !string.IsNullOrEmpty(r))
+                .Select(r => TaskEnvironment.GetAbsolutePath(r))
+                .ToArray();
+
+            PackagesToPrune = LoadPackagesToPrune(key, targetingPackRoots, prunePackageDataRoot, Log, AllowMissingPrunePackageData);
 
             BuildEngine4.RegisterTaskObject(key, PackagesToPrune, RegisteredTaskObjectLifetime.Build, true);
         }
 
-        static TaskItem[] LoadPackagesToPrune(CacheKey key, string[] targetingPackRoots, string prunePackageDataRoot, Logger log, bool allowMissingPrunePackageData)
+        static TaskItem[] LoadPackagesToPrune(CacheKey key, AbsolutePath[] targetingPackRoots, AbsolutePath prunePackageDataRoot, Logger log, bool allowMissingPrunePackageData)
         {
             Dictionary<string, NuGetVersion> packagesToPrune = new();
 
@@ -225,7 +234,7 @@ namespace Microsoft.NET.Build.Tasks
             return frameworkPackages;
         }
 
-        static Dictionary<string, NuGetVersion> LoadPackagesToPruneFromPrunePackageData(string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, string prunePackageDataRoot)
+        static Dictionary<string, NuGetVersion> LoadPackagesToPruneFromPrunePackageData(string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, AbsolutePath prunePackageDataRoot)
         {
             string packageOverridesPath = Path.Combine(prunePackageDataRoot, targetFrameworkVersion, frameworkReference, "PackageOverrides.txt");
             if (File.Exists(packageOverridesPath))
@@ -238,7 +247,7 @@ namespace Microsoft.NET.Build.Tasks
             return null;
         }
 
-        static Dictionary<string, NuGetVersion> LoadPackagesToPruneFromTargetingPack(Logger log, string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, string [] targetingPackRoots)
+        static Dictionary<string, NuGetVersion> LoadPackagesToPruneFromTargetingPack(Logger log, string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, AbsolutePath[] targetingPackRoots)
         {
             var nugetFramework = new NuGetFramework(targetFrameworkIdentifier, Version.Parse(targetFrameworkVersion));
 
@@ -256,7 +265,7 @@ namespace Microsoft.NET.Build.Tasks
             return null;
         }
 
-        static Dictionary<string, NuGetVersion> TryLoadPackagesToPruneForVersion(Logger log, string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, string[] targetingPackRoots, string prunePackageDataRoot, bool loadPrunePackageDataFromNearestFramework)
+        static Dictionary<string, NuGetVersion> TryLoadPackagesToPruneForVersion(Logger log, string targetFrameworkIdentifier, string targetFrameworkVersion, string frameworkReference, AbsolutePath[] targetingPackRoots, AbsolutePath prunePackageDataRoot, bool loadPrunePackageDataFromNearestFramework)
         {
             var currentVersion = Version.Parse(targetFrameworkVersion);
             

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -64,11 +64,20 @@ namespace Microsoft.NET.Build.Tasks
             public HashSet<string> FrameworkReferences { get; set; }
             public bool LoadPrunePackageDataFromNearestFramework { get; set; }
 
+            //  The resolved (absolutized) prune package data root and targeting pack roots are part of the cache key.
+            //  Otherwise two projects with the same framework values but different resolved roots (for example, the same
+            //  project-relative path under different TaskEnvironment.ProjectDirectory values) could incorrectly reuse the
+            //  first project's package data from the build-wide cache.
+            public string PrunePackageDataRoot { get; set; }
+            public string[] TargetingPackRoots { get; set; }
+
             public override bool Equals(object obj) => obj is CacheKey key &&
                 TargetFrameworkIdentifier == key.TargetFrameworkIdentifier &&
                 TargetFrameworkVersion == key.TargetFrameworkVersion &&
                 FrameworkReferences.SetEquals(key.FrameworkReferences) &&
-                LoadPrunePackageDataFromNearestFramework == key.LoadPrunePackageDataFromNearestFramework;
+                LoadPrunePackageDataFromNearestFramework == key.LoadPrunePackageDataFromNearestFramework &&
+                PrunePackageDataRoot == key.PrunePackageDataRoot &&
+                TargetingPackRoots.SequenceEqual(key.TargetingPackRoots);
             public override int GetHashCode()
             {
 #if NET
@@ -80,6 +89,11 @@ namespace Microsoft.NET.Build.Tasks
                     hashCode.Add(frameworkReference);
                 }
                 hashCode.Add(LoadPrunePackageDataFromNearestFramework);
+                hashCode.Add(PrunePackageDataRoot);
+                foreach (var targetingPackRoot in TargetingPackRoots)
+                {
+                    hashCode.Add(targetingPackRoot);
+                }
                 return hashCode.ToHashCode();
 #else
                 int hashCode = 1436330440;
@@ -91,6 +105,11 @@ namespace Microsoft.NET.Build.Tasks
                     hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(frameworkReference);
                 }
                 hashCode = hashCode * -1521134295 + LoadPrunePackageDataFromNearestFramework.GetHashCode();
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(PrunePackageDataRoot);
+                foreach (var targetingPackRoot in TargetingPackRoots)
+                {
+                    hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(targetingPackRoot);
+                }
                 return hashCode;
 #endif
             }
@@ -121,12 +140,21 @@ namespace Microsoft.NET.Build.Tasks
                 }
             }
 
+            AbsolutePath prunePackageDataRoot = TaskEnvironment.GetAbsolutePath(PrunePackageDataRoot);
+
+            AbsolutePath[] targetingPackRoots = TargetingPackRoots
+                .Where(r => !string.IsNullOrEmpty(r))
+                .Select(r => TaskEnvironment.GetAbsolutePath(r))
+                .ToArray();
+
             CacheKey key = new()
             {
                 TargetFrameworkIdentifier = TargetFrameworkIdentifier,
                 TargetFrameworkVersion = TargetFrameworkVersion,
                 FrameworkReferences = runtimeFrameworks.ToHashSet(),
-                LoadPrunePackageDataFromNearestFramework = LoadPrunePackageDataFromNearestFramework
+                LoadPrunePackageDataFromNearestFramework = LoadPrunePackageDataFromNearestFramework,
+                PrunePackageDataRoot = prunePackageDataRoot.Value,
+                TargetingPackRoots = targetingPackRoots.Select(r => r.Value).ToArray()
             };
 
             //  Cache framework package values per build
@@ -136,12 +164,6 @@ namespace Microsoft.NET.Build.Tasks
                 PackagesToPrune = (TaskItem[])existingResult;
                 return;
             }
-            AbsolutePath prunePackageDataRoot = TaskEnvironment.GetAbsolutePath(PrunePackageDataRoot);
-
-            AbsolutePath[] targetingPackRoots = TargetingPackRoots
-                .Where(r => !string.IsNullOrEmpty(r))
-                .Select(r => TaskEnvironment.GetAbsolutePath(r))
-                .ToArray();
 
             PackagesToPrune = LoadPackagesToPrune(key, targetingPackRoots, prunePackageDataRoot, Log, AllowMissingPrunePackageData);
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs
@@ -163,11 +163,7 @@ namespace Microsoft.NET.Build.Tasks
                 TargetingPackRoots = targetingPackRoots.Select(r => r.Value).ToArray()
             };
 
-            //  Cache framework package values per build.  Under multithreaded execution two instances can pass this
-            //  check and compute concurrently for the same key, but that race is benign: the task object registry is
-            //  thread-safe (last writer wins) and the result is deterministic for a given key, so racing instances
-            //  produce equivalent PackagesToPrune regardless of which registration wins.  The only cost is the
-            //  occasional redundant computation, which we accept rather than serialize all instances on a shared lock.
+            //  Cache framework package values per build.
             var existingResult = BuildEngine4.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.Build);
             if (existingResult != null)
             {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAFrameworkPackages.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAFrameworkPackages.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.ComponentDetection.Detectors.NuGet;
+using NuGet.Frameworks;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    /// <summary>
+    /// Direct unit tests for <see cref="FrameworkPackages.LoadFrameworkPackagesFromPack"/>, which after the
+    /// multithreaded-task migration takes an <see cref="AbsolutePath"/> for the targeting pack root. These
+    /// exercise the method in isolation (the early-out guards, the missing-folder branch, and a successful
+    /// PackageOverrides.txt load) rather than only through <see cref="GetPackagesToPrune"/>.
+    /// </summary>
+    public class GivenAFrameworkPackages
+    {
+        private const string NetCoreApp = "Microsoft.NETCore.App";
+
+        private sealed class TestLogger : Logger
+        {
+            protected override void LogCore(in Message message) { }
+        }
+
+        private static NuGetFramework Net10 => new NuGetFramework(".NETCoreApp", new Version(10, 0, 0));
+
+        private static AbsolutePath AbsolutePathFor(string path) =>
+            TaskEnvironmentHelper.CreateForTest(Path.GetTempPath()).GetAbsolutePath(path);
+
+        [Fact]
+        public void ItReturnsNullWhenFrameworkIsNotANetCoreAppPack()
+        {
+            // null framework and non-.NETCoreApp frameworks both short-circuit to null.
+            FrameworkPackages.LoadFrameworkPackagesFromPack(new TestLogger(), framework: null, NetCoreApp, AbsolutePathFor(Path.GetTempPath()))
+                .Should().BeNull("a null framework is not a .NETCoreApp targeting pack");
+
+            var netFramework = new NuGetFramework(".NETFramework", new Version(4, 7, 2));
+            FrameworkPackages.LoadFrameworkPackagesFromPack(new TestLogger(), netFramework, NetCoreApp, AbsolutePathFor(Path.GetTempPath()))
+                .Should().BeNull("only .NETCoreApp frameworks have targeting pack data");
+        }
+
+        [Fact]
+        public void ItReturnsNullWhenTargetingPackFolderDoesNotExist()
+        {
+            var missingRoot = Path.Combine(Path.GetTempPath(), "fp-missing-" + Guid.NewGuid().ToString("N"));
+
+            FrameworkPackages.LoadFrameworkPackagesFromPack(new TestLogger(), Net10, NetCoreApp, AbsolutePathFor(missingRoot))
+                .Should().BeNull("a non-existent targeting pack folder yields no packages");
+        }
+
+        [Fact]
+        public void ItLoadsPackageOverridesFromTargetingPack()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "fp-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                // <root>/Microsoft.NETCore.App.Ref/10.0.0/data/PackageOverrides.txt
+                var overridesFile = Path.Combine(root, NetCoreApp + ".Ref", "10.0.0", "data", "PackageOverrides.txt");
+                Directory.CreateDirectory(Path.GetDirectoryName(overridesFile)!);
+                File.WriteAllText(overridesFile, "Newtonsoft.Json|13.0.1");
+
+                var result = FrameworkPackages.LoadFrameworkPackagesFromPack(new TestLogger(), Net10, NetCoreApp, AbsolutePathFor(root));
+
+                result.Should().NotBeNull("a PackageOverrides.txt exists under the targeting pack root");
+                result.Packages.Should().ContainKey("Newtonsoft.Json");
+                result.Packages["Newtonsoft.Json"].ToString().Should().Be("13.0.1");
+            }
+            finally
+            {
+                try { Directory.Delete(root, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -20,6 +20,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         private static GetPackagesToPrune CreateTask(TaskTestEnvironment env, string targetingPackRoots, string prunePackageDataRoot, bool allowMissing = false)
         {
+            return CreateTask(env, new[] { targetingPackRoots }, prunePackageDataRoot, allowMissing);
+        }
+
+        private static GetPackagesToPrune CreateTask(TaskTestEnvironment env, string[] targetingPackRoots, string prunePackageDataRoot, bool allowMissing = false)
+        {
             var frameworkReference = new TaskItem(NetCoreApp);
             var targetingPack = new TaskItem(NetCoreApp);
             targetingPack.SetMetadata("RuntimeFrameworkName", NetCoreApp);
@@ -32,7 +37,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 TargetFrameworkVersion = TargetFrameworkVersion,
                 FrameworkReferences = new ITaskItem[] { frameworkReference },
                 TargetingPacks = new ITaskItem[] { targetingPack },
-                TargetingPackRoots = new[] { targetingPackRoots },
+                TargetingPackRoots = targetingPackRoots,
                 PrunePackageDataRoot = prunePackageDataRoot,
                 AllowMissingPrunePackageData = allowMissing,
                 LoadPrunePackageDataFromNearestFramework = false,
@@ -110,6 +115,66 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.PackagesToPrune.Should().ContainSingle()
                 .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void ItFallsBackToALaterTargetingPackRootWhenAnEarlierOneHasNoData()
+        {
+            using var env = new TaskTestEnvironment();
+
+            // Only the second targeting pack root has the data; the first points at an
+            // existing-but-empty directory. This verifies LoadFrameworkPackagesFromPack
+            // iterates the AbsolutePath[] and absolutizes each entry (not just the first).
+            const string emptyTargetingPackRoot = "packs-empty";
+            const string realTargetingPackRoot = "packs-real";
+            env.CreateProjectDirectory(emptyTargetingPackRoot);
+            env.CreateProjectFile(
+                Path.Combine(
+                    realTargetingPackRoot,
+                    NetCoreApp + ".Ref",
+                    TargetFrameworkVersion + ".0",
+                    "data",
+                    "PackageOverrides.txt"),
+                "Newtonsoft.Json|13.0.1");
+
+            // Empty-but-existing prune data so the task falls back to the targeting pack lookup.
+            const string emptyPruneDataRelative = "EmptyPruneData";
+            env.CreateProjectDirectory(emptyPruneDataRelative);
+
+            var task = CreateTask(
+                env,
+                targetingPackRoots: new[] { emptyTargetingPackRoot, realTargetingPackRoot },
+                prunePackageDataRoot: emptyPruneDataRelative);
+
+            task.Execute().Should().BeTrue(
+                "the lookup should continue to later targeting pack roots when an earlier one has no data");
+
+            task.PackagesToPrune.Should().ContainSingle()
+                .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void ItSucceedsWithNoPackagesWhenTargetingPackFolderDoesNotExist()
+        {
+            using var env = new TaskTestEnvironment();
+
+            // Point both roots at non-existent folders so Directory.Exists(packsFolder) is false
+            // (the missing-folder branch in LoadFrameworkPackagesFromPack). With AllowMissing set,
+            // the task should succeed without throwing and produce no packages.
+            const string missingTargetingPackRoot = "does-not-exist";
+            const string emptyPruneDataRelative = "EmptyPruneData";
+            env.CreateProjectDirectory(emptyPruneDataRelative);
+
+            var task = CreateTask(
+                env,
+                targetingPackRoots: missingTargetingPackRoot,
+                prunePackageDataRoot: emptyPruneDataRelative,
+                allowMissing: true);
+
+            task.Execute().Should().BeTrue(
+                "a non-existent targeting pack folder should be handled gracefully when AllowMissingPrunePackageData is true");
+
+            task.PackagesToPrune.Should().BeEmpty();
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -118,63 +118,65 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [Fact]
-        public void ItFallsBackToALaterTargetingPackRootWhenAnEarlierOneHasNoData()
+        public void ItDoesNotReuseCachedDataForDifferentResolvedTargetingPackRoots()
         {
             using var env = new TaskTestEnvironment();
 
-            // Only the second targeting pack root has the data; the first points at an
-            // existing-but-empty directory. This verifies LoadFrameworkPackagesFromPack
-            // iterates the AbsolutePath[] and absolutizes each entry (not just the first).
-            const string emptyTargetingPackRoot = "packs-empty";
-            const string realTargetingPackRoot = "packs-real";
-            env.CreateProjectDirectory(emptyTargetingPackRoot);
+            // Two roots with the SAME framework values but DIFFERENT data. The build-wide cache key
+            // must include the resolved roots; otherwise the second task would incorrectly reuse the
+            // first one's packages.
+            const string rootA = "packs-a";
+            const string rootB = "packs-b";
             env.CreateProjectFile(
-                Path.Combine(
-                    realTargetingPackRoot,
-                    NetCoreApp + ".Ref",
-                    TargetFrameworkVersion + ".0",
-                    "data",
-                    "PackageOverrides.txt"),
+                Path.Combine(rootA, NetCoreApp + ".Ref", TargetFrameworkVersion + ".0", "data", "PackageOverrides.txt"),
                 "Newtonsoft.Json|13.0.1");
+            env.CreateProjectFile(
+                Path.Combine(rootB, NetCoreApp + ".Ref", TargetFrameworkVersion + ".0", "data", "PackageOverrides.txt"),
+                "System.Text.Json|8.0.0");
 
-            // Empty-but-existing prune data so the task falls back to the targeting pack lookup.
+            // Empty-but-existing prune data so both fall back to the targeting pack lookup.
             const string emptyPruneDataRelative = "EmptyPruneData";
             env.CreateProjectDirectory(emptyPruneDataRelative);
 
-            var task = CreateTask(
-                env,
-                targetingPackRoots: new[] { emptyTargetingPackRoot, realTargetingPackRoot },
-                prunePackageDataRoot: emptyPruneDataRelative);
+            // A SHARED caching engine across both task runs (MockBuildEngine caches by CacheKey).
+            var sharedEngine = new MockBuildEngine();
 
-            task.Execute().Should().BeTrue(
-                "the lookup should continue to later targeting pack roots when an earlier one has no data");
+            var taskA = CreateTask(env, targetingPackRoots: rootA, prunePackageDataRoot: emptyPruneDataRelative);
+            taskA.BuildEngine = sharedEngine;
+            taskA.Execute().Should().BeTrue();
+            taskA.PackagesToPrune.Should().ContainSingle().Which.ItemSpec.Should().Be("Newtonsoft.Json");
 
-            task.PackagesToPrune.Should().ContainSingle()
-                .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+            var taskB = CreateTask(env, targetingPackRoots: rootB, prunePackageDataRoot: emptyPruneDataRelative);
+            taskB.BuildEngine = sharedEngine;
+            taskB.Execute().Should().BeTrue();
+            taskB.PackagesToPrune.Should().ContainSingle().Which.ItemSpec.Should().Be(
+                "System.Text.Json",
+                "different resolved targeting pack roots must not collide in the build-wide cache");
         }
 
         [Fact]
-        public void ItSucceedsWithNoPackagesWhenTargetingPackFolderDoesNotExist()
+        public void ItReusesCachedDataForIdenticalInputs()
         {
             using var env = new TaskTestEnvironment();
 
-            // Point both roots at non-existent folders so Directory.Exists(packsFolder) is false
-            // (the missing-folder branch in LoadFrameworkPackagesFromPack). With AllowMissing set,
-            // the task should succeed without throwing and produce no packages.
-            const string missingTargetingPackRoot = "does-not-exist";
-            const string emptyPruneDataRelative = "EmptyPruneData";
-            env.CreateProjectDirectory(emptyPruneDataRelative);
+            const string prunePackageDataRelative = "PrunePackageData";
+            env.CreateProjectFile(
+                Path.Combine(prunePackageDataRelative, TargetFrameworkVersion, NetCoreApp, "PackageOverrides.txt"),
+                "Newtonsoft.Json|13.0.1");
 
-            var task = CreateTask(
-                env,
-                targetingPackRoots: missingTargetingPackRoot,
-                prunePackageDataRoot: emptyPruneDataRelative,
-                allowMissing: true);
+            var sharedEngine = new MockBuildEngine();
 
-            task.Execute().Should().BeTrue(
-                "a non-existent targeting pack folder should be handled gracefully when AllowMissingPrunePackageData is true");
+            var first = CreateTask(env, targetingPackRoots: "packs", prunePackageDataRelative);
+            first.BuildEngine = sharedEngine;
+            first.Execute().Should().BeTrue();
 
-            task.PackagesToPrune.Should().BeEmpty();
+            var second = CreateTask(env, targetingPackRoots: "packs", prunePackageDataRelative);
+            second.BuildEngine = sharedEngine;
+            second.Execute().Should().BeTrue();
+
+            // The second run with identical inputs should hit the cache and return the very same array.
+            second.PackagesToPrune.Should().BeSameAs(first.PackagesToPrune,
+                "identical framework values and resolved roots should produce a cache hit");
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    /// <summary>
+    /// Functional tests for <see cref="GetPackagesToPrune"/> focused on how the task
+    /// resolves <c>PrunePackageDataRoot</c> and <c>TargetingPackRoots</c> through
+    /// <see cref="TaskEnvironment"/>. These tests pass RELATIVE paths and verify that
+    /// the task reads the on-disk data from the right place even when the process
+    /// current working directory differs from the project directory.
+    /// </summary>
+    public class GivenAGetPackagesToPrune
+    {
+        private const string NetCoreApp = "Microsoft.NETCore.App";
+        private const string TargetFrameworkVersion = "10.0";
+
+        private static GetPackagesToPrune CreateTask(TaskTestEnvironment env, string targetingPackRoots, string prunePackageDataRoot, bool allowMissing = false)
+        {
+            var frameworkReference = new TaskItem(NetCoreApp);
+            var targetingPack = new TaskItem(NetCoreApp);
+            targetingPack.SetMetadata("RuntimeFrameworkName", NetCoreApp);
+
+            return new GetPackagesToPrune
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                TaskEnvironment = env.TaskEnvironment,
+                TargetFrameworkIdentifier = ".NETCoreApp",
+                TargetFrameworkVersion = TargetFrameworkVersion,
+                FrameworkReferences = new ITaskItem[] { frameworkReference },
+                TargetingPacks = new ITaskItem[] { targetingPack },
+                TargetingPackRoots = new[] { targetingPackRoots },
+                PrunePackageDataRoot = prunePackageDataRoot,
+                AllowMissingPrunePackageData = allowMissing,
+                LoadPrunePackageDataFromNearestFramework = false,
+            };
+        }
+
+        [Fact]
+        public void ItResolvesPrunePackageDataRootRelativeToTaskEnvironmentProjectDirectory()
+        {
+            using var env = new TaskTestEnvironment();
+
+            // Lay out a PackageOverrides.txt at <ProjectDir>/PrunePackageData/<tfmVersion>/<frameworkRef>/
+            const string prunePackageDataRelative = "PrunePackageData";
+            env.CreateProjectFile(
+                Path.Combine(prunePackageDataRelative, TargetFrameworkVersion, NetCoreApp, "PackageOverrides.txt"),
+                "Newtonsoft.Json|13.0.1");
+
+            var task = CreateTask(env, targetingPackRoots: env.GetProjectPath("targetingpacks"), prunePackageDataRelative);
+
+            task.Execute().Should().BeTrue(
+                "PrunePackageDataRoot is relative and must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD");
+
+            task.PackagesToPrune.Should().ContainSingle()
+                .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void ItResolvesTargetingPackRootsRelativeToTaskEnvironmentProjectDirectory()
+        {
+            using var env = new TaskTestEnvironment();
+
+            // Lay out a targeting-pack PackageOverrides.txt at
+            // <ProjectDir>/packs/Microsoft.NETCore.App.Ref/<major>.<minor>.0/data/PackageOverrides.txt
+            const string targetingPackRootRelative = "packs";
+            env.CreateProjectFile(
+                Path.Combine(
+                    targetingPackRootRelative,
+                    NetCoreApp + ".Ref",
+                    TargetFrameworkVersion + ".0",
+                    "data",
+                    "PackageOverrides.txt"),
+                "Newtonsoft.Json|13.0.1");
+
+            // Point PrunePackageDataRoot at an existing-but-empty directory so the task falls back
+            // to the targeting pack lookup (LoadPackagesToPruneFromPrunePackageData returns null).
+            const string emptyPruneDataRelative = "EmptyPruneData";
+            env.CreateProjectDirectory(emptyPruneDataRelative);
+
+            var task = CreateTask(env, targetingPackRoots: targetingPackRootRelative, prunePackageDataRoot: emptyPruneDataRelative);
+
+            task.Execute().Should().BeTrue(
+                "TargetingPackRoots is relative and must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD");
+
+            task.PackagesToPrune.Should().ContainSingle()
+                .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+        }
+
+        [Fact]
+        public void ItIgnoresEmptyTargetingPackRootEntries()
+        {
+            using var env = new TaskTestEnvironment();
+
+            // Provide valid prune data so the task can succeed without any targeting pack roots.
+            const string prunePackageDataRelative = "PrunePackageData";
+            env.CreateProjectFile(
+                Path.Combine(prunePackageDataRelative, TargetFrameworkVersion, NetCoreApp, "PackageOverrides.txt"),
+                "Newtonsoft.Json|13.0.1");
+
+            var task = CreateTask(env, targetingPackRoots: string.Empty, prunePackageDataRelative);
+
+            // An empty string in TargetingPackRoots must be skipped without throwing from
+            // TaskEnvironment.GetAbsolutePath("").
+            task.Execute().Should().BeTrue(
+                "empty entries in TargetingPackRoots should be silently skipped, preserving pre-migration behavior");
+
+            task.PackagesToPrune.Should().ContainSingle()
+                .Which.ItemSpec.Should().Be("Newtonsoft.Json");
+        }
+    }
+}


### PR DESCRIPTION
Fixes dotnet/msbuild#13892

## Migrate `GetPackagesToPrune` to the MSBuild multithreaded task model

Brings `GetPackagesToPrune` (and its `FrameworkPackages.LoadFrameworkPackagesFromPack` helper) onto the multithreaded task model so the task can safely run under MSBuild multi-threaded execution mode without depending on the process working directory.

### Changes

**`src/Tasks/Microsoft.NET.Build.Tasks/GetPackagesToPrune.cs`**
- Annotated with `[MSBuildMultiThreadableTask]` and now implements `IMultiThreadableTask` with `TaskEnvironment = TaskEnvironment.Fallback`.
- `PrunePackageDataRoot` and non-empty `TargetingPackRoots` are absolutized via `TaskEnvironment.GetAbsolutePath(...)` before any file I/O.
- Internal helper signatures (`LoadPackagesToPrune`, `TryLoadPackagesToPruneForVersion`, `LoadPackagesToPruneFromTargetingPack`, `LoadPackagesToPruneFromPrunePackageData`) now take `AbsolutePath` / `AbsolutePath[]` so the safe-path contract is preserved end-to-end.
- Empty entries in `TargetingPackRoots` are filtered out before absolutization to keep the original skip-empty-root behavior (`TaskEnvironment.GetAbsolutePath("")` would otherwise throw).

**`src/Tasks/Microsoft.NET.Build.Tasks/FrameworkPackages/FrameworkPackages.cs`**
- `LoadFrameworkPackagesFromPack` now accepts `AbsolutePath targetingPackRoot` (was `string`). This eliminates the transitive unsafe-call diagnostics that the `ThreadSafeTaskAnalyzer` was reporting through this helper.
- File I/O uses the absolute value (via the implicit `AbsolutePath -> string` conversion to `Value`), while user-facing log messages that mention the root use `targetingPackRoot.OriginalValue` so existing log text remains compatible.
- Empty-root check switched from `!string.IsNullOrEmpty(...)` to `targetingPackRoot.Value is not null` to match the `default(AbsolutePath)` contract.

### Tests

Added `test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs` with three focused functional tests (no concurrency / no attribute checks):

1. `ItResolvesPrunePackageDataRootRelativeToTaskEnvironmentProjectDirectory` — verifies a relative `PrunePackageDataRoot` is resolved against `TaskEnvironment.ProjectDirectory`, not the process CWD.
2. `ItResolvesTargetingPackRootsRelativeToTaskEnvironmentProjectDirectory` — verifies the same for `TargetingPackRoots`, exercising the targeting-pack fallback path in `FrameworkPackages.LoadFrameworkPackagesFromPack`.
3. `ItIgnoresEmptyTargetingPackRootEntries` — locks in the empty-root behavior we explicitly preserved during migration.

All three tests pass.

### Validation

- `Microsoft.NET.Build.Tasks` builds clean.
- `Microsoft.NET.Build.Tasks.Tests` builds clean; new tests pass (`3 Passed, 0 Failed`).
- `ThreadSafeTaskAnalyzer` (from `dotnet/msbuild`) no longer reports transitive unsafe-API diagnostics on `GetPackagesToPrune` after the helper signature change.