### PR TITLE
Skip full Build for AOT publish, use Compile instead

### DIFF
--- a/documentation/general/publish-build-optimization.md
+++ b/documentation/general/publish-build-optimization.md
@@ -1,0 +1,137 @@
+# Publish Build Optimization
+
+## Overview
+
+When `dotnet publish` runs, it implicitly runs a full `Build` before the publish step.
+This is necessary because the SDK cannot assume the previous `dotnet build` used the same
+configuration (e.g., the default build configuration is `Debug` while publish defaults to
+`Release`), runtime identifier, or other settings.
+
+However, for some publish modes, the full `Build` output (written to `bin\<config>\<tfm>\<rid>\`)
+is never used by the publish pipeline. The publish steps read from intermediate outputs
+(`obj\`) and resolution items, not from the `bin\` directory. This means the `Build` step
+produces artifacts that are confusing to users and automation, as `bin\<config>\<tfm>\<rid>\`
+contains a full self-contained managed deployment that is not the intended output.
+
+## How Publish Modes Work Today
+
+### Common Architecture
+
+All publish modes share this flow:
+
+1. **Build** (or equivalent) — produces the IL assembly at `@(IntermediateAssembly)` in `obj\`
+2. **ComputeResolvedFilesToPublishList** — collects files to publish from `@(IntermediateAssembly)`,
+   `@(RuntimeCopyLocalItems)`, `@(RuntimePackAsset)`, and content items
+3. **Post-processing** — mode-specific transformations (ILC, ILLink, crossgen2, bundler)
+4. **Copy to PublishDir** — final output written to `bin\<config>\<tfm>\<rid>\publish\`
+
+Key insight: All post-processing steps read from `@(IntermediateAssembly)` (obj) and
+`@(ResolvedFileToPublish)` (resolved from NuGet/project references), **never** from the
+`Build` output directory.
+
+### PublishAot (Native AOT)
+
+**Status: Optimized (this PR)**
+
+- `IlcCompile` reads `@(IntermediateAssembly)` from `obj\` and produces a native binary
+- The full `Build` was running a self-contained deployment to `bin\<config>\<tfm>\<rid>\`,
+  including apphost, managed DLLs, deps.json, runtimeconfig.json, and runtime pack files
+- **None of these files are used** by the AOT pipeline
+- **Optimization**: Replace `Build` with `Compile` (plus resource/satellite targets)
+- **Opt-out**: Set `UseAotOptimizedPublish=false` to restore full Build behavior
+
+Target chain for optimized AOT publish:
+```
+BuildOnlySettings → PrepareForBuild → PrepareResources → Compile → CreateSatelliteAssemblies
+```
+
+Where `Compile` includes `ResolveReferences → ResolveProjectReferences → CoreCompile`.
+
+### PublishTrimmed (IL Trimming)
+
+**Status: Not yet optimized — candidate for future optimization**
+
+- `ILLink` (the IL trimmer) processes `@(ResolvedFileToPublish)` items marked with
+  `PostprocessAssembly=true`
+- These items come from `ComputeResolvedFilesToPublishList` which reads from
+  `@(IntermediateAssembly)` (obj) and resolved references
+- The `Build` output in `bin\` is not consumed by the trimmer
+- The same `Compile`-based optimization would apply here
+
+### PublishReadyToRun (R2R / Crossgen2)
+
+**Status: Not yet optimized — candidate for future optimization**
+
+- `RunCrossgen2` processes `@(ResolvedFileToPublish)` items
+- Input assemblies come from resolution, not from `Build` output
+- Same optimization opportunity as trimming
+
+### PublishSingleFile (Single-File Bundling)
+
+**Status: Not yet optimized — candidate for future optimization**
+
+- `GenerateSingleFileBundle` bundles `@(ResolvedFileToPublish)` items into one executable
+- All inputs come from resolved items and `@(IntermediateAssembly)`
+- Same optimization opportunity
+
+### Combined Modes
+
+These modes can be combined (e.g., `PublishAot` implies `PublishTrimmed`). The optimization
+applies when the outermost mode is optimized:
+
+| Combination | Optimized? | Notes |
+|---|---|---|
+| PublishAot (implies trimmed) | ✅ Yes | AOT is the outermost mode |
+| PublishTrimmed + PublishSingleFile | ❌ Not yet | Future candidate |
+| PublishReadyToRun + PublishSingleFile | ❌ Not yet | Future candidate |
+| PublishTrimmed alone | ❌ Not yet | Future candidate |
+| PublishReadyToRun alone | ❌ Not yet | Future candidate |
+
+## Breaking Change: AOT Publish Build Optimization
+
+### What Changed
+
+Starting in .NET 10, `dotnet publish` with `PublishAot=true` no longer runs a full `Build`
+before publish. Instead, it runs only `Compile` (and resource/satellite assembly targets).
+
+### Impact
+
+- **BeforeBuild / AfterBuild targets**: These will not execute during AOT publish. If you have
+  custom targets attached to `BeforeBuild`, `AfterBuild`, or using
+  `BeforeTargets="Build"` / `AfterTargets="Build"`, they will not run.
+  - **Workaround**: Attach your targets to `BeforeTargets="Publish"` / `AfterTargets="Publish"`,
+    or to `BeforeTargets="Compile"` / `AfterTargets="Compile"` instead.
+- **PostBuildEvent**: Will not execute during AOT publish (consistent with `--no-build` behavior).
+- **Third-party NuGet Build hooks**: Targets from NuGet packages that hook into `Build` will be
+  skipped (consistent with `--no-build` behavior).
+- **Output directory**: `bin\<config>\<tfm>\<rid>\` will no longer contain managed apphost,
+  DLLs, deps.json, runtimeconfig.json, or runtime pack files. Only `native\` and `publish\`
+  subdirectories will be present.
+
+### Opt-Out
+
+To restore the previous behavior of running a full `Build` before AOT publish, set:
+
+```xml
+<PropertyGroup>
+  <UseAotOptimizedPublish>false</UseAotOptimizedPublish>
+</PropertyGroup>
+```
+
+Or pass it on the command line:
+
+```
+dotnet publish /p:UseAotOptimizedPublish=false
+```
+
+## Future Work
+
+The same optimization could be applied to `PublishTrimmed`, `PublishReadyToRun`, and
+`PublishSingleFile` modes, as they all share the same architecture of reading from
+`@(IntermediateAssembly)` and resolved references rather than `Build` output. Each mode
+would need:
+
+1. Its own condition check (e.g., `UseTrimmingOptimizedPublish`)
+2. The same target chain: `BuildOnlySettings → PrepareForBuild → PrepareResources → Compile → CreateSatelliteAssemblies`
+3. Tests verifying no managed artifacts in the output directory
+4. Documentation of the breaking change for that mode

--- a/documentation/general/publish-build-optimization.md
+++ b/documentation/general/publish-build-optimization.md
@@ -39,6 +39,7 @@ Key insight: All post-processing steps read from `@(IntermediateAssembly)` (obj)
 - **None of these files are used** by the AOT pipeline
 - **Optimization**: Replace `Build` with `Compile` (plus resource/satellite targets)
 - **Opt-out**: Set `UseAotOptimizedPublish=false` to restore full Build behavior
+- `UseAotOptimizedPublish` has no effect when `PublishAot` is not enabled
 
 Target chain for optimized AOT publish:
 ```
@@ -101,7 +102,8 @@ before publish. Instead, it runs only `Compile` (and resource/satellite assembly
   `BeforeTargets="Build"` / `AfterTargets="Build"`, they will not run.
   - **Workaround**: Attach your targets to `BeforeTargets="Publish"` / `AfterTargets="Publish"`,
     or to `BeforeTargets="Compile"` / `AfterTargets="Compile"` instead.
-- **PostBuildEvent**: Will not execute during AOT publish (consistent with `--no-build` behavior).
+- **PreBuildEvent / PostBuildEvent**: These will not execute during AOT publish (consistent
+  with `--no-build` behavior).
 - **Third-party NuGet Build hooks**: Targets from NuGet packages that hook into `Build` will be
   skipped (consistent with `--no-build` behavior).
 - **Output directory**: `bin\<config>\<tfm>\<rid>\` will no longer contain managed apphost,

--- a/documentation/general/publish-build-optimization.md
+++ b/documentation/general/publish-build-optimization.md
@@ -31,7 +31,7 @@ Key insight: All post-processing steps read from `@(IntermediateAssembly)` (obj)
 
 ### PublishAot (Native AOT)
 
-**Status: Optimized (this PR)**
+**Status: Optimized**
 
 - `IlcCompile` reads `@(IntermediateAssembly)` from `obj\` and produces a native binary
 - The full `Build` was running a self-contained deployment to `bin\<config>\<tfm>\<rid>\`,
@@ -91,7 +91,7 @@ applies when the outermost mode is optimized:
 
 ### What Changed
 
-Starting in .NET 10, `dotnet publish` with `PublishAot=true` no longer runs a full `Build`
+Starting in .NET 11, `dotnet publish` with `PublishAot=true` no longer runs a full `Build`
 before publish. Instead, it runs only `Compile` (and resource/satellite assembly targets).
 
 ### Impact

--- a/documentation/general/publish-build-optimization.md
+++ b/documentation/general/publish-build-optimization.md
@@ -38,8 +38,8 @@ Key insight: All post-processing steps read from `@(IntermediateAssembly)` (obj)
   including apphost, managed DLLs, deps.json, runtimeconfig.json, and runtime pack files
 - **None of these files are used** by the AOT pipeline
 - **Optimization**: Replace `Build` with `Compile` (plus resource/satellite targets)
-- **Opt-out**: Set `UseAotOptimizedPublish=false` to restore full Build behavior
-- `UseAotOptimizedPublish` has no effect when `PublishAot` is not enabled
+- **Opt-out**: Set `UseOptimizedPublish=false` to restore full Build behavior
+- `UseOptimizedPublish` currently has no effect when `PublishAot` is not enabled
 
 Target chain for optimized AOT publish:
 ```
@@ -116,14 +116,14 @@ To restore the previous behavior of running a full `Build` before AOT publish, s
 
 ```xml
 <PropertyGroup>
-  <UseAotOptimizedPublish>false</UseAotOptimizedPublish>
+  <UseOptimizedPublish>false</UseOptimizedPublish>
 </PropertyGroup>
 ```
 
 Or pass it on the command line:
 
 ```
-dotnet publish /p:UseAotOptimizedPublish=false
+dotnet publish /p:UseOptimizedPublish=false
 ```
 
 ## Future Work
@@ -133,7 +133,7 @@ The same optimization could be applied to `PublishTrimmed`, `PublishReadyToRun`,
 `@(IntermediateAssembly)` and resolved references rather than `Build` output. Each mode
 would need:
 
-1. Its own condition check (e.g., `UseTrimmingOptimizedPublish`)
+1. Compatibility analysis for Build hooks used by projects and NuGet packages
 2. The same target chain: `BuildOnlySettings → PrepareForBuild → PrepareResources → Compile → CreateSatelliteAssemblies`
-3. Tests verifying no managed artifacts in the output directory
+3. Tests verifying the expected build and publish outputs
 4. Documentation of the breaking change for that mode

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -303,6 +303,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateStaticWebAssetsManifestDependsOn>$(GenerateStaticWebAssetsManifestDependsOn);ResolveBuildStaticWebAssets</GenerateStaticWebAssetsManifestDependsOn>
 
+    <!-- The AOT-optimized publish path (UseAotOptimizedPublish) runs Compile instead of full Build,
+         which skips PrepareForRun and therefore GenerateStaticWebAssetsManifest. The publish pipeline
+         still expects the static web assets build manifest (staticwebassets.build.json) to exist, so
+         contribute manifest generation to the AOT build-alternative extension point. This writes only
+         to the intermediate (obj\) directory and does not copy assets to the output (bin\) directory. -->
+    <_AdditionalAotBuildAlternativeTargets>$(_AdditionalAotBuildAlternativeTargets);GenerateStaticWebAssetsManifest</_AdditionalAotBuildAlternativeTargets>
+
     <!-- There are now three stages:
       ResolveCoreStaticWebAssets: This is the stage where we resolve the static web assets for the current project, packages and project references. These assets exist on disk
       and are part of the project or one of its dependencies.

--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.targets
@@ -303,12 +303,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <GenerateStaticWebAssetsManifestDependsOn>$(GenerateStaticWebAssetsManifestDependsOn);ResolveBuildStaticWebAssets</GenerateStaticWebAssetsManifestDependsOn>
 
-    <!-- The AOT-optimized publish path (UseAotOptimizedPublish) runs Compile instead of full Build,
+    <!-- The AOT-optimized publish path (UseOptimizedPublish) runs Compile instead of full Build,
          which skips PrepareForRun and therefore GenerateStaticWebAssetsManifest. The publish pipeline
          still expects the static web assets build manifest (staticwebassets.build.json) to exist, so
-         contribute manifest generation to the AOT build-alternative extension point. This writes only
+         contribute manifest generation to the optimized publish extension point. This writes only
          to the intermediate (obj\) directory and does not copy assets to the output (bin\) directory. -->
-    <_AdditionalAotBuildAlternativeTargets>$(_AdditionalAotBuildAlternativeTargets);GenerateStaticWebAssetsManifest</_AdditionalAotBuildAlternativeTargets>
+    <_AdditionalOptimizedPublishTargets>$(_AdditionalOptimizedPublishTargets);GenerateStaticWebAssetsManifest</_AdditionalOptimizedPublishTargets>
 
     <!-- There are now three stages:
       ResolveCoreStaticWebAssets: This is the stage where we resolve the static web assets for the current project, packages and project references. These assets exist on disk

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -148,11 +148,28 @@ Copyright (c) .NET Foundation. All rights reserved.
     </_CorePublishTargets>
 
     <_PublishNoBuildAlternativeDependsOn>$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)</_PublishNoBuildAlternativeDependsOn>
+
+    <!-- For AOT publish, we only need Compile (not full Build) since IlcCompile reads from
+         @(IntermediateAssembly) in obj\, not from bin\ output. Skipping Build avoids producing
+         unnecessary self-contained managed output (apphost, deps.json, runtimeconfig, runtime
+         pack files) in the output directory that would confuse users and automation. -->
+    <_BeforePublishAotBuildTargets Condition="'$(PublishAot)' == 'true'">
+      BuildOnlySettings;
+      PrepareForBuild;
+      PrepareResources;
+      Compile;
+      CreateSatelliteAssemblies;
+    </_BeforePublishAotBuildTargets>
+    <_PublishAotBuildAlternativeDependsOn>$(_BeforePublishAotBuildTargets);$(_CorePublishTargets)</_PublishAotBuildAlternativeDependsOn>
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(PublishAot)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
+
+  <Target Name="_PublishAotBuildAlternative"
+          Condition="'$(NoBuild)' != 'true' and '$(PublishAot)' == 'true'"
+          DependsOnTargets="$(_PublishAotBuildAlternativeDependsOn)" />
 
   <Target Name="_PublishNoBuildAlternative"
           Condition="'$(NoBuild)' == 'true'"
@@ -160,7 +177,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="Publish"
           Condition="$(IsPublishable) == 'true'"
-          DependsOnTargets="_PublishBuildAlternative;_PublishNoBuildAlternative" >
+          DependsOnTargets="_PublishBuildAlternative;_PublishAotBuildAlternative;_PublishNoBuildAlternative" >
 
     <!-- Ensure there is minimal verbosity output pointing to the publish directory and not just the
          build step's minimal output. Otherwise there is no indication at minimal verbosity of where

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -152,8 +152,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- For AOT publish, we only need Compile (not full Build) since IlcCompile reads from
          @(IntermediateAssembly) in obj\, not from bin\ output. Skipping Build avoids producing
          unnecessary self-contained managed output (apphost, deps.json, runtimeconfig, runtime
-         pack files) in the output directory that would confuse users and automation. -->
-    <_BeforePublishAotBuildTargets Condition="'$(PublishAot)' == 'true'">
+         pack files) in the output directory that would confuse users and automation.
+         Set UseAotOptimizedPublish=false to restore the previous behavior of running full Build. -->
+    <UseAotOptimizedPublish Condition="'$(UseAotOptimizedPublish)' == '' and '$(PublishAot)' == 'true'">true</UseAotOptimizedPublish>
+    <_BeforePublishAotBuildTargets Condition="'$(UseAotOptimizedPublish)' == 'true'">
       BuildOnlySettings;
       PrepareForBuild;
       PrepareResources;
