### PR TITLE
Allow GenAPI to include additional API

### DIFF
--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/GenAPITask.cs
@@ -51,6 +51,16 @@ namespace Microsoft.DotNet.GenAPI.Task
         public string[]? ExcludeAttributesFiles { get; set; }
 
         /// <summary>
+        /// The path to one or more api inclusion files with types in DocId format.
+        /// </summary>
+        public string[]? IncludeApiFiles { get; set; }
+
+        /// <summary>
+        /// If true, opts out of emitting the curated set of internal compiler attributes.
+        /// </summary>
+        public bool ExcludeInternalCompilerAttributes { get; set; }
+
+        /// <summary>
         /// If true, includes both internal and public API.
         /// </summary>
         public bool RespectInternals { get; set; }
@@ -74,6 +84,8 @@ namespace Microsoft.DotNet.GenAPI.Task
                     ExceptionMessage = ExceptionMessage,
                     ExcludeApiFiles = ExcludeApiFiles,
                     ExcludeAttributesFiles = ExcludeAttributesFiles,
+                    IncludeApiFiles = IncludeApiFiles,
+                    ExcludeInternalCompilerAttributes = ExcludeInternalCompilerAttributes,
                     RespectInternals = RespectInternals,
                     IncludeAssemblyAttributes = IncludeAssemblyAttributes,
                 });

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/build/Microsoft.DotNet.GenAPI.Task.targets
@@ -53,6 +53,8 @@
       ExceptionMessage="$(GenAPIExceptionMessage)"
       ExcludeApiFiles="@(GenAPIExcludeApiList)"
       ExcludeAttributesFiles="@(GenAPIExcludeAttributesList)"
+      IncludeApiFiles="@(GenAPIIncludeApiList)"
+      ExcludeInternalCompilerAttributes="$(GenAPIExcludeInternalCompilerAttributes)"
       RespectInternals="$(GenAPIRespectInternals)"
       IncludeAssemblyAttributes="$(GenAPIIncludeAssemblyAttributes)" />
 

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tool/Program.cs
@@ -50,6 +50,20 @@ namespace Microsoft.DotNet.GenAPI.Tool
                 Recursive = true
             };
 
