### PR TITLE
Support daily channels for specific previews

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs
@@ -111,22 +111,33 @@ internal class ChannelVersionResolver
         }
 
         // The only two forms that include a '-' are:
-        //   * "<partial-version>-daily" (e.g. "10.0-daily", "10.0.1xx-daily").
-        //     Daily only applies to partial versions; "10.0.103-daily" is rejected
-        //     because a specific patch is already specific.
+        //   * "<partial-version>-daily" (e.g. "10.0-daily", "10.0.1xx-daily"),
+        //     optionally with a prerelease-label qualifier ("11.0.1xx-preview.5-daily"
+        //     or "11.0.1xx-preview5-daily"). Daily only applies to scopes; a
+        //     specific patch like "10.0.103-daily" is already specific and is
+        //     rejected.
         //   * a fully-qualified version with a prerelease tag (e.g. "10.0.100-preview.1.32640").
         //     The prerelease tag is opaque; we only validate the numeric prefix.
+        if (channel.EndsWith(DailySuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var basePart = channel.Substring(0, channel.Length - DailySuffix.Length);
+            if (string.IsNullOrEmpty(basePart))
+            {
+                return false;
+            }
+
+            if (UpdateChannel.TrySplitPartialVersionAndPrereleaseLabel(basePart, out var bandPart, out _))
+            {
+                return IsValidPartialVersion(bandPart);
+            }
+
+            return IsValidPartialVersion(basePart);
+        }
+
         var dashIndex = channel.IndexOf('-', StringComparison.Ordinal);
         if (dashIndex >= 0)
         {
             var versionPart = channel.Substring(0, dashIndex);
-            var suffix = channel.Substring(dashIndex);
-
-            if (suffix.Equals(DailySuffix, StringComparison.OrdinalIgnoreCase))
-            {
-                return !string.IsNullOrEmpty(versionPart) && IsValidPartialVersion(versionPart);
-            }
-
             return IsValidNumericVersion(versionPart);
         }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -87,7 +87,21 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         // "<M>-daily" → use "<M>.0" as the aka.ms partial version (aka.ms paths use major.minor).
-        string partialVersion = NormalizePartialVersion(UpdateChannel.StripDailySuffix(channel.Name));
+        // For prerelease-qualified daily channels ("<band>-preview.5-daily"), translate the
+        // label to aka.ms's dotless form ("preview5") so the URL has the shape aka.ms
+        // expects: ".../<band>-preview5/daily/...".
+        string scope = UpdateChannel.StripDailySuffix(channel.Name);
+        string partialVersion;
+        if (UpdateChannel.TrySplitPartialVersionAndPrereleaseLabel(scope, out var bandPart, out var prereleaseLabel))
+        {
+            string akaMsLabel = prereleaseLabel.Replace(".", string.Empty, StringComparison.Ordinal);
+            partialVersion = $"{NormalizePartialVersion(bandPart)}-{akaMsLabel}";
+        }
+        else
+        {
+            partialVersion = NormalizePartialVersion(scope);
+        }
+
         return TryResolvePartialVersion(partialVersion, archivePrefix, rid, extension);
     }
 

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -87,15 +87,22 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         // "<M>-daily" → use "<M>.0" as the aka.ms partial version (aka.ms paths use major.minor).
-        // For prerelease-qualified daily channels ("<band>-preview.5-daily"), translate the
-        // label to aka.ms's dotless form ("preview5") so the URL has the shape aka.ms
-        // expects: ".../<band>-preview5/daily/...".
+        // For prerelease-qualified daily channels ("<band>-preview.5-daily"):
+        //   1. Translate the label to aka.ms's dotless form ("preview5") so the URL has
+        //      the shape aka.ms expects: ".../<band>-preview5/daily/...".
+        //   2. If the band is a bare major.minor (e.g. "11.0-preview.5-daily"), inject
+        //      the default ".1xx" feature band. aka.ms only publishes prerelease-qualified
+        //      daily shortlinks under a feature-band path, so "11.0-preview5" has no
+        //      target; "11.0.1xx-preview5" is the canonical form aka.ms serves and it
+        //      returns the right artifact for any component (SDK, runtime, aspnetcore,
+        //      windowsdesktop).
         string scope = UpdateChannel.StripDailySuffix(channel.Name);
         string partialVersion;
         if (UpdateChannel.TrySplitPartialVersionAndPrereleaseLabel(scope, out var bandPart, out var prereleaseLabel))
         {
             string akaMsLabel = prereleaseLabel.Replace(".", string.Empty, StringComparison.Ordinal);
-            partialVersion = $"{NormalizePartialVersion(bandPart)}-{akaMsLabel}";
+            string normalizedBand = EnsureFeatureBand(NormalizePartialVersion(bandPart));
+            partialVersion = $"{normalizedBand}-{akaMsLabel}";
         }
         else
         {
@@ -103,6 +110,18 @@ internal sealed class DailyChannelResolver : IDisposable
         }
 
         return TryResolvePartialVersion(partialVersion, archivePrefix, rid, extension);