@@ -164,11 +166,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(PublishAot)' != 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
   <Target Name="_PublishAotBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(PublishAot)' == 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' == 'true'"
           DependsOnTargets="$(_PublishAotBuildAlternativeDependsOn)" />
 
   <Target Name="_PublishNoBuildAlternative"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -162,16 +162,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       Compile;
       CreateSatelliteAssemblies;
     </_BeforePublishAotBuildTargets>
-    <_PublishAotBuildAlternativeDependsOn>$(_BeforePublishAotBuildTargets);$(_CorePublishTargets)</_PublishAotBuildAlternativeDependsOn>
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
           Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
+  <!-- $(_AdditionalAotBuildAlternativeTargets) is an extension point for SDKs (e.g. Static Web Assets)
+       that hook additional work into the full Build via targets which the AOT-optimized path skips.
+       It is referenced in the DependsOnTargets attribute (not a pre-computed property) so it is expanded
+       at build time, allowing contributions from targets imported after this file. It runs after
+       Compile so contributors can rely on the intermediate assembly, and before the core publish
+       targets that consume its outputs. -->
   <Target Name="_PublishAotBuildAlternative"
           Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' == 'true'"
-          DependsOnTargets="$(_PublishAotBuildAlternativeDependsOn)" />
+          DependsOnTargets="$(_BeforePublishAotBuildTargets);$(_AdditionalAotBuildAlternativeTargets);$(_CorePublishTargets)" />
 
   <Target Name="_PublishNoBuildAlternative"
           Condition="'$(NoBuild)' == 'true'"

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -153,29 +153,30 @@ Copyright (c) .NET Foundation. All rights reserved.
          @(IntermediateAssembly) in obj\, not from bin\ output. Skipping Build avoids producing
          unnecessary self-contained managed output (apphost, deps.json, runtimeconfig, runtime
          pack files) in the output directory that would confuse users and automation.
