### PR TITLE
Diagnose #54580: capture binlog on three intermittently hung MTP tests

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -24,6 +24,21 @@ namespace Microsoft.NET.TestFramework.Commands
         /// </summary>
         public bool CreateNewProcessGroup { get; set; }
 
+        /// <summary>
+        /// Optional watchdog timeout for the spawned child process. When set and exceeded,
+        /// the child process tree is killed and the resulting <see cref="CommandResult"/>
+        /// reflects the killed exit code. Use to convert silent hangs (e.g. dotnet/sdk#54580
+        /// where <c>dotnet test</c> hung silently for 60 minutes before the Helix blame
+        /// collector intervened) into actionable, fast test failures.
+        /// </summary>
+        public TimeSpan? Timeout { get; set; }
+
+        public TestCommand WithTimeout(TimeSpan timeout)
+        {
+            Timeout = timeout;
+            return this;
+        }
+
         //  These only work via Execute(), not when using GetProcessStartInfo()
         public Action<string>? CommandOutputHandler { get; set; }
         public Action<Process>? ProcessStartedHandler { get; set; }
@@ -186,8 +201,91 @@ namespace Microsoft.NET.TestFramework.Commands
             var display = $"{fileToShow} {string.Join(" ", spec.Arguments)}";
 
             Log.WriteLine($"Executing '{display}':");
-            var result = command.Execute(ProcessStartedHandler);
-            Log.WriteLine($"Command '{display}' exited with exit code {result.ExitCode}.");
+
+            // If a timeout was configured, install a watchdog that kills the spawned process
+            // tree when it fires. Without this, a silent hang inside the child runs until the
+            // outer harness (e.g. Helix blame collector) intervenes, wasting CI minutes and
+            // producing no actionable failure (see https://github.com/dotnet/sdk/issues/54580).
+            Process? spawnedProcess = null;
+            var userProcessStartedHandler = ProcessStartedHandler;
+            Action<Process>? effectiveProcessStartedHandler = userProcessStartedHandler;
+            CancellationTokenSource? watchdogCts = null;
+            Task? watchdogTask = null;
+            var timedOut = false;
+
+            if (Timeout is TimeSpan timeout)
+            {
+                effectiveProcessStartedHandler = process =>
+                {
+                    spawnedProcess = process;
+                    userProcessStartedHandler?.Invoke(process);
+                };
+
+                watchdogCts = new CancellationTokenSource();
+                var token = watchdogCts.Token;
+                watchdogTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await Task.Delay(timeout, token).ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        return;
+                    }
+
+                    var processToKill = spawnedProcess;
+                    if (processToKill is null)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        if (!processToKill.HasExited)
+                        {
+                            Log.WriteLine($"[Timeout] '{display}' exceeded {timeout.TotalMinutes:F0} min - killing process tree (PID {processToKill.Id}) to convert a silent hang into a fast test failure.");
+                            processToKill.Kill(entireProcessTree: true);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.WriteLine($"[Timeout] Failed to kill PID {processToKill.Id}: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }, token);
+            }
+
+            CommandResult result;
+            try
+            {
+                result = command.Execute(effectiveProcessStartedHandler);
+            }
+            finally
+            {
+                if (watchdogCts is not null)
+                {
+                    timedOut = watchdogTask is { IsCompleted: true, IsCanceled: false };
+                    watchdogCts.Cancel();
+                    try
+                    {
+                        watchdogTask?.Wait(TimeSpan.FromSeconds(5));
+                    }
+                    catch
+                    {
+                        // Watchdog cancellation may surface as AggregateException(TaskCanceledException); ignore.
+                    }
+                    watchdogCts.Dispose();
+                }
+            }
+
+            if (timedOut)
+            {
+                Log.WriteLine($"Command '{display}' was killed after exceeding the configured timeout of {Timeout!.Value.TotalMinutes:F0} min. Exit code reported: {result.ExitCode}.");
+            }
+            else
+            {
+                Log.WriteLine($"Command '{display}' exited with exit code {result.ExitCode}.");
+            }
 
             if (Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT") is string uploadRoot)
             {

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -419,9 +419,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 : new[] { "-c", configuration, "-bl" };
 
             // -bl is passed so any future hang produces an MSBuild binlog that the test framework
-            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
+            // uploads from the working directory. The 5-minute watchdog turns the silent
+            // 60-minute hang seen in https://github.com/dotnet/sdk/issues/54580 into a fast,
+            // actionable test failure instead of letting Helix's blame collector intervene.
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
+                                    .WithTimeout(TimeSpan.FromMinutes(5))
                                     .Execute(args);
 
             if (!SdkTestContext.IsLocalized())

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -415,9 +415,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithSource();
 
             string[] args = useFrameworkOption
-                ? new[] { "-c", configuration, "-f", ToolsetInfo.CurrentTargetFramework }
-                : new[] { "-c", configuration };
+                ? new[] { "-c", configuration, "-f", ToolsetInfo.CurrentTargetFramework, "-bl" }
+                : new[] { "-c", configuration, "-bl" };
 
+            // -bl is passed so any future hang produces an MSBuild binlog that the test framework
+            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .Execute(args);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -107,9 +107,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithSource();
             testInstance.WithTargetFrameworks($"{DotnetVersionHelper.GetPreviousDotnetVersion()};{ToolsetInfo.CurrentTargetFramework}", "TestProject");
 
+            // Pass -bl so any future hang produces an MSBuild binlog that the test framework
+            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
-                                    .Execute("--property", $"TestTfmsInParallel={testTfmsInParallel}");
+                                    .Execute("--property", $"TestTfmsInParallel={testTfmsInParallel}", "-bl");
 
             if (testTfmsInParallel)
             {

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -108,9 +108,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             testInstance.WithTargetFrameworks($"{DotnetVersionHelper.GetPreviousDotnetVersion()};{ToolsetInfo.CurrentTargetFramework}", "TestProject");
 
             // Pass -bl so any future hang produces an MSBuild binlog that the test framework
-            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
+            // uploads from the working directory. The 5-minute watchdog turns the silent
+            // 60-minute hang seen in https://github.com/dotnet/sdk/issues/54580 into a fast,
+            // actionable test failure instead of letting Helix's blame collector intervene.
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
+                                    .WithTimeout(TimeSpan.FromMinutes(5))
                                     .Execute("--property", $"TestTfmsInParallel={testTfmsInParallel}", "-bl");
 
             if (testTfmsInParallel)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -23,9 +23,11 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("ConsoleAppDoesNothing", Guid.NewGuid().ToString())
                 .WithSource();
 
+            // Pass -bl so any future hang produces an MSBuild binlog that the test framework
+            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
-                                    .Execute("-c", configuration);
+                                    .Execute("-c", configuration, "-bl");
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure, "dotnet test should fail with a meaningful error when run against console app without MTP handshake");
         }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -24,9 +24,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithSource();
 
             // Pass -bl so any future hang produces an MSBuild binlog that the test framework
-            // uploads from the working directory (see https://github.com/dotnet/sdk/issues/54580).
+            // uploads from the working directory. The 5-minute watchdog turns the silent
+            // 60-minute hang seen in https://github.com/dotnet/sdk/issues/54580 into a fast,
+            // actionable test failure instead of letting Helix's blame collector intervene.
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
+                                    .WithTimeout(TimeSpan.FromMinutes(5))
                                     .Execute("-c", configuration, "-bl");
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure, "dotnet test should fail with a meaningful error when run against console app without MTP handshake");


### PR DESCRIPTION
> _This PR was opened by GitHub Copilot acting under @Evangelink's account._

Investigation + mitigation for #54580.

### Investigation summary
Three unrelated MTP tests hung in the same Helix work item (job `c2dccf78`) on macOS x64 for ~60 minutes each before the blame collector intervened. The Helix host log shows the spawned `dotnet test` produced **zero output** for the entire window (no banner, no error). The process tree at `createdump` time showed the `dotnet test` orchestrator with **no child processes** – MSBuild never began emitting and the test app never spawned. That puts the hang either in early `dotnet test` startup or in the in-process MSBuild restore call (`MSBuildForwardingAppWithoutLogging.ExecuteInProc`). Three unrelated tests hanging together on one agent is a strong infrastructure / agent-state signal.

### What this PR does
Two changes that move us from blind to diagnosable, **without** masking real failures elsewhere:

**1. `-bl` on the affected tests** (commit 59645fa)  
Adds `-bl` to the three tests so the existing `TestCommand` Helix upload (`HELIX_WORKITEM_UPLOAD_ROOT`) captures a binlog on the next recurrence. Without this, even if the hang repros we currently have no information about which target/task was stuck.

**2. Active watchdog via `TestCommand.WithTimeout`** (commit 0279fe1)  
`TestCommand` now exposes `Timeout` / `WithTimeout(TimeSpan)`. When set, a `Task.Delay`-based watchdog calls `Process.Kill(entireProcessTree: true)` on the spawned child once the timeout fires. The three known hung tests chain `.WithTimeout(TimeSpan.FromMinutes(5))`. Next recurrence will:
- Fail in ~5 minutes instead of burning ~60.
- Surface a normal xUnit failure with the killed exit code (instead of a silent `createdump`).
- Upload the partial binlog written before the kill.

Opt-in only: all other tests keep current behavior.

### Files changed
- `test/Microsoft.NET.TestFramework/Commands/TestCommand.cs` – `Timeout` / `WithTimeout` + watchdog in `Execute(IEnumerable<string>)`.
- `test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs` – `-bl` + 5-min timeout on `RunConsoleAppDoesNothing_ShouldReturnCorrectExitCode`.
- `test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs` – `-bl` + 5-min timeout on `RunOnProjectWithClassLibrary_ShouldReturnExitCodeSuccess`.
- `test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs` – `-bl` + 5-min timeout on `RunProjectWithMultipleTFMs_ParallelizationTest_RunInParallelShouldFail`.

### Not done in this PR
- No root-cause fix in `dotnet test` / MSBuild – the evidence currently in the issue is not sufficient to pin down which call hung. The watchdog + binlog will give us that on the next recurrence.
- No expansion of the timeout beyond the three known hung tests, to keep this PR minimal and avoid noise.