+    }
+
+    /// <summary>
+    /// Ensures a partial version has a feature-band component. <c>"11.0"</c> →
+    /// <c>"11.0.1xx"</c>; <c>"11.0.2xx"</c> passes through unchanged. Used when the
+    /// aka.ms path requires a feature band (prerelease-qualified daily channels) but
+    /// the user supplied only major.minor.
+    /// </summary>
+    private static string EnsureFeatureBand(string partialVersion)
+    {
+        var parts = partialVersion.Split('.');
+        return parts.Length == 2 ? $"{partialVersion}.1xx" : partialVersion;
     }
 
     /// <summary>

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DailyChannelResolver.cs
@@ -101,7 +101,7 @@ internal sealed class DailyChannelResolver : IDisposable
         if (UpdateChannel.TrySplitPartialVersionAndPrereleaseLabel(scope, out var bandPart, out var prereleaseLabel))
         {
             string akaMsLabel = prereleaseLabel.Replace(".", string.Empty, StringComparison.Ordinal);
-            string normalizedBand = EnsureFeatureBand(NormalizePartialVersion(bandPart));
+            string normalizedBand = EnsureFeatureBandForPreviewDaily(NormalizePartialVersion(bandPart));
             partialVersion = $"{normalizedBand}-{akaMsLabel}";
         }
         else
@@ -113,12 +113,14 @@ internal sealed class DailyChannelResolver : IDisposable
     }
 
     /// <summary>
-    /// Ensures a partial version has a feature-band component. <c>"11.0"</c> →
-    /// <c>"11.0.1xx"</c>; <c>"11.0.2xx"</c> passes through unchanged. Used when the
-    /// aka.ms path requires a feature band (prerelease-qualified daily channels) but
-    /// the user supplied only major.minor.
+    /// Injects the default <c>.1xx</c> feature band into a bare major.minor partial version:
+    /// <c>"11.0"</c> → <c>"11.0.1xx"</c>; <c>"11.0.2xx"</c> passes through unchanged. Only valid
+    /// for prerelease-qualified daily channels, where the requested version is at the start of a
+    /// major version's life and <c>.1xx</c> is the only band aka.ms publishes a shortlink for.
+    /// Do not use for non-prerelease daily scopes (e.g. <c>"10.0-daily"</c>), which can resolve to
+    /// a later band such as <c>10.0.4xx</c>.
     /// </summary>
