### PR TITLE
Simplify customization of browser connection loggers

### DIFF
--- a/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -22,11 +22,15 @@ namespace Microsoft.DotNet.HotReload;
 /// Communicates with aspnetcore-browser-refresh.js loaded in the browser.
 /// Associated with a project instance.
 /// </summary>
-internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPath, ILogger logger, ILoggerFactory loggerFactory) : IDisposable
+internal abstract class AbstractBrowserRefreshServer(
+    string middlewareAssemblyPath,
+    ILogger logger,
+    Func<int, ILogger> connectionServerLoggerFactory,
+    Func<int, ILogger> connectionAgentLoggerFactory) : IDisposable
 {
-    public const string ServerLogComponentName = "BrowserRefreshServer";
-
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private static int s_lastConnectionId;
 
     private readonly List<BrowserConnection> _activeConnections = [];
     private readonly TaskCompletionSource<None> _browserConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -102,19 +106,39 @@ internal abstract class AbstractBrowserRefreshServer(string middlewareAssemblyPa
         }
     }
 
+    /// <summary>
+    /// Takes ownership of the <paramref name="clientSocket"/>.
+    /// </summary>
     protected BrowserConnection OnBrowserConnected(WebSocket clientSocket, string? subProtocol)
     {
-        var sharedSecret = (subProtocol != null) ? _sharedSecretProvider.DecryptSecret(WebUtility.UrlDecode(subProtocol)) : null;
-
-        var connection = new BrowserConnection(clientSocket, sharedSecret, loggerFactory);
-
-        lock (_activeConnections)
+        bool connectionPublished = false;
+        try
         {
-            _activeConnections.Add(connection);
-        }
+            var sharedSecret = (subProtocol != null) ? _sharedSecretProvider.DecryptSecret(WebUtility.UrlDecode(subProtocol)) : null;
 
-        _browserConnected.TrySetResult(default);
-        return connection;
+            var connectionId = Interlocked.Increment(ref s_lastConnectionId);
+            var serverLogger = connectionServerLoggerFactory(connectionId);
+            var agentLogger = connectionAgentLoggerFactory(connectionId);
+            var connection = new BrowserConnection(clientSocket, sharedSecret, connectionId, serverLogger, agentLogger);
+
+            lock (_activeConnections)
+            {
+                _activeConnections.Add(connection);
+            }
+
+            connectionPublished = true;
+
+            serverLogger.Log(LogEvents.ConnectedToRefreshServer);
+            _browserConnected.TrySetResult(default);
+            return connection;
+        }
+        finally
+        {
+            if (!connectionPublished)
+            {
+                clientSocket.Dispose();
+            }
+        }
     }
 
     /// <summary>

--- a/src/Dotnet.Watch/HotReloadClient/Web/BrowserConnection.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/BrowserConnection.cs
@@ -12,33 +12,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.HotReload;
 
