### PR TITLE
Add dotnet sdk add and dotnet sdk remove commands

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -268,7 +268,7 @@ The default is 'false.' However, when targeting .NET 7 or lower, the default is 
     <value>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</value>
   </data>
   <data name="SdkIdentityArgumentIdIsNull" xml:space="preserve">
-    <value>SDK reference name must not be null.</value>
+    <value>SDK reference name must not be null or empty.</value>
   </data>
   <data name="SdkIdentityArgumentVersionIsEmpty" xml:space="preserve">
     <value>SDK version must not be empty when specified using the '@' separator.</value>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -264,6 +264,15 @@ The default is 'false.' However, when targeting .NET 7 or lower, the default is 
   <data name="PackageIdentityArgumentDescription" xml:space="preserve">
     <value>Package reference in the form of a package identifier like '{0}' or package identifier and version separated by '@' like '{0}@{1}'.</value>
   </data>
+  <data name="SdkIdentityArgumentDescription" xml:space="preserve">
+    <value>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</value>
+  </data>
+  <data name="SdkIdentityArgumentIdIsNull" xml:space="preserve">
+    <value>SDK reference name must not be null.</value>
+  </data>
+  <data name="SdkIdentityArgumentVersionIsEmpty" xml:space="preserve">
+    <value>SDK version must not be empty when specified using the '@' separator.</value>
+  </data>
   <data name="PackageIdentityArgumentIdOrVersionIsNull" xml:space="preserve">
     <value>Package reference id and version must not be null.</value>
   </data>
@@ -514,6 +523,9 @@ This is equivalent to deleting project.assets.json.</value>
   </data>
   <data name="CmdPackage" xml:space="preserve">
     <value>PACKAGE_NAME</value>
+  </data>
+  <data name="CmdSdk" xml:space="preserve">
+    <value>SDK_NAME</value>
   </data>
   <data name="CmdPackageDirectory" xml:space="preserve">
     <value>PACKAGE_DIR</value>
@@ -867,6 +879,18 @@ If not specified the file will be generated inside the default 'TestResults' dir
   </data>
   <data name="PackageRemoveAppHelpText" xml:space="preserve">
     <value>The package reference to remove.</value>
+  </data>
+  <data name="SdkAddAppFullName" xml:space="preserve">
+    <value>Add an SDK reference to the project.</value>
+  </data>
+  <data name="SdkAddCmdNoRestoreDescription" xml:space="preserve">
+    <value>Add the SDK reference without running restore.</value>
+  </data>
+  <data name="SdkRemoveAppFullName" xml:space="preserve">
+    <value>Remove an SDK reference from the project.</value>
+  </data>
+  <data name="SdkRemoveAppHelpText" xml:space="preserve">
+    <value>The SDK reference to remove.</value>
   </data>
   <data name="PackageSearchCommandDescription" xml:space="preserve">
     <value>Searches one or more package sources for packages that match a search term. If no sources are specified, all sources defined in the NuGet.Config are used.</value>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Add/AddCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Add/AddCommandDefinition.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add.Package;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add.Reference;
+using Microsoft.DotNet.Cli.Commands.Hidden.Add.Sdk;
 using Microsoft.DotNet.Cli.Commands.Package;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.Add;
@@ -16,6 +17,7 @@ internal sealed class AddCommandDefinition : Command
 
     public readonly AddPackageCommandDefinition PackageCommand = new();
     public readonly AddReferenceCommandDefinition ReferenceCommand = new();
+    public readonly AddSdkCommandDefinition SdkCommand = new();
 
     public readonly Argument<string> ProjectOrFileArgument = PackageCommandDefinition.CreateProjectOrFileArgument();
 
@@ -28,5 +30,6 @@ internal sealed class AddCommandDefinition : Command
         Arguments.Add(ProjectOrFileArgument);
         Subcommands.Add(PackageCommand);
         Subcommands.Add(ReferenceCommand);
