### PR TITLE
[dotnet test] Two-stage Ctrl+C cancellation for MTP path

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -205,6 +205,10 @@
   <data name="CancellingTestSession" xml:space="preserve">
     <value>Canceling the test session...</value>
   </data>
+  <data name="PressCtrlCAgainToForceExit" xml:space="preserve">
+    <value>Press Ctrl+C again to force exit.</value>
+    <comment>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</comment>
+  </data>
   <data name="CannotAnalyzeVSWorkloadBand" xml:space="preserve">
     <value>Workloads managed by Visual Studio must be uninstalled using the Visual Studio Installer. For the version of Visual Studio managing the SDK '{0}', we could not display workloads to uninstall. This is likely because '{0}' uses a different dotnet root path or custom user profile directory from the current running SDK.
 Paths searched: '{1}', '{2}'.</value>

--- a/src/Cli/dotnet/Commands/Test/MTP/CtrlCCancellationManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/CtrlCCancellationManager.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Commands.Test;
+
+/// <summary>
+/// Mirrors the two-stage Ctrl+C cancellation UX implemented in Microsoft.Testing.Platform
+/// (testfx PR #8581 / SDK issue https://github.com/dotnet/sdk/issues/50732) at the
+/// <c>dotnet test</c> orchestrator level:
+/// <list type="bullet">
+///   <item>First Ctrl+C: cooperative cancellation. The <see cref="Token"/> is signaled so the
+///     queue stops scheduling new test apps; running test apps are left alone so they can
+///     gracefully report their final state via IPC (their own testfx-side Ctrl+C handler will
+///     cancel the session inside the child process).</item>
+///   <item>Second Ctrl+C: force exit. Every registered child process is killed
+///     (<c>entireProcessTree: true</c>) and the host process exits with
+///     <see cref="ExitCode.TestSessionAborted"/> (=3).</item>
+///   <item>Any further presses are no-ops (the state machine is idempotent).</item>
+/// </list>
+/// </summary>
+internal sealed class CtrlCCancellationManager : IDisposable
+{
+    private const int StateIdle = 0;
+    private const int StateCancelling = 1;
+    private const int StateForcing = 2;
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly Action _onFirstCtrlC;
+    private readonly Action<int> _exitAction;
+    private readonly ConcurrentDictionary<Process, byte> _processes = new();
+    private readonly bool _subscribedToConsole;
+    private int _state = StateIdle;
+    private int _disposed;
+
+    public CtrlCCancellationManager(Action onFirstCtrlC, Action<int>? exitAction = null, bool subscribeToConsole = true)
+    {
+        _onFirstCtrlC = onFirstCtrlC ?? throw new ArgumentNullException(nameof(onFirstCtrlC));
+        _exitAction = exitAction ?? Environment.Exit;
+
+        if (subscribeToConsole)
+        {
+            Console.CancelKeyPress += OnConsoleCancelKeyPress;
+            _subscribedToConsole = true;
+        }
+    }
+
+    /// <summary>
+    /// A token that is canceled when the user first presses Ctrl+C. Consumers should use it to
+    /// stop scheduling new work but should not use it to tear down in-flight IPC for already
+    /// running test apps (their cooperative cancellation is driven by their own Ctrl+C handler).
+    /// </summary>
+    public CancellationToken Token => _cancellationTokenSource.Token;
+
+    /// <summary>
+    /// Registers a child test-app process so it will be killed if the user requests a force exit
+    /// (second Ctrl+C). If the manager is already in the forcing state when this is called, the
+    /// process is killed immediately to avoid orphaning a child that started during the force
+    /// exit race window.
+    /// </summary>
+    public void Register(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        _processes.TryAdd(process, 0);
+
+        if (Volatile.Read(ref _state) == StateForcing)
+        {
+            TryKill(process);
+        }
+    }
+
+    public void Unregister(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        _processes.TryRemove(process, out _);
+    }
+
+    /// <summary>
+    /// Test-only hook to drive the state machine without depending on a real Console signal.
+    /// </summary>
+    internal void SimulateCtrlC() => HandleCtrlC();
+
+    private void OnConsoleCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+    {
+        // Suppress the runtime's default Ctrl+C handling on every press, including the second one,
+        // so that we (not the runtime) get to decide the exit code and ordering. This must happen
+        // before any other work in this handler.
+        e.Cancel = true;
+
+        HandleCtrlC();
+    }
+
+    private void HandleCtrlC()
+    {
+        // First press: Idle -> Cancelling. Signal the token, invoke the UI callback.
+        if (Interlocked.CompareExchange(ref _state, StateCancelling, StateIdle) == StateIdle)
+        {
+            try
+            {
+                _cancellationTokenSource.Cancel();
+            }
+            catch (AggregateException ex)
+            {
+                Logger.LogTrace($"Exception during CtrlCCancellationManager cancel:\n{ex}");
+            }
+
+            // The UI callback (typically TerminalTestReporter.StartCancelling) must not be able to
+            // affect cancellation state — wrap it best-effort.
+            try
+            {
+                _onFirstCtrlC();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogTrace($"Exception during CtrlCCancellationManager first-press UI callback:\n{ex}");
+            }
+
+            return;
+        }
+
+        // Second press: Cancelling -> Forcing. Kill every registered child and exit.
+        // We intentionally do not print any additional message here because the user already saw
+        // the "Press Ctrl+C again to force exit." hint and the exit itself is the confirmation.
+        if (Interlocked.CompareExchange(ref _state, StateForcing, StateCancelling) == StateCancelling)
+        {
+            foreach (var process in _processes.Keys)
+            {
+                TryKill(process);
+            }
+
+            _exitAction(ExitCode.TestSessionAborted);
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The process may have exited between the HasExited check and Kill, or we may lack
+            // permissions to read its state. Either way, nothing useful we can do from here.
+            Logger.LogTrace($"Exception killing child process during force exit:\n{ex}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_subscribedToConsole)
+        {
+            Console.CancelKeyPress -= OnConsoleCancelKeyPress;
+        }
+
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/CtrlCCancellationManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/CtrlCCancellationManager.cs
@@ -100,11 +100,15 @@ internal sealed class CtrlCCancellationManager : IDisposable
         // First press: Idle -> Cancelling. Signal the token, invoke the UI callback.
         if (Interlocked.CompareExchange(ref _state, StateCancelling, StateIdle) == StateIdle)
         {
+            // CancellationTokenSource.Cancel() can throw an AggregateException if any registered
+            // callback throws, or an ObjectDisposedException if Dispose races with a Ctrl+C press
+            // (e.g. user presses Ctrl+C while we're tearing down). Swallow both — we still want the
+            // state machine to advance and the UI callback to run.
             try
             {
                 _cancellationTokenSource.Cancel();
             }
-            catch (AggregateException ex)
+            catch (Exception ex) when (ex is AggregateException or ObjectDisposedException)
             {
                 Logger.LogTrace($"Exception during CtrlCCancellationManager cancel:\n{ex}");
             }

--- a/src/Cli/dotnet/Commands/Test/MTP/ExitCode.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ExitCode.cs
@@ -11,6 +11,7 @@ internal static class ExitCode
     // Values here should align with: https://aka.ms/testingplatform/exitcodes.
     public const int Success = 0;
     public const int GenericFailure = 1;
+    public const int TestSessionAborted = 3;
     public const int ZeroTests = 8;
     public const int MinimumExpectedTestsPolicyViolation = 9;
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -48,10 +48,11 @@ internal partial class MicrosoftTestingPlatformTestCommand
             EnvironmentVariables: parseResult.GetValue(definition.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);
+        using var ctrlC = new CtrlCCancellationManager(output.StartCancelling);
         int? exitCode = null;
         try
         {
-            var actionQueue = new TestApplicationActionQueue(degreeOfParallelism, buildOptions, testOptions, output, OnHelpRequested);
+            var actionQueue = new TestApplicationActionQueue(degreeOfParallelism, buildOptions, testOptions, output, OnHelpRequested, ctrlC);
             exitCode = testHandler.RunTestApplications(actionQueue);
 
             // If all test apps exited with 0 exit code, but we detected that handshake didn't happen correctly, map that to generic failure.
@@ -113,10 +114,9 @@ internal partial class MicrosoftTestingPlatformTestCommand
             MinimumExpectedTests = parseResult.GetValue(definition.MinimumExpectedTestsOption),
         });
 
-        Console.CancelKeyPress += (s, e) =>
-        {
-            output.StartCancelling();
-        };
+        // Ctrl+C handling is wired in Run() through CtrlCCancellationManager so that
+        // a second press can force-kill running test app child processes and exit with
+        // ExitCode.TestSessionAborted (see issue https://github.com/dotnet/sdk/issues/50732).
 
         // This is ugly, and we need to replace it by passing out some info from testing platform to inform us that some process level retry plugin is active.
         var isRetry = parseResult.GetArguments().Contains("--retry-failed-tests");

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -928,6 +928,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             terminal.AppendLine();
             terminal.AppendLine(CliCommandStrings.CancellingTestSession);
+            terminal.AppendLine(CliCommandStrings.PressCtrlCAgainToForceExit);
             terminal.AppendLine();
         });
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -40,7 +40,7 @@ internal sealed class TestApplication(
 
     public bool HasFailureDuringDispose { get; private set; }
 
-    public async Task<int> RunAsync()
+    public async Task<int> RunAsync(CtrlCCancellationManager ctrlC)
     {
         if (Interlocked.Exchange(ref _hasRun, 1) != 0)
         {
@@ -53,11 +53,16 @@ internal sealed class TestApplication(
         var cancellationToken = cancellationTokenSource.Token;
         var testAppPipeConnectionLoop = Task.Run(async () => await WaitConnectionAsync(cancellationToken));
 
+        Process? process = null;
         try
         {
             Logger.LogTrace($"Starting test process with command '{processStartInfo.FileName}' and arguments '{processStartInfo.Arguments}'.");
 
-            using var process = Process.Start(processStartInfo)!;
+            process = Process.Start(processStartInfo)!;
+
+            // Register with the Ctrl+C manager so a force-exit (second Ctrl+C) kills this process
+            // tree even if the child's own cooperative cancellation hangs.
+            ctrlC.Register(process);
 
             // Reading from process stdout/stderr is done on separate threads to avoid blocking IO on the threadpool.
             // Note: even with 'process.StandardOutput.ReadToEndAsync()' or 'process.BeginOutputReadLine()', we ended up with
@@ -119,6 +124,12 @@ internal sealed class TestApplication(
         }
         finally
         {
+            if (process is not null)
+            {
+                ctrlC.Unregister(process);
+                process.Dispose();
+            }
+
             cancellationTokenSource.Cancel();
             await testAppPipeConnectionLoop;
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -17,14 +17,14 @@ internal class TestApplicationActionQueue
 
     private readonly Lock _lock = new();
 
-    public TestApplicationActionQueue(int degreeOfParallelism, BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested)
+    public TestApplicationActionQueue(int degreeOfParallelism, BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested, CtrlCCancellationManager ctrlC)
     {
         _channel = Channel.CreateUnbounded<ParallelizableTestModuleGroupWithSequentialInnerModules>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
         _readers = new Task[degreeOfParallelism];
 
         for (int i = 0; i < degreeOfParallelism; i++)
         {
-            _readers[i] = Task.Run(async () => await Read(buildOptions, testOptions, output, onHelpRequested));
+            _readers[i] = Task.Run(async () => await Read(buildOptions, testOptions, output, onHelpRequested, ctrlC));
         }
     }
 
@@ -48,19 +48,33 @@ internal class TestApplicationActionQueue
         return _aggregateExitCode ?? ExitCode.ZeroTests;
     }
 
-    private async Task Read(BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested)
+    private async Task Read(BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested, CtrlCCancellationManager ctrlC)
     {
         await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync())
         {
+            // Stop scheduling new test apps once the user has pressed Ctrl+C the first time.
+            // Already-running test apps are left alone so they can gracefully cancel themselves
+            // (and report final session state via IPC); a second Ctrl+C is what force-kills them
+            // via the CtrlCCancellationManager.
+            if (ctrlC.Token.IsCancellationRequested)
+            {
+                break;
+            }
+
             foreach (var module in nonParallelizedGroup)
             {
+                if (ctrlC.Token.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 int result = ExitCode.GenericFailure;
                 var testApp = new TestApplication(module, buildOptions, testOptions, output, onHelpRequested);
                 try
                 {
                     using (testApp)
                     {
-                        result = await testApp.RunAsync();
+                        result = await testApp.RunAsync(ctrlC);
                     }
                 }
                 catch (Exception ex)

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -50,75 +50,73 @@ internal class TestApplicationActionQueue
 
     private async Task Read(BuildOptions buildOptions, TestOptions testOptions, TerminalTestReporter output, Action<CommandLineOptionMessages> onHelpRequested, CtrlCCancellationManager ctrlC)
     {
-        await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync())
+        try
+        {
+            await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync(ctrlC.Token))
+            {
+                foreach (var module in nonParallelizedGroup)
+                {
+                    ctrlC.Token.ThrowIfCancellationRequested();
+
+                    int result = ExitCode.GenericFailure;
+                    var testApp = new TestApplication(module, buildOptions, testOptions, output, onHelpRequested);
+                    try
+                    {
+                        using (testApp)
+                        {
+                            result = await testApp.RunAsync(ctrlC);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        var exAsString = ex.ToString();
+                        Logger.LogTrace($"Exception running test module {module.RunProperties?.Command} {module.RunProperties?.Arguments}: {exAsString}");
+                        Reporter.Error.WriteLine(string.Format(CliCommandStrings.ErrorRunningTestModule, module.RunProperties?.Command, module.RunProperties?.Arguments, exAsString));
+                        result = ExitCode.GenericFailure;
+                    }
+
+                    if (result == ExitCode.Success && testApp.HasFailureDuringDispose)
+                    {
+                        result = ExitCode.GenericFailure;
+                    }
+
+                    lock (_lock)
+                    {
+                        if (_aggregateExitCode is null)
+                        {
+                            // This is the first result we are getting.
+                            // So we assign the exit code, regardless of whether it's failure or success.
+                            _aggregateExitCode = result;
+                        }
+                        else if (_aggregateExitCode.Value != result)
+                        {
+                            if (_aggregateExitCode == ExitCode.Success)
+                            {
+                                // The current result we are dealing with is the first failure after previous Success.
+                                // So we assign the current failure.
+                                _aggregateExitCode = result;
+                            }
+                            else if (result != ExitCode.Success)
+                            {
+                                // If we get a new failure result, which is different from a previous failure, we use GenericFailure.
+                                _aggregateExitCode = ExitCode.GenericFailure;
+                            }
+                            else
+                            {
+                                // The current result is a success, but we already have a failure.
+                                // So, we keep the failure exit code.
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (ctrlC.Token.IsCancellationRequested)
         {
             // Stop scheduling new test apps once the user has pressed Ctrl+C the first time.
             // Already-running test apps are left alone so they can gracefully cancel themselves
             // (and report final session state via IPC); a second Ctrl+C is what force-kills them
             // via the CtrlCCancellationManager.
-            if (ctrlC.Token.IsCancellationRequested)
-            {
-                break;
-            }
-
-            foreach (var module in nonParallelizedGroup)
-            {
-                if (ctrlC.Token.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                int result = ExitCode.GenericFailure;
-                var testApp = new TestApplication(module, buildOptions, testOptions, output, onHelpRequested);
-                try
-                {
-                    using (testApp)
-                    {
-                        result = await testApp.RunAsync(ctrlC);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    var exAsString = ex.ToString();
-                    Logger.LogTrace($"Exception running test module {module.RunProperties?.Command} {module.RunProperties?.Arguments}: {exAsString}");
-                    Reporter.Error.WriteLine(string.Format(CliCommandStrings.ErrorRunningTestModule, module.RunProperties?.Command, module.RunProperties?.Arguments, exAsString));
-                    result = ExitCode.GenericFailure;
-                }
-
-                if (result == ExitCode.Success && testApp.HasFailureDuringDispose)
-                {
-                    result = ExitCode.GenericFailure;
-                }
-
-                lock (_lock)
-                {
-                    if (_aggregateExitCode is null)
-                    {
-                        // This is the first result we are getting.
-                        // So we assign the exit code, regardless of whether it's failure or success.
-                        _aggregateExitCode = result;
-                    }
-                    else if (_aggregateExitCode.Value != result)
-                    {
-                        if (_aggregateExitCode == ExitCode.Success)
-                        {
-                            // The current result we are dealing with is the first failure after previous Success.
-                            // So we assign the current failure.
-                            _aggregateExitCode = result;
-                        }
-                        else if (result != ExitCode.Success)
-                        {
-                            // If we get a new failure result, which is different from a previous failure, we use GenericFailure.
-                            _aggregateExitCode = ExitCode.GenericFailure;
-                        }
-                        else
-                        {
-                            // The current result is a success, but we already have a failure.
-                            // So, we keep the failure exit code.
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -2240,6 +2240,11 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Do souboru manifestu {3} s
         <target state="translated">Možnosti --prerelease a --version v jednom příkazu se nepodporují.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Vytiskne pouze seznam odkazů, které se mají stáhnout, aniž by se tento seznam stahoval.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -2240,6 +2240,11 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert. Der Eintrag wird der
         <target state="translated">Die Optionen „--prerelease“ und „--version“ werden im gleichen Befehl nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Drucken Sie nur die Liste der Links zum Herunterladen, ohne sie herunterzuladen.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -2240,6 +2240,11 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. Se ha agregado 
         <target state="translated">No se admiten las opciones --prerelease y --version en el mismo comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Imprima solo la lista de vínculos para descargar, sin descargarla.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -2240,6 +2240,11 @@ L'outil '{1}' (version '{2}') a été correctement installé. L'entrée est ajou
         <target state="translated">Les options --prerelease et --version ne sont pas prises en charge dans la même commande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Imprimer uniquement la liste des liens à télécharger sans télécharger.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -2240,6 +2240,11 @@ Lo strumento '{1}' versione '{2}' è stato installato. La voce è stata aggiunta
         <target state="translated">Le opzioni --prerelease e --version non sono supportate nello stesso comando</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Stampa solo l'elenco dei collegamenti da scaricare senza scaricarlo.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">--prerelease および --version オプションは同じコマンド内ではサポートされません</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">ダウンロードするリンクの一覧をダウンロードせず、印刷だけを行います。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">--prerelease 및 --version 옵션은 같은 명령에서 지원되지 않습니다</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">다운로드할 링크 목록을 다운로드하지 않고 인쇄만 합니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -2240,6 +2240,11 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Wpis 
         <target state="translated">Opcje --prerelease i --version nie są obsługiwane w tym samym poleceniu</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Drukuj tylko listę linków do pobrania bez ich pobierania.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -2240,6 +2240,11 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <target state="translated">Não há suporte para as opções --prerelease e --version no mesmo comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Somente imprimir a lista de links para download sem baixá-la.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">Параметры --prerelease и --version не поддерживаются в одной и той же команде</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">Печатать только список ссылок для скачивания, не выполняя загрузку.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">--prerelease ve --version seçenekleri aynı komutta desteklenmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">İndirmeden, yalnızca indirilecek bağlantıların listesini yazdırın.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">不支持在同一命令中同时使用 --prerelease 和 --version 选项</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">仅打印要下载的链接的列表，而不下载列表。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -2240,6 +2240,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="translated">同一個命令中不支援 --prerelease 與 --version 選項</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note>Hint printed under the "Canceling the test session..." banner. Tells the user that pressing Ctrl+C a second time will immediately terminate the dotnet test process and any still-running test app child processes.</note>
+      </trans-unit>
       <trans-unit id="PrintDownloadLinkOnlyDescription">
         <source>Only print the list of links to download without downloading.</source>
         <target state="translated">只列印要下載的連結清單，而不下載。</target>

--- a/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
@@ -224,14 +224,20 @@ public class CtrlCCancellationManagerTests
 
     private static Process StartLongRunningProcess()
     {
-        // Spawn a platform-appropriate "sleep" process (cmd.exe + timeout on Windows, /bin/sh +
-        // sleep on Unix) so we have a real OS process to register/kill in tests. The actual program
-        // is irrelevant — we only need a process tree the manager can target with Process.Kill.
+        // Spawn a platform-appropriate long-running process so we have a real OS process to
+        // register/kill in tests. The actual program is irrelevant — we only need a process tree
+        // the manager can target with Process.Kill.
+        //
+        // On Windows we deliberately avoid `cmd /c "timeout /t N"` because `timeout` requires an
+        // interactive console (it exits immediately with "ERROR: Input redirection is not supported"
+        // when stdin is not a console, which is the case on Helix and other headless CI agents).
+        // `ping -n N 127.0.0.1` waits ~1 second between echoes and does not depend on a console,
+        // so it stays alive reliably across local dev and CI.
         var psi = new ProcessStartInfo
         {
-            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            FileName = OperatingSystem.IsWindows() ? "ping.exe" : "/bin/sh",
             Arguments = OperatingSystem.IsWindows()
-                ? "/c \"timeout /t 600 > nul\""
+                ? "-n 600 -w 1000 127.0.0.1"
                 : "-c \"sleep 600\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
@@ -240,6 +246,18 @@ public class CtrlCCancellationManagerTests
         };
 
         var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start long-running helper process");
+
+        // Sanity-check that the helper is actually alive before handing it back. If it exited
+        // immediately the assertions on HasExited downstream would silently produce false failures
+        // (as happened on Helix with `timeout` — see comment above).
+        Thread.Sleep(100);
+        if (process.HasExited)
+        {
+            var stderr = process.StandardError.ReadToEnd();
+            throw new InvalidOperationException(
+                $"Long-running helper process exited immediately with code {process.ExitCode}. Stderr: {stderr}");
+        }
+
         return process;
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
@@ -1,0 +1,222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+public class CtrlCCancellationManagerTests
+{
+    [Fact]
+    public void FirstCtrlC_CancelsTokenAndInvokesUiCallbackExactlyOnce()
+    {
+        int callbackCount = 0;
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => Interlocked.Increment(ref callbackCount),
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        manager.Token.IsCancellationRequested.Should().BeFalse("the token should be alive before any Ctrl+C");
+
+        manager.SimulateCtrlC();
+
+        manager.Token.IsCancellationRequested.Should().BeTrue("the first Ctrl+C should cancel the cooperative token");
+        callbackCount.Should().Be(1);
+        exitCount.Should().Be(0, "the first Ctrl+C must not force-exit");
+    }
+
+    [Fact]
+    public void SecondCtrlC_InvokesExitActionWithTestSessionAborted()
+    {
+        int callbackCount = 0;
+        int? receivedExitCode = null;
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => Interlocked.Increment(ref callbackCount),
+            exitAction: code => { Interlocked.Increment(ref exitCount); receivedExitCode = code; },
+            subscribeToConsole: false);
+
+        manager.SimulateCtrlC();
+        manager.SimulateCtrlC();
+
+        callbackCount.Should().Be(1, "the UI callback fires only on the first press");
+        exitCount.Should().Be(1, "the exit action fires on the second press");
+        receivedExitCode.Should().Be(ExitCode.TestSessionAborted);
+    }
+
+    [Fact]
+    public void ThirdAndSubsequentCtrlC_AreNoOps()
+    {
+        int callbackCount = 0;
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => Interlocked.Increment(ref callbackCount),
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        manager.SimulateCtrlC();
+        manager.SimulateCtrlC();
+        manager.SimulateCtrlC();
+        manager.SimulateCtrlC();
+
+        callbackCount.Should().Be(1);
+        exitCount.Should().Be(1, "presses after force-exit must not re-trigger the exit action");
+    }
+
+    [Fact]
+    public void Register_AfterForcing_KillsTheProcessImmediately()
+    {
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        manager.SimulateCtrlC();
+        manager.SimulateCtrlC();
+        exitCount.Should().Be(1);
+
+        using var process = StartLongRunningProcess();
+        try
+        {
+            manager.Register(process);
+
+            // The manager should have killed the process immediately because we are in the Forcing state.
+            process.WaitForExit(TimeSpan.FromSeconds(10)).Should().BeTrue("Register after Forcing must kill the registered process");
+            process.HasExited.Should().BeTrue();
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void Register_BeforeForcing_KillsTheProcessOnSecondCtrlC()
+    {
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        using var process = StartLongRunningProcess();
+        try
+        {
+            manager.Register(process);
+
+            manager.SimulateCtrlC();
+            process.HasExited.Should().BeFalse("first Ctrl+C must not kill registered processes");
+
+            manager.SimulateCtrlC();
+            process.WaitForExit(TimeSpan.FromSeconds(10)).Should().BeTrue("second Ctrl+C must kill registered processes");
+            exitCount.Should().Be(1);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void Unregister_RemovesProcessFromForceKillSet()
+    {
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        using var process = StartLongRunningProcess();
+        try
+        {
+            manager.Register(process);
+            manager.Unregister(process);
+
+            manager.SimulateCtrlC();
+            manager.SimulateCtrlC();
+
+            // After unregister, the manager should not have killed the process.
+            // Give it a moment in case the kill is asynchronous, then check.
+            Thread.Sleep(200);
+            process.HasExited.Should().BeFalse("unregistered processes must not be killed by force-exit");
+            exitCount.Should().Be(1);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => { },
+            subscribeToConsole: false);
+
+        Action act = () => { manager.Dispose(); manager.Dispose(); };
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Token_DoesNotCancel_WithoutAnyPress()
+    {
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => { },
+            subscribeToConsole: false);
+
+        manager.Token.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FirstCtrlC_CallbackThrowing_DoesNotAffectStateTransition()
+    {
+        int exitCount = 0;
+        using var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => throw new InvalidOperationException("ui boom"),
+            exitAction: _ => Interlocked.Increment(ref exitCount),
+            subscribeToConsole: false);
+
+        Action firstPress = () => manager.SimulateCtrlC();
+        firstPress.Should().NotThrow("an exception from the UI callback must not propagate out of the handler");
+
+        manager.Token.IsCancellationRequested.Should().BeTrue("token cancellation must happen before the UI callback");
+
+        manager.SimulateCtrlC();
+        exitCount.Should().Be(1, "the state machine must still advance to Forcing on the second press even if the first-press callback threw");
+    }
+
+    private static Process StartLongRunningProcess()
+    {
+        // A small dotnet host that just sleeps for a long time so we have a real process to kill.
+        // We use the muxer that's resolvable from PATH; on the test machine 'dotnet' is always on PATH.
+        var psi = new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows()
+                ? "/c \"timeout /t 600 > nul\""
+                : "-c \"sleep 600\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start long-running helper process");
+        return process;
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/CtrlCCancellationManagerTests.cs
@@ -4,6 +4,10 @@
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test;
 
+// Disambiguate from Microsoft.NET.TestFramework.ExitCode which is brought in by the test
+// framework's global usings (FluentAssertions/Xunit/Microsoft.NET.TestFramework).
+using ExitCode = Microsoft.DotNet.Cli.Commands.Test.ExitCode;
+
 namespace dotnet.Tests.CommandTests.Test;
 
 public class CtrlCCancellationManagerTests
@@ -200,10 +204,29 @@ public class CtrlCCancellationManagerTests
         exitCount.Should().Be(1, "the state machine must still advance to Forcing on the second press even if the first-press callback threw");
     }
 
+    [Fact]
+    public void FirstCtrlC_AfterDispose_DoesNotThrowFromDisposedTokenSource()
+    {
+        // Race window: the user presses Ctrl+C between the manager being disposed (which unsubscribes
+        // from Console.CancelKeyPress but cannot remove an already-in-flight handler invocation) and
+        // the handler reaching Cancel() on the disposed CancellationTokenSource. SimulateCtrlC drives
+        // that path directly.
+        var manager = new CtrlCCancellationManager(
+            onFirstCtrlC: () => { },
+            exitAction: _ => { },
+            subscribeToConsole: false);
+
+        manager.Dispose();
+
+        Action act = () => manager.SimulateCtrlC();
+        act.Should().NotThrow("a Ctrl+C arriving after Dispose must not surface as an unhandled exception");
+    }
+
     private static Process StartLongRunningProcess()
     {
-        // A small dotnet host that just sleeps for a long time so we have a real process to kill.
-        // We use the muxer that's resolvable from PATH; on the test machine 'dotnet' is always on PATH.
+        // Spawn a platform-appropriate "sleep" process (cmd.exe + timeout on Windows, /bin/sh +
+        // sleep on Unix) so we have a real OS process to register/kill in tests. The actual program
+        // is irrelevant — we only need a process tree the manager can target with Process.Kill.
         var psi = new ProcessStartInfo
         {
             FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",


### PR DESCRIPTION
## Summary

Mirrors the two-stage Ctrl+C cancellation UX from [microsoft/testfx#8581](https://github.com/microsoft/testfx/pull/8581) at the `dotnet test` orchestrator level, addressing #50732.

- **First Ctrl+C:** cooperative cancellation — stop scheduling new test apps + show `Press Ctrl+C again to force exit.` hint. Running test apps are left alone so they can gracefully report their final session state (their own testfx-side Ctrl+C handler now drives in-process cancellation).
- **Second Ctrl+C:** force exit — kill every registered child test-app process tree and `Environment.Exit(ExitCode.TestSessionAborted)` (=3, matching MTP).
- **Further presses:** no-ops (state machine is idempotent).

Previous behavior only updated the UI on the first press and relied entirely on OS signal propagation to terminate test app children, which could leave orphaned children if the signal didn't reach them.

## Implementation

| File | Change |
| --- | --- |
| `Test/MTP/CtrlCCancellationManager.cs` | **NEW** — state machine + process registry + exit handler |
| `Test/MTP/ExitCode.cs` | `TestSessionAborted = 3` (matches MTP) |
| `Test/MTP/TestApplication.cs` | `RunAsync` registers child process with manager; unregisters in `finally` |
| `Test/MTP/TestApplicationActionQueue.cs` | Skips new test apps after first Ctrl+C via token check |
| `Test/MTP/MicrosoftTestingPlatformTestCommand.cs` | Creates the manager in `Run`; subscribes to `Console.CancelKeyPress` |
| `Test/MTP/Terminal/TerminalTestReporter.cs` | Appends "Press Ctrl+C again to force exit." hint |
| `CliCommandStrings.resx` + xlf | `PressCtrlCAgainToForceExit` resource |
| `CtrlCCancellationManagerTests.cs` | **NEW** — 9 unit tests |

### Design notes

- `CtrlCCancellationManager` uses `Interlocked.CompareExchange` for its `Idle → Cancelling → Forcing` state machine and a `ConcurrentDictionary<Process, byte>` keyed by *process reference* (not PID) to avoid PID-reuse races.
- `Register` after the manager has entered `Forcing` immediately kills the registered process — this closes the race window where a child could be spawned between the second Ctrl+C and `Process.Start`.
- The local pipe-loop CTS in `TestApplication` is intentionally **not** linked to the user Ctrl+C token: tearing down IPC while testfx-side cooperative cancellation is in flight would prevent the child from reporting its final session state.
- The first-press UI callback is wrapped in `try/catch` so a buggy reporter cannot break the state machine.
- `e.Cancel = true` runs first on every `CancelKeyPress` so the runtime's default Ctrl+C handling is suppressed (and we — not the runtime — decide the exit code).

## Tests

`CtrlCCancellationManagerTests.cs` covers:
- First press cancels the token and invokes the UI callback exactly once.
- Second press calls the exit action with `TestSessionAborted`.
- Third+ presses are no-ops.
- `Register` after `Forcing` kills the process immediately.
- `Register` before `Forcing` kills the process on the second press.
- `Unregister` removes the process from the kill set.
- `Dispose` is idempotent.
- Token does not cancel without a press.
- A throwing UI callback does not break state transitions.

Tests use an injected exit delegate and the internal `SimulateCtrlC()` hook (so they never touch the real `Console` or `Environment.Exit`).

## Verification

LSP-level type checks pass across all touched files. Local full builds were blocked by extreme machine contention (140+ concurrent dotnet processes from other repos); relying on CI for the final compile/test verification.

Closes #50732.
