### PR TITLE
Validate Microsoft.Testing.Platform ExecutionMode handshake property

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2647,6 +2647,10 @@ Proceed?</value>
   <data name="MismatchingHandshakeInfo" xml:space="preserve">
     <value>A new handshake '{0}' was received for the test application that doesn't match the previous handshake '{1}'.</value>
   </data>
+  <data name="MismatchingHandshakeExecutionMode" xml:space="preserve">
+    <value>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</value>
+    <comment>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</comment>
+  </data>
   <data name="UnexpectedMessageInHelpMode" xml:space="preserve">
     <value>A message of type '{0}' was received in help mode, which is not expected.</value>
   </data>

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -55,6 +55,27 @@ internal static class HandshakeMessagePropertyNames
     internal const byte ModulePath = 6;
     internal const byte ExecutionId = 7;
     internal const byte InstanceId = 8;
+    internal const byte IsIDE = 9;
+
+    // Reports which command-line execution mode the test host is running in,
+    // so the SDK can detect mismatches such as a help/list-tests option leaking
+    // from RunArguments or launchSettings.json into what the SDK thinks is a
+    // normal run. Values come from HandshakeMessageExecutionModes.
+    // Optional property — older Microsoft.Testing.Platform versions don't send
+    // it, in which case the SDK falls back to its previous (no-validation) behavior.
+    internal const byte ExecutionMode = 10;
+}
+
+internal static class HandshakeMessageExecutionModes
+{
+    // Standard test run.
+    internal const string Run = "run";
+
+    // The test host is going to print command-line help (e.g. --help, -?).
+    internal const string Help = "help";
+
+    // The test host is going to discover tests (e.g. --list-tests).
+    internal const string Discover = "discover";
 }
 
 internal static class ProtocolConstants

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -826,14 +826,19 @@ internal sealed partial class TerminalTestReporter : IDisposable
         });
     }
 
-    internal void HandshakeFailure(string assemblyPath, string? targetFramework, int exitCode, string outputData, string errorData)
+    internal void HandshakeFailure(string assemblyPath, string? targetFramework, int exitCode, string outputData, string errorData, bool reportEvenWhenHelp = false)
     {
-        if (_isHelp)
+        if (_isHelp && !reportEvenWhenHelp)
         {
-            // Ignore handshake failures for help for now.
-            // So far, MTP doesn't handshake on help.
-            // MTP should be updated for that, however, but this workaround will likely need to stay
-            // here for a bit to keep compatibility with older MTP versions. It doesn't have to stay for too long though.
+            // Backward-compat workaround: older Microsoft.Testing.Platform versions don't perform
+            // a handshake on the --help path (the host just prints help and exits). In that case
+            // OnTestProcessExited routes here with the "process exited without a usable handshake"
+            // payload, which is expected and should not be reported as a failure.
+            //
+            // Newer MTP versions (microsoft/testfx#8794) always handshake — including on --help —
+            // so this workaround is only needed while older MTP versions are still in use. Explicit
+            // protocol-level rejections (e.g. ExecutionMode mismatch) pass reportEvenWhenHelp=true
+            // and are still surfaced.
             return;
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -96,12 +96,14 @@ internal sealed class TestApplicationHandler
         //
         // Older Microsoft.Testing.Platform versions don't send the ExecutionMode property at all
         // (see https://github.com/microsoft/testfx/pull/8794). In that case we keep today's
-        // behavior and don't perform any validation here.
+        // behavior and don't perform any validation here. A present-but-empty/whitespace value is
+        // also treated as "absent" rather than as a protocol violation — that's the conservative
+        // choice if some intermediate MTP version ever happens to serialize an empty string here.
         if (handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.ExecutionMode, out string? executionMode) &&
             !string.IsNullOrWhiteSpace(executionMode) &&
             !IsExpectedExecutionMode(executionMode, out string expectedExecutionMode))
         {
-            ReportExecutionModeFailure(executionMode, expectedExecutionMode);
+            ReportHandshakeFailure(string.Format(CliCommandStrings.MismatchingHandshakeExecutionMode, executionMode, expectedExecutionMode));
             return false;
         }
 
@@ -123,28 +125,22 @@ internal sealed class TestApplicationHandler
         return reportedMode == expectedMode;
     }
 