-    private static string EnsureFeatureBand(string partialVersion)
+    private static string EnsureFeatureBandForPreviewDaily(string partialVersion)
     {
         var parts = partialVersion.Split('.');
         return parts.Length == 2 ? $"{partialVersion}.1xx" : partialVersion;

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -44,6 +44,105 @@ internal class UpdateChannel
             : channelName;
 
     /// <summary>
+    /// Tries to split a daily-scope string into a partial-version prefix and a
+    /// prerelease label. Accepts both <c>preview5</c> and <c>preview.5</c>
+    /// spellings of the label (e.g. <c>"11.0.1xx-preview.5"</c> →
+    /// <c>("11.0.1xx", "preview.5")</c>; <c>"11.0.1xx-preview5"</c> →
+    /// <c>("11.0.1xx", "preview.5")</c>). The returned <paramref name="prereleaseLabel"/>
+    /// is always normalized to <c>label.N</c> form (i.e. with the dot) so it can
+    /// be compared directly against a <see cref="ReleaseVersion.Prerelease"/>.
+    /// </summary>
+    internal static bool TrySplitPartialVersionAndPrereleaseLabel(
+        string scope,
+        out string partialVersion,
+        out string prereleaseLabel)
+    {
+        partialVersion = string.Empty;
+        prereleaseLabel = string.Empty;
+
+        int dashIndex = scope.IndexOf('-', StringComparison.Ordinal);
+        if (dashIndex <= 0 || dashIndex >= scope.Length - 1)
+        {
+            return false;
+        }
+
+        string left = scope.Substring(0, dashIndex);
+        string right = scope.Substring(dashIndex + 1);
+
+        if (!TryNormalizePrereleaseLabel(right, out string normalized))
+        {
+            return false;
+        }
+
+        partialVersion = left;
+        prereleaseLabel = normalized;
+        return true;
+    }
+
+    /// <summary>
+    /// Normalizes a prerelease label to <c>name.N</c> form (e.g.
+    /// <c>"preview5"</c> and <c>"preview.5"</c> both produce <c>"preview.5"</c>).
+    /// Returns <c>false</c> if the input doesn't match a <c>{letters}{digits}</c>
+    /// or <c>{letters}.{digits}</c> shape.
+    /// </summary>
+    internal static bool TryNormalizePrereleaseLabel(string label, out string normalized)
+    {
+        normalized = string.Empty;
+        if (string.IsNullOrEmpty(label))
+        {
+            return false;
+        }
+
+        string name;
+        string number;
+        int dotIndex = label.IndexOf('.', StringComparison.Ordinal);
+        if (dotIndex >= 0)
+        {
+            name = label.Substring(0, dotIndex);
+            number = label.Substring(dotIndex + 1);
+        }
+        else
+        {
+            // No dot: find the boundary between the alpha name and the digit run.
+            int boundary = 0;
+            while (boundary < label.Length && char.IsLetter(label[boundary]))
+            {
+                boundary++;
+            }
+            if (boundary == 0 || boundary == label.Length)
+            {
+                return false;
+            }
+            name = label.Substring(0, boundary);
+            number = label.Substring(boundary);
+        }
+
+        if (name.Length == 0 || number.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (char c in name)
+        {
+            if (!char.IsLetter(c))
+            {
+                return false;
+            }
+        }
+
+        foreach (char c in number)
+        {
+            if (!char.IsDigit(c))
+            {
+                return false;
+            }
+        }
+
+        normalized = $"{name.ToLowerInvariant()}.{number}";
+        return true;
+    }
+
+    /// <summary>
     /// Checks if the channel string looks like an SDK version or feature band pattern rather than a runtime version.
     /// SDK versions have a third component >= 100 (e.g., "9.0.103", "9.0.304") or use "xx" patterns (e.g., "9.0.1xx").
     /// Runtime versions have a third component &lt; 100 (e.g., "9.0.12", "9.0.0").
@@ -112,11 +211,12 @@ internal class UpdateChannel
             return version.Major == major;
         }
 
-        // Scoped daily channels (e.g. "10.0-daily", "10.0.1xx-daily") match the
-        // same versions their base scope would, but restricted to prerelease
-        // versions. A stable release is not a daily build, even if its version
-        // falls inside the base scope; rejecting it here keeps the channel's
-        // "what satisfies me?" answer coherent for GC and reporting.
+        // Scoped daily channels (e.g. "10.0-daily", "10.0.1xx-daily",
+        // "11.0.1xx-preview.5-daily") match the same versions their base scope
+        // would, but restricted to prerelease versions. A stable release is not
+        // a daily build, even if its version falls inside the base scope;
+        // rejecting it here keeps the channel's "what satisfies me?" answer
+        // coherent for GC and reporting.
         if (IsDaily)
         {
             if (IsStableRelease(version))
@@ -124,7 +224,23 @@ internal class UpdateChannel
                 return false;
             }
 
-            return new UpdateChannel(StripDailySuffix(Name)).Matches(version);
+            string scope = StripDailySuffix(Name);
+
+            // Prerelease-qualified daily channels ("<band>-preview.5-daily") match only
+            // versions whose prerelease starts with the requested label, in addition to the
+            // base scope matching.
+            if (TrySplitPartialVersionAndPrereleaseLabel(scope, out string partialVersion, out string prereleaseLabel))
+            {
+                if (!new UpdateChannel(partialVersion).Matches(version))
+                {
+                    return false;
+                }
+
+                return version.Prerelease.Equals(prereleaseLabel, StringComparison.OrdinalIgnoreCase)
+                    || version.Prerelease.StartsWith(prereleaseLabel + ".", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return new UpdateChannel(scope).Matches(version);
         }
 
         return MatchesMajorMinorOrFeatureBand(version);

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/UpdateChannel.cs
@@ -45,7 +45,10 @@ internal class UpdateChannel
 
     /// <summary>
     /// Tries to split a daily-scope string into a partial-version prefix and a
-    /// prerelease label. Accepts both <c>preview5</c> and <c>preview.5</c>
+    /// prerelease label. The <paramref name="scope"/> is a channel name with the
+    /// <c>-daily</c> suffix already removed: a partial version (e.g. <c>"11.0"</c> or
+    /// <c>"11.0.1xx"</c>) optionally followed by a prerelease label, never a
+    /// fully-qualified version. Accepts both <c>preview5</c> and <c>preview.5</c>
     /// spellings of the label (e.g. <c>"11.0.1xx-preview.5"</c> →
     /// <c>("11.0.1xx", "preview.5")</c>; <c>"11.0.1xx-preview5"</c> →
     /// <c>("11.0.1xx", "preview.5")</c>). The returned <paramref name="prereleaseLabel"/>

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -113,6 +113,7 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("11.0-daily")]
         [InlineData("11.0.1xx-preview.5-daily")]
         [InlineData("11.0.1xx-preview5-daily")]
+        [InlineData("11.0-preview.5-daily")]
         public void GetLatestVersionForChannel_Daily_ResolvesAgainstLiveAkaMs(string channelName)
         {
             var resolver = new ChannelVersionResolver();

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -111,6 +111,8 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("daily")]
         [InlineData("10.0-daily")]
         [InlineData("11.0-daily")]
+        [InlineData("11.0.1xx-preview.5-daily")]
+        [InlineData("11.0.1xx-preview5-daily")]
         public void GetLatestVersionForChannel_Daily_ResolvesAgainstLiveAkaMs(string channelName)
         {
             var resolver = new ChannelVersionResolver();
@@ -151,6 +153,9 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("10-daily", true)]
         [InlineData("10.0-daily", true)]
         [InlineData("10.0.1xx-daily", true)]
+        [InlineData("11.0.1xx-preview.5-daily", true)]
+        [InlineData("11.0.1xx-preview5-daily", true)]
+        [InlineData("10.0.1xx-rc.1-daily", true)]
         [InlineData("10.0-DAILY", true)]
         public void IsValidChannelFormat_ValidInputs_ReturnsTrue(string channel, bool expected)
         {
@@ -173,6 +178,10 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("-daily", false)]  // Empty scope before -daily
         [InlineData("preview-daily", false)]  // Named channels can't take -daily
         [InlineData("100-daily", false)]  // Major outside reasonable range
+        [InlineData("11.0.1xx--daily", false)]  // Empty phase label
+        [InlineData("11.0.1xx-preview-daily", false)]  // Phase label missing number
+        [InlineData("11.0.1xx-5-daily", false)]  // Phase label missing letters
+        [InlineData("11.0.103-preview.5-daily", false)]  // Specific patch + phase still rejected
         public void IsValidChannelFormat_InvalidInputs_ReturnsFalse(string channel, bool expected)
         {
             Assert.Equal(expected, ChannelVersionResolver.IsValidChannelFormat(channel));

--- a/test/dotnetup.Tests/ChannelVersionResolverTests.cs
+++ b/test/dotnetup.Tests/ChannelVersionResolverTests.cs
@@ -183,6 +183,8 @@ namespace Microsoft.DotNet.Tools.Dotnetup.Tests
         [InlineData("11.0.1xx-preview-daily", false)]  // Phase label missing number
         [InlineData("11.0.1xx-5-daily", false)]  // Phase label missing letters
         [InlineData("11.0.103-preview.5-daily", false)]  // Specific patch + phase still rejected
+        [InlineData("invalid.invalid.1xx-daily", false)]  // Non-numeric scope
+        [InlineData("bad.0.1xx-preview.5-daily", false)]  // Valid phase label but invalid band still rejected
         public void IsValidChannelFormat_InvalidInputs_ReturnsFalse(string channel, bool expected)
         {
             Assert.Equal(expected, ChannelVersionResolver.IsValidChannelFormat(channel));

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -115,6 +115,29 @@ public class DailyChannelResolverTests
         version.Should().NotBeNull();
     }
 
+    [Theory]
+    [InlineData("11.0.1xx-preview.5-daily")]
+    [InlineData("11.0.1xx-preview5-daily")]
+    public void Resolve_PhaseQualifiedDaily_UsesDotlessAkaMsPath(string channelName)
+    {
+        // Both "preview.5" and "preview5" forms of the channel must resolve to the
+        // dotless aka.ms path segment ".../11.0.1xx-preview5/daily/..." that the
+        // service actually serves.
+        const string archiveUrl =
+            "https://ci.dot.net/public/Sdk/11.0.100-preview.5.26302.115/dotnet-sdk-11.0.100-preview.5.26302.115-win-x64.zip";
+        using var handler = new RedirectHandler(new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/11.0.1xx-preview5/daily/dotnet-sdk-"] = archiveUrl,
+        });
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel(channelName), InstallArchitecture.x64);
+
+        version.Should().NotBeNull();
+        version!.ToString().Should().Be("11.0.100-preview.5.26302.115");
+    }
+
     [Fact]
     public void Resolve_AkaMsReturnsNotFound_ReturnsNull()
     {

--- a/test/dotnetup.Tests/DailyChannelResolverTests.cs
+++ b/test/dotnetup.Tests/DailyChannelResolverTests.cs
@@ -138,6 +138,36 @@ public class DailyChannelResolverTests
         version!.ToString().Should().Be("11.0.100-preview.5.26302.115");
     }
 
+    [Theory]
+    [InlineData("11.0-preview.5-daily", InstallComponent.SDK)]
+    [InlineData("11.0-preview.5-daily", InstallComponent.Runtime)]
+    [InlineData("11.0-preview.5-daily", InstallComponent.ASPNETCore)]
+    public void Resolve_MajorMinorPrereleaseDaily_InjectsDefaultFeatureBand(string channelName, InstallComponent component)
+    {
+        // aka.ms only publishes prerelease-qualified daily shortlinks under the SDK
+        // feature-band path (".../11.0.1xx-preview5/daily/...") — even for non-SDK
+        // components. When the user types the more natural runtime form
+        // "11.0-preview.5-daily", DailyChannelResolver must inject the default ".1xx"
+        // band so the URL it queries actually has a target.
+        var archiveUrls = new Dictionary<string, string>
+        {
+            ["https://aka.ms/dotnet/11.0.1xx-preview5/daily/dotnet-sdk-"]
+                = "https://ci.dot.net/public/Sdk/11.0.100-preview.5.26302.115/dotnet-sdk-11.0.100-preview.5.26302.115-win-x64.zip",
+            ["https://aka.ms/dotnet/11.0.1xx-preview5/daily/dotnet-runtime-"]
+                = "https://ci.dot.net/public/Runtime/11.0.0-preview.5.26302.115/dotnet-runtime-11.0.0-preview.5.26302.115-win-x64.zip",
+            ["https://aka.ms/dotnet/11.0.1xx-preview5/daily/aspnetcore-runtime-"]
+                = "https://ci.dot.net/public/aspnetcore/Runtime/11.0.0-preview.5.26302.115/aspnetcore-runtime-11.0.0-preview.5.26302.115-win-x64.zip",
+        };
+        using var handler = new RedirectHandler(archiveUrls);
+        using var httpClient = new HttpClient(handler);
+        using var resolver = new DailyChannelResolver(new ReleaseManifest(), httpClient);
+
+        var version = resolver.Resolve(new UpdateChannel(channelName), InstallArchitecture.x64, component);
+
+        version.Should().NotBeNull();
+        version!.Prerelease.Should().StartWith("preview.5");
+    }
+
     [Fact]
     public void Resolve_AkaMsReturnsNotFound_ReturnsNull()
     {

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -47,6 +47,13 @@ public class UpdateChannelTests
     [InlineData("11.0.1xx-preview.5-daily", "11.0.204-preview.5.26302.115", false)] // wrong feature band
     [InlineData("10.0.1xx-rc.1-daily", "10.0.100-rc.1.25451.107", true)]
     [InlineData("10.0.1xx-rc1-daily", "10.0.100-rc.1.25451.107", true)]
+    // Runtime-form prerelease-qualified daily channels: users type major.minor
+    // without an SDK feature band; the channel must still match the version's
+    // major.minor + prerelease, since aka.ms maps these to the SDK band internally.
+    [InlineData("11.0-preview.5-daily", "11.0.0-preview.5.26302.115", true)]   // runtime
+    [InlineData("11.0-preview.5-daily", "11.0.100-preview.5.26302.115", true)] // SDK in same band
+    [InlineData("11.0-preview.5-daily", "11.0.0-preview.6.26302.118", false)]  // wrong label
+    [InlineData("11.0-preview.5-daily", "11.0.0", false)]                       // stable
     public void Matches_ReturnsExpectedResult(string channel, string versionString, bool expected)
     {
         var updateChannel = new UpdateChannel(channel);

--- a/test/dotnetup.Tests/UpdateChannelTests.cs
+++ b/test/dotnetup.Tests/UpdateChannelTests.cs
@@ -39,6 +39,14 @@ public class UpdateChannelTests
     [InlineData("10.0.1xx-daily", "10.0.103-preview.1", true)]
     [InlineData("10.0.1xx-daily", "10.0.103", false)]
     [InlineData("10.0.1xx-daily", "10.0.204-preview.1", false)]
+    // Phase-qualified daily channels: the version's prerelease label must also match.
+    [InlineData("11.0.1xx-preview.5-daily", "11.0.100-preview.5.26302.115", true)]
+    [InlineData("11.0.1xx-preview5-daily", "11.0.100-preview.5.26302.115", true)]   // dotless form accepted
+    [InlineData("11.0.1xx-preview.5-daily", "11.0.100-preview.6.26302.118", false)] // wrong phase
+    [InlineData("11.0.1xx-preview.5-daily", "11.0.100", false)]                     // stable
+    [InlineData("11.0.1xx-preview.5-daily", "11.0.204-preview.5.26302.115", false)] // wrong feature band
+    [InlineData("10.0.1xx-rc.1-daily", "10.0.100-rc.1.25451.107", true)]
+    [InlineData("10.0.1xx-rc1-daily", "10.0.100-rc.1.25451.107", true)]
     public void Matches_ReturnsExpectedResult(string channel, string versionString, bool expected)
     {
         var updateChannel = new UpdateChannel(channel);
@@ -54,6 +62,9 @@ public class UpdateChannelTests
     [InlineData("10.0-daily", true)]
     [InlineData("10.0.1xx-daily", true)]
     [InlineData("10.0-DAILY", true)]
+    [InlineData("11.0.1xx-preview.5-daily", true)]
+    [InlineData("11.0.1xx-preview5-daily", true)]
+    [InlineData("10.0.1xx-rc1-daily", true)]
     [InlineData("10.0", false)]
     [InlineData("preview", false)]
     [InlineData("10.0.100-preview.1", false)]


### PR DESCRIPTION
Support channels such as `11.0.1xx-preview.5-daily`.

Example:

```
> dotnetup sdk install 11.0.1xx-preview.5-daily 11.0.1xx-preview.4-daily 10.0.4xx-daily
Installing .NET SDK 11.0.100-preview.5.26302.115, .NET SDK 11.0.100-preview.4.26257.104, .NET SDK
10.0.400-preview.0.26281.104 to C:\Users\Daniel\AppData\Local\dotnet...

  Downloading .NET SDK                 11.0.100-preview.5.26302.115 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Downloading .NET SDK                 11.0.100-preview.4.26257.104 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Downloading .NET SDK                 10.0.400-preview.0.26281.104 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Installing  .NET SDK                 11.0.100-preview.5.26302.115 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Installing  .NET SDK                 11.0.100-preview.4.26257.104 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Installing  .NET SDK                 10.0.400-preview.0.26281.104 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%

Installed at C:\Users\Daniel\AppData\Local\dotnet:
  .NET SDK 11.0.100-preview.5.26302.115
  .NET SDK 11.0.100-preview.4.26257.104
  .NET SDK 10.0.400-preview.0.26281.104
```