### PR TITLE
Reduce Helix work items with platform-aware partitioning

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         /// - [Required] TargetPath: the output dll path
         /// - [Required] RuntimeTargetFramework: the target framework to run tests on
         /// - [Optional] Arguments: a string of arguments to be passed to the XUnit console runner
-        /// - [Optional] MethodLimitMultiplier: a positive integer multiplier applied to the base method limit
-        ///   used for partitioning tests into Helix shards (base is 16, or 32 for FullFramework)
+        /// - [Optional] MethodLimitMultiplier: a positive integer multiplier applied to BaseMethodLimit
+        ///   used for partitioning tests into Helix shards
         /// The two required parameters will be automatically created if XUnitProject.Identity is set to the path of the XUnit csproj file
         /// </summary>
         [Required]
@@ -42,6 +42,13 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         /// The runtime identifier of the target Helix queue (e.g. osx-arm64, linux-x64).
         /// </summary>
         public string TargetRid { get; set; } = "";
+
+        /// <summary>
+        /// Base number of test methods per Helix work item shard.
+        /// Per-project MethodLimitMultiplier scales this value.
+        /// Defaults to 32.
+        /// </summary>
+        public int BaseMethodLimit { get; set; } = 32;
 
         /// <summary>
         /// Optional timeout for all created workitems
@@ -154,20 +161,20 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 msbuildAdditionalSdkResolverFolder = "";
             }
 
-            var isFullMSBuild = string.Equals(Environment.GetEnvironmentVariable("TestFullMSBuild"), "true", StringComparison.OrdinalIgnoreCase);
-            var baseMethodLimit = isFullMSBuild ? 32 : 16;
+            var methodLimit = BaseMethodLimit;
             if (xunitProject.TryGetMetadata("MethodLimitMultiplier", out string multiplierStr))
             {
                 if (int.TryParse(multiplierStr, out int multiplier) && multiplier > 0)
                 {
-                    baseMethodLimit *= multiplier;
+                    methodLimit *= multiplier;
                 }
                 else
                 {
                     Log.LogWarning($"Invalid MethodLimitMultiplier \"{multiplierStr}\" for {assemblyName}; must be a positive integer. Using default method limit.");
                 }
             }
-            var scheduler = new AssemblyScheduler(methodLimit: baseMethodLimit);
+
+            var scheduler = new AssemblyScheduler(methodLimit: methodLimit);
             var assemblyPartitionInfos = scheduler.Schedule(targetPath);
 
             var partitionedWorkItem = new List<ITaskItem>();

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -71,6 +71,15 @@
     <SDKCustomXUnitProject Include="**\*.AoT.Tests.csproj" />
   </ItemGroup>
 
+  <!-- Helix work-item partitioning configuration.
+       effective limit = BaseMethodLimit × MethodLimitMultiplier (per-project).
+       Targeting ~5 minutes per work item across all platforms. -->
+  <PropertyGroup>
+    <BaseMethodLimit Condition="'$(TestFullMSBuild)' == 'true'">64</BaseMethodLimit>
+    <BaseMethodLimit Condition="$(TargetRid.StartsWith('osx-arm64'))">128</BaseMethodLimit>
+    <BaseMethodLimit Condition="'$(BaseMethodLimit)' == ''">32</BaseMethodLimit>
+  </PropertyGroup>
+
   <!-- Consolidate Helix shards for assemblies with very short test durations.
        MethodLimitMultiplier increases the methods-per-shard threshold, producing
        fewer (but larger) work items and reducing per-item overhead on Helix queues. -->

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -95,6 +95,7 @@
         XUnitProjects="@(SDKCustomXUnitProject)"
         IsPosixShell="$(IsPosixShell)"
         TargetRid="$(TargetRid)"
+        BaseMethodLimit="$(BaseMethodLimit)"
         XUnitArguments="$(SDKCustomXUnitArgument)"
         XUnitWorkItemTimeout="$(XUnitWorkItemTimeout)">
       <Output TaskParameter="XUnitWorkItems" ItemName="HelixWorkItem"/>


### PR DESCRIPTION
﻿## Summary

Consolidate Helix work item partitions to target ~5 minutes per work item, reducing overall work item count by ~58%.

### Problem

The current base method limit of 16 methods per shard was producing far too many short-running work items, especially on faster platforms like mac-arm64 where the average work item took only 42 seconds.

### Changes

All partitioning configuration now lives in `test/UnitTests.proj`:

- **Raised base method limit** from 16 → 32 (64 for FullFramework, 128 for osx-arm64)
- **Moved all limit configuration into UnitTests.proj** — the C# task (`SDKCustomCreateXUnitWorkItemsWithTestExclusion`) is now a consumer of `BaseMethodLimit` rather than hardcoding values
- **Formula**: `effective limit = BaseMethodLimit × MethodLimitMultiplier`

### Projected Impact

| Queue | Current Avg | Projected Avg | Work Items |
|-------|------------|--------------|-----------|
| Windows | 2.9 min | ~5.7 min | 590 → ~295 |
| mac-x64 | 2.2 min | ~4.5 min | 352 → ~176 |
| Linux | 1.9 min | ~3.8 min | 347 → ~174 |
| mac-arm64 | 0.7 min | ~5.6 min | 347 → ~44 |
| **Total** | | | **1,636 → ~689 (~58% reduction)** |

### Configuration at a glance (`test/UnitTests.proj`)

```xml
<!-- Base method limit: platform-aware -->
<BaseMethodLimit Condition="'$(TestFullMSBuild)' == 'true'">64</BaseMethodLimit>
<BaseMethodLimit Condition="$(TargetRid.StartsWith('osx-arm64'))">128</BaseMethodLimit>
<BaseMethodLimit Condition="'$(BaseMethodLimit)' == ''">32</BaseMethodLimit>

<!-- Per-project multipliers -->
<!-- NetAnalyzers:      5x  (effective: 160 / 640 on arm64) -->
<!-- TemplateEngine:   20x  (effective: 640 - prevents splitting) -->
<!-- ApiCompat/GenAPI: 10x  (effective: 320 - prevents splitting) -->
```