+            Option<string[]?> includeApiFilesOption = new("--include-api-file")
+            {
+                Description = "The path to one or more api inclusion files with types in DocId format. APIs listed in these files are emitted even if they would otherwise be filtered out.",
+                CustomParser = ParseAssemblyArgument,
+                Arity = ArgumentArity.ZeroOrMore,
+                Recursive = true
+            };
+
+            Option<bool> excludeInternalCompilerAttributesOption = new("--exclude-internal-compiler-attributes")
+            {
+                Description = "If true, opts out of emitting the curated set of internal compiler attributes (e.g. IsExternalInit) that are emitted by default.",
+                Recursive = true
+            };
+
             Option<string?> outputPathOption = new("--output-path")
             {
                 Description = @"Output path. Default is the console. Can specify an existing directory as well
@@ -89,6 +103,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
             rootCommand.Options.Add(assemblyReferencesOption);
             rootCommand.Options.Add(excludeApiFilesOption);
             rootCommand.Options.Add(excludeAttributesFilesOption);
+            rootCommand.Options.Add(includeApiFilesOption);
+            rootCommand.Options.Add(excludeInternalCompilerAttributesOption);
             rootCommand.Options.Add(outputPathOption);
             rootCommand.Options.Add(headerFileOption);
             rootCommand.Options.Add(exceptionMessageOption);
@@ -113,6 +129,8 @@ namespace Microsoft.DotNet.GenAPI.Tool
                         ExceptionMessage = parseResult.GetValue(exceptionMessageOption),
                         ExcludeApiFiles = parseResult.GetValue(excludeApiFilesOption),
                         ExcludeAttributesFiles = parseResult.GetValue(excludeAttributesFilesOption),
+                        IncludeApiFiles = parseResult.GetValue(includeApiFilesOption),
+                        ExcludeInternalCompilerAttributes = parseResult.GetValue(excludeInternalCompilerAttributesOption),
                         RespectInternals = respectInternals,
                         IncludeAssemblyAttributes = parseResult.GetValue(includeAssemblyAttributesOption),
                     });

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIApp.cs
@@ -14,6 +14,33 @@ namespace Microsoft.DotNet.GenAPI
     /// </summary>
     public static class GenAPIApp
     {
+        // A curated set of internal compiler attributes that, when defined in an assembly, enable out-of-band
+        // language features. GenAPI emits these by default so that the generated reference assembly keeps working
+        // with the same language features as the original assembly.
+        // NOTE: This is a heuristic curated list. A more general, namespace-based approach is tracked by
+        // https://github.com/dotnet/sdk/issues/54527.
+        private static readonly string[] s_compilerAttributes =
+        [
+            "T:System.Runtime.CompilerServices.IsExternalInit",
+            "T:System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute",
+            "T:System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+            "T:System.Runtime.CompilerServices.RequiredMemberAttribute",
+            "T:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute",
+            "T:System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
+            "T:System.Runtime.CompilerServices.CollectionBuilderAttribute",
+            "T:System.Diagnostics.CodeAnalysis.AllowNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.NotNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute",
+            "T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute",
+            "T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute",
+            "T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute",
+            "T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute"
+        ];
+
         /// <summary>
         /// Initialize and run Roslyn-based GenAPI tool using <see cref="GenAPIOptions"/>.
         /// </summary>
@@ -34,6 +61,8 @@ namespace Microsoft.DotNet.GenAPI
                 options.ExceptionMessage,
                 options.ExcludeApiFiles,
                 options.ExcludeAttributesFiles,
+                options.IncludeApiFiles,
+                options.ExcludeInternalCompilerAttributes,
                 options.RespectInternals,
                 options.IncludeAssemblyAttributes);
         }
@@ -49,6 +78,8 @@ namespace Microsoft.DotNet.GenAPI
             string? exceptionMessage,
             string[]? excludeApiFiles,
             string[]? excludeAttributesFiles,
+            string[]? includeApiFiles,
+            bool excludeInternalCompilerAttributes,
             bool respectInternals,
             bool includeAssemblyAttributes)
         {
@@ -58,6 +89,11 @@ namespace Microsoft.DotNet.GenAPI
                 includeEffectivelyPrivateSymbols: true,
                 includeExplicitInterfaceImplementationSymbols: true);
 
+            // Build an optional filter that includes additional APIs which would otherwise be filtered out by the
+            // accessibility filter: APIs explicitly listed via includeApiFiles and, unless opted out, the curated set
+            // of internal compiler attributes.
+            ISymbolFilter? additionalApiInclusionFilter = CreateAdditionalApiInclusionFilter(includeApiFiles, excludeInternalCompilerAttributes);
+
             // Invoke the CSharpFileBuilder for each directly loaded assembly.
             foreach (KeyValuePair<string, IAssemblySymbol> kvp in assemblySymbols)
             {
@@ -65,10 +101,12 @@ namespace Microsoft.DotNet.GenAPI
 
                 ISymbolFilter symbolFilter = SymbolFilterFactory.GetFilterFromFiles(
                         excludeApiFiles, accessibilitySymbolFilter,
-                        respectInternals: respectInternals);
+                        respectInternals: respectInternals,
+                        additionalApiInclusionFilter: additionalApiInclusionFilter);
                 ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromFiles(
                         excludeAttributesFiles, accessibilitySymbolFilter,
-                        respectInternals: respectInternals);
+                        respectInternals: respectInternals,
+                        additionalApiInclusionFilter: additionalApiInclusionFilter);
 
                 string? headerText = headerFile != null ? File.ReadAllText(headerFile) : null;
 
@@ -85,6 +123,31 @@ namespace Microsoft.DotNet.GenAPI
 
                 fileBuilder.WriteAssembly(kvp.Value);
             }
