### PR TITLE
Fix parallel-build race when packing ApiCompat.Task / GenAPI.Task test packages

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -69,4 +69,20 @@
 
   <Import Project="..\Microsoft.DotNet.ApiCompat.Shared\Microsoft.DotNet.ApiCompat.Shared.projitems" Label="Shared" />
 
+  <!-- Copy the nupkg to TestPackagesDir so the Compatibility integration tests can consume it.
+       This replaces the BuildTestPackages.targets entry that re-packed this project with different
+       global properties, which caused a parallel-build race condition on referenced projects' obj/
+       output DLLs (e.g. Microsoft.DotNet.ApiCompatibility.resources.dll). This project is single-TFM,
+       so the TargetFrameworks=='' guard ensures the copy runs once. -->
+  <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
+          Condition="'$(TestLayoutDir)' != '' and '$(DotNetBuild)' != 'true' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
+    <PropertyGroup>
+      <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(_TestPackagesDir)" Condition="!Exists('$(_TestPackagesDir)')" />
+    <Copy SourceFiles="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg"
+          DestinationFolder="$(_TestPackagesDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -45,4 +45,20 @@
     </ItemGroup>
   </Target>
 
+  <!-- Copy the nupkg to TestPackagesDir so the Compatibility integration tests can consume it.
+       This replaces the BuildTestPackages.targets entry that re-packed this project with different
+       global properties, which caused a parallel-build race condition on referenced projects' obj/
+       output DLLs (e.g. Microsoft.DotNet.ApiCompatibility.resources.dll). This project is single-TFM,
+       so the TargetFrameworks=='' guard ensures the copy runs once. -->
+  <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
+          Condition="'$(TestLayoutDir)' != '' and '$(DotNetBuild)' != 'true' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
+    <PropertyGroup>
+      <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(_TestPackagesDir)" Condition="!Exists('$(_TestPackagesDir)')" />
+    <Copy SourceFiles="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg"
+          DestinationFolder="$(_TestPackagesDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -159,21 +159,13 @@
         <ProjectName>Microsoft.Net.Sdk.Compilers.Toolset.csproj</ProjectName>
         <Version>$(Version)</Version>
       </BaseTestPackageProject>
-      <!-- Microsoft.TemplateEngine.Authoring.Tasks and Microsoft.TemplateSearch.TemplateDiscovery
-           are excluded here because they are already packed elsewhere. Packing them again with
-           different global properties (PackageOutputPath, Version) causes a parallel-build
-           race condition on referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll).
-           Both projects copy their nupkg to TestPackagesDir themselves. -->
-      <BaseTestPackageProject Include="src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task">
-        <Name>Microsoft.DotNet.ApiCompat.Task</Name>
-        <ProjectName>Microsoft.DotNet.ApiCompat.Task.csproj</ProjectName>
-        <Version>$(Version)</Version>
-      </BaseTestPackageProject>
-      <BaseTestPackageProject Include="src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task">
-        <Name>Microsoft.DotNet.GenAPI.Task</Name>
-        <ProjectName>Microsoft.DotNet.GenAPI.Task.csproj</ProjectName>
-        <Version>$(Version)</Version>
-      </BaseTestPackageProject>
+      <!-- Microsoft.TemplateEngine.Authoring.Tasks, Microsoft.TemplateSearch.TemplateDiscovery,
+           Microsoft.DotNet.ApiCompat.Task, and Microsoft.DotNet.GenAPI.Task are excluded here
+           because they are already packed elsewhere. Packing them again with different global
+           properties (PackageOutputPath, Version) causes a parallel-build race condition on
+           referenced projects' obj/ output DLLs (e.g. RunnableProjects.dll,
+           Microsoft.DotNet.ApiCompatibility.resources.dll). Each project copies its own nupkg to
+           TestPackagesDir via a CopyPackageToTestPackagesDir target (AfterTargets=Pack). -->
 
       <BaseTestPackageProject>
         <NuPkgName Condition=" '%(NuPkgName)' == '' ">%(Name)</NuPkgName>


### PR DESCRIPTION
Same fix as #54380, this time for ApiCompat and GenAPI.

This was failing in #54410, locally, and probably in other PRs.