-         Set UseAotOptimizedPublish=false to restore the previous behavior of running full Build. -->
-    <UseAotOptimizedPublish Condition="'$(UseAotOptimizedPublish)' == '' and '$(PublishAot)' == 'true'">true</UseAotOptimizedPublish>
-    <_UseAotOptimizedPublish Condition="'$(PublishAot)' == 'true' and '$(UseAotOptimizedPublish)' == 'true'">true</_UseAotOptimizedPublish>
-    <_BeforePublishAotBuildTargets Condition="'$(_UseAotOptimizedPublish)' == 'true'">
+         Set UseOptimizedPublish=false to restore the previous behavior of running full Build. -->
+    <UseOptimizedPublish Condition="'$(UseOptimizedPublish)' == '' and '$(PublishAot)' == 'true'">true</UseOptimizedPublish>
+    <!-- Native AOT is currently the only publish mode that supports optimized publish. -->
+    <_UseOptimizedPublish Condition="'$(PublishAot)' == 'true' and '$(UseOptimizedPublish)' == 'true'">true</_UseOptimizedPublish>
+    <_BeforeOptimizedPublishTargets Condition="'$(_UseOptimizedPublish)' == 'true'">
       BuildOnlySettings;
       PrepareForBuild;
       PrepareResources;
       Compile;
       CreateSatelliteAssemblies;
