### PR TITLE
Fix configure toolset dotnetup lookup executable extension

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -25,7 +25,7 @@ function InstallBootstrapSdkWithDotnetup() {
     Write-Host "Installing SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' via dotnetup..." -ForegroundColor Cyan
 
     $dotnetupDir = Join-Path $PSScriptRoot 'dotnetup'
-    $dotnetupExe = Join-Path $dotnetupDir 'dotnetup.exe'
+    $dotnetupExe = Join-Path $dotnetupDir (GetExecutableFileName 'dotnetup')
 
     # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
     $skipDownload = $false

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -133,7 +133,7 @@ function InstallDotNetSharedFrameworks([string[]]$versions) {
     }
 
     $dotnetupDir = Join-Path $PSScriptRoot "dotnetup"
-    $dotnetupExe = Join-Path $dotnetupDir "dotnetup.exe"
+    $dotnetupExe = Join-Path $dotnetupDir (GetExecutableFileName "dotnetup")
 
     # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
     $skipDownload = $false


### PR DESCRIPTION
It was using .exe on unix which is not valid.

ci run to validate: https://dev.azure.com/dnceng/internal/_build/results?buildId=2987344&view=results