### PR TITLE
Remove the package zip cache download

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -33,9 +33,7 @@ set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets
 REM call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive
 
-REM We downloaded a special zip of files to the .nuget folder so add that as a source
 dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
-PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure"
 dotnet nuget add source %DOTNET_ROOT%\.nuget --configfile %TestExecutionDirectory%\nuget.config
 if exist %TestExecutionDirectory%\Testpackages dotnet nuget add source %TestExecutionDirectory%\Testpackages --name testpackages --configfile %TestExecutionDirectory%\nuget.config
 
@@ -43,6 +41,12 @@ dotnet nuget remove source dotnet6-transport --configfile %TestExecutionDirector
 dotnet nuget remove source dotnet6-internal-transport --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet7-transport --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet7-internal-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet8-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet8-internal-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet9-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet9-internal-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet10-transport --configfile %TestExecutionDirectory%\nuget.config
+dotnet nuget remove source dotnet10-internal-transport --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source richnav --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source vs-impl --configfile %TestExecutionDirectory%\nuget.config
 dotnet nuget remove source dotnet-libraries-transport --configfile %TestExecutionDirectory%\nuget.config

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -20,7 +20,6 @@ export DOTNET_SDK_TEST_ASSETS_DIRECTORY=$TestExecutionDirectory/TestAssets
 # call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive
 
-# We downloaded a special zip of files to the .nuget folder so add that as a source
 dotnet nuget list source --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget add source $DOTNET_ROOT/.nuget --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget add source $TestExecutionDirectory/Testpackages --configfile $TestExecutionDirectory/NuGet.config
@@ -29,6 +28,12 @@ dotnet nuget remove source dotnet6-transport --configfile $TestExecutionDirector
 dotnet nuget remove source dotnet6-internal-transport --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet7-transport --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet7-internal-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet8-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet8-internal-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet9-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet9-internal-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet10-transport --configfile $TestExecutionDirectory/NuGet.config
+dotnet nuget remove source dotnet10-internal-transport --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source richnav --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source vs-impl --configfile $TestExecutionDirectory/NuGet.config
 dotnet nuget remove source dotnet-libraries-transport --configfile $TestExecutionDirectory/NuGet.config

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -177,18 +177,6 @@
         <Destination>r</Destination>
       </HelixCorrelationPayload>
 
-      <HelixCorrelationPayload Include="SDKTestRunPackages.zip">
-        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
-        <Destination>d/.nuget</Destination>
-        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages.zip</Uri>
-      </HelixCorrelationPayload>
-
-      <HelixCorrelationPayload Include="SDKTestRunPackages2.zip">
-        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
-        <Destination>d/.nuget</Destination>
-        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages2.zip</Uri>
-      </HelixCorrelationPayload>
-
       <HelixCorrelationPayload Include="$(ArtifactsShippingPackages)">
         <PayloadDirectory>$(ArtifactsShippingPackages)</PayloadDirectory>
         <Destination>d/.nuget</Destination>


### PR DESCRIPTION
Remove additional transport feeds from the test nuget.config. We call all in parallel during the tests so it explodes our volume of azdo feed calls.

This has been removed in main for a while without negative impact that we can tell.  See #52660. From internal data, the download time in main is ~29 seconds per work item but in 10 branches, its close to 48. We believe this change is the predominant cause of that delta.

It should be safe to remove from 10 as we have limited codeflow there because of low number of branding PRs. Leaving in 8/9 for now as those still have a large number of branding flows each month and so could still need this.