### PR TITLE
[clr-ios] Pass references hidden from the composite to crossgen2 when building a partial composite

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/PrepareForReadyToRunCompilation.cs
@@ -158,7 +158,7 @@ namespace Microsoft.NET.Build.Tasks
                 if (eligibility.IsReference)
                     r2rReferenceList.Add(file);
 
-                if (eligibility.IsReference && !eligibility.ReferenceHiddenFromCompositeBuild && !eligibility.Compile)
+                if (eligibility.IsReference && !eligibility.Compile)
                     r2rCompositeReferenceList.Add(file);
 
                 if (!eligibility.Compile)


### PR DESCRIPTION
## Description
When publishing a composite R2R image that covers only a subset of the BCL (e.g. only `System.Private.CoreLib`, with the rest excluded via `PublishReadyToRunExclude`), `PrepareForReadyToRunCompilation` flags the excluded assemblies as `HideReferenceFromComposite` and drops them from `ReadyToRunCompositeBuildReferences`, so crossgen2 receives no `-r` references and CoreCLR rejects the resulting image at startup.

This will be validated in dotnet/macios@44b767cf66 (PR dotnet/macios#25583).