### PR TITLE
Tune Helix partitioning/payload

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -132,6 +132,40 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 }
             }
 
+            // Handle additional payload files that should be included in this project's work items.
+            // Files are copied into the publish directory and a pre-command copies them to the
+            // correlation payload destination at runtime.
+            string additionalPayloadPreCommand = "";
+            xunitProject.TryGetMetadata("AdditionalPayloadDir", out string additionalPayloadDir);
+            xunitProject.TryGetMetadata("AdditionalPayloadDestination", out string additionalPayloadDestination);
+
+            if (!string.IsNullOrEmpty(additionalPayloadDir) && Directory.Exists(additionalPayloadDir))
+            {
+                string payloadSubdir = Path.Combine(publishDirectory, "_additionalPayload");
+                Directory.CreateDirectory(payloadSubdir);
+
+                foreach (string sourceFile in Directory.GetFiles(additionalPayloadDir, "*", SearchOption.AllDirectories))
+                {
+                    string relativePath = sourceFile.Substring(additionalPayloadDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Length + 1);
+                    string destFile = Path.Combine(payloadSubdir, relativePath);
+                    Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
+                    File.Copy(sourceFile, destFile, overwrite: true);
+                }
+
+                if (!string.IsNullOrEmpty(additionalPayloadDestination))
+                {
+                    if (IsPosixShell)
+                    {
+                        additionalPayloadPreCommand = $"cp -r $HELIX_WORKITEM_PAYLOAD/_additionalPayload/* $HELIX_CORRELATION_PAYLOAD/{additionalPayloadDestination}/ && ";
+                    }
+                    else
+                    {
+                        string destPath = $"%HELIX_CORRELATION_PAYLOAD%\\{additionalPayloadDestination.Replace('/', '\\')}";
+                        additionalPayloadPreCommand = $"robocopy %HELIX_WORKITEM_PAYLOAD%\\_additionalPayload {destPath} /E /NP /NJH /NJS /NDL >nul & ";
+                    }
+                }
+            }
+
             string assemblyName = Path.GetFileName(targetPath);
 
             string driver = $"{PathToDotnet}";
@@ -193,7 +227,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 // On macOS, ad-hoc sign the test exe with get-task-allow entitlement so createdump can attach via task_for_pid for crash dumps.
                 string codesignPrefix = IsPosixShell && TargetRid.StartsWith("osx") ? $"codesign -s - -f --entitlements $HELIX_CORRELATION_PAYLOAD/t/helix-debug-entitlements.plist {exeName} && " : "";
 
-                string command = $"{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
+                string command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
                           $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout 60m {testFilter} {enableDiagLogging} {arguments}";
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -93,6 +93,15 @@
     <SDKCustomXUnitProject Update="**\Microsoft.DotNet.ApiCompatibility.Tests.csproj;**\Microsoft.DotNet.ApiDiff.Tests.csproj;**\Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj;**\Microsoft.DotNet.GenAPI.Tests.csproj">
       <MethodLimitMultiplier>10</MethodLimitMultiplier>
     </SDKCustomXUnitProject>
+    <!-- EndToEnd.Tests needs installer archives which are excluded from the shared
+         correlation payload to reduce download/unpack overhead for all other work items.
+         AdditionalPayloadDir: directory whose files are included in the per-item payload.
+         AdditionalPayloadDestination: relative path under the correlation payload root
+         where files are copied at runtime so the test's expected paths resolve correctly. -->
+    <SDKCustomXUnitProject Update="EndToEnd.Tests\EndToEnd.Tests.csproj">
+      <AdditionalPayloadDir>$(RepoRoot)artifacts\tmp\HelixInstallerArchives</AdditionalPayloadDir>
+      <AdditionalPayloadDestination>d/.nuget</AdditionalPayloadDestination>
+    </SDKCustomXUnitProject>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(CustomHelixTargetQueue)' != '' ">
@@ -155,7 +164,24 @@
 
     <PropertyGroup>
       <HelixPayloadOnHost>$(RepoRoot)artifacts\tmp\Helixpayload</HelixPayloadOnHost>
+      <HelixNuGetPayload>$(RepoRoot)artifacts\tmp\HelixNuGetPayload</HelixNuGetPayload>
+      <HelixInstallerArchives>$(RepoRoot)artifacts\tmp\HelixInstallerArchives</HelixInstallerArchives>
     </PropertyGroup>