+        }
+
+        // Builds an OR composite filter that includes APIs listed in includeApiFiles and, unless opted out, the
+        // curated set of internal compiler attributes. Returns null when there is nothing additional to include.
+        private static ISymbolFilter? CreateAdditionalApiInclusionFilter(string[]? includeApiFiles, bool excludeInternalCompilerAttributes)
+        {
+            bool hasIncludeApiFiles = includeApiFiles?.Length > 0;
+            if (!hasIncludeApiFiles && excludeInternalCompilerAttributes)
+            {
+                return null;
+            }
+
+            CompositeSymbolFilter inclusionFilter = new(CompositeSymbolFilterMode.Or);
+
+            if (hasIncludeApiFiles)
+            {
+                inclusionFilter.Add(DocIdSymbolFilter.CreateFromFiles(includeApiFiles!, includeDocIds: true));
+            }
+
+            if (!excludeInternalCompilerAttributes)
+            {
+                inclusionFilter.Add(DocIdSymbolFilter.CreateFromLists(s_compilerAttributes, includeDocIds: true));
+            }
+
+            return inclusionFilter;
         }
 
         // Creates a TextWriter capable of writing into Console or a cs file.

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIOptions.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/GenAPIOptions.cs
@@ -51,6 +51,19 @@ public sealed class GenAPIOptions
     public string[]? ExcludeAttributesFiles { get; set; }
 
     /// <summary>
+    /// The path to one or more api inclusion files with types in DocId format. APIs listed in these files are
+    /// emitted even if they would otherwise be filtered out (e.g. internal types).
+    /// </summary>
+    public string[]? IncludeApiFiles { get; set; }
+
+    /// <summary>
+    /// By default, GenAPI emits a curated set of internal compiler attributes (e.g. <c>IsExternalInit</c>,
+    /// <c>RequiredMemberAttribute</c>) when they are defined in the assembly, since these enable out-of-band language
+    /// features. Set this to <see langword="true"/> to opt out of that behavior.
+    /// </summary>
+    public bool ExcludeInternalCompilerAttributes { get; set; }
+
+    /// <summary>
     /// If true, includes both internal and public API.
     /// </summary>
     public bool RespectInternals { get; set; }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/CompositeSymbolFilter.cs
@@ -9,8 +9,18 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
     /// Implements the composite pattern, group the list of <see cref="ISymbol"/> and interact with them
     /// the same way as a single instance of a <see cref="ISymbol"/> object.
     /// </summary>
-    public sealed class CompositeSymbolFilter(params IEnumerable<ISymbolFilter> filters) : ISymbolFilter
+    /// <param name="mode">Determines how the inner filters are combined. Defaults to <see cref="CompositeSymbolFilterMode.And"/>.</param>
+    /// <param name="filters">The inner filters to combine.</param>
+    public sealed class CompositeSymbolFilter(CompositeSymbolFilterMode mode = CompositeSymbolFilterMode.And,
+        params IEnumerable<ISymbolFilter> filters) : ISymbolFilter
     {
+        /// <summary>
+        /// Determines how the inner filters are combined. <see cref="CompositeSymbolFilterMode.And"/> requires all
+        /// filters to include a symbol, while <see cref="CompositeSymbolFilterMode.Or"/> includes a symbol if any
+        /// filter includes it.
+        /// </summary>
+        public CompositeSymbolFilterMode Mode { get; } = mode;
+
         /// <summary>
         /// List on inner filters.
         /// </summary>
@@ -21,7 +31,12 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         /// </summary>
         /// <param name="symbol"><see cref="ISymbol"/> to evaluate.</param>
         /// <returns>True to include the <paramref name="symbol"/> or false to filter it out.</returns>
-        public bool Include(ISymbol symbol) => Filters.All(f => f.Include(symbol));
+        public bool Include(ISymbol symbol) => Mode switch
+        {
+            CompositeSymbolFilterMode.And => Filters.All(f => f.Include(symbol)),
+            CompositeSymbolFilterMode.Or => Filters.Any(f => f.Include(symbol)),
+            _ => throw new InvalidOperationException()
+        };
 
         /// <summary>
         /// Add a filter object to a list of filters.
@@ -33,5 +48,21 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
             Filters.Add(filter);
             return this;
         }
