### PR TITLE
Remove redundant -restore from Queue Tests pipeline step

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -135,18 +135,27 @@ jobs:
     ############### TESTING ###############
     - ${{ if eq(parameters.runTests, true) }}:
 
-      # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
+      # Queue tests directly via MSBuild on UnitTests.proj, bypassing Arcade's
+      # build.ps1 Restore/Build pipeline overhead. The build step already compiled
+      # all projects; BuildSDKCustomXUnitProjects (BeforeTargets=CoreBuild) handles
+      # per-project RID-specific publish before queuing to Helix.
       - ${{ if eq(parameters.pool.os, 'windows') }}:
-        - powershell: eng/common/build.ps1
-            -restore -test -ci -prepareMachine -nativeToolsOnMachine
-            -configuration $(buildConfiguration)
-            /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
-            /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
-            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-            ${{ parameters.runtimeSourceProperties }}
-            /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
-            /p:EnableHelixJobMonitor=true
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
+        - powershell: |
+            $env:NativeToolsOnMachine = 'true'
+            & $env:BUILD_SOURCESDIRECTORY\.dotnet\dotnet msbuild "${{ parameters.testProjects }}" `
+              /t:Build /t:Test `
+              /p:Configuration=$(buildConfiguration) `
+              /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}" `
+              /p:TargetArchitecture=${{ parameters.targetArchitecture }} `
+              ${{ parameters.runtimeSourceProperties }} `
+              /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }} `
+              /p:EnableHelixJobMonitor=true `
+              /p:ContinuousIntegrationBuild=true `
+              /p:MSBuildEnableWorkloadResolver=false `
+              /nr:false `
+              /m `
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.
@@ -156,21 +165,24 @@ jobs:
             TestFullMSBuild: ${{ parameters.testFullMSBuild }}
 
       - ${{ else }}:
-        # For the /p:Projects syntax for Bash, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1690189034
-        # The /p:CustomHelixTargetQueue syntax is: <queue-name>@<container-url>
+        # For the /p:CustomHelixTargetQueue syntax: <queue-name>@<container-url>
         # For the Helix containers, see the 'simpleTags' arrays here: https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
-        - script: eng/common/build.sh
-            -restore -test -ci -prepareMachine
-            -configuration $(buildConfiguration)
-            '/p:Projects="${{ parameters.testProjects }}"'
-            /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
-            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-            /p:TargetRid=${{ parameters.runtimeIdentifier }}
-            ${{ parameters.osProperties }}
-            ${{ parameters.runtimeSourceProperties }}
-            /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
-            /p:EnableHelixJobMonitor=true
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
+        - script: |
+            "$BUILD_SOURCESDIRECTORY/.dotnet/dotnet" msbuild "${{ parameters.testProjects }}" \
+              /t:Build /t:Test \
+              /p:Configuration=$(buildConfiguration) \
+              /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}" \
+              /p:TargetArchitecture=${{ parameters.targetArchitecture }} \
+              /p:TargetRid=${{ parameters.runtimeIdentifier }} \
+              ${{ parameters.osProperties }} \
+              ${{ parameters.runtimeSourceProperties }} \
+              /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }} \
+              /p:EnableHelixJobMonitor=true \
+              /p:ContinuousIntegrationBuild=true \
+              /p:MSBuildEnableWorkloadResolver=false \
+              /nr:false \
+              /m \
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
           displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -338,4 +338,6 @@ function CleanOutStage0ToolsetsAndRuntimes {
 
 InitializeCustomSDKToolset
 
-CleanOutStage0ToolsetsAndRuntimes
+if ($restore) {
+  CleanOutStage0ToolsetsAndRuntimes
+}

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -294,4 +294,6 @@ function CleanOutStage0ToolsetsAndRuntimes {
 
 InitializeCustomSDKToolset
 
-CleanOutStage0ToolsetsAndRuntimes
+if [[ "$restore" == true ]]; then
+  CleanOutStage0ToolsetsAndRuntimes
+fi

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -41,12 +41,10 @@
 
   <Target Name="RestoreSDKCustomXUnitProjects"
           Condition="'@(SDKCustomXUnitProject)' != ''"
-          BeforeTargets="Restore"
-          Outputs="%(SDKCustomXUnitProject.Identity)%(SDKCustomXUnitProject.TargetFramework)%(SDKCustomXUnitProject.RuntimeTargetFramework)%(SDKCustomXUnitProject.AdditionalProperties)">
-    <MSBuild Projects="%(SDKCustomXUnitProject.Identity)"
-             Targets="Restore"
-             Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);RuntimeIdentifiers=$(TargetRid);%(SDKCustomXUnitProject.AdditionalProperties)">
-    </MSBuild>
+          BeforeTargets="Restore">
+    <!-- Intentionally empty: the per-project RID restore is done inside
+         BuildSDKCustomXUnitProjects before each publish. Keeping this target
+         defined (but empty) avoids breaking any existing target dependencies. -->
   </Target>
 
   <Target Name="BuildSDKCustomXUnitProjects"


### PR DESCRIPTION
## Summary

The Queue Tests pipeline step was passing -restore to eng/common/build.ps1/uild.sh, causing a redundant sequential NuGet restore of 200+ test projects that were already restored during the Build step (via sdk.slnx).

## Changes

- **Remove -restore** from both Windows and Linux Queue Tests steps in eng/pipelines/templates/jobs/sdk-build.yml
- **Guard CleanOutStage0ToolsetsAndRuntimes** behind the restore flag in both eng/restore-toolset.ps1 and eng/restore-toolset.sh to prevent unbound variable errors on Linux (DOTNET_INSTALL_DIR is only set by InitializeCustomSDKToolset which returns early without -restore)

## Why this is safe

1. The build step already restores all test projects via sdk.slnx
2. The Helix SDK is resolved via \global.json\ (no NuGet restore needed)
3. The per-project RID-specific restore in \BuildSDKCustomXUnitProjects\ (XUnitRunner.targets) remains active — it adds the RID target to existing assets files needed for publish
4. \CleanOutStage0ToolsetsAndRuntimes\ only needs to run during the build step (which still passes \-restore\)

## Expected impact

Eliminates the ~6 minute overhead from \RestoreSDKCustomXUnitProjects\ sequentially evaluating/restoring 200+ already-restored test projects.

## Depends on

- #54583 (Helix Job Monitor integration)