### PR TITLE
fix: normalize IntermediateOutputPath slashes in posix platforms

### DIFF
--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -62,7 +62,14 @@ internal static class ProjectGraphUtilities
         => projectNode.ProjectInstance.GetPropertyValue(PropertyNames.TargetName);
 
     public static string? GetIntermediateOutputDirectory(this ProjectInstance project)
-        => project.GetPropertyValue(PropertyNames.IntermediateOutputPath) is { Length: >0 } path ? Path.Combine(project.Directory, path) : null;
+    {
+        var intermediateOutputPath = project.GetPropertyValue(PropertyNames.IntermediateOutputPath);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            intermediateOutputPath = intermediateOutputPath.Replace("\\", "");
+        }
+        return intermediateOutputPath is { Length: > 0 } path ? Path.Combine(project.Directory, path) : null;
+    }
 
     public static IEnumerable<string> GetCapabilities(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetItems(ItemNames.ProjectCapability).Select(item => item.EvaluatedInclude);

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -62,7 +62,7 @@ internal static class ProjectGraphUtilities
         => projectNode.ProjectInstance.GetPropertyValue(PropertyNames.TargetName);
 
     private static string NormalizeSeparators(string path)
-        => string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');
+        => Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');
 
     public static string? GetIntermediateOutputDirectory(this ProjectInstance project)
         => project.GetPropertyValue(PropertyNames.IntermediateOutputPath) is { Length: >0 } path ? Path.Combine(project.Directory, NormalizeSeparators(path)) : null;

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -56,20 +56,16 @@ internal static class ProjectGraphUtilities
         => projectNode.GetCapabilities().Any(static value => value is ProjectCapability.AspNetCore or ProjectCapability.WebAssembly);
 
     public static string? GetOutputDirectory(this ProjectInstance project)
-        => project.GetPropertyValue(PropertyNames.TargetPath) is { Length: >0 } path ? Path.GetDirectoryName(Path.Combine(project.Directory, path)) : null;
+        => project.GetPropertyValue(PropertyNames.TargetPath) is { Length: >0 } path ? Path.GetDirectoryName(Path.Combine(project.Directory, NormalizeSeparators(path))) : null;
 
     public static string GetAssemblyName(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetPropertyValue(PropertyNames.TargetName);
 
+    private static string NormalizeSeparators(string path)
+        => string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');
+
     public static string? GetIntermediateOutputDirectory(this ProjectInstance project)
-    {
-        var intermediateOutputPath = project.GetPropertyValue(PropertyNames.IntermediateOutputPath);
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            intermediateOutputPath = intermediateOutputPath.Replace("\\", "");
-        }
-        return intermediateOutputPath is { Length: > 0 } path ? Path.Combine(project.Directory, path) : null;
-    }
+        => project.GetPropertyValue(PropertyNames.IntermediateOutputPath) is { Length: >0 } path ? Path.Combine(project.Directory, NormalizeSeparators(path)) : null;
 
     public static IEnumerable<string> GetCapabilities(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetItems(ItemNames.ProjectCapability).Select(item => item.EvaluatedInclude);
@@ -81,6 +77,7 @@ internal static class ProjectGraphUtilities
         => projectNode.GetBooleanPropertyValue(PropertyNames.EnableDefaultItems);
 
     public static IReadOnlyList<string> GetDefaultItemExcludes(this ProjectGraphNode projectNode)
+        // NormalizeSeparators is not required for globs as MSBuildGlob.Parse treats `\` as a directory separator on Linux
         => projectNode.GetStringListPropertyValue(PropertyNames.DefaultItemExcludes);
 
     public static IReadOnlyList<string> GetStringListPropertyValue(this ProjectGraphNode projectNode, string propertyName)

--- a/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
+++ b/src/Dotnet.Watch/Watch/Build/ProjectGraphUtilities.cs
@@ -61,7 +61,7 @@ internal static class ProjectGraphUtilities
     public static string GetAssemblyName(this ProjectGraphNode projectNode)
         => projectNode.ProjectInstance.GetPropertyValue(PropertyNames.TargetName);
 
-    private static string NormalizeSeparators(string path)
+    internal static string NormalizeSeparators(string path)
         => Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');
 
     public static string? GetIntermediateOutputDirectory(this ProjectInstance project)

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -40,7 +40,7 @@ public class ProjectGraphUtilitiesTests
 
     [TestMethod]
     [DataRow(@"a\b/c", @"a\b/c", @"a\b")]
-    [DataRow(@"a\b/c/", @"a\b/c/", @"a\b/c")]
+    [DataRow(@"a\b/c/", @"a\b/c/", @"a\b\c")]
     [OSCondition(OperatingSystems.Windows)]
     public void ShouldNotNormalizeSeparatorsInWindows(string input, string expectedIntermediatePath, string expectedOutputPath)
     {

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -16,63 +16,59 @@ public class ProjectGraphUtilitiesTests
     private TestAssetsManager TestAssets => field ??= new(Output);
 
     [TestMethod]
-    [DataRow(@"foo\", @"foo/")]
-    [DataRow(@"foo\bar", @"foo/bar")]
-    [DataRow(@"foo/bar", @"foo/bar")]
-    [DataRow(@"foo\bar\", @"foo/bar/")]
-    [DataRow(@"foo/bar\", @"foo/bar/")]
-    [DataRow(@"foo/bar/", @"foo/bar/")]
-    [DataRow(@"foo\bar/", @"foo/bar/")]
+    [DataRow(@"a\b/c", "a/b/c", "a/b")]
+    [DataRow(@"a\b/c/", "a/b/c/", "a/b/c")]
     [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
-    public void NormalizeSeparatorsInIntermediateOutputDirectory(string input, string expected)
+    public void NormalizeSeparatorsWhenReadingOutputDirectoryInPosixSystems(string input, string expectedIntermediatePath, string expectedOutputPath)
     {
-
         var project = new TestProject("A");
         var testAsset = TestAssets.CreateTestProject(project);
         var projectPath = Path.Combine(testAsset.TestRoot, "A", "A.csproj");
 
         var projectInstance = new ProjectInstance(
             projectFile: projectPath,
-            globalProperties: new Dictionary<string, string> { [PropertyNames.IntermediateOutputPath] = input },
+            globalProperties: new Dictionary<string, string>
+            {
+                [PropertyNames.IntermediateOutputPath] = input,
+                [PropertyNames.TargetPath] = input
+            },
             toolsVersion: "Current"
         );
-        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expected), projectInstance.GetIntermediateOutputDirectory());
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expectedIntermediatePath), projectInstance.GetIntermediateOutputDirectory());
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expectedOutputPath), projectInstance.GetOutputDirectory());
     }
 
     [TestMethod]
-    [DataRow("foo", "")]
-    [DataRow(@"foo\", @"foo")]
-    [DataRow(@"foo/", @"foo")]
-    [DataRow(@"foo\bar", @"foo")]
-    [DataRow(@"foo/bar", @"foo")]
-    [DataRow(@"foo\bar\", @"foo/bar")]
-    [DataRow(@"foo/bar\", @"foo/bar")]
-    [DataRow(@"foo/bar/", @"foo/bar")]
-    [DataRow(@"foo\bar/", @"foo/bar")]
-    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
-    public void NormalizeSeparatorsInOutputDirectory(string input, string expected)
+    [DataRow(@"a\b/c", @"a\b/c", @"a\b")]
+    [DataRow(@"a\b/c/", @"a\b/c/", @"a\b/c")]
+    [OSCondition(OperatingSystems.Linux)]
+    public void ShouldNotNormalizeSeparatorsInWindows(string input, string expectedIntermediatePath, string expectedOutputPath)
     {
-
         var project = new TestProject("A");
         var testAsset = TestAssets.CreateTestProject(project);
         var projectPath = Path.Combine(testAsset.TestRoot, "A", "A.csproj");
 
         var projectInstance = new ProjectInstance(
             projectFile: projectPath,
-            globalProperties: new Dictionary<string, string> { [PropertyNames.TargetPath] = input },
+            globalProperties: new Dictionary<string, string>
+            {
+                [PropertyNames.IntermediateOutputPath] = input,
+                [PropertyNames.TargetPath] = input
+            },
             toolsVersion: "Current"
         );
-        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expected), projectInstance.GetOutputDirectory());
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expectedIntermediatePath), projectInstance.GetIntermediateOutputDirectory());
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expectedOutputPath), projectInstance.GetOutputDirectory());
     }
 
     [TestMethod]
     [DataRow(
         @"bin\Debug//**;bin\/**;bin\Debug/linux-x64/publish//**;**/*.user",
         new string[] {
-        "bin\\Debug//**",
-        "bin\\/**",
-        "bin\\Debug/linux-x64/publish//**",
-        "**/*.user",
+        @"bin\Debug//**",
+        @"bin\/**",
+        @"bin\Debug/linux-x64/publish//**",
+        @"**/*.user",
     })]
     public void DefaultItemExcludesDontNeedNormalization(string input, string[] expected)
     {

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -1,14 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
+using Microsoft.Build.Execution;
+using Microsoft.Build.Graph;
+
 namespace Microsoft.DotNet.Watch.UnitTests.Build;
 
 [TestClass]
 public class ProjectGraphUtilitiesTests
 {
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper Output => field ??= new(new TestContextOutputHelper(TestContext));
+    private TestAssetsManager TestAssets => field ??= new(Output);
+
     [TestMethod]
-    [DataRow("", "")]
-    [DataRow(@"\", "/")]
     [DataRow(@"foo\", @"foo/")]
     [DataRow(@"foo\bar", @"foo/bar")]
     [DataRow(@"foo/bar", @"foo/bar")]
@@ -17,10 +24,64 @@ public class ProjectGraphUtilitiesTests
     [DataRow(@"foo/bar/", @"foo/bar/")]
     [DataRow(@"foo\bar/", @"foo/bar/")]
     [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
-    public void GetDirectoryWithTrailingSlash(string input, string expected)
+    public void NormalizeSeparatorsInIntermediateOutputDirectory(string input, string expected)
     {
-        var normalized = ProjectGraphUtilities.NormalizeSeparators(input);
-        Assert.AreEqual(expected, normalized);
+
+        var project = new TestProject("A");
+        var testAsset = TestAssets.CreateTestProject(project);
+        var projectPath = Path.Combine(testAsset.TestRoot, "A", "A.csproj");
+
+        var projectInstance = new ProjectInstance(
+            projectFile: projectPath,
+            globalProperties: new Dictionary<string, string> { [PropertyNames.IntermediateOutputPath] = input },
+            toolsVersion: "Current"
+        );
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expected), projectInstance.GetIntermediateOutputDirectory());
+    }
+
+    [TestMethod]
+    [DataRow("foo", "")]
+    [DataRow(@"foo\", @"foo")]
+    [DataRow(@"foo/", @"foo")]
+    [DataRow(@"foo\bar", @"foo")]
+    [DataRow(@"foo/bar", @"foo")]
+    [DataRow(@"foo\bar\", @"foo/bar")]
+    [DataRow(@"foo/bar\", @"foo/bar")]
+    [DataRow(@"foo/bar/", @"foo/bar")]
+    [DataRow(@"foo\bar/", @"foo/bar")]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void NormalizeSeparatorsInOutputDirectory(string input, string expected)
+    {
+
+        var project = new TestProject("A");
+        var testAsset = TestAssets.CreateTestProject(project);
+        var projectPath = Path.Combine(testAsset.TestRoot, "A", "A.csproj");
+
+        var projectInstance = new ProjectInstance(
+            projectFile: projectPath,
+            globalProperties: new Dictionary<string, string> { [PropertyNames.TargetPath] = input },
+            toolsVersion: "Current"
+        );
+        Assert.AreEqual(Path.Combine(testAsset.TestRoot, "A", expected), projectInstance.GetOutputDirectory());
+    }
+
+    [TestMethod]
+    [DataRow(
+        @"bin\Debug//**;bin\/**;bin\Debug/linux-x64/publish//**;**/*.user",
+        new string[] {
+        "bin\\Debug//**",
+        "bin\\/**",
+        "bin\\Debug/linux-x64/publish//**",
+        "**/*.user",
+    })]
+    public void DefaultItemExcludesDontNeedNormalization(string input, string[] expected)
+    {
+
+        var project = new TestProject("A");
+        var testAsset = TestAssets.CreateTestProject(project);
+        var projectPath = Path.Combine(testAsset.TestRoot, "A", "A.csproj");
+
+        var graph = new ProjectGraph(projectPath, new Dictionary<string, string> { [PropertyNames.DefaultItemExcludes] = input });
+        Assert.AreSequenceEqual(expected, graph.ProjectNodes.First().GetDefaultItemExcludes());
     }
 }
-

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Watch.UnitTests.Build;
+
+[TestClass]
+public class ProjectGraphUtilitiesTests
+{
+    [TestMethod]
+    [DataRow("", "")]
+    [DataRow(@"\", "/")]
+    [DataRow(@"foo\", @"foo/")]
+    [DataRow(@"foo\bar", @"foo/bar")]
+    [DataRow(@"foo/bar", @"foo/bar")]
+    [DataRow(@"foo\bar\", @"foo/bar/")]
+    [DataRow(@"foo/bar\", @"foo/bar/")]
+    [DataRow(@"foo/bar/", @"foo/bar/")]
+    [DataRow(@"foo\bar/", @"foo/bar/")]
+    public void GetDirectoryWithTrailingSlash(string input, string expected)
+    {
+        var normalized = ProjectGraphUtilities.NormalizeSeparators(input);
+        Assert.AreEqual(expected, normalized);
+    }
+}
+

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -41,7 +41,7 @@ public class ProjectGraphUtilitiesTests
     [TestMethod]
     [DataRow(@"a\b/c", @"a\b/c", @"a\b")]
     [DataRow(@"a\b/c/", @"a\b/c/", @"a\b/c")]
-    [OSCondition(OperatingSystems.Linux)]
+    [OSCondition(OperatingSystems.Windows)]
     public void ShouldNotNormalizeSeparatorsInWindows(string input, string expectedIntermediatePath, string expectedOutputPath)
     {
         var project = new TestProject("A");

--- a/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphUtilitiesTests.cs
@@ -16,6 +16,7 @@ public class ProjectGraphUtilitiesTests
     [DataRow(@"foo/bar\", @"foo/bar/")]
     [DataRow(@"foo/bar/", @"foo/bar/")]
     [DataRow(@"foo\bar/", @"foo/bar/")]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
     public void GetDirectoryWithTrailingSlash(string input, string expected)
     {
         var normalized = ProjectGraphUtilities.NormalizeSeparators(input);


### PR DESCRIPTION
Fixes #54309

Path returned by `ProjectGraphUtilities.GetIntermediateOutputDirectory` contains forward slashes, this PR normalizes them in Linux | FreeBsd | Osx platforms, so that `dotnet-watch` can point properly to `staticwebassets.development.json` in machines that use POSIX paths.

Maybe something like in this commit https://github.com/dotnet/msbuild/pull/13222/changes/cbb63e2628bf2e25a8592a0e8e0c05d3b20b58cb from https://github.com/dotnet/msbuild/pull/13222  should be done here? 