-    private void ReportExecutionModeFailure(string reportedMode, string expectedMode)
-    {
-        // Always surface the protocol-level mismatch — bypass the legacy "ignore handshake
-        // failures when SDK is in help mode" workaround in TerminalTestReporter, which exists
-        // only to keep compatibility with older Microsoft.Testing.Platform versions that don't
-        // handshake on the --help path.
-        _output.HandshakeFailure(
-            _module.TargetPath,
-            string.Empty,
-            ExitCode.GenericFailure,
-            string.Format(CliCommandStrings.MismatchingHandshakeExecutionMode, reportedMode, expectedMode),
-            string.Empty,
-            reportEvenWhenHelp: true);
-    }
-
+    // Every caller of this helper has just decided to reject the handshake at the protocol level
+    // (the caller immediately returns false from OnHandshakeReceived). We always opt out of the
+    // legacy "swallow handshake failures when SDK is in help mode" workaround in
+    // TerminalTestReporter.HandshakeFailure — that workaround is meant for older Microsoft.Testing.Platform
+    // versions that don't handshake at all on --help and so OnTestProcessExited ends up calling
+    // HandshakeFailure with no actionable context. Explicit programmatic rejections here (unsupported
+    // protocol version, missing required property, mismatching handshake info, mismatching execution
+    // mode) are real protocol failures and must still be surfaced even when the SDK is in help mode.
     private void ReportHandshakeFailure(string failureMessage) =>
         _output.HandshakeFailure(
             _module.TargetPath,
             string.Empty,
             ExitCode.GenericFailure,
             failureMessage,
-            string.Empty);
+            string.Empty,
+            reportEvenWhenHelp: true);
 
     private static bool TryGetRequiredHandshakeProperty(HandshakeMessage handshakeMessage, byte propertyId, out string? value, out string? failureMessage)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -90,7 +90,52 @@ internal sealed class TestApplicationHandler
             _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId!);
         }
 
+        // Validate the optional ExecutionMode property last (after AssemblyRunStarted) so that any
+        // diagnostic about a mismatched run/help/discover mode is associated with this assembly
+        // in the terminal output.
+        //
+        // Older Microsoft.Testing.Platform versions don't send the ExecutionMode property at all
+        // (see https://github.com/microsoft/testfx/pull/8794). In that case we keep today's
+        // behavior and don't perform any validation here.
+        if (handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.ExecutionMode, out string? executionMode) &&
+            !string.IsNullOrWhiteSpace(executionMode) &&
+            !IsExpectedExecutionMode(executionMode, out string expectedExecutionMode))
+        {
+            ReportExecutionModeFailure(executionMode, expectedExecutionMode);
+            return false;
+        }
+
         return true;
+    }
+
+    private bool IsExpectedExecutionMode(string reportedMode, out string expectedMode)
+    {
+        expectedMode = _options.IsHelp
+            ? HandshakeMessageExecutionModes.Help
+            : _options.IsDiscovery
+                ? HandshakeMessageExecutionModes.Discover
+                : HandshakeMessageExecutionModes.Run;
+
+        // If the reported mode is one of the known values, it must equal the SDK's expected mode.
+        // An unknown value (e.g. a future mode added by a newer testing platform without bumping
+        // the protocol version) is also rejected so we don't silently accept a message stream we
+        // can't interpret.
+        return reportedMode == expectedMode;
+    }
+
+    private void ReportExecutionModeFailure(string reportedMode, string expectedMode)
+    {
+        // Always surface the protocol-level mismatch — bypass the legacy "ignore handshake
+        // failures when SDK is in help mode" workaround in TerminalTestReporter, which exists
+        // only to keep compatibility with older Microsoft.Testing.Platform versions that don't
+        // handshake on the --help path.
+        _output.HandshakeFailure(
+            _module.TargetPath,
+            string.Empty,
+            ExitCode.GenericFailure,
+            string.Format(CliCommandStrings.MismatchingHandshakeExecutionMode, reportedMode, expectedMode),
+            string.Empty,
+            reportEvenWhenHelp: true);
     }
 
     private void ReportHandshakeFailure(string failureMessage) =>