+    }
+
+    /// <summary>
+    /// Determines how the inner filters of a <see cref="CompositeSymbolFilter"/> are combined.
+    /// </summary>
+    public enum CompositeSymbolFilterMode
+    {
+        /// <summary>
+        /// All filters must include a symbol for it to be included.
+        /// </summary>
+        And,
+
+        /// <summary>
+        /// Any filter can include a symbol for it to be included.
+        /// </summary>
+        Or
     }
 }

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -6,49 +6,57 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
 {
     /// <summary>
-    /// Implements the logic of filtering out api.
+    /// Implements the logic of filtering api.
     /// Reads the file with the list of attributes, types, members in DocId format.
     /// </summary>
     public class DocIdSymbolFilter : ISymbolFilter
     {
-        private readonly HashSet<string> _docIdsToExclude;
+        private readonly HashSet<string> _docIds;
+        private readonly bool _includeDocIds;
 
         /// <summary>
-        /// Creates a filter to exclude APIs using the DocIDs provided in the specified files.
+        /// Creates a filter based on the DocIDs provided in the specified files.
         /// </summary>
-        /// <param name="filesWithDocIdsToExclude">A collection of files each containing multiple DocIDs to exclude.</param>
+        /// <param name="filesWithDocIds">A collection of files each containing multiple DocIDs.</param>
+        /// <param name="includeDocIds">When <see langword="false"/> (the default), symbols matching the DocIDs are
+        /// excluded. When <see langword="true"/>, only symbols matching the DocIDs are included.</param>
         /// <returns>An instance of the symbol filter.</returns>
-        public static DocIdSymbolFilter CreateFromFiles(params string[] filesWithDocIdsToExclude)
+        public static DocIdSymbolFilter CreateFromFiles(string[] filesWithDocIds, bool includeDocIds = false)
         {
             List<string> docIds = new();
 
-            foreach (string docIdsToExcludeFile in filesWithDocIdsToExclude)
+            foreach (string docIdsFile in filesWithDocIds)
             {
-                if (string.IsNullOrWhiteSpace(docIdsToExcludeFile))
+                if (string.IsNullOrWhiteSpace(docIdsFile))
                 {
                     continue;
                 }
 
-                foreach (string docId in ReadDocIdsFromList(File.ReadAllLines(docIdsToExcludeFile)))
+                foreach (string docId in ReadDocIdsFromList(File.ReadAllLines(docIdsFile)))
                 {
                     docIds.Add(docId);
                 }
             }
 
-            return new DocIdSymbolFilter(docIds);
+            return new DocIdSymbolFilter(docIds, includeDocIds);
         }
 
         /// <summary>
-        /// Creates a filter to exclude APIs using the DocIDs provided in the specified list.
+        /// Creates a filter based on the DocIDs provided in the specified list.
         /// </summary>
-        /// <param name="docIdsToExclude">A collection of DocIDs to exclude.</param>
+        /// <param name="docIds">A collection of DocIDs.</param>
+        /// <param name="includeDocIds">When <see langword="false"/> (the default), symbols matching the DocIDs are
+        /// excluded. When <see langword="true"/>, only symbols matching the DocIDs are included.</param>
         /// <returns>An instance of the symbol filter.</returns>
-        public static DocIdSymbolFilter CreateFromLists(params string[] docIdsToExclude)
-            => new DocIdSymbolFilter(ReadDocIdsFromList(docIdsToExclude));
+        public static DocIdSymbolFilter CreateFromLists(string[] docIds, bool includeDocIds = false)
+            => new DocIdSymbolFilter(ReadDocIdsFromList(docIds), includeDocIds);
 
         // Private constructor to avoid creating an instance with an empty list.
-        private DocIdSymbolFilter(IEnumerable<string> docIdsToExclude)
-            => _docIdsToExclude = [.. docIdsToExclude];
+        private DocIdSymbolFilter(IEnumerable<string> docIds, bool includeDocIds)
+        {
+            _docIds = [.. docIds];
+            _includeDocIds = includeDocIds;
+        }
 
         /// <summary>
         ///  Determines whether the <see cref="ISymbol"/> should be included.
@@ -58,12 +66,12 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         public bool Include(ISymbol symbol)
         {
             string? docId = symbol.GetDocumentationCommentId();
-            if (docId is not null && _docIdsToExclude.Contains(docId))
+            if (docId is not null && _docIds.Contains(docId))
             {
-                return false;
+                return _includeDocIds;
             }
 
-            return true;
+            return !_includeDocIds;
         }
 
         private static IEnumerable<string> ReadDocIdsFromList(params string[] ids)

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/SymbolFilterFactory.cs
@@ -19,19 +19,22 @@ public static class SymbolFilterFactory
     /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
     /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
     /// <param name="includeImplicitSymbolFilter">Whether to include implicit symbols or not.</param>
+    /// <param name="additionalApiInclusionFilter">An optional filter that, when provided, includes additional APIs that
+    /// would otherwise be filtered out by the accessibility filter.</param>
     /// <returns>An instance of the symbol filter.</returns>
     public static ISymbolFilter GetFilterFromFiles(string[]? apiExclusionFilePaths,
                                                    AccessibilitySymbolFilter? accessibilitySymbolFilter = null,
                                                    bool respectInternals = false,
                                                    bool includeEffectivelyPrivateSymbols = true,
                                                    bool includeExplicitInterfaceImplementationSymbols = true,
-                                                   bool includeImplicitSymbolFilter = true)
+                                                   bool includeImplicitSymbolFilter = true,
+                                                   ISymbolFilter? additionalApiInclusionFilter = null)
     {
         DocIdSymbolFilter? docIdSymbolFilter =
             apiExclusionFilePaths?.Length > 0 ?
             DocIdSymbolFilter.CreateFromFiles(apiExclusionFilePaths) : null;
 
-        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter);
+        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter, additionalApiInclusionFilter);
     }
 
     /// <summary>
