### PR TITLE
Bump MSTest, NUnit, and xUnit packages to latest in dotnet new test templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.2">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -43,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,5 +1,5 @@
 <!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.2">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -48,7 +48,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.2">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -43,7 +43,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.0.2" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.0.2">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -45,7 +45,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
     <PackageReference Include="Microsoft.Playwright.MSTest.v4" Version="1.55.0" />
-    <PackageReference Include="MSTest" Version="4.0.2" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-NUnit-CSharp/Company.TestProject1.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.52.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -16,7 +16,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps the test framework packages used by the `dotnet new` test project templates to their latest stable versions.

| Package | Old | New |
| --- | --- | --- |
| `MSTest.Sdk` | 4.0.2 | 4.2.3 |
| `MSTest` | 4.0.2 | 4.2.3 |
| `NUnit` | 4.3.2 | 4.6.1 |
| `NUnit.Analyzers` | 4.7.0 | 4.14.0 |
| `NUnit3TestAdapter` | 5.0.0 | 6.2.0 |
| `xunit.runner.visualstudio` | 3.1.4 | 3.1.5 |

`xunit` is already at the latest stable 2.x version (2.9.3); no change.

Templates affected (all under `template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/`):

- `MSTest-CSharp`, `MSTest-FSharp`, `MSTest-VisualBasic`, `Playwright-MSTest-CSharp`
- `NUnit-CSharp`, `NUnit-FSharp`, `NUnit-VisualBasic`, `Playwright-NUnit-CSharp`
- `XUnit-CSharp`, `XUnit-FSharp`, `XUnit-VisualBasic`

Out of scope (left untouched on purpose):

- `Microsoft.NET.Test.Sdk` (currently a mix of 17.14.0 / 17.14.1 — would be a major-version jump to 18.x)
- `coverlet.collector` (6.0.4)
- `Microsoft.Playwright.MSTest.v4` / `Microsoft.Playwright.NUnit`
