### PR TITLE
Discover installed 8.0.x runtime in DepsJson version test

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatAPublishedDepsJsonShouldContainVersionInformation.cs
@@ -140,7 +140,18 @@ static class Program
 
             var exePath = Path.Combine(publishDirectory.FullName, testProject.Name + ".dll");
 
-            string rollForwardVersion = "8.0.0";
+            //  Find the actual installed 8.0.x runtime version.  With dotnetup, only the latest patch
+            //  (e.g. 8.0.22) may be installed rather than 8.0.0, so we need to discover it dynamically.
+            string dotnetRoot = SdkTestContext.Current.ToolsetUnderTest.DotNetRoot;
+            string sharedFxDir = Path.Combine(dotnetRoot, "shared", "Microsoft.NETCore.App");
+            string rollForwardVersion = Directory.Exists(sharedFxDir)
+                ? Directory.GetDirectories(sharedFxDir, "8.0.*")
+                    .Select(Path.GetFileName)
+                    .Where(v => !string.IsNullOrEmpty(v) && Version.TryParse(v, out _))
+                    .OrderByDescending(v => Version.Parse(v))
+                    .FirstOrDefault()
+                : null
+                ?? "8.0.0";
 
             var runAppCommand = new DotnetCommand(Log, "exec", "--fx-version", rollForwardVersion, exePath);
 


### PR DESCRIPTION
dotnetup installs the latest 8.0 patch (channel '8.0') rather than exactly 8.0.0, so in this test, 'dotnet exec --fx-version 8.0.0' failed with the runtime missing. Discover the actual installed 8.0.x version from the toolset's shared framework dir instead of hard-coding 8.0.0. Mirrors the fix already in `release/dnup`.

resolves https://github.com/dotnet/sdk/issues/54608