### PR TITLE
SDK `main` uses dotnetup to install the bootstrap SDK and test runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ cmake/
 # Helix payload
 .dotnet.payload
 
+# dotnetup build output
+eng/dotnetup/
+
 # MSBuild Logs
 **/MSBuild_Logs/MSBuild_pid-*.failure.txt
 

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -4,3 +4,82 @@
 
 $script:useInstalledDotNetCli = $false
 
+function Test-NativeProcessArchitectureMismatch() {
+    try {
+        return [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+    }
+    catch {
+        return $false
+    }
+}
+
+# Pre-install the bootstrap SDK pinned in global.json using dotnetup into the
+# repo-local .dotnet directory that arcade's InitializeDotnetCli will pick up.
+#
+# Skipped during VMR / source-build (no network) and when -restore was not requested.
+function InstallBootstrapSdkWithDotnetup() {
+    $dotnetSdkVersion = $GlobalJson.tools.dotnet
+    if ((-not $restore) -or $fromVmr -or [string]::IsNullOrEmpty($dotnetSdkVersion)) {
+        return
+    }
+
+    # Collect all SDK versions to install (primary + any additional).
+    $sdkVersions = @($dotnetSdkVersion)
+    if ($GlobalJson.tools.PSObject.Properties['additionalDotNetVersions']) {
+        $sdkVersions += @($GlobalJson.tools.additionalDotNetVersions | Where-Object { -not [string]::IsNullOrEmpty($_) })
+    }
+
+    $dotnetRoot = Join-Path $RepoRoot '.dotnet'
+
+    Write-Host "Installing SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' via dotnetup..." -ForegroundColor Cyan
+
+    $dotnetupDir = Join-Path $PSScriptRoot 'dotnetup'
+    $dotnetupExe = Join-Path $dotnetupDir (GetExecutableFileName 'dotnetup')
+
+    # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
+    $skipDownload = $false
+    if (Test-Path $dotnetupExe) {
+        $age = (Get-Date) - (Get-Item $dotnetupExe).LastWriteTime
+        if ($age.TotalHours -lt 24) {
+            Write-Host "dotnetup binary is less than 24 hours old; skipping re-download." -ForegroundColor DarkGray
+            $skipDownload = $true
+        }
+    }
+
+    if ($skipDownload -and (Test-NativeProcessArchitectureMismatch)) {
+        Write-Host "Native architecture differs from process architecture; re-downloading dotnetup for the native architecture." -ForegroundColor DarkGray
+        $skipDownload = $false
+    }
+
+    if (-not $skipDownload) {
+        # Seed $LASTEXITCODE so strict mode can read it if the called script
+        # short-circuits without invoking a native process.
+        if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+        & (Join-Path $RepoRoot 'scripts\get-dotnetup.ps1') -InstallDir $dotnetupDir
+        if ($LASTEXITCODE -ne 0) {
+            Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to acquire dotnetup (exit code '$LASTEXITCODE')."
+            ExitWithExitCode $LASTEXITCODE
+        }
+    }
+
+    # Keep dotnetup's manifest under artifacts instead of the user's home dir.
+    $env:DOTNET_DOTNETUP_DATA_DIR = Join-Path $ArtifactsDir '.dotnetup'
+
+    if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+    & $dotnetupExe sdk install @sdkVersions `
+        --install-path $dotnetRoot `
+        --untracked `
+        --set-default-install false `
+        --interactive false
+    if ($LASTEXITCODE -ne 0) {
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install .NET SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' using dotnetup (exit code '$LASTEXITCODE')."
+        ExitWithExitCode $LASTEXITCODE
+    }
+
+    # Record the installed SDK so CleanOutStage0ToolsetsAndRuntimes does not
+    # later treat this install as stale and wipe it (forcing a build rerun).
+    Set-Content -Path (Join-Path $dotnetRoot '.version') -Value $dotnetSdkVersion -NoNewline
+}
+
+InstallBootstrapSdkWithDotnetup
+

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -4,5 +4,114 @@
 
 useInstalledDotNetCli="false"
 
+function GetNativeMachineArchitecture {
+  if [[ "$(uname)" == "Darwin" ]] && [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]; then
+    echo "arm64"
+    return
+  fi
+  case "$(uname -m)" in
+    arm64|aarch64) echo "arm64" ;;
+    amd64|x86_64) echo "x64" ;;
+    armv*l) echo "arm" ;;
+    i[3-6]86) echo "x86" ;;
+    *) echo "x64" ;;
+  esac
+}
+
+function IsRunningUnderRosettaOnArm64Mac {
+  [[ "$(uname)" == "Darwin" && "$(GetNativeMachineArchitecture)" == "arm64" && "$(uname -m)" == "x86_64" ]]
+}
+
+# Pre-install the bootstrap SDK pinned in global.json using dotnetup into the
+# repo-local .dotnet directory that arcade's InitializeDotNetCli will pick up.
+#
+# Skipped during VMR / source-build (no network) and when --restore was not requested.
+function InstallBootstrapSdkWithDotnetup {
+  ReadGlobalVersion "dotnet"
+  local dotnet_sdk_version=$_ReadGlobalVersion
+  if [[ "$restore" != true || "$from_vmr" == true || -z "$dotnet_sdk_version" ]]; then
+    return
+  fi
+
+  # Collect all SDK versions to install (primary + any additional).
+  local sdk_versions=("$dotnet_sdk_version")
+  # Extract additionalDotNetVersions from global.json using grep/sed (no python dependency).
+  # Matches lines like:  "10.0.100-preview.1.12345"  inside the array.
+  local in_block=false
+  while IFS= read -r line; do
+    if [[ "$line" == *"\"additionalDotNetVersions\""* ]]; then
+      in_block=true
+      continue
+    fi
+    if [[ "$in_block" == true ]]; then
+      if [[ "$line" == *"]"* ]]; then
+        break
+      fi
+      local ver
+      ver=$(echo "$line" | sed -n 's/.*"\([^"]*\)".*/\1/p')
+      if [[ -n "$ver" ]]; then
+        sdk_versions+=("$ver")
+      fi
+    fi
+  done < "$repo_root/global.json"
+
+  local dotnet_root="$repo_root.dotnet"
+
+  echo "Installing SDK(s) '${sdk_versions[*]}' to '$dotnet_root' via dotnetup..."
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local dotnetup_dir="$script_dir/dotnetup"
+  local dotnetup_exe="$dotnetup_dir/dotnetup"
+
+  # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
+  local skip_download=false
+  if [[ -f "$dotnetup_exe" ]]; then
+    local current_time
+    current_time=$(date +%s)
+    local file_time
+    file_time=$(stat -c %Y "$dotnetup_exe" 2>/dev/null || stat -f %m "$dotnetup_exe" 2>/dev/null || echo 0)
+    local age_seconds=$((current_time - file_time))
+    if [[ $age_seconds -lt 86400 ]]; then
+      echo "dotnetup binary is less than 24 hours old; skipping re-download."
+      skip_download=true
+    fi
+  fi
+
+  if [[ "$skip_download" == true ]] && IsRunningUnderRosettaOnArm64Mac; then
+    echo "Running under Rosetta 2 on arm64 macOS; re-downloading dotnetup for the native architecture."
+    skip_download=false
+  fi
+
+  if [[ "$skip_download" != true ]]; then
+    # build.sh runs under `set -e`; guard so we can emit a diagnostic.
+    if ! "$repo_root/scripts/get-dotnetup.sh" --install-dir "$dotnetup_dir"; then
+      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup."
+      ExitWithExitCode 1
+    fi
+  fi
+
+  # Keep dotnetup's manifest under artifacts instead of the user's home dir.
+  export DOTNET_DOTNETUP_DATA_DIR="$artifacts_dir/.dotnetup"
+
+  "$dotnetup_exe" sdk install "${sdk_versions[@]}" \
+    --install-path "$dotnet_root" \
+    --untracked \
+    --set-default-install false \
+    --interactive false
+  local lastexitcode=$?
+
+  if [[ $lastexitcode != 0 ]]; then
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install .NET SDK(s) '${sdk_versions[*]}' to '$dotnet_root' using dotnetup (exit code '$lastexitcode')."
+    ExitWithExitCode $lastexitcode
+  fi
+
+  # Record the installed SDK so CleanOutStage0ToolsetsAndRuntimes does not
+  # later treat this install as stale and wipe it (forcing a build rerun).
+  printf '%s' "$dotnet_sdk_version" > "$dotnet_root/.version"
+}
+
+InstallBootstrapSdkWithDotnetup
+
 # Working around issue https://github.com/dotnet/arcade/issues/7327
 DisableNativeToolsetInstalls=true

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -1,68 +1,108 @@
 # Detect native OS architecture, which may differ from the process architecture
 # (e.g., x64 process running on ARM64 Windows via emulation).
 function Get-NativeMachineArchitecture {
-  try {
-    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
-      return "arm64"
+    try {
+        $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
+            return "arm64"
+        }
+        if ($osArch -eq [System.Runtime.InteropServices.Architecture]::X86) {
+            return "x86"
+        }
+        if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm) {
+            return "arm"
+        }
     }
