### PR TITLE
Default IlcPgoOptimize=true for PublishAot apps

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -21,6 +21,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <!-- PublishAot depends on PublishTrimmed. This must be set early enough for the KnownILLinkPack to be restored. -->
     <PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(PublishAot)' == 'true'">true</PublishTrimmed>
+    <!-- Always consume the PGO (.mibc) data shipped in the NativeAOT runtime pack so that AOT apps
+         benefit from the BCL profile-guided optimization data by default. Users can opt out by
+         explicitly setting IlcPgoOptimize=false. Must be set before the ILCompiler targets are
+         imported (see Microsoft.NET.Sdk.targets) so it wins over the targets' default of only
+         enabling PGO when OptimizationPreference is 'Speed'. -->
+    <IlcPgoOptimize Condition="'$(IlcPgoOptimize)' == '' And '$(PublishAot)' == 'true'">true</IlcPgoOptimize>
     <IsTrimmable Condition="'$(IsTrimmable)' == '' and '$(IsAotCompatible)' == 'true'">true</IsTrimmable>
 
     <_FirstTargetFrameworkToSupportTrimming>net6.0</_FirstTargetFrameworkToSupportTrimming>

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs
@@ -251,6 +251,121 @@ namespace Microsoft.NET.Publish.Tests
             File.Exists(depsPath).Should().BeTrue();
         }
 
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_consumes_pgo_mibc_by_default_when_PublishAot_is_enabled(string targetFramework)
+        {
+            // The SDK should enable IlcPgoOptimize by default whenever PublishAot=true so that AOT
+            // apps consume the BCL profile-guided optimization data (.mibc files) shipped in the
+            // NativeAOT runtime pack. Without this, --mibc: would only appear in the ILC response
+            // file when the user explicitly set OptimizationPreference=Speed or IlcPgoOptimize=true.
+            var projectName = "NativeAotPgoMibcDefault";
+
+            var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+            testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier", "IlcPgoOptimize");
+            testProject.AdditionalProperties["PublishAot"] = "true";
+
+            var testAsset = TestAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute("/p:UseCurrentRuntimeIdentifier=true", "/p:SelfContained=true")
+                .Should().Pass();
+
+            var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
+            buildProperties["IlcPgoOptimize"].Should().Be("true");
+
+            var rid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
+            var intermediateNativeDir = Path.Combine(
+                publishCommand.GetIntermediateDirectory(targetFramework, runtimeIdentifier: rid).FullName,
+                "native");
+            var responseFile = Path.Combine(intermediateNativeDir, $"{projectName}.ilc.rsp");
+            File.Exists(responseFile).Should().BeTrue($"Expected ILC response file at {responseFile}");
+
+            // The MibcFile item population (and therefore the resulting --mibc: ILC arg) is wired
+            // by Microsoft.NETCore.Native.targets from $(IlcMibcPath)*.mibc, which defaults to
+            // <RuntimePackPath>/mibc/. Only assert the --mibc: arg appears when the runtime pack
+            // actually ships .mibc files there, so this test reflects pure SDK behavior today and
+            // lights up the end-to-end assertion automatically once the runtime starts shipping
+            // PGO data in the NativeAOT runtime pack.
+            var runtimePackMibcDir = GetNativeAotRuntimePackMibcDir(responseFile);
+            if (runtimePackMibcDir is not null && Directory.EnumerateFiles(runtimePackMibcDir, "*.mibc").Any())
+            {
+                var responseFileContents = File.ReadAllLines(responseFile);
+                responseFileContents.Should()
+                    .Contain(line => line.StartsWith("--mibc:", StringComparison.Ordinal),
+                        $"ILC response file should reference the PGO (.mibc) data shipped at {runtimePackMibcDir}");
+            }
+        }
+
+        [RequiresMSBuildVersionTheory("17.0.0.32901")]
+        [InlineData(ToolsetInfo.CurrentTargetFramework)]
+        public void NativeAot_does_not_override_explicit_IlcPgoOptimize_false(string targetFramework)
+        {
+            // Users must still be able to opt out of PGO consumption by setting IlcPgoOptimize=false.
+            var projectName = "NativeAotPgoMibcOptOut";
+
+            var testProject = CreateHelloWorldTestProject(targetFramework, projectName, true);
+            testProject.RecordProperties("NETCoreSdkPortableRuntimeIdentifier", "IlcPgoOptimize");
+            testProject.AdditionalProperties["PublishAot"] = "true";
+            testProject.AdditionalProperties["IlcPgoOptimize"] = "false";
+
+            var testAsset = TestAssetsManager.CreateTestProject(testProject, identifier: targetFramework);
+            var publishCommand = new PublishCommand(Log, Path.Combine(testAsset.TestRoot, testProject.Name));
+            publishCommand
+                .Execute("/p:UseCurrentRuntimeIdentifier=true", "/p:SelfContained=true")
+                .Should().Pass();
+
+            var buildProperties = testProject.GetPropertyValues(testAsset.TestRoot, targetFramework);
+            buildProperties["IlcPgoOptimize"].Should().Be("false");
+
+            var rid = buildProperties["NETCoreSdkPortableRuntimeIdentifier"];
+            var intermediateNativeDir = Path.Combine(
+                publishCommand.GetIntermediateDirectory(targetFramework, runtimeIdentifier: rid).FullName,
+                "native");
+            var responseFile = Path.Combine(intermediateNativeDir, $"{projectName}.ilc.rsp");
+            File.Exists(responseFile).Should().BeTrue($"Expected ILC response file at {responseFile}");
+
+            var responseFileContents = File.ReadAllLines(responseFile);
+            responseFileContents.Should()
+                .NotContain(line => line.StartsWith("--mibc:", StringComparison.Ordinal),
+                    "ILC response file should not reference any .mibc files when IlcPgoOptimize=false");
+        }
+
+        // Walks an ILC response file looking for a referenced framework assembly so we can locate
+        // the resolved NativeAOT runtime pack root and probe whether it ships .mibc PGO data.
+        private static string GetNativeAotRuntimePackMibcDir(string responseFile)
+        {
+            foreach (var line in File.ReadAllLines(responseFile))
+            {
+                if (!line.StartsWith("-r:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var referencedAssembly = line.Substring("-r:".Length);
+                var libDir = Path.GetDirectoryName(referencedAssembly);  // .../runtimes/<rid>/lib/<tfm>
+                if (libDir is null)
+                {
+                    continue;
+                }
+
+                // .../runtimes/<rid>/lib/<tfm> -> .../runtimes/<rid>
+                var ridDir = Path.GetDirectoryName(Path.GetDirectoryName(libDir));
+                if (ridDir is null)
+                {
+                    continue;
+                }
+
+                var mibcDir = Path.Combine(ridDir, "mibc");
+                if (Directory.Exists(mibcDir))
+                {
+                    return mibcDir;
+                }
+            }
+
+            return null;
+        }
+
         private const string Net7ExplicitPackageVersion = "7.0.0";
 
         [RequiresMSBuildVersionTheory("17.0.0.32901", Skip = "https://github.com/dotnet/sdk/issues/51361")]


### PR DESCRIPTION
## Summary

Default `IlcPgoOptimize=true` whenever `PublishAot=true` so that every NativeAOT publish automatically consumes the BCL PGO (`.mibc`) data shipped in the NativeAOT runtime pack.

## Why

`Microsoft.NETCore.Native.targets` (in [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets)) already wires `--mibc:` ILC args from any `.mibc` files found at `$(IlcMibcPath)` (default `$(RuntimePackagePath)\mibc\`), but only when `IlcPgoOptimize == ''true''`. The runtime targets only default `IlcPgoOptimize=true` when the user has opted into `OptimizationPreference=Speed`, which means today most AOT apps don''t benefit from the PGO data the runtime team collects for the BCL.

After this change, the SDK turns `IlcPgoOptimize` on by default for any `PublishAot=true` build. Users who explicitly want to skip PGO consumption can still set `IlcPgoOptimize=false`.

## How

Single property defaulting in `Microsoft.NET.Publish.targets`:

```xml
<IlcPgoOptimize Condition="''$(IlcPgoOptimize)'' == '''' And ''$(PublishAot)'' == ''true''">true</IlcPgoOptimize>
```

`Microsoft.NET.Publish.targets` is imported **before** `$(ILCompilerTargetsPath)` in `Microsoft.NET.Sdk.targets`, so the SDK default wins over the runtime targets'' weaker default.

## Tests

Two new tests in `GivenThatWeWantToPublishAnAotApp.cs`:

1. **`NativeAot_consumes_pgo_mibc_by_default_when_PublishAot_is_enabled`** — verifies `IlcPgoOptimize=true` by default under `PublishAot=true`, and asserts `--mibc:` appears in `ilc.rsp` _conditionally_ on the runtime pack actually shipping `.mibc` files. The test reflects pure SDK behavior today and will light up the end-to-end assertion automatically once the runtime starts shipping the data.
2. **`NativeAot_does_not_override_explicit_IlcPgoOptimize_false`** — verifies the explicit opt-out still works (no `--mibc:` args).

## Runtime side dependency

⚠️ I verified locally that the current `Microsoft.NETCore.App.Runtime.NativeAOT.<rid>` runtime pack does **not** yet ship any `.mibc` files at `runtimes/<rid>/mibc/`. A companion dotnet/runtime change is needed to drop the BCL PGO data there (e.g. `DotNet_TechEmpower.mibc` from `optimization.<rid>.mibc.runtime`). Once that lands, this SDK change lights up `--mibc:` in `ilc.rsp` with no further SDK work required.

The BCL PGO data already exists as separate NuGet packages (`optimization.<rid>.mibc.runtime`) and is consumed today by the F# compiler via [`src/Layout/redist/tools/tool_fsc.csproj`](https://github.com/dotnet/sdk/blob/main/src/Layout/redist/tools/tool_fsc.csproj#L14).

## Verification

End users wanting to try this today (before the runtime side lands) can either:

- Set `IlcMibcPath` to point at a folder containing `.mibc` files, e.g. an extracted `optimization.<rid>.mibc.runtime` package, OR
- Add explicit `<MibcFile Include="..." />` items.

In both cases `ilc.rsp` will contain the corresponding `--mibc:<path>` arguments.