@@ -43,19 +46,22 @@ public static class SymbolFilterFactory
     /// <param name="includeEffectivelyPrivateSymbols">Whether to include effectively private symbols or not.</param>
     /// <param name="includeExplicitInterfaceImplementationSymbols">Whether to include explicit interface implementation symbols or not.</param>
     /// <param name="includeImplicitSymbolFilter">Whether to include implicit symbols or not.</param>
+    /// <param name="additionalApiInclusionFilter">An optional filter that, when provided, includes additional APIs that
+    /// would otherwise be filtered out by the accessibility filter.</param>
     /// <returns>An instance of the symbol filter.</returns>
     public static ISymbolFilter GetFilterFromList(string[]? apiExclusionList,
                                                   AccessibilitySymbolFilter? accessibilitySymbolFilter = null,
                                                   bool respectInternals = false,
                                                   bool includeEffectivelyPrivateSymbols = true,
                                                   bool includeExplicitInterfaceImplementationSymbols = true,
-                                                  bool includeImplicitSymbolFilter = true)
+                                                  bool includeImplicitSymbolFilter = true,
+                                                  ISymbolFilter? additionalApiInclusionFilter = null)
     {
         DocIdSymbolFilter? docIdSymbolFilter =
             apiExclusionList?.Count() > 0 ?
             DocIdSymbolFilter.CreateFromLists(apiExclusionList) : null;
 
-        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter);
+        return GetCompositeSymbolFilter(docIdSymbolFilter, accessibilitySymbolFilter, respectInternals, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, includeImplicitSymbolFilter, additionalApiInclusionFilter);
     }
 
     private static ISymbolFilter GetCompositeSymbolFilter(DocIdSymbolFilter? customFilter,
@@ -63,7 +69,8 @@ public static class SymbolFilterFactory
                                                           bool respectInternals,
                                                           bool includeEffectivelyPrivateSymbols,
                                                           bool includeExplicitInterfaceImplementationSymbols,
-                                                          bool includeImplicitSymbolFilter)
+                                                          bool includeImplicitSymbolFilter,
+                                                          ISymbolFilter? additionalApiInclusionFilter = null)
     {
         accessibilitySymbolFilter ??= new(
                 respectInternals,
@@ -81,7 +88,16 @@ public static class SymbolFilterFactory
             filter.Add(new ImplicitSymbolFilter());
         }
 
-        filter.Add(accessibilitySymbolFilter);
+        // When an additional inclusion filter is provided, a symbol is kept if it is either accessible or
+        // explicitly included. Otherwise only accessibility governs whether a symbol is kept.
+        if (additionalApiInclusionFilter != null)
+        {
+            filter.Add(new CompositeSymbolFilter(CompositeSymbolFilterMode.Or, accessibilitySymbolFilter, additionalApiInclusionFilter));
+        }
+        else
+        {
+            filter.Add(accessibilitySymbolFilter);
+        }
 
         return filter;
     }

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Type.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Type.Tests.cs
@@ -309,6 +309,39 @@ public class DiffTypeTests : DiffBaseTests
 
     #endregion
 