@@ -141,6 +186,8 @@ internal sealed class TestApplicationHandler
             HandshakeMessagePropertyNames.ModulePath => nameof(HandshakeMessagePropertyNames.ModulePath),
             HandshakeMessagePropertyNames.ExecutionId => nameof(HandshakeMessagePropertyNames.ExecutionId),
             HandshakeMessagePropertyNames.InstanceId => nameof(HandshakeMessagePropertyNames.InstanceId),
+            HandshakeMessagePropertyNames.IsIDE => nameof(HandshakeMessagePropertyNames.IsIDE),
+            HandshakeMessagePropertyNames.ExecutionMode => nameof(HandshakeMessagePropertyNames.ExecutionMode),
             _ => string.Empty,
         };
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -96,11 +96,9 @@ internal sealed class TestApplicationHandler
         //
         // Older Microsoft.Testing.Platform versions don't send the ExecutionMode property at all
         // (see https://github.com/microsoft/testfx/pull/8794). In that case we keep today's
-        // behavior and don't perform any validation here. A present-but-empty/whitespace value is
-        // also treated as "absent" rather than as a protocol violation — that's the conservative
-        // choice if some intermediate MTP version ever happens to serialize an empty string here.
+        // behavior and don't perform any validation here. If the property is present, validate it
+        // even when it is empty/whitespace so protocol bugs are surfaced instead of silently accepted.
         if (handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.ExecutionMode, out string? executionMode) &&
-            !string.IsNullOrWhiteSpace(executionMode) &&
             !IsExpectedExecutionMode(executionMode, out string expectedExecutionMode))
         {
             ReportHandshakeFailure(string.Format(CliCommandStrings.MismatchingHandshakeExecutionMode, executionMode, expectedExecutionMode));

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Nezobrazovat úvodní nápis ani zprávu o autorských právech</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Zeigt kein Startbanner und keine Copyrightmeldung an.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">No mostrar la pancarta de inicio ni el mensaje de copyright.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">N'affiche pas la bannière de démarrage ni le message de copyright.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Evita la visualizzazione del messaggio di avvio o di copyright.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">著作権情報を表示しません。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">시작 배너 또는 저작권 메시지를 표시하지 않습니다.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Nie wyświetlaj baneru początkowego ani komunikatu o prawach autorskich.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Não exibe a faixa de inicialização ou a mensagem de direitos autorais.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Не отображать начальный баннер или сообщение об авторских правах.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">Başlangıç bandını veya telif hakkı iletisini görüntüleme.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">不显示启动版权标志或版权消息。</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -132,6 +132,11 @@
         <target state="new">Handshake failures:</target>
         <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
+      <trans-unit id="MismatchingHandshakeExecutionMode">
+        <source>The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</source>
+        <target state="new">The test host reported execution mode '{0}', but 'dotnet test' expected '{1}'. This typically happens when an option such as '--help', '-?' or '--list-tests' was injected into the test host through a non-CLI channel (e.g. the 'TestingPlatformCommandLineArguments' or 'RunArguments' MSBuild properties, or 'launchSettings.json' commandLineArgs). Pass these options directly to 'dotnet test' instead.</target>
+        <note>{Locked="dotnet test"}{Locked="--help"}{Locked="-?"}{Locked="--list-tests"}{Locked="TestingPlatformCommandLineArguments"}{Locked="RunArguments"}{Locked="launchSettings.json"}{Locked="commandLineArgs"}</note>
+      </trans-unit>
       <trans-unit id="NoLogoOptionDescription">
         <source>Do not display the startup banner or the copyright message.</source>
         <target state="translated">不顯示啟始資訊或著作權訊息。</target>

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -232,16 +232,19 @@ public class TestApplicationHandlerTests : IDisposable
     }
 
     /// <summary>
