### PR TITLE
[PROTOTYPE] Add Microsoft.NET.Sdk.Testing skeleton (#49294)

### DIFF
--- a/sdk.slnx
+++ b/sdk.slnx
@@ -308,6 +308,36 @@
   <Folder Name="/src/WebSdk/Worker/Tasks/">
     <Project Path="src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj" />
   </Folder>
+  <Folder Name="/src/TestingSdk/" />
+  <Folder Name="/src/TestingSdk/Sdk/">
+    <File Path="src/TestingSdk/Sdk/Sdk.props" />
+    <File Path="src/TestingSdk/Sdk/Sdk.targets" />
+  </Folder>
+  <Folder Name="/src/TestingSdk/Targets/">
+    <File Path="src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props" />
+    <File Path="src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.targets" />
+  </Folder>
+  <Folder Name="/src/TestingSdk/Targets/Frameworks/">
+    <File Path="src/TestingSdk/Targets/Frameworks/Expecto.props" />
+    <File Path="src/TestingSdk/Targets/Frameworks/Expecto.targets" />
+    <File Path="src/TestingSdk/Targets/Frameworks/MSTest.props" />
+    <File Path="src/TestingSdk/Targets/Frameworks/MSTest.targets" />
+    <File Path="src/TestingSdk/Targets/Frameworks/NUnit.props" />
+    <File Path="src/TestingSdk/Targets/Frameworks/NUnit.targets" />
+    <File Path="src/TestingSdk/Targets/Frameworks/TUnit.props" />
+    <File Path="src/TestingSdk/Targets/Frameworks/TUnit.targets" />
+    <File Path="src/TestingSdk/Targets/Frameworks/XUnit.props" />
+    <File Path="src/TestingSdk/Targets/Frameworks/XUnit.targets" />
+  </Folder>
+  <Folder Name="/src/TestingSdk/Targets/Platforms/">
+    <File Path="src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.props" />
+    <File Path="src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.targets" />
+    <File Path="src/TestingSdk/Targets/Platforms/VSTest.props" />
+    <File Path="src/TestingSdk/Targets/Platforms/VSTest.targets" />
+  </Folder>
+  <Folder Name="/src/TestingSdk/Tasks/">
+    <Project Path="src/TestingSdk/Tasks/Microsoft.NET.Sdk.Testing.Tasks.csproj" />
+  </Folder>
   <Folder Name="/src/Workloads/" />
   <Folder Name="/src/Workloads/Manifests/">
     <Project Path="src/Workloads/Manifests/manifest-packages.csproj" />

--- a/source-build.slnf
+++ b/source-build.slnf
@@ -62,6 +62,7 @@
       "src\\WebSdk\\Publish\\Tasks\\Microsoft.NET.Sdk.Publish.Tasks.csproj",
       "src\\WebSdk\\Web\\Tasks\\Microsoft.NET.Sdk.Web.Tasks.csproj",
       "src\\WebSdk\\Worker\\Tasks\\Microsoft.NET.Sdk.Worker.Tasks.csproj",
+      "src\\TestingSdk\\Tasks\\Microsoft.NET.Sdk.Testing.Tasks.csproj",
       "template_feed\\Microsoft.DotNet.Common.ItemTemplates\\Microsoft.DotNet.Common.ItemTemplates.csproj",
       "template_feed\\Microsoft.DotNet.Common.ProjectTemplates.11.0\\Microsoft.DotNet.Common.ProjectTemplates.11.0.csproj",
       "template_feed\\Microsoft.TemplateEngine.Authoring.Templates\\Microsoft.TemplateEngine.Authoring.Templates.csproj"

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -197,9 +197,12 @@
   <Target Name="PublishNetSdks" DependsOnTargets="PublishNETAnalyzers;PublishDotnetFormat;PublishBlazorWasmTools;PublishStaticWebAssetsTools;PublishRazorSdkTools">
     <ItemGroup>
       <WebSdkProjectFile Include="$(RepoRoot)src\WebSdk\**\*.csproj" />
+      <!-- PROTOTYPE for https://github.com/dotnet/sdk/issues/49294 -->
+      <TestingSdkProjectFile Include="$(RepoRoot)src\TestingSdk\**\*.csproj" />
     </ItemGroup>
 
     <MSBuild Projects="@(WebSdkProjectFile)" />
+    <MSBuild Projects="@(TestingSdkProjectFile)" />
 
     <PropertyGroup>
       <NETSdkSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk</NETSdkSourceRoot>
@@ -211,6 +214,7 @@
       <NETSdkWasmSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk.WebAssembly</NETSdkWasmSourceRoot>
       <NETSdkRazorSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk.Razor</NETSdkRazorSourceRoot>
       <NETSdkStaticWebAssetsSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk.StaticWebAssets</NETSdkStaticWebAssetsSourceRoot>
+      <NETSdkTestingSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk.Testing</NETSdkTestingSourceRoot>
     </PropertyGroup>
 
     <ItemGroup>
@@ -232,6 +236,8 @@
                       DeploymentSubPath="Sdks\Microsoft.NET.Sdk.Razor"/>
       <NETSdksContent Include="$(NETSdkStaticWebAssetsSourceRoot)\**\*.*"
                       DeploymentSubPath="Sdks\Microsoft.NET.Sdk.StaticWebAssets"/>
+      <NETSdksContent Include="$(NETSdkTestingSourceRoot)\**\*.*"
+                      DeploymentSubPath="Sdks\Microsoft.NET.Sdk.Testing"/>
     </ItemGroup>
 
     <Copy SourceFiles="@(NETSdksContent)"

--- a/src/TestingSdk/README.md
+++ b/src/TestingSdk/README.md
@@ -15,7 +15,18 @@ framework-specific is shipped in-band.
 
 ## What a consuming project looks like
 
-xUnit v3 on MTP (most common case):
+xUnit v3 on MTP (most common case) — uses the SDK's pinned default version, no version property required:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Testing">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestFramework>XUnit</TestFramework>
+  </PropertyGroup>
+</Project>
+```
+
+Same thing, pinning to a specific xUnit version (recommended for libraries that want hermetic builds):
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Testing">
@@ -23,6 +34,18 @@ xUnit v3 on MTP (most common case):
     <TargetFramework>net10.0</TargetFramework>
     <TestFramework>XUnit</TestFramework>
     <XUnitVersion>3.0.0</XUnitVersion>
+  </PropertyGroup>
+</Project>
+```
+
+Opt into floating to always pick up the latest stable xUnit on each restore (non-deterministic; use only with a NuGet lock file if you care about reproducibility):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Testing">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestFramework>XUnit</TestFramework>
+    <XUnitVersion>*</XUnitVersion>
   </PropertyGroup>
 </Project>
 ```
@@ -34,10 +57,7 @@ NUnit on VSTest (explicit platform opt-out of the MTP default):
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestFramework>NUnit</TestFramework>
-    <NUnitVersion>4.3.0</NUnitVersion>
     <TestPlatform>VSTest</TestPlatform>
-    <MicrosoftNETTestSdkVersion>17.12.0</MicrosoftNETTestSdkVersion>
-    <NUnit3TestAdapterVersion>4.6.0</NUnit3TestAdapterVersion>
   </PropertyGroup>
 </Project>
 ```
@@ -49,7 +69,6 @@ xUnit test-helpers library (no Exe, lower-level packages):
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestFramework>XUnit</TestFramework>
-    <XUnitVersion>3.0.0</XUnitVersion>
     <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 </Project>
@@ -59,13 +78,14 @@ xUnit test-helpers library (no Exe, lower-level packages):
 
 Required:
 - `TestFramework` — `MSTest` | `NUnit` | `XUnit` | `TUnit` | `Expecto`. `XUnit` always means xUnit v3.
-- `<Framework>Version` — e.g. `XUnitVersion`, `MSTestVersion`, etc. **Mandatory in this prototype** to avoid silent test-framework upgrades on SDK bumps.
 
 Optional:
+- `<Framework>Version` (e.g. `XUnitVersion`, `MSTestVersion`, `NUnitVersion`, `TUnitVersion`, `ExpectoVersion`) — defaults to a value pinned by this SDK (see `Targets/_DefaultPackageVersions.props`). Override with a fixed version to lock the test framework, or with `*` (or `*-*`) to float to the latest stable (or latest including prerelease). Floating restores are not reproducible without a NuGet lock file.
 - `TestPlatform` — `MicrosoftTestingPlatform` (alias `MTP`) | `VSTest`. Defaults from framework.
 - `IsTestUtilityProject` — defaults `false`. When `true`: no `Exe` output, no `Microsoft.NET.Test.Sdk` reference, framework metapackage swapped for the assert/extensibility packages.
 - `TestingExtensionsProfile` — MTP-only. `Default` | `AllMicrosoft` | `None`. Mirrors `MSTest.Sdk`.
 - `EnableMicrosoftTestingExtensions<Name>` and `MicrosoftTestingExtensions<Name>Version` — per-extension toggles and version overrides; mirror `MSTest.Sdk`.
+- Companion-package versions (`XUnitRunnerVisualStudioVersion`, `NUnit3TestAdapterVersion`, `NUnitAnalyzersVersion`, `YoloDevExpectoTestSdkVersion`, `MicrosoftNETTestSdkVersion`, `MicrosoftTestingPlatformVersion`) — all have pinned defaults; override the same way as the framework version.
 
 Framework × platform validity:
 
@@ -91,6 +111,7 @@ src/TestingSdk/
 ├── Targets/
 │   ├── Microsoft.NET.Sdk.Testing.props      # Dispatch + validation
 │   ├── Microsoft.NET.Sdk.Testing.targets
+│   ├── _DefaultPackageVersions.props        # Centralized pinned defaults (user-overridable)
 │   ├── Frameworks/                          # One file pair per framework
 │   │   ├── {MSTest,NUnit,XUnit,TUnit,Expecto}.{props,targets}
 │   └── Platforms/

--- a/src/TestingSdk/README.md
+++ b/src/TestingSdk/README.md
@@ -87,6 +87,17 @@ Optional:
 - `EnableMicrosoftTestingExtensions<Name>` and `MicrosoftTestingExtensions<Name>Version` — per-extension toggles and version overrides; mirror `MSTest.Sdk`.
 - Companion-package versions (`XUnitRunnerVisualStudioVersion`, `NUnit3TestAdapterVersion`, `NUnitAnalyzersVersion`, `YoloDevExpectoTestSdkVersion`, `MicrosoftNETTestSdkVersion`, `MicrosoftTestingPlatformVersion`) — all have pinned defaults; override the same way as the framework version.
 
+## Central Package Management (CPM)
+
+`ManagePackageVersionsCentrally=true` is fully supported. The SDK uses the pattern documented in `MSTest.Sdk`:
+
+- When CPM is **off**, the `<Version>` metadata is set directly on each `<PackageReference>` the SDK adds.
+- When CPM is **on**, the `<PackageReference>` is emitted without a version, and a matching `<PackageVersion Include="..." Version="..." />` item is added so the CPM resolver picks up the SDK-supplied default.
+
+This pattern works regardless of `CentralPackageVersionOverrideEnabled` (no use of `VersionOverride`, so `NU1013` is not a concern), and does not produce `NU1009` "implicit reference" warnings.
+
+To override the SDK default while staying in CPM, the simplest path is to set the corresponding MSBuild property (e.g. `<XUnitVersion>3.0.1</XUnitVersion>`) in your csproj or in a `Directory.Build.props`. That value flows into the `PackageVersion` the SDK emits, so the resolved version matches what you asked for.
+
 Framework × platform validity:
 
 | Framework | MTP | VSTest | Default when omitted |

--- a/src/TestingSdk/README.md
+++ b/src/TestingSdk/README.md
@@ -75,7 +75,7 @@ Framework × platform validity:
 | NUnit     | ✅   | ✅      | MTP                  |
 | XUnit (v3)| ✅   | ✅      | MTP                  |
 | TUnit     | ✅   | ❌      | MTP                  |
-| Expecto   | ✅   | ❌      | MTP                  |
+| Expecto   | ✅   | ✅      | MTP                  |
 
 Invalid pairs error at evaluation.
 

--- a/src/TestingSdk/README.md
+++ b/src/TestingSdk/README.md
@@ -1,0 +1,122 @@
+# Microsoft.NET.Sdk.Testing — prototype
+
+**Status:** prototype for the design proposed in
+[dotnet/sdk#49294](https://github.com/dotnet/sdk/issues/49294). Not yet wired
+into templates, not yet validated end-to-end, MTP-only path is the only well-
+exercised one.
+
+## What this is
+
+A new MSBuild SDK that lives in-band in the .NET SDK and lets test projects
+declare what framework + platform they want without manually wiring up
+`PackageReference` entries and runner properties. Versions of the test
+frameworks themselves come from NuGet at user-pinned versions — nothing
+framework-specific is shipped in-band.
+
+## What a consuming project looks like
+
+xUnit v3 on MTP (most common case):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Testing">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestFramework>XUnit</TestFramework>
+    <XUnitVersion>3.0.0</XUnitVersion>
+  </PropertyGroup>
+</Project>
+```
+
+NUnit on VSTest (explicit platform opt-out of the MTP default):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Testing">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestFramework>NUnit</TestFramework>
+    <NUnitVersion>4.3.0</NUnitVersion>
+    <TestPlatform>VSTest</TestPlatform>
+    <MicrosoftNETTestSdkVersion>17.12.0</MicrosoftNETTestSdkVersion>
+    <NUnit3TestAdapterVersion>4.6.0</NUnit3TestAdapterVersion>
+  </PropertyGroup>
+</Project>
+```
+
+xUnit test-helpers library (no Exe, lower-level packages):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Testing">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TestFramework>XUnit</TestFramework>
+    <XUnitVersion>3.0.0</XUnitVersion>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
+  </PropertyGroup>
+</Project>
+```
+
+## Property surface (prototype scope)
+
+Required:
+- `TestFramework` — `MSTest` | `NUnit` | `XUnit` | `TUnit` | `Expecto`. `XUnit` always means xUnit v3.
+- `<Framework>Version` — e.g. `XUnitVersion`, `MSTestVersion`, etc. **Mandatory in this prototype** to avoid silent test-framework upgrades on SDK bumps.
+
+Optional:
+- `TestPlatform` — `MicrosoftTestingPlatform` (alias `MTP`) | `VSTest`. Defaults from framework.
+- `IsTestUtilityProject` — defaults `false`. When `true`: no `Exe` output, no `Microsoft.NET.Test.Sdk` reference, framework metapackage swapped for the assert/extensibility packages.
+- `TestingExtensionsProfile` — MTP-only. `Default` | `AllMicrosoft` | `None`. Mirrors `MSTest.Sdk`.
+- `EnableMicrosoftTestingExtensions<Name>` and `MicrosoftTestingExtensions<Name>Version` — per-extension toggles and version overrides; mirror `MSTest.Sdk`.
+
+Framework × platform validity:
+
+| Framework | MTP | VSTest | Default when omitted |
+|-----------|-----|--------|----------------------|
+| MSTest    | ✅   | ✅      | MTP                  |
+| NUnit     | ✅   | ✅      | MTP                  |
+| XUnit (v3)| ✅   | ✅      | MTP                  |
+| TUnit     | ✅   | ❌      | MTP                  |
+| Expecto   | ✅   | ❌      | MTP                  |
+
+Invalid pairs error at evaluation.
+
+## Layout
+
+Mirrors `src/WebSdk/Worker/` so MSBuild's SDK resolver picks the SDK up the same way:
+
+```
+src/TestingSdk/
+├── Sdk/
+│   ├── Sdk.props            # MSBuild SDK entry point
+│   └── Sdk.targets
+├── Targets/
+│   ├── Microsoft.NET.Sdk.Testing.props      # Dispatch + validation
+│   ├── Microsoft.NET.Sdk.Testing.targets
+│   ├── Frameworks/                          # One file pair per framework
+│   │   ├── {MSTest,NUnit,XUnit,TUnit,Expecto}.{props,targets}
+│   └── Platforms/
+│       ├── MicrosoftTestingPlatform.{props,targets}
+│       └── VSTest.{props,targets}
+└── Tasks/
+    └── Microsoft.NET.Sdk.Testing.Tasks.csproj   # Packaging only; no compiled code
+```
+
+The packaging csproj sets `PackageLayoutOutputPath` to
+`artifacts/bin/<Configuration>/Sdks/Microsoft.NET.Sdk.Testing/` (via the
+shared `src/WebSdk/CopyPackageLayout.targets`), and
+`src/Layout/redist/targets/GenerateLayout.targets` copies that into the
+redist SDK layout next to `Sdks/Microsoft.NET.Sdk.Worker/` etc.
+
+## Known gaps in the prototype
+
+- **MSTest path is naive.** A real implementation should delegate to
+  `MSTest.Sdk` rather than re-implementing it.
+- **No template integration.** `dotnet new mstest/nunit/xunit` still emit the
+  classic `Microsoft.NET.Sdk` + `Microsoft.NET.Test.Sdk` PackageReference shape.
+  Template changes live in `dotnet/templating`.
+- **Aspire / Playwright / NativeAOT-MSTest.Engine** features that
+  `MSTest.Sdk` exposes via `Features/` are not yet ported.
+- **`<Framework>PackageSource`** (Arcade-style local-path override) is not
+  implemented; v2 work.
+- **Not yet exercised by a test asset** in `test/TestAssets/TestProjects`.
+- **Localized strings** (the `<Error Text="...">` content) live inline; a
+  real version would move them to a `.resx` and `.xlf` set.

--- a/src/TestingSdk/Sdk/Sdk.props
+++ b/src/TestingSdk/Sdk/Sdk.props
@@ -1,0 +1,26 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+  PROTOTYPE — Microsoft.NET.Sdk.Testing
+
+  Draft prototype for https://github.com/dotnet/sdk/issues/49294. Layout mirrors
+  Microsoft.NET.Sdk.Worker. Loaded by MSBuild when a project sets
+  Sdk="Microsoft.NET.Sdk.Testing".
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- Marker that downstream tooling (Arcade SDK, analyzers, etc.) can detect. -->
+    <UsingMicrosoftNETSdkTesting>true</UsingMicrosoftNETSdkTesting>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Testing.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Testing.props')" />
+
+</Project>

--- a/src/TestingSdk/Sdk/Sdk.targets
+++ b/src/TestingSdk/Sdk/Sdk.targets
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Sdk.targets
+
+  PROTOTYPE — Microsoft.NET.Sdk.Testing
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <Import Project="$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Testing.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.Testing.targets')" />
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/Expecto.props
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.props
@@ -1,0 +1,20 @@
+<!--
+  PROTOTYPE: Expecto (F#) framework wiring for Microsoft.NET.Sdk.Testing.
+  Expecto on MTP is provided via Expecto.TestingPlatformAdapter.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(ExpectoVersion)' != ''">
+    <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
+    <PackageReference Include="Expecto.TestingPlatformAdapter" Version="$(ExpectoVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(ExpectoVersion)' != ''">
+    <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/Expecto.props
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.props
@@ -10,15 +10,33 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(ExpectoVersion)' != ''">
-    <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
-    <PackageReference Include="Expecto.TestingPlatformAdapter" Version="$(ExpectoVersion)"
-                      Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform'" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="$(YoloDevExpectoTestSdkVersion)"
-                      Condition="'$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' != ''" />
+    <PackageReference Include="Expecto">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(ExpectoVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="Expecto" Version="$(ExpectoVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="Expecto.TestingPlatformAdapter"
+                      Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform'">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(ExpectoVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="Expecto.TestingPlatformAdapter" Version="$(ExpectoVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(TestPlatform)' == 'MicrosoftTestingPlatform' " />
+
+    <PackageReference Include="YoloDev.Expecto.TestSdk"
+                      Condition="'$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' != ''">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(YoloDevExpectoTestSdkVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="YoloDev.Expecto.TestSdk" Version="$(YoloDevExpectoTestSdkVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' != '' " />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(ExpectoVersion)' != ''">
-    <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
+    <PackageReference Include="Expecto">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(ExpectoVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="Expecto" Version="$(ExpectoVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/Expecto.props
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.props
@@ -1,16 +1,20 @@
 <!--
   PROTOTYPE: Expecto (F#) framework wiring for Microsoft.NET.Sdk.Testing.
   Expecto on MTP is provided via Expecto.TestingPlatformAdapter.
+  Expecto on VSTest is provided via YoloDev.Expecto.TestSdk.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TestingPlatformDotnetTestSupport Condition="'$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(ExpectoVersion)' != ''">
     <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
-    <PackageReference Include="Expecto.TestingPlatformAdapter" Version="$(ExpectoVersion)" />
+    <PackageReference Include="Expecto.TestingPlatformAdapter" Version="$(ExpectoVersion)"
+                      Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform'" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="$(YoloDevExpectoTestSdkVersion)"
+                      Condition="'$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(ExpectoVersion)' != ''">
@@ -18,3 +22,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/src/TestingSdk/Targets/Frameworks/Expecto.targets
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateExpectoTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(ExpectoVersion)' == ''"
+           Text="The 'ExpectoVersion' MSBuild property is required when TestFramework=Expecto." />
+    <Error Condition="'$(TestPlatform)' != 'MicrosoftTestingPlatform'"
+           Text="Expecto in this SDK only supports TestPlatform=MicrosoftTestingPlatform." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/Expecto.targets
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.targets
@@ -2,7 +2,8 @@
   <Target Name="_ValidateExpectoTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
     <Error Condition="'$(ExpectoVersion)' == ''"
            Text="The 'ExpectoVersion' MSBuild property is required when TestFramework=Expecto." />
-    <Error Condition="'$(TestPlatform)' != 'MicrosoftTestingPlatform'"
-           Text="Expecto in this SDK only supports TestPlatform=MicrosoftTestingPlatform." />
+    <Error Condition="'$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' == ''"
+           Text="The 'YoloDevExpectoTestSdkVersion' MSBuild property is required when TestFramework=Expecto and TestPlatform=VSTest (provides the YoloDev.Expecto.TestSdk VSTest adapter)." />
   </Target>
 </Project>
+

--- a/src/TestingSdk/Targets/Frameworks/Expecto.targets
+++ b/src/TestingSdk/Targets/Frameworks/Expecto.targets
@@ -1,9 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_ValidateExpectoTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(ExpectoVersion)' == ''"
-           Text="The 'ExpectoVersion' MSBuild property is required when TestFramework=Expecto." />
-    <Error Condition="'$(TestPlatform)' == 'VSTest' and '$(YoloDevExpectoTestSdkVersion)' == ''"
-           Text="The 'YoloDevExpectoTestSdkVersion' MSBuild property is required when TestFramework=Expecto and TestPlatform=VSTest (provides the YoloDev.Expecto.TestSdk VSTest adapter)." />
-  </Target>
+  <!--
+    No mandatory-version validation: ExpectoVersion and YoloDevExpectoTestSdkVersion
+    have pinned defaults in _DefaultPackageVersions.props. Override with a fixed
+    version or '*'.
+  -->
 </Project>
 

--- a/src/TestingSdk/Targets/Frameworks/MSTest.props
+++ b/src/TestingSdk/Targets/Frameworks/MSTest.props
@@ -14,11 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(MSTestVersion)' != ''">
-    <PackageReference Include="MSTest" Version="$(MSTestVersion)" />
+    <PackageReference Include="MSTest">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(MSTestVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="MSTest" Version="$(MSTestVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(MSTestVersion)' != ''">
-    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.TestFramework">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(MSTestVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="MSTest.TestFramework" Version="$(MSTestVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/MSTest.props
+++ b/src/TestingSdk/Targets/Frameworks/MSTest.props
@@ -1,0 +1,24 @@
+<!--
+  PROTOTYPE: MSTest framework wiring for Microsoft.NET.Sdk.Testing.
+
+  NOTE: A future iteration may delegate to MSTest.Sdk via Sdk import rather than
+  re-implementing the MSTest reference shape here. For the prototype we inline a
+  minimal MSTest setup so the SDK can be exercised end-to-end without depending
+  on MSTest.Sdk being available.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <EnableMSTestRunner Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(EnableMSTestRunner)' == ''">true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(MSTestVersion)' != ''">
+    <PackageReference Include="MSTest" Version="$(MSTestVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(MSTestVersion)' != ''">
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/MSTest.targets
+++ b/src/TestingSdk/Targets/Frameworks/MSTest.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateMSTestTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(MSTestVersion)' == ''"
+           Text="The 'MSTestVersion' MSBuild property is required when TestFramework=MSTest." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/MSTest.targets
+++ b/src/TestingSdk/Targets/Frameworks/MSTest.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_ValidateMSTestTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(MSTestVersion)' == ''"
-           Text="The 'MSTestVersion' MSBuild property is required when TestFramework=MSTest." />
-  </Target>
+  <!--
+    No mandatory-version validation: MSTestVersion has a pinned default in
+    _DefaultPackageVersions.props. Users can override with a fixed version or '*'.
+  -->
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/NUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/NUnit.props
@@ -8,14 +8,31 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(NUnitVersion)' != ''">
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
-    <!-- MTP path: pull in NUnit3TestAdapter built atop MTP via TestingPlatformAdapter, plus the MTP entry point. -->
-    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" Condition="'$(NUnitAnalyzersVersion)' != ''" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterVersion)" Condition="'$(NUnit3TestAdapterVersion)' != ''" />
+    <PackageReference Include="NUnit">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(NUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="NUnit" Version="$(NUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="NUnit.Analyzers" Condition="'$(NUnitAnalyzersVersion)' != ''">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(NUnitAnalyzersVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(NUnitAnalyzersVersion)' != '' " />
+
+    <PackageReference Include="NUnit3TestAdapter" Condition="'$(NUnit3TestAdapterVersion)' != ''">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(NUnit3TestAdapterVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(NUnit3TestAdapterVersion)' != '' " />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(NUnitVersion)' != ''">
-    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <PackageReference Include="NUnit">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(NUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="NUnit" Version="$(NUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/NUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/NUnit.props
@@ -1,0 +1,21 @@
+<!--
+  PROTOTYPE: NUnit framework wiring for Microsoft.NET.Sdk.Testing.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(NUnitVersion)' != ''">
+    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+    <!-- MTP path: pull in NUnit3TestAdapter built atop MTP via TestingPlatformAdapter, plus the MTP entry point. -->
+    <PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersVersion)" Condition="'$(NUnitAnalyzersVersion)' != ''" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterVersion)" Condition="'$(NUnit3TestAdapterVersion)' != ''" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(NUnitVersion)' != ''">
+    <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/NUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/NUnit.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateNUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(NUnitVersion)' == ''"
+           Text="The 'NUnitVersion' MSBuild property is required when TestFramework=NUnit." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/NUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/NUnit.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_ValidateNUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(NUnitVersion)' == ''"
-           Text="The 'NUnitVersion' MSBuild property is required when TestFramework=NUnit." />
-  </Target>
+  <!--
+    No mandatory-version validation: NUnitVersion (and companions) have pinned
+    defaults in _DefaultPackageVersions.props. Override with a fixed version or '*'.
+  -->
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/TUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/TUnit.props
@@ -9,12 +9,25 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(TUnitVersion)' != ''">
-    <PackageReference Include="TUnit" Version="$(TUnitVersion)" />
+    <PackageReference Include="TUnit">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(TUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="TUnit" Version="$(TUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(TUnitVersion)' != ''">
-    <PackageReference Include="TUnit.Core" Version="$(TUnitVersion)" />
-    <PackageReference Include="TUnit.Assertions" Version="$(TUnitVersion)" />
+    <PackageReference Include="TUnit.Core">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(TUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="TUnit.Core" Version="$(TUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="TUnit.Assertions">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(TUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="TUnit.Assertions" Version="$(TUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/TUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/TUnit.props
@@ -1,0 +1,20 @@
+<!--
+  PROTOTYPE: TUnit framework wiring for Microsoft.NET.Sdk.Testing.
+  TUnit is MTP-only by design.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(TUnitVersion)' != ''">
+    <PackageReference Include="TUnit" Version="$(TUnitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(TUnitVersion)' != ''">
+    <PackageReference Include="TUnit.Core" Version="$(TUnitVersion)" />
+    <PackageReference Include="TUnit.Assertions" Version="$(TUnitVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/TUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/TUnit.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateTUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(TUnitVersion)' == ''"
+           Text="The 'TUnitVersion' MSBuild property is required when TestFramework=TUnit." />
+    <Error Condition="'$(TestPlatform)' != 'MicrosoftTestingPlatform'"
+           Text="TUnit only supports TestPlatform=MicrosoftTestingPlatform (it does not have a VSTest adapter)." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/TUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/TUnit.targets
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="_ValidateTUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(TUnitVersion)' == ''"
-           Text="The 'TUnitVersion' MSBuild property is required when TestFramework=TUnit." />
+    <!-- TUnitVersion has a pinned default in _DefaultPackageVersions.props; no version check needed. -->
     <Error Condition="'$(TestPlatform)' != 'MicrosoftTestingPlatform'"
            Text="TUnit only supports TestPlatform=MicrosoftTestingPlatform (it does not have a VSTest adapter)." />
   </Target>

--- a/src/TestingSdk/Targets/Frameworks/XUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/XUnit.props
@@ -9,14 +9,32 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(XUnitVersion)' != ''">
-    <PackageReference Include="xunit.v3" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)"
-                      Condition="'$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' != ''" />
+    <PackageReference Include="xunit.v3">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(XUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="xunit.v3" Version="$(XUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="xunit.runner.visualstudio"
+                      Condition="'$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' != ''">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(XUnitRunnerVisualStudioVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' and '$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' != '' " />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(XUnitVersion)' != ''">
-    <PackageReference Include="xunit.v3.extensibility.core" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.v3.assert"             Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.v3.extensibility.core">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(XUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="xunit.v3.assert">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(XUnitVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="xunit.v3.assert" Version="$(XUnitVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/XUnit.props
+++ b/src/TestingSdk/Targets/Frameworks/XUnit.props
@@ -1,0 +1,22 @@
+<!--
+  PROTOTYPE: XUnit (always v3) framework wiring for Microsoft.NET.Sdk.Testing.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <UseMicrosoftTestingPlatformRunner Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(UseMicrosoftTestingPlatformRunner)' == ''">true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform' and '$(TestingPlatformDotnetTestSupport)' == ''">true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(XUnitVersion)' != ''">
+    <PackageReference Include="xunit.v3" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)"
+                      Condition="'$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' != ''" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' == 'true' and '$(XUnitVersion)' != ''">
+    <PackageReference Include="xunit.v3.extensibility.core" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.v3.assert"             Version="$(XUnitVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Frameworks/XUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/XUnit.targets
@@ -1,8 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_ValidateXUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(XUnitVersion)' == ''"
-           Text="The 'XUnitVersion' MSBuild property is required when TestFramework=XUnit. (Mandatory in v1 of Microsoft.NET.Sdk.Testing to prevent silent test-framework upgrades when the .NET SDK is updated.)" />
-    <Error Condition="'$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' == ''"
-           Text="The 'XUnitRunnerVisualStudioVersion' MSBuild property is required when TestFramework=XUnit and TestPlatform=VSTest." />
-  </Target>
+  <!--
+    No mandatory-version validation: XUnitVersion and XUnitRunnerVisualStudioVersion
+    have pinned defaults in _DefaultPackageVersions.props. Override with a fixed
+    version or '*'.
+  -->
 </Project>

--- a/src/TestingSdk/Targets/Frameworks/XUnit.targets
+++ b/src/TestingSdk/Targets/Frameworks/XUnit.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateXUnitTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(XUnitVersion)' == ''"
+           Text="The 'XUnitVersion' MSBuild property is required when TestFramework=XUnit. (Mandatory in v1 of Microsoft.NET.Sdk.Testing to prevent silent test-framework upgrades when the .NET SDK is updated.)" />
+    <Error Condition="'$(TestPlatform)' == 'VSTest' and '$(XUnitRunnerVisualStudioVersion)' == ''"
+           Text="The 'XUnitRunnerVisualStudioVersion' MSBuild property is required when TestFramework=XUnit and TestPlatform=VSTest." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
+++ b/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
@@ -44,8 +44,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!--
+    Centralized default package versions. Imported BEFORE the per-framework dispatch
+    so that framework props see populated <Framework>Version properties. Users can
+    override any of these in their csproj, including with floating values like '*'.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)_DefaultPackageVersions.props" />
+
+  <!--
     Dispatch to the per-framework props file. Each framework file is responsible for:
-      - Validating its <Framework>Version property is set.
       - Validating that TestPlatform is supported by that framework.
       - Emitting the PackageReference(s) (metapackage for tests, lower-level packages for utilities).
       - Setting framework-specific MSBuild properties (EnableMSTestRunner, UseMicrosoftTestingPlatformRunner, etc.).

--- a/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
+++ b/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
@@ -28,7 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       NUnit   -> MTP (also supports VSTest)
       XUnit   -> MTP (also supports VSTest); always means xUnit v3 in this SDK
       TUnit   -> MTP only
-      Expecto -> MTP only
+      Expecto -> MTP (also supports VSTest via YoloDev.Expecto.TestSdk)
   -->
   <PropertyGroup Condition="'$(TestPlatform)' == ''">
     <TestPlatform Condition="'$(_TestFramework)' == 'MSTest'">MicrosoftTestingPlatform</TestPlatform>

--- a/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
+++ b/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.props
@@ -1,0 +1,76 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Testing.props
+
+  PROTOTYPE — Microsoft.NET.Sdk.Testing core props.
+
+  Validates the user-supplied TestFramework/TestPlatform pair, defaults the
+  platform per-framework, and dispatches to a per-framework props file that
+  adds the appropriate PackageReference(s) and runner wiring.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- Default: a project using this SDK is a test application (Exe) unless explicitly a test utility library. -->
+    <IsTestUtilityProject Condition="'$(IsTestUtilityProject)' == ''">false</IsTestUtilityProject>
+
+    <!-- Normalize TestFramework for case-insensitive comparison downstream. -->
+    <_TestFramework>$(TestFramework)</_TestFramework>
+  </PropertyGroup>
+
+  <!--
+    Default TestPlatform per framework when the user did not specify one.
+    Matrix:
+      MSTest  -> MTP (also supports VSTest)
+      NUnit   -> MTP (also supports VSTest)
+      XUnit   -> MTP (also supports VSTest); always means xUnit v3 in this SDK
+      TUnit   -> MTP only
+      Expecto -> MTP only
+  -->
+  <PropertyGroup Condition="'$(TestPlatform)' == ''">
+    <TestPlatform Condition="'$(_TestFramework)' == 'MSTest'">MicrosoftTestingPlatform</TestPlatform>
+    <TestPlatform Condition="'$(_TestFramework)' == 'NUnit'">MicrosoftTestingPlatform</TestPlatform>
+    <TestPlatform Condition="'$(_TestFramework)' == 'XUnit'">MicrosoftTestingPlatform</TestPlatform>
+    <TestPlatform Condition="'$(_TestFramework)' == 'TUnit'">MicrosoftTestingPlatform</TestPlatform>
+    <TestPlatform Condition="'$(_TestFramework)' == 'Expecto'">MicrosoftTestingPlatform</TestPlatform>
+  </PropertyGroup>
+
+  <!-- Accept 'MTP' as a short alias for 'MicrosoftTestingPlatform'. -->
+  <PropertyGroup>
+    <TestPlatform Condition="'$(TestPlatform)' == 'MTP'">MicrosoftTestingPlatform</TestPlatform>
+  </PropertyGroup>
+
+  <!--
+    Dispatch to the per-framework props file. Each framework file is responsible for:
+      - Validating its <Framework>Version property is set.
+      - Validating that TestPlatform is supported by that framework.
+      - Emitting the PackageReference(s) (metapackage for tests, lower-level packages for utilities).
+      - Setting framework-specific MSBuild properties (EnableMSTestRunner, UseMicrosoftTestingPlatformRunner, etc.).
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\MSTest.props"   Condition="'$(_TestFramework)' == 'MSTest'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\NUnit.props"    Condition="'$(_TestFramework)' == 'NUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\XUnit.props"    Condition="'$(_TestFramework)' == 'XUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\TUnit.props"    Condition="'$(_TestFramework)' == 'TUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\Expecto.props"  Condition="'$(_TestFramework)' == 'Expecto'" />
+
+  <!-- Platform-level props (currently MTP only; VSTest path adds Microsoft.NET.Test.Sdk reference). -->
+  <Import Project="$(MSBuildThisFileDirectory)Platforms\MicrosoftTestingPlatform.props"
+          Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform'" />
+  <Import Project="$(MSBuildThisFileDirectory)Platforms\VSTest.props"
+          Condition="'$(TestPlatform)' == 'VSTest'" />
+
+  <!-- OutputType: test applications are executables; test utility libraries are libraries. -->
+  <PropertyGroup Condition="'$(IsTestUtilityProject)' != 'true'">
+    <OutputType Condition="'$(UseWinUI)' == 'true' or '$(UseUwpTools)' == 'true'">WinExe</OutputType>
+    <OutputType Condition="'$(OutputType)' == '' or '$(OutputType)' == 'Library'">Exe</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Test projects rarely participate in pack; defer to NuGet's own default but make it explicit. -->
+    <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.targets
+++ b/src/TestingSdk/Targets/Microsoft.NET.Sdk.Testing.targets
@@ -1,0 +1,36 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Testing.targets
+
+  PROTOTYPE — Microsoft.NET.Sdk.Testing core targets.
+
+  Validation that needs to happen after evaluation. Per-framework / per-platform
+  targets are imported here in the same dispatch shape as the .props file.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\MSTest.targets"   Condition="'$(TestFramework)' == 'MSTest'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\NUnit.targets"    Condition="'$(TestFramework)' == 'NUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\XUnit.targets"    Condition="'$(TestFramework)' == 'XUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\TUnit.targets"    Condition="'$(TestFramework)' == 'TUnit'" />
+  <Import Project="$(MSBuildThisFileDirectory)Frameworks\Expecto.targets"  Condition="'$(TestFramework)' == 'Expecto'" />
+
+  <Import Project="$(MSBuildThisFileDirectory)Platforms\MicrosoftTestingPlatform.targets"
+          Condition="'$(TestPlatform)' == 'MicrosoftTestingPlatform'" />
+  <Import Project="$(MSBuildThisFileDirectory)Platforms\VSTest.targets"
+          Condition="'$(TestPlatform)' == 'VSTest'" />
+
+  <!-- Hard validation: TestFramework is required. -->
+  <Target Name="_ValidateMicrosoftNETSdkTesting" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(TestFramework)' == ''"
+           Text="The 'TestFramework' MSBuild property is required when using Microsoft.NET.Sdk.Testing. Valid values: MSTest, NUnit, XUnit, TUnit, Expecto." />
+    <Error Condition="'$(TestFramework)' != 'MSTest' and '$(TestFramework)' != 'NUnit' and '$(TestFramework)' != 'XUnit' and '$(TestFramework)' != 'TUnit' and '$(TestFramework)' != 'Expecto'"
+           Text="Unknown 'TestFramework' value '$(TestFramework)'. Valid values: MSTest, NUnit, XUnit, TUnit, Expecto." />
+    <Error Condition="'$(TestPlatform)' != 'MicrosoftTestingPlatform' and '$(TestPlatform)' != 'VSTest'"
+           Text="Unknown 'TestPlatform' value '$(TestPlatform)'. Valid values: MicrosoftTestingPlatform (or alias 'MTP'), VSTest." />
+  </Target>
+
+</Project>

--- a/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.props
+++ b/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.props
@@ -1,0 +1,10 @@
+<!--
+  PROTOTYPE: Microsoft.Testing.Platform (MTP) platform wiring.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_UsesMicrosoftTestingPlatform>true</_UsesMicrosoftTestingPlatform>
+  </PropertyGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.targets
+++ b/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.targets
@@ -9,9 +9,6 @@
 
   <PropertyGroup>
     <TestingExtensionsProfile Condition="'$(TestingExtensionsProfile)' == ''">Default</TestingExtensionsProfile>
-
-    <!-- Common version that per-extension <Name>Version properties fall back to. -->
-    <MicrosoftTestingExtensionsCommonVersion Condition="'$(MicrosoftTestingExtensionsCommonVersion)' == ''">$(MicrosoftTestingPlatformVersion)</MicrosoftTestingExtensionsCommonVersion>
   </PropertyGroup>
 
   <Target Name="_ValidateTestingExtensionsProfile" BeforeTargets="CollectPackageReferences;BeforeBuild">

--- a/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.targets
+++ b/src/TestingSdk/Targets/Platforms/MicrosoftTestingPlatform.targets
@@ -1,0 +1,56 @@
+<!--
+  PROTOTYPE: Microsoft.Testing.Platform (MTP) extension wiring.
+
+  Mirrors the surface MSTest.Sdk exposes in
+  src/Package/MSTest.Sdk/Sdk/Runner/Common.targets, applied uniformly across
+  test frameworks (the extensions hook MTP itself, not the framework).
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <TestingExtensionsProfile Condition="'$(TestingExtensionsProfile)' == ''">Default</TestingExtensionsProfile>
+
+    <!-- Common version that per-extension <Name>Version properties fall back to. -->
+    <MicrosoftTestingExtensionsCommonVersion Condition="'$(MicrosoftTestingExtensionsCommonVersion)' == ''">$(MicrosoftTestingPlatformVersion)</MicrosoftTestingExtensionsCommonVersion>
+  </PropertyGroup>
+
+  <Target Name="_ValidateTestingExtensionsProfile" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(TestingExtensionsProfile)' != 'Default' and '$(TestingExtensionsProfile)' != 'AllMicrosoft' and '$(TestingExtensionsProfile)' != 'None'"
+           Text="Invalid value for property TestingExtensionsProfile. Valid values are 'Default', 'AllMicrosoft' and 'None'." />
+  </Target>
+
+  <!--
+    Default profile turns on a small curated set (TRX + code coverage).
+    AllMicrosoft profile turns on every Microsoft-shipped MTP extension.
+    None requires explicit opt-in per extension.
+    Users can always override any individual EnableMicrosoftTestingExtensions<Name>.
+  -->
+  <PropertyGroup>
+    <!-- TRX report -->
+    <EnableMicrosoftTestingExtensionsTrxReport Condition="'$(EnableMicrosoftTestingExtensionsTrxReport)' == '' and ('$(TestingExtensionsProfile)' == 'Default' or '$(TestingExtensionsProfile)' == 'AllMicrosoft')">true</EnableMicrosoftTestingExtensionsTrxReport>
+
+    <!-- Code coverage -->
+    <EnableMicrosoftTestingExtensionsCodeCoverage Condition="'$(EnableMicrosoftTestingExtensionsCodeCoverage)' == '' and ('$(TestingExtensionsProfile)' == 'Default' or '$(TestingExtensionsProfile)' == 'AllMicrosoft')">true</EnableMicrosoftTestingExtensionsCodeCoverage>
+
+    <!-- The remaining extensions are only auto-enabled by AllMicrosoft. -->
+    <EnableMicrosoftTestingExtensionsCrashDump Condition="'$(EnableMicrosoftTestingExtensionsCrashDump)' == '' and '$(TestingExtensionsProfile)' == 'AllMicrosoft'">true</EnableMicrosoftTestingExtensionsCrashDump>
+    <EnableMicrosoftTestingExtensionsHangDump  Condition="'$(EnableMicrosoftTestingExtensionsHangDump)'  == '' and '$(TestingExtensionsProfile)' == 'AllMicrosoft'">true</EnableMicrosoftTestingExtensionsHangDump>
+    <EnableMicrosoftTestingExtensionsHotReload Condition="'$(EnableMicrosoftTestingExtensionsHotReload)' == '' and '$(TestingExtensionsProfile)' == 'AllMicrosoft'">true</EnableMicrosoftTestingExtensionsHotReload>
+    <EnableMicrosoftTestingExtensionsRetry     Condition="'$(EnableMicrosoftTestingExtensionsRetry)'     == '' and '$(TestingExtensionsProfile)' == 'AllMicrosoft'">true</EnableMicrosoftTestingExtensionsRetry>
+  </PropertyGroup>
+
+  <!--
+    Per-extension version defaulting. Each Enable<Name> toggle is consumed by the
+    extension's own NuGet package or by MTP itself; we only ensure each version
+    property has a sensible default.
+  -->
+  <PropertyGroup>
+    <MicrosoftTestingExtensionsTrxReportVersion        Condition="'$(MicrosoftTestingExtensionsTrxReportVersion)'        == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsTrxReportVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion     Condition="'$(MicrosoftTestingExtensionsCodeCoverageVersion)'     == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCrashDumpVersion        Condition="'$(MicrosoftTestingExtensionsCrashDumpVersion)'        == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsCrashDumpVersion>
+    <MicrosoftTestingExtensionsHangDumpVersion         Condition="'$(MicrosoftTestingExtensionsHangDumpVersion)'         == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsHangDumpVersion>
+    <MicrosoftTestingExtensionsHotReloadVersion        Condition="'$(MicrosoftTestingExtensionsHotReloadVersion)'        == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsHotReloadVersion>
+    <MicrosoftTestingExtensionsRetryVersion            Condition="'$(MicrosoftTestingExtensionsRetryVersion)'            == ''">$(MicrosoftTestingExtensionsCommonVersion)</MicrosoftTestingExtensionsRetryVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Platforms/VSTest.props
+++ b/src/TestingSdk/Targets/Platforms/VSTest.props
@@ -1,0 +1,13 @@
+<!--
+  PROTOTYPE: VSTest platform wiring.
+
+  Brings in Microsoft.NET.Test.Sdk so that VSTest (`dotnet test`'s legacy path,
+  vstest.console.exe, VS Test Explorer) can discover and run tests.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(MicrosoftNETTestSdkVersion)' != ''">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestingSdk/Targets/Platforms/VSTest.props
+++ b/src/TestingSdk/Targets/Platforms/VSTest.props
@@ -7,7 +7,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="'$(IsTestUtilityProject)' != 'true' and '$(MicrosoftNETTestSdkVersion)' != ''">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(MicrosoftNETTestSdkVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)"
+                    Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/TestingSdk/Targets/Platforms/VSTest.targets
+++ b/src/TestingSdk/Targets/Platforms/VSTest.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_ValidateVSTestTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
-    <Error Condition="'$(MicrosoftNETTestSdkVersion)' == ''"
-           Text="The 'MicrosoftNETTestSdkVersion' MSBuild property is required when TestPlatform=VSTest." />
-  </Target>
+  <!--
+    No mandatory-version validation: MicrosoftNETTestSdkVersion has a pinned default
+    in _DefaultPackageVersions.props. Override with a fixed version or '*'.
+  -->
 </Project>

--- a/src/TestingSdk/Targets/Platforms/VSTest.targets
+++ b/src/TestingSdk/Targets/Platforms/VSTest.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_ValidateVSTestTestingSdk" BeforeTargets="CollectPackageReferences;BeforeBuild">
+    <Error Condition="'$(MicrosoftNETTestSdkVersion)' == ''"
+           Text="The 'MicrosoftNETTestSdkVersion' MSBuild property is required when TestPlatform=VSTest." />
+  </Target>
+</Project>

--- a/src/TestingSdk/Targets/_DefaultPackageVersions.props
+++ b/src/TestingSdk/Targets/_DefaultPackageVersions.props
@@ -1,0 +1,54 @@
+<!--
+***********************************************************************************************
+_DefaultPackageVersions.props
+
+  PROTOTYPE — Default package versions for Microsoft.NET.Sdk.Testing.
+
+  Users can override any of these to:
+    - Pin to a different fixed version (recommended for reproducible builds).
+    - Float by setting `*` (or `*-*` to include prerelease).
+
+  In the real SDK these values would be sourced from eng/Versions.props (or an
+  equivalent version-synced file generated at SDK build time) so they advance
+  with each .NET SDK release rather than being hand-edited here.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="MTP platform + extensions">
+    <MicrosoftTestingPlatformVersion Condition="'$(MicrosoftTestingPlatformVersion)' == ''">1.5.0</MicrosoftTestingPlatformVersion>
+    <!-- Per-extension <Name>Version properties fall back to this in MicrosoftTestingPlatform.targets. -->
+    <MicrosoftTestingExtensionsCommonVersion Condition="'$(MicrosoftTestingExtensionsCommonVersion)' == ''">$(MicrosoftTestingPlatformVersion)</MicrosoftTestingExtensionsCommonVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="VSTest platform">
+    <MicrosoftNETTestSdkVersion Condition="'$(MicrosoftNETTestSdkVersion)' == ''">17.12.0</MicrosoftNETTestSdkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="MSTest">
+    <MSTestVersion Condition="'$(MSTestVersion)' == ''">3.7.0</MSTestVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="NUnit">
+    <NUnitVersion Condition="'$(NUnitVersion)' == ''">4.2.2</NUnitVersion>
+    <NUnitAnalyzersVersion Condition="'$(NUnitAnalyzersVersion)' == ''">4.3.0</NUnitAnalyzersVersion>
+    <NUnit3TestAdapterVersion Condition="'$(NUnit3TestAdapterVersion)' == ''">4.6.0</NUnit3TestAdapterVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="xUnit (always v3 in this SDK)">
+    <XUnitVersion Condition="'$(XUnitVersion)' == ''">1.0.1</XUnitVersion>
+    <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">3.0.0</XUnitRunnerVisualStudioVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="TUnit">
+    <TUnitVersion Condition="'$(TUnitVersion)' == ''">0.6.157</TUnitVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Expecto">
+    <ExpectoVersion Condition="'$(ExpectoVersion)' == ''">10.2.3</ExpectoVersion>
+    <YoloDevExpectoTestSdkVersion Condition="'$(YoloDevExpectoTestSdkVersion)' == ''">0.15.0</YoloDevExpectoTestSdkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/TestingSdk/Tasks/Microsoft.NET.Sdk.Testing.Tasks.csproj
+++ b/src/TestingSdk/Tasks/Microsoft.NET.Sdk.Testing.Tasks.csproj
@@ -1,0 +1,55 @@
+<Project>
+
+  <!--
+    PROTOTYPE packaging project for Microsoft.NET.Sdk.Testing.
+
+    Mirrors src/WebSdk/Worker/Tasks/Microsoft.NET.Sdk.Worker.Tasks.csproj:
+    no compiled task code, only used to (a) lay out Sdk/ + Targets/ under
+    artifacts/bin/<Configuration>/Sdks/Microsoft.NET.Sdk.Testing/ via
+    CopyPackageLayout.targets so GenerateLayout.targets can pick them up,
+    and (b) produce a NuGet package for out-of-band consumption.
+  -->
+
+  <PropertyGroup>
+    <TestingSdkRoot Condition="'$(TestingSdkRoot)' == ''">$(RepoRoot)\src\TestingSdk\</TestingSdkRoot>
+    <PackageId>Microsoft.NET.Sdk.Testing</PackageId>
+    <OutDirName>$(Configuration)\Sdks\$(PackageId)\tools</OutDirName>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <OutputPath>$(BaseOutputPath)</OutputPath>
+    <IsPackable>true</IsPackable>
+    <PackageLayoutOutputPath>$(ArtifactsBinDir)$(Configuration)\Sdks\$(PackageId)\</PackageLayoutOutputPath>
+    <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>MSBuild SDK for .NET test projects (PROTOTYPE for https://github.com/dotnet/sdk/issues/49294).</Description>
+    <ProjectUrl>https://github.com/dotnet/sdk</ProjectUrl>
+    <PackageTags>Sdk;Testing</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalContent Include="$(TestingSdkRoot)\Targets\**\*.*">
+      <Pack>true</Pack>
+      <PackagePath>targets</PackagePath>
+    </AdditionalContent>
+
+    <AdditionalContent Include="$(TestingSdkRoot)\Sdk\**\*.*">
+      <Pack>true</Pack>
+      <PackagePath>Sdk</PackagePath>
+    </AdditionalContent>
+  </ItemGroup>
+
+  <Import Project="$(RepoRoot)\src\WebSdk\CopyPackageLayout.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+</Project>


### PR DESCRIPTION
> [!WARNING]
> **Draft / prototype, not for merge.** Opening this so the shape of [#49294](https://github.com/dotnet/sdk/issues/49294) can be discussed against concrete code rather than just a design doc. The MTP path for xUnit/NUnit/TUnit is the only one anywhere close to validated; MSTest support is naive (a real impl should delegate to `MSTest.Sdk`); no template integration; no test asset yet; strings are inline (no `.resx`/`.xlf` yet).

## What this is

Prototype of `Microsoft.NET.Sdk.Testing`, the proposal in #49294, as an in-tree MSBuild SDK shipped in-band with the .NET SDK. Layout mirrors `src/WebSdk/Worker/` so MSBuild''s SDK resolver picks it up the same way the existing per-area SDKs (`Microsoft.NET.Sdk.Worker`, `Microsoft.NET.Sdk.Razor`, etc.) are.

## Design decisions reflected in this prototype

1. **Framework + platform are two properties, platform defaults from framework.** Valid combos enforced at evaluation:

   | Framework | MTP | VSTest | Default when omitted |
   |-----------|-----|--------|----------------------|
   | MSTest    | ✅   | ✅      | MTP                  |
   | NUnit     | ✅   | ✅      | MTP                  |
   | XUnit (v3)| ✅   | ✅      | MTP                  |
   | TUnit     | ✅   | ❌      | MTP                  |
   | Expecto   | ✅   | ✅      | MTP                  |

2. **Frameworks come from NuGet** — nothing framework-specific is shipped in-band. Avoids the maintenance/CVE-response burden of in-banding code the SDK team doesn''t own. Every `<Framework>Version` (and companion package version) has a pinned default in `Targets/_DefaultPackageVersions.props` so projects don''t need to specify a version. Users can override with a fixed version (recommended for reproducibility) or with `*` / `*-*` to opt into NuGet floating. The defaults shipped here are placeholders for the prototype; in the real SDK they would be sourced from `eng/Versions.props` at build time so the matrix advances on each .NET SDK release.

3. **MTP extensions surface mirrors `MSTest.Sdk`** (`TestingExtensionsProfile` + per-extension `Enable<Name>` and `<Name>Version`), applied uniformly across frameworks because the extensions hook MTP, not the framework.

4. **`<Framework>PackageSource` local-path override** (Arcade-style) is **not** in this prototype; deferred to v2 per the design discussion.

5. **`IsTestProject` semantic conflict** is handled additively: `IsTestProject` stays VSTest-owned (set by `Microsoft.NET.Test.Sdk` package), `IsTestUtilityProject` is the new evaluation-time signal. Zero regression for `_CalculateIsVSTestTestProject`, `IsRidAgnostic`, and Arcade.

## Layout

```
src/TestingSdk/
├── README.md
├── Sdk/
│   ├── Sdk.props                                    # MSBuild SDK entry
│   └── Sdk.targets
├── Targets/
│   ├── Microsoft.NET.Sdk.Testing.props              # Dispatch + validation
│   ├── Microsoft.NET.Sdk.Testing.targets
│   ├── Frameworks/
│   │   ├── MSTest.{props,targets}
│   │   ├── NUnit.{props,targets}
│   │   ├── XUnit.{props,targets}
│   │   ├── TUnit.{props,targets}
│   │   └── Expecto.{props,targets}
│   └── Platforms/
│       ├── MicrosoftTestingPlatform.{props,targets}
│       └── VSTest.{props,targets}
└── Tasks/
    └── Microsoft.NET.Sdk.Testing.Tasks.csproj       # Packaging only
```

Plus wiring in:
- `src/Layout/redist/targets/GenerateLayout.targets` — `PublishNetSdks` builds the new csproj and lays out `Sdks/Microsoft.NET.Sdk.Testing/`.
- `sdk.slnx`, `source-build.slnf`.

## Sample consuming project

```xml
<Project Sdk="Microsoft.NET.Sdk.Testing">
  <PropertyGroup>
    <TargetFramework>net10.0</TargetFramework>
    <TestFramework>XUnit</TestFramework>
    <TestingExtensionsProfile>AllMicrosoft</TestingExtensionsProfile>
  </PropertyGroup>
</Project>
```

The xUnit version is omitted above — the SDK supplies a pinned default. Add `<XUnitVersion>3.0.0</XUnitVersion>` to lock to a specific version, or `<XUnitVersion>*</XUnitVersion>` to float to the latest stable on each restore.

## What I''d like reviewers to push back on

1. **MSTest carve-out:** delegate to `MSTest.Sdk` (recommended) vs re-implement inline (current prototype)?
2. **Token spelling:** `MicrosoftTestingPlatform` (canonical) + `MTP` (alias) — fine, or pick one?
3. **`XUnit` = always v3 with no v2 path** — confirmed direction?
4. **Default versions vs `*` floating vs explicit pins** — the prototype now ships pinned defaults and exposes all three modes (no property = SDK default, `<Version>X.Y</Version>` = explicit pin, `<Version>*</Version>` = float). Reasonable tradeoff?
5. **Validating with `BeforeTargets="CollectPackageReferences;BeforeBuild"`** for required-property checks — early enough? Better target?

## Known gaps (also in `src/TestingSdk/README.md`)

- MSTest path is inline; should delegate to `MSTest.Sdk`.
- No `dotnet new` template changes (lives in `dotnet/templating`).
- No `Features/Aspire.targets`, `Features/Playwright.targets`, `Runner/NativeAOT.targets` analogues yet.
- No `<Framework>PackageSource` (v2).
- No test asset under `test/TestAssets/TestProjects` yet.
- Error messages inline; should move to `.resx`/`.xlf` for localization.
- Has not yet been validated end-to-end through a `build.cmd` + dogfood + `dotnet new` + `dotnet test` cycle on my machine — CI on this PR will be the first real exercise.

Closes: nothing — keep #49294 open for design discussion.