-    </_BeforePublishAotBuildTargets>
+    </_BeforeOptimizedPublishTargets>
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(_UseAotOptimizedPublish)' != 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(_UseOptimizedPublish)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
-  <!-- $(_AdditionalAotBuildAlternativeTargets) is an extension point for SDKs (e.g. Static Web Assets)
+  <!-- $(_AdditionalOptimizedPublishTargets) is an extension point for SDKs (e.g. Static Web Assets)
        that hook additional work into the full Build via targets which the AOT-optimized path skips.
        It runs after Compile so contributors can rely on the intermediate assembly, and before the core
        publish targets that consume its outputs. -->
-  <Target Name="_PublishAotBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(_UseAotOptimizedPublish)' == 'true'"
-          DependsOnTargets="$(_BeforePublishAotBuildTargets);$(_AdditionalAotBuildAlternativeTargets);$(_CorePublishTargets)" />
+  <Target Name="_PublishOptimizedBuildAlternative"
+          Condition="'$(NoBuild)' != 'true' and '$(_UseOptimizedPublish)' == 'true'"
+          DependsOnTargets="$(_BeforeOptimizedPublishTargets);$(_AdditionalOptimizedPublishTargets);$(_CorePublishTargets)" />
 
   <Target Name="_PublishNoBuildAlternative"
           Condition="'$(NoBuild)' == 'true'"
@@ -183,7 +184,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="Publish"
           Condition="$(IsPublishable) == 'true'"
-          DependsOnTargets="_PublishBuildAlternative;_PublishAotBuildAlternative;_PublishNoBuildAlternative" >
+          DependsOnTargets="_PublishBuildAlternative;_PublishOptimizedBuildAlternative;_PublishNoBuildAlternative" >
 
     <!-- Ensure there is minimal verbosity output pointing to the publish directory and not just the
          build step's minimal output. Otherwise there is no indication at minimal verbosity of where

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -170,10 +170,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- $(_AdditionalAotBuildAlternativeTargets) is an extension point for SDKs (e.g. Static Web Assets)
        that hook additional work into the full Build via targets which the AOT-optimized path skips.
-       It is referenced in the DependsOnTargets attribute (not a pre-computed property) so it is expanded
-       at build time, allowing contributions from targets imported after this file. It runs after
-       Compile so contributors can rely on the intermediate assembly, and before the core publish
-       targets that consume its outputs. -->
+       It runs after Compile so contributors can rely on the intermediate assembly, and before the core
+       publish targets that consume its outputs. -->
   <Target Name="_PublishAotBuildAlternative"
           Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' == 'true'"
           DependsOnTargets="$(_BeforePublishAotBuildTargets);$(_AdditionalAotBuildAlternativeTargets);$(_CorePublishTargets)" />

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -155,7 +155,8 @@ Copyright (c) .NET Foundation. All rights reserved.
          pack files) in the output directory that would confuse users and automation.
          Set UseAotOptimizedPublish=false to restore the previous behavior of running full Build. -->
     <UseAotOptimizedPublish Condition="'$(UseAotOptimizedPublish)' == '' and '$(PublishAot)' == 'true'">true</UseAotOptimizedPublish>
-    <_BeforePublishAotBuildTargets Condition="'$(UseAotOptimizedPublish)' == 'true'">
+    <_UseAotOptimizedPublish Condition="'$(PublishAot)' == 'true' and '$(UseAotOptimizedPublish)' == 'true'">true</_UseAotOptimizedPublish>
+    <_BeforePublishAotBuildTargets Condition="'$(_UseAotOptimizedPublish)' == 'true'">
       BuildOnlySettings;
       PrepareForBuild;
       PrepareResources;