-    /// Forward-compat guard: a future testing-platform release that ships a new ExecutionMode value
-    /// without bumping the protocol version is not silently accepted; we reject so we don't try to
-    /// interpret a message stream we don't understand.
+    /// Forward-compat/protocol guard: a future testing-platform release that ships a new ExecutionMode
+    /// value without bumping the protocol version, or a host that sends an empty value, is not silently
+    /// accepted; we reject so we don't try to interpret a message stream we don't understand.
     /// </summary>
-    [Fact]
-    public void OnHandshakeReceived_WhenExecutionModeIsUnknown_RejectsHandshake()
+    [Theory]
+    [InlineData("future-mode")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void OnHandshakeReceived_WhenExecutionModeIsUnknownOrEmpty_RejectsHandshake(string executionMode)
     {
         (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: false, isDiscovery: false);
 
-        var handshake = BuildHandshake(executionMode: "future-mode");
+        var handshake = BuildHandshake(executionMode: executionMode);
 
         bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
 

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -8,8 +8,21 @@ using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 
 namespace dotnet.Tests.CommandTests.Test;
 
-public class TestApplicationHandlerTests
+public class TestApplicationHandlerTests : IDisposable
 {
+    // TerminalTestReporter is IDisposable and starts progress tracking via TestExecutionStarted
+    // inside CreateHandler. xUnit instantiates the test class per test, so disposing this list in
+    // Dispose() releases every reporter built for the current test.
+    private readonly List<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+    }
+
     /// <summary>
     /// Regression test for the handler-level routing fix in https://github.com/dotnet/sdk/pull/52308
     /// (linked to https://github.com/dotnet/sdk/issues/51608). When the test host process exits
@@ -280,7 +293,7 @@ public class TestApplicationHandlerTests
     private const string ProjectPath = "/repo/MyTest.csproj";
     private const string TargetFramework = "net9.0";
 
-    private static (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery)
+    private (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery)
     {
         var capturingConsole = new CapturingConsole();
 
@@ -291,6 +304,7 @@ public class TestApplicationHandlerTests
         };
 
         var reporter = new TerminalTestReporter(capturingConsole, reporterOptions);
+        _disposables.Add(reporter);
 
         // Mirror the test options on the reporter — TerminalTestReporter._isHelp / _isDiscovery are set
         // here, not in the constructor. The reporter's _isHelp flag drives the legacy "swallow handshake

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -169,6 +169,56 @@ public class TestApplicationHandlerTests
     }
 
     /// <summary>
+    /// Every protocol-level rejection inside <c>OnHandshakeReceived</c> (not just ExecutionMode
+    /// mismatch) opts out of the legacy "swallow handshake failures when SDK is in help mode"
+    /// workaround. Missing-required-property is one such rejection — covered here. The workaround
+    /// is intentionally scoped to <c>OnTestProcessExited</c> calling <c>HandshakeFailure</c>
+    /// without ever having received a real handshake (older MTP behavior on <c>--help</c>).
+    /// </summary>
+    [Fact]
+    public void OnHandshakeReceived_WhenSdkInHelpModeAndRequiredPropertyMissing_StillReportsFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        // Build a handshake that's missing the required ExecutionId property.
+        var handshake = BuildHandshake(executionMode: null);
+        var properties = handshake.Properties.Where(kvp => kvp.Key != HandshakeMessagePropertyNames.ExecutionId).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var incompleteHandshake = new HandshakeMessage(properties);
+
+        bool accepted = handler.OnHandshakeReceived(incompleteHandshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// When the protocol version itself is unsupported, that failure is reported and we exit early
+    /// — we don't also report an ExecutionMode mismatch on the same handshake, since the version
+    /// rejection makes any subsequent property validation moot (and it would be confusing to
+    /// surface two distinct failures for one handshake).
+    /// </summary>
+    [Fact]
+    public void OnHandshakeReceived_WhenUnsupportedProtocolVersion_DoesNotAlsoReportExecutionModeMismatch()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        // ExecutionMode is "help" which would mismatch (SDK expects "run") if we got that far.
+        var handshake = BuildHandshake(HandshakeMessageExecutionModes.Help);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: false);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        // The version-related failure IS reported and the ExecutionMode-related one is NOT —
+        // both sides of the assertion matter: it should catch a regression that produces no
+        // failure at all (no version error) as well as one that produces both.
+        string rendered = console.GetOutput();
+        rendered.Should().Contain("protocol version", "the unsupported-protocol-version failure is expected to be reported");
+        rendered.Should().NotContain("execution mode", "the ExecutionMode validation should be skipped when the protocol version itself was rejected");
+    }
+
+    /// <summary>
     /// Forward-compat guard: a future testing-platform release that ships a new ExecutionMode value
     /// without bumping the protocol version is not silently accepted; we reject so we don't try to
     /// interpret a message stream we don't understand.

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -81,4 +81,210 @@ public class TestApplicationHandlerTests
         rendered.Should().Contain("stdout-line");
         rendered.Should().Contain("stderr-line");
     }