+
+    <!-- Stage nupkgs (excluding installer archives) for the shared correlation payload.
+         This avoids downloading large SDK archives on every work item. -->
+    <ItemGroup>
+      <_ShippingNuGetPackages Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.nupkg" />
+      <_InstallerArchives Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.zip;
+                                   $(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.tar.gz;
+                                   $(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.rpm;
+                                   $(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.deb;
+                                   $(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.exe;
+                                   $(RepoRoot)artifacts\packages\$(Configuration)\Shipping\**\*.pkg" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_ShippingNuGetPackages)" DestinationFiles="@(_ShippingNuGetPackages->'$(HelixNuGetPayload)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_InstallerArchives)" DestinationFiles="@(_InstallerArchives->'$(HelixInstallerArchives)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <Copy SourceFiles="@(Engfolder)" DestinationFiles="@(Engfolder->'$(HelixPayloadOnHost)\eng\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(GlobalJson)" DestinationFiles="@(GlobalJson->'$(HelixPayloadOnHost)\%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -184,7 +210,6 @@
       <MSBuildSdkResolverDir>$(RepoRoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
       <HelixStage0Targz>$(RepoRoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>
       <MicrosoftNETBuildExtensions>$(RepoRoot)artifacts\bin\$(Configuration)\Sdks\Microsoft.NET.Build.Extensions</MicrosoftNETBuildExtensions>
-      <ArtifactsShippingPackages>$(RepoRoot)artifacts\packages\$(Configuration)\Shipping</ArtifactsShippingPackages>
     </PropertyGroup>
 
     <TarGzFileCreateFromDirectory
@@ -214,7 +239,7 @@
         <Destination>r</Destination>
       </HelixCorrelationPayload>
 
-      <HelixCorrelationPayload Include="$(ArtifactsShippingPackages)">
+      <HelixCorrelationPayload Include="$(HelixNuGetPayload)">
         <Destination>d/.nuget</Destination>
       </HelixCorrelationPayload>
     </ItemGroup>

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -76,7 +76,7 @@
        Targeting ~5 minutes per work item across all platforms. -->
   <PropertyGroup>
     <BaseMethodLimit Condition="'$(TestFullMSBuild)' == 'true'">64</BaseMethodLimit>
-    <BaseMethodLimit Condition="$(TargetRid.StartsWith('osx-arm64'))">128</BaseMethodLimit>
+    <BaseMethodLimit Condition="'$(TargetOS)' == 'osx' and '$(TargetArchitecture)' == 'arm64'">128</BaseMethodLimit>
     <BaseMethodLimit Condition="'$(BaseMethodLimit)' == ''">32</BaseMethodLimit>
   </PropertyGroup>
 
@@ -85,7 +85,7 @@
        fewer (but larger) work items and reducing per-item overhead on Helix queues. -->
   <ItemGroup>
     <SDKCustomXUnitProject Update="$(RepoRoot)src\Microsoft.CodeAnalysis.NetAnalyzers\tests\**\*.*Tests.csproj">
-      <MethodLimitMultiplier>5</MethodLimitMultiplier>
+      <MethodLimitMultiplier>10</MethodLimitMultiplier>
     </SDKCustomXUnitProject>
     <SDKCustomXUnitProject Update="TemplateEngine\**\*.csproj;**\Microsoft.TemplateEngine.Cli.UnitTests.csproj">
       <MethodLimitMultiplier>20</MethodLimitMultiplier>


### PR DESCRIPTION
## Summary
Follow-up to #54502. Tuning changes for Helix work item partitioning and payload optimization:

### 1. Replace `TargetRid.StartsWith('osx-arm64')` with `TargetOS`/`TargetArchitecture`
Clearer, more explicit platform detection using properties that are already available in the evaluation context.

### 2. Bump NetAnalyzers `MethodLimitMultiplier` from 5 to 10
NetAnalyzers was over-partitioned (41 work items on Windows with total time of ~104 min). Doubling the multiplier targets ~21 parts at ~5 min/item, saving ~20 work items on Windows alone.

### 3. Exclude installer archives from shared Helix correlation payload
Large installer archives in `ArtifactsShippingPackages` were included in the `d/.nuget` correlation payload downloaded by every Helix machine. These archives are only needed by `EndToEnd.Tests`.

**Changes:**
- NuGet packages are staged to a filtered directory (`HelixNuGetPayload`) excluding archives, and used as the `d/.nuget` correlation payload
- Archives are staged separately (`HelixInstallerArchives`) and included only in EndToEnd.Tests work items via a generic `AdditionalPayloadDir` metadata mechanism on `SDKCustomXUnitProject` items
- At runtime, a pre-command copies archives from the work item payload to the correlation payload's `d/.nuget` directory so test path resolution is unchanged

**Total correlation payload per Helix machine (wire size, before vs after):**

All sizes below are wire cost (compressed zip/tar.gz as transmitted over the network). The correlation payload is downloaded once per machine and shared across all work items on that machine.

| Platform | d (SDK) | d/.nuget before | d/.nuget after | t (tests) | other | **Total Before** | **Total After** | **Reduction** |
|----------|---------|----------------|---------------|-----------|-------|-----------------|----------------|--------------|
| **Windows x64** | ~508 MB | 760.3 MB | 67.8 MB | ~100 MB | ~4 MB | **~1,372 MB** | **~680 MB** | **~692 MB (50%)** |
| **Mac arm64** | ~437 MB | 408.9 MB | 67.8 MB | ~100 MB | ~4 MB | **~950 MB** | **~609 MB** | **~341 MB (36%)** |
| **Linux x64** | 453.8 MB | 246.2 MB | 67.9 MB | 99.9 MB | ~4 MB | **804 MB** | **626 MB** | **178 MB (22%)** |

> Linux x64 sizes are exact (from Helix telemetry). Windows/Mac `d (SDK)` sizes estimated from download component ratios (~1.08x sum of runtime archives). The `d/.nuget` before/after sizes are exact (measured from actual payload zips).

**Installer files excluded from shared payload per platform:**

| Platform | Files excluded (now only in EndToEnd.Tests) |
|----------|---------------------------------------------|
| **Windows** | `.zip` (280.5 MB), `.tar.gz` (214.8 MB), `.exe` (196.6 MB), `.wixpdb` (0.5 MB) |
| **Linux x64** | `.tar.gz` (178.4 MB) |
| **Mac arm64** | `.tar.gz` (170.4 MB), `.pkg` (170.6 MB) |

The remaining ~67.8 MB across all platforms is the actual NuGet packages needed by tests.