@@ -165,7 +166,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_PublishBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' != 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(_UseAotOptimizedPublish)' != 'true'"
           DependsOnTargets="Build;$(_CorePublishTargets)" />
 
   <!-- $(_AdditionalAotBuildAlternativeTargets) is an extension point for SDKs (e.g. Static Web Assets)
@@ -173,7 +174,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        It runs after Compile so contributors can rely on the intermediate assembly, and before the core
        publish targets that consume its outputs. -->
   <Target Name="_PublishAotBuildAlternative"
-          Condition="'$(NoBuild)' != 'true' and '$(UseAotOptimizedPublish)' == 'true'"
+          Condition="'$(NoBuild)' != 'true' and '$(_UseAotOptimizedPublish)' == 'true'"
           DependsOnTargets="$(_BeforePublishAotBuildTargets);$(_AdditionalAotBuildAlternativeTargets);$(_CorePublishTargets)" />
 
   <Target Name="_PublishNoBuildAlternative"

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             // Linux symbol files are embedded and require additional steps to be stripped to a separate file
             // assumes /bin (or /usr/bin) are in the PATH
@@ -124,6 +125,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateAppForConfigCheck(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["Configuration"] = projectConfiguration;
             // Linux symbol files are embedded and require additional steps to be stripped to a separate file
@@ -176,6 +178,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateAppForConfigCheck(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["Configuration"] = projectConfiguration;
             // Linux symbol files are embedded and require additional steps to be stripped to a separate file
@@ -267,6 +270,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
 
             // This will add a reference to a package that will also be automatically imported by the SDK
@@ -390,6 +394,7 @@ namespace Microsoft.NET.Publish.Tests
 
                 var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
                 testProject.RecordProperties("BundledNETCoreAppPackageVersion");
+                testProject.RecordPropertiesBeforeTarget("Publish");
                 testProject.AdditionalProperties["PublishAot"] = "true";
 
                 // This will add a reference to a package that will also be automatically imported by the SDK
@@ -732,6 +737,7 @@ namespace Microsoft.NET.Publish.Tests
             // PublishAot should enable the EnableAotAnalyzer, EnableTrimAnalyzer and EnableSingleFileAnalyzer
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["SuppressTrimAnalysisWarnings"] = "false";
             testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "true";
@@ -829,6 +835,7 @@ namespace Microsoft.NET.Publish.Tests
             // only if they don't have a predefined value
             var testProject = CreateTestProjectWithAnalysisWarnings(targetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["EnableAotAnalyzer"] = "false";
             testProject.AdditionalProperties["EnableTrimAnalyzer"] = "false";
@@ -869,6 +876,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "true";
             testProject.AdditionalProperties["SelfContained"] = "true";
@@ -925,6 +933,7 @@ namespace Microsoft.NET.Publish.Tests
 
             var testProject = CreateTestProjectWithAotLibrary(targetFramework, projectName);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "true";
             testProject.AdditionalProperties["NativeLib"] = "Shared";
@@ -1085,6 +1094,7 @@ namespace Microsoft.NET.Publish.Tests
             var projectName = "NativeAotAppWithSatellites";
             var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, projectName, true);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["SatelliteResourceLanguages"] = "fr;de";
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -1378,6 +1388,122 @@ public class NativeLibraryClass
             {
                 return true;
             }
+        }
+
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        public void NativeAot_publish_does_not_produce_managed_build_output()
+        {
+            // AOT publish should not create managed build artifacts (apphost, .dll, .deps.json,
+            // .runtimeconfig.json, runtime pack files) in the output directory (bin\<config>\<tfm>\<rid>\).
+            // The ILC pipeline reads from obj\, so full Build output in bin\ is unnecessary and confusing.
+            var projectName = "NativeAotCleanOutput";
+
+            var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, projectName, true);
+            testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            // Record properties before Publish since Build is skipped for AOT
+            testProject.RecordPropertiesBeforeTarget("Publish");
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                testProject.AdditionalProperties["StripSymbols"] = "true";
+            }
+            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand
+                .Execute("/p:UseCurrentRuntimeIdentifier=true", "/p:SelfContained=true")
+                .Should().Pass();
+
+            var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, ToolsetInfo.CurrentTargetFramework);
+            var rid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: ToolsetInfo.CurrentTargetFramework, runtimeIdentifier: rid).FullName;
+            var publishedExe = Path.Combine(publishDirectory, $"{testProject.Name}{Constants.ExeSuffix}");
+
+            // The publish directory should contain the native AOT binary
+            File.Exists(publishedExe).Should().BeTrue("the AOT-compiled native binary should exist in the publish directory");
+            IsNativeImage(publishedExe).Should().BeTrue("the published binary should be a native image");
+
+            // The output directory (parent of publish\) should NOT contain managed build artifacts.
+            // It may contain subdirectories like native\ and publish\, but should not have managed
+            // apphost, .dll, .deps.json, .runtimeconfig.json, or runtime pack files.
+            var outputDirectory = Path.GetDirectoryName(publishDirectory);
+            var managedBuildArtifacts = Directory.GetFiles(outputDirectory)
+                .Select(Path.GetFileName)
+                .ToList();
+
+            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}{Constants.ExeSuffix}", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain a managed apphost executable from Build");
+            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.dll", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain a managed assembly from Build");
+            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.deps.json", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain deps.json from Build");
+            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.runtimeconfig.json", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain runtimeconfig.json from Build");
+        }
+
+        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        public void NativeAot_publish_with_project_reference_succeeds()
+        {
+            // Verify that AOT publish still builds project references correctly via
+            // Compile → ResolveReferences → ResolveProjectReferences.
+            var referencedProject = new TestProject()
+            {
+                Name = "AotRefLib",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+            referencedProject.SourceFiles["AotRefLib.cs"] = @"
+namespace AotRefLib
+{
+    public class Greeter
+    {
+        public static string Greet() => ""Hello from referenced project"";
+    }
+}";
+
+            var testProject = new TestProject()
+            {
+                Name = "AotAppWithRef",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+                IsExe = true,
+            };
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                testProject.AdditionalProperties["StripSymbols"] = "true";
+            }
+            testProject.ReferencedProjects.Add(referencedProject);
+            testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            // Record properties before Publish since Build is skipped for AOT
+            testProject.RecordPropertiesBeforeTarget("Publish");
+            testProject.SourceFiles["AotAppWithRef.cs"] = @"
+using System;
+class Test
+{
+    static void Main()
+    {
+        Console.WriteLine(AotRefLib.Greeter.Greet());
+    }
+}";
+
+            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+
+            var publishCommand = new PublishCommand(testAsset);
+            publishCommand
+                .Execute("/p:UseCurrentRuntimeIdentifier=true", "/p:SelfContained=true")
+                .Should().Pass();
+
+            var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, ToolsetInfo.CurrentTargetFramework);
+            var rid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
+            var publishDirectory = publishCommand.GetOutputDirectory(targetFramework: ToolsetInfo.CurrentTargetFramework, runtimeIdentifier: rid).FullName;
+            var publishedExe = Path.Combine(publishDirectory, $"{testProject.Name}{Constants.ExeSuffix}");
+
+            File.Exists(publishedExe).Should().BeTrue("the AOT-compiled native binary should exist");
+            IsNativeImage(publishedExe).Should().BeTrue("the published binary should be a native image");
+
+            var result = new RunExeCommand(Log, publishedExe)
+                .Execute();
+            result.Should().Pass()
+                .And.HaveStdOutContaining("Hello from referenced project");
         }
 
         private void AddRuntimeConfigOption(XDocument project)

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1439,6 +1439,13 @@ public class NativeLibraryClass
                 "the output directory should not contain deps.json from Build");
             managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.runtimeconfig.json", StringComparison.OrdinalIgnoreCase),
                 "the output directory should not contain runtimeconfig.json from Build");