+    #region Internal compiler types
+
+    // GenAPI emits a curated set of internal compiler attributes (e.g. IsExternalInit) by default so that the
+    // generated reference source keeps compiling. ApiDiff shares the GenAPI backend but builds its own filters
+    // without that inclusion, so such internal types must not surface as API differences.
+    [Fact]
+    public Task InternalCompilerTypeAddNotShown() => RunTestAsync(
+                beforeCode: """
+                namespace MyNamespace
+                {
+                    public class MyClass
+                    {
+                    }
+                }
+                """,
+                afterCode: """
+                namespace MyNamespace
+                {
+                    public class MyClass
+                    {
+                    }
+                }
+                namespace System.Runtime.CompilerServices
+                {
+                    internal static class IsExternalInit
+                    {
+                    }
+                }
+                """,
+                expectedCode: ""); // The added internal compiler type is not shown
+
+    #endregion
+
     #region Other
 
     [Fact]

--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;
+using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 using Moq;
 
 namespace Microsoft.DotNet.GenAPI.Tests
@@ -32,12 +33,13 @@ namespace Microsoft.DotNet.GenAPI.Tests
             bool includeExplicitInterfaceImplementationSymbols = true,
             bool allowUnsafe = false,
             string[] excludedAttributeList = null,
+            ISymbolFilter additionalApiInclusionFilter = null,
             [CallerMemberName] string assemblyName = "",
             // Empty string is considered a valid header, null causes to use the default CSharpFileBuilder header
             string header = "")
         {
             string resultedString = GenerateOutput(original, includeInternalSymbols, includeEffectivelyPrivateSymbols,
-                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, assemblyName, header);
+                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, additionalApiInclusionFilter, assemblyName, header);
 
             SyntaxTree resultedSyntaxTree = GetSyntaxTree(resultedString);
             SyntaxTree expectedSyntaxTree = GetSyntaxTree(expected);
@@ -59,7 +61,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
             string header = "")
         {
             string resultedString = GenerateOutput(original, includeInternalSymbols, includeEffectivelyPrivateSymbols,
-                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, assemblyName, header);
+                includeExplicitInterfaceImplementationSymbols, allowUnsafe, excludedAttributeList, additionalApiInclusionFilter: null, assemblyName, header);
 
             Assert.Equal(expected.ReplaceLineEndings("\n"), resultedString.ReplaceLineEndings("\n"));
         }
