### PR TITLE
Migrate templating search cache publishing to ESRP

### DIFF
--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -29,6 +29,19 @@ variables:
 # aka.ms client app id used to authenticate to the Redirection API. The pipeline must be granted
 # access to this variable group. Same source dotnet/arcade uses in eng/publishing/v3/publish.yml.
 - group: Publish-Build-Assets
+# Static aka.ms constants (source-of-truth in this repo; not in the Variables UI). These rarely
+# change and are derived from our own code (short URLs) or are well-known fixed values (tenants).
+# The dnceng-owned, drift-prone values (AkaMsCert*, AkaMsOwners) stay as pipeline Variables.
+- name: AkaMsTenantId                 # aka.ms redirection tenant in the /api/aka/1/{tenant} path (NOT an AAD GUID)
+  value: ncd
+- name: AkaMsAuthorityTenantId        # corp AAD tenant the app authenticates against (arcade hardcodes this too)
+  value: 72f988bf-86f1-41af-91ab-2d7cd011db47
+- name: AkaMsShortUrl                  # consumed by NuGetPackSourceCheckerFactory.cs (no 'aka.ms/' prefix)
+  value: dotnet/templating/searchcacheurl
+- name: AkaMsNonTemplatePacksShortUrl  # consumed by NuGetPackSourceCheckerFactory.cs (no 'aka.ms/' prefix)
+  value: dotnet/templating/nontemplatepacksurl
+- name: AkaMsGroupOwner               # owning security-group alias; empty unless the team has one
+  value: ''
 
 resources:
   repositories:
@@ -252,17 +265,15 @@ extends:
             #   - AkaMsCertServiceConnection can read the cert secret from the key vault.
             #   - The app/cert is allowed to manage the 'dotnet/templating/*' links in the 'ncd' tenant.
             #
-            # Variables (pipeline Variables UI unless noted):
-            #   akams-app-id                     - aka.ms client app id (secret, from the Publish-Build-Assets KV group)
+            # Pipeline Variables (set in the Variables UI; the rest are static in this YAML's
+            # 'variables:' block or come from the linked Publish-Build-Assets group):
+            #   akams-app-id                     - aka.ms client app id (secret, auto-supplied by the Publish-Build-Assets KV group)
             #   AkaMsCertServiceConnection       - AzureRM service connection that can read the key vault (e.g. DotNet-Engineering-Services_KeyVault)
             #   AkaMsCertVaultName               - key vault holding the cert (e.g. EngKeyVault)
             #   AkaMsCertSecretName              - cert secret name (e.g. Redirection-UST-Client-NetCoreDeployment)
-            #   AkaMsAuthorityTenantId           - AAD tenant to authenticate the app against (corp 72f988bf-86f1-41af-91ab-2d7cd011db47)
-            #   AkaMsTenantId                    - aka.ms redirection tenant in the /api/aka/1/{tenant} path (the dotnet tenant is 'ncd', NOT the AAD tenant GUID)
-            #   AkaMsShortUrl                    - 'dotnet/templating/searchcacheurl' (no 'aka.ms/' prefix)
-            #   AkaMsNonTemplatePacksShortUrl    - 'dotnet/templating/nontemplatepacksurl' (no 'aka.ms/' prefix)
-            #   AkaMsOwners                      - semicolon-delimited owner aliases
-            #   AkaMsGroupOwner                  - owning security-group alias (may be empty)
+            #   AkaMsOwners                      - semicolon-delimited owner aliases (first is used as lastModifiedBy)
+            # Static in YAML (see the 'variables:' block): AkaMsTenantId, AkaMsAuthorityTenantId,
+            # AkaMsShortUrl, AkaMsNonTemplatePacksShortUrl, AkaMsGroupOwner.
             # Only repoint the production links from main; manual/test runs on other branches
             # should not move them (point the short-url vars at test links to validate this step).
             - task: AzureCLI@2

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -238,11 +238,21 @@ extends:
                 ESRP_RELEASE_DETAILS: $(ESRP_RELEASE_DETAILS)
 
             # Repoint the aka.ms links at the new ESRP URLs using the corp Redirection Management
-            # API (same contract as dotnet/arcade's AkaMSLinkManager). The /bulk endpoint accepts
-            # an array, so both links are updated in a single call. The service connection identity
-            # must own the links. The following variables are defined in the pipeline's Variables UI:
-            #   AkaMsServiceConnection           - AzureRM service connection whose identity can manage the links
-            #   AkaMsTenantId                    - redirection (AME) tenant identifier (the dotnet tenant is 'ncd', not a GUID)
+            # API (same endpoint/scope as dotnet/arcade's AkaMSLinkManager). The /bulk endpoint
+            # accepts an array, so both links are updated in a single call.
+            #
+            # AUTH (read before configuring): the Redirection API only accepts tokens from an AAD
+            # app that has been registered and onboarded as an aka.ms client. AkaMsServiceConnection
+            # MUST therefore be an AzureRM (workload-identity / federated) service connection whose
+            # backing identity is that onboarded app -- a generic pipeline connection will get 401/403.
+            # Ask dnceng for the service-connection name (and have them confirm the identity is
+            # authorized on the Redirection API). The token authority tenant is fixed to the corp
+            # tenant (72f988bf-86f1-41af-91ab-2d7cd011db47), which is the service connection's own
+            # tenant; we do not supply it.
+            #
+            # Variables defined in the pipeline's Variables UI:
+            #   AkaMsServiceConnection           - federated AzureRM service connection (identity onboarded to the Redirection API)
+            #   AkaMsTenantId                    - aka.ms redirection tenant in the /api/aka/1/{tenant} path (the dotnet tenant is 'ncd', NOT the AAD tenant GUID)
             #   AkaMsShortUrl                    - 'dotnet/templating/searchcacheurl' (no 'aka.ms/' prefix)
             #   AkaMsNonTemplatePacksShortUrl    - 'dotnet/templating/nontemplatepacksurl' (no 'aka.ms/' prefix)
             #   AkaMsOwners                      - semicolon-delimited owner aliases

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -25,6 +25,10 @@ parameters:
 variables:
 # Variables used: DncEngInternalBuildPool
 - template: /eng/common/templates-official/variables/pool-providers.yml