+            // Also verify no runtime pack assemblies leaked from a self-contained Build
+            managedBuildArtifacts.Should().NotContain(f => f.Equals("System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain runtime pack assemblies from Build");
+            managedBuildArtifacts.Should().NotContain(f => f.Equals("coreclr.dll", StringComparison.OrdinalIgnoreCase) ||
+                                                           f.Equals("libcoreclr.so", StringComparison.OrdinalIgnoreCase) ||
+                                                           f.Equals("libcoreclr.dylib", StringComparison.OrdinalIgnoreCase),
+                "the output directory should not contain the CoreCLR runtime from Build");
         }
 
         [RequiresMSBuildVersionFact("17.0.0.32901")]

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1390,7 +1390,8 @@ public class NativeLibraryClass
             }
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [TestMethod]
+        [RequiresMSBuildVersion("17.0.0.32901")]
         public void NativeAot_publish_does_not_produce_managed_build_output()
         {
             // AOT publish should not create managed build artifacts (apphost, .dll, .deps.json,
@@ -1448,7 +1449,8 @@ public class NativeLibraryClass
                 "the output directory should not contain the CoreCLR runtime from Build");
         }
 
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [TestMethod]
+        [RequiresMSBuildVersion("17.0.0.32901")]
         public void NativeAot_publish_with_project_reference_succeeds()
         {
             // Verify that AOT publish still builds project references correctly via

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1394,19 +1394,18 @@ public class NativeLibraryClass
         public void Aot_optimized_publish_targets_are_reviewed_when_CoreBuildDependsOn_changes()
         {
             var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "CoreBuildDependsOn", true);
-            testProject.RecordProperties("CoreBuildDependsOn");
-            testProject.RecordPropertiesBeforeTarget("Compile");
             var testAsset = TestAssetsManager.CreateTestProject(testProject);
 
-            new BuildCommand(testAsset)
+            var getValuesCommand = new GetValuesCommand(testAsset, "CoreBuildDependsOn")
+            {
+                ShouldCompile = false
+            };
+
+            getValuesCommand
                 .Execute()
                 .Should().Pass();
 
-            var coreBuildDependsOn = testProject
-                .GetPropertyValues(testAsset.TestRoot, ToolsetInfo.CurrentTargetFramework)["CoreBuildDependsOn"]
-                .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-
-            coreBuildDependsOn.Should().Equal(
+            getValuesCommand.GetValues().Should().Equal(
                 "_CheckForBuildWithNoBuild",
                 "BuildOnlySettings",
                 "PrepareForBuild",

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1395,6 +1395,7 @@ public class NativeLibraryClass
         {
             var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "CoreBuildDependsOn", true);
             testProject.RecordProperties("CoreBuildDependsOn");
+            testProject.RecordPropertiesBeforeTarget("Compile");
             var testAsset = TestAssetsManager.CreateTestProject(testProject);
 
             new BuildCommand(testAsset)

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1429,6 +1429,27 @@ public class NativeLibraryClass
         }
 
         [TestMethod]
+        public void UseAotOptimizedPublish_does_not_skip_build_for_non_Aot_publish()
+        {
+            var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "NonAotOptimizedPublish", true);
+            testProject.AdditionalProperties["UseAotOptimizedPublish"] = "true";
+            var testAsset = TestAssetsManager.CreateTestProject(testProject)
+                .WithProjectChanges(project =>
+                {
+                    project.Root.Add(XElement.Parse("""
+                        <Target Name="ConfirmBuildExecuted" AfterTargets="Build">
+                          <Message Importance="High" Text="Build target executed" />
+                        </Target>
+                        """));
+                });
+
+            new PublishCommand(testAsset)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Build target executed");
+        }
+
+        [TestMethod]
         [RequiresMSBuildVersion("17.0.0.32901")]
         public void NativeAot_publish_does_not_produce_managed_build_output()
         {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1429,10 +1429,10 @@ public class NativeLibraryClass
         }
 
         [TestMethod]
-        public void UseAotOptimizedPublish_does_not_skip_build_for_non_Aot_publish()
+        public void UseOptimizedPublish_does_not_skip_build_for_unsupported_publish_modes()
         {
-            var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "NonAotOptimizedPublish", true);
-            testProject.AdditionalProperties["UseAotOptimizedPublish"] = "true";
+            var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "UnsupportedOptimizedPublish", true);
+            testProject.AdditionalProperties["UseOptimizedPublish"] = "true";
             var testAsset = TestAssetsManager.CreateTestProject(testProject)
                 .WithProjectChanges(project =>
                 {

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1405,7 +1405,7 @@ public class NativeLibraryClass
                 .Execute()
                 .Should().Pass();
 
-            getValuesCommand.GetValues().Should().Equal(
+            getValuesCommand.GetValues().Should().Equal([
                 "_CheckForBuildWithNoBuild",
                 "BuildOnlySettings",
                 "PrepareForBuild",
@@ -1425,7 +1425,8 @@ public class NativeLibraryClass
                 "IncrementalClean",
                 "PostBuildEvent",
                 "GenerateBuildDependencyFile",
-                "GenerateBuildRuntimeConfigurationFiles");
+                "GenerateBuildRuntimeConfigurationFiles"],
+                because: "CoreBuildDependsOn changed. Review added or removed targets for their impact on optimized publish, update the optimized target chain if necessary, then update this expected list.");
         }
 
         [TestMethod]

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -1391,6 +1391,44 @@ public class NativeLibraryClass
         }
 
         [TestMethod]
