### PR TITLE
Fix GenAPI omitting explicitly implemented interface events

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -654,7 +654,19 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
         m.Modifiers.Any(SyntaxKind.PublicKeyword) || m.Modifiers.Any(SyntaxKind.ProtectedKeyword) ||
         // Enum member declarations don't have any modifiers
         m is EnumMemberDeclarationSyntax ||
-        m.IsKind(SyntaxKind.DestructorDeclaration);
+        m.IsKind(SyntaxKind.DestructorDeclaration) ||
+        // Explicit interface implementations don't have access modifiers but are part of the public API
+        // when the implemented interface is public.
+        HasExplicitInterfaceSpecifier(m);
+
+    private static bool HasExplicitInterfaceSpecifier(MemberDeclarationSyntax m) => m switch
+    {
+        MethodDeclarationSyntax method => method.ExplicitInterfaceSpecifier != null,
+        PropertyDeclarationSyntax property => property.ExplicitInterfaceSpecifier != null,
+        EventDeclarationSyntax @event => @event.ExplicitInterfaceSpecifier != null,
+        IndexerDeclarationSyntax indexer => indexer.ExplicitInterfaceSpecifier != null,
+        _ => false
+    };
 
     private static IEnumerable<T> GetMembersOfType<T>(SyntaxNode node) where T : MemberDeclarationSyntax => node
         .ChildNodes()

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -227,9 +227,16 @@ public sealed class CSharpAssemblyDocumentGenerator
                 }
             }
 
-            // If the property is derived from an interface that was filtered out, we must not filter it out either.
+            // If the property is derived from an interface that was filtered out, we must filter it out as well.
             if (member is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty &&
                 property.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol)))
+            {
+                continue;
+            }
+
+            // If the event is derived from an interface that was filtered out, we must filter it out as well.
+            if (member is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsEmpty &&
+                @event.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol)))
             {
                 continue;
             }

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -229,14 +229,18 @@ public sealed class CSharpAssemblyDocumentGenerator
 
             // If the property is derived from an interface that was filtered out, we must filter it out as well.
             if (member is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty &&
-                property.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol)))
+                property.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol) ||
+                // if explicit interface implementation property has inaccessible type argument
+                m.ContainingType.HasInaccessibleTypeArgument(_options.SymbolFilter)))
             {
                 continue;
             }
 
             // If the event is derived from an interface that was filtered out, we must filter it out as well.
             if (member is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsEmpty &&
-                @event.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol)))
+                @event.ExplicitInterfaceImplementations.Any(m => !_options.SymbolFilter.Include(m.ContainingSymbol) ||
+                // if explicit interface implementation event has inaccessible type argument
+                m.ContainingType.HasInaccessibleTypeArgument(_options.SymbolFilter)))
             {
                 continue;
             }

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxGeneratorExtensions.cs
@@ -81,6 +81,15 @@ namespace Microsoft.DotNet.GenAPI
 
             if (symbol is IEventSymbol eventSymbol && !eventSymbol.IsAbstract)
             {
+                // SyntaxGenerator.CustomEventDeclaration does not support generating explicit interface
+                // implementations, so build the EventDeclarationSyntax directly in that case. Otherwise
+                // GenAPI emits nothing for the explicit event and the generated reference source fails
+                // to compile (CS0535).
+                if (!eventSymbol.ExplicitInterfaceImplementations.IsEmpty)
+                {
+                    return CreateExplicitInterfaceEventDeclaration(syntaxGenerator, eventSymbol);
+                }
+
                 // adds generation of add & remove accessors for the non abstract events.
                 return syntaxGenerator.CustomEventDeclaration(eventSymbol.Name,
                     syntaxGenerator.TypeExpression(eventSymbol.Type),
@@ -107,6 +116,35 @@ namespace Microsoft.DotNet.GenAPI
                 // re-throw the ArgumentException with the symbol that caused it.
                 throw new ArgumentException(ex.Message, symbol.ToDisplayString(), innerException: ex);
             }
+        }
+
+        // Builds an EventDeclarationSyntax for an explicit interface implementation event with empty
+        // add/remove accessors. SyntaxGenerator.CustomEventDeclaration does not expose an overload
+        // for specifying an explicit interface specifier.
+        private static EventDeclarationSyntax CreateExplicitInterfaceEventDeclaration(
+            SyntaxGenerator syntaxGenerator,
+            IEventSymbol eventSymbol)
+        {
+            IEventSymbol implementedEvent = eventSymbol.ExplicitInterfaceImplementations[0];
+            TypeSyntax eventType = (TypeSyntax)syntaxGenerator.TypeExpression(eventSymbol.Type);
+            NameSyntax interfaceName = (NameSyntax)syntaxGenerator.TypeExpression(implementedEvent.ContainingType);
+
+            AccessorListSyntax accessorList = SyntaxFactory.AccessorList(SyntaxFactory.List(new[]
+            {
+                SyntaxFactory.AccessorDeclaration(SyntaxKind.AddAccessorDeclaration)
+                    .WithBody(SyntaxFactory.Block()),
+                SyntaxFactory.AccessorDeclaration(SyntaxKind.RemoveAccessorDeclaration)
+                    .WithBody(SyntaxFactory.Block())
+            }));
+
+            return SyntaxFactory.EventDeclaration(
+                attributeLists: default,
+                modifiers: default,
+                eventKeyword: SyntaxFactory.Token(SyntaxKind.EventKeyword),
+                type: eventType,
+                explicitInterfaceSpecifier: SyntaxFactory.ExplicitInterfaceSpecifier(interfaceName),
+                identifier: SyntaxFactory.Identifier(implementedEvent.Name),
+                accessorList: accessorList);
         }
 
         // Gets the list of base class and interfaces for a given symbol INamedTypeSymbol.

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/ImplicitSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/ImplicitSymbolFilter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
                 // If the method is an explicitly implemented getter or setter, exclude it.
                 // https://github.com/dotnet/roslyn/issues/53911
                 if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation &&
