### PR TITLE
Update implicit versions for June

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,8 +35,8 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>27</VersionFeature80>
-    <VersionFeature90>16</VersionFeature90>
+    <VersionFeature80>28</VersionFeature80>
+    <VersionFeature90>17</VersionFeature90>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
Update implicit version numbers for the June 2026 release.

- `VersionFeature80`: 27 → 28 (for .NET 8.0.28)
- `VersionFeature90`: 16 → 17 (for .NET 9.0.17)

Release branch — only updating older servicing bands (N-1).