+        public void Aot_optimized_publish_targets_are_reviewed_when_CoreBuildDependsOn_changes()
+        {
+            var testProject = CreateHelloWorldTestProject(ToolsetInfo.CurrentTargetFramework, "CoreBuildDependsOn", true);
+            testProject.RecordProperties("CoreBuildDependsOn");
+            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+
+            new BuildCommand(testAsset)
+                .Execute()
+                .Should().Pass();
+
+            var coreBuildDependsOn = testProject
+                .GetPropertyValues(testAsset.TestRoot, ToolsetInfo.CurrentTargetFramework)["CoreBuildDependsOn"]
+                .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            coreBuildDependsOn.Should().Equal(
+                "_CheckForBuildWithNoBuild",
+                "BuildOnlySettings",
+                "PrepareForBuild",
+                "PreBuildEvent",
+                "ResolveReferences",
+                "PrepareResources",
+                "ResolveKeySource",
+                "Compile",
+                "ExportWindowsMDFile",
+                "UnmanagedUnregistration",
+                "GenerateSerializationAssemblies",
+                "CreateSatelliteAssemblies",
+                "GenerateManifests",
+                "GetTargetPath",
+                "PrepareForRun",
+                "UnmanagedRegistration",
+                "IncrementalClean",
+                "PostBuildEvent",
+                "GenerateBuildDependencyFile",
+                "GenerateBuildRuntimeConfigurationFiles");
+        }
+
+        [TestMethod]
         [RequiresMSBuildVersion("17.0.0.32901")]
         public void NativeAot_publish_does_not_produce_managed_build_output()
         {
@@ -1412,7 +1450,7 @@ public class NativeLibraryClass
 
             var publishCommand = new PublishCommand(testAsset);
             publishCommand
-                .Execute("/p:UseCurrentRuntimeIdentifier=true", "/p:SelfContained=true")
+                .Execute()
                 .Should().Pass();
 
             var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, ToolsetInfo.CurrentTargetFramework);
@@ -1424,29 +1462,10 @@ public class NativeLibraryClass
             File.Exists(publishedExe).Should().BeTrue("the AOT-compiled native binary should exist in the publish directory");
             IsNativeImage(publishedExe).Should().BeTrue("the published binary should be a native image");
 
-            // The output directory (parent of publish\) should NOT contain managed build artifacts.
-            // It may contain subdirectories like native\ and publish\, but should not have managed
-            // apphost, .dll, .deps.json, .runtimeconfig.json, or runtime pack files.
+            // The output directory (parent of publish\) should only contain subdirectories.
             var outputDirectory = Path.GetDirectoryName(publishDirectory);
