### PR TITLE
[clr-ios] Keep R2R debug and inlining info in Debug for Apple mobile RIDs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -35,11 +35,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">false</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('osx-'))">false</PublishReadyToRunEmitSymbols>
 
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
 
     <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
     <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -41,11 +41,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
 
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
 
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripILBodies>
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripILBodies>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -28,30 +28,16 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRunContainerFormat)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 11.0))">pe</PublishReadyToRunContainerFormat>
     <PublishReadyToRunCreateSharedLibrary Condition="'$(PublishReadyToRunCreateSharedLibrary)' == ''">true</PublishReadyToRunCreateSharedLibrary>
 
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">false</PublishReadyToRunEmitSymbols>
-    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">false</PublishReadyToRunEmitSymbols>
+    <_IsIOSLikeRid Condition="$(RuntimeIdentifier.StartsWith('ios-')) or $(RuntimeIdentifier.StartsWith('tvos-')) or $(RuntimeIdentifier.StartsWith('iossimulator-')) or $(RuntimeIdentifier.StartsWith('tvossimulator-')) or $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</_IsIOSLikeRid>
+
+    <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and '$(_IsIOSLikeRid)' == 'true'">false</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunEmitSymbols Condition="'$(PublishReadyToRunEmitSymbols)' == '' and $(RuntimeIdentifier.StartsWith('osx-'))">false</PublishReadyToRunEmitSymbols>
 
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
-    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
+    <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripInliningInfo>
 
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripDebugInfo>
 
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripILBodies>
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripILBodies>
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripILBodies>
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripILBodies>
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripILBodies>
 
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -41,11 +41,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
 
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
 
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripILBodies>
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripILBodies>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -41,11 +41,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripInliningInfo>
     <PublishReadyToRunStripInliningInfo Condition="'$(PublishReadyToRunStripInliningInfo)' == '' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripInliningInfo>
 
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
-    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(Configuration)' != 'Debug' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('iossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('tvossimulator-'))">true</PublishReadyToRunStripDebugInfo>
+    <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and $(RuntimeIdentifier.StartsWith('maccatalyst-'))">true</PublishReadyToRunStripDebugInfo>
 
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('ios-'))">true</PublishReadyToRunStripILBodies>
     <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and $(RuntimeIdentifier.StartsWith('tvos-'))">true</PublishReadyToRunStripILBodies>


### PR DESCRIPTION
## Description

`PublishReadyToRunStripDebugInfo` and `PublishReadyToRunStripInliningInfo` default to `true` for Apple mobile RIDs (`ios-*`, `tvos-*`, `iossimulator-*`, `tvossimulator-*`, `maccatalyst-*`), which passes `--strip-debug-info` and `--strip-inlining-info` to crossgen2 and drops `READYTORUN_SECTION_DEBUG_INFO` (and inlining info) from the R2R image.

Without that section, the CoreCLR debugger cannot map IL offsets to native offsets for R2R'd methods: `ReadyToRunInfo::GetDebugInfo` returns NULL, `ReadyToRunJitManager::GetBoundariesAndVars` returns FALSE, `DebuggerJitInfo::LazyInitBounds` never populates `m_sequenceMap`, and line-level breakpoints cannot bind to anything other than the method entry.

## Change

Gate the default `PublishReadyToRunStripDebugInfo=true` and `PublishReadyToRunStripInliningInfo=true` for Apple mobile RIDs on `'$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug'`:

- `DebuggerSupport` is the canonical property the trimmers use to decide whether to keep debugger support (see <a href="https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options">trimming options</a>). The macios SDK sets it from `Xamarin.Shared.Sdk.targets`.
- `Configuration != 'Debug'` is kept as a fallback for projects that do not flow through the macios SDK and therefore never populate `DebuggerSupport` (ref <a href="https://github.com/dotnet/sdk/issues/31918">#31918</a> on custom configuration names is acknowledged; the fallback only relaxes stripping for the literal `Debug` name, which is the documented default).

Release (and other non-Debug, non-`DebuggerSupport=true`) builds continue stripping R2R debug and inlining info via `--strip-debug-info` and `--strip-inlining-info`, preserving current size/perf characteristics.