### PR TITLE
[10.0.4xx] Remove predownload of packages that was originally a workaround

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -33,9 +33,7 @@ set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets
 REM call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive
 
-REM List current NuGet sources and, if test packages are present, add them as a local source
 dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
-PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure"
 if exist %TestExecutionDirectory%\Testpackages dotnet nuget add source %TestExecutionDirectory%\Testpackages --name testpackages --configfile %TestExecutionDirectory%\nuget.config
 
 dotnet nuget remove source dotnet6-transport --configfile %TestExecutionDirectory%\nuget.config

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -172,18 +172,6 @@
         <Destination>r</Destination>
       </HelixCorrelationPayload>
 
-      <HelixCorrelationPayload Include="SDKTestRunPackages.zip">
-        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
-        <Destination>d/.nuget</Destination>
-        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages.zip</Uri>
-      </HelixCorrelationPayload>
-
-      <HelixCorrelationPayload Include="SDKTestRunPackages2.zip">
-        <PayloadDirectory>$(TestHostDotNetRoot)</PayloadDirectory>
-        <Destination>d/.nuget</Destination>
-        <Uri>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/any/sdk-test-assets/SDKTestRunPackages2.zip</Uri>
-      </HelixCorrelationPayload>
-
       <HelixCorrelationPayload Include="$(ArtifactsShippingPackages)">
         <PayloadDirectory>$(ArtifactsShippingPackages)</PayloadDirectory>
         <Destination>d/.nuget</Destination>


### PR DESCRIPTION
Backport of #52660 to release/10.0.4xx.

This removes the longstanding workaround for AzDO feed throttling that is no longer needed since the creation of the VMR.

---

Original PR: https://github.com/dotnet/sdk/pull/52660