-            var managedBuildArtifacts = Directory.GetFiles(outputDirectory)
-                .Select(Path.GetFileName)
-                .ToList();
-
-            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}{Constants.ExeSuffix}", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain a managed apphost executable from Build");
-            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.dll", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain a managed assembly from Build");
-            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.deps.json", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain deps.json from Build");
-            managedBuildArtifacts.Should().NotContain(f => f.Equals($"{projectName}.runtimeconfig.json", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain runtimeconfig.json from Build");
-            // Also verify no runtime pack assemblies leaked from a self-contained Build
-            managedBuildArtifacts.Should().NotContain(f => f.Equals("System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain runtime pack assemblies from Build");
-            managedBuildArtifacts.Should().NotContain(f => f.Equals("coreclr.dll", StringComparison.OrdinalIgnoreCase) ||
-                                                           f.Equals("libcoreclr.so", StringComparison.OrdinalIgnoreCase) ||
-                                                           f.Equals("libcoreclr.dylib", StringComparison.OrdinalIgnoreCase),
-                "the output directory should not contain the CoreCLR runtime from Build");
+            Directory.GetFiles(outputDirectory).Should().BeEmpty(
+                "the AOT-optimized publish should not produce Build output files");
         }
 
         [TestMethod]

--- a/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -84,6 +84,9 @@ namespace Microsoft.NET.Sdk.Web.Tests
 
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
+            // AOT publish runs Compile instead of full Build, so the AfterBuild target (the default
+            // anchor for recording properties) never runs. Record before Publish, which always runs.
+            testProject.RecordPropertiesBeforeTarget("Publish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "true";
             testProject.PropertiesToRecord.Add("PublishTrimmed");

--- a/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
+++ b/test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs
@@ -85,8 +85,10 @@ namespace Microsoft.NET.Sdk.Web.Tests
             var testProject = CreateTestProjectForILLinkTesting(targetFramework, projectName);
             testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier");
             // AOT publish runs Compile instead of full Build, so the AfterBuild target (the default
-            // anchor for recording properties) never runs. Record before Publish, which always runs.
-            testProject.RecordPropertiesBeforeTarget("Publish");
+            // anchor for recording properties) never runs. Record before PrepareForPublish, which
+            // runs after Compile but before publish-time trimming (PrepareForILLink) defaults
+            // TrimMode to "full" - matching the pre-trimming values the original AfterBuild anchor saw.
+            testProject.RecordPropertiesBeforeTarget("PrepareForPublish");
             testProject.AdditionalProperties["PublishAot"] = "true";
             testProject.AdditionalProperties["UseCurrentRuntimeIdentifier"] = "true";
             testProject.PropertiesToRecord.Add("PublishTrimmed");


### PR DESCRIPTION
When publishing with PublishAot=true, the implicit Build step was producing a full self-contained managed deployment (apphost, DLLs, deps.json, runtimeconfig, runtime pack files) in the output directory. This output is completely unused by the AOT pipeline, which reads from @(IntermediateAssembly) in obj\\, not from bin\\ output.

This change introduces _PublishAotBuildAlternative that runs Compile (plus resource and satellite assembly targets) instead of full Build for AOT publish. This eliminates the confusing managed artifacts from the output directory while preserving all AOT publish functionality.

The target list for AOT publish is:
- BuildOnlySettings: configures build-time settings
- PrepareForBuild: creates output directories
- PrepareResources: compiles .resx to .resources files
- Compile: produces IL assembly in obj\\ (includes ResolveReferences)
- CreateSatelliteAssemblies: generates culture-specific resource DLLs


## Tactics

### Summary

When publishing with `PublishAot=true`, the full MSBuild `Build` target was executing as part of the publish pipeline, producing a complete self-contained managed deployment (apphost, DLLs, deps.json, runtimeconfig.json, and runtime pack files) in the output (`bin\\`) directory. These artifacts are entirely unused by the AOT pipeline, which reads from `@(IntermediateAssembly)` in `obj\\`, not from `bin\\`. This change introduces a new `_PublishOptimizedBuild` target that runs only `Compile` (plus resource and satellite assembly targets) instead of the full `Build` for AOT publish, eliminating the confusing managed artifacts from the output directory while preserving all AOT publish functionality. A public opt-out property `UseOptimizedPublish` is provided for projects that rely on `Build` extensibility points (e.g., `BeforeBuild`, `AfterBuild`, `BeforeTargets`/`AfterTargets="Build"`) or packages like `Microsoft.Extensions.ApiDescription.Server`. This fix is scoped to AOT-only in .NET 11 to minimize risk; expansion to other publish modes is planned for .NET 12 early previews (tracked in #55911).

### Customer Impact

Customers performing `dotnet publish /p:PublishAot=true` received a cluttered output directory containing the full managed self-contained deployment alongside the expected `publish\\` and `native\\` subdirectories. This caused confusion when developers accidentally deployed the build-output DLLs/apphost instead of the AOT-compiled binaries. The issue affects all users on .NET 11 using Native AOT publish. There is no workaround other than manually deleting the spurious files. After this fix, the output directory contains only subdirectories (`native\\`, `publish\\`), with no loose managed artifacts. Projects with custom `Build` targets or packages with `BeforeTargets="Build"` hooks must opt out via `<UseOptimizedPublish>false</UseOptimizedPublish>`.

### Regression?

Unknown — this is not a regression but rather a long-standing behavior of the publish pipeline where `Build` was always invoked unconditionally. The PR improves the behavior for .NET 11 Native AOT publish. The feature is new in .NET 11 and targets `release/11.0.1xx`.

### Testing

- **Unit/integration tests added**: 175 lines of new tests added in `test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs`, including assertions that the parent output directory contains no loose files after AOT publish, and a focused test that records the evaluated `CoreBuildDependsOn` target sequence so any unexpected additions require explicit review. 5 lines added in `test/Microsoft.NET.Sdk.Web.Tests/PublishTests.cs`.
- **Ecosystem compatibility**: NuGet top-100 package scan performed; only `Microsoft.Extensions.ApiDescription.Server` was found with a direct `Build` hook, documented in the opt-out guidance.
- **MAUI/mobile concern**: iOS and Android workload impact was flagged; the PR is intentionally held from rc1 and targeting rc2 to allow MAUI team testing. The extension point `$(_AdditionalOptimizedBuildTargets)` and `UseOptimizedPublish=false` opt-out are provided for workloads.
- **CI**: PR CI runs on the `release/11.0.1xx` branch.

### Risk

Medium. The change alters the publish pipeline for all `PublishAot=true` projects by skipping the full `Build` target in favor of `Compile`-only. While `Build` extensibility points (`BeforeBuild`, `AfterBuild`, custom `BeforeTargets`/`AfterTargets="Build"`) are bypassed by default, an opt-out (`UseOptimizedPublish=false`) is provided and documented. The MAUI/iOS/Android workloads have not yet completed testing, which is why the PR is targeted for rc2. The NuGet ecosystem scan found only one affected package. The change is limited to `PublishAot=true` scenarios, reducing blast radius.

<!-- gh-aw-workflow-id: add-tactics-template-on-comment -->