-internal readonly struct BrowserConnection : IDisposable
+/// <summary>
+/// Represents a connection to a browser that facilitates Hot Reload operations.
+/// </summary>
+internal readonly struct BrowserConnection(WebSocket clientSocket, string? sharedSecret, int id, ILogger serverLogger, ILogger agentLogger) : IDisposable
 {
-    public const string ServerLogComponentName = $"{nameof(BrowserConnection)}:Server";
-    public const string AgentLogComponentName = $"{nameof(BrowserConnection)}:Agent";
-
-    private static int s_lastId;
-
-    public WebSocket ClientSocket { get; }
-    public string? SharedSecret { get; }
-    public int Id { get; }
-    public ILogger ServerLogger { get; }
-    public ILogger AgentLogger { get; }
-
     public readonly TaskCompletionSource<None> Disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-    public BrowserConnection(WebSocket clientSocket, string? sharedSecret, ILoggerFactory loggerFactory)
-    {
-        ClientSocket = clientSocket;
-        SharedSecret = sharedSecret;
-        Id = Interlocked.Increment(ref s_lastId);
-
-        var displayName = $"Browser #{Id}";
-        ServerLogger = loggerFactory.CreateLogger(ServerLogComponentName, displayName);
-        AgentLogger = loggerFactory.CreateLogger(AgentLogComponentName, displayName);
-
-        ServerLogger.Log(LogEvents.ConnectedToRefreshServer);
-    }
 
     public void Dispose()
     {
@@ -47,6 +26,12 @@ internal readonly struct BrowserConnection : IDisposable
         Disconnected.TrySetResult(default);
         ServerLogger.LogDebug("Disconnected.");
     }
+
+    public WebSocket ClientSocket => clientSocket;
+    public string? SharedSecret => sharedSecret;
+    public int Id => id;
+    public ILogger ServerLogger => serverLogger;
+    public ILogger AgentLogger => agentLogger;
 
     internal async ValueTask<bool> TrySendMessageAsync(ReadOnlyMemory<byte> messageBytes, CancellationToken cancellationToken)
     {

--- a/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
@@ -23,12 +23,13 @@ namespace Microsoft.DotNet.HotReload;
 /// </summary>
 internal sealed class BrowserRefreshServer(
     ILogger logger,
-    ILoggerFactory loggerFactory,
+    Func<int, ILogger> connectionServerLoggerFactory,
+    Func<int, ILogger> connectionAgentLoggerFactory,
     string middlewareAssemblyPath,
     string dotnetPath,
     WebSocketConfig webSocketConfig,
     bool suppressTimeouts)
-    : AbstractBrowserRefreshServer(middlewareAssemblyPath, logger, loggerFactory)
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath, logger, connectionServerLoggerFactory, connectionAgentLoggerFactory)
 {
     protected override bool SuppressTimeouts
         => suppressTimeouts;
@@ -62,6 +63,7 @@ internal sealed class BrowserRefreshServer(
 
         var clientSocket = await context.WebSockets.AcceptWebSocketAsync(subProtocol);
 
+        // client socket ownership is transferred to the connection:
         var connection = OnBrowserConnected(clientSocket, subProtocol);
         await connection.Disconnected.Task;
     }

--- a/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
@@ -10,6 +10,10 @@ namespace Microsoft.DotNet.Watch;
 
 internal abstract class WebApplicationAppModel(DotNetWatchContext context) : HotReloadAppModel
 {
+    public const string ServerLogComponentName = "BrowserRefreshServer";
+    public const string ConnectionServerLogComponentName = "BrowserConnection:Server";
+    public const string ConnectionAgentLogComponentName = "BrowserConnection:Agent";
+
     // This needs to be in sync with the version BrowserRefreshMiddleware is compiled against.
     private static readonly Version s_minimumSupportedVersion = Versions.Version6_0;
     private const string MiddlewareTargetFramework = "net6.0";
@@ -49,13 +53,14 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
 
     public BrowserRefreshServer? TryCreateRefreshServer(ProjectGraphNode projectNode)
     {
-        var logger = context.LoggerFactory.CreateLogger(BrowserRefreshServer.ServerLogComponentName, projectNode.GetDisplayName());
+        var logger = context.LoggerFactory.CreateLogger(ServerLogComponentName, projectNode.GetDisplayName());
 
         if (IsServerSupported(projectNode, logger))
         {
             return new BrowserRefreshServer(
                 logger,
-                context.LoggerFactory,
+                connectionServerLoggerFactory: connectionId => context.LoggerFactory.CreateLogger(ConnectionServerLogComponentName, GetBrowserLoggerName(connectionId)),
+                connectionAgentLoggerFactory: connectionId => context.LoggerFactory.CreateLogger(ConnectionAgentLogComponentName, GetBrowserLoggerName(connectionId)),
                 middlewareAssemblyPath: GetMiddlewareAssemblyPath(),
                 dotnetPath: context.EnvironmentOptions.GetMuxerPath(),
                 webSocketConfig: context.EnvironmentOptions.BrowserWebSocketConfig,
@@ -64,6 +69,9 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
 
         return null;
     }
+
+    private string GetBrowserLoggerName(int connectionId)
+        => $"Browser #{connectionId}";
 
     public bool IsServerSupported(ProjectGraphNode projectNode, ILogger logger)
     {

--- a/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
@@ -70,7 +70,7 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
         return null;
     }
 
-    private string GetBrowserLoggerName(int connectionId)
+    private static string GetBrowserLoggerName(int connectionId)
         => $"Browser #{connectionId}";
 
     public bool IsServerSupported(ProjectGraphNode projectNode, ILogger logger)

--- a/src/Dotnet.Watch/Watch/UI/IReporter.cs
+++ b/src/Dotnet.Watch/Watch/UI/IReporter.cs
@@ -175,9 +175,9 @@ internal abstract class MessageDescriptor(string? format, Emoji emoji, LogLevel 
         .Add(DotNetWatchContext.BuildLogComponentName, Emoji.Build)
         .Add(HotReloadDotNetWatcher.ClientLogComponentName, Emoji.HotReload)
         .Add(HotReloadDotNetWatcher.AgentLogComponentName, Emoji.Agent)
-        .Add(BrowserRefreshServer.ServerLogComponentName, Emoji.Refresh)
-        .Add(BrowserConnection.AgentLogComponentName, Emoji.Agent)
-        .Add(BrowserConnection.ServerLogComponentName, Emoji.Browser)
+        .Add(WebApplicationAppModel.ServerLogComponentName, Emoji.Refresh)
+        .Add(WebApplicationAppModel.ConnectionAgentLogComponentName, Emoji.Agent)
+        .Add(WebApplicationAppModel.ConnectionServerLogComponentName, Emoji.Browser)
         .Add(AspireServiceFactory.AspireLogComponentName, Emoji.Aspire);
 
     // predefined messages used for testing:

--- a/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.HotReload;
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal class TestBrowserRefreshServer(string middlewareAssemblyPath)
-    : AbstractBrowserRefreshServer(middlewareAssemblyPath, new TestLogger(), new TestLoggerFactory())
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath, new TestLogger(), _ => new TestLogger(), _ => new TestLogger())
 {
     public Func<WebServerHost>? CreateAndStartHostImpl;
 


### PR DESCRIPTION
Allow customization of connection related loggers without leaking dotnet-watch specific logger creation logic to consumers of Microsoft.Dotnet.Watch.Client source package.