### PR TITLE
Produce standalone TemplateLocator package in pass 2

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -4,13 +4,14 @@
     <ProjectToBuild Include="$(RepoRoot)source-build.slnf" />
   </ItemGroup>
 
-  <!-- For product build, build MSBuildExtensions and VSTemplateLocator in the second build pass on win-x64 as
+  <!-- For product build, build MSBuildExtensions, TemplateLocator, and VSTemplateLocator in the second build pass on win-x64 as
        they depend on assets from other verticals that are built in the first build pass. -->
   <ItemGroup Condition="'$(DotNetBuildPass)' == '2' and
                         '$(TargetOS)' == 'windows' and
                         '$(TargetArchitecture)' == 'x64' and
                         '$(BuildWorkloads)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions\VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.proj" DotNetBuildPass="2" />
+    <ProjectToBuild Include="$(RepoRoot)src\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" DotNetBuildPass="2" />
     <ProjectToBuild Include="$(RepoRoot)src\Layout\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.proj" DotNetBuildPass="2" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -8,6 +8,7 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <IsPackable>true</IsPackable>
     <IsPackable Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">false</IsPackable>
+    <PackageId>microsoft.dotnet.templateLocator</PackageId>
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     <!-- https://github.com/dotnet/sdk/issues/14801 -->

--- a/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
+++ b/src/Microsoft.DotNet.TemplateLocator/Microsoft.DotNet.TemplateLocator.csproj
@@ -8,7 +8,6 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <IsPackable>true</IsPackable>
     <IsPackable Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">false</IsPackable>
-    <PackageId>microsoft.dotnet.templateLocator</PackageId>
     <!-- Create FileDefinitions items for ResolveHostfxrCopyLocalContent target -->
     <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
     <!-- https://github.com/dotnet/sdk/issues/14801 -->


### PR DESCRIPTION
## Summary

Schedule `Microsoft.DotNet.TemplateLocator` as a top-level pass-2 project in product builds so the standalone TemplateLocator NuGet package is produced alongside the VS redist layout package.

## Motivation

`Microsoft.DotNet.TemplateLocator.csproj` is packable only during `DotNetBuildPass=2`, but it was only being built as a dependency of the VS redist layout project. That produced `VS.Redist.Common.Net.Core.SDK.VSTemplateLocator`, but did not produce the standalone TemplateLocator package.

## Validation

Validated on Windows x64 with a pass-2 product-style pack:

```cmd
build.cmd -pack /p:DotNetBuild=true /p:DotNetBuildPass=2 /p:TargetOS=windows /p:TargetArchitecture=x64
```

Confirmed both packages are produced:

- `artifacts\packages\Debug\NonShipping\Microsoft.DotNet.TemplateLocator.11.0.100-dev.nupkg`
- `artifacts\packages\Debug\NonShipping\VS.Redist.Common.Net.Core.SDK.VSTemplateLocator.11.0.100-dev.nupkg`

Also ran the local publish/manifest phase before the latest cleanup and confirmed the generated asset manifest contains TemplateLocator as a `<Package>` asset, not only the VS redist package.