### PR TITLE
Emit IndexerNameAttribute for custom-named indexers in GenAPI

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/SyntaxNodeExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
@@ -11,6 +13,9 @@ namespace Microsoft.DotNet.GenAPI
 {
     internal static class SyntaxNodeExtensions
     {
+        // The default metadata name for an indexer that doesn't customize its name with the IndexerNameAttribute.
+        private const string DefaultIndexerName = "Item";
+
         public static SyntaxNode Rewrite(this SyntaxNode node, CSharpSyntaxRewriter rewriter) => rewriter.Visit(node);
 
         public static SyntaxNode AddMemberAttributes(this SyntaxNode node,
@@ -18,6 +23,22 @@ namespace Microsoft.DotNet.GenAPI
             ISymbol member,
             ISymbolFilter attributeDataSymbolFilter)
         {
+            // The IndexerNameAttribute is consumed by the compiler to change the metadata name of an indexer and
+            // is therefore not part of the symbol's custom attributes. SyntaxGenerator doesn't emit it either
+            // (see https://github.com/dotnet/roslyn/issues/72007), so synthesize it here for indexers that use a
+            // non-default name. Explicit interface implementations inherit their name from the interface and can't
+            // carry the attribute, so they are skipped.
+            if (member is IPropertySymbol property &&
+                property.IsIndexer &&
+                property.ExplicitInterfaceImplementations.IsEmpty &&
+                !string.Equals(property.MetadataName, DefaultIndexerName, StringComparison.Ordinal))
+            {
+                node = syntaxGenerator.AddAttributes(node, syntaxGenerator.Attribute(typeof(IndexerNameAttribute).FullName!,
+                    SyntaxFactory.AttributeArgument(
+                        SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                            SyntaxFactory.Literal(property.MetadataName)))));
+            }
+
             foreach (AttributeData attribute in member.GetAttributes().ExcludeNonVisibleOutsideOfAssembly(attributeDataSymbolFilter))
             {
                 // The C# compiler emits the DefaultMemberAttribute on any type containing an indexer.

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -3409,6 +3409,89 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [Fact]
+        public void TestIndexerWithCustomName()
+        {
+            RunTest(original: """
+                    namespace a
+                    {
+                        public partial class Foo
+                        {
+                            [System.Runtime.CompilerServices.IndexerName("MyItem")]
+                            public string this[int index] => string.Empty;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace a
+                    {
+                        public partial class Foo
+                        {
+                            [System.Runtime.CompilerServices.IndexerName("MyItem")]
+                            public string this[int index] { get { throw null; } }
+                        }
+                    }
+                    """);
+        }
+
+        [Fact]
+        public void TestIndexerWithDefaultNameDoesNotEmitIndexerNameAttribute()
+        {
+            RunTest(original: """
+                    namespace a
+                    {
+                        public partial class Foo
+                        {
+                            public string this[int index] => string.Empty;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace a
+                    {
+                        public partial class Foo
+                        {
+                            public string this[int index] { get { throw null; } }
+                        }
+                    }
+                    """);
+        }
+
+        [Fact]
+        public void TestExplicitInterfaceIndexerWithCustomNameDoesNotEmitIndexerNameAttribute()
+        {
+            RunTest(original: """
+                    namespace a
+                    {
+                        public partial interface IFoo
+                        {
+                            [System.Runtime.CompilerServices.IndexerName("MyItem")]
+                            string this[int index] { get; }
+                        }
+
+                        public partial class Foo : IFoo
+                        {
+                            string IFoo.this[int index] => string.Empty;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace a
+                    {
+                        public partial class Foo : IFoo
+                        {
+                            string IFoo.this[int index] { get { throw null; } }
+                        }
+
+                        public partial interface IFoo
+                        {
+                            [System.Runtime.CompilerServices.IndexerName("MyItem")]
+                            string this[int index] { get; }
+                        }
+                    }
+                    """);
+        }
+
+        [Fact]
         public void TestExplicitInterfaceNonGenericCollections()
         {
             RunTest(original: """


### PR DESCRIPTION
Fixes #38633

## Problem
When an indexer customizes its name with `IndexerNameAttribute`, GenAPI omitted the attribute from the generated reference source. The C# compiler consumes `IndexerNameAttribute` to change the indexer's metadata name (e.g. `Item` -> `MyItem`), so it is not part of the symbol's custom attributes, and Roslyn's `SyntaxGenerator` does not re-emit it (dotnet/roslyn#72007). Since that won't be fixed in `SyntaxGenerator` soon, this works around it in GenAPI.

The old CCI-based GenAPI had an equivalent [special case](https://github.com/dotnet/arcade/blob/e9a8e07465adf515a595e2afde2ffe893e973838/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs#L39-L50).

## Fix
In `AddMemberAttributes`, synthesize `[System.Runtime.CompilerServices.IndexerName("...")]` for indexers whose metadata name differs from the default `Item`. Explicit interface implementations inherit their name from the interface and cannot carry the attribute, so they are excluded.

## Tests
Added three test cases in `CSharpFileBuilderTests`:
- Custom-named indexer emits the attribute.
- Default-named indexer does not emit the attribute.
- Explicit interface implementation of a custom-named interface indexer does not emit the attribute.

Full GenAPI suite: 106 tests, 0 failures (2 pre-existing skips).
