### PR TITLE
Add --test-runner option to nunit templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "shortName": "p",
       "longName": "enable-pack"
     },
+    "TestRunner": {
+      "shortName": "",
+      "longName": "test-runner"
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/ide.host.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/ide.host",
   "icon": "ide/icon.ico",
+  "symbolInfo": [
+    {
+      "id": "TestRunner",
+      "isVisible": true,
+      "persistenceScope": "shared"
+    }
+  ],
   "tags": [
     {
       "type": "platform",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/localize/templatestrings.en.json
@@ -9,11 +9,17 @@
   "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/EnablePack/description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
   "symbols/EnablePack/displayName": "Enable pack",
+  "symbols/TestRunner/description": "Select the runner/platform.",
+  "symbols/TestRunner/displayName": "Test runner",
+  "symbols/TestRunner/choices/Microsoft.Testing.Platform/description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information.",
+  "symbols/TestRunner/choices/VSTest/description": "Use VSTest platform",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/skipRestore/displayName": "Skip restore",
   "symbols/langVersion/description": "Sets the LangVersion property in the created project file",
   "symbols/langVersion/displayName": "Language version",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/addJsonProperty/description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+  "postActions/addJsonProperty/manualInstructions/default/text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens UnitTest1.cs in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/.template.config/template.json
@@ -46,6 +46,24 @@
       "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
       "displayName": "Enable pack"
     },
+    "TestRunner": {
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "description": "Select the runner/platform.",
+      "displayName": "Test runner",
+      "defaultValue": "VSTest",
+      "choices": [
+        {
+          "choice": "Microsoft.Testing.Platform",
+          "description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information."
+        },
+        {
+          "choice": "VSTest",
+          "description": "Use VSTest platform"
+        }
+      ]
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"
@@ -84,6 +102,25 @@
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(TestRunner == \"Microsoft.Testing.Platform\")",
+      "description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+      "manualInstructions": [{ "text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform" }],
+      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
+      "id": "addJsonProperty",
+      "args": {
+        "allowFileCreation": true,
+        "allowPathCreation": true,
+        "jsonFileName": "global.json",
+        "parentPropertyPath": "test",
+        "newJsonPropertyName": "runner",
+        "newJsonPropertyValue": "Microsoft.Testing.Platform",
+        "detectRepositoryRoot": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
+      },
       "continueOnError": true
     },
     {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -23,9 +23,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-<!--#endif-->
+<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -23,7 +23,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -19,11 +19,13 @@
   <ItemGroup>
 <!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+<!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+<!--#endif-->
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-CSharp/Company.TestProject1.csproj
@@ -9,10 +9,17 @@
     <Nullable>enable</Nullable>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+<!--#if (TestRunner == "Microsoft.Testing.Platform")-->
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <OutputType>Exe</OutputType>
+<!--#endif-->
   </PropertyGroup>
 
   <ItemGroup>
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "shortName": "p",
       "longName": "enable-pack"
     },
+    "TestRunner": {
+      "shortName": "",
+      "longName": "test-runner"
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/ide.host.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/ide.host",
   "icon": "ide/icon.ico",
+  "symbolInfo": [
+    {
+      "id": "TestRunner",
+      "isVisible": true,
+      "persistenceScope": "shared"
+    }
+  ],
   "tags": [
     {
       "type": "platform",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/localize/templatestrings.en.json
@@ -9,11 +9,17 @@
   "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/EnablePack/description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
   "symbols/EnablePack/displayName": "Enable pack",
+  "symbols/TestRunner/description": "Select the runner/platform.",
+  "symbols/TestRunner/displayName": "Test runner",
+  "symbols/TestRunner/choices/Microsoft.Testing.Platform/description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information.",
+  "symbols/TestRunner/choices/VSTest/description": "Use VSTest platform",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/skipRestore/displayName": "Skip restore",
   "symbols/langVersion/description": "Sets the LangVersion property in the created project file",
   "symbols/langVersion/displayName": "Language version",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/addJsonProperty/description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+  "postActions/addJsonProperty/manualInstructions/default/text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens UnitTest1.fs in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/.template.config/template.json
@@ -46,6 +46,24 @@
       "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
       "displayName": "Enable pack"
     },
+    "TestRunner": {
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "description": "Select the runner/platform.",
+      "displayName": "Test runner",
+      "defaultValue": "VSTest",
+      "choices": [
+        {
+          "choice": "Microsoft.Testing.Platform",
+          "description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information."
+        },
+        {
+          "choice": "VSTest",
+          "description": "Use VSTest platform"
+        }
+      ]
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"
@@ -66,6 +84,16 @@
       "displayName": "Language version"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(TestRunner == \"Microsoft.Testing.Platform\")",
+          "exclude": [ "Program.fs" ]
+        }
+      ]
+    }
+  ],
   "primaryOutputs": [
     { "path": "Company.TestProject1.fsproj" },
     {
@@ -80,6 +108,25 @@
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(TestRunner == \"Microsoft.Testing.Platform\")",
+      "description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+      "manualInstructions": [{ "text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform" }],
+      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
+      "id": "addJsonProperty",
+      "args": {
+        "allowFileCreation": true,
+        "allowPathCreation": true,
+        "jsonFileName": "global.json",
+        "parentPropertyPath": "test",
+        "newJsonPropertyName": "runner",
+        "newJsonPropertyValue": "Microsoft.Testing.Platform",
+        "detectRepositoryRoot": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
+      },
       "continueOnError": true
     },
     {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -29,9 +29,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-<!--#endif-->
+<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -29,7 +29,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -8,15 +8,24 @@
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+<!--#if (TestRunner == "Microsoft.Testing.Platform")-->
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <OutputType>Exe</OutputType>
+<!--#endif-->
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="UnitTest1.fs"/>
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <Compile Include="Program.fs"/>
+<!--#endif-->
   </ItemGroup>
 
   <ItemGroup>
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/Company.TestProject1.fsproj
@@ -25,11 +25,13 @@
   <ItemGroup>
 <!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+<!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+<!--#endif-->
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/UnitTest1.fs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-FSharp/UnitTest1.fs
@@ -1,4 +1,8 @@
-﻿module Company.TestProject1
+﻿#if (TestRunner == "Microsoft.Testing.Platform")
+module Company.TestProject1.Tests
+#else
+module Company.TestProject1
+#endif
 
 open NUnit.Framework
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "shortName": "p",
       "longName": "enable-pack"
     },
+    "TestRunner": {
+      "shortName": "",
+      "longName": "test-runner"
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/ide.host.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/ide.host",
   "icon": "ide/icon.ico",
+  "symbolInfo": [
+    {
+      "id": "TestRunner",
+      "isVisible": true,
+      "persistenceScope": "shared"
+    }
+  ],
   "tags": [
     {
       "type": "platform",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -9,11 +9,17 @@
   "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/EnablePack/description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
   "symbols/EnablePack/displayName": "Enable pack",
+  "symbols/TestRunner/description": "Select the runner/platform.",
+  "symbols/TestRunner/displayName": "Test runner",
+  "symbols/TestRunner/choices/Microsoft.Testing.Platform/description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information.",
+  "symbols/TestRunner/choices/VSTest/description": "Use VSTest platform",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/skipRestore/displayName": "Skip restore",
   "symbols/langVersion/description": "Sets the LangVersion property in the created project file",
   "symbols/langVersion/displayName": "Language version",
   "postActions/restoreNugetPackages/description": "Restore NuGet packages required by this project.",
   "postActions/restoreNugetPackages/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/addJsonProperty/description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+  "postActions/addJsonProperty/manualInstructions/default/text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform",
   "postActions/openInEditor/description": "Opens UnitTest1.vb in the editor"
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/.template.config/template.json
@@ -46,6 +46,24 @@
       "description": "Whether or not to enable packaging (via \"dotnet pack\") for the project.",
       "displayName": "Enable pack"
     },
+    "TestRunner": {
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "description": "Select the runner/platform.",
+      "displayName": "Test runner",
+      "defaultValue": "VSTest",
+      "choices": [
+        {
+          "choice": "Microsoft.Testing.Platform",
+          "description": "Use Microsoft.Testing.Platform. See https://aka.ms/mtp-overview for more information."
+        },
+        {
+          "choice": "VSTest",
+          "description": "Use VSTest platform"
+        }
+      ]
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"
@@ -80,6 +98,25 @@
       "manualInstructions": [{ "text": "Run 'dotnet restore'" }],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "id": "restoreNugetPackages",
+      "continueOnError": true
+    },
+    {
+      "condition": "(TestRunner == \"Microsoft.Testing.Platform\")",
+      "description": "Create or update 'global.json' file required by Microsoft.Testing.Platform.",
+      "manualInstructions": [{ "text": "Manually update or create 'global.json' file setting the test runner to Microsoft.Testing.Platform" }],
+      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
+      "id": "addJsonProperty",
+      "args": {
+        "allowFileCreation": true,
+        "allowPathCreation": true,
+        "jsonFileName": "global.json",
+        "parentPropertyPath": "test",
+        "newJsonPropertyName": "runner",
+        "newJsonPropertyValue": "Microsoft.Testing.Platform",
+        "detectRepositoryRoot": true,
+        "includeAllDirectoriesInSearch": false,
+        "includeAllParentDirectoriesInSearch": true
+      },
       "continueOnError": true
     },
     {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -17,11 +17,13 @@
   <ItemGroup>
 <!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+<!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+<!--#endif-->
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -21,7 +21,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -7,10 +7,17 @@
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+<!--#if (TestRunner == "Microsoft.Testing.Platform")-->
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <OutputType>Exe</OutputType>
+<!--#endif-->
   </PropertyGroup>
 
   <ItemGroup>
+<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+<!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/NUnit-VisualBasic/Company.TestProject1.vbproj
@@ -21,9 +21,7 @@
 <!--#endif-->
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
-<!--#if (TestRunner != "Microsoft.Testing.Platform")-->
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-<!--#endif-->
+<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -275,6 +275,54 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             DeleteDirectoryWithRetry(workingDirectory);
         }
 
+        [Theory]
+        [MemberData(nameof(GetNUnitTestRunnerCombinations))]
+        public void NUnitProjectTemplate_WithTestRunner_CanBeInstalledAndTestsArePassing(
+            string targetFramework,
+            string language,
+            string testRunner)
+        {
+            string testProjectName = GenerateTestProjectName();
+            string outputDirectory = CreateTemporaryFolder(folderName: "Home");
+
+            // Prevent the global.json post action from walking up the directory parents up to our own solution root, which would affect other tests.
+            Directory.CreateDirectory(Path.Combine(outputDirectory, ".git"));
+
+            string workingDirectory = CreateTemporaryFolder();
+
+            // Create new test project: dotnet new nunit -n <testProjectName> -f <targetFramework> -lang <language> --test-runner <testRunner>
+            string args = $"nunit -n {testProjectName} -f {targetFramework} -lang {language} -o {outputDirectory} --test-runner {testRunner}";
+            new DotnetNewCommand(_log, args)
+                .WithCustomHive(outputDirectory).WithRawArguments()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            var isMTP = testRunner == "Microsoft.Testing.Platform";
+            if (isMTP)
+            {
+                File.Exists(Path.Combine(outputDirectory, "global.json")).Should().BeTrue();
+            }
+
+            var result = new DotnetTestCommand(_log, false)
+                .WithWorkingDirectory(outputDirectory)
+#pragma warning disable SA1010 // Opening square brackets should be spaced correctly - false positive. Current formatting is good.
+                .Execute(isMTP ? ["--project", outputDirectory] : [outputDirectory]);
+#pragma warning restore SA1010 // Opening square brackets should be spaced correctly
+
+            result.Should().Pass();
+
+            result.StdOut.Should().Contain("Passed!");
+            result.StdOut.Should().MatchRegex(isMTP ? "succeeded: 1" : @"Passed:\s*1");
+
+            // After executing dotnet new and before cleaning up
+            RecordPackages(outputDirectory);
+
+            DeleteDirectoryWithRetry(outputDirectory);
+            DeleteDirectoryWithRetry(workingDirectory);
+        }
+
         private void AddItemToFsproj(string itemName, string outputDirectory, string projectName)
         {
             var fsproj = Path.Combine(outputDirectory, $"{projectName}.fsproj");
@@ -522,6 +570,21 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                     foreach (var testRunner in testRunners)
                     {
                         yield return new object[] { "mstest-playwright", targetFramework, Languages.CSharp, coverageTool, testRunner, false };
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> GetNUnitTestRunnerCombinations()
+        {
+            var testRunners = new[] { "VSTest", "Microsoft.Testing.Platform" };
+            foreach (var targetFramework in SupportedTargetFrameworks)
+            {
+                foreach (var language in Languages.All)
+                {
+                    foreach (var testRunner in testRunners)
+                    {
+                        yield return new object[] { targetFramework, language, testRunner };
                     }
                 }
             }


### PR DESCRIPTION
Partial fix for #54499 — companion to #54636 (which added the same option to the xunit templates).

This PR adds a `TestRunner` choice parameter to the `nunit` project templates (C#, F#, VB), mirroring the option already exposed by the `mstest` and `xunit` templates:

- `--test-runner VSTest` (default) — preserves existing behavior, no changes to existing users.
- `--test-runner Microsoft.Testing.Platform` — opts in to the MTP runner.

## MTP path details

When `Microsoft.Testing.Platform` is selected the generated project:

- sets `EnableNUnitRunner=true`, `IsTestingPlatformApplication=true`, `OutputType=Exe`;
- bumps `NUnit3TestAdapter` from 5.0.0 to 6.2.0 — required because 5.0.0 transitively pins `Microsoft.Testing.Platform` 1.5.3, which uses an older handshake protocol incompatible with the .NET 10+ SDK `dotnet test` orchestrator. 6.2.0 pulls in MTP 2.1.0. The bump is **conditional**, so the VSTest path keeps the existing 5.0.0 pin and is not affected;
- drops `coverlet.collector` (incompatible with the NUnit MTP runner per Microsoft docs);
- for F#: excludes `Program.fs` (MTP auto-generates the entry point) and renames the test module to `Company.TestProject1.Tests` to avoid a namespace/module collision with the generated entry point;
- creates/updates `global.json` with `"runner": "Microsoft.Testing.Platform"` via an `addJsonProperty` post-action.

## Tests

Added `NUnitProjectTemplate_WithTestRunner_CanBeInstalledAndTestsArePassing` to `DotnetNewTestTemplatesTests`, covering 3 languages × 2 runners = 6 cases. All 6 pass locally.

## Localization

Only `templatestrings.en.json` is updated. The `.xlf` files will need a follow-up `/t:UpdateXlf` pass.
