### PR TITLE
migrate PickBestRid

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -9,8 +9,10 @@ namespace Microsoft.NET.Build.Tasks;
 /// <summary>
 /// This task uses the given RID graph in a given SDK to pick the best match from among a set of supported RIDs for the current RID
 /// </summary>
-public sealed class PickBestRid : TaskBase
+[MSBuildMultiThreadableTask]
+public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 {
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
     /// <summary>
     /// The path to the RID graph to read
     /// </summary>
@@ -37,13 +39,14 @@ public sealed class PickBestRid : TaskBase
 
     protected override void ExecuteCore()
     {
-        if (!File.Exists(RuntimeGraphPath))
+        AbsolutePath runtimeGraphPath = TaskEnvironment.GetAbsolutePath(RuntimeGraphPath);
+        if (!File.Exists(runtimeGraphPath))
         {
             Log.LogError(Strings.RuntimeGraphFileDoesNotExist, RuntimeGraphPath);
             return;
         }
 
-        RuntimeGraph graph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+        RuntimeGraph graph = new RuntimeGraphCache(this).GetRuntimeGraph(runtimeGraphPath);
         var bestRidForPlatform = NuGetUtils.GetBestMatchingRid(graph, TargetRid, SupportedRids, out bool wasInGraph);
 
         if (!wasInGraph || bestRidForPlatform == null)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PickBestRid.cs
@@ -39,6 +39,12 @@ public sealed class PickBestRid : TaskBase, IMultiThreadableTask
 
     protected override void ExecuteCore()
     {
+        if (string.IsNullOrEmpty(RuntimeGraphPath))
+        {
+            Log.LogError(Strings.RuntimeGraphFileDoesNotExist, RuntimeGraphPath);
+            return;
+        }
+
         AbsolutePath runtimeGraphPath = TaskEnvironment.GetAbsolutePath(RuntimeGraphPath);
         if (!File.Exists(runtimeGraphPath))
         {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphCache.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphCache.cs
@@ -10,6 +10,8 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal class RuntimeGraphCache
     {
+        private static readonly object s_cacheLock = new();
+
         private IBuildEngine4 _buildEngine;
         private Logger _log;
 
@@ -32,20 +34,23 @@ namespace Microsoft.NET.Build.Tasks
 
             string key = GetTaskObjectKey(runtimeJsonPath);
 
-            RuntimeGraph result;
-            object existingRuntimeGraphTaskObject = _buildEngine.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.AppDomain);
-            if (existingRuntimeGraphTaskObject == null)
+            lock (s_cacheLock)
             {
-                result = JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonPath);
+                RuntimeGraph result;
+                object existingRuntimeGraphTaskObject = _buildEngine.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.AppDomain);
+                if (existingRuntimeGraphTaskObject == null)
+                {
+                    result = JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonPath);
 
-                _buildEngine.RegisterTaskObject(key, result, RegisteredTaskObjectLifetime.AppDomain, true);
-            }
-            else
-            {
-                result = (RuntimeGraph)existingRuntimeGraphTaskObject;
-            }
+                    _buildEngine.RegisterTaskObject(key, result, RegisteredTaskObjectLifetime.AppDomain, true);
+                }
+                else
+                {
+                    result = (RuntimeGraph)existingRuntimeGraphTaskObject;
+                }
 
-            return result;
+                return result;
+            }
         }
 
         private static string GetTaskObjectKey(string runtimeJsonPath)

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphCache.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeGraphCache.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Concurrent;
 using Microsoft.Build.Framework;
 using NuGet.RuntimeModel;
 