+
+    /// <summary>
+    /// Backward-compat regression test. Older Microsoft.Testing.Platform versions don't include the
+    /// optional <see cref="HandshakeMessagePropertyNames.ExecutionMode"/> property at all (added in
+    /// https://github.com/microsoft/testfx/pull/8794). When the property is absent the SDK must keep
+    /// today's behavior and not perform any execution-mode validation.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void OnHandshakeReceived_WhenExecutionModePropertyIsAbsent_AcceptsHandshakeAndDoesNotReportFailure(bool isHelp, bool isDiscovery)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(executionMode: null);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+        console.GetOutput().Should().NotContain("MismatchingHandshakeExecutionMode");
+    }
+
+    [Theory]
+    [InlineData(false, false, HandshakeMessageExecutionModes.Run)]
+    [InlineData(true, false, HandshakeMessageExecutionModes.Help)]
+    [InlineData(false, true, HandshakeMessageExecutionModes.Discover)]
+    public void OnHandshakeReceived_WhenExecutionModeMatchesSdkExpectation_AcceptsHandshake(bool isHelp, bool isDiscovery, string executionMode)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(executionMode);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Drives the new validation added in this change: if the host reports an execution mode that
+    /// doesn't match what <c>dotnet test</c> intended (e.g. <c>RunArguments</c> or
+    /// <c>launchSettings.json</c> injected a <c>--help</c> or <c>--list-tests</c> option), the SDK
+    /// must reject the handshake at the protocol level and report the mismatch.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false, HandshakeMessageExecutionModes.Help, HandshakeMessageExecutionModes.Run)]
+    [InlineData(false, false, HandshakeMessageExecutionModes.Discover, HandshakeMessageExecutionModes.Run)]
+    [InlineData(true, false, HandshakeMessageExecutionModes.Run, HandshakeMessageExecutionModes.Help)]
+    [InlineData(false, true, HandshakeMessageExecutionModes.Run, HandshakeMessageExecutionModes.Discover)]
+    public void OnHandshakeReceived_WhenExecutionModeMismatch_RejectsHandshakeAndReportsFailure(
+        bool isHelp, bool isDiscovery, string reportedMode, string expectedMode)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(reportedMode);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        string rendered = console.GetOutput();
+        rendered.Should().Contain(reportedMode);
+        rendered.Should().Contain(expectedMode);
+    }
+
+    /// <summary>
+    /// Even when the SDK itself was invoked in help mode, an explicit ExecutionMode mismatch reported
+    /// by the test host is a protocol-level rejection and must still be surfaced. This pins down the
+    /// <c>reportEvenWhenHelp: true</c> opt-out around the legacy "swallow handshake failures in help
+    /// mode" workaround in <see cref="TerminalTestReporter.HandshakeFailure"/>.
+    /// </summary>
+    [Fact]
+    public void OnHandshakeReceived_WhenSdkInHelpModeAndExecutionModeMismatch_StillReportsFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        var handshake = BuildHandshake(HandshakeMessageExecutionModes.Run);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Forward-compat guard: a future testing-platform release that ships a new ExecutionMode value
+    /// without bumping the protocol version is not silently accepted; we reject so we don't try to
+    /// interpret a message stream we don't understand.
+    /// </summary>
+    [Fact]
+    public void OnHandshakeReceived_WhenExecutionModeIsUnknown_RejectsHandshake()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        var handshake = BuildHandshake(executionMode: "future-mode");
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A controller-host handshake (no <c>AssemblyRunStarted</c> bookkeeping) with a mismatched
+    /// ExecutionMode must still be rejected — the validation lives in <c>OnHandshakeReceived</c>,
+    /// not in a code path gated on <c>HostType == "TestHost"</c>.
+    /// </summary>
+    [Fact]
+    public void OnHandshakeReceived_WhenControllerHostReportsMismatchedExecutionMode_RejectsHandshake()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        var handshake = BuildHandshake(
+            executionMode: HandshakeMessageExecutionModes.Help,
+            hostType: "TestHostController",
+            includeInstanceId: false);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Old-MTP help path: the test host exits without performing a handshake at all because older
+    /// Microsoft.Testing.Platform versions don't handshake on <c>--help</c>. The SDK's existing
+    /// workaround in <see cref="TerminalTestReporter.HandshakeFailure"/> must keep swallowing that
+    /// case so we don't print a spurious failure for the legacy host. The new
+    /// <c>reportEvenWhenHelp</c> opt-out must not break this — only the explicit protocol-level
+    /// mismatch path opts in.
+    /// </summary>
+    [Fact]
+    public void OnTestProcessExited_WhenSdkInHelpModeAndNoHandshakeReceived_DoesNotReportFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        Action act = () => handler.OnTestProcessExited(exitCode: 0, outputData: "help text", errorData: string.Empty);
+        act.Should().NotThrow();
+
+        reporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
+    private const string TargetPath = "/repo/bin/Debug/net9.0/MyTest.dll";
+    private const string ProjectPath = "/repo/MyTest.csproj";
+    private const string TargetFramework = "net9.0";
+
+    private static (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery)
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var reporterOptions = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        };
+
+        var reporter = new TerminalTestReporter(capturingConsole, reporterOptions);
+
+        // Mirror the test options on the reporter — TerminalTestReporter._isHelp / _isDiscovery are set
+        // here, not in the constructor. The reporter's _isHelp flag drives the legacy "swallow handshake
+        // failures when in help mode" path that the new reportEvenWhenHelp opt-out is meant to bypass.
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: isDiscovery, isHelp: isHelp, isRetry: false);
+
+        var module = new TestModule(
+            RunProperties: new RunProperties("dotnet", TargetPath, "/repo"),
+            ProjectFullPath: ProjectPath,
+            TargetFramework: TargetFramework,
+            IsTestingPlatformApplication: true,
+            LaunchSettings: null,
+            TargetPath: TargetPath,
+            DotnetRootArchVariableName: null);
+
+        var testOptions = new TestOptions(IsHelp: isHelp, IsDiscovery: isDiscovery, EnvironmentVariables: new Dictionary<string, string>());
+
+        return (new TestApplicationHandler(reporter, module, testOptions), reporter, capturingConsole);
+    }
+
+    private static HandshakeMessage BuildHandshake(string? executionMode, string hostType = "TestHost", bool includeInstanceId = true)
+    {
+        var properties = new Dictionary<byte, string>
+        {
+            [HandshakeMessagePropertyNames.PID] = "1234",
+            [HandshakeMessagePropertyNames.Architecture] = "x64",
+            [HandshakeMessagePropertyNames.Framework] = ".NETCoreApp,Version=v9.0",
+            [HandshakeMessagePropertyNames.OS] = "Windows",
+            [HandshakeMessagePropertyNames.SupportedProtocolVersions] = ProtocolConstants.SupportedVersions,
+            [HandshakeMessagePropertyNames.HostType] = hostType,
+            [HandshakeMessagePropertyNames.ModulePath] = TargetPath,
+            [HandshakeMessagePropertyNames.ExecutionId] = "exec-1",
+        };
+
+        if (includeInstanceId)
+        {
+            properties[HandshakeMessagePropertyNames.InstanceId] = "inst-1";
+        }
+
+        if (executionMode is not null)
+        {
+            properties[HandshakeMessagePropertyNames.ExecutionMode] = executionMode;
+        }
+
+        return new HandshakeMessage(properties);
+    }
 }


