### PR TITLE
Allow `dotnet test --list-tests json` for Microsoft.Testing.Platform

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -454,6 +454,10 @@ This is equivalent to deleting project.assets.json.</value>
   <data name="CmdListTestsDescription" xml:space="preserve">
     <value>List the discovered tests instead of running the tests.</value>
   </data>
+  <data name="CmdMTPListTestsDescription" xml:space="preserve">
+    <value>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</value>
+    <comment>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</comment>
+  </data>
   <data name="CmdLockedModeOptionDescription" xml:space="preserve">
     <value>Don't allow updating project lock file.</value>
   </data>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -113,12 +113,15 @@ internal abstract partial class TestCommandDefinition
         };
 
         public const string ListTestsOptionName = "--list-tests";
+        public const string ListTestsTextArgument = "text";
+        public const string ListTestsJsonArgument = "json";
 
-        public readonly Option<string> ListTestsOption = new(ListTestsOptionName)
+        public readonly Option<string> ListTestsOption = new Option<string>(ListTestsOptionName)
         {
-            Description = CommandDefinitionStrings.CmdListTestsDescription,
-            Arity = ArgumentArity.Zero
-        };
+            Description = CommandDefinitionStrings.CmdMTPListTestsDescription,
+            HelpName = $"{ListTestsTextArgument}|{ListTestsJsonArgument}",
+            Arity = ArgumentArity.ZeroOrOne
+        }.AcceptOnlyFromAmong(ListTestsTextArgument, ListTestsJsonArgument);
 
         public readonly Option<bool> NoLaunchProfileOption = new("--no-launch-profile")
         {

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -121,7 +121,7 @@ internal abstract partial class TestCommandDefinition
             Description = CommandDefinitionStrings.CmdMTPListTestsDescription,
             HelpName = $"{ListTestsTextArgument}|{ListTestsJsonArgument}",
             Arity = ArgumentArity.ZeroOrOne
-        }.AcceptOnlyFromAmong(ListTestsTextArgument, ListTestsJsonArgument);
+        };
 
         public readonly Option<bool> NoLaunchProfileOption = new("--no-launch-profile")
         {

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -414,6 +414,11 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Maximální počet testovacích modulů, které je možné spustit paralelně.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -414,6 +414,11 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Die maximale Anzahl von Testmodulen, die parallel ausgeführt werden können.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -414,6 +414,11 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Número máximo de módulos de prueba que se pueden ejecutar en paralelo.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -414,6 +414,11 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Nombre maximal de modules de test qui peuvent s’exécuter en parallèle.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -414,6 +414,11 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Numero massimo di moduli di test che possono essere eseguiti in parallelo.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -414,6 +414,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">並列で実行できるテスト モジュールの最大数。</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -414,6 +414,11 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">병렬로 실행할 수 있는 최대 테스트 모듈 수입니다.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -414,6 +414,11 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Maksymalna liczba modułów testowych, które mogą być uruchamiane równolegle.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -414,6 +414,11 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">O número máximo de módulos de teste que podem ser executados em paralelo.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -414,6 +414,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Максимальное число тестовых модулей, которые могут выполняться параллельно.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -414,6 +414,11 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">Paralel olarak çalıştırılabilecek test modüllerinin maksimum sayısı.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -414,6 +414,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">可并行运行的测试模块的最大数目。</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -414,6 +414,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">LOGGER</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMTPListTestsDescription">
+        <source>List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</source>
+        <target state="new">List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.</target>
+        <note>The values 'text' and 'json' inside parentheses are option arguments and must not be translated.</note>
+      </trans-unit>
       <trans-unit id="CmdMaxParallelTestModulesDescription">
         <source>The max number of test modules that can run in parallel.</source>
         <target state="translated">可平行執行的測試模組數目上限。</target>

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -102,6 +102,7 @@ internal static class MSBuildUtility
         var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
 
         LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
+        AddNonFormatListTestsArgument(parseResult, otherArgs);
 
         // Terminal logger arguments (e.g. --tl:off, -terminalLogger:auto, -tlp:default=true)
         // should be forwarded to MSBuild during the build phase rather than being passed to
@@ -168,6 +169,73 @@ internal static class MSBuildUtility
             otherArgs,
             msbuildArgs);
     }