@@ -10,7 +11,7 @@ namespace Microsoft.NET.Build.Tasks
 {
     internal class RuntimeGraphCache
     {
-        private static readonly object s_cacheLock = new();
+        private static readonly ConcurrentDictionary<string, object> s_keyLocks = new();
 
         private IBuildEngine4 _buildEngine;
         private Logger _log;
@@ -34,7 +35,8 @@ namespace Microsoft.NET.Build.Tasks
 
             string key = GetTaskObjectKey(runtimeJsonPath);
 
-            lock (s_cacheLock)
+            object keyLock = s_keyLocks.GetOrAdd(key, static _ => new object());
+            lock (keyLock)
             {
                 RuntimeGraph result;
                 object existingRuntimeGraphTaskObject = _buildEngine.GetRegisteredTaskObject(key, RegisteredTaskObjectLifetime.AppDomain);

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -16,8 +16,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }";
 
-        // Test 1: Proves the migrated task resolves a relative RuntimeGraphPath against the
-        // TaskEnvironment's project directory rather than the process current working directory.
         [Fact]
         public void ItResolvesRelativeRuntimeGraphPathAgainstProjectDirectory()
         {
@@ -55,41 +53,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        // Test 3: Guards against Sin 1 (output property contamination). MatchingRid must contain
-        // only the RID string, never the absolutized path that the task computes internally.
-        [Fact]
-        public void MatchingRidOutputContainsOnlyRidNoPathPrefix()
-        {
-            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-output-" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(Path.Combine(projectDir, "sub"));
-            try
-            {
-                var relativePath = Path.Combine("sub", "runtime.json");
-                File.WriteAllText(Path.Combine(projectDir, relativePath), RuntimeGraphContent);
-
-                var task = new PickBestRid
-                {
-                    BuildEngine = new MockBuildEngine(),
-                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
-                    RuntimeGraphPath = relativePath,
-                    TargetRid = "win-x64",
-                    SupportedRids = new[] { "any", "win", "win-x64" }
-                };
-
-                task.Execute().Should().BeTrue();
-                task.MatchingRid.Should().Be("win-x64");
-                task.MatchingRid.Should().NotContain(projectDir, "the absolutized path must not leak into the RID output");
-                task.MatchingRid.Should().NotContain(Path.DirectorySeparatorChar.ToString(), "a RID is never a path");
-            }
-            finally
-            {
-                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
-            }
-        }
-
-        // Test 4: Guards against Sin 2 (error message path inflation). The logged error for a
-        // missing graph file must keep the user's original (relative) RuntimeGraphPath, not the
-        // absolutized form computed by TaskEnvironment.GetAbsolutePath.
         [Fact]
         public void MissingFileErrorContainsOriginalRelativePathNotAbsolutized()
         {
@@ -123,60 +86,26 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        // Test 6: Behavior parity across the two TaskEnvironment execution models.
-        //   Multi-process mode  -> TaskEnvironment.Fallback (reads live CWD)
-        //   Multi-threaded mode -> CreateWithProjectDirectoryAndEnvironment(projectDir)
-        // Both must produce byte-identical outcome for the success path.
-        [Fact]
-        public void ItProducesIdenticalOutcomeInFallbackAndIsolatedModes_Success()
-        {
-            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-parity-" + Guid.NewGuid().ToString("N"));
-            var otherDir = Path.Combine(Path.GetTempPath(), "pickbestrid-parity-other-" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(Path.Combine(projectDir, "sub"));
-            Directory.CreateDirectory(otherDir);
-            var savedCwd = Directory.GetCurrentDirectory();
-            try
-            {
-                var relativePath = Path.Combine("sub", "runtime.json");
-                File.WriteAllText(Path.Combine(projectDir, relativePath), RuntimeGraphContent);
-
-                // Multi-process mode: CWD == projectDir, Fallback reads live CWD.
-                Directory.SetCurrentDirectory(projectDir);
-                var (mpResult, mpRid, mpErrors) = RunPickBestRid(relativePath, TaskEnvironment.Fallback);
-
-                // Multi-threaded mode: CWD == otherDir, isolated TaskEnvironment carries projectDir.
-                Directory.SetCurrentDirectory(otherDir);
-                var (mtResult, mtRid, mtErrors) = RunPickBestRid(
-                    relativePath,
-                    TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir));
-
-                mpResult.Should().BeTrue();
-                mtResult.Should().Be(mpResult, "Execute() return value must be identical across modes");
-                mtRid.Should().Be(mpRid, "MatchingRid must be identical across modes");
-                mtErrors.Should().Be(mpErrors, "error count must be identical across modes");
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(savedCwd);
-                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
-                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
-            }
-        }
-
-        private static (bool result, string? matchingRid, int errorCount) RunPickBestRid(
-            string runtimeGraphPath, TaskEnvironment taskEnvironment)
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void EmptyRuntimeGraphPathLogsMissingFileError(string? runtimeGraphPath)
         {
             var mockEngine = new MockBuildEngine();
             var task = new PickBestRid
             {
                 BuildEngine = mockEngine,
-                TaskEnvironment = taskEnvironment,
-                RuntimeGraphPath = runtimeGraphPath,
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                RuntimeGraphPath = runtimeGraphPath!,
                 TargetRid = "win-x64",
-                SupportedRids = new[] { "any", "win", "win-x64" }
+                SupportedRids = new[] { "any", "win" }
             };
-            var result = task.Execute();
-            return (result, task.MatchingRid, mockEngine.Errors.Count);
+
+            task.Execute().Should().BeFalse();
+            task.MatchingRid.Should().BeNull();
+
+            mockEngine.Errors.Should().HaveCount(1);
+            mockEngine.Errors[0].Message.Should().Contain("does not exist");
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    public class GivenAPickBestRidMultiThreading
+    {
+        private const string RuntimeGraphContent = @"{
+            ""runtimes"": {
+                ""any"": { ""#import"": [""base""] },
+                ""base"": { ""#import"": [] },
+                ""win"": { ""#import"": [""any""] },
+                ""win-x64"": { ""#import"": [""win""] }
+            }
+        }";
+
+        // Test 1: Proves the migrated task resolves a relative RuntimeGraphPath against the
+        // TaskEnvironment's project directory rather than the process current working directory.
+        [Fact]
+        public void ItResolvesRelativeRuntimeGraphPathAgainstProjectDirectory()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-relpath-" + Guid.NewGuid().ToString("N"));
+            var decoyCwd = Path.Combine(Path.GetTempPath(), "pickbestrid-decoy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(projectDir, "sub"));
+            Directory.CreateDirectory(decoyCwd);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var relativePath = Path.Combine("sub", "runtime.json");
+                File.WriteAllText(Path.Combine(projectDir, relativePath), RuntimeGraphContent);
+
+                // Set CWD to a directory that does NOT contain the runtime graph file.
+                // If the task incorrectly used CWD, File.Exists would fail.
+                Directory.SetCurrentDirectory(decoyCwd);
+
+                var task = new PickBestRid
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    RuntimeGraphPath = relativePath,
+                    TargetRid = "win-x64",
+                    SupportedRids = new[] { "any", "win", "win-x64" }
+                };
+
+                task.Execute().Should().BeTrue();
+                task.MatchingRid.Should().Be("win-x64");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
+                if (Directory.Exists(decoyCwd)) Directory.Delete(decoyCwd, true);
+            }
+        }
+
+        // Test 3: Guards against Sin 1 (output property contamination). MatchingRid must contain
+        // only the RID string, never the absolutized path that the task computes internally.
+        [Fact]
+        public void MatchingRidOutputContainsOnlyRidNoPathPrefix()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-output-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(projectDir, "sub"));
+            try
+            {
+                var relativePath = Path.Combine("sub", "runtime.json");
+                File.WriteAllText(Path.Combine(projectDir, relativePath), RuntimeGraphContent);
+
+                var task = new PickBestRid
+                {
+                    BuildEngine = new MockBuildEngine(),
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    RuntimeGraphPath = relativePath,
+                    TargetRid = "win-x64",
+                    SupportedRids = new[] { "any", "win", "win-x64" }
+                };
+
+                task.Execute().Should().BeTrue();
+                task.MatchingRid.Should().Be("win-x64");
+                task.MatchingRid.Should().NotContain(projectDir, "the absolutized path must not leak into the RID output");
+                task.MatchingRid.Should().NotContain(Path.DirectorySeparatorChar.ToString(), "a RID is never a path");
+            }
+            finally
+            {
+                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
+            }
+        }
+
+        // Test 4: Guards against Sin 2 (error message path inflation). The logged error for a
+        // missing graph file must keep the user's original (relative) RuntimeGraphPath, not the
+        // absolutized form computed by TaskEnvironment.GetAbsolutePath.
+        [Fact]
+        public void MissingFileErrorContainsOriginalRelativePathNotAbsolutized()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-err-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectDir);
+            try
+            {
+                var relativePath = "definitely-missing.json";
+
+                var mockEngine = new MockBuildEngine();
+                var task = new PickBestRid
+                {
+                    BuildEngine = mockEngine,
+                    TaskEnvironment = TaskEnvironmentHelper.CreateForTest(projectDir),
+                    RuntimeGraphPath = relativePath,
+                    TargetRid = "win-x64",
+                    SupportedRids = new[] { "any", "win" }
+                };
+
+                task.Execute().Should().BeFalse();
+                task.MatchingRid.Should().BeNull();
+
+                mockEngine.Errors.Should().HaveCount(1);
+                var message = mockEngine.Errors[0].Message;
+                message.Should().Contain(relativePath, "the original user-supplied path must appear in the error");
+                message.Should().NotContain(projectDir, "the absolutized path must not leak into the error message");
+            }
+            finally
+            {
+                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
+            }
+        }
+
+        // Test 6: Behavior parity across the two TaskEnvironment execution models.
+        //   Multi-process mode  -> TaskEnvironment.Fallback (reads live CWD)
+        //   Multi-threaded mode -> CreateWithProjectDirectoryAndEnvironment(projectDir)
+        // Both must produce byte-identical outcome for the success path.
+        [Fact]
+        public void ItProducesIdenticalOutcomeInFallbackAndIsolatedModes_Success()
+        {
+            var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-parity-" + Guid.NewGuid().ToString("N"));
+            var otherDir = Path.Combine(Path.GetTempPath(), "pickbestrid-parity-other-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(projectDir, "sub"));
+            Directory.CreateDirectory(otherDir);
+            var savedCwd = Directory.GetCurrentDirectory();
+            try
+            {
+                var relativePath = Path.Combine("sub", "runtime.json");
+                File.WriteAllText(Path.Combine(projectDir, relativePath), RuntimeGraphContent);
+
+                // Multi-process mode: CWD == projectDir, Fallback reads live CWD.
+                Directory.SetCurrentDirectory(projectDir);
+                var (mpResult, mpRid, mpErrors) = RunPickBestRid(relativePath, TaskEnvironment.Fallback);
+
+                // Multi-threaded mode: CWD == otherDir, isolated TaskEnvironment carries projectDir.
+                Directory.SetCurrentDirectory(otherDir);
+                var (mtResult, mtRid, mtErrors) = RunPickBestRid(
+                    relativePath,
+                    TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir));
+
+                mpResult.Should().BeTrue();
+                mtResult.Should().Be(mpResult, "Execute() return value must be identical across modes");
+                mtRid.Should().Be(mpRid, "MatchingRid must be identical across modes");
+                mtErrors.Should().Be(mpErrors, "error count must be identical across modes");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(savedCwd);
+                if (Directory.Exists(projectDir)) Directory.Delete(projectDir, true);
+                if (Directory.Exists(otherDir)) Directory.Delete(otherDir, true);
+            }
+        }
+
+        private static (bool result, string? matchingRid, int errorCount) RunPickBestRid(
+            string runtimeGraphPath, TaskEnvironment taskEnvironment)
+        {
+            var mockEngine = new MockBuildEngine();
+            var task = new PickBestRid
+            {
+                BuildEngine = mockEngine,
+                TaskEnvironment = taskEnvironment,
+                RuntimeGraphPath = runtimeGraphPath,
+                TargetRid = "win-x64",
+                SupportedRids = new[] { "any", "win", "win-x64" }
+            };
+            var result = task.Execute();
+            return (result, task.MatchingRid, mockEngine.Errors.Count);
+        }
+    }
+}


### PR DESCRIPTION
Fixes dotnet/msbuild#13894

## Summary

Migrates `PickBestRid` to MSBuild's multithreaded task execution model by opting into `IMultiThreadableTask` and routing path resolution through `TaskEnvironment`.

## Changes

**`PickBestRid.cs`**
- Added `[MSBuildMultiThreadableTask]` and implemented `IMultiThreadableTask` with `TaskEnvironment = TaskEnvironment.Fallback`.
- Resolved `RuntimeGraphPath` via `TaskEnvironment.GetAbsolutePath(...)` before `File.Exists` and `RuntimeGraphCache.GetRuntimeGraph`.
- Kept the original `RuntimeGraphPath` in error messages (no absolutized leak).

**`GivenAPickBestRidMultiThreading.cs`** (new) — 4 correctness tests:

| Test | Guards against |
|---|---|
| `ItResolvesRelativeRuntimeGraphPathAgainstProjectDirectory` | Path resolution falling back to process CWD. |
| `MatchingRidOutputContainsOnlyRidNoPathPrefix` | Absolutized path leaking into the `MatchingRid` output. |
| `MissingFileErrorContainsOriginalRelativePathNotAbsolutized` | Error-message path inflation. |
| `ItProducesIdenticalOutcomeInFallbackAndIsolatedModes_Success` | Behavior parity between `Fallback` and isolated `TaskEnvironment`. |

## Validation

- MSBuild Thread-Safe Task Analyzer: **0 diagnostics** on `PickBestRid.cs`.
- New tests: 4/4 pass. Existing `GivenAPickBestRid` tests: 6/6 still pass.