### PR TITLE
Isolate InfoCommandTests so WithList variants don't read user state

### DIFF
--- a/test/dotnetup.Tests/InfoCommandTests.cs
+++ b/test/dotnetup.Tests/InfoCommandTests.cs
@@ -4,11 +4,19 @@
 using System.Text.Json;
 using Microsoft.DotNet.Tools.Bootstrapper;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Info;
+using Microsoft.DotNet.Tools.Dotnetup.Tests.Utilities;
 
 namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
 
-public class InfoCommandTests
+[Collection("DotnetupInstallCollection")]
+public class InfoCommandTests : IDisposable
 {
+    //  Create a test environment, which will set up a temp directory for the manifest and
+    // default install path.  The "WithList" tests end up depending on these values to list
+    // existing installs, so this isolates those tests from system state.
+    private readonly TestEnvironment _testEnv = DotnetupTestUtilities.CreateTestEnvironment();
+
+    public void Dispose() => _testEnv.Dispose();
     [Fact]
     public void Parser_ShouldParseInfoCommand()
     {


### PR DESCRIPTION
Some `dotnetup --info` tests weren't isolating their state, which seemed to be leading to test flakiness.  This should fix that.

**Copilot description**

InfoCommand_HumanReadable_WithList_ShouldIncludeListOutput and InfoCommand_Json_WithList_ShouldContainInstallationsProperty call InfoCommand.Execute with noList: false, which runs InstallationLister.GetListData(verify: true) against DotnetupPaths.ManifestPath. With no test isolation that resolves to the test agent's actual user manifest.

On Windows CI agents that path can have stale entries pointing at missing directories. The verifier throws, CommandBase.Execute catches the exception and writes the error to the global AnsiConsole.Console (NOT to the StringWriter the test passed in), and the test sees an empty captured string. Failure looks like
'Expected output [empty] to contain "dotnetup Information:"' or 'JsonReaderException: input does not contain any JSON tokens'.

Use the existing DotnetupTestUtilities.CreateTestEnvironment() helper (which sets DOTNET_TESTHOOK_MANIFEST_PATH /
DOTNET_TESTHOOK_DEFAULT_INSTALL_PATH to a fresh temp dir) to give each test instance its own empty manifest. Those env vars are process-wide, so join the existing DotnetupInstallCollection so we serialize against the other tests that also mutate global install state.