-    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::X86) {
-      return "x86"
+    catch {
+        # Fallback for environments where RuntimeInformation is unavailable
     }
-    if ($osArch -eq [System.Runtime.InteropServices.Architecture]::Arm) {
-      return "arm"
+    return "x64"
+}
+
+function Get-ProcessMachineArchitecture {
+    try {
+        $processArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+        if ($processArch -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
+            return "arm64"
+        }
+        if ($processArch -eq [System.Runtime.InteropServices.Architecture]::X86) {
+            return "x86"
+        }
+        if ($processArch -eq [System.Runtime.InteropServices.Architecture]::Arm) {
+            return "arm"
+        }
     }
-  } catch {
-    # Fallback for environments where RuntimeInformation is unavailable
-  }
-  return "x64"
+    catch {
+        # Fallback for environments where RuntimeInformation is unavailable
+    }
+    return "x64"
+}
+
+function Get-DotNetInstallFallbackArchitecture {
+    if (-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) {
+        $nativeArch = Get-NativeMachineArchitecture
+        if ($env:TARGET_ARCHITECTURE -ne $nativeArch) {
+            return $env:TARGET_ARCHITECTURE
+        }
+    }
+
+    return ""
 }
 
 function InitializeCustomSDKToolset {
-  if ($env:TestFullMSBuild -eq "true") {
-     $env:DOTNET_SDK_TEST_MSBUILD_PATH = InitializeVisualStudioMSBuild -install:$true -vsRequirements:$GlobalJson.tools.'vs-opt'
-     Write-Host "INFO: Tests will run against full MSBuild in $env:DOTNET_SDK_TEST_MSBUILD_PATH"
-  }
+    if ($env:TestFullMSBuild -eq "true") {
+        $env:DOTNET_SDK_TEST_MSBUILD_PATH = InitializeVisualStudioMSBuild -install:$true -vsRequirements:$GlobalJson.tools.'vs-opt'
+        Write-Host "INFO: Tests will run against full MSBuild in $env:DOTNET_SDK_TEST_MSBUILD_PATH"
+    }
 
-  if (-not $restore) {
-    return
-  }
+    if (-not $restore) {
+        return
+    }
 
-  # The following frameworks and tools are used only for testing.
-  # Do not attempt to install them when building in the VMR.
-  if ($fromVmr) {
-    return
-  }
+    # The following frameworks and tools are used only for testing.
+    # Do not attempt to install them when building in the VMR.
+    if ($fromVmr) {
+        return
+    }
 
-  $cli = InitializeDotnetCli -install:$true
+    $cli = InitializeDotnetCli -install:$true
 
-  $nativeArch = Get-NativeMachineArchitecture
-  InstallDotNetSharedFramework "6.0.0" $nativeArch
-  InstallDotNetSharedFramework "7.0.0" $nativeArch
-  InstallDotNetSharedFramework "8.0.0" $nativeArch
-  InstallDotNetSharedFramework "9.0.0" $nativeArch
-  InstallDotNetSharedFramework "10.0.0" $nativeArch
+    # Redirect dotnetup data directory under artifacts so build scripts
+    # don't read/write the user's home-folder manifest.
+    $env:DOTNET_DOTNETUP_DATA_DIR = Join-Path $ArtifactsDir ".dotnetup"
 
-  CreateBuildEnvScripts
-  CreateVSShortcut
-  InstallNuget
+    # The following shared frameworks are only needed for testing.
+    # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
+    if ($env:DOTNET_INSTALL_TEST_RUNTIMES -ne 'false') {
+        $fallbackArchitecture = Get-DotNetInstallFallbackArchitecture
+        $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
+        if ([string]::IsNullOrEmpty($fallbackArchitecture)) {
+            # Also install the exact runtime versions that arcade's toolset requires
+            # (from Version.Details.props) so tests can target those specific versions.
+            $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
+        }
+        InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -Architecture $fallbackArchitecture
+    }
+
+    CreateBuildEnvScripts
+    CreateVSShortcut
+    InstallNuget
 }
 
 function InstallNuGet {
-  $NugetInstallDir = Join-Path $ArtifactsDir ".nuget"
-  $NugetExe = Join-Path $NugetInstallDir "nuget.exe"
+    $NugetInstallDir = Join-Path $ArtifactsDir ".nuget"
+    $NugetExe = Join-Path $NugetInstallDir "nuget.exe"
 
-  if (!(Test-Path -Path $NugetExe)) {
-    Create-Directory $NugetInstallDir
-    Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -UseBasicParsing -OutFile $NugetExe
-  }
+    if (!(Test-Path -Path $NugetExe)) {
+        Create-Directory $NugetInstallDir
+        Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -UseBasicParsing -OutFile $NugetExe
+    }
 }
 
