### PR TITLE
Avoid possible test timeout due to very verbose output

### DIFF
--- a/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
+++ b/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.TestFramework
+{
+    /// <summary>
+    /// An <see cref="ITestOutputHelper"/> wrapper that forwards only a bounded amount of output to an
+    /// inner helper. The first <c>maxHeadCharacters</c> characters are forwarded as they are written,
+    /// the most recent <c>maxTailCharacters</c> characters are buffered and emitted by
+    /// <see cref="WriteBufferedTail"/>, and everything in between is dropped (replaced with a short note
+    /// describing how much was omitted). A character budget is used rather than a line count because
+    /// individual lines can be arbitrarily long.
+    /// </summary>
+    /// <remarks>
+    /// This is useful for commands that intentionally produce an enormous amount of output (for example
+    /// <c>dotnet test -v diag</c>). Echoing every line to xUnit's output buffer can flush hundreds of
+    /// megabytes over the test host's single IPC channel when the test completes, which is enough to
+    /// starve the blame hang-dump collector's inactivity timer and trigger a spurious timeout.
+    /// </remarks>
+    public sealed class TruncatingTestOutputHelper : ITestOutputHelper
+    {
+        private const int DefaultHeadCharacters = 50_000;
+        private const int DefaultTailCharacters = 50_000;
+
+        private readonly ITestOutputHelper _inner;
+        private readonly int _maxHeadCharacters;
+        private readonly int _maxTailCharacters;
+        private readonly object _lock = new();
+        private readonly Queue<string> _tail = new();
+
+        private int _headCharactersWritten;
+        private bool _headFull;
+        private int _tailCharacters;
+        private long _omittedCharacters;
+        private int _omittedLines;
+        private bool _flushed;
+
+        public TruncatingTestOutputHelper(ITestOutputHelper inner, int maxHeadCharacters = DefaultHeadCharacters, int maxTailCharacters = DefaultTailCharacters)
+        {
+            _inner = inner;
+            _maxHeadCharacters = maxHeadCharacters;
+            _maxTailCharacters = maxTailCharacters;
+        }
+
+        public void WriteLine(string message)
+        {
+            message ??= string.Empty;
+
+            lock (_lock)
+            {
+                if (!_headFull)
+                {
+                    // Still within the head budget: forward immediately so the start of the output is
+                    // preserved even if the test later throws before the tail is flushed.
+                    _inner.WriteLine(message);
+                    _headCharactersWritten += message.Length;
+                    if (_headCharactersWritten >= _maxHeadCharacters)
+                    {
+                        _headFull = true;
+                    }
+
+                    return;
+                }
+
+                // Past the head budget: keep only the most recent lines within the tail budget.
+                _tail.Enqueue(message);
+                _tailCharacters += message.Length;
+
+                while (_tailCharacters > _maxTailCharacters && _tail.Count > 1)
+                {
+                    string dropped = _tail.Dequeue();
+                    _tailCharacters -= dropped.Length;
+                    _omittedCharacters += dropped.Length;
+                    _omittedLines++;
+                }
+            }
+        }
+
+        public void WriteLine(string format, params object[] args) => WriteLine(string.Format(format, args));
+
+        /// <summary>
+        /// Emits the buffered tail (preceded by a note describing any omitted output) to the inner
+        /// helper. Call this once the command being logged has finished. Safe to call more than once.
+        /// </summary>
+        public void WriteBufferedTail()
+        {
+            lock (_lock)
+            {
+                if (_flushed)
+                {
+                    return;
+                }
+
+                _flushed = true;
+
+                if (_omittedLines > 0)
+                {
+                    _inner.WriteLine($"... [{_omittedLines} lines / {_omittedCharacters} characters of output omitted by {nameof(TruncatingTestOutputHelper)}] ...");
+                }
+
+                foreach (string line in _tail)
+                {
+                    _inner.WriteLine(line);
+                }
+
+                _tail.Clear();
+                _tailCharacters = 0;
+            }
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
+++ b/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NET.TestFramework
     /// megabytes over the test host's single IPC channel when the test completes, which is enough to
     /// starve the blame hang-dump collector's inactivity timer and trigger a spurious timeout.
     /// </remarks>
-    public sealed class TruncatingTestOutputHelper : ITestOutputHelper
+    public sealed class TruncatingTestOutputHelper : ITestOutputHelper, IDisposable
     {
         private const int DefaultHeadCharacters = 50_000;
         private const int DefaultTailCharacters = 50_000;
@@ -50,33 +50,69 @@ namespace Microsoft.NET.TestFramework
             {
                 if (!_headFull)
                 {
-                    // Still within the head budget: forward immediately so the start of the output is
-                    // preserved even if the test later throws before the tail is flushed.
-                    _inner.WriteLine(message);
-                    _headCharactersWritten += message.Length;
-                    if (_headCharactersWritten >= _maxHeadCharacters)
+                    int remainingHead = _maxHeadCharacters - _headCharactersWritten;
+                    if (message.Length <= remainingHead)
                     {
-                        _headFull = true;
+                        // Still within the head budget: forward immediately so the start of the output
+                        // is preserved even if the test later throws before the tail is flushed.
+                        _inner.WriteLine(message);
+                        _headCharactersWritten += message.Length;
+                        if (_headCharactersWritten >= _maxHeadCharacters)
+                        {
+                            _headFull = true;
+                        }
+
+                        return;
                     }
 
-                    return;
+                    // This single message crosses the head budget. Forward only the part that fits in
+                    // the head so one very large WriteLine (e.g. an entire captured StdOut written at
+                    // once) cannot push the whole payload through immediately, then buffer the rest as
+                    // tail below.
+                    if (remainingHead > 0)
+                    {
+                        _inner.WriteLine(message.Substring(0, remainingHead));
+                        message = message.Substring(remainingHead);
+                    }
+
+                    _headFull = true;
                 }
 
-                // Past the head budget: keep only the most recent lines within the tail budget.
-                _tail.Enqueue(message);
-                _tailCharacters += message.Length;
+                // Past the head budget: keep only the most recent characters within the tail budget.
+                EnqueueTail(message);
+            }
+        }
 
-                while (_tailCharacters > _maxTailCharacters && _tail.Count > 1)
-                {
-                    string dropped = _tail.Dequeue();
-                    _tailCharacters -= dropped.Length;
-                    _omittedCharacters += dropped.Length;
-                    _omittedLines++;
-                }
+        private void EnqueueTail(string message)
+        {
+            // If a single message is on its own larger than the entire tail budget, keep only its
+            // final portion so the buffered tail can never exceed the bound.
+            if (_maxTailCharacters > 0 && message.Length > _maxTailCharacters)
+            {
+                _omittedCharacters += message.Length - _maxTailCharacters;
+                message = message.Substring(message.Length - _maxTailCharacters);
+            }
+
+            _tail.Enqueue(message);
+            _tailCharacters += message.Length;
+
+            while (_tailCharacters > _maxTailCharacters && _tail.Count > 1)
+            {
+                string dropped = _tail.Dequeue();
+                _tailCharacters -= dropped.Length;
+                _omittedCharacters += dropped.Length;
+                _omittedLines++;
             }
         }
 
         public void WriteLine(string format, params object[] args) => WriteLine(string.Format(format, args));
+
+        /// <summary>
+        /// Emits the buffered tail (see <see cref="WriteBufferedTail"/>). Disposing in a <c>using</c>
+        /// block guarantees the tail is flushed even if the logged command (or a later assertion)
+        /// throws, without needing an explicit <c>try/finally</c>.
+        /// </summary>
+        public void Dispose() => WriteBufferedTail();
 
         /// <summary>
         /// Emits the buffered tail (preceded by a note describing any omitted output) to the inner

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -350,15 +350,13 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // hang-dump collector's inactivity timer and trigger a spurious 15-minute timeout. The
             // assertions below only inspect the captured StdOut, so for the diag case forward just a
             // bounded head and tail of the output to the log instead of the whole firehose.
-            var diagOutputLimiter = verbosity == "diag" ? new TruncatingTestOutputHelper(Log) : null;
+            using var diagOutputLimiter = verbosity == "diag" ? new TruncatingTestOutputHelper(Log) : null;
             ITestOutputHelper commandLog = diagOutputLimiter ?? Log;
 
             // Call test
             CommandResult result = new DotnetTestCommand(commandLog, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute("-v", verbosity);
-
-            diagOutputLimiter?.WriteBufferedTail();
 
             // Verify
             if (!TestContext.IsLocalized())

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -344,10 +344,21 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
 
+            // At diagnostic verbosity 'dotnet test -v diag' emits a huge volume of MSBuild output.
+            // Echoing every line to the xUnit ITestOutputHelper makes the test host flush hundreds of
+            // megabytes over its single IPC channel when the test completes, which can starve the blame
+            // hang-dump collector's inactivity timer and trigger a spurious 15-minute timeout. The
+            // assertions below only inspect the captured StdOut, so for the diag case forward just a
+            // bounded head and tail of the output to the log instead of the whole firehose.
+            var diagOutputLimiter = verbosity == "diag" ? new TruncatingTestOutputHelper(Log) : null;
+            ITestOutputHelper commandLog = diagOutputLimiter ?? Log;
+
             // Call test
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
+            CommandResult result = new DotnetTestCommand(commandLog, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute("-v", verbosity);
+
+            diagOutputLimiter?.WriteBufferedTail();
 
             // Verify
             if (!TestContext.IsLocalized())


### PR DESCRIPTION
The `diag` case of `ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests` runs `dotnet test -v diag`, which makes MSBuild emit hundreds of thousands of lines of output. `TestCommand.Execute` echoes every captured line to the xUnit `ITestOutputHelper`; xUnit buffers it and flushes hundreds of megabytes over the test host's single IPC channel when the test completes.  That can saturates the channel, and cause xUnit to think the test didn't finish and cancel it after 15 minutes.

This adds a new `TruncatingTestOutputHelper` that forwards only a bounded head and tail of the output (by character budget) to the log and drops the middle. This keeps useful diagnostics from both ends while preventing the IPC flood, and preserves the diagnostic-verbosity coverage.

Observed failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1453617 on https://github.com/dotnet/sdk/pull/54592