@@ -70,6 +72,7 @@ namespace Microsoft.DotNet.GenAPI.Tests
             bool includeExplicitInterfaceImplementationSymbols,
             bool allowUnsafe,
             string[] excludedAttributeList,
+            ISymbolFilter additionalApiInclusionFilter,
             string assemblyName,
             string header)
         {
@@ -80,8 +83,8 @@ namespace Microsoft.DotNet.GenAPI.Tests
             (IAssemblySymbolLoader loader, Dictionary<string, IAssemblySymbol> assemblySymbols) = TestAssemblyLoaderFactory
                 .CreateFromTexts(log.Object, assemblyTexts: [(assemblyName, original)], respectInternals: includeInternalSymbols, allowUnsafe: allowUnsafe);
 
-            ISymbolFilter symbolFilter = SymbolFilterFactory.GetFilterFromList([], null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols);
-            ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromList(excludedAttributeList, null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols);
+            ISymbolFilter symbolFilter = SymbolFilterFactory.GetFilterFromList([], null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, additionalApiInclusionFilter: additionalApiInclusionFilter);
+            ISymbolFilter attributeDataSymbolFilter = SymbolFilterFactory.GetFilterFromList(excludedAttributeList, null, includeInternalSymbols, includeEffectivelyPrivateSymbols, includeExplicitInterfaceImplementationSymbols, additionalApiInclusionFilter: additionalApiInclusionFilter);
 
             IAssemblySymbolWriter csharpFileBuilder = new CSharpFileBuilder(
                 log.Object,
@@ -3483,6 +3486,122 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
                         }
                     }
                     """,
+                includeInternalSymbols: false);
+        }
+
+        [Fact]
+        public void TestIncludeApiFileEmitsInternalOOBAttribute()
+        {
+            using TempDirectory root = new();
+            string includeDocIdFilePath = Path.Combine(root.DirPath, "inclusions.txt");
+            File.WriteAllText(includeDocIdFilePath, """
+            T:System.Runtime.CompilerServices.CollectionBuilderAttribute
+            """);
+
+            ISymbolFilter inclusionFilter = new CompositeSymbolFilter(CompositeSymbolFilterMode.Or)
+                .Add(DocIdSymbolFilter.CreateFromFiles([includeDocIdFilePath], includeDocIds: true));
+
+            RunTest(original: """
+                    using System;
+                    using System.Collections;
+                    using System.Collections.Generic;
+                    using System.Runtime.CompilerServices;
+                    namespace a
+                    {
+                        #pragma warning disable CS0436
+                        [CollectionBuilder(typeof(LineBufferBuilder), "Create")]
+                        #pragma warning restore CS0436
+                        public class LineBuffer : IEnumerable<char>
+                        {
+                            public LineBuffer(ReadOnlySpan<char> buffer) { }
+
+                            public IEnumerator<char> GetEnumerator() => default!;
+                            IEnumerator IEnumerable.GetEnumerator() => default!;
+                        }
+
+                        public static class LineBufferBuilder
+                        {
+                            public static LineBuffer Create(ReadOnlySpan<char> values) => new LineBuffer(values);
+                        }
+                    }
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal sealed class CollectionBuilderAttribute(Type builderType, string methodName) : Attribute
+                        {
+                            public Type BuilderType { get; } = builderType;
+
+                            public string MethodName { get; } = methodName;
+                        }
+                    }
+                    """,
+                expected: """
+                    namespace a
+                    {
+                        [System.Runtime.CompilerServices.CollectionBuilder(typeof(LineBufferBuilder), "Create")]
+                        public partial class LineBuffer : System.Collections.Generic.IEnumerable<char>, System.Collections.IEnumerable
+                        {
+                            public LineBuffer(System.ReadOnlySpan<char> buffer) { }
+
+                            public System.Collections.Generic.IEnumerator<char> GetEnumerator() { throw null; }
+
+                            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+                        }
+
+                        public static partial class LineBufferBuilder
+                        {
+                            public static LineBuffer Create(System.ReadOnlySpan<char> values) { throw null; }
+                        }
+                    }
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal sealed partial class CollectionBuilderAttribute : Attribute
+                        {
+                            public CollectionBuilderAttribute(Type builderType, string methodName) { }
+
+                            public Type BuilderType { get { throw null; } }
+
+                            public string MethodName { get { throw null; } }
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                additionalApiInclusionFilter: inclusionFilter);
+        }
+
+        [Fact]
+        public void TestIncludeInternalCompilerAttributeByDocIdList()
+        {
+            ISymbolFilter inclusionFilter = new CompositeSymbolFilter(CompositeSymbolFilterMode.Or)
+                .Add(DocIdSymbolFilter.CreateFromLists(["T:System.Runtime.CompilerServices.IsExternalInit"], includeDocIds: true));
+
+            RunTest(original: """
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal static class IsExternalInit { }
+                    }
+                    """,
+                expected: """
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal static partial class IsExternalInit
+                        {
+                        }
+                    }
+                    """,
+                includeInternalSymbols: false,
+                additionalApiInclusionFilter: inclusionFilter);
+        }
+
+        [Fact]
+        public void TestInternalOOBAttributeNotEmittedWithoutInclusionFilter()
+        {
+            RunTest(original: """
+                    namespace System.Runtime.CompilerServices
+                    {
+                        internal static class IsExternalInit { }
+                    }
+                    """,
+                expected: "",
                 includeInternalSymbols: false);
         }
     }