### PR DESCRIPTION
Microsoft.Testing.Platform now reports an explicit `ExecutionMode` in the handshake (`run`/`help`/`discover`) — see microsoft/testfx#8794 and the design issue at microsoft/testfx#8793. This wires the SDK side: read the new property, validate it against what `dotnet test` intended, and surface mismatches as a structured handshake failure so the user gets a clear diagnostic when an option such as `--help`, `-?` or `--list-tests` leaks into the test host through `RunArguments` / `TestingPlatformCommandLineArguments` MSBuild properties or `launchSettings.json` `commandLineArgs`.

### Backward compatibility (per microsoft/testfx#8793 (comment))

Per Youssef's review comment, older MTP versions don't send the `ExecutionMode` property at all (no protocol version bump). When the property is **absent** the SDK keeps today's no-validation behavior — only when the host actually reports a mode do we validate it.

### Changes

- `CliConstants.cs`: mirror the testfx-side wire constants — added `IsIDE = 9` and `ExecutionMode = 10` to `HandshakeMessagePropertyNames`, plus a new `HandshakeMessageExecutionModes` class (`Run`/`Help`/`Discover`).
- `TestApplicationHandler.OnHandshakeReceived`: after the existing required-property checks and `AssemblyRunStarted`, validate the optional `ExecutionMode` if present. Mismatches and unknown values are rejected at the protocol level (returns `false`) and reported via `HandshakeFailure` with a new localized string. Validation runs after `AssemblyRunStarted` so the failure is associated with the right assembly row in the terminal output.
- `TerminalTestReporter.HandshakeFailure`: kept the legacy `_isHelp` early-return that swallows spurious failures from older MTP versions that exit without handshaking on `--help`, but added a narrow `reportEvenWhenHelp` opt-out so explicit protocol-level rejections (ExecutionMode mismatch) are still surfaced even when the SDK itself is in help mode.
- `CliCommandStrings.resx` + xlf: new `MismatchingHandshakeExecutionMode` localized resource with the typical injection vectors called out as `{Locked=...}`.

