### PR TITLE
Fix interactive flag on dotnetup command with no other arguments

### DIFF
--- a/src/Installer/dotnetup.Library/Parser.cs
+++ b/src/Installer/dotnetup.Library/Parser.cs
@@ -65,6 +65,13 @@ internal class Parser
         rootCommand.Subcommands.Add(DotnetCommandParser.GetCommand());
         rootCommand.Subcommands.Add(InitCommandParser.GetCommand());
 
+        // Bare `dotnetup` routes to SdkInstallCommand. Register --interactive on the root
+        // so that ParseResult.GetValue(InteractiveOption) finds the option bound to the
+        // parsed (root) command and invokes its DefaultValueFactory
+        // (!IsCIEnvironmentOrRedirected()). Without this, GetValue returns default(bool)
+        // for bare `dotnetup`, suppressing first-use onboarding.
+        rootCommand.Options.Add(CommonOptions.InteractiveOption);
+
         ConfigureHelp(rootCommand);
 
         rootCommand.SetAction(parseResult =>

--- a/test/dotnetup.Tests/ParserTests.cs
+++ b/test/dotnetup.Tests/ParserTests.cs
@@ -417,6 +417,21 @@ public class ParserTests
         parseResult.GetValue(CommonOptions.UntrackedOption).Should().BeTrue();
     }
 
+    [Fact]
+    public void Parser_BareDotnetup_BindsInteractiveOption()
+    {
+        // Regression test: bare `dotnetup` routes to SdkInstallCommand, but until
+        // CommonOptions.InteractiveOption was registered on the root command,
+        // ParseResult.GetValue returned default(bool)=false for the option without
+        // running its DefaultValueFactory (!IsCIEnvironmentOrRedirected()). That
+        // suppressed first-use onboarding for bare `dotnetup` invocations.
+        var parseResult = Parser.Parse([]);
+
+        parseResult.Errors.Should().BeEmpty();
+        parseResult.GetResult(CommonOptions.InteractiveOption).Should().NotBeNull(
+            "InteractiveOption must be bound on the root command so its DefaultValueFactory runs for bare `dotnetup`");
+    }
+
     #endregion
 
     #region Help Differentiation Tests


### PR DESCRIPTION
Running `dotnetup` by itself is supposed to be the same as running `dotnetup sdk install`.  However, it wasn't going through the init walkthrough on first run.

This turned out to be because there was no `--interactive` flag declared on the root command, which meant the default value factory which sets it to true wasn't run.  So it was running in non-interactive mode, which disables the walkthrough.

We might want to consider adding other options to the root command, but for now this fixes the experience by just adding the `--interactive`  flag.