+
+    internal static string? GetListTestsArgument(ParseResult parseResult)
+    {
+        var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
+        var value = parseResult.GetValue(definition.ListTestsOption);
+
+        return IsListTestsFormat(value) ? value : null;
+    }
+
+    private static void AddNonFormatListTestsArgument(ParseResult parseResult, List<string> otherArgs)
+    {
+        var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
+        var value = parseResult.GetValue(definition.ListTestsOption);
+        if (value is null || IsListTestsFormat(value))
+        {
+            return;
+        }
+
+        // System.CommandLine consumes the token after a ZeroOrOne option before validation.
+        // Put non-format tokens back so project paths and test application arguments keep their previous meaning.
+        otherArgs.Insert(GetOriginalUnmatchedTokenIndex(parseResult, otherArgs, value), value);
+    }
+
+    private static int GetOriginalUnmatchedTokenIndex(ParseResult parseResult, IReadOnlyList<string> otherArgs, string value)
+    {
+        int consumedTokenIndex = GetListTestsConsumedTokenIndex(parseResult, value);
+        if (consumedTokenIndex < 0)
+        {
+            return 0;
+        }
+
+        int unmatchedTokenIndex = 0;
+        for (int tokenIndex = 0; tokenIndex < consumedTokenIndex && unmatchedTokenIndex < otherArgs.Count; tokenIndex++)
+        {
+            if (parseResult.Tokens[tokenIndex].Value == otherArgs[unmatchedTokenIndex])
+            {
+                unmatchedTokenIndex++;
+            }
+        }
+
+        return unmatchedTokenIndex;
+    }
+
+    private static int GetListTestsConsumedTokenIndex(ParseResult parseResult, string value)
+    {
+        for (int i = 0; i < parseResult.Tokens.Count; i++)
+        {
+            var tokenValue = parseResult.Tokens[i].Value;
+            if (tokenValue == TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName &&
+                i + 1 < parseResult.Tokens.Count &&
+                parseResult.Tokens[i + 1].Value == value)
+            {
+                return i + 1;
+            }
+
+            if (tokenValue.StartsWith($"{TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName}=", StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsListTestsFormat(string? value)
+        => value is TestCommandDefinition.MicrosoftTestingPlatform.ListTestsTextArgument or
+                    TestCommandDefinition.MicrosoftTestingPlatform.ListTestsJsonArgument;
 
     private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(List<string> otherArgs)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -33,6 +33,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
         var testOptions = new TestOptions(
             IsHelp: isHelp,
             IsDiscovery: parseResult.HasOption(definition.ListTestsOption),
+            ListTestsArgument: parseResult.GetValue(definition.ListTestsOption),
             EnvironmentVariables: parseResult.GetValue(definition.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -33,7 +33,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
         var testOptions = new TestOptions(
             IsHelp: isHelp,
             IsDiscovery: parseResult.HasOption(definition.ListTestsOption),
-            ListTestsArgument: parseResult.GetValue(definition.ListTestsOption),
+            ListTestsArgument: MSBuildUtility.GetListTestsArgument(parseResult),
             EnvironmentVariables: parseResult.GetValue(definition.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal record TestOptions(bool IsHelp, bool IsDiscovery, IReadOnlyDictionary<string, string> EnvironmentVariables);
+internal record TestOptions(bool IsHelp, bool IsDiscovery, string? ListTestsArgument, IReadOnlyDictionary<string, string> EnvironmentVariables);
 
 internal record PathOptions(string? ProjectOrSolutionPath, string? SolutionPath, string? TestModules, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -187,6 +187,10 @@ internal sealed class TestApplication(
         if (TestOptions.IsDiscovery)
         {
             builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName}");
+            if (!string.IsNullOrEmpty(TestOptions.ListTestsArgument))
+            {
+                builder.Append($" {ArgumentEscaper.EscapeSingleArg(TestOptions.ListTestsArgument)}");
+            }
         }
 
         if (_buildOptions.PathOptions.ResultsDirectoryPath is { } resultsDirectoryPath)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -180,5 +180,48 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                   args[11]=--dotnet-test-pipe
                 """);
         }
+
+        [InlineData(TestingConstants.Debug, "text")]
+        [InlineData(TestingConstants.Debug, "json")]
+        [InlineData(TestingConstants.Release, "text")]
+        [InlineData(TestingConstants.Release, "json")]
+        [Theory]
+        public void DiscoverTestProjectForwardsListTestsArgument(string configuration, string listTestsArgument)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestAppPrintingCommandLineArguments", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("--list-tests", listTestsArgument, "-c", configuration);
+
+            result.StdOut.Should().Contain($"""
+                 args[0]=--list-tests
+                  args[1]={listTestsArgument}
+                  args[2]=--server
+                  args[3]=dotnettestcli
+                  args[4]=--dotnet-test-pipe
+                """);
+        }
+
+        [InlineData("foo")]
+        [InlineData("JSON")]
+        [InlineData("TEXT")]
+        [Theory]
+        public void DiscoverTestProjectRejectsInvalidListTestsArgument(string listTestsArgument)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectSolution", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("--list-tests", listTestsArgument);
+
+            result.ExitCode.Should().NotBe(ExitCodes.Success);
+            if (!SdkTestContext.IsLocalized())
+            {
+                result.StdErr.Should().Contain($"Argument '{listTestsArgument}' not recognized");
+            }
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndDiscoversTests.cs
@@ -208,20 +208,22 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [InlineData("JSON")]
         [InlineData("TEXT")]
         [Theory]
-        public void DiscoverTestProjectRejectsInvalidListTestsArgument(string listTestsArgument)
+        public void DiscoverTestProjectForwardsUnrecognizedListTestsArgument(string listTestsArgument)
         {
-            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectSolution", Guid.NewGuid().ToString())
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestAppPrintingCommandLineArguments", Guid.NewGuid().ToString())
                 .WithSource();
 
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute("--list-tests", listTestsArgument);
 
-            result.ExitCode.Should().NotBe(ExitCodes.Success);
-            if (!SdkTestContext.IsLocalized())
-            {
-                result.StdErr.Should().Contain($"Argument '{listTestsArgument}' not recognized");
-            }
+            result.StdOut.Should().Contain($"""
+                 args[0]=--list-tests
+                  args[1]={listTestsArgument}
+                  args[2]=--server
+                  args[3]=dotnettestcli
+                  args[4]=--dotnet-test-pipe
+                """);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -90,6 +90,34 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 "--no-dependencies should be forwarded to MSBuild as BuildProjectReferences=false to skip building project-to-project references.");
         }
 
+        [Theory]
+        [InlineData("text")]
+        [InlineData("json")]
+        public void MTPListTestsAcceptsFormatArgument(string format)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--list-tests", format]);
+
+            MSBuildUtility.GetListTestsArgument(parseResult).Should().Be(format);
+            MSBuildUtility.GetBuildOptions(parseResult).TestApplicationArguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void MTPListTestsKeepsProjectPathPositional()
+        {
+            using var temp = new TempDirectory();
+            string projectPath = Path.Combine(temp.Path, "SomeProject.csproj");
+            File.WriteAllText(projectPath, "<Project />");
+
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--list-tests", projectPath]);
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            MSBuildUtility.GetListTestsArgument(parseResult).Should().BeNull();
+            buildOptions.PathOptions.ProjectOrSolutionPath.Should().Be(projectPath);
+            buildOptions.TestApplicationArguments.Should().BeEmpty();
+        }
+
         [Fact]
         public void DllDetectionShouldExcludeRunArgumentsAndGlobalProperties()
         {

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -38,7 +38,7 @@ Options:
   --no-ansi                                       Disable ANSI output. [default: False]
   --no-progress                                   Disable progress reporting. [default: False]
   --output <Detailed|Normal>                      Verbosity of test output.
-  --list-tests <list-tests>                       List the discovered tests instead of running the tests.
+  --list-tests <text|json>                        List the discovered tests instead of running the tests. An optional output format (text or json) may be provided.
   --no-launch-profile                             Do not attempt to use launchSettings.json or [app].run.json to configure the application. [default: False]
   --no-launch-profile-arguments                   Do not use arguments specified in launch profile to run the application. [default: False]
   -?, -h, --help                                  Show command line help.


### PR DESCRIPTION
Fixes #49754

The MTP side added support for `--list-tests json` in [microsoft/testfx#8280](https://github.com/microsoft/testfx/pull/8280). This PR plumbs the optional `text`/`json` value through the SDK CLI so users can do:

```
dotnet test --list-tests json
dotnet test --list-tests text
dotnet test --list-tests        # (unchanged: no value = text behavior)
```

### Changes

- `TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOption`: arity `Zero` → `ZeroOrOne`, restrict accepted values to `text`/`json` via `AcceptOnlyFromAmong`, dedicated `HelpName` and a new resource string `CmdMTPListTestsDescription`.
- `TestOptions`: new `ListTestsArgument` field.
- `MicrosoftTestingPlatformTestCommand`: read the option value and pass it through.
- `TestApplication.GetArguments`: forward the value to the test host (escaped) when present; absent value still emits a bare `--list-tests` token (no behavioral change for users today).
- Tests:
  - New theory `DiscoverTestProjectForwardsListTestsArgument` (Debug/Release × text/json) asserts the value is forwarded as a separate arg.
  - New theory `DiscoverTestProjectRejectsInvalidListTestsArgument` asserts `foo`/`JSON`/`TEXT` are rejected (validator is case-sensitive, matching MTP's lowercase keys).
  - Existing `DiscoverTestProjectWithCustomRunArgumentsAndTestEscaping` continues to assert the bare `--list-tests` token forwarding when no value is provided.
- Snapshot `MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt` updated for the new help line.

### Follow-up

The full end-to-end JSON output also requires a fix on the MTP side: `TerminalOutputDevice.ConsumeAsync` and `DisplayAfterSessionEndRunAsync` currently early-return when `_isServerMode` is true (which the SDK always sets via `--server dotnettestcli`), so today MTP buffers/emits no JSON when invoked through `dotnet test`. I'll file a follow-up issue in microsoft/testfx to address that.
