### PR TITLE
Move macOS x64 TestBuild PR leg to CI-only, switch to ARM64

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -29,12 +29,6 @@ pr:
     - README.md
     - CODEOWNERS
 
-parameters:
-- name: enableArm64Job
-  displayName: Enables the ARM64 job
-  type: boolean
-  default: true
-
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml
 # Variables used: DncEngPublicBuildPool
@@ -75,20 +69,19 @@ stages:
         name: Azure Pipelines
         vmImage: macOS-latest
         os: macOS
-      helixTargetQueue: osx.15.amd64.open
-  ### ARM64 ###
-  - ${{ if eq(parameters.enableArm64Job, true) }}:
+      helixTargetQueue: osx.15.arm64.open
+  ### x64 (CI only) ###
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
       parameters:
         pool:
           name: Azure Pipelines
           vmImage: macOS-latest
           os: macOS
-        helixTargetQueue: osx.15.arm64.open
+        helixTargetQueue: osx.15.amd64.open
         macOSJobParameterSets:
         - categoryName: TestBuild
-          targetArchitecture: arm64
-          runtimeIdentifier: osx-arm64
+          runtimeIdentifier: osx-x64
 
   ############### DOTNET-FORMAT ###############
   - template: /eng/dotnet-format/dotnet-format-integration.yml

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -134,11 +134,6 @@ jobs:
 
     ############### TESTING ###############
     - ${{ if eq(parameters.runTests, true) }}:
-      - ${{ if eq(parameters.runAoTTests, true) }}:
-        # For the reason this is here, see: https://github.com/dotnet/sdk/issues/22655
-        - script: $(Build.SourcesDirectory)/artifacts/bin/redist/$(buildConfiguration)/dotnet/dotnet workload install wasm-tools --skip-manifest-update
-          workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
-          displayName: 🟣 Install wasm-tools Workload
 
       # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
       - ${{ if eq(parameters.pool.os, 'windows') }}:

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -29,10 +29,12 @@ parameters:
   ### MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild
-    runtimeIdentifier: osx-x64
+    targetArchitecture: arm64
+    runtimeIdentifier: osx-arm64
   - categoryName: AoT
     runAoTTests: true
-    runtimeIdentifier: osx-x64
+    targetArchitecture: arm64
+    runtimeIdentifier: osx-arm64
 
 jobs:
 ### ONELOCBUILD ###

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -203,6 +203,12 @@
     <PropertyGroup>
       <HelixPreCommands Condition="!$(IsPosixShell)">call %HELIX_CORRELATION_PAYLOAD%\t\SetupHelixEnvironment.cmd $(TestFullMSBuild);$(HelixPreCommands)</HelixPreCommands>
       <HelixPreCommands Condition="$(IsPosixShell)">. $HELIX_CORRELATION_PAYLOAD/t/SetupHelixEnvironment.sh;$(HelixPreCommands)</HelixPreCommands>
+      <!-- Install wasm-tools workload on Helix for AoT tests (see: https://github.com/dotnet/sdk/issues/22655).
+           This must happen on Helix (not the build machine) because cross-arch builds produce a dotnet binary
+           that cannot execute on the build machine's architecture.
+           Point to the test NuGet.config so the workload packs can be resolved from the configured feeds. -->
+      <HelixPreCommands Condition="'$(RunAoTTests)' == 'true' and !$(IsPosixShell)">$(HelixPreCommands);%DOTNET_ROOT%\dotnet workload install wasm-tools --skip-manifest-update --configfile %TestExecutionDirectory%\NuGet.config</HelixPreCommands>
+      <HelixPreCommands Condition="'$(RunAoTTests)' == 'true' and $(IsPosixShell)">$(HelixPreCommands);$DOTNET_ROOT/dotnet workload install wasm-tools --skip-manifest-update --configfile $TestExecutionDirectory/NuGet.config</HelixPreCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure";$(HelixPostCommands)</HelixPostCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "Get-ChildItem -Recurse -File -Filter '*hangdump.dmp' | Copy-Item -Destination $env:HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
       <HelixPostCommands Condition="$(IsPosixShell)">find "$HELIX_WORKITEM_UPLOAD_ROOT/../../.." -name '*hangdump.dmp' -print0 | xargs -0 -I@ cp @ "$HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>


### PR DESCRIPTION
## Move macOS x64 TestBuild PR leg to CI-only, switch to ARM64

### Summary

This PR simplifies the macOS test matrix for PRs by:

1. **Switching the macOS TestBuild leg from x64 to ARM64** — ARM64 is our primary macOS target going forward.
2. **Moving the macOS x64 TestBuild leg to CI-only** (`.vsts-pr.yml` push trigger to `main`) — x64 tests no longer run on PRs.
3. **Removing the `enableArm64Job` parameter** — ARM64 always runs now, so the toggle is unnecessary. This parameter was originally added when ARM64 support was first being stood up.

The AoT leg remains on x64 because the build machine is Intel and cannot execute arm64 binaries (needed for wasm-tools workload install).

### Files changed

- `eng/pipelines/templates/jobs/sdk-job-matrix.yml` — Default macOS TestBuild switched from osx-x64 to osx-arm64
- `.vsts-pr.yml` — Removed `enableArm64Job` parameter; added CI-only condition for x64 TestBuild leg

### Notes

- `.vsts-ci.yml` is intentionally not modified here; it needs a larger refactor which will be handled in a separate PR.