### Tests

New unit tests in `TestApplicationHandlerTests`:

- **Old MTP**: handshake without `ExecutionMode` → accepted (covers the `_isHelp`/`_isDiscovery`/run cases via `[Theory]`).
- **Match**: `ExecutionMode` equals SDK expectation for each of Run/Help/Discover → accepted.
- **Mismatch**: each pairwise mismatch → rejected, `HasHandshakeFailure` true, message contains reported and expected modes.
- **SDK-in-help mismatch**: SDK `IsHelp=true`, MTP reports `run` → still surfaces, validating the `reportEvenWhenHelp=true` opt-out actually bypasses the legacy workaround.
- **Unknown mode**: `ExecutionMode="future-mode"` → rejected (forward-compat guard — future modes must come with a protocol-version bump).
- **Controller host mismatch**: `HostType="TestHostController"` with mismatched mode → still rejected.
- **Old-MTP help with no handshake at all**: `OnTestProcessExited` with `_isHelp=true` and no prior handshake → no failure reported, proving the legacy workaround still works.

### Validation

- `dotnet build src/Cli/dotnet/dotnet.csproj` ✅
- `dotnet build test/dotnet.Tests/dotnet.Tests.csproj` ✅
- `dotnet exec artifacts/bin/redist/Debug/dotnet.Tests.dll -class dotnet.Tests.CommandTests.Test.TestApplicationHandlerTests` ✅ — 15/15 passing.
- `dotnet msbuild src/Cli/dotnet/dotnet.csproj /t:UpdateXlf` ✅ — xlf changes generated, not hand-edited.

### References

- testfx PR (merged): microsoft/testfx#8794
- testfx design issue: microsoft/testfx#8793