-function CreateBuildEnvScripts()
-{
-  Create-Directory $ArtifactsDir
-  $scriptPath = Join-Path $ArtifactsDir "sdk-build-env.bat"
-  $scriptContents = @"
+function CreateBuildEnvScripts() {
+    Create-Directory $ArtifactsDir
+    $scriptPath = Join-Path $ArtifactsDir "sdk-build-env.bat"
+    $scriptContents = @"
 @echo off
 title SDK Build ($RepoRoot)
 REM https://aka.ms/vs/unsigned-dotnet-debugger-lib
@@ -78,11 +118,11 @@ set DOTNET_ADD_GLOBAL_TOOLS_TO_PATH=0
 DOSKEY killdotnet=taskkill /F /IM dotnet.exe /T ^& taskkill /F /IM VSTest.Console.exe /T ^& taskkill /F /IM msbuild.exe /T
 "@
 
-  Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
+    Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
 
-  Create-Directory $ArtifactsDir
-  $scriptPath = Join-Path $ArtifactsDir "sdk-build-env.ps1"
-  $scriptContents = @"
+    Create-Directory $ArtifactsDir
+    $scriptPath = Join-Path $ArtifactsDir "sdk-build-env.ps1"
+    $scriptContents = @"
 `$host.ui.RawUI.WindowTitle = "SDK Build ($RepoRoot)"
 # https://aka.ms/vs/unsigned-dotnet-debugger-lib
 `$env:VSDebugger_ValidateDotnetDebugLibSignatures=0
@@ -101,98 +141,199 @@ function killdotnet {
 }
 "@
 
-  Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
+    Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII
 }
 
-function CreateVSShortcut()
-{
-  # https://github.com/microsoft/vswhere/wiki/Installing
-  $installerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-  if(-Not (Test-Path -Path $installerPath))
-  {
-    return
-  }
+function CreateVSShortcut() {
+    # https://github.com/microsoft/vswhere/wiki/Installing
+    $installerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+    if (-Not (Test-Path -Path $installerPath)) {
+        return
+    }
 
-  $versionFilePath = Join-Path $RepoRoot 'src\Layout\redist\minimumMSBuildVersion'
-  # Gets the first digit (ex. 17) and appends '.0' to it.
-  $vsMajorVersion = "$(((Get-Content $versionFilePath).Split('.'))[0]).0"
-  $devenvPath = (& "$installerPath\vswhere.exe" -all -prerelease -latest -version $vsMajorVersion -find Common7\IDE\devenv.exe) | Select-Object -First 1
-  if(-Not $devenvPath)
-  {
-    return
-  }
+    $versionFilePath = Join-Path $RepoRoot 'src\Layout\redist\minimumMSBuildVersion'
+    # Gets the first digit (ex. 17) and appends '.0' to it.
+    $vsMajorVersion = "$(((Get-Content $versionFilePath).Split('.'))[0]).0"
+    $devenvPath = (& "$installerPath\vswhere.exe" -all -prerelease -latest -version $vsMajorVersion -find Common7\IDE\devenv.exe) | Select-Object -First 1
+    if (-Not $devenvPath) {
+        return
+    }
 
-  $scriptPath = Join-Path $ArtifactsDir 'sdk-build-env.ps1'
-  $slnPath = Join-Path $RepoRoot 'sdk.slnx'
-  $commandToLaunch = "& '$scriptPath'; & '$devenvPath' '$slnPath'"
-  $powershellPath = '%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe'
-  $shortcutPath = Join-Path $ArtifactsDir 'VS with sdk.slnx.lnk'
+    $scriptPath = Join-Path $ArtifactsDir 'sdk-build-env.ps1'
+    $slnPath = Join-Path $RepoRoot 'sdk.slnx'
+    $commandToLaunch = "& '$scriptPath'; & '$devenvPath' '$slnPath'"
+    $powershellPath = '%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe'
+    $shortcutPath = Join-Path $ArtifactsDir 'VS with sdk.slnx.lnk'
 
-  # https://stackoverflow.com/a/9701907/294804
-  # https://learn.microsoft.com/en-us/troubleshoot/windows-client/admin-development/create-desktop-shortcut-with-wsh
-  $wsShell = New-Object -ComObject WScript.Shell
-  $shortcut = $wsShell.CreateShortcut($shortcutPath)
-  $shortcut.TargetPath = $powershellPath
-  $shortcut.Arguments = "-WindowStyle Hidden -ExecutionPolicy Bypass -Command ""$commandToLaunch"""
-  $shortcut.IconLocation = $devenvPath
-  $shortcut.WindowStyle = 7 # Minimized
-  $shortcut.Save()
+    # https://stackoverflow.com/a/9701907/294804
+    # https://learn.microsoft.com/en-us/troubleshoot/windows-client/admin-development/create-desktop-shortcut-with-wsh
+    $wsShell = New-Object -ComObject WScript.Shell
+    $shortcut = $wsShell.CreateShortcut($shortcutPath)
+    $shortcut.TargetPath = $powershellPath
+    $shortcut.Arguments = "-WindowStyle Hidden -ExecutionPolicy Bypass -Command ""$commandToLaunch"""
+    $shortcut.IconLocation = $devenvPath
+    $shortcut.WindowStyle = 7 # Minimized
+    $shortcut.Save()
 }
 
-function InstallDotNetSharedFramework([string]$version, [string]$arch = "") {
-  $dotnetRoot = $env:DOTNET_INSTALL_DIR
-  $fxDir = Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$version"
+# Maps a dotnetup channel version (e.g. "9.0") to the specific version
+# expected by the dotnet-install script's -Version parameter (e.g. "9.0.0").
+# Full versions (e.g. "9.0.0-preview.5.24306.7") are passed through unchanged.
+function ConvertTo-DotNetInstallScriptVersion([string]$version) {
+    if ($version -match '^\d+\.\d+$') {
+        return "$version.0"
+    }
 
-  if (!(Test-Path $fxDir)) {
-    $installScript = GetDotNetInstallScript $dotnetRoot
-    $installArgs = @{
-      Version = $version
-      InstallDir = $dotnetRoot
-      Runtime = "dotnet"
-      SkipNonVersionedFiles = $true
-    }
-    if ($arch) {
-      $installArgs.Architecture = $arch
-    }
-    & $installScript @installArgs
+    return $version
+}
 
-    if($lastExitCode -ne 0) {
-      throw "Failed to install shared Framework $version to '$dotnetRoot' (exit code '$lastExitCode')."
+function Get-VersionDetailsProperty([string]$propertyName) {
+    $versionDetails = [xml](Get-Content -Raw -Path (Join-Path $RepoRoot 'eng\Version.Details.props'))
+    $property = $versionDetails.SelectSingleNode("//$propertyName")
+    if ($null -eq $property) {
+        return ""
     }
-  }
+
+    return $property.InnerText
+}
+
+function Get-CurrentRuntimeToolsetSpecs() {
+    $runtimeVersion = Get-VersionDetailsProperty 'MicrosoftNETCoreAppRefPackageVersion'
+    $aspNetCoreVersion = Get-VersionDetailsProperty 'MicrosoftAspNetCoreAppRefPackageVersion'
+
+    $specs = @()
+    if (-not [string]::IsNullOrEmpty($runtimeVersion)) {
+        $specs += $runtimeVersion
+    }
+    if (-not [string]::IsNullOrEmpty($aspNetCoreVersion)) {
+        $specs += "aspnetcore@$aspNetCoreVersion"
+    }
+
+    return $specs
+}
+
+function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$architecture = "") {
+    $dotnetRoot = $env:DOTNET_INSTALL_DIR
+
+    # Skip if every requested framework is already on disk. Accept either a
+    # dotnet runtime version/channel or a component@version spec such as
+    # aspnetcore@11.0.0-preview.6. Treat major.minor channels as present if any
+    # matching patch (e.g. 6.0.36) exists.
+    $runtimeSpecsToInstall = @($runtimeSpecs | Where-Object {
+            $component, $version = if ($_ -match '^([^@]+)@(.+)$') { $matches[1], $matches[2] } else { 'dotnet', $_ }
+            $sharedFrameworkName = if ($component -eq 'aspnetcore') { 'Microsoft.AspNetCore.App' } elseif ($component -eq 'windowsdesktop') { 'Microsoft.WindowsDesktop.App' } else { 'Microsoft.NETCore.App' }
+            $fxRoot = Join-Path $dotnetRoot "shared\$sharedFrameworkName"
+            -not (Test-Path -PathType Container (Join-Path $fxRoot "$version*"))
+        })
+    if ($runtimeSpecsToInstall.Count -eq 0) {
+        return
+    }
+
+    # dotnetup installs runtimes for its own process architecture and has no
+    # architecture override (InstallerUtilities.GetDefaultInstallArchitecture uses
+    # RuntimeInformation.ProcessArchitecture). On a cross-build (e.g. an x64 host
+    # producing an arm64 test payload), dotnetup would silently install the host
+    # architecture, so the test runtimes would not match the target Helix queue.
+    # When a specific architecture is requested, use the dotnet-install script
+    # directly since it honors -Architecture.
+    if (-not [string]::IsNullOrEmpty($architecture)) {
+        InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
+        return
+    }
+
+    $dotnetupDir = Join-Path $PSScriptRoot "dotnetup"
+    $dotnetupExe = Join-Path $dotnetupDir (GetExecutableFileName "dotnetup")
+
+    # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
+    $skipDownload = $false
+    if (Test-Path $dotnetupExe) {
+        $age = (Get-Date) - (Get-Item $dotnetupExe).LastWriteTime
+        if ($age.TotalHours -lt 24) {
+            Write-Host "dotnetup binary is less than 24 hours old; skipping re-download." -ForegroundColor DarkGray
+            $skipDownload = $true
+        }
+    }
+
+    if ($skipDownload -and ((Get-NativeMachineArchitecture) -ne (Get-ProcessMachineArchitecture))) {
+        Write-Host "Native architecture differs from process architecture; re-downloading dotnetup for the native architecture." -ForegroundColor DarkGray
+        $skipDownload = $false
+    }
+
+    if (-not $skipDownload) {
+        # Acquire the latest dotnetup daily build using the in-repo install script.
+        # get-dotnetup.ps1 may short-circuit without invoking a native process,
+        # leaving $LASTEXITCODE unset; seed it so strict mode can read it.
+        if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+        & (Join-Path $RepoRoot "scripts\get-dotnetup.ps1") -InstallDir $dotnetupDir
+        if ($lastExitCode -ne 0) {
+            Write-Host "Failed to acquire dotnetup (exit code '$lastExitCode'); falling back to dotnet install script." -ForegroundColor Yellow
+            InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
+            return
+        }
+    }
+
+    if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+    & $dotnetupExe runtime install @runtimeSpecsToInstall --install-path $dotnetRoot --set-default-install false --untracked --interactive false
+
+    if ($lastExitCode -ne 0) {
+        Write-Host "Failed to install shared frameworks ($($runtimeSpecsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode'); falling back to dotnet install script." -ForegroundColor Yellow
+        InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
+    }
+}
+
+function InstallDotNetSharedFrameworksWithInstallScript([string[]]$runtimeSpecs, [string]$dotNetRoot, [string]$architecture = "") {
+    $installScript = GetDotNetInstallScript $dotNetRoot
+    foreach ($spec in $runtimeSpecs) {
+        $component, $version = if ($spec -match '^([^@]+)@(.+)$') { $matches[1], $matches[2] } else { 'dotnet', $spec }
+        $installVersion = ConvertTo-DotNetInstallScriptVersion $version
+        $installArgs = @{
+            Version               = $installVersion
+            InstallDir            = $dotNetRoot
+            Runtime               = $component
+            SkipNonVersionedFiles = $true
+        }
+        if (-not [string]::IsNullOrEmpty($architecture)) {
+            $installArgs.Architecture = $architecture
+        }
+
+        if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+        & $installScript @installArgs
+
+        if ($lastExitCode -ne 0) {
+            throw "Failed to install shared framework $version to '$dotNetRoot' using dotnet install script for architecture '$architecture' (exit code '$lastExitCode')."
+        }
+    }
 }
 
 # Let's clear out the stage-zero folders that map to the current runtime to keep stage 2 clean
 function CleanOutStage0ToolsetsAndRuntimes {
-  $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot 'global.json') | ConvertFrom-Json
-  $dotnetSdkVersion = $GlobalJson.tools.dotnet
-  $dotnetRoot = $env:DOTNET_INSTALL_DIR
-  $versionPath = Join-Path $dotnetRoot '.version'
-  $aspnetRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' ,'Microsoft.AspNetCore.App')
-  $coreRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' ,'Microsoft.NETCore.App')
-  $wdRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared', 'Microsoft.WindowsDesktop.App')
-  $sdkPath = Join-Path $dotnetRoot 'sdk'
-  $majorVersion = $dotnetSdkVersion.Substring(0,1)
+    $GlobalJson = Get-Content -Raw -Path (Join-Path $RepoRoot 'global.json') | ConvertFrom-Json
+    $dotnetSdkVersion = $GlobalJson.tools.dotnet
+    $dotnetRoot = $env:DOTNET_INSTALL_DIR
+    $versionPath = Join-Path $dotnetRoot '.version'
+    $aspnetRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' , 'Microsoft.AspNetCore.App')
+    $coreRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared' , 'Microsoft.NETCore.App')
+    $wdRuntimePath = [IO.Path]::Combine( $dotnetRoot, 'shared', 'Microsoft.WindowsDesktop.App')
+    $sdkPath = Join-Path $dotnetRoot 'sdk'
+    $majorVersion = $dotnetSdkVersion.Substring(0, 1)
 
-  if (Test-Path($versionPath)) {
-    $lastInstalledSDK = Get-Content -Raw -Path ($versionPath)
-    if ($lastInstalledSDK -ne $dotnetSdkVersion)
-    {
-      $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
-      Remove-Item (Join-Path $aspnetRuntimePath "$majorVersion.*") -Recurse
-      Remove-Item (Join-Path $coreRuntimePath "$majorVersion.*") -Recurse
-      Remove-Item (Join-Path $wdRuntimePath "$majorVersion.*") -Recurse
-      Remove-Item (Join-Path $sdkPath "*") -Recurse
-      Remove-Item (Join-Path $dotnetRoot "packs") -Recurse
-      Remove-Item (Join-Path $dotnetRoot "sdk-manifests") -Recurse
-      Remove-Item (Join-Path $dotnetRoot "templates") -Recurse
-      throw "Installed a new SDK, deleting existing shared frameworks and sdk folders. Please rerun build"
+    if (Test-Path($versionPath)) {
+        $lastInstalledSDK = Get-Content -Raw -Path ($versionPath)
+        if ($lastInstalledSDK -ne $dotnetSdkVersion) {
+            $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
+            Remove-Item (Join-Path $aspnetRuntimePath "$majorVersion.*") -Recurse
+            Remove-Item (Join-Path $coreRuntimePath "$majorVersion.*") -Recurse
+            Remove-Item (Join-Path $wdRuntimePath "$majorVersion.*") -Recurse
+            Remove-Item (Join-Path $sdkPath "*") -Recurse
+            Remove-Item (Join-Path $dotnetRoot "packs") -Recurse
+            Remove-Item (Join-Path $dotnetRoot "sdk-manifests") -Recurse
+            Remove-Item (Join-Path $dotnetRoot "templates") -Recurse
+            throw "Installed a new SDK, deleting existing shared frameworks and sdk folders. Please rerun build"
+        }
     }
-  }
-  else
-  {
-    $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
-  }
+    else {
+        $dotnetSdkVersion | Out-File -FilePath $versionPath -NoNewline
+    }
 }
 
 InitializeCustomSDKToolset

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -222,7 +222,7 @@ function InstallDotNetSharedFrameworksWithInstallScript {
     local lastexitcode=$?
 
     if [[ $lastexitcode != 0 ]]; then
-      echo "Failed to install shared framework $version to '$dotnet_root' using dotnet install script for architecture '$arch' (exit code '$lastexitcode')."
+      echo "Failed to install shared framework spec '$spec' to '$dotnet_root' using dotnet install script for architecture '$arch' (exit code '$lastexitcode')."
       ExitWithExitCode $lastexitcode
     fi
   done

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -37,51 +37,183 @@ function InitializeCustomSDKToolset {
 
   InitializeDotNetCli true
 
-  local native_arch
-  native_arch=$(GetNativeMachineArchitecture)
+  # Redirect dotnetup data directory under artifacts so build scripts
+  # don't read/write the user's home-folder manifest.
+  export DOTNET_DOTNETUP_DATA_DIR="$artifacts_dir/.dotnetup"
 
-  # Use the pipeline's target architecture for runtime installation when set,
-  # otherwise fall back to the native machine architecture. This handles
-  # cross-compilation scenarios (e.g., x64 build machine targeting arm64).
-  local runtime_arch="${TARGET_ARCHITECTURE:-$native_arch}"
+  # The following shared frameworks are only needed for testing.
+  # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
+  if [[ "${DOTNET_INSTALL_TEST_RUNTIMES:-true}" != "false" ]]; then
+    local install_script_arch=""
+    local native_arch
+    native_arch=$(GetNativeMachineArchitecture)
+    if [[ -n "${TARGET_ARCHITECTURE:-}" && "$TARGET_ARCHITECTURE" != "$native_arch" ]]; then
+      install_script_arch="$TARGET_ARCHITECTURE"
+    fi
 
-  # On macOS arm64 running under Rosetta 2, uname -m reports x86_64 and
-  # Arcade installs the x64 SDK. Reinstall with the native architecture so
-  # the dotnet host and shared frameworks match the hardware.
-  if [[ "$native_arch" == "arm64" ]] && [[ "$(uname -m)" == "x86_64" ]]; then
-    ReadGlobalVersion "dotnet"
-    local dotnet_sdk_version=$_ReadGlobalVersion
-    echo "Native architecture is arm64 but SDK was installed as x64 (Rosetta 2). Reinstalling for arm64..."
-    rm -rf "$DOTNET_INSTALL_DIR/sdk/$dotnet_sdk_version"
-    InstallDotNet "$DOTNET_INSTALL_DIR" "$dotnet_sdk_version" "$native_arch" "sdk" "false" $runtime_source_feed $runtime_source_feed_key
+    local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
+    if [[ -z "$install_script_arch" ]]; then
+      # Also install the exact runtime versions that arcade's toolset requires
+      # (from Version.Details.props) so tests can target those specific versions.
+      local runtime_version
+      runtime_version=$(ReadVersionDetailsProperty "MicrosoftNETCoreAppRefPackageVersion")
+      local aspnetcore_version
+      aspnetcore_version=$(ReadVersionDetailsProperty "MicrosoftAspNetCoreAppRefPackageVersion")
+      if [[ -n "$runtime_version" ]]; then
+        runtime_specs+=("$runtime_version")
+      fi
+      if [[ -n "$aspnetcore_version" ]]; then
+        runtime_specs+=("aspnetcore@$aspnetcore_version")
+      fi
+    fi
 
-    # Remove any cached x64 test runtimes from previous builds
-    for fx_version in "6.0.0" "7.0.0" "8.0.0" "9.0.0" "10.0.0"; do
-      rm -rf "$DOTNET_INSTALL_DIR/shared/Microsoft.NETCore.App/$fx_version"
-    done
+    InstallDotNetSharedFrameworks "$install_script_arch" "${runtime_specs[@]}"
   fi
-
-  InstallDotNetSharedFramework "6.0.0" "$runtime_arch"
-  InstallDotNetSharedFramework "7.0.0" "$runtime_arch"
-  InstallDotNetSharedFramework "8.0.0" "$runtime_arch"
-  InstallDotNetSharedFramework "9.0.0" "$runtime_arch"
-  InstallDotNetSharedFramework "10.0.0" "$runtime_arch"
 
   CreateBuildEnvScript
 }
 
-# Installs additional shared frameworks for testing purposes
-function InstallDotNetSharedFramework {
-  local version=$1
-  local arch=${2:-}
+function ReadVersionDetailsProperty {
+  local property_name=$1
+  sed -n "s:.*<$property_name>\([^<]*\)</$property_name>.*:\1:p" "$repo_root/eng/Version.Details.props" | head -n 1
+}
+
+# Installs additional shared frameworks for testing purposes.
+function InstallDotNetSharedFrameworks {
+  local arch=$1
+  shift
   local dotnet_root=$DOTNET_INSTALL_DIR
-  local fx_dir="$dotnet_root/shared/Microsoft.NETCore.App/$version"
+  local specs_to_install=()
 
-  if [[ ! -d "$fx_dir" ]]; then
-    GetDotNetInstallScript "$dotnet_root"
-    local install_script=$_GetDotNetInstallScript
+  for spec in "$@"; do
+    # Accept either a dotnet runtime version/channel or a component@version spec
+    # such as aspnetcore@11.0.0-preview.6. Treat major.minor channels as present
+    # if any matching patch (e.g. 6.0.36) exists.
+    local component="dotnet"
+    local version="$spec"
+    if [[ "$spec" == *@* ]]; then
+      component="${spec%@*}"
+      version="${spec#*@}"
+    fi
 
-    local install_args=(--version $version --install-dir "$dotnet_root" --runtime "dotnet" --skip-non-versioned-files)
+    local shared_framework_name="Microsoft.NETCore.App"
+    if [[ "$component" == "aspnetcore" ]]; then
+      shared_framework_name="Microsoft.AspNetCore.App"
+    elif [[ "$component" == "windowsdesktop" ]]; then
+      shared_framework_name="Microsoft.WindowsDesktop.App"
+    fi
+
+    if ! compgen -G "$dotnet_root/shared/$shared_framework_name/$version*" > /dev/null; then
+      specs_to_install+=("$spec")
+    fi
+  done
+
+  if [[ ${#specs_to_install[@]} -eq 0 ]]; then
+    return
+  fi
+
+  # dotnetup installs runtimes for its own process architecture and has no
+  # architecture override (InstallerUtilities.GetDefaultInstallArchitecture uses
+  # RuntimeInformation.ProcessArchitecture). On a cross-build (e.g. an x64 host
+  # producing an arm64 test payload), dotnetup would silently install the host
+  # architecture, so the test runtimes would not match the target Helix queue.
+  # When a specific architecture is requested, use the dotnet-install script
+  # directly since it honors --architecture.
+  if [[ -n "$arch" ]]; then
+    InstallDotNetSharedFrameworksWithInstallScript "$dotnet_root" "$arch" "${specs_to_install[@]}"
+    return
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local dotnetup_dir="$script_dir/dotnetup"
+  local dotnetup_exe="$dotnetup_dir/dotnetup"
+
+  # Re-download dotnetup at most once every 24 hours to avoid unnecessary network calls.
+  local skip_download=false
+  if [[ -f "$dotnetup_exe" ]]; then
+    local current_time
+    current_time=$(date +%s)
+    local file_time
+    file_time=$(stat -c %Y "$dotnetup_exe" 2>/dev/null || stat -f %m "$dotnetup_exe" 2>/dev/null || echo 0)
+    local age_seconds=$((current_time - file_time))
+    if [[ $age_seconds -lt 86400 ]]; then
+      echo "dotnetup binary is less than 24 hours old; skipping re-download."
+      skip_download=true
+    fi
+  fi
+
+  if [[ "$skip_download" == true && -f "$dotnetup_exe" ]]; then
+    # dotnetup installs runtimes for its own process architecture, so a cached
+    # binary of the wrong architecture (e.g. an x64 dotnetup left on a reused
+    # arm64 agent, or one downloaded under Rosetta 2) would install the wrong
+    # runtimes. Verify the cached binary's actual architecture against the native
+    # architecture and re-download on mismatch rather than trusting uname.
+    local native_arch
+    native_arch="$(GetNativeMachineArchitecture)"
+    local cached_arch=""
+    if [[ "$(uname)" == "Darwin" ]]; then
+      if file "$dotnetup_exe" 2>/dev/null | grep -q 'arm64'; then
+        cached_arch="arm64"
+      elif file "$dotnetup_exe" 2>/dev/null | grep -q 'x86_64'; then
+        cached_arch="x64"
+      fi
+    fi
+    if [[ -n "$cached_arch" && "$cached_arch" != "$native_arch" ]]; then
+      echo "Cached dotnetup architecture ($cached_arch) does not match native architecture ($native_arch); re-downloading."
+      skip_download=false
+    fi
+  fi
+
+  if [[ "$skip_download" != true ]]; then
+    # Acquire the latest dotnetup daily build using the in-repo install script.
+    # build.sh runs under `set -e`; guard so we can emit a diagnostic.
+    if ! "$repo_root/scripts/get-dotnetup.sh" --install-dir "$dotnetup_dir"; then
+      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup; falling back to dotnet install script."
+      InstallDotNetSharedFrameworksWithInstallScript "$dotnet_root" "$arch" "${specs_to_install[@]}"
+      return
+    fi
+  fi
+
+  local restore_errexit=false
+  if [[ $- == *e* ]]; then
+    restore_errexit=true
+    set +e
+  fi
+  "$dotnetup_exe" runtime install "${specs_to_install[@]}" --install-path "$dotnet_root" --set-default-install false --untracked --interactive false
+  local lastexitcode=$?
+  if [[ "$restore_errexit" == true ]]; then
+    set -e
+  fi
+
+  if [[ $lastexitcode != 0 ]]; then
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install shared frameworks (${specs_to_install[*]}) to '$dotnet_root' using dotnetup (exit code '$lastexitcode'); falling back to dotnet install script."
+    InstallDotNetSharedFrameworksWithInstallScript "$dotnet_root" "$arch" "${specs_to_install[@]}"
+  fi
+}
+
+function InstallDotNetSharedFrameworksWithInstallScript {
+  local dotnet_root=$1
+  local arch=$2
+  shift 2
+
+  GetDotNetInstallScript "$dotnet_root"
+  local install_script=$_GetDotNetInstallScript
+
+  for spec in "$@"; do
+    local component="dotnet"
+    local install_version="$spec"
+    if [[ "$spec" == *@* ]]; then
+      component="${spec%@*}"
+      install_version="${spec#*@}"
+    fi
+    # Map dotnetup channel (e.g. "9.0") to the specific version the install
+    # script's --version parameter expects (e.g. "9.0.0").
+    if [[ "$install_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+      install_version="$install_version.0"
+    fi
+
+    local install_args=(--version "$install_version" --install-dir "$dotnet_root" --runtime "$component" --skip-non-versioned-files)
     if [[ -n "$arch" ]]; then
       install_args+=(--architecture "$arch")
     fi
@@ -90,10 +222,10 @@ function InstallDotNetSharedFramework {
     local lastexitcode=$?
 
     if [[ $lastexitcode != 0 ]]; then
-      echo "Failed to install Shared Framework $version to '$dotnet_root' (exit code '$lastexitcode')."
+      echo "Failed to install shared framework $version to '$dotnet_root' using dotnet install script for architecture '$arch' (exit code '$lastexitcode')."
       ExitWithExitCode $lastexitcode
     fi
-  fi
+  done
 }
 
 function CreateBuildEnvScript {

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -1,0 +1,232 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Downloads the latest dotnetup daily build and installs it locally.
+
+.DESCRIPTION
+    Downloads dotnetup from the public aka.ms shortlinks (e.g.
+    https://aka.ms/dotnet/dotnetup/daily/dotnetup-win-x64.exe), verifies the
+    SHA-512 checksum, and installs the binary to a local directory.
+
+.PARAMETER InstallDir
+    Directory to install dotnetup into. Defaults to ~/.dotnetup.
+
+.PARAMETER Quality
+    Build quality to install. Defaults to 'daily'.
+
+.PARAMETER RuntimeId
+    Override automatic OS/architecture detection with an explicit RID
+    (e.g. win-x64, linux-arm64, osx-arm64, linux-musl-x64).
+
+.EXAMPLE
+    ./get-dotnetup.ps1
+
+.EXAMPLE
+    ./get-dotnetup.ps1 -RuntimeId linux-musl-x64 -InstallDir /opt/dotnetup
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallDir = (Join-Path $HOME ".dotnetup"),
+    [string]$Quality = "daily",
+    [string]$RuntimeId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$BaseUrl = "https://aka.ms/dotnet/dotnetup/$Quality"
+
+function Get-RuntimeId {
+    if ($RuntimeId) {
+        return $RuntimeId
+    }
+
+    # Use RuntimeInformation so this works on both Windows PowerShell 5.1
+    # and PowerShell Core ($IsWindows/$IsMacOS/$IsLinux only exist on Core).
+
+    # Detect OS
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        $os = "win"
+    }
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        $os = "osx"
+    }
+    elseif ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::Linux)) {
+        $os = "linux"
+
+        # Detect musl vs glibc
+        $isMusl = $false
+        try {
+            $lddOutput = & ldd --version 2>&1 | Out-String
+            if ($lddOutput -match "musl") {
+                $isMusl = $true
+            }
+        }
+        catch { }
+
+        if (-not $isMusl) {
+            try {
+                $null = & getconf GNU_LIBC_VERSION 2>&1
+                # If getconf succeeds, it's glibc
+            }
+            catch {
+                # getconf failed — likely musl
+                $isMusl = $true
+            }
+        }
+
+        if ($isMusl) {
+            $os = "linux-musl"
+        }
+    }
+    else {
+        throw "Unsupported operating system. Use -RuntimeId to specify a RID manually."
+    }
+
+    # Detect architecture
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $archStr = switch ($arch) {
+        "X64" { "x64" }
+        "Arm64" { "arm64" }
+        default { throw "Unsupported architecture: $arch. Use -RuntimeId to specify a RID manually." }
+    }
+
+    return "$os-$archStr"
+}
+
+# --- Main ---
+
+$rid = Get-RuntimeId
+Write-Host "Detected runtime: $rid" -ForegroundColor Cyan
+
+$binaryName = if ($rid -like "win-*") { "dotnetup.exe" } else { "dotnetup" }
+$fileName = if ($rid -like "win-*") { "dotnetup-$rid.exe" } else { "dotnetup-$rid" }
+$downloadUrl = "$BaseUrl/$fileName"
+$checksumUrl = "$downloadUrl.sha512"
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "dotnetup-install-$([System.IO.Path]::GetRandomFileName())"
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+try {
+    $tempBinary = Join-Path $tempDir $fileName
+
+    function Invoke-WithRetry {
+        param([scriptblock]$ScriptBlock, [string]$ActionDescription, [int]$MaxAttempts = 3)
+        $attempt = 1
+        while ($true) {
+            try {
+                & $ScriptBlock
+                return
+            }
+            catch {
+                if ($attempt -ge $MaxAttempts) {
+                    throw "${ActionDescription} failed after $MaxAttempts attempts.`nError: $($_.Exception.Message)"
+                }
+                $delay = [Math]::Pow(2, $attempt)
+                Write-Host "${ActionDescription} failed (attempt $attempt of $MaxAttempts): $($_.Exception.Message). Retrying in $delay seconds..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $delay
+                $attempt++
+            }
+        }
+    }
+
+    Write-Host "Downloading $downloadUrl" -ForegroundColor Cyan
+    try {
+        Invoke-WithRetry -ActionDescription "Download from $downloadUrl" -ScriptBlock {
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $tempBinary -UseBasicParsing
+        }
+    }
+    catch {
+        throw @"
+Failed to download dotnetup from $downloadUrl
+Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64
+Use -RuntimeId to specify the correct RID, or -Quality to select a different build quality.
+
+Error: $($_.Exception.Message)
+"@
+    }
+
+    Write-Host "Verifying SHA-512 checksum..." -ForegroundColor Cyan
+    $tempChecksum = Join-Path $tempDir "$fileName.sha512"
+    Invoke-WithRetry -ActionDescription "Download checksum from $checksumUrl" -ScriptBlock {
+        Invoke-WebRequest -Uri $checksumUrl -OutFile $tempChecksum -UseBasicParsing
+    }
+
+    $expected = ((Get-Content $tempChecksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+    # Compute SHA-512 directly via .NET to avoid relying on Get-FileHash, which is
+    # not always resolvable in stripped-down PowerShell hosts (e.g., some CI agents).
+    $sha512 = [System.Security.Cryptography.SHA512]::Create()
+    try {
+        $stream = [System.IO.File]::OpenRead($tempBinary)
+        try {
+            $hashBytes = $sha512.ComputeHash($stream)
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $sha512.Dispose()
+    }
+    $actual = ([System.BitConverter]::ToString($hashBytes) -replace '-', '').ToLowerInvariant()
+    if ($expected -ne $actual) {
+        throw "Checksum mismatch.`n  Expected: $expected`n  Actual:   $actual"
+    }
+    Write-Host "Checksum verified." -ForegroundColor Green
+
+    # Install just the binary (renamed to plain dotnetup[.exe])
+    Write-Host "Installing to $InstallDir..." -ForegroundColor Cyan
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $installedBinary = Join-Path $InstallDir $binaryName
+    Copy-Item -Path $tempBinary -Destination $installedBinary -Force
+
+    if (-not (Test-Path $installedBinary)) {
+        throw "Installation failed: '$installedBinary' not found after copy."
+    }
+
+    # Set executable bit on non-Windows
+    if ($rid -notlike "win-*") {
+        chmod +x $installedBinary
+    }
+
+    Write-Host ""
+    Write-Host "dotnetup installed successfully to $InstallDir" -ForegroundColor Green
+    Write-Host ""
+
+    # Check if install dir is on PATH
+    $pathDirs = $env:PATH -split [System.IO.Path]::PathSeparator
+    $onPath = $pathDirs | Where-Object { $_ -eq $InstallDir -or $_ -eq "$InstallDir/" -or $_ -eq "$InstallDir\" }
+
+    if (-not $onPath) {
+        Write-Host "To add dotnetup to your PATH, run:" -ForegroundColor Yellow
+        Write-Host ""
+        if ($rid -like "win-*") {
+            Write-Host "  # Current session:" -ForegroundColor DarkGray
+            Write-Host "  `$env:PATH = `"$InstallDir;`$env:PATH`""
+            Write-Host ""
+            Write-Host "  # Permanently (current user):" -ForegroundColor DarkGray
+            Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `"$InstallDir;`$([Environment]::GetEnvironmentVariable('PATH', 'User'))`", 'User')"
+        }
+        else {
+            Write-Host "  # Current session:" -ForegroundColor DarkGray
+            Write-Host "  export PATH=`"$InstallDir`:`$PATH`""
+            Write-Host ""
+            Write-Host "  # Permanently (add to your shell profile):" -ForegroundColor DarkGray
+            Write-Host "  echo 'export PATH=`"$InstallDir`:`$PATH`"' >> ~/.bashrc"
+        }
+        Write-Host ""
+    }
+    else {
+        Write-Host "dotnetup is already on your PATH. Run 'dotnetup --help' to get started." -ForegroundColor Green
+    }
+}
+finally {
+    # Cleanup temp files
+    if (Test-Path $tempDir) { Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue }
+}

--- a/scripts/get-dotnetup.sh
+++ b/scripts/get-dotnetup.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# get-dotnetup.sh
+#
+# Downloads the latest dotnetup daily build and installs it locally.
+#
+# Downloads dotnetup from the public aka.ms shortlinks (e.g.
+# https://aka.ms/dotnet/dotnetup/daily/dotnetup-linux-x64), verifies the
+# SHA-512 checksum, and installs the binary to a local directory.
+#
+# Usage:
+#   ./get-dotnetup.sh
+#   ./get-dotnetup.sh --install-dir /opt/dotnetup
+#   ./get-dotnetup.sh --runtime-id linux-musl-x64
+#   ./get-dotnetup.sh --quality daily
+
+set -euo pipefail
+
+# --- Defaults ---
+INSTALL_DIR="$HOME/.dotnetup"
+QUALITY="daily"
+RUNTIME_ID=""
+
+# --- Colors (disabled if not a terminal) ---
+if [ -t 1 ]; then
+    CYAN='\033[0;36m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    RED='\033[0;31m'
+    GRAY='\033[0;90m'
+    NC='\033[0m'
+else
+    CYAN='' GREEN='' YELLOW='' RED='' GRAY='' NC=''
+fi
+
+info()  { printf "${CYAN}%s${NC}\n" "$*"; }
+ok()    { printf "${GREEN}%s${NC}\n" "$*"; }
+warn()  { printf "${YELLOW}%s${NC}\n" "$*"; }
+err()   { printf "${RED}%s${NC}\n" "$*" >&2; }
+gray()  { printf "${GRAY}%s${NC}\n" "$*"; }
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install-dir)  INSTALL_DIR="$2"; shift 2 ;;
+        --quality)      QUALITY="$2"; shift 2 ;;
+        --runtime-id)   RUNTIME_ID="$2"; shift 2 ;;
+        --help|-h)
+            cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Downloads the latest dotnetup daily build from aka.ms and installs it locally.
+
+Options:
+  --install-dir DIR     Installation directory (default: ~/.dotnetup)
+  --quality QUALITY     Build quality (default: daily)
+  --runtime-id RID      Override OS/architecture detection (e.g. linux-musl-x64, osx-arm64)
+  --help, -h            Show this help message
+
+Examples:
+  ./get-dotnetup.sh
+  ./get-dotnetup.sh --runtime-id linux-musl-x64
+  ./get-dotnetup.sh --install-dir /opt/dotnetup
+EOF
+            exit 0
+            ;;
+        *)
+            err "Unknown option: $1"
+            err "Run '$(basename "$0") --help' for usage."
+            exit 1
+            ;;
+    esac
+done
+
+BASE_URL="https://aka.ms/dotnet/dotnetup/${QUALITY}"
+
+# --- Check prerequisites ---
+if command -v curl &>/dev/null; then
+    DOWNLOADER="curl"
+elif command -v wget &>/dev/null; then
+    DOWNLOADER="wget"
+else
+    err "Neither 'curl' nor 'wget' was found on PATH. One of them is required to download dotnetup."
+    exit 1
+fi
+
+download() {
+    local url="$1" out="$2"
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl --fail --silent --show-error --location --retry 3 --output "$out" "$url"
+    else
+        wget --quiet --tries=3 --output-document="$out" "$url"
+    fi
+}
+
+# --- Detect runtime ID ---
+is_musl() {
+    # Layer 1: Check if getconf reports glibc
+    if getconf GNU_LIBC_VERSION &>/dev/null; then
+        return 1  # glibc
+    fi
+
+    # Layer 2: Check ldd --version output for "musl"
+    if ldd --version 2>&1 | grep -qi "musl"; then
+        return 0  # musl
+    fi
+
+    # Layer 3: Check if /lib contains musl libc
+    if ls /lib/ld-musl-* &>/dev/null; then
+        return 0  # musl
+    fi
+
+    # Default: assume glibc
+    return 1
+}
+
+detect_rid() {
+    if [ -n "$RUNTIME_ID" ]; then
+        echo "$RUNTIME_ID"
+        return
+    fi
+
+    local os arch
+
+    # Detect OS
+    case "$(uname -s)" in
+        Linux)
+            if is_musl; then
+                os="linux-musl"
+            else
+                os="linux"
+            fi
+            ;;
+        Darwin)
+            os="osx"
+            ;;
+        *)
+            err "Unsupported OS: $(uname -s). Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    # Detect architecture. On macOS, `uname -m` reports x86_64 when the shell is
+    # running under Rosetta 2, so prefer the native hardware capability signal.
+    local machine_arch
+    if [ "$os" = "osx" ] && [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+        machine_arch="arm64"
+    else
+        machine_arch="$(uname -m)"
+    fi
+
+    case "$machine_arch" in
+        x86_64|amd64)    arch="x64" ;;
+        aarch64|arm64)   arch="arm64" ;;
+        *)
+            err "Unsupported architecture: $machine_arch. Use --runtime-id to specify a RID manually."
+            exit 1
+            ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+# --- Main ---
+
+RID=$(detect_rid)
+info "Detected runtime: $RID"
+
+FILE_NAME="dotnetup-${RID}"
+DOWNLOAD_URL="${BASE_URL}/${FILE_NAME}"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha512"
+
+INSTALLED_BINARY="${INSTALL_DIR}/dotnetup"
+
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+TEMP_BINARY="${TEMP_DIR}/${FILE_NAME}"
+
+info "Downloading ${DOWNLOAD_URL}"
+if ! download "$DOWNLOAD_URL" "$TEMP_BINARY"; then
+    err "Failed to download dotnetup from $DOWNLOAD_URL"
+    err "Available RIDs: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64"
+    err "Use --runtime-id to specify the correct RID, or --quality to select a different build quality."
+    exit 1
+fi
+
+info "Verifying SHA-512 checksum..."
+TEMP_CHECKSUM="${TEMP_DIR}/${FILE_NAME}.sha512"
+if ! download "$CHECKSUM_URL" "$TEMP_CHECKSUM"; then
+    err "Failed to download checksum from $CHECKSUM_URL"
+    exit 1
+fi
+
+EXPECTED=$(awk '{print tolower($1)}' "$TEMP_CHECKSUM")
+if command -v sha512sum &>/dev/null; then
+    ACTUAL=$(sha512sum "$TEMP_BINARY" | awk '{print tolower($1)}')
+elif command -v shasum &>/dev/null; then
+    ACTUAL=$(shasum -a 512 "$TEMP_BINARY" | awk '{print tolower($1)}')
+else
+    err "Neither 'sha512sum' nor 'shasum' was found on PATH."
+    exit 1
+fi
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+    err "Checksum mismatch."
+    err "  Expected: $EXPECTED"
+    err "  Actual:   $ACTUAL"
+    exit 1
+fi
+ok "Checksum verified."
+
+# Install the binary (renamed to plain 'dotnetup')
+info "Installing to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR"
+cp "$TEMP_BINARY" "$INSTALL_DIR/dotnetup"
+chmod +x "$INSTALL_DIR/dotnetup"
+
+if [ ! -x "$INSTALL_DIR/dotnetup" ]; then
+    err "Installation failed: '$INSTALL_DIR/dotnetup' not found or not executable after copy."
+    exit 1
+fi
+
+echo ""
+ok "dotnetup installed successfully to $INSTALL_DIR"
+echo ""
+
+# Check if install dir is on PATH (resolve to absolute path, handle trailing slashes)
+RESOLVED_INSTALL_DIR=$(cd "$INSTALL_DIR" 2>/dev/null && pwd -P || echo "$INSTALL_DIR")
+on_path() {
+    local dir
+    while IFS= read -r -d ':' dir || [ -n "$dir" ]; do
+        dir="${dir%/}"
+        [ -z "$dir" ] && continue
+        local resolved
+        resolved=$(cd "$dir" 2>/dev/null && pwd -P || echo "$dir")
+        if [ "$resolved" = "$RESOLVED_INSTALL_DIR" ]; then
+            return 0
+        fi
+    done <<< "$PATH"
+    return 1
+}
+
+if on_path; then
+    ok "dotnetup is already on your PATH. Run 'dotnetup --help' to get started."
+else
+    warn "To add dotnetup to your PATH:"
+    echo ""
+    gray "  # Current session:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    gray "  # Permanently (add to your shell profile):"
+
+    # Detect current shell for profile recommendation
+    SHELL_NAME=$(basename "${SHELL:-/bin/bash}")
+    case "$SHELL_NAME" in
+        zsh)   PROFILE="~/.zshrc" ;;
+        fish)  PROFILE="~/.config/fish/config.fish" ;;
+        *)     PROFILE="~/.bashrc" ;;
+    esac
+
+    if [ "$SHELL_NAME" = "fish" ]; then
+        echo "  fish_add_path \"$INSTALL_DIR\""
+    else
+        echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $PROFILE"
+    fi
+    echo ""
+fi


### PR DESCRIPTION
For https://github.com/dotnet/sdk/issues/54257

Port the dotnetup-based acquisition scripts from https://github.com/dotnet/sdk/tree/release/dnup.
The implementation is reviewed within https://github.com/dotnet/sdk/pull/54586. No code is new within  ce484c30b4b9da850080fdd6bd6ce41f80134d92, but I could not reasonably cherry-pick, the commits were too sharded. History will continue to be preserved in `release/dnup`. 

In this PR, we:
configure-toolset installs the bootstrap SDK from global.json and restore-toolset installs the test shared frameworks, both via dotnetup (downloaded by scripts/get-dotnetup.{sh,ps1}).
The dotnet-install script is retained as a fallback. 

Modify .gitignore to Ignore the downloaded eng/dotnetup/ binary.