### PR TITLE
Remove dnx shim from Linux SDK package

### DIFF
--- a/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/Layout/pkg/dotnet-sdk.proj
@@ -47,9 +47,6 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" />
   </ItemGroup>
 
-  <ItemGroup>
-    <LinuxPackageSymlink Include="/usr/bin/dnx" LinkTarget="../share/dotnet/dnx" />
-  </ItemGroup>
 
   <Import Project="$(RepoRoot)src\Tasks\sdk-tasks\sdk-tasks.InTree.targets" />
 
@@ -64,7 +61,6 @@
       <CLISdkFiles Include="$(RedistInstallerLayoutPath)sdk/**/*" />
       <TemplatesFiles Include="$(RedistInstallerLayoutPath)templates/**/*" />
       <ManifestFiles Include="$(RedistInstallerLayoutPath)sdk-manifests/**/*" />
-      <DnxShimSource Include="$(RedistInstallerLayoutPath)dnx*" />
     </ItemGroup>
 
     <!-- Create layout: Binaries -->
@@ -90,9 +86,6 @@
       OverwriteReadOnlyFiles="True"
       SkipUnchangedFiles="False"
       UseHardlinksIfPossible="False" />
-
-    <!-- Create layout: DNX shim -->
-    <Copy SourceFiles="@(DnxShimSource)" DestinationFolder="$(OutputPath)" />
   </Target>
 
   <Target Name="SetCustomPackagingProperties" AfterTargets="_GetInstallerProperties">


### PR DESCRIPTION
Per the [.NET distribution-packaging guidelines](https://learn.microsoft.com/dotnet/core/distribution-packaging), the dnx dispatcher script and the `/usr/bin/dnx` symlink live in the `dotnet-host` package, not the `dotnet-sdk` package. Shipping them from both causes a dpkg file conflict on systems that already have Canonical's `dotnet-host` installed (#53834).

This change removes the dnx file copy and the `/usr/bin/dnx` symlink. `src/Layout/redist/dnx` is preserved because it's still consumed by `LayoutDnxShim` for the tarball, macOS `.pkg`, and Windows MSI/zip layouts.

Must ship alongside https://github.com/dotnet/runtime/pull/129258, which adds the dnx file and the `/usr/bin/dnx` symlink to the `dotnet-host` package.

Contributes to #53834