### PR TITLE
Fix Flakey Run Parser Tests

### DIFF
--- a/test/dotnet.Tests/CommandTests/Reference/Add/AddReferenceParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Reference/Add/AddReferenceParserTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine.Parsing;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add.Reference;
-using Microsoft.DotNet.Cli.Utils;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests.ParserTests
@@ -25,10 +24,14 @@ namespace Microsoft.DotNet.Tests.ParserTests
 
             var command = Assert.IsType<AddReferenceCommandDefinition>(result.CommandResult.Command);
 
+            // Compare against the same cached value the argument's default factory uses
+            // (CommonOptions.NormalizedCurrentDirectory) rather than a fresh
+            // Directory.GetCurrentDirectory(). The current directory is process-global mutable
+            // state, and other tests in this assembly call Directory.SetCurrentDirectory while
+            // running in parallel, so re-deriving it here races and makes this test flaky.
             result.GetValue(command.Parent.ProjectOrFileArgument)
                 .Should()
-                .BeEquivalentTo(
-                    PathUtilities.EnsureTrailingSlash(Directory.GetCurrentDirectory()));
+                .BeEquivalentTo(CommonOptions.NormalizedCurrentDirectory.Value);
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -20,10 +20,11 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var tam = new TestAssetsManager(output);
             var testAsset = tam.CopyTestAsset("HelloWorld").WithSource();
             var newWorkingDir = testAsset.Path;
-
-            Directory.SetCurrentDirectory(newWorkingDir);
             var projectPath = Path.Combine(newWorkingDir, "HelloWorld.csproj");
-                
+
+            // An absolute --project path is passed, so resolution does not depend on the process-wide
+            // current directory. Avoid Directory.SetCurrentDirectory so this test does not leak CWD
+            // state onto other tests running in parallel.
             var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath, "--", "foo" });
             runCommand.ApplicationArgs.Single().Should().Be("foo");
         }
@@ -34,12 +35,23 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var tam = new TestAssetsManager(output);
             var testAsset = tam.CopyTestAsset("HelloWorld").WithSource();
             var newWorkingDir = testAsset.Path;
-
-            Directory.SetCurrentDirectory(newWorkingDir);
             var projectPath = @".\HelloWorld.csproj";
-            // Should not throw on Windows
-            var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath });
-            runCommand.ProjectFileFullPath.Should().NotBeNull();
+
+            // This scenario resolves a relative --project path against the process-wide current
+            // directory, so it must be changed. Restore it in a finally so the change does not leak
+            // onto other parallel tests (see AddReferenceHasDefaultArgumentSetToCurrentDirectory).
+            var originalWorkingDir = Directory.GetCurrentDirectory();
+            try
+            {
+                Directory.SetCurrentDirectory(newWorkingDir);
+                // Should not throw on Windows
+                var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath });
+                runCommand.ProjectFileFullPath.Should().NotBeNull();
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalWorkingDir);
+            }
         }
 
         [UnixOnlyFact]
@@ -48,12 +60,23 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var tam = new TestAssetsManager(output);
             var testAsset = tam.CopyTestAsset("HelloWorld").WithSource();
             var newWorkingDir = testAsset.Path;
-
-            Directory.SetCurrentDirectory(newWorkingDir);
             var projectPath = @".\HelloWorld.csproj";
-            // Should not throw on Linux with backslash separators
-            var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath });
-            runCommand.ProjectFileFullPath.Should().NotBeNull();
+
+            // This scenario resolves a relative --project path against the process-wide current
+            // directory, so it must be changed. Restore it in a finally so the change does not leak
+            // onto other parallel tests (see AddReferenceHasDefaultArgumentSetToCurrentDirectory).
+            var originalWorkingDir = Directory.GetCurrentDirectory();
+            try
+            {
+                Directory.SetCurrentDirectory(newWorkingDir);
+                // Should not throw on Linux with backslash separators
+                var runCommand = RunCommand.FromArgs(new[] { "--project", projectPath });
+                runCommand.ProjectFileFullPath.Should().NotBeNull();
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalWorkingDir);
+            }
         }
     }
 }


### PR DESCRIPTION
# Human:

Hypothesis: Summary; the lazy value of the compared directory did not align with concurrent tests

I considered use of a Banned API to block this from occurring again or a try / finally that restored CWD  but don't think that is the best approach.

Before merging I should actually verify these claims are not bogus.

# Generated with AI:

Directory.GetCurrentDirectory() is process-global mutable state, and xunit runs dotnet.Tests at 10 parallel threads. The smoking gun: RunParserTests.cs:24 calls Directory.SetCurrentDirectory(testAsset.Path) (a copy under t/dotnetSdkTests.XXXX) and never restores it — three tests do this with no finally. While those run, AddReferenceHasDefaultArgumentSetToCurrentDirectory:

reads the cached NormalizedCurrentDirectory.Value (frozen at the process-start dir w/AEC4092E/e), and asserts it equals a fresh Directory.GetCurrentDirectory() (now the polluted t/dotnetSd…). → mismatch → fail. The Lazy amplifies this (stale across CWD epochs), but even without it a small race window remains between the two GetCurrentDirectory() reads.