+# EngKeyVault-backed group (dnceng/internal). Provides the secret $(akams-app-id) -- the onboarded
+# aka.ms client app id used to authenticate to the Redirection API. The pipeline must be granted
+# access to this variable group. Same source dotnet/arcade uses in eng/publishing/v3/publish.yml.
+- group: Publish-Build-Assets
 
 resources:
   repositories:
@@ -237,21 +241,23 @@ extends:
               env:
                 ESRP_RELEASE_DETAILS: $(ESRP_RELEASE_DETAILS)
 
-            # Repoint the aka.ms links at the new ESRP URLs using the corp Redirection Management
-            # API (same endpoint/scope as dotnet/arcade's AkaMSLinkManager). The /bulk endpoint
-            # accepts an array, so both links are updated in a single call.
+            # Repoint the aka.ms links at the new ESRP URLs. We authenticate to the corp Redirection
+            # Management API the same way dotnet/arcade does: as the onboarded aka.ms client app
+            # ($(akams-app-id), from the EngKeyVault-backed Publish-Build-Assets variable group) using
+            # a client certificate pulled from EngKeyVault. The /bulk endpoint accepts an array, so
+            # both links are updated in a single PUT.
             #
-            # AUTH (read before configuring): the Redirection API only accepts tokens from an AAD
-            # app that has been registered and onboarded as an aka.ms client. AkaMsServiceConnection
-            # MUST therefore be an AzureRM (workload-identity / federated) service connection whose
-            # backing identity is that onboarded app -- a generic pipeline connection will get 401/403.
-            # Ask dnceng for the service-connection name (and have them confirm the identity is
-            # authorized on the Redirection API). The token authority tenant is fixed to the corp
-            # tenant (72f988bf-86f1-41af-91ab-2d7cd011db47), which is the service connection's own
-            # tenant; we do not supply it.
+            # Prerequisites (dnceng-owned; the pipeline must be granted access):
+            #   - The 'Publish-Build-Assets' variable group is linked (provides secret $(akams-app-id)).
+            #   - AkaMsCertServiceConnection can read the cert secret from the key vault.
+            #   - The app/cert is allowed to manage the 'dotnet/templating/*' links in the 'ncd' tenant.
             #
-            # Variables defined in the pipeline's Variables UI:
-            #   AkaMsServiceConnection           - federated AzureRM service connection (identity onboarded to the Redirection API)
+            # Variables (pipeline Variables UI unless noted):
+            #   akams-app-id                     - aka.ms client app id (secret, from the Publish-Build-Assets KV group)
+            #   AkaMsCertServiceConnection       - AzureRM service connection that can read the key vault (e.g. DotNet-Engineering-Services_KeyVault)
+            #   AkaMsCertVaultName               - key vault holding the cert (e.g. EngKeyVault)
+            #   AkaMsCertSecretName              - cert secret name (e.g. Redirection-UST-Client-NetCoreDeployment)
+            #   AkaMsAuthorityTenantId           - AAD tenant to authenticate the app against (corp 72f988bf-86f1-41af-91ab-2d7cd011db47)
             #   AkaMsTenantId                    - aka.ms redirection tenant in the /api/aka/1/{tenant} path (the dotnet tenant is 'ncd', NOT the AAD tenant GUID)
             #   AkaMsShortUrl                    - 'dotnet/templating/searchcacheurl' (no 'aka.ms/' prefix)
             #   AkaMsNonTemplatePacksShortUrl    - 'dotnet/templating/nontemplatepacksurl' (no 'aka.ms/' prefix)
@@ -260,30 +266,93 @@ extends:
             # Only repoint the production links from main; manual/test runs on other branches
             # should not move them (point the short-url vars at test links to validate this step).
             - task: AzureCLI@2
-              displayName: Update aka.ms search cache links
+              displayName: Fetch aka.ms client certificate
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
               inputs:
-                azureSubscription: $(AkaMsServiceConnection)
+                azureSubscription: $(AkaMsCertServiceConnection)
                 scriptType: pscore
                 scriptLocation: inlineScript
                 inlineScript: |
                   $ErrorActionPreference = 'Stop'
-                  $searchCacheUrl      = $env:SEARCH_CACHE_URL
-                  $nonTemplatePacksUrl = $env:NON_TEMPLATE_PACKS_URL
-                  $shortUrl            = $env:AKAMS_SHORT_URL
-                  $nonShortUrl         = $env:AKAMS_NONTEMPLATEPACKS_SHORT_URL
-                  $tenant              = $env:AKAMS_TENANT_ID
-                  $owners              = $env:AKAMS_OWNERS
-                  $groupOwner          = $env:AKAMS_GROUP_OWNER
+                  $value = az keyvault secret show --vault-name $env:AKAMS_CERT_VAULT --name $env:AKAMS_CERT_SECRET --query value -o tsv
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($value)) { Write-Error 'Failed to read the aka.ms certificate secret from the key vault.'; exit 1 }
+                  $path = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.b64'
+                  Set-Content -Path $path -Value $value -NoNewline
+                  Write-Host "Wrote certificate material to $path"
+              env:
+                AKAMS_CERT_VAULT: $(AkaMsCertVaultName)
+                AKAMS_CERT_SECRET: $(AkaMsCertSecretName)
 
