### PR TITLE
Add 'Investigating PRs and CI failures' guidance to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,10 @@ Testing:
   - Test commands in the dogfood shell (e.g., `dnx --help`, `dotnet tool install --help`)
   - The dogfood script sets up PATH and environment to use the newly built SDK
 
+Investigating PRs and CI failures:
+- When asked to look at, investigate, or diagnose a pull request or build, first read the PR itself — its state, checks, and the conversation/comments — before deep analysis. Maintainers often post the root cause or the decided fix in the discussion, and a linked PR or issue may already carry it.
+- If a PR's CI checks are failing, prefer the `ci-analysis` skill (`.claude/skills/ci-analysis`) for the deep dive — Azure DevOps/Helix failures, known-issue matching, and retry guidance — rather than ad-hoc investigation.
+
 Output Considerations:
 - When considering how output should look, solicit advice from baronfel.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,9 +29,9 @@ Testing:
   - Test commands in the dogfood shell (e.g., `dnx --help`, `dotnet tool install --help`)
   - The dogfood script sets up PATH and environment to use the newly built SDK
 
-Investigating PRs and CI failures:
-- When asked to look at, investigate, or diagnose a pull request or build, first read the PR itself — its state, checks, and the conversation/comments — before deep analysis. Maintainers often post the root cause or the decided fix in the discussion, and a linked PR or issue may already carry it.
-- If a PR's CI checks are failing, prefer the `ci-analysis` skill (`.claude/skills/ci-analysis`) for the deep dive — Azure DevOps/Helix failures, known-issue matching, and retry guidance — rather than ad-hoc investigation.
+Investigating PR validation failures:
+1. Read the PR and its comments/reviews. Check for references to other PRs or issues where the problem might have already been solved.
+2. Use the `ci-analysis` skill (if available) to diagnose build failures.
 
 Output Considerations:
 - When considering how output should look, solicit advice from baronfel.


### PR DESCRIPTION
## What

Adds a short **Investigating PRs and CI failures** section to `.github/copilot-instructions.md`:

> - When asked to look at, investigate, or diagnose a pull request or build, first read the PR itself — its state, checks, and the conversation/comments — before deep analysis. Maintainers often post the root cause or the decided fix in the discussion, and a linked PR or issue may already carry it.
> - If a PR's CI checks are failing, prefer the `ci-analysis` skill (`.claude/skills/ci-analysis`) for the deep dive — Azure DevOps/Helix failures, known-issue matching, and retry guidance — rather than ad-hoc investigation.

## Why

When asked to "look at" a PR, the agent tends to jump straight into ad-hoc investigation and skips the PR discussion — where the answer often already is. Concrete example: diagnosing #54484 (a `release/10.0.1xx → 10.0.3xx` auto-merge failing Restore with `'[]' is not a valid version string`), the discussion already had the maintainer's root cause and the decided resolution (wait for the 10.0.9 servicing build to flow through the VMR, then pin the reference), and pointed at the linked PR that added the component. Reading the PR + conversation first would have landed on the right answer immediately.

The repo already ships a `ci-analysis` skill built for exactly this, but a generic prompt like "Look at the issue with #54484" doesn't match its CI-failure trigger phrases, so it isn't auto-selected. This guidance routes failing-CI investigations to it.

## Why this shape

- **Repo-scoped** and **conditioned on failing checks**, so it won't over-trigger `ci-analysis` on code-review/explain requests.
- The first bullet is **tool-agnostic** — "read the PR + conversation first" helps regardless of which skill is right.
- Matches the file's existing "Title: + bullets" style; no behavior/code changes.