+        Subcommands.Add(SdkCommand);
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Add/Sdk/AddSdkCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Add/Sdk/AddSdkCommandDefinition.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Sdk.Add;
+
+namespace Microsoft.DotNet.Cli.Commands.Hidden.Add.Sdk;
+
+internal sealed class AddSdkCommandDefinition() : SdkAddCommandDefinitionBase(Name)
+{
+    public new const string Name = "sdk";
+
+    public AddCommandDefinition Parent => (AddCommandDefinition)Parents.Single();
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => Parent.ProjectOrFileArgument;
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/RemoveCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/RemoveCommandDefinition.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Hidden.Remove.Package;
 using Microsoft.DotNet.Cli.Commands.Hidden.Remove.Reference;
+using Microsoft.DotNet.Cli.Commands.Hidden.Remove.Sdk;
 using Microsoft.DotNet.Cli.Commands.Package;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.Remove;
@@ -19,6 +20,7 @@ internal sealed class RemoveCommandDefinition : Command
 
     public readonly RemovePackageCommandDefinition PackageCommand = new();
     public readonly RemoveReferenceCommandDefinition ReferenceCommand = new();
+    public readonly RemoveSdkCommandDefinition SdkCommand = new();
 
     public RemoveCommandDefinition()
         : base(Name, CommandDefinitionStrings.NetRemoveCommand)
@@ -29,5 +31,6 @@ internal sealed class RemoveCommandDefinition : Command
         Arguments.Add(ProjectOrFileArgument);
         Subcommands.Add(PackageCommand);
         Subcommands.Add(ReferenceCommand);
+        Subcommands.Add(SdkCommand);
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/Sdk/RemoveSdkCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Hidden/Remove/Sdk/RemoveSdkCommandDefinition.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Sdk.Remove;
+
+namespace Microsoft.DotNet.Cli.Commands.Hidden.Remove.Sdk;
+
+internal sealed class RemoveSdkCommandDefinition() : SdkRemoveCommandDefinitionBase(Name)
+{
+    public new const string Name = "sdk";
+
+    public RemoveCommandDefinition Parent => (RemoveCommandDefinition)Parents.Single();
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => Parent.ProjectOrFileArgument;
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Package;
+
+namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
+
+public class SdkAddCommandDefinition() : SdkAddCommandDefinitionBase(Name)
+{
+    public new const string Name = "add";
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => null;
+}
+
+public abstract class SdkAddCommandDefinitionBase : Command
+{
+    public static Option<string> CreateVersionOption() => new Option<string>("--version", "-v")
+    {
+        Description = CommandDefinitionStrings.CmdVersionDescription,
+        HelpName = CommandDefinitionStrings.CmdVersion,
+    };
+
+    public static Option<bool> CreateNoRestoreOption() => new("--no-restore", "-n")
+    {
+        Description = CommandDefinitionStrings.SdkAddCmdNoRestoreDescription,
+        Arity = ArgumentArity.Zero
+    };
+
+    public static Option<bool> CreateInteractiveOption() => CommonOptions.CreateInteractiveOption().ForwardIfEnabled("--interactive");
+
+    public readonly Argument<SdkReferenceIdentity> SdkIdArgument = CommonArguments.CreateRequiredSdkReferenceIdentityArgument();
+    public readonly Option<string> VersionOption = CreateVersionOption();
+    public readonly Option<bool> NoRestoreOption = CreateNoRestoreOption();
+    public readonly Option<bool> InteractiveOption = CreateInteractiveOption();
+    public readonly Option<string?> ProjectOption = PackageCommandDefinition.CreateProjectOption();
+    public readonly Option<string?> FileOption = PackageCommandDefinition.CreateFileOption();
+
+    public SdkAddCommandDefinitionBase(string name)
+        : base(name, CommandDefinitionStrings.SdkAddAppFullName)
+    {
+        VersionOption.Validators.Add(result =>
+        {
+            if (result.Parent?.GetValue(SdkIdArgument).HasVersion == true)
+            {
+                result.AddError(CommandDefinitionStrings.ValidationFailedDuplicateVersion);
+            }
+        });
+
+        Arguments.Add(SdkIdArgument);
+
+        Options.Add(VersionOption);
+        Options.Add(NoRestoreOption);
+        Options.Add(InteractiveOption);
+        Options.Add(ProjectOption);
+        Options.Add(FileOption);
+    }
+
+    public abstract Argument<string>? GetProjectOrFileArgument();
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
@@ -17,7 +17,7 @@ internal sealed class SdkAddCommandDefinition() : SdkAddCommandDefinitionBase(Na
 
 internal abstract class SdkAddCommandDefinitionBase : Command
 {
-    public static Option<string> CreateVersionOption() => new Option<string>("--version", "-v")
+    public static Option<string?> CreateVersionOption() => new Option<string?>("--version", "-v")
     {
         Description = CommandDefinitionStrings.CmdVersionDescription,
         HelpName = CommandDefinitionStrings.CmdVersion,
@@ -32,7 +32,7 @@ internal abstract class SdkAddCommandDefinitionBase : Command
     public static Option<bool> CreateInteractiveOption() => CommonOptions.CreateInteractiveOption().ForwardIfEnabled("--interactive");
 
     public readonly Argument<SdkReferenceIdentity> SdkIdArgument = CommonArguments.CreateRequiredSdkReferenceIdentityArgument();
-    public readonly Option<string> VersionOption = CreateVersionOption();
+    public readonly Option<string?> VersionOption = CreateVersionOption();
     public readonly Option<bool> NoRestoreOption = CreateNoRestoreOption();
     public readonly Option<bool> InteractiveOption = CreateInteractiveOption();
     public readonly Option<string?> ProjectOption = PackageCommandDefinition.CreateProjectOption();

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkAddCommandDefinition.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.Cli.Commands.Package;
 
 namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
 
-public class SdkAddCommandDefinition() : SdkAddCommandDefinitionBase(Name)
+internal sealed class SdkAddCommandDefinition() : SdkAddCommandDefinitionBase(Name)
 {
     public new const string Name = "add";
 
@@ -15,7 +15,7 @@ public class SdkAddCommandDefinition() : SdkAddCommandDefinitionBase(Name)
         => null;
 }
 
-public abstract class SdkAddCommandDefinitionBase : Command
+internal abstract class SdkAddCommandDefinitionBase : Command
 {
     public static Option<string> CreateVersionOption() => new Option<string>("--version", "-v")
     {

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkCommandDefinition.cs
@@ -3,7 +3,9 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Sdk.Add;
 using Microsoft.DotNet.Cli.Commands.Sdk.Check;
+using Microsoft.DotNet.Cli.Commands.Sdk.Remove;
 
 namespace Microsoft.DotNet.Cli.Commands.Sdk;
 
@@ -12,11 +14,15 @@ internal sealed class SdkCommandDefinition : Command
     private const string Link = "https://aka.ms/dotnet-sdk";
 
     public readonly SdkCheckCommandDefinition CheckCommand = new();
+    public readonly SdkAddCommandDefinition AddCommand = new();
+    public readonly SdkRemoveCommandDefinition RemoveCommand = new();
 
     public SdkCommandDefinition()
         : base("sdk", CommandDefinitionStrings.SdkAppFullName)
     {
         this.DocsLink = Link;
         Subcommands.Add(CheckCommand);
+        Subcommands.Add(AddCommand);
+        Subcommands.Add(RemoveCommand);
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkRemoveCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkRemoveCommandDefinition.cs
@@ -17,9 +17,10 @@ internal sealed class SdkRemoveCommandDefinition() : SdkRemoveCommandDefinitionB
 
 internal abstract class SdkRemoveCommandDefinitionBase : Command
 {
-    public readonly Argument<string[]> SdkIdArgument = new(CommandDefinitionStrings.CmdSdk)
+    public readonly Argument<string[]> SdkIdArgument = new(CommonArguments.SdkIdArgumentName)
     {
         Description = CommandDefinitionStrings.SdkRemoveAppHelpText,
+        HelpName = CommandDefinitionStrings.CmdSdk,
         Arity = ArgumentArity.OneOrMore,
     };
 

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkRemoveCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Sdk/SdkRemoveCommandDefinition.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Package;
+
+namespace Microsoft.DotNet.Cli.Commands.Sdk.Remove;
+
+internal sealed class SdkRemoveCommandDefinition() : SdkRemoveCommandDefinitionBase(Name)
+{
+    public new const string Name = "remove";
+
+    public override Argument<string>? GetProjectOrFileArgument()
+        => null;
+}
+
+internal abstract class SdkRemoveCommandDefinitionBase : Command
+{
+    public readonly Argument<string[]> SdkIdArgument = new(CommandDefinitionStrings.CmdSdk)
+    {
+        Description = CommandDefinitionStrings.SdkRemoveAppHelpText,
+        Arity = ArgumentArity.OneOrMore,
+    };
+
+    public readonly Option<bool> InteractiveOption = CommonOptions.CreateInteractiveOption().ForwardIfEnabled("--interactive");
+    public readonly Option<string?> ProjectOption = PackageCommandDefinition.CreateProjectOption();
+    public readonly Option<string?> FileOption = PackageCommandDefinition.CreateFileOption();
+
+    public SdkRemoveCommandDefinitionBase(string name)
+        : base(name, CommandDefinitionStrings.SdkRemoveAppFullName)
+    {
+        Arguments.Add(SdkIdArgument);
+        Options.Add(InteractiveOption);
+        Options.Add(ProjectOption);
+        Options.Add(FileOption);
+    }
+
+    public abstract Argument<string>? GetProjectOrFileArgument();
+}

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
@@ -81,6 +81,17 @@ namespace Microsoft.DotNet.Cli
                 IsDynamic = true
             };
 
+        public static string GetSdkIdFromIdentityArgument(string sdkIdentity)
+        {
+            SdkReferenceIdentity? identity = ParseSdkReferenceIdentity(sdkIdentity);
+            if (identity is null)
+            {
+                throw new GracefulException(CommandDefinitionStrings.SdkIdentityArgumentIdIsNull);
+            }
+
+            return identity.Value.Id;
+        }
+
         private static SdkReferenceIdentity? ParseSdkReferenceIdentity(string? sdkIdentity, char versionSeparator = '@')
         {
             if (string.IsNullOrEmpty(sdkIdentity))

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
@@ -58,11 +58,58 @@ namespace Microsoft.DotNet.Cli
 
             return new PackageIdentityWithRange(packageId, versionRange);
         }
+
+        public const string SdkIdArgumentName = "sdkId";
+
+        public static Argument<SdkReferenceIdentity> CreateRequiredSdkReferenceIdentityArgument(
+            string exampleSdk = "Cake.Sdk",
+            string exampleVersion = "6.2.0") =>
+            new(SdkIdArgumentName)
+            {
+                Description = string.Format(CommandDefinitionStrings.SdkIdentityArgumentDescription, exampleSdk, exampleVersion),
+                CustomParser = argumentResult => ParseSdkReferenceIdentity(argumentResult.Tokens[0]?.Value)!.Value,
+                Arity = ArgumentArity.ExactlyOne,
+                IsDynamic = true
+            };
+
+        private static SdkReferenceIdentity? ParseSdkReferenceIdentity(string? sdkIdentity, char versionSeparator = '@')
+        {
+            if (string.IsNullOrEmpty(sdkIdentity))
+            {
+                return null;
+            }
+
+            string[] splitSdkIdentity = sdkIdentity.Split(versionSeparator);
+            var sdkId = splitSdkIdentity.ElementAtOrDefault(0);
+            var version = splitSdkIdentity.ElementAtOrDefault(1);
+
+            if (string.IsNullOrEmpty(sdkId))
+            {
+                throw new GracefulException(CommandDefinitionStrings.SdkIdentityArgumentIdIsNull);
+            }
+
+            if (splitSdkIdentity.Length > 2)
+            {
+                version = string.Join(versionSeparator, splitSdkIdentity.Skip(1));
+            }
+
+            if (sdkIdentity.Contains(versionSeparator) && string.IsNullOrWhiteSpace(version))
+            {
+                throw new GracefulException(CommandDefinitionStrings.SdkIdentityArgumentVersionIsEmpty);
+            }
+
+            return new SdkReferenceIdentity(sdkId, string.IsNullOrEmpty(version) ? null : version);
+        }
     }
 
     public readonly record struct PackageIdentityWithRange(string Id, VersionRange? VersionRange)
     {
         [MemberNotNullWhen(returnValue: true, nameof(VersionRange))]
         public bool HasVersion => VersionRange != null;
+    }
+
+    public readonly record struct SdkReferenceIdentity(string Id, string? Version)
+    {
+        public bool HasVersion => Version != null;
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
@@ -67,7 +67,16 @@ namespace Microsoft.DotNet.Cli
             new(SdkIdArgumentName)
             {
                 Description = string.Format(CommandDefinitionStrings.SdkIdentityArgumentDescription, exampleSdk, exampleVersion),
-                CustomParser = argumentResult => ParseSdkReferenceIdentity(argumentResult.Tokens[0]?.Value)!.Value,
+                CustomParser = argumentResult =>
+                {
+                    SdkReferenceIdentity? identity = ParseSdkReferenceIdentity(argumentResult.Tokens[0]?.Value);
+                    if (identity is null)
+                    {
+                        throw new GracefulException(CommandDefinitionStrings.SdkIdentityArgumentIdIsNull);
+                    }
+
+                    return identity.Value;
+                },
                 Arity = ArgumentArity.ExactlyOne,
                 IsDynamic = true
             };

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonArguments.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli
                 Description = string.Format(CommandDefinitionStrings.SdkIdentityArgumentDescription, exampleSdk, exampleVersion),
                 CustomParser = argumentResult =>
                 {
-                    SdkReferenceIdentity? identity = ParseSdkReferenceIdentity(argumentResult.Tokens[0]?.Value);
+                    SdkReferenceIdentity? identity = ParseSdkReferenceIdentity(argumentResult.Tokens.FirstOrDefault()?.Value);
                     if (identity is null)
                     {
                         throw new GracefulException(CommandDefinitionStrings.SdkIdentityArgumentIdIsNull);

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -576,6 +576,11 @@ Pokud zadaný adresář neexistuje, bude vytvořen.</target>
         <target state="translated">Cílový modul runtime pro obnovení balíčků</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Nastaví v balíčku příznak obsluhovatelnosti. Další informace najdete na adrese https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <target state="translated">Zobrazí schéma příkazu jako JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Příkaz sady .NET SDK</target>
@@ -1744,6 +1759,31 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Příkaz kontroly sady .NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -576,6 +576,11 @@ Das angegebene Verzeichnis wird erstellt, wenn es nicht vorhanden ist.</target>
         <target state="translated">Die Zielruntime für die Wiederherstellung von Paketen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Hiermit wird das Verarbeitungsflag im Paket festgelegt. Weitere Informationen finden Sie unter https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <target state="translated">Das Befehlsschema als JSON anzeigen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK-Befehl</target>
@@ -1744,6 +1759,31 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Befehl zur .NET SDK-Überprüfung</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -576,6 +576,11 @@ Si no existe, se creará el directorio especificado.</target>
         <target state="translated">El tiempo de ejecución de destino para el que se restauran los paquetes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Establece la marca serviceable en el paquete. Para obtener más información, consulte https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <target state="translated">Muestre el esquema de comandos como JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Comando del SDK de .NET</target>
@@ -1744,6 +1759,31 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Comando de comprobación del SDK de .NET</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -576,6 +576,11 @@ Le répertoire spécifié est créé, s'il n'existe pas déjà.</target>
         <target state="translated">Runtime cible pour lequel la restauration des packages est effectuée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Définissez l'indicateur de maintenance dans le package. Pour plus d'informations, consultez https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <target state="translated">Affichez le schéma de commande au format JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Commande du kit SDK .NET</target>
@@ -1744,6 +1759,31 @@ La valeur par défaut est de publier une application dépendante du framework.</
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Commande de vérification du kit SDK .NET</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -576,6 +576,11 @@ Se non esiste, la directory specificata verrà creata.</target>
         <target state="translated">Runtime di destinazione per cui ripristinare i pacchetti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Imposta il flag serviceable nel pacchetto. Per altre informazioni, vedere https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <target state="translated">Visualizza lo schema del comando in formato JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Comando SDK .NET</target>
@@ -1744,6 +1759,31 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Comando per controllo disponibilità .NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -576,6 +576,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">パッケージを復元するターゲット ランタイム。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">パッケージに処理可能なフラグを設定します。詳細については、https://aka.ms/nupkgservicing をご覧ください。</target>
@@ -1736,6 +1741,16 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">コマンド スキーマを JSON として表示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK コマンド</target>
@@ -1744,6 +1759,31 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">.NET SDK のチェック コマンド</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -576,6 +576,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">패키지를 복원할 대상 런타임입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">패키지에서 서비스 가능 플래그를 설정합니다. 자세한 내용은 https://aka.ms/nupkgservicing을 참조하세요.</target>
@@ -1736,6 +1741,16 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">명령 스키마를 JSON으로 표시합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK 명령</target>
@@ -1744,6 +1759,31 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">.NET SDK 확인 명령</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -576,6 +576,11 @@ Jeśli określony katalog nie istnieje, zostanie utworzony.</target>
         <target state="translated">Docelowe środowisko uruchomieniowe, dla którego mają zostać przywrócone pakiety.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Ustaw w pakiecie flagę oznaczającą możliwość serwisowania. Aby uzyskać więcej informacji, zobacz https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <target state="translated">Wyświetl schemat polecenia jako kod JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Polecenie zestawu .NET SDK</target>
@@ -1744,6 +1759,31 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Polecenie sprawdzania zestawu .NET SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -576,6 +576,11 @@ O diretório especificado será criado se ele ainda não existir.</target>
         <target state="translated">O runtime de destino no qual os pacotes serão restaurados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Definir o sinalizador operacional no pacote. Para obter mais informações, confira https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <target state="translated">Exibir o esquema do comando em JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Comando do SDK do .NET</target>
@@ -1744,6 +1759,31 @@ O padrão é publicar uma aplicação dependente de framework.</target>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Comando de Verificação do SDK do .NET</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -576,6 +576,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">Целевая среда выполнения для восстановления пакетов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Задание для пакета флага "подлежит обслуживанию". Дополнительные сведения: https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">Отобразить схему команды в формате JSON.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">Команда .NET SDK</target>
@@ -1744,6 +1759,31 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">Команда проверки пакета SDK для .NET</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -576,6 +576,11 @@ Belirtilen dizin yoksa oluşturulur.</target>
         <target state="translated">Paketlerin geri yükleneceği hedef çalışma zamanı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">Pakette serviceable bayrağını ayarlar. Daha fazla bilgi için bkz. https://aka.ms/nupkgservicing.</target>
@@ -1736,6 +1741,16 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <target state="translated">Komut şemasını JSON formatında görüntüle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK Komutu</target>
@@ -1744,6 +1759,31 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">.NET SDK Denetim Komutu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -576,6 +576,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">要还原包的目标运行时。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">在包中设置可用标志。有关详细信息，请参阅 https://aka.ms/nupkgservicing。</target>
@@ -1736,6 +1741,16 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">将命令架构显示为 JSON。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK 命令</target>
@@ -1744,6 +1759,31 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">.NET SDK 检查命令</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CommandDefinitionStrings.resx">
     <body>
@@ -1767,8 +1767,8 @@ The default is to publish a framework-dependent application.</source>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentIdIsNull">
-        <source>SDK reference name must not be null.</source>
-        <target state="new">SDK reference name must not be null.</target>
+        <source>SDK reference name must not be null or empty.</source>
+        <target state="new">SDK reference name must not be null or empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkIdentityArgumentVersionIsEmpty">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -576,6 +576,11 @@ The specified directory will be created if it does not exist.</source>
         <target state="translated">要對其還原套件的目標執行階段。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdSdk">
+        <source>SDK_NAME</source>
+        <target state="new">SDK_NAME</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdServiceableDescription">
         <source>Set the serviceable flag in the package. See https://aka.ms/nupkgservicing for more information.</source>
         <target state="translated">設定套件中的服務旗標。如需詳細資訊，請參閱 https://aka.ms/nupkgservicing。</target>
@@ -1736,6 +1741,16 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">以 JSON 格式顯示命令結構描述。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkAddAppFullName">
+        <source>Add an SDK reference to the project.</source>
+        <target state="new">Add an SDK reference to the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkAddCmdNoRestoreDescription">
+        <source>Add the SDK reference without running restore.</source>
+        <target state="new">Add the SDK reference without running restore.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkAppFullName">
         <source>.NET SDK Command</source>
         <target state="translated">.NET SDK 命令</target>
@@ -1744,6 +1759,31 @@ The default is to publish a framework-dependent application.</source>
       <trans-unit id="SdkCheckAppFullName">
         <source>.NET SDK Check Command</source>
         <target state="translated">.NET SDK 檢查命令</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentDescription">
+        <source>SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</source>
+        <target state="new">SDK reference in the form of an SDK name like '{0}' or SDK name and version separated by '@' like '{0}@{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentIdIsNull">
+        <source>SDK reference name must not be null.</source>
+        <target state="new">SDK reference name must not be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkIdentityArgumentVersionIsEmpty">
+        <source>SDK version must not be empty when specified using the '@' separator.</source>
+        <target state="new">SDK version must not be empty when specified using the '@' separator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppFullName">
+        <source>Remove an SDK reference from the project.</source>
+        <target state="new">Remove an SDK reference from the project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkRemoveAppHelpText">
+        <source>The SDK reference to remove.</source>
+        <target state="new">The SDK reference to remove.</target>
         <note />
       </trans-unit>
       <trans-unit id="SelfContainAndNoSelfContainedConflict">

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1253,6 +1253,46 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <comment>{0} is a directive kind (like '#:package'). {1} is number of removed directives.
     {2} is directive key (e.g., package name). {3} is file path from which directives were removed.</comment>
   </data>
+  <data name="SdkReferenceAddedToProject" xml:space="preserve">
+    <value>SDK reference '{0}'{1} added to file '{2}'.</value>
+    <comment>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</comment>
+  </data>
+  <data name="SdkReferenceUpdatedInProject" xml:space="preserve">
+    <value>SDK reference '{0}'{1} updated in file '{2}'.</value>
+    <comment>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</comment>
+  </data>
+  <data name="SdkReferenceUpdatedInFile" xml:space="preserve">
+    <value>SDK reference '{0}'{1} updated in file '{2}'.</value>
+    <comment>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</comment>
+  </data>
+  <data name="SdkReferenceUnchangedInProject" xml:space="preserve">
+    <value>SDK reference '{0}' is already present in file '{1}'.</value>
+  </data>
+  <data name="SdkReferenceAddedToFile" xml:space="preserve">
+    <value>SDK reference '{0}'{1} added to file '{2}'.</value>
+    <comment>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</comment>
+  </data>
+  <data name="SdkReferenceUnchangedInFile" xml:space="preserve">
+    <value>SDK reference '{0}' is already present in file '{1}'.</value>
+  </data>
+  <data name="SdkReferenceRemovedFromProject" xml:space="preserve">
+    <value>Removing SDK reference '{0}' from project '{1}'.</value>
+  </data>
+  <data name="SdkReferenceNotFoundInProject" xml:space="preserve">
+    <value>SDK reference '{0}' not found in project '{1}'.</value>
+  </data>
+  <data name="SdkReferenceNotFoundInFile" xml:space="preserve">
+    <value>SDK reference '{0}' not found in file '{1}'.</value>
+  </data>
+  <data name="CannotRemovePrimarySdkReference" xml:space="preserve">
+    <value>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</value>
+  </data>
+  <data name="GlobalJsonFileParsingFailed" xml:space="preserve">
+    <value>Could not parse global.json file '{0}': {1}</value>
+  </data>
+  <data name="SdkVersionResolutionFailed" xml:space="preserve">
+    <value>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</value>
+  </data>
   <data name="PackagesCommandNameCollisionConclusion" xml:space="preserve">
     <value>Command names conflict. Command names are case insensitive.
 {0}</value>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1254,11 +1254,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     {2} is directive key (e.g., package name). {3} is file path from which directives were removed.</comment>
   </data>
   <data name="SdkReferenceAddedToProject" xml:space="preserve">
-    <value>SDK reference '{0}'{1} added to file '{2}'.</value>
+    <value>SDK reference '{0}'{1} added to project '{2}'.</value>
     <comment>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</comment>
   </data>
   <data name="SdkReferenceUpdatedInProject" xml:space="preserve">
-    <value>SDK reference '{0}'{1} updated in file '{2}'.</value>
+    <value>SDK reference '{0}'{1} updated in project '{2}'.</value>
     <comment>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</comment>
   </data>
   <data name="SdkReferenceUpdatedInFile" xml:space="preserve">
@@ -1266,7 +1266,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <comment>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</comment>
   </data>
   <data name="SdkReferenceUnchangedInProject" xml:space="preserve">
-    <value>SDK reference '{0}' is already present in file '{1}'.</value>
+    <value>SDK reference '{0}' is already present in project '{1}'.</value>
   </data>
   <data name="SdkReferenceAddedToFile" xml:space="preserve">
     <value>SDK reference '{0}'{1} added to file '{2}'.</value>
@@ -1286,6 +1286,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   </data>
   <data name="CannotRemovePrimarySdkReference" xml:space="preserve">
     <value>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</value>
+  </data>
+  <data name="CannotRemovePrimarySdkReferenceInFile" xml:space="preserve">
+    <value>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</value>
   </data>
   <data name="GlobalJsonFileParsingFailed" xml:space="preserve">
     <value>Could not parse global.json file '{0}': {1}</value>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -1285,7 +1285,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>SDK reference '{0}' not found in file '{1}'.</value>
   </data>
   <data name="CannotRemovePrimarySdkReference" xml:space="preserve">
-    <value>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</value>
+    <value>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</value>
   </data>
   <data name="CannotRemovePrimarySdkReferenceInFile" xml:space="preserve">
     <value>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</value>

--- a/src/Cli/dotnet/Commands/Hidden/Add/AddCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Hidden/Add/AddCommandParser.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Package;
 using Microsoft.DotNet.Cli.Commands.Reference.Add;
+using Microsoft.DotNet.Cli.Commands.Sdk.Add;
 using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.Add;
@@ -16,5 +17,6 @@ internal static class AddCommandParser
 
         PackageCommandParser.ConfigureAddCommand(command.PackageCommand);
         command.ReferenceCommand.SetAction(parseResult => new ReferenceAddCommand(parseResult).Execute());
+        command.SdkCommand.SetAction(parseResult => new SdkAddCommand(parseResult).Execute());
     }
 }

--- a/src/Cli/dotnet/Commands/Hidden/Remove/RemoveCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Hidden/Remove/RemoveCommandParser.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Package.Remove;
 using Microsoft.DotNet.Cli.Commands.Reference.Remove;
+using Microsoft.DotNet.Cli.Commands.Sdk.Remove;
 using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Cli.Commands.Hidden.Remove;
@@ -16,5 +17,6 @@ internal static class RemoveCommandParser
 
         command.PackageCommand.SetAction(parseResult => new PackageRemoveCommand(parseResult).Execute());
         command.ReferenceCommand.SetAction(parseResult => new ReferenceRemoveCommand(parseResult).Execute());
+        command.SdkCommand.SetAction(parseResult => new SdkRemoveCommand(parseResult).Execute());
     }
 }

--- a/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
+++ b/src/Cli/dotnet/Commands/Run/FileBasedAppSourceEditor.cs
@@ -94,6 +94,15 @@ internal sealed class FileBasedAppSourceEditor
             return new TextChange(toReplace.Info.Span, newText: directive.ToString() + NewLine);
         }
 
+        // SDK directive order is semantic: the first directive is the primary SDK.
+        // Append new SDKs after the last existing SDK rather than sorting by name.
+        if (directive is CSharpDirective.Sdk &&
+            Directives.OfType<CSharpDirective.Sdk>().LastOrDefault() is { } lastSdk)
+        {
+            var span = new TextSpan(start: lastSdk.Info.Span.End, length: 0);
+            return new TextChange(span, newText: directive.ToString() + NewLine);
+        }
+
         // Find the last directive of the first group of directives of the same kind.
         // If found, we will insert the new directive after it.
         CSharpDirective? addAfter = null;

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
@@ -1,0 +1,203 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Package;
+using Microsoft.DotNet.Cli.Commands.Restore;
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
+
+namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
+
+internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
+{
+    private readonly SdkReferenceIdentity _sdkId;
+
+    public SdkAddCommand(ParseResult parseResult)
+        : base(parseResult)
+    {
+        _sdkId = parseResult.GetValue(Definition.SdkIdArgument);
+    }
+
+    public override int Execute()
+    {
+        var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(
+            Definition.FileOption,
+            Definition.ProjectOption,
+            Definition.GetProjectOrFileArgument(),
+            _parseResult);
+
+        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuilder.IsValidEntryPointPath(fileOrDirectory))
+        {
+            return ExecuteForFileBasedApp(fileOrDirectory);
+        }
+
+        Debug.Assert(allowedAppKinds.HasFlag(AppKinds.ProjectBased));
+
+        string projectFilePath = File.Exists(fileOrDirectory)
+            ? fileOrDirectory
+            : MsbuildProject.GetProjectFileFromDirectory(fileOrDirectory);
+
+        return ExecuteForProject(projectFilePath);
+    }
+
+    private int ExecuteForProject(string projectFilePath)
+    {
+        bool userVersionSpecified = IsVersionSpecified();
+        string? userVersion = GetSpecifiedVersion();
+        var startDirectory = Path.GetDirectoryName(projectFilePath) ?? Environment.CurrentDirectory;
+
+        bool interactive = _parseResult.GetValue(Definition.InteractiveOption);
+
+        using var projects = new ProjectCollection();
+        var msbuildProject = MsbuildProject.FromFile(projects, projectFilePath, interactive);
+
+        if (!userVersionSpecified && ProjectSdkReferenceHelper.ContainsSdk(msbuildProject.ProjectRootElement, _sdkId.Id))
+        {
+            WriteAddResultMessage(SdkAddResult.Unchanged, version: null, projectFilePath, forFile: false);
+            return 0;
+        }
+
+        var (version, leaveExistingUnchanged) = SdkAddVersionHelper.ResolveVersion(
+            _sdkId.Id,
+            userVersion,
+            userVersionSpecified,
+            startDirectory);
+
+        byte[]? snapshot = null;
+
+        SdkAddResult result = ProjectSdkReferenceHelper.AddOrUpdateSdk(
+            msbuildProject.ProjectRootElement,
+            _sdkId.Id,
+            version,
+            leaveExistingUnchanged);
+
+        if (result == SdkAddResult.Unchanged)
+        {
+            WriteAddResultMessage(result, version, projectFilePath, forFile: false);
+            return 0;
+        }
+
+        snapshot = File.ReadAllBytes(projectFilePath);
+        msbuildProject.ProjectRootElement.Save();
+
+        if (_parseResult.GetValue(Definition.NoRestoreOption))
+        {
+            WriteAddResultMessage(result, version, projectFilePath, forFile: false);
+            return 0;
+        }
+
+        int exitCode = RestoreCommand.FromArgs([projectFilePath, interactive ? "--interactive" : "--nologo", "-v:q"]).Execute();
+        if (exitCode != 0)
+        {
+            File.WriteAllBytes(projectFilePath, snapshot);
+            return exitCode;
+        }
+
+        WriteAddResultMessage(result, version, projectFilePath, forFile: false);
+        return 0;
+    }
+
+    private int ExecuteForFileBasedApp(string path)
+    {
+        bool userVersionSpecified = IsVersionSpecified();
+        string? userVersion = GetSpecifiedVersion();
+        var fullPath = Path.GetFullPath(path);
+        var startDirectory = Path.GetDirectoryName(fullPath) ?? Environment.CurrentDirectory;
+
+        var file = SourceFile.Load(fullPath);
+        var editor = FileBasedAppSourceEditor.Load(file);
+
+        var existing = editor.Directives
+            .OfType<CSharpDirective.Sdk>()
+            .FirstOrDefault(s => string.Equals(s.Name, _sdkId.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (!userVersionSpecified && existing != null)
+        {
+            WriteAddResultMessage(SdkAddResult.Unchanged, version: null, fullPath, forFile: true);
+            return 0;
+        }
+
+        var (version, _) = SdkAddVersionHelper.ResolveVersion(
+            _sdkId.Id,
+            userVersion,
+            userVersionSpecified,
+            startDirectory);
+
+        SdkAddResult result;
+        string? effectiveVersion = userVersionSpecified ? userVersion : version ?? existing?.Version;
+
+        var command = new VirtualProjectBuildingCommand(
+            entryPointFileFullPath: fullPath,
+            msbuildArgs: MSBuildArgs.FromProperties(new Dictionary<string, string>(1)
+            {
+                ["NuGetInteractive"] = _parseResult.GetValue(Definition.InteractiveOption).ToString(),
+            }.AsReadOnly()))
+        {
+            NoCache = true,
+            NoBuild = true,
+        };
+
+        editor.Add(new CSharpDirective.Sdk(default) { Name = _sdkId.Id, Version = effectiveVersion });
+        command.Directives = editor.Directives;
+        result = existing != null ? SdkAddResult.Updated : SdkAddResult.Added;
+
+        if (_parseResult.GetValue(Definition.NoRestoreOption))
+        {
+            editor.SourceFile.Save();
+            WriteAddResultMessage(result, effectiveVersion, fullPath, forFile: true);
+            return 0;
+        }
+
+        int exitCode = command.Execute();
+        if (exitCode != 0)
+        {
+            return exitCode;
+        }
+
+        editor.SourceFile.Save();
+        WriteAddResultMessage(result, effectiveVersion, fullPath, forFile: true);
+        return 0;
+    }
+
+    private void WriteAddResultMessage(SdkAddResult result, string? version, string path, bool forFile)
+    {
+        switch (result)
+        {
+            case SdkAddResult.Added:
+                Reporter.Output.WriteLine(
+                    forFile ? CliCommandStrings.SdkReferenceAddedToFile : CliCommandStrings.SdkReferenceAddedToProject,
+                    _sdkId.Id,
+                    FormatVersionSuffix(version),
+                    path);
+                break;
+            case SdkAddResult.Updated:
+                Reporter.Output.WriteLine(
+                    forFile ? CliCommandStrings.SdkReferenceUpdatedInFile : CliCommandStrings.SdkReferenceUpdatedInProject,
+                    _sdkId.Id,
+                    FormatVersionSuffix(version),
+                    path);
+                break;
+            case SdkAddResult.Unchanged:
+                Reporter.Output.WriteLine(
+                    forFile ? CliCommandStrings.SdkReferenceUnchangedInFile : CliCommandStrings.SdkReferenceUnchangedInProject,
+                    _sdkId.Id,
+                    path);
+                break;
+        }
+    }
+
+    private string? GetSpecifiedVersion()
+        => _sdkId.HasVersion ? _sdkId.Version : _parseResult.GetValue(Definition.VersionOption);
+
+    private bool IsVersionSpecified()
+        => _sdkId.HasVersion || _parseResult.HasOption(Definition.VersionOption);
+
+    private static string FormatVersionSuffix(string? version)
+        => string.IsNullOrEmpty(version) ? string.Empty : $" version '{version}'";
+}

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
@@ -69,8 +69,6 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             userVersionSpecified,
             startDirectory);
 
-        byte[]? snapshot = null;
-
         SdkAddResult result = ProjectSdkReferenceHelper.AddOrUpdateSdk(
             msbuildProject.ProjectRootElement,
             _sdkId.Id,
@@ -83,7 +81,7 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             return 0;
         }
 
-        snapshot = File.ReadAllBytes(projectFilePath);
+        byte[] snapshot = File.ReadAllBytes(projectFilePath);
         msbuildProject.ProjectRootElement.Save();
 
         if (_parseResult.GetValue(Definition.NoRestoreOption))
@@ -92,7 +90,10 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             return 0;
         }
 
-        int exitCode = RestoreCommand.FromArgs([projectFilePath, interactive ? "--interactive" : "--nologo", "-v:q"]).Execute();
+        string[] restoreArgs = interactive
+            ? [projectFilePath, "--nologo", "-v:q", "--interactive"]
+            : [projectFilePath, "--nologo", "-v:q"];
+        int exitCode = RestoreCommand.FromArgs(restoreArgs).Execute();
         if (exitCode != 0)
         {
             File.WriteAllBytes(projectFilePath, snapshot);

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddCommand.cs
@@ -67,7 +67,8 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             _sdkId.Id,
             userVersion,
             userVersionSpecified,
-            startDirectory);
+            startDirectory,
+            interactive);
 
         SdkAddResult result = ProjectSdkReferenceHelper.AddOrUpdateSdk(
             msbuildProject.ProjectRootElement,
@@ -110,6 +111,7 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
         string? userVersion = GetSpecifiedVersion();
         var fullPath = Path.GetFullPath(path);
         var startDirectory = Path.GetDirectoryName(fullPath) ?? Environment.CurrentDirectory;
+        bool interactive = _parseResult.GetValue(Definition.InteractiveOption);
 
         var file = SourceFile.Load(fullPath);
         var editor = FileBasedAppSourceEditor.Load(file);
@@ -128,7 +130,8 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             _sdkId.Id,
             userVersion,
             userVersionSpecified,
-            startDirectory);
+            startDirectory,
+            interactive);
 
         SdkAddResult result;
         string? effectiveVersion = userVersionSpecified ? userVersion : version ?? existing?.Version;
@@ -137,7 +140,7 @@ internal sealed class SdkAddCommand : CommandBase<SdkAddCommandDefinitionBase>
             entryPointFileFullPath: fullPath,
             msbuildArgs: MSBuildArgs.FromProperties(new Dictionary<string, string>(1)
             {
-                ["NuGetInteractive"] = _parseResult.GetValue(Definition.InteractiveOption).ToString(),
+                ["NuGetInteractive"] = interactive.ToString(),
             }.AsReadOnly()))
         {
             NoCache = true,

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -3,6 +3,7 @@
 
 extern alias DotNetNativeWrapper;
 
+using System.Security;
 using System.Text.Json;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
@@ -65,7 +66,7 @@ internal static class SdkAddVersionHelper
         {
             document = JsonDocument.Parse(File.ReadAllText(globalJsonPath));
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or SecurityException)
         {
             throw new GracefulException(
                 string.Format(CliCommandStrings.GlobalJsonFileParsingFailed, globalJsonPath, ex.Message));

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias DotNetNativeWrapper;
+
+using System.Text.Json;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using NuGet.Versioning;
+using EnvironmentProvider = DotNetNativeWrapper::Microsoft.DotNet.NativeWrapper.EnvironmentProvider;
+using HostFxrNotFoundException = DotNetNativeWrapper::Microsoft.DotNet.NativeWrapper.HostFxrNotFoundException;
+using HostFxrRuntimePropertyNotSetException = DotNetNativeWrapper::Microsoft.DotNet.NativeWrapper.HostFxrRuntimePropertyNotSetException;
+using NETCoreSdkResolverNativeWrapper = DotNetNativeWrapper::Microsoft.DotNet.NativeWrapper.NETCoreSdkResolverNativeWrapper;
+
+namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
+
+/// <summary>
+/// Resolves the SDK version to write when the user does not specify one explicitly.
+/// </summary>
+internal static class SdkAddVersionHelper
+{
+    /// <summary>
+    /// Resolves the version to store in the project or file-based app, and whether an existing reference may be left unchanged.
+    /// </summary>
+    public static (string? Version, bool LeaveExistingUnchangedWhenVersionIsNull) ResolveVersion(
+        string sdkName,
+        string? userVersion,
+        bool userVersionSpecified,
+        string startDirectory)
+    {
+        if (userVersionSpecified)
+        {
+            return (userVersion, LeaveExistingUnchangedWhenVersionIsNull: false);
+        }
+
+        if (TryGetMsbuildSdkVersionFromGlobalJson(startDirectory, sdkName, out _))
+        {
+            return (null, LeaveExistingUnchangedWhenVersionIsNull: true);
+        }
+
+        if (IsBundledInCurrentDotNetSdk(sdkName, startDirectory))
+        {
+            return (null, LeaveExistingUnchangedWhenVersionIsNull: true);
+        }
+
+        var nugetVersion = GetLatestNuGetSdkVersion(sdkName, startDirectory);
+        return (nugetVersion, LeaveExistingUnchangedWhenVersionIsNull: false);
+    }
+
+    internal static bool TryGetMsbuildSdkVersionFromGlobalJson(string? startDirectory, string sdkName, out string? version)
+    {
+        version = null;
+        string? globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(startDirectory);
+        if (globalJsonPath is null)
+        {
+            return false;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(File.ReadAllText(globalJsonPath));
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            throw new GracefulException(
+                string.Format(CliCommandStrings.GlobalJsonFileParsingFailed, globalJsonPath, ex.Message));
+        }
+
+        using (document)
+        {
+            if (!document.RootElement.TryGetProperty("msbuild-sdks", out JsonElement msbuildSdks) ||
+                msbuildSdks.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            foreach (JsonProperty property in msbuildSdks.EnumerateObject())
+            {
+                if (string.Equals(property.Name, sdkName, StringComparison.OrdinalIgnoreCase) &&
+                    property.Value.ValueKind == JsonValueKind.String)
+                {
+                    version = property.Value.GetString();
+                    return !string.IsNullOrEmpty(version);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsBundledInCurrentDotNetSdk(string sdkName, string startDirectory)
+    {
+        string? dotnetDir = EnvironmentProvider.GetDotnetExeDirectory(
+            key => Environment.GetEnvironmentVariable(key),
+            getCurrentProcessPath: () => Environment.ProcessPath ?? string.Empty);
+
+        if (string.IsNullOrEmpty(dotnetDir))
+        {
+            return false;
+        }
+
+        foreach (string sdkDirectory in GetSdkDirectoriesToSearch(dotnetDir, startDirectory))
+        {
+            string sdkImportPath = Path.Combine(sdkDirectory, "Sdks", sdkName, "Sdk");
+            if (Directory.Exists(sdkImportPath))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetSdkDirectoriesToSearch(string dotnetDir, string startDirectory)
+    {
+        string? resolvedSdkDirectory = TryResolveSdkDirectory(dotnetDir, startDirectory);
+        if (resolvedSdkDirectory is not null)
+        {
+            yield return resolvedSdkDirectory;
+            yield break;
+        }
+
+        foreach (string sdkDirectory in GetInstalledSdkDirectories(dotnetDir))
+        {
+            yield return sdkDirectory;
+        }
+    }
+
+    private static string? TryResolveSdkDirectory(string dotnetDir, string startDirectory)
+    {
+        try
+        {
+            return NETCoreSdkResolverNativeWrapper.ResolveSdk(dotnetDir, startDirectory).ResolvedSdkDirectory;
+        }
+        catch (Exception ex) when (ex is HostFxrRuntimePropertyNotSetException or HostFxrNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<string> GetInstalledSdkDirectories(string dotnetDir)
+    {
+        string sdkRoot = Path.Combine(dotnetDir, "sdk");
+        if (!Directory.Exists(sdkRoot))
+        {
+            yield break;
+        }
+
+        IEnumerable<string> sdkDirectories;
+        try
+        {
+            sdkDirectories = NETCoreSdkResolverNativeWrapper.GetAvailableSdks(dotnetDir);
+        }
+        catch (Exception ex) when (ex is HostFxrRuntimePropertyNotSetException or HostFxrNotFoundException)
+        {
+            sdkDirectories = Directory.GetDirectories(sdkRoot);
+        }
+
+        var yielded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrEmpty(Product.Version))
+        {
+            string productVersionPath = Path.Combine(sdkRoot, Product.Version);
+            if (Directory.Exists(productVersionPath) && yielded.Add(productVersionPath))
+            {
+                yield return productVersionPath;
+            }
+        }
+
+        foreach (string sdkDirectory in sdkDirectories)
+        {
+            if (yielded.Add(sdkDirectory))
+            {
+                yield return sdkDirectory;
+            }
+        }
+    }
+
+    private static string GetLatestNuGetSdkVersion(string sdkName, string startDirectory)
+    {
+        var downloader = new NuGetPackageDownloader.NuGetPackageDownloader(
+            packageInstallDir: new DirectoryPath(Path.GetTempPath()),
+            currentWorkingDirectory: startDirectory);
+
+        try
+        {
+            NuGetVersion version = downloader
+                .GetLatestPackageVersion(new PackageId(sdkName), includePreview: false)
+                .GetAwaiter()
+                .GetResult();
+
+            return version.ToNormalizedString();
+        }
+        catch (Exception ex)
+        {
+            throw new GracefulException(
+                string.Format(CliCommandStrings.SdkVersionResolutionFailed, sdkName, ex.Message));
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -200,7 +200,7 @@ internal static class SdkAddVersionHelper
 
             return version.ToNormalizedString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException and not GracefulException)
         {
             throw new GracefulException(
                 string.Format(CliCommandStrings.SdkVersionResolutionFailed, sdkName, ex.Message));

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -85,8 +85,8 @@ internal static class SdkAddVersionHelper
                 if (string.Equals(property.Name, sdkName, StringComparison.OrdinalIgnoreCase) &&
                     property.Value.ValueKind == JsonValueKind.String)
                 {
-                    version = property.Value.GetString();
-                    return !string.IsNullOrEmpty(version);
+                    version = property.Value.GetString()?.Trim();
+                    return !string.IsNullOrWhiteSpace(version);
                 }
             }
         }

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
 /// </summary>
 internal static class SdkAddVersionHelper
 {
+    private const string PackageCacheFolderName = "dotnet-sdk-add";
     /// <summary>
     /// Resolves the version to store in the project or file-based app, and whether an existing reference may be left unchanged.
     /// </summary>
@@ -182,12 +183,15 @@ internal static class SdkAddVersionHelper
 
     private static string GetLatestNuGetSdkVersion(string sdkName, string startDirectory)
     {
-        var downloader = new NuGetPackageDownloader.NuGetPackageDownloader(
-            packageInstallDir: new DirectoryPath(Path.GetTempPath()),
-            currentWorkingDirectory: startDirectory);
+        string packageInstallDir = Path.Combine(Path.GetTempPath(), PackageCacheFolderName, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(packageInstallDir);
 
         try
         {
+            var downloader = new NuGetPackageDownloader.NuGetPackageDownloader(
+                packageInstallDir: new DirectoryPath(packageInstallDir),
+                currentWorkingDirectory: startDirectory);
+
             NuGetVersion version = downloader
                 .GetLatestPackageVersion(new PackageId(sdkName), includePreview: false)
                 .GetAwaiter()
@@ -199,6 +203,27 @@ internal static class SdkAddVersionHelper
         {
             throw new GracefulException(
                 string.Format(CliCommandStrings.SdkVersionResolutionFailed, sdkName, ex.Message));
+        }
+        finally
+        {
+            TryDeleteDirectory(packageInstallDir);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 }

--- a/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Add/SdkAddVersionHelper.cs
@@ -24,6 +24,13 @@ namespace Microsoft.DotNet.Cli.Commands.Sdk.Add;
 internal static class SdkAddVersionHelper
 {
     private const string PackageCacheFolderName = "dotnet-sdk-add";
+
+    private static readonly JsonDocumentOptions s_jsonDocumentOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+    };
+
     /// <summary>
     /// Resolves the version to store in the project or file-based app, and whether an existing reference may be left unchanged.
     /// </summary>
@@ -31,7 +38,8 @@ internal static class SdkAddVersionHelper
         string sdkName,
         string? userVersion,
         bool userVersionSpecified,
-        string startDirectory)
+        string startDirectory,
+        bool interactive)
     {
         if (userVersionSpecified)
         {
@@ -48,7 +56,7 @@ internal static class SdkAddVersionHelper
             return (null, LeaveExistingUnchangedWhenVersionIsNull: true);
         }
 
-        var nugetVersion = GetLatestNuGetSdkVersion(sdkName, startDirectory);
+        var nugetVersion = GetLatestNuGetSdkVersion(sdkName, startDirectory, interactive);
         return (nugetVersion, LeaveExistingUnchangedWhenVersionIsNull: false);
     }
 
@@ -64,7 +72,7 @@ internal static class SdkAddVersionHelper
         JsonDocument document;
         try
         {
-            document = JsonDocument.Parse(File.ReadAllText(globalJsonPath));
+            document = JsonDocument.Parse(File.ReadAllText(globalJsonPath), s_jsonDocumentOptions);
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or SecurityException)
         {
@@ -182,7 +190,7 @@ internal static class SdkAddVersionHelper
         }
     }
 
-    private static string GetLatestNuGetSdkVersion(string sdkName, string startDirectory)
+    private static string GetLatestNuGetSdkVersion(string sdkName, string startDirectory, bool interactive)
     {
         string packageInstallDir = Path.Combine(Path.GetTempPath(), PackageCacheFolderName, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(packageInstallDir);
@@ -191,7 +199,8 @@ internal static class SdkAddVersionHelper
         {
             var downloader = new NuGetPackageDownloader.NuGetPackageDownloader(
                 packageInstallDir: new DirectoryPath(packageInstallDir),
-                currentWorkingDirectory: startDirectory);
+                currentWorkingDirectory: startDirectory,
+                restoreActionConfig: new RestoreActionConfig(Interactive: interactive));
 
             NuGetVersion version = downloader
                 .GetLatestPackageVersion(new PackageId(sdkName), includePreview: false)

--- a/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
@@ -18,7 +18,7 @@ internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(pa
 
     public override int Execute()
     {
-        var sdkNames = _parseResult.GetValue(_definition.SdkIdArgument) ?? [];
+        var sdkNames = DeduplicateSdkNames(_parseResult.GetValue(_definition.SdkIdArgument) ?? []);
 
         var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(
             _definition.FileOption,
@@ -150,5 +150,20 @@ internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(pa
         }
 
         return removedCounts.Count > 0 ? 0 : 1;
+    }
+
+    private static List<string> DeduplicateSdkNames(IEnumerable<string> sdkNames)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (string sdkName in sdkNames)
+        {
+            if (seen.Add(sdkName))
+            {
+                result.Add(sdkName);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.Diagnostics;
 using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.Package;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
@@ -18,7 +19,9 @@ internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(pa
 
     public override int Execute()
     {
-        var sdkNames = DeduplicateSdkNames(_parseResult.GetValue(_definition.SdkIdArgument) ?? []);
+        var sdkNames = DeduplicateSdkNames(
+            (_parseResult.GetValue(_definition.SdkIdArgument) ?? [])
+                .Select(CommonArguments.GetSdkIdFromIdentityArgument));
 
         var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(
             _definition.FileOption,

--- a/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
@@ -101,7 +101,7 @@ internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(pa
             if (primarySdk != null &&
                 string.Equals(primarySdk.Name, sdkName, StringComparison.OrdinalIgnoreCase))
             {
-                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReference, sdkName);
+                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReferenceInFile, sdkName);
             }
         }
 

--- a/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli.Commands.Package;
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.FileBasedPrograms;
+using Microsoft.DotNet.ProjectTools;
+
+namespace Microsoft.DotNet.Cli.Commands.Sdk.Remove;
+
+internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(parseResult)
+{
+    private readonly SdkRemoveCommandDefinitionBase _definition = (SdkRemoveCommandDefinitionBase)parseResult.CommandResult.Command;
+
+    public override int Execute()
+    {
+        var sdkNames = _parseResult.GetValue(_definition.SdkIdArgument) ?? [];
+
+        var (fileOrDirectory, allowedAppKinds) = PackageCommandParser.ProcessPathOptions(
+            _definition.FileOption,
+            _definition.ProjectOption,
+            _definition.GetProjectOrFileArgument(),
+            _parseResult);
+
+        if (allowedAppKinds.HasFlag(AppKinds.FileBased) && VirtualProjectBuilder.IsValidEntryPointPath(fileOrDirectory))
+        {
+            return ExecuteForFileBasedApp(fileOrDirectory, sdkNames);
+        }
+
+        Debug.Assert(allowedAppKinds.HasFlag(AppKinds.ProjectBased));
+
+        string projectFilePath = File.Exists(fileOrDirectory)
+            ? fileOrDirectory
+            : MsbuildProject.GetProjectFileFromDirectory(fileOrDirectory);
+
+        return ExecuteForProject(projectFilePath, sdkNames);
+    }
+
+    private static int ExecuteForProject(string projectFilePath, IEnumerable<string> sdkNames)
+    {
+        using var projects = new ProjectCollection();
+        var msbuildProject = MsbuildProject.FromFile(projects, projectFilePath, interactive: false);
+        var project = msbuildProject.ProjectRootElement;
+        var sdkNameList = sdkNames as IList<string> ?? [.. sdkNames];
+
+        foreach (var sdkName in sdkNameList)
+        {
+            if (ProjectSdkReferenceHelper.IsPrimarySdkReference(project, sdkName))
+            {
+                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReference, sdkName);
+            }
+        }
+
+        var removed = new List<string>();
+        var notFound = new List<string>();
+
+        foreach (var sdkName in sdkNameList)
+        {
+            if (ProjectSdkReferenceHelper.TryRemoveSdk(project, sdkName))
+            {
+                removed.Add(sdkName);
+            }
+            else
+            {
+                notFound.Add(sdkName);
+            }
+        }
+
+        if (removed.Count > 0)
+        {
+            msbuildProject.ProjectRootElement.Save();
+        }
+
+        foreach (var sdkName in removed)
+        {
+            Reporter.Output.WriteLine(CliCommandStrings.SdkReferenceRemovedFromProject, sdkName, projectFilePath);
+        }
+
+        foreach (var sdkName in notFound)
+        {
+            Reporter.Output.WriteLine(CliCommandStrings.SdkReferenceNotFoundInProject, sdkName, projectFilePath);
+        }
+
+        return removed.Count > 0 ? 0 : 1;
+    }
+
+    private static int ExecuteForFileBasedApp(string path, IEnumerable<string> sdkNames)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var editor = FileBasedAppSourceEditor.Load(SourceFile.Load(fullPath));
+
+        var primarySdk = editor.Directives.OfType<CSharpDirective.Sdk>().FirstOrDefault();
+        var sdkNameList = sdkNames as IList<string> ?? [.. sdkNames];
+
+        foreach (var sdkName in sdkNameList)
+        {
+            if (primarySdk != null &&
+                string.Equals(primarySdk.Name, sdkName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReference, sdkName);
+            }
+        }
+
+        var removedCounts = new List<(string SdkName, int Count)>();
+        var notFound = new List<string>();
+
+        foreach (var sdkName in sdkNameList)
+        {
+            int count = 0;
+            var directives = editor.Directives;
+            for (int i = directives.Length - 1; i >= 0; i--)
+            {
+                var directive = directives[i];
+                if (directive is CSharpDirective.Sdk sdk &&
+                    string.Equals(sdk.Name, sdkName, StringComparison.OrdinalIgnoreCase))
+                {
+                    editor.Remove(directive);
+                    count++;
+                }
+            }
+
+            if (count > 0)
+            {
+                removedCounts.Add((sdkName, count));
+            }
+            else
+            {
+                notFound.Add(sdkName);
+            }
+        }
+
+        if (removedCounts.Count > 0)
+        {
+            editor.SourceFile.Save();
+        }
+
+        foreach (var (sdkName, count) in removedCounts)
+        {
+            Reporter.Output.WriteLine(CliCommandStrings.DirectivesRemoved, "#:sdk", count, sdkName, fullPath);
+        }
+
+        foreach (var sdkName in notFound)
+        {
+            Reporter.Output.WriteLine(CliCommandStrings.SdkReferenceNotFoundInFile, sdkName, fullPath);
+        }
+
+        return removedCounts.Count > 0 ? 0 : 1;
+    }
+}

--- a/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
+++ b/src/Cli/dotnet/Commands/Sdk/Remove/SdkRemoveCommand.cs
@@ -37,13 +37,14 @@ internal sealed class SdkRemoveCommand(ParseResult parseResult) : CommandBase(pa
             ? fileOrDirectory
             : MsbuildProject.GetProjectFileFromDirectory(fileOrDirectory);
 
-        return ExecuteForProject(projectFilePath, sdkNames);
+        bool interactive = _parseResult.GetValue(_definition.InteractiveOption);
+        return ExecuteForProject(projectFilePath, sdkNames, interactive);
     }
 
-    private static int ExecuteForProject(string projectFilePath, IEnumerable<string> sdkNames)
+    private static int ExecuteForProject(string projectFilePath, IEnumerable<string> sdkNames, bool interactive)
     {
         using var projects = new ProjectCollection();
-        var msbuildProject = MsbuildProject.FromFile(projects, projectFilePath, interactive: false);
+        var msbuildProject = MsbuildProject.FromFile(projects, projectFilePath, interactive);
         var project = msbuildProject.ProjectRootElement;
         var sdkNameList = sdkNames as IList<string> ?? [.. sdkNames];
 

--- a/src/Cli/dotnet/Commands/Sdk/SdkCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Sdk/SdkCommandParser.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Sdk.Add;
 using Microsoft.DotNet.Cli.Commands.Sdk.Check;
+using Microsoft.DotNet.Cli.Commands.Sdk.Remove;
 using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Cli.Commands.Sdk;
@@ -13,5 +15,7 @@ internal static class SdkCommandParser
     {
         command.SetAction(parseResult => parseResult.HandleMissingCommand());
         command.CheckCommand.SetAction(SdkCheckCommand.Run);
+        command.AddCommand.SetAction(parseResult => new SdkAddCommand(parseResult).Execute());
+        command.RemoveCommand.SetAction(parseResult => new SdkRemoveCommand(parseResult).Execute());
     }
 }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET Builder</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <target state="translated">Máte nainstalované další verze sady SDK, které se dají použít ke spuštění této šablony. Pokud chcete spustit tuto šablonu, přepněte na některou z následujících sad SDK ve vašem systému: {0}. Podrobnosti o výběru verze sady SDK, která se má spustit: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">Sady .NET SDK:</target>
@@ -2936,6 +2991,11 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">Možnost --sdk-version se už pro tento příkaz nepodporuje.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET-Generator</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <target state="translated">Sie haben andere SDK-Versionen installiert, die zum Ausführen dieser Vorlage verwendet werden können. Wechseln Sie zu einem der folgenden SDK(s) auf Ihrem System, um diese Vorlage auszuführen: „{0}“. Details zum Auswählen der auszuführenden SDK-Version: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDKs:</target>
@@ -2936,6 +2991,11 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">Die Option "--sdk-version" wird für diesen Befehl nicht mehr unterstützt.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Generador para .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <target state="translated">Tiene instaladas otras versiones del SDK que se pueden usar para ejecutar esta plantilla. Cambie a cualquiera de los siguientes SDK en el sistema para ejecutar esta plantilla: "{0}". Detalles sobre la selección de la versión del SDK que se va a ejecutar: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">SDK de .NET:</target>
@@ -2936,6 +2991,11 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">La opción --sdk-version ya no es compatible con este comando.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Générateur .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <target state="translated">Vous avez d'autres versions du SDK installées qui peuvent être utilisées pour exécuter ce modèle. Basculez vers l'un des SDK suivants sur votre système pour exécuter ce modèle : '{0}'. Détails sur la sélection de la version du SDK à exécuter : https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">Kits SDK .NET :</target>
@@ -2936,6 +2991,11 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">L’option --sdk-version n’est plus prise en charge pour cette commande.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Generatore .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <target state="translated">Sono installate altre versioni dell'SDK che possono essere usate per eseguire questo modello. Per eseguire questo modello, passare a uno degli SDK seguenti nel sistema: '{0}'. Dettagli sulla selezione della versione SDK da eseguire: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK:</target>
@@ -2936,6 +2991,11 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">L'opzione --sdk-version non è più supportata per questo comando.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET ビルダー</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">このテンプレートの実行に使用できる他の SDK バージョンがインストールされています。システム上の SDK '{0}' のいずれかに切り替えてこのテンプレートを実行してください。実行する SDK バージョンの選択の詳細については、https://docs.microsoft.com/dotnet/core/tools/global-json をご覧ください。</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK:</target>
@@ -2936,6 +2991,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">このコマンドでは、--sdk-version オプションはサポートされなくなりました。</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET 작성기</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">이 템플릿을 실행하는 데 사용할 수 있는 다른 SDK 버전이 설치되어 있습니다. 이 템플릿을 실행하려면 시스템에서 다음 SDK 중 하나로 전환하세요. '{0}'. 실행할 SDK 버전 선택에 대한 세부 정보: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK:</target>
@@ -2936,6 +2991,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">--sdk-version 옵션은 더 이상 이 명령의 지원을 받지 않습니다.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Konstruktor platformy .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <target state="translated">Masz zainstalowane inne wersje zestawów SDK, których można użyć do uruchomienia tego szablonu. Przełącz się do dowolnego z następujących zestawów SDK w systemie, aby uruchomić ten szablon: „{0}”. Szczegóły dotyczące wybierania wersji zestawu SDK do uruchomienia: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">Zestawy .NET SDK:</target>
@@ -2936,6 +2991,11 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">Opcja --sdk-version nie jest już obsługiwana dla tego polecenia.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Construtor do .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <target state="translated">Você tem outras versões do SDK instaladas que podem ser usadas para executar este modelo. Alterne para qualquer um dos seguintes SDKs em seu sistema para executar este modelo: '{0}'. Detalhes sobre como selecionar a versão do SDK a ser executada: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">SDKs do .NET:</target>
@@ -2936,6 +2991,11 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">A opção --sdk-version não tem mais suporte para este comando.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Построитель .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">У вас установлены другие версии пакета SDK, которые можно использовать для запуска этого шаблона. Переключитесь на любой из следующих пакетов SDK в системе, чтобы запустить этот шаблон: "{0}". Сведения о выборе версии пакета SDK для запуска: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">Пакеты SDK для .NET:</target>
@@ -2936,6 +2991,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">Параметр --sdk-version больше не поддерживается для этой команды.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET Oluşturucusu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <target state="translated">Bu şablonu çalıştırmak için kullanılabilen başka SDK sürümü/sürümleri yüklü. Bu şablonu çalıştırmak için sisteminizde aşağıdaki SDK’(lar)dan herhangi birine geçiş yapın: '{0}'. Çalıştırılacak SDK sürümünü seçmeyle ilgili ayrıntılar için: https://docs.microsoft.com/dotnet/core/tools/global-json.</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK'ları:</target>
@@ -2936,6 +2991,11 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">--sdk-version seçeneği artık bu komut için desteklenmiyor.</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET 生成器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">已安装可用于运行此模板的其他 SDK 版本。切换到系统上以下任一 SDK 以运行此模板:“{0}”。有关选择要运行的 SDK 版本的详细信息，请参阅: https://docs.microsoft.com/dotnet/core/tools/global-json。</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK:</target>
@@ -2936,6 +2991,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">此命令不再支持 --sdk-version 选项。</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReference">
-        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
-        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <source>Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</source>
+        <target state="new">Cannot remove the primary SDK '{0}'. This SDK must remain as the project's main SDK reference.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotRemovePrimarySdkReferenceInFile">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="translated">.NET 產生器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReference">
+        <source>Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -135,6 +140,11 @@
       <trans-unit id="DotnetTestMissingRequiredMessageProperty">
         <source>The required property '{0}' was missing or empty in the message of type '{1}'.</source>
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalJsonFileParsingFailed">
+        <source>Could not parse global.json file '{0}': {1}</source>
+        <target state="new">Could not parse global.json file '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
@@ -2927,6 +2937,51 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">您已安裝其他可用來執行此範本的 SDK 版本。請在系統上切換至下列任一 SDK 以執行此範本: '{0}'。有關選取要執行之 SDK 版本的詳細資料: https://docs.microsoft.com/dotnet/core/tools/global-json。</target>
         <note>{0} is the list of installed and supported versions.</note>
       </trans-unit>
+      <trans-unit id="SdkReferenceAddedToFile">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceAddedToProject">
+        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInProject">
+        <source>SDK reference '{0}' not found in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceNotFoundInFile">
+        <source>SDK reference '{0}' not found in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' not found in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceRemovedFromProject">
+        <source>Removing SDK reference '{0}' from project '{1}'.</source>
+        <target state="new">Removing SDK reference '{0}' from project '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInFile">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUnchangedInProject">
+        <source>SDK reference '{0}' is already present in file '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInProject">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
+      </trans-unit>
+      <trans-unit id="SdkReferenceUpdatedInFile">
+        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
+      </trans-unit>
       <trans-unit id="SdkSectionHeader">
         <source>.NET SDKs:</source>
         <target state="translated">.NET SDK:</target>
@@ -2936,6 +2991,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The --sdk-version option is no longer supported for this command.</source>
         <target state="translated">此命令已不再支援 --sdk-version 選項。</target>
         <note>{Locked="--sdk-version"}</note>
+      </trans-unit>
+      <trans-unit id="SdkVersionResolutionFailed">
+        <source>Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</source>
+        <target state="new">Could not resolve a NuGet version for SDK '{0}'. Specify a version explicitly. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="ShouldInstallAWorkloadSet">
         <source>No workload sets are installed. Run "dotnet workload restore" to install a workload set.</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="new">Cannot remove the primary SDK '{0}' specified on the project element. Remove additive SDK references using the &lt;Sdk&gt; element instead.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotRemovePrimarySdkReferenceInFile">
+        <source>Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</source>
+        <target state="new">Cannot remove the primary SDK '{0}' specified by the first '#:sdk' directive.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
@@ -2943,8 +2948,8 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note>{0} is SDK name. {1} is optional version suffix. {2} is C# file path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceAddedToProject">
-        <source>SDK reference '{0}'{1} added to file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} added to file '{2}'.</target>
+        <source>SDK reference '{0}'{1} added to project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} added to project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceNotFoundInProject">
@@ -2968,13 +2973,13 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUnchangedInProject">
-        <source>SDK reference '{0}' is already present in file '{1}'.</source>
-        <target state="new">SDK reference '{0}' is already present in file '{1}'.</target>
+        <source>SDK reference '{0}' is already present in project '{1}'.</source>
+        <target state="new">SDK reference '{0}' is already present in project '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInProject">
-        <source>SDK reference '{0}'{1} updated in file '{2}'.</source>
-        <target state="new">SDK reference '{0}'{1} updated in file '{2}'.</target>
+        <source>SDK reference '{0}'{1} updated in project '{2}'.</source>
+        <target state="new">SDK reference '{0}'{1} updated in project '{2}'.</target>
         <note>{0} is SDK name. {1} is optional version suffix like " version '6.2.0'". {2} is project path.</note>
       </trans-unit>
       <trans-unit id="SdkReferenceUpdatedInFile">

--- a/src/Cli/dotnet/ProjectSdkReferenceHelper.cs
+++ b/src/Cli/dotnet/ProjectSdkReferenceHelper.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Construction;
+using Microsoft.DotNet.Cli.Commands;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli;
+
+internal enum SdkAddResult
+{
+    Added,
+    Updated,
+    Unchanged,
+}
+
+/// <summary>
+/// Reads and updates SDK references in SDK-style MSBuild project files.
+/// </summary>
+internal static class ProjectSdkReferenceHelper
+{
+    /// <summary>
+    /// Returns whether the project file already references the given SDK.
+    /// </summary>
+    public static bool ContainsSdk(ProjectRootElement project, string sdkName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sdkName);
+
+        var attributeSdks = ParseSdkAttribute(project.Sdk);
+        if (attributeSdks.Exists(s => string.Equals(s.Name, sdkName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return GetSdkElements(project).Any(s => string.Equals(s.Name, sdkName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Adds or updates an SDK reference in the project file.
+    /// When <paramref name="leaveExistingUnchangedWhenVersionIsNull"/> is <see langword="true"/> and
+    /// <paramref name="version"/> is <see langword="null"/>, an existing reference is left unchanged.
+    /// </summary>
+    public static SdkAddResult AddOrUpdateSdk(
+        ProjectRootElement project,
+        string sdkName,
+        string? version,
+        bool leaveExistingUnchangedWhenVersionIsNull)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sdkName);
+
+        var attributeSdks = ParseSdkAttribute(project.Sdk);
+        for (int i = 0; i < attributeSdks.Count; i++)
+        {
+            if (string.Equals(attributeSdks[i].Name, sdkName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (leaveExistingUnchangedWhenVersionIsNull && version is null)
+                {
+                    return SdkAddResult.Unchanged;
+                }
+
+                attributeSdks[i] = new SdkReference(sdkName, version);
+                project.Sdk = FormatSdkAttribute(attributeSdks);
+                return SdkAddResult.Updated;
+            }
+        }
+
+        foreach (var sdkElement in GetSdkElements(project))
+        {
+            if (string.Equals(sdkElement.Name, sdkName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (leaveExistingUnchangedWhenVersionIsNull && version is null)
+                {
+                    return SdkAddResult.Unchanged;
+                }
+
+                SetSdkElementVersion(sdkElement, version);
+                return SdkAddResult.Updated;
+            }
+        }
+
+        var newSdkElement = project.CreateProjectSdkElement(sdkName, version ?? string.Empty);
+        SetSdkElementVersion(newSdkElement, version);
+        InsertAdditiveSdkElement(project, newSdkElement);
+
+        return SdkAddResult.Added;
+    }
+
+    /// <summary>
+    /// Removes an SDK reference from the project file.
+    /// </summary>
+    /// <returns><see langword="true"/> if the SDK reference was removed.</returns>
+    public static bool TryRemoveSdk(ProjectRootElement project, string sdkName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sdkName);
+
+        var attributeSdks = ParseSdkAttribute(project.Sdk);
+        for (int i = 0; i < attributeSdks.Count; i++)
+        {
+            if (!string.Equals(attributeSdks[i].Name, sdkName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (IsPrimarySdkReference(project, sdkName))
+            {
+                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReference, sdkName);
+            }
+
+            attributeSdks.RemoveAt(i);
+            project.Sdk = FormatSdkAttribute(attributeSdks);
+            return true;
+        }
+
+        foreach (var sdkElement in GetSdkElements(project).ToList())
+        {
+            if (!string.Equals(sdkElement.Name, sdkName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (IsPrimarySdkReference(project, sdkName))
+            {
+                throw new GracefulException(CliCommandStrings.CannotRemovePrimarySdkReference, sdkName);
+            }
+
+            project.RemoveChild(sdkElement);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns whether the given SDK name is the primary SDK for the project.
+    /// </summary>
+    public static bool IsPrimarySdkReference(ProjectRootElement project, string sdkName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sdkName);
+
+        return TryGetPrimarySdk(project, out string primaryName, out _) &&
+               string.Equals(primaryName, sdkName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetPrimarySdk(ProjectRootElement project, out string name, out string? version)
+    {
+        name = string.Empty;
+        version = null;
+
+        var attributeSdks = ParseSdkAttribute(project.Sdk);
+        if (attributeSdks.Count > 0)
+        {
+            name = attributeSdks[0].Name;
+            version = attributeSdks[0].Version;
+            return true;
+        }
+
+        var firstSdkElement = GetSdkElements(project).FirstOrDefault();
+        if (firstSdkElement is null)
+        {
+            return false;
+        }
+
+        name = firstSdkElement.Name;
+        version = string.IsNullOrEmpty(firstSdkElement.Version) ? null : firstSdkElement.Version;
+        return true;
+    }
+
+    /// <summary>
+    /// Inserts an additive <c>&lt;Sdk&gt;</c> after existing SDK elements to preserve import order.
+    /// </summary>
+    private static void InsertAdditiveSdkElement(ProjectRootElement project, ProjectSdkElement newSdkElement)
+    {
+        var sdkElements = GetSdkElements(project).ToList();
+        if (sdkElements.Count > 0)
+        {
+            project.InsertAfterChild(newSdkElement, sdkElements[^1]);
+            return;
+        }
+
+        var insertBefore = project.Children.FirstOrDefault();
+        if (insertBefore is null)
+        {
+            project.AppendChild(newSdkElement);
+        }
+        else
+        {
+            project.InsertBeforeChild(newSdkElement, insertBefore);
+        }
+    }
+
+    private static IEnumerable<ProjectSdkElement> GetSdkElements(ProjectRootElement project)
+        => project.Children.OfType<ProjectSdkElement>();
+
+    private static List<SdkReference> ParseSdkAttribute(string? sdkAttribute)
+    {
+        if (string.IsNullOrWhiteSpace(sdkAttribute))
+        {
+            return [];
+        }
+
+        return sdkAttribute
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseSingleSdkReference)
+            .ToList();
+    }
+
+    private static SdkReference ParseSingleSdkReference(string reference)
+    {
+        var slashIndex = reference.IndexOf('/');
+        if (slashIndex >= 0)
+        {
+            return new SdkReference(reference[..slashIndex], reference[(slashIndex + 1)..]);
+        }
+
+        return new SdkReference(reference, null);
+    }
+
+    private static string FormatSdkAttribute(IReadOnlyList<SdkReference> sdks)
+        => string.Join(";", sdks.Select(FormatSingleSdkReference));
+
+    private static string FormatSingleSdkReference(SdkReference sdk)
+        => sdk.Version is null ? sdk.Name : $"{sdk.Name}/{sdk.Version}";
+
+    private static void SetSdkElementVersion(ProjectSdkElement sdkElement, string? version)
+    {
+        if (version is null)
+        {
+            sdkElement.Version = string.Empty;
+        }
+        else
+        {
+            sdkElement.Version = version;
+        }
+    }
+
+    private readonly record struct SdkReference(string Name, string? Version);
+}

--- a/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/FileBasedAppSourceEditorTests.cs
@@ -395,6 +395,27 @@ public sealed class FileBasedAppSourceEditorTests : SdkTest
     }
 
     /// <summary>
+    /// New SDK directives should be appended after the last existing SDK to preserve primary SDK order.
+    /// </summary>
+    [Fact]
+    public void SdkAppendPreservesPrimaryOrder()
+    {
+        Verify(
+            """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:property X=Y
+            Console.WriteLine();
+            """,
+            (static editor => editor.Add(new CSharpDirective.Sdk(default) { Name = "Cake.Sdk", Version = "6.2.0" }),
+            """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+            #:property X=Y
+            Console.WriteLine();
+            """));
+    }
+
+    /// <summary>
     /// New package directive should be sorted into the correct location in the package group.
     /// </summary>
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
@@ -24,7 +24,7 @@ public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
             .WithWorkingDirectory(projectDirectory)
             .Execute("add", "sdk", sdkName, "--version", sdkVersion, "--no-restore")
             .Should().Pass()
-            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to file '{projectFilePath}'");
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to project '{projectFilePath}'");
 
         File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="{sdkVersion}" />""");
     }
@@ -46,7 +46,7 @@ public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
             .WithWorkingDirectory(projectDirectory)
             .Execute("add", "sdk", $"{sdkName}@{sdkVersion}", "--no-restore")
             .Should().Pass()
-            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to file '{projectFilePath}'");
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to project '{projectFilePath}'");
 
         File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="{sdkVersion}" />""");
     }
@@ -220,7 +220,7 @@ public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
             .WithWorkingDirectory(projectDirectory)
             .Execute("add", "sdk", $"{sdkName}@6.2.0", "--no-restore")
             .Should().Pass()
-            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '6.2.0' updated in file '{projectFilePath}'");
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '6.2.0' updated in project '{projectFilePath}'");
 
         File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="6.2.0" />""");
     }
@@ -286,7 +286,7 @@ public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
             .WithWorkingDirectory(projectDirectory)
             .Execute("sdk", "add", sdkName, "--no-restore")
             .Should().Pass()
-            .And.HaveStdOutContaining($"SDK reference '{sdkName}' added to file");
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' added to project");
 
         File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" />""");
     }

--- a/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
@@ -1,0 +1,392 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands;
+
+namespace Microsoft.DotNet.Cli.Sdk.Add.Tests;
+
+public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
+{
+    [Fact]
+    public void WhenValidSdkIsPassedItGetsAddedToProject()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        const string sdkVersion = "6.2.0";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("add", "sdk", sdkName, "--version", sdkVersion, "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to file '{projectFilePath}'");
+
+        File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="{sdkVersion}" />""");
+    }
+
+    [Fact]
+    public void WhenValidSdkIsPassedWithVersionSuffixItGetsAddedToProject()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        const string sdkVersion = "6.2.0";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("add", "sdk", $"{sdkName}@{sdkVersion}", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '{sdkVersion}' added to file '{projectFilePath}'");
+
+        File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="{sdkVersion}" />""");
+    }
+
+    [Fact]
+    public void WhenSdkInSemicolonDelimitedAttributeIsUpdatedOtherSdksArePreserved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk/9.0.100;Aspire.AppHost.Sdk/9.1.0">
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", "Microsoft.NET.Sdk@9.0.200", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining("SDK reference 'Microsoft.NET.Sdk' version '9.0.200' updated");
+
+        File.ReadAllText(projectFilePath).Should().Contain("Microsoft.NET.Sdk/9.0.200;Aspire.AppHost.Sdk/9.1.0");
+    }
+
+    [Fact]
+    public void WhenProjectUsesTopLevelPrimarySdkNewSdkIsInsertedAfterIt()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project>
+
+              <Sdk Name="Microsoft.NET.Sdk" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", "Cake.Sdk@6.2.0", "--no-restore")
+            .Should().Pass();
+
+        var contents = File.ReadAllText(projectFilePath);
+        contents.Should().Contain($"""<Sdk Name="Cake.Sdk" Version="6.2.0" />""");
+        contents.IndexOf("Microsoft.NET.Sdk", StringComparison.Ordinal)
+            .Should().BeLessThan(contents.IndexOf("Cake.Sdk", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WhenExistingSdkIsPassedWithoutVersionPinnedVersionIsPreserved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <Sdk Name="{sdkName}" Version="6.2.0" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", sdkName, "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' is already present");
+
+        File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="6.2.0" />""");
+    }
+
+    [Fact]
+    public void WhenGlobalJsonSpecifiesSdkVersionProjectOmitsVersion()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        File.WriteAllText(Path.Combine(projectDirectory, "global.json"), """
+            {
+              "msbuild-sdks": {
+                "Cake.Sdk": "6.2.0"
+              }
+            }
+            """);
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", "Cake.Sdk", "--no-restore")
+            .Should().Pass();
+
+        File.ReadAllText(projectFilePath).Should().Contain("""<Sdk Name="Cake.Sdk" />""");
+    }
+
+    [Fact]
+    public void FileBasedApp_WithoutVersionPreservesPinnedVersion()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk", "--file", "Program.cs", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining("SDK reference 'Cake.Sdk' is already present");
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void WhenExistingAdditiveSdkIsPassedItGetsUpdated()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <Sdk Name="{sdkName}" Version="1.0.0" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("add", "sdk", $"{sdkName}@6.2.0", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' version '6.2.0' updated in file '{projectFilePath}'");
+
+        File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" Version="6.2.0" />""");
+    }
+
+    [Fact]
+    public void FileBasedApp()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk@6.2.0", "--file", "Program.cs", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining("SDK reference 'Cake.Sdk' version '6.2.0' added to file");
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Cake.Sdk@6.2.0
+
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void FileBasedApp_AdditiveSdkPreservesPrimary()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk@6.2.0", "--file", "Program.cs", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining("SDK reference 'Cake.Sdk' version '6.2.0' added to file");
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void WhenBundledSdkIsAddedWithoutVersionVersionIsOmitted()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Microsoft.NET.Sdk.Web";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", sdkName, "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"SDK reference '{sdkName}' added to file");
+
+        File.ReadAllText(projectFilePath).Should().Contain($"""<Sdk Name="{sdkName}" />""");
+    }
+
+    [Fact]
+    public void WhenGlobalJsonIsMalformedAddingNewSdkFailsGracefully()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var appDirectory = Path.Join(testInstance.Path, "app");
+        Directory.CreateDirectory(appDirectory);
+        File.WriteAllText(Path.Combine(appDirectory, "global.json"), "{ invalid json");
+
+        var file = Path.Join(appDirectory, "Program.cs");
+        File.WriteAllText(file, """
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk", "--file", "app/Program.cs", "--no-restore")
+            .Should().Fail()
+            .And.HaveStdErrContaining("Could not parse global.json file");
+    }
+
+    [Fact]
+    public void WhenExistingSdkIsReAddedWithoutVersionMalformedGlobalJsonIsIgnored()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var appDirectory = Path.Join(testInstance.Path, "app");
+        Directory.CreateDirectory(appDirectory);
+        File.WriteAllText(Path.Combine(appDirectory, "global.json"), "{ invalid json");
+
+        var file = Path.Join(appDirectory, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk", "--file", "app/Program.cs", "--no-restore")
+            .Should().Pass()
+            .And.HaveStdOutContaining("SDK reference 'Cake.Sdk' is already present");
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void FileBasedApp_ReplaceExisting()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Cake.Sdk@1.0.0
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("add", "sdk", "Cake.Sdk@6.2.0", "--file", "Program.cs", "--no-restore")
+            .Should().Pass();
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Cake.Sdk@6.2.0
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void WhenSdkIdentityHasEmptyVersionSuffixItFails()
+    {
+        new DotnetCommand(Log)
+            .Execute("sdk", "add", "Cake.Sdk@")
+            .Should().Fail()
+            .And.HaveStdErrContaining("SDK version must not be empty");
+    }
+
+    [Fact]
+    public void WhenRestoreFailsProjectFileEncodingIsPreserved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        var projectContents = File.ReadAllText(projectFilePath);
+        File.WriteAllText(projectFilePath, projectContents, Encoding.Unicode);
+        var originalBytes = File.ReadAllBytes(projectFilePath);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", "Cake.Sdk@99999.0.0")
+            .Should().Fail();
+
+        File.ReadAllBytes(projectFilePath).Should().Equal(originalBytes);
+        File.ReadAllText(projectFilePath, Encoding.Unicode).Should().NotContain("Cake.Sdk");
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Add/GivenDotnetAddSdk.cs
@@ -172,6 +172,33 @@ public sealed class GivenDotnetAddSdk(ITestOutputHelper log) : SdkTest(log)
     }
 
     [Fact]
+    public void WhenGlobalJsonHasCommentsAndTrailingCommasProjectOmitsVersion()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        File.WriteAllText(Path.Combine(projectDirectory, "global.json"), """
+            {
+              // pin Cake SDK centrally
+              "msbuild-sdks": {
+                "Cake.Sdk": "6.2.0",
+              },
+            }
+            """);
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "add", "Cake.Sdk", "--no-restore")
+            .Should().Pass();
+
+        File.ReadAllText(projectFilePath).Should().Contain("""<Sdk Name="Cake.Sdk" />""");
+    }
+
+    [Fact]
     public void FileBasedApp_WithoutVersionPreservesPinnedVersion()
     {
         var testInstance = TestAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Sdk/Remove/GivenDotnetRemoveSdk.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Remove/GivenDotnetRemoveSdk.cs
@@ -1,0 +1,280 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands;
+
+namespace Microsoft.DotNet.Cli.Sdk.Remove.Tests;
+
+public sealed class GivenDotnetRemoveSdk(ITestOutputHelper log) : SdkTest(log)
+{
+    [Fact]
+    public void WhenReferencedSdkIsPassedItGetsRemoved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <Sdk Name="{sdkName}" Version="6.2.0" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("remove", "sdk", sdkName)
+            .Should().Pass()
+            .And.HaveStdOutContaining($"Removing SDK reference '{sdkName}' from project '{projectFilePath}'");
+
+        File.ReadAllText(projectFilePath).Should().NotContain(sdkName);
+    }
+
+    [Fact]
+    public void WhenSdkInSemicolonDelimitedAttributeIsPassedItGetsRemoved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk;Aspire.AppHost.Sdk/9.1.0">
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "remove", "Aspire.AppHost.Sdk")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"Removing SDK reference 'Aspire.AppHost.Sdk' from project '{projectFilePath}'");
+
+        var contents = File.ReadAllText(projectFilePath);
+        contents.Should().Contain("""<Project Sdk="Microsoft.NET.Sdk">""");
+        contents.Should().NotContain("Aspire.AppHost.Sdk");
+    }
+
+    [Fact]
+    public void WhenPrimarySdkIsPassedItFails()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("remove", "sdk", "Microsoft.NET.Sdk")
+            .Should().Fail();
+    }
+
+    [Fact]
+    public void WhenPrimaryRemovalFailsEarlierAdditiveRemovalIsNotPersisted()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string additiveSdk = "Cake.Sdk";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <Sdk Name="{additiveSdk}" Version="6.2.0" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("remove", "sdk", additiveSdk, "Microsoft.NET.Sdk")
+            .Should().Fail();
+
+        File.ReadAllText(projectFilePath).Should().Contain(additiveSdk);
+    }
+
+    [Fact]
+    public void WhenPrimaryTopLevelSdkElementIsPassedItFails()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project>
+
+              <Sdk Name="Microsoft.NET.Sdk" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "remove", "Microsoft.NET.Sdk")
+            .Should().Fail();
+
+        File.ReadAllText(projectFilePath).Should().Contain("""<Sdk Name="Microsoft.NET.Sdk" />""");
+    }
+
+    [Fact]
+    public void FileBasedApp()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Cake.Sdk", "--file", "Program.cs")
+            .Should().Pass()
+            .And.HaveStdOut(string.Format(CliCommandStrings.DirectivesRemoved, "#:sdk", 1, "Cake.Sdk", file));
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Microsoft.NET.Sdk.Web
+
+            Console.WriteLine();
+            """);
+    }
+
+    [Fact]
+    public void FileBasedApp_PrimarySdkFails()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Microsoft.NET.Sdk.Web", "--file", "Program.cs")
+            .Should().Fail();
+
+        File.ReadAllText(file).Should().Contain("#:sdk Microsoft.NET.Sdk.Web");
+        File.ReadAllText(file).Should().Contain("#:sdk Cake.Sdk@6.2.0");
+    }
+
+    [Fact]
+    public void FileBasedApp_PrimaryRemovalDoesNotRemoveAdditive()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Cake.Sdk", "Microsoft.NET.Sdk.Web", "--file", "Program.cs")
+            .Should().Fail();
+
+        File.ReadAllText(file).Should().Contain("#:sdk Cake.Sdk@6.2.0");
+    }
+
+    [Fact]
+    public void FileBasedApp_NotFound()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Cake.Sdk", "--file", "Program.cs")
+            .Should().Fail()
+            .And.HaveStdOut(string.Format(CliCommandStrings.SdkReferenceNotFoundInFile, "Cake.Sdk", file));
+    }
+
+    [Fact]
+    public void FileBasedApp_PrimaryValidatedBeforeAnyRemoval()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Microsoft.NET.Sdk.Web", "Cake.Sdk", "--file", "Program.cs")
+            .Should().Fail();
+
+        File.ReadAllText(file).Should().Contain("#:sdk Cake.Sdk@6.2.0");
+    }
+
+    [Fact]
+    public void FileBasedApp_Multiple()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        var file = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(file, """
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Cake.Sdk@6.2.0
+            #:sdk Another.Sdk@1.0.0
+            #:sdk Cake.Sdk@2.0.0
+
+            Console.WriteLine();
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("remove", "sdk", "Cake.Sdk", "--file", "Program.cs")
+            .Should().Pass()
+            .And.HaveStdOut(string.Format(CliCommandStrings.DirectivesRemoved, "#:sdk", 2, "Cake.Sdk", file));
+
+        File.ReadAllText(file).Should().Be("""
+            #:sdk Microsoft.NET.Sdk.Web
+            #:sdk Another.Sdk@1.0.0
+
+            Console.WriteLine();
+            """);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Sdk/Remove/GivenDotnetRemoveSdk.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Remove/GivenDotnetRemoveSdk.cs
@@ -40,6 +40,39 @@ public sealed class GivenDotnetRemoveSdk(ITestOutputHelper log) : SdkTest(log)
     }
 
     [Fact]
+    public void WhenReferencedSdkIsPassedWithVersionSuffixItGetsRemoved()
+    {
+        const string testAsset = "TestAppSimple";
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset)
+            .WithSource()
+            .Path;
+
+        const string sdkName = "Cake.Sdk";
+        const string sdkVersion = "6.2.0";
+        var projectFilePath = Path.Combine(projectDirectory, $"{testAsset}.csproj");
+        File.WriteAllText(projectFilePath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <Sdk Name="{sdkName}" Version="{sdkVersion}" />
+
+              <PropertyGroup>
+                <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """);
+
+        new DotnetCommand(Log)
+            .WithWorkingDirectory(projectDirectory)
+            .Execute("sdk", "remove", $"{sdkName}@{sdkVersion}")
+            .Should().Pass()
+            .And.HaveStdOutContaining($"Removing SDK reference '{sdkName}' from project '{projectFilePath}'");
+
+        File.ReadAllText(projectFilePath).Should().NotContain(sdkName);
+    }
+
+    [Fact]
     public void WhenSdkInSemicolonDelimitedAttributeIsPassedItGetsRemoved()
     {
         const string testAsset = "TestAppSimple";


### PR DESCRIPTION
## Summary

- Adds `dotnet sdk add` and `dotnet sdk remove` for managing MSBuild SDK references in SDK-style project files and file-based apps (`#:sdk` directives).
- Supports version resolution from explicit input, `global.json` `msbuild-sdks`, bundled SDKs, or NuGet; protects the primary SDK from removal; rolls back project changes on failed restore.
- Includes hidden aliases (`dotnet add sdk`, `dotnet remove sdk`), localized strings, and integration tests for project and file-based scenarios.

## Test plan

- [x] `dotnet sdk add Cake.Sdk --version 6.2.0 --no-restore` adds `<Sdk>` element to a project
- [x] `dotnet sdk add Cake.Sdk@6.2.0` works with `@` version syntax
- [x] Semicolon-delimited `Project Sdk="..."` attributes are updated without dropping other SDKs
- [x] Additive SDKs are inserted after the primary SDK / existing `<Sdk>` elements
- [x] Version omitted when SDK is in `global.json` or bundled with the .NET SDK
- [x] Malformed `global.json` fails gracefully with a clear error
- [x] Restore failure rolls back project file changes (including encoding)
- [x] `dotnet sdk remove` removes additive SDK references from projects and files
- [x] Primary SDK removal is rejected before any file changes are persisted
- [x] Batch remove is transactional when primary SDK is in the list
- [x] File-based `#:sdk` directives preserve primary SDK order on add
- [x] `GivenDotnetAddSdk` and `GivenDotnetRemoveSdk` integration tests pass

## Example usage & use cases

```bash
# Add an additive SDK to a project (creates <Sdk Name="Cake.Sdk" Version="6.2.0" />)
dotnet sdk add Cake.Sdk --version 6.2.0

# Same using name@version syntax
dotnet sdk add Cake.Sdk@6.2.0

# Add without pinning a version when global.json or the bundled SDK supplies it
dotnet sdk add Microsoft.NET.Sdk.Web

# Add an Aspire AppHost SDK alongside the primary SDK
dotnet sdk add Aspire.AppHost.Sdk@9.1.0

# Add to a specific project
dotnet sdk add Cake.Sdk@6.2.0 --project ./src/MyApp/MyApp.csproj

# Add to a file-based app
dotnet add sdk Cake.Sdk@6.2.0 --file Program.cs

# Skip restore (useful in scripts or when restore will run separately)
dotnet sdk add Cake.Sdk@6.2.0 --no-restore

# Remove one additive SDK
dotnet sdk remove Cake.Sdk

# Remove Aspire.AppHost.Sdk from a multi-SDK project
dotnet sdk remove Aspire.AppHost.Sdk

# Remove multiple SDKs in one command
dotnet sdk remove Cake.Sdk Aspire.AppHost.Sdk

# Remove from a file-based app
dotnet remove sdk Cake.Sdk --file Program.cs
```

**Use cases**

- **Build tooling SDKs** — Add SDKs like `Cake.Sdk` or custom MSBuild SDK packages without hand-editing `.csproj` files.
- **Aspire / multi-SDK projects** — Manage semicolon-delimited `Project Sdk="Microsoft.NET.Sdk;Aspire.AppHost.Sdk/9.1.0"` references safely.
- **Version pinning policy** — Omit versions when `global.json` centralizes `msbuild-sdks`, or pin explicitly with `--version` / `@version`.
- **File-based apps** — Manage `#:sdk` directives the same way as package references, with primary SDK order preserved.
- **Cleanup / migration** — Remove additive SDK references when migrating off a tool or consolidating SDK usage, without risking accidental removal of the primary project SDK.