### PR DESCRIPTION
Revives #38232. Adds the ability for GenAPI to **include additional API** that the default accessibility filter would otherwise drop.
Fixes https://github.com/dotnet/sdk/issues/33693

## What's added

1. **Explicit include list** `--include-api-file` (CLI) / `IncludeApiFiles` (task) / `@(GenAPIIncludeApiList)` (MSBuild): one or more files listing DocIDs to force-include.
2. **Curated internal compiler attributes**, included **by default** when defined in the assembly, because they enable out-of-band (OOB) language features and must be present in the reference source for it to compile/behave equivalently. Examples: `IsExternalInit`, `RequiredMemberAttribute`, `CollectionBuilderAttribute`, `CompilerFeatureRequiredAttribute`, and the nullable-analysis attributes. Opt out via `--exclude-internal-compiler-attributes` / `ExcludeInternalCompilerAttributes` / `GenAPIExcludeInternalCompilerAttributes`.

## Infrastructure changes (Microsoft.DotNet.ApiSymbolExtensions, a non-shipping helper assembly)

- `CompositeSymbolFilter` gains a `CompositeSymbolFilterMode` (`And`/`Or`).
- `DocIdSymbolFilter` gains an `includeDocIds` mode (include vs. exclude the matched DocIDs).
- `SymbolFilterFactory` accepts an optional `additionalApiInclusionFilter` which is OR-combined with the accessibility filter, giving `AND(notExcluded, implicitOK, OR(accessible, included))`.

The same inclusion filter is applied to both the API filter and the attribute-usage filter, so listing an attribute **type** DocID emits both its declaration and its usages on public API.

## ⚠️ Behavior change

Enabling the curated compiler-attribute inclusion **by default** changes the generated reference source and will require **baseline updates** in downstream consumers (source-build-assets) that diff GenAPI output. The opt-out switch is provided for consumers that don't want this.

## Deferred

The namespace-based heuristic proposed in the original PR (auto-include internal types under known compiler namespaces) is **not** included here. It's tracked by #54527.

## Tests

- `TestIncludeApiFileEmitsInternalOOBAttribute` – include-file path; an internal `CollectionBuilderAttribute` (with constructor + properties) and its usage on a public type are emitted.
- `TestIncludeInternalCompilerAttributeByDocIdList` – list-based inclusion of `IsExternalInit`.
- `TestInternalOOBAttributeNotEmittedWithoutInclusionFilter` – baseline: not emitted without inclusion.

Full GenAPI suite (106) and `SymbolFilterFactoryTests` are green.