-                    method.ExplicitInterfaceImplementations.Any(m => m is { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet }))
+                    method.ExplicitInterfaceImplementations.Any(m => m is { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove }))
                 {
                     return false;
                 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/SymbolExtensions.cs
@@ -78,7 +78,8 @@ namespace Microsoft.DotNet.ApiSymbolExtensions
         /// <returns>true if the symbol is the explicit interface implementation method</returns>
         public static bool IsExplicitInterfaceImplementation(this ISymbol symbol) =>
             symbol is IMethodSymbol method && method.MethodKind == MethodKind.ExplicitInterfaceImplementation ||
-            symbol is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty;
+            symbol is IPropertySymbol property && !property.ExplicitInterfaceImplementations.IsEmpty ||
+            symbol is IEventSymbol @event && !@event.ExplicitInterfaceImplementations.IsEmpty;
 
         private static bool HasVisibleConstructor(ITypeSymbol type, bool includeInternalSymbols)
         {

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Event.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Event.Tests.cs
@@ -138,4 +138,41 @@ public class DiffEventTests : DiffBaseTests
               }
           }
         """);
+
+    [Fact]
+    public Task ExplicitInterfaceEventAdd() => RunTestAsync(
+        beforeCode: """
+        using System;
+        namespace MyNamespace
+        {
+            public interface IMyInterface
+            {
+                event EventHandler MyEvent;
+            }
+        }
+        """,
+        afterCode: """
+        using System;
+        namespace MyNamespace
+        {
+            public interface IMyInterface
+            {
+                event EventHandler MyEvent;
+            }
+            public class MyClass : IMyInterface
+            {
+                event EventHandler IMyInterface.MyEvent { add { } remove { } }
+            }
+        }
+        """,
+        expectedCode: """
+          namespace MyNamespace
+          {
+        +     public class MyClass : MyNamespace.IMyInterface
+        +     {
+        +         event System.EventHandler MyNamespace.IMyInterface.MyEvent { add; remove; }
+        +         public MyClass();
+        +     }
+          }
+        """);
 }

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1205,6 +1205,70 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestExplicitInterfaceEventGeneration()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    public interface INotifications
+                    {
+                        event System.Action<string> PublicEvent;
+                        event System.Action<int> ExplicitEvent;
+                    }
+
+                    public class EventSource : INotifications
+                    {
+                        public event System.Action<string> PublicEvent { add { } remove { } }
+                        event System.Action<int> INotifications.ExplicitEvent { add { } remove { } }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class EventSource : INotifications
+                    {
+                        event System.Action<int> INotifications.ExplicitEvent { add { } remove { } }
+                        public event System.Action<string> PublicEvent { add { } remove { } }
+                    }
+
+                    public partial interface INotifications
+                    {
+                        event System.Action<int> ExplicitEvent;
+                        event System.Action<string> PublicEvent;
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public void TestExplicitInterfaceEventFromInternalInterfaceIsExcluded()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    internal interface IInternalNotifications
+                    {
+                        event System.Action<int> InternalEvent;
+                    }
+
+                    public class EventSource : IInternalNotifications
+                    {
+                        event System.Action<int> IInternalNotifications.InternalEvent { add { } remove { } }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class EventSource
+                    {
+                    }
+                }
+                """,
+                includeInternalSymbols: false);
+        }
+        [Fact]
         public void TestCustomAttributeGeneration()
         {
             RunTest(original: """

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -1268,6 +1268,41 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
                 """,
                 includeInternalSymbols: false);
         }
+
+        [Fact]
+        public void TestExplicitInterfaceEventWithInaccessibleTypeArgumentIsExcluded()
+        {
+            RunTest(original: """
+                namespace Foo
+                {
+                    internal class InternalArg { }
+
+                    public interface IPublicNotifications<T>
+                    {
+                        event System.Action<T> Notify;
+                    }
+
+                    public class EventSource : IPublicNotifications<InternalArg>
+                    {
+                        event System.Action<InternalArg> IPublicNotifications<InternalArg>.Notify { add { } remove { } }
+                    }
+                }
+                """,
+                expected: """
+                namespace Foo
+                {
+                    public partial class EventSource
+                    {
+                    }
+
+                    public partial interface IPublicNotifications<T>
+                    {
+                        event System.Action<T> Notify;
+                    }
+                }
+                """,
+                includeInternalSymbols: false);
+        }
         [Fact]
         public void TestCustomAttributeGeneration()
         {


### PR DESCRIPTION
Fixes #54464

GenAPI silently dropped explicit interface event implementations, causing generated reference assemblies to fail compilation with CS0535.

## Root cause

Two layers:

1. `SymbolExtensions.IsExplicitInterfaceImplementation` only recognized `IMethodSymbol` and `IPropertySymbol`. Explicit-impl events have `DeclaredAccessibility=Private` and were filtered out as private members before reaching the syntax generator.
2. `SyntaxGeneratorExtensions.DeclarationExt` routed all events through `SyntaxGenerator.CustomEventDeclaration`, which has no overload that accepts an `ExplicitInterfaceSpecifier`, so the explicit qualification was lost even when the symbol made it through.

## Changes

- **SymbolExtensions**: recognize `IEventSymbol` explicit impls. This shared helper is used by ApiCompat, ApiDiff and GenAPI, so the fix benefits all three.
- **SyntaxGeneratorExtensions**: new `CreateExplicitInterfaceEventDeclaration` helper emits `EventDeclarationSyntax` with `ExplicitInterfaceSpecifier` and empty add/remove blocks.
- **CSharpAssemblyDocumentGenerator**: mirror the existing method/property filter for events. An explicit-impl event whose containing interface is excluded by the symbol filter is also excluded. This preserves the invariant (already honored for methods and properties) that explicit interface implementations are part of the public API only when the underlying interface is public.
- **ImplicitSymbolFilter**: extend the explicit-impl accessor filter to also drop `EventAdd` / `EventRemove` accessor methods, paralleling the existing `PropertyGet` / `PropertySet` handling so accessors are not emitted twice.

## Tests

- `TestExplicitInterfaceEventGeneration` — happy path, asserts the explicit event is emitted with the correct interface qualifier.
- `TestExplicitInterfaceEventFromInternalInterfaceIsExcluded` — asserts the new filter actually drops explicit events whose underlying interface is internal.

Full GenAPI test suite: 100 pass, 2 pre-existing skips, 0 failures.