-                  foreach ($required in @{ SEARCH_CACHE_URL = $searchCacheUrl; NON_TEMPLATE_PACKS_URL = $nonTemplatePacksUrl; AKAMS_SHORT_URL = $shortUrl; AKAMS_NONTEMPLATEPACKS_SHORT_URL = $nonShortUrl; AKAMS_TENANT_ID = $tenant; AKAMS_OWNERS = $owners }.GetEnumerator()) {
-                    if ([string]::IsNullOrWhiteSpace($required.Value)) { Write-Error "Required value '$($required.Key)' is empty."; exit 1 }
+            # Authenticate as the aka.ms client app with the certificate and PUT both links. Run as a
+            # plain pwsh step (not AzureCLI@2) so our 'az login --service-principal' owns the az context;
+            # it is reverted in the finally block.
+            - pwsh: |
+                $ErrorActionPreference = 'Stop'
+                $searchCacheUrl      = $env:SEARCH_CACHE_URL
+                $nonTemplatePacksUrl = $env:NON_TEMPLATE_PACKS_URL
+                $appId               = $env:AKAMS_APP_ID
+                $authorityTenant     = $env:AKAMS_AUTHORITY_TENANT
+                $shortUrl            = $env:AKAMS_SHORT_URL
+                $nonShortUrl         = $env:AKAMS_NONTEMPLATEPACKS_SHORT_URL
+                $tenant              = $env:AKAMS_TENANT_ID
+                $owners              = $env:AKAMS_OWNERS
+                $groupOwner          = $env:AKAMS_GROUP_OWNER
+
+                foreach ($required in @{ SEARCH_CACHE_URL = $searchCacheUrl; NON_TEMPLATE_PACKS_URL = $nonTemplatePacksUrl; AKAMS_APP_ID = $appId; AKAMS_AUTHORITY_TENANT = $authorityTenant; AKAMS_SHORT_URL = $shortUrl; AKAMS_NONTEMPLATEPACKS_SHORT_URL = $nonShortUrl; AKAMS_TENANT_ID = $tenant; AKAMS_OWNERS = $owners }.GetEnumerator()) {
+                  if ([string]::IsNullOrWhiteSpace($required.Value)) { Write-Error "Required value '$($required.Key)' is empty."; exit 1 }
+                }
+
+                # The key vault certificate secret is a base64-encoded PKCS#12 (PFX). Decode it, load
+                # it, and re-emit it as a PEM (private key + certificate) for 'az login --certificate'.
+                $b64Path = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.b64'
+                if (-not (Test-Path $b64Path)) { Write-Error "Certificate material '$b64Path' is missing; the fetch step did not run."; exit 1 }
+                $raw = (Get-Content -Raw $b64Path) -replace '\s', ''
+                $storageFlags = `
+                  [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable -bor `
+                  [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet
+                try {
+                  if ($raw -match '-----BEGIN') {
+                    Write-Error 'The certificate secret is stored as PEM, but this step expects a base64 PFX. Adjust the secret or this step.'
+                    exit 1
                   }
+                  $pfxBytes = [Convert]::FromBase64String($raw)
+                  $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($pfxBytes, '', $storageFlags)
+                } catch {
+                  Write-Error "Could not load the certificate secret as a base64 PFX. Details: $($_.Exception.Message)"
+                  exit 1
+                }
+                if (-not $cert.HasPrivateKey) { Write-Error 'The certificate does not contain a private key.'; exit 1 }
+                $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+                if ($null -eq $rsa) { Write-Error 'The certificate does not contain an exportable RSA private key.'; exit 1 }
+
+                function Format-Pem([byte[]] $bytes, [string] $label) {
+                  $text = [Convert]::ToBase64String($bytes)
+                  $sb = [System.Text.StringBuilder]::new()
+                  [void]$sb.AppendLine("-----BEGIN $label-----")
+                  for ($i = 0; $i -lt $text.Length; $i += 64) {
+                    [void]$sb.AppendLine($text.Substring($i, [Math]::Min(64, $text.Length - $i)))
+                  }
+                  [void]$sb.AppendLine("-----END $label-----")
+                  $sb.ToString()
+                }
+                $pemPath = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.pem'
+                (Format-Pem $rsa.ExportPkcs8PrivateKey() 'PRIVATE KEY') + (Format-Pem $cert.RawData 'CERTIFICATE') |
+                  Set-Content -Path $pemPath -NoNewline
+
+                try {
+                  $azConfigDir = Join-Path $env:AGENT_TEMPDIRECTORY 'az-akams'
+                  New-Item -ItemType Directory -Force -Path $azConfigDir | Out-Null
+                  $env:AZURE_CONFIG_DIR = $azConfigDir
+
+                  az login --service-principal --username $appId --tenant $authorityTenant `
+                    --certificate $pemPath --use-cert-sn-issuer --allow-no-subscriptions 1>$null
+                  if ($LASTEXITCODE -ne 0) { Write-Error 'az login with the aka.ms client certificate failed.'; exit 1 }
 
                   $token = az account get-access-token `
                     --scope 'https://msazurecloud.onmicrosoft.com/RedirectionMgmtApi-Prod/.default' `
                     --query accessToken -o tsv
-                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) { Write-Error 'Failed to acquire redirection API token.'; exit 1 }
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) { Write-Error 'Failed to acquire the redirection API token.'; exit 1 }
+                  Write-Host "##vso[task.setsecret]$token"
 
                   $lastModifiedBy = $owners.Split(';')[0].Trim()
                   function New-Link($short, $target, $description) {
@@ -298,7 +367,7 @@ extends:
                       isAllowParam   = $true
                     }
                   }
-                  $body = ConvertTo-Json @(
+                  $body = ConvertTo-Json -Depth 5 -AsArray @(
                     (New-Link $shortUrl    $searchCacheUrl      'dotnet templating search cache (published via ESRP)'),
                     (New-Link $nonShortUrl $nonTemplatePacksUrl 'dotnet templating non-template packs (published via ESRP)')
                   )
@@ -311,9 +380,19 @@ extends:
                     -Headers @{ Authorization = "Bearer $token" } `
                     -ContentType 'application/json' -Body $body
                   Write-Host "Redirection API status: $($resp.StatusCode)"
+                }
+                finally {
+                  az logout 2>$null | Out-Null
+                  Remove-Item -Force -Recurse -ErrorAction SilentlyContinue `
+                    $pemPath, $b64Path, $azConfigDir
+                }
+              displayName: Update aka.ms search cache links
+              condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
               env:
                 SEARCH_CACHE_URL: $(capture.SearchCacheDownloadUrl)
                 NON_TEMPLATE_PACKS_URL: $(capture.NonTemplatePacksDownloadUrl)
+                AKAMS_APP_ID: $(akams-app-id)
+                AKAMS_AUTHORITY_TENANT: $(AkaMsAuthorityTenantId)
                 AKAMS_SHORT_URL: $(AkaMsShortUrl)
                 AKAMS_NONTEMPLATEPACKS_SHORT_URL: $(AkaMsNonTemplatePacksShortUrl)
                 AKAMS_TENANT_ID: $(AkaMsTenantId)

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -198,9 +198,14 @@ extends:
           # download.visualstudio.microsoft.com. This replaces the retired,
           # DDFUN-managed 'dotnettemplating' blob storage account.
           # The ESRP connected service, key vault, and signing cert are baked into the
-          # template. $(ESRPOwners)/$(ESRPApprovers) are comma-separated aliases defined
-          # in the pipeline's Variables UI; both must be PME-account holders.
-          - template: azure-pipelines/MicroBuild.Publish.ReleaseStudio.yml@MicroBuildTemplates
+          # template. $(ESRPOwners)/$(ESRPApprovers) are semicolon-separated full email
+          # addresses defined in the pipeline's Variables UI; both must be PME-account holders.
+          # NOTE: no 'azure-pipelines/' path prefix here (unlike the top-level 'extends').
+          # The 1ES.Official.Publish.yml extends template lives in the MicroBuildTemplate
+          # repo's azure-pipelines/ folder and re-resolves @MicroBuildTemplates references in
+          # injected steps relative to its own directory, so a prefix would double it
+          # (azure-pipelines/azure-pipelines/...).
+          - template: MicroBuild.Publish.ReleaseStudio.yml@MicroBuildTemplates
             parameters:
               intent: 'filedownloadlinkgeneration'
               contentType: 'Binaries'

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -13,8 +13,12 @@ schedules:
   always: true # Trigger even when there are no code changes.
 
 parameters:
-- name: publishToBlob
-  displayName: Publish to blob?
+- name: publishFiles
+  displayName: Publish files to ESRP (download.visualstudio.microsoft.com)?
+  type: boolean
+  default: true
+- name: updateAkaMsLink
+  displayName: Update aka.ms/dotnet/templating/searchcacheurl to the new ESRP URL?
   type: boolean
   default: true
 
@@ -24,13 +28,16 @@ variables:
 
 resources:
   repositories:
-  - repository: 1ESPipelineTemplates
+  # MicroBuild publish wrapper. It internally declares the 1ESPipelineTemplates
+  # repository resource and extends v1/1ES.Official.PipelineTemplate.yml, while
+  # injecting the MicroBuild publish-authorization plugin required for ESRP publishing.
+  - repository: MicroBuildTemplates
     type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: azure-pipelines/1ES.Official.Publish.yml@MicroBuildTemplates
   parameters:
     sdl:
       sourceAnalysisPool:
@@ -46,6 +53,11 @@ extends:
           image: 1es-ubuntu-2204
           os: linux
         templateContext:
+          # The MicroBuild publish-authorization plugin only needs to run on the
+          # publishing job, not on this Linux build job.
+          mb:
+            publish:
+              enabled: false
           outputs:
           - output: pipelineArtifact
             targetPath: $(Build.ArtifactStagingDirectory)
@@ -148,9 +160,8 @@ extends:
               nonTemplatePacks.json
             TargetFolder: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/
 
-      - ${{ if eq(parameters.publishToBlob, true) }}:
-        # An entirely separate job is required to run AzureFileCopy@6, which is a Windows-only task.
-        # If the Create job was rewritten to use PowerShell instead of Bash, Create and Publish could be combined into a single Windows job.
+      - ${{ if eq(parameters.publishFiles, true) }}:
+        # An entirely separate Windows job is required for ESRP publishing.
         - job: Publish
           dependsOn: Create
           pool:
@@ -166,13 +177,135 @@ extends:
               artifactName: ArtifactsToPublish
 
           steps:
-          - task: AzureFileCopy@6
-            displayName: Upload to blob storage
-            inputs:
-              SourcePath: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/*.json
-              # Service connection: https://dnceng.visualstudio.com/internal/_settings/adminservices?resourceId=010b0bdc-9487-484f-af2d-ca3ae3235b84
-              azureSubscription: DOTNET-Templating - PME
-              Destination: AzureBlob
-              # These variables are defined in the pipeline's Variables UI.
-              storage: $(CacheFileStorageAccount)
-              ContainerName: $(CacheFileStorageContainer)
+          # Publish the search cache JSON files via ESRP (Release Studio) to
+          # download.visualstudio.microsoft.com. This replaces the retired,
+          # DDFUN-managed 'dotnettemplating' blob storage account.
+          # The ESRP connected service, key vault, and signing cert are baked into the
+          # template. $(ESRPOwners)/$(ESRPApprovers) are comma-separated aliases defined
+          # in the pipeline's Variables UI; both must be PME-account holders.
+          - template: azure-pipelines/MicroBuild.Publish.ReleaseStudio.yml@MicroBuildTemplates
+            parameters:
+              intent: 'filedownloadlinkgeneration'
+              contentType: 'Binaries'
+              contentSource: 'Folder'
+              folderLocation: '$(System.DefaultWorkingDirectory)/ArtifactsToPublish'
+              waitForReleaseCompletion: true
+              owners: '$(ESRPOwners)'
+              approvers: '$(ESRPApprovers)'
+
+          # Capture the per-file download URLs that ESRP generated. Each publish run produces
+          # brand-new, GUID-based URLs under download.visualstudio.microsoft.com, so the
+          # aka.ms link must be repointed every run.
+          # ESRP_RELEASE_DETAILS schema:
+          #   { "status": "pass", "files": [ { "fileDownloadDetails": [ { "downloadUrl": "..." } ] } ] }
+          - ${{ if eq(parameters.updateAkaMsLink, true) }}:
+            - pwsh: |
+                $ErrorActionPreference = 'Stop'
+                $json = $env:ESRP_RELEASE_DETAILS
+                if ([string]::IsNullOrEmpty($json)) { Write-Error 'ESRP_RELEASE_DETAILS is not set or empty.'; exit 1 }
+                $details = ConvertFrom-Json $json
+                if ($details.status -ne 'pass') { Write-Error "ESRP publishing did not pass. Status: '$($details.status)'."; exit 1 }
+
+                # The aka.ms links track the v2 search cache file and the non-template-packs file.
+                # Match on the published file name (the original name is preserved as the last URL
+                # segment) rather than on a release-details property name, which is more robust
+                # across schema revisions.
+                $searchCacheUrl = $null
+                $nonTemplatePacksUrl = $null
+                foreach ($file in $details.files) {
+                  foreach ($detail in $file.fileDownloadDetails) {
+                    $url = $detail.downloadUrl
+                    Write-Host "Published: $url"
+                    if ($url -like '*/NuGetTemplateSearchInfoVer2.json') { $searchCacheUrl = $url }
+                    if ($url -like '*/nonTemplatePacks.json') { $nonTemplatePacksUrl = $url }
+                  }
+                }
+                if ([string]::IsNullOrWhiteSpace($searchCacheUrl)) {
+                  Write-Error 'Could not find the NuGetTemplateSearchInfoVer2.json download URL in ESRP_RELEASE_DETAILS.'
+                  exit 1
+                }
+                if ([string]::IsNullOrWhiteSpace($nonTemplatePacksUrl)) {
+                  Write-Error 'Could not find the nonTemplatePacks.json download URL in ESRP_RELEASE_DETAILS.'
+                  exit 1
+                }
+                Write-Host "Search cache URL: $searchCacheUrl"
+                Write-Host "Non-template packs URL: $nonTemplatePacksUrl"
+                Write-Host "##vso[task.setvariable variable=SearchCacheDownloadUrl;isOutput=true]$searchCacheUrl"
+                Write-Host "##vso[task.setvariable variable=NonTemplatePacksDownloadUrl;isOutput=true]$nonTemplatePacksUrl"
+              name: capture
+              displayName: Capture ESRP download URLs
+              env:
+                ESRP_RELEASE_DETAILS: $(ESRP_RELEASE_DETAILS)
+
+            # Repoint the aka.ms links at the new ESRP URLs using the corp Redirection Management
+            # API (same contract as dotnet/arcade's AkaMSLinkManager). The /bulk endpoint accepts
+            # an array, so both links are updated in a single call. The service connection identity
+            # must own the links. The following variables are defined in the pipeline's Variables UI:
+            #   AkaMsServiceConnection           - AzureRM service connection whose identity can manage the links
+            #   AkaMsTenantId                    - redirection (AME) tenant GUID
+            #   AkaMsShortUrl                    - 'dotnet/templating/searchcacheurl' (no 'aka.ms/' prefix)
+            #   AkaMsNonTemplatePacksShortUrl    - 'dotnet/templating/nontemplatepacksurl' (no 'aka.ms/' prefix)
+            #   AkaMsOwners                      - semicolon-delimited owner aliases
+            #   AkaMsGroupOwner                  - owning security-group alias (may be empty)
+            # Only repoint the production links from main; manual/test runs on other branches
+            # should not move them (point the short-url vars at test links to validate this step).
+            - task: AzureCLI@2
+              displayName: Update aka.ms search cache links
+              condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+              inputs:
+                azureSubscription: $(AkaMsServiceConnection)
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $ErrorActionPreference = 'Stop'
+                  $searchCacheUrl      = $env:SEARCH_CACHE_URL
+                  $nonTemplatePacksUrl = $env:NON_TEMPLATE_PACKS_URL
+                  $shortUrl            = $env:AKAMS_SHORT_URL
+                  $nonShortUrl         = $env:AKAMS_NONTEMPLATEPACKS_SHORT_URL
+                  $tenant              = $env:AKAMS_TENANT_ID
+                  $owners              = $env:AKAMS_OWNERS
+                  $groupOwner          = $env:AKAMS_GROUP_OWNER
+
+                  foreach ($required in @{ SEARCH_CACHE_URL = $searchCacheUrl; NON_TEMPLATE_PACKS_URL = $nonTemplatePacksUrl; AKAMS_SHORT_URL = $shortUrl; AKAMS_NONTEMPLATEPACKS_SHORT_URL = $nonShortUrl; AKAMS_TENANT_ID = $tenant; AKAMS_OWNERS = $owners }.GetEnumerator()) {
+                    if ([string]::IsNullOrWhiteSpace($required.Value)) { Write-Error "Required value '$($required.Key)' is empty."; exit 1 }
+                  }
+
+                  $token = az account get-access-token `
+                    --scope 'https://msazurecloud.onmicrosoft.com/RedirectionMgmtApi-Prod/.default' `
+                    --query accessToken -o tsv
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) { Write-Error 'Failed to acquire redirection API token.'; exit 1 }
+
+                  $lastModifiedBy = $owners.Split(';')[0].Trim()
+                  function New-Link($short, $target, $description) {
+                    @{
+                      shortUrl       = $short
+                      targetUrl      = $target
+                      owners         = $owners
+                      groupOwner     = $groupOwner
+                      lastModifiedBy = $lastModifiedBy
+                      description    = $description
+                      isVanity       = $true
+                      isAllowParam   = $true
+                    }
+                  }
+                  $body = ConvertTo-Json @(
+                    (New-Link $shortUrl    $searchCacheUrl      'dotnet templating search cache (published via ESRP)'),
+                    (New-Link $nonShortUrl $nonTemplatePacksUrl 'dotnet templating non-template packs (published via ESRP)')
+                  )
+
+                  $uri = "https://redirectionapi-ame.trafficmanager.net/api/aka/1/$tenant/bulk"
+                  Write-Host "PUT $uri"
+                  Write-Host "  $shortUrl -> $searchCacheUrl"
+                  Write-Host "  $nonShortUrl -> $nonTemplatePacksUrl"
+                  $resp = Invoke-WebRequest -Method Put -Uri $uri `
+                    -Headers @{ Authorization = "Bearer $token" } `
+                    -ContentType 'application/json' -Body $body -UseBasicParsing
+                  Write-Host "Redirection API status: $($resp.StatusCode)"
+              env:
+                SEARCH_CACHE_URL: $(capture.SearchCacheDownloadUrl)
+                NON_TEMPLATE_PACKS_URL: $(capture.NonTemplatePacksDownloadUrl)
+                AKAMS_SHORT_URL: $(AkaMsShortUrl)
+                AKAMS_NONTEMPLATEPACKS_SHORT_URL: $(AkaMsNonTemplatePacksShortUrl)
+                AKAMS_TENANT_ID: $(AkaMsTenantId)
+                AKAMS_OWNERS: $(AkaMsOwners)
+                AKAMS_GROUP_OWNER: $(AkaMsGroupOwner)

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -18,7 +18,7 @@ parameters:
   type: boolean
   default: true
 - name: updateAkaMsLink
-  displayName: Update aka.ms/dotnet/templating/searchcacheurl to the new ESRP URL?
+  displayName: Update the aka.ms links (searchcacheurl and nontemplatepacksurl) to the new ESRP URLs?
   type: boolean
   default: true
 
@@ -299,7 +299,7 @@ extends:
                   Write-Host "  $nonShortUrl -> $nonTemplatePacksUrl"
                   $resp = Invoke-WebRequest -Method Put -Uri $uri `
                     -Headers @{ Authorization = "Bearer $token" } `
-                    -ContentType 'application/json' -Body $body -UseBasicParsing
+                    -ContentType 'application/json' -Body $body
                   Write-Host "Redirection API status: $($resp.StatusCode)"
               env:
                 SEARCH_CACHE_URL: $(capture.SearchCacheDownloadUrl)

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -242,7 +242,7 @@ extends:
             # an array, so both links are updated in a single call. The service connection identity
             # must own the links. The following variables are defined in the pipeline's Variables UI:
             #   AkaMsServiceConnection           - AzureRM service connection whose identity can manage the links
-            #   AkaMsTenantId                    - redirection (AME) tenant GUID
+            #   AkaMsTenantId                    - redirection (AME) tenant identifier (the dotnet tenant is 'ncd', not a GUID)
             #   AkaMsShortUrl                    - 'dotnet/templating/searchcacheurl' (no 'aka.ms/' prefix)
             #   AkaMsNonTemplatePacksShortUrl    - 'dotnet/templating/nontemplatepacksurl' (no 'aka.ms/' prefix)
             #   AkaMsOwners                      - semicolon-delimited owner aliases

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -194,7 +194,7 @@ extends:
               artifactName: ArtifactsToPublish
             mb:
               publish:
-                feedsource: 'https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                feedSource: 'https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
           steps:
           # Publish the search cache JSON files via ESRP (Release Studio) to

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -344,6 +344,14 @@ extends:
                 $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
                 if ($null -eq $rsa) { Write-Error 'The certificate does not contain an exportable RSA private key.'; exit 1 }
 
+                # On Windows the private key is backed by CNG (RSACng), whose ExportPkcs8PrivateKey()
+                # throws "The requested operation is not supported" even for keys loaded as Exportable.
+                # CNG does allow exporting the raw parameters, so round-trip them through a fresh
+                # managed RSA instance, which supports PKCS#8 export, and use that for the PEM.
+                $rsaParameters = $rsa.ExportParameters($true)
+                $exportableRsa = [System.Security.Cryptography.RSA]::Create()
+                $exportableRsa.ImportParameters($rsaParameters)
+
                 function Format-Pem([byte[]] $bytes, [string] $label) {
                   $text = [Convert]::ToBase64String($bytes)
                   $sb = [System.Text.StringBuilder]::new()
@@ -355,7 +363,7 @@ extends:
                   $sb.ToString()
                 }
                 $pemPath = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.pem'
-                (Format-Pem $rsa.ExportPkcs8PrivateKey() 'PRIVATE KEY') + (Format-Pem $cert.RawData 'CERTIFICATE') |
+                (Format-Pem $exportableRsa.ExportPkcs8PrivateKey() 'PRIVATE KEY') + (Format-Pem $cert.RawData 'CERTIFICATE') |
                   Set-Content -Path $pemPath -NoNewline
 
                 try {

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -75,6 +75,7 @@ extends:
           mb:
             publish:
               enabled: false
+              feedsource: 'https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json'
           outputs:
           - output: pipelineArtifact
             targetPath: $(Build.ArtifactStagingDirectory)

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -302,9 +302,11 @@ extends:
                 AKAMS_CERT_VAULT: $(AkaMsCertVaultName)
                 AKAMS_CERT_SECRET: $(AkaMsCertSecretName)
 
-            # Authenticate as the aka.ms client app with the certificate and PUT both links. Run as a
-            # plain pwsh step (not AzureCLI@2) so our 'az login --service-principal' owns the az context;
-            # it is reverted in the finally block.
+            # Authenticate as the aka.ms client app with the certificate and PUT both links. The agent's
+            # key-vault certificate has a non-exportable private key, so we cannot emit a PEM for
+            # 'az login --certificate'. Instead we sign a client-assertion JWT directly with the
+            # certificate (which works with non-exportable CNG keys) and exchange it for a token, the
+            # same way MSAL/ClientCertificateCredential authenticates.
             - pwsh: |
                 $ErrorActionPreference = 'Stop'
                 $searchCacheUrl      = $env:SEARCH_CACHE_URL
@@ -321,13 +323,13 @@ extends:
                   if ([string]::IsNullOrWhiteSpace($required.Value)) { Write-Error "Required value '$($required.Key)' is empty."; exit 1 }
                 }
 
-                # The key vault certificate secret is a base64-encoded PKCS#12 (PFX). Decode it, load
-                # it, and re-emit it as a PEM (private key + certificate) for 'az login --certificate'.
+                # The key vault certificate secret is a base64-encoded PKCS#12 (PFX). Decode it and load
+                # it so we can sign a client-assertion JWT with its private key. The key may be
+                # non-exportable, so we never try to export it - signing alone is sufficient.
                 $b64Path = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.b64'
                 if (-not (Test-Path $b64Path)) { Write-Error "Certificate material '$b64Path' is missing; the fetch step did not run."; exit 1 }
                 $raw = (Get-Content -Raw $b64Path) -replace '\s', ''
                 $storageFlags = `
-                  [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable -bor `
                   [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet
                 try {
                   if ($raw -match '-----BEGIN') {
@@ -342,43 +344,52 @@ extends:
                 }
                 if (-not $cert.HasPrivateKey) { Write-Error 'The certificate does not contain a private key.'; exit 1 }
                 $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
-                if ($null -eq $rsa) { Write-Error 'The certificate does not contain an exportable RSA private key.'; exit 1 }
+                if ($null -eq $rsa) { Write-Error 'The certificate does not have an RSA private key.'; exit 1 }
 
-                # On Windows the private key is backed by CNG (RSACng), whose ExportPkcs8PrivateKey()
-                # throws "The requested operation is not supported" even for keys loaded as Exportable.
-                # CNG does allow exporting the raw parameters, so round-trip them through a fresh
-                # managed RSA instance, which supports PKCS#8 export, and use that for the PEM.
-                $rsaParameters = $rsa.ExportParameters($true)
-                $exportableRsa = [System.Security.Cryptography.RSA]::Create()
-                $exportableRsa.ImportParameters($rsaParameters)
-
-                function Format-Pem([byte[]] $bytes, [string] $label) {
-                  $text = [Convert]::ToBase64String($bytes)
-                  $sb = [System.Text.StringBuilder]::new()
-                  [void]$sb.AppendLine("-----BEGIN $label-----")
-                  for ($i = 0; $i -lt $text.Length; $i += 64) {
-                    [void]$sb.AppendLine($text.Substring($i, [Math]::Min(64, $text.Length - $i)))
-                  }
-                  [void]$sb.AppendLine("-----END $label-----")
-                  $sb.ToString()
+                function ConvertTo-Base64Url([byte[]] $bytes) {
+                  [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
                 }
-                $pemPath = Join-Path $env:AGENT_TEMPDIRECTORY 'akamscert.pem'
-                (Format-Pem $exportableRsa.ExportPkcs8PrivateKey() 'PRIVATE KEY') + (Format-Pem $cert.RawData 'CERTIFICATE') |
-                  Set-Content -Path $pemPath -NoNewline
 
                 try {
-                  $azConfigDir = Join-Path $env:AGENT_TEMPDIRECTORY 'az-akams'
-                  New-Item -ItemType Directory -Force -Path $azConfigDir | Out-Null
-                  $env:AZURE_CONFIG_DIR = $azConfigDir
+                  # Build and sign a client-assertion JWT (RS256) with the certificate's private key.
+                  # Subject Name + Issuer (SNI) auth: include x5t (sha1 thumbprint) and x5c (the cert)
+                  # in the header so AAD accepts the first-party app's certificate by subject/issuer.
+                  $scope         = 'https://msazurecloud.onmicrosoft.com/RedirectionMgmtApi-Prod/.default'
+                  $tokenEndpoint = "https://login.microsoftonline.com/$authorityTenant/oauth2/v2.0/token"
+                  $now = [DateTimeOffset]::UtcNow
+                  $thumbprint = [System.Security.Cryptography.SHA1]::HashData($cert.RawData)
+                  $header = [ordered]@{
+                    alg = 'RS256'
+                    typ = 'JWT'
+                    x5t = (ConvertTo-Base64Url $thumbprint)
+                    x5c = @([Convert]::ToBase64String($cert.RawData))
+                  } | ConvertTo-Json -Compress
+                  $payload = [ordered]@{
+                    aud = $tokenEndpoint
+                    iss = $appId
+                    sub = $appId
+                    jti = [Guid]::NewGuid().ToString()
+                    nbf = $now.ToUnixTimeSeconds()
+                    exp = $now.AddMinutes(10).ToUnixTimeSeconds()
+                  } | ConvertTo-Json -Compress
+                  $unsigned = (ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes($header))) + '.' +
+                              (ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes($payload)))
+                  $signature = $rsa.SignData(
+                    [Text.Encoding]::ASCII.GetBytes($unsigned),
+                    [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                    [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+                  $assertion = $unsigned + '.' + (ConvertTo-Base64Url $signature)
 
-                  az login --service-principal --username $appId --tenant $authorityTenant `
-                    --certificate $pemPath --use-cert-sn-issuer --allow-no-subscriptions 1>$null
-                  if ($LASTEXITCODE -ne 0) { Write-Error 'az login with the aka.ms client certificate failed.'; exit 1 }
-
-                  $token = az account get-access-token `
-                    --scope 'https://msazurecloud.onmicrosoft.com/RedirectionMgmtApi-Prod/.default' `
-                    --query accessToken -o tsv
-                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) { Write-Error 'Failed to acquire the redirection API token.'; exit 1 }
+                  $tokenResponse = Invoke-RestMethod -Method Post -Uri $tokenEndpoint `
+                    -ContentType 'application/x-www-form-urlencoded' -Body @{
+                      client_id             = $appId
+                      scope                 = $scope
+                      grant_type            = 'client_credentials'
+                      client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+                      client_assertion      = $assertion
+                    }
+                  $token = $tokenResponse.access_token
+                  if ([string]::IsNullOrWhiteSpace($token)) { Write-Error 'Failed to acquire the redirection API token.'; exit 1 }
                   Write-Host "##vso[task.setsecret]$token"
 
                   $lastModifiedBy = $owners.Split(';')[0].Trim()
@@ -409,9 +420,7 @@ extends:
                   Write-Host "Redirection API status: $($resp.StatusCode)"
                 }
                 finally {
-                  az logout 2>$null | Out-Null
-                  Remove-Item -Force -Recurse -ErrorAction SilentlyContinue `
-                    $pemPath, $b64Path, $azConfigDir
+                  Remove-Item -Force -ErrorAction SilentlyContinue $b64Path
                 }
               displayName: Update aka.ms search cache links
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -405,7 +405,10 @@ extends:
                       isAllowParam   = $true
                     }
                   }
-                  $body = ConvertTo-Json -Depth 5 -AsArray @(
+                  # The Redirection API /bulk endpoint expects a top-level JSON array of links. The
+                  # input is already a two-element array, so do NOT use -AsArray here (it would wrap
+                  # the collection again and produce a nested [[ ... ]], which the API rejects).
+                  $body = ConvertTo-Json -Depth 5 @(
                     (New-Link $shortUrl    $searchCacheUrl      'dotnet templating search cache (published via ESRP)'),
                     (New-Link $nonShortUrl $nonTemplatePacksUrl 'dotnet templating non-template packs (published via ESRP)')
                   )

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -86,8 +86,8 @@ extends:
         steps:
         - script: >
             $(Build.SourcesDirectory)/build.sh
-              --projects $(Build.SourcesDirectory)/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
-              -bl
+            --projects $(Build.SourcesDirectory)/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+            -bl
           displayName: Build Cache Updater
 
         - task: CopyFiles@2

--- a/eng/pipelines/search-cache-pipeline.yml
+++ b/eng/pipelines/search-cache-pipeline.yml
@@ -75,7 +75,6 @@ extends:
           mb:
             publish:
               enabled: false
-              feedsource: 'https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json'
           outputs:
           - output: pipelineArtifact
             targetPath: $(Build.ArtifactStagingDirectory)
@@ -193,6 +192,9 @@ extends:
             - input: pipelineArtifact
               targetPath: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/
               artifactName: ArtifactsToPublish
+            mb:
+              publish:
+                feedsource: 'https://pkgs.dev.azure.com/dnceng/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
           steps:
           # Publish the search cache JSON files via ESRP (Release Studio) to

--- a/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NuGetPackSourceCheckerFactory.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NuGetPackSourceCheckerFactory.cs
@@ -62,7 +62,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
         private static async Task<IEnumerable<FilteredPackageInfo>?> LoadKnownPackagesListAsync(CommandArgs config, CancellationToken cancellationToken)
         {
             Verbose.WriteLine($"Loading existing non-packages information.");
-            const string uri = "https://dotnettemplating.blob.core.windows.net/search/nonTemplatePacks.json";
+            // aka.ms link should point to the future absolute URL for nonTemplatePacks.json
+            // (published alongside the search cache by eng/pipelines/search-cache-pipeline.yml).
+            const string uri = "https://aka.ms/dotnet/templating/nontemplatepacksurl";
 
             FileInfo? fileLocation = config.DiffOverrideKnownPackagesLocation;
             if (fileLocation == null)


### PR DESCRIPTION
## Summary
Migrates the templating search-cache publishing pipeline off the retiring, DDFUN-managed `dotnettemplating` Azure storage account onto **ESRP (Release Studio)** publishing to `download.visualstudio.microsoft.com`, per the storage-account ownership transition (Option 2).

## Changes
- **`eng/pipelines/search-cache-pipeline.yml`**
  - Replace the `AzureFileCopy@6` blob upload with the MicroBuild ESRP publish template (`MicroBuild.Publish.ReleaseStudio.yml`), extending `1ES.Official.Publish.yml`.
  - ESRP download URLs are GUID-based and regenerate every run, so a capture step extracts the per-run URLs for both published files and a single `/bulk` PUT repoints the aka.ms links via the corp Redirection API (same contract as arcade's `AkaMSLinksManager`). The link update is gated to `main`.
  - aka.ms auth uses a **client certificate** (mirroring arcade's `eng/publishing/v3/publish.yml`): the cert is read from EngKeyVault and the pipeline authenticates as the onboarded aka.ms app (`akams-app-id`, supplied by the linked `Publish-Build-Assets` variable group).
  - The genuine aka.ms constants are now **static in the YAML `variables:` block** (not the pipeline UI): `AkaMsTenantId` (`ncd`), `AkaMsAuthorityTenantId`, `AkaMsShortUrl`, `AkaMsNonTemplatePacksShortUrl`, `AkaMsGroupOwner`.
- **`NuGetPackSourceCheckerFactory.cs`**
  - Point the `nonTemplatePacks.json` source at `https://aka.ms/dotnet/templating/nontemplatepacksurl` instead of the hardcoded `dotnettemplating.blob.core.windows.net` URL (which would otherwise break `--diff` runs once the storage account is retired). Mirrors the existing `searchcacheurl` pattern.

## Required pipeline Variables (defined in the pipeline UI)
Only the values that are secret, dnceng-owned, or team-roster data remain in the UI:

ESRP publishing:
- `ESRPOwners`, `ESRPApprovers` — **comma-separated full email addresses** (PME-account holders), e.g. `nikolam@microsoft.com,miyanni@microsoft.com`. Multiple are allowed; the same list may be reused for both.

Aka.ms publishing:
- `AkaMsCertServiceConnection` (AzureRM SC that can read the cert from the key vault, e.g. `DotNet-Engineering-Services_KeyVault`)
- `AkaMsCertVaultName` (e.g. `EngKeyVault`)
- `AkaMsCertSecretName` (e.g. `Redirection-UST-Client-NetCoreDeployment`)
- `AkaMsOwners` (`;`-delimited; first alias is used as `lastModifiedBy`)

`akams-app-id` is supplied automatically by the linked `Publish-Build-Assets` group — do **not** add it to the UI. The `AkaMs*` constants listed above are static in the YAML and need no UI entry.

## Prerequisites
- ESRP service connection `ddrelstudio-id-pme-prod` authorized on the pipeline.
- The pipeline is granted access to the `Publish-Build-Assets` variable group and the cert secret (via `AkaMsCertServiceConnection`).
- New aka.ms link `dotnet/templating/nontemplatepacksurl` created; the aka.ms app/cert must own **both** links under tenant `ncd`.

## Notes
- **Template path resolution:** the injected ESRP step references the template **without** an `azure-pipelines/` prefix (`MicroBuild.Publish.ReleaseStudio.yml@MicroBuildTemplates`), while the top-level `extends` keeps it. `1ES.Official.Publish.yml` lives in the MicroBuildTemplate repo's `azure-pipelines/` folder and re-resolves `@MicroBuildTemplates` references in injected steps relative to its own directory, so a prefix doubles the path (`azure-pipelines/azure-pipelines/...`). Verified against the official ESRP samples (`Engineering/ReleaseStudio` `ESRP_AzDo_Sample.yml` and `DDFUN-ReleasePipelines` `DDPublish.yml`).
- **Publish-job pool:** uses the dnceng pool (`$(DncEngInternalBuildPool)` / `1es-windows-2022`) since this pipeline runs in the dnceng org; the ESRP samples' VSEng MicroBuild pools are DevDiv-org and not reachable from dnceng. Revisit only if a MicroBuild-plugin initialization failure appears on the publish job.
- The aka.ms update step is grounded on arcade's API contract but untested against the live API; recommend validating on `main` with throwaway test links first.
- The cert step assumes the key-vault secret is a base64-encoded PFX (as arcade stores it); if it's PEM, the step fails with a clear message and needs a small tweak.
- If the external `dotnet new search` client in dotnet/templating reads these files directly, it may need the same link updates there.
