### PR TITLE
Fix tests which changed CWD without resetting

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -5,14 +5,23 @@ using Microsoft.DotNet.Cli.Commands.Run;
 
 namespace Microsoft.DotNet.Tests.ParserTests
 {
-    public class RunParserTests
+    public class RunParserTests : IDisposable
     {
+        private readonly ITestOutputHelper output;
+        private readonly string _previousWorkingDirectory;
+
         public RunParserTests(ITestOutputHelper output)
         {
             this.output = output;
+
+            // Reset current working directory after tests run to avoid breaking other tests
+            _previousWorkingDirectory = Directory.GetCurrentDirectory();
         }
 
-        private readonly ITestOutputHelper output;
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_previousWorkingDirectory);
+        }
 
         [Fact]
         public void RunParserCanGetArgumentFromDoubleDash()
@@ -21,9 +30,8 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var testAsset = tam.CopyTestAsset("HelloWorld").WithSource();
             var newWorkingDir = testAsset.Path;
 
-            Directory.SetCurrentDirectory(newWorkingDir);
             var projectPath = Path.Combine(newWorkingDir, "HelloWorld.csproj");
-                
+
             var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath, "--", "foo" });
             runCommand.ApplicationArgs.Single().Should().Be("foo");
         }


### PR DESCRIPTION
**Fix flaky `AddReferenceHasDefaultArgumentSetToCurrentDirectory` test**

`RunParserTests` called `Directory.SetCurrentDirectory` without restoring it, leaking the process-wide current directory into later tests in the assembly. When it ran before `AddReferenceHasDefaultArgumentSetToCurrentDirectory`, that test's `Directory.GetCurrentDirectory()` no longer matched the argument's startup-cached default, causing a spurious failure.

Fix: restore the current directory after each test via `IDisposable`, and drop an unnecessary `SetCurrentDirectory` from the double-dash test (its project path is already absolute).

Seen in PR run for https://github.com/dotnet/sdk/pull/54591