### PR TITLE
Dotnetup: detect UI language without requiring ICU on Linux

### DIFF
--- a/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
+++ b/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
@@ -9,25 +9,27 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 /// <summary>
 /// Resolves and applies the user's UI language for dotnetup.
 ///
-/// dotnetup is published with <c>InvariantGlobalization=true</c> only on Linux, where libicu is
-/// not guaranteed to be present (running non-invariant there crashes on startup with
-/// "Couldn't find a valid ICU package"). Windows and macOS ship globalization in-box, so the
-/// binary runs non-invariant there and the runtime initializes
-/// <see cref="CultureInfo.CurrentUICulture"/> from the operating system automatically.
+/// dotnetup is published with <c>InvariantGlobalization=true</c> on every platform except Windows
+/// and macOS, which are the only ones known to ship globalization in-box. Elsewhere (Linux,
+/// including musl/Alpine, FreeBSD, etc.) libicu is not guaranteed, and running non-invariant there
+/// crashes on startup with "Couldn't find a valid ICU package". On the invariant platforms the
+/// runtime no longer initializes <see cref="CultureInfo.CurrentUICulture"/> from the operating
+/// system, so it would otherwise always be the invariant (English) culture.
 ///
 /// This type therefore:
 /// <list type="bullet">
-/// <item>On Windows/macOS, applies only the standard .NET CLI override
+/// <item>On Windows/macOS (non-invariant), applies only the standard .NET CLI override
 /// (<c>DOTNET_CLI_UI_LANGUAGE</c> / <c>VSLANG</c>), since the runtime already initialized the UI
 /// culture and <see cref="CultureInfo"/>'s parent fallback works.</item>
-/// <item>On Linux, where invariant mode disables both the runtime's OS-locale detection and
-/// <see cref="CultureInfo.Parent"/> fallback, resolves the desired locale (override, else the
-/// POSIX environment) and maps it onto an exact shipped satellite culture via
-/// <see cref="MatchSupportedLanguage"/>.</item>
+/// <item>On the invariant platforms, where invariant mode disables both the runtime's OS-locale
+/// detection and <see cref="CultureInfo.Parent"/> fallback, resolves the desired locale (the same
+/// CLI override, else the POSIX environment) and maps it onto an exact shipped satellite culture
+/// via <see cref="MatchSupportedLanguage"/>.</item>
 /// </list>
-/// On Linux the project also sets <c>PredefinedCulturesOnly=false</c> so the matched culture can
-/// be created by name (it carries invariant formatting data but retains its name, which is what
-/// drives satellite-resource lookup).
+/// On the invariant platforms the project also sets <c>PredefinedCulturesOnly=false</c> so the
+/// matched culture can be created by name (it carries invariant formatting data but retains its
+/// name, which is what drives satellite-resource lookup). The Windows/macOS-vs-rest split here
+/// mirrors the <c>InvariantGlobalization</c> condition in dotnetup.csproj.
 /// </summary>
 internal static class DotnetupUILanguage
 {
@@ -35,9 +37,9 @@ internal static class DotnetupUILanguage
     // message category, then LANG as the catch-all default.
     private static readonly string[] s_posixLocaleVariables = ["LC_ALL", "LC_MESSAGES", "LANG"];
 
-    // The UI languages dotnetup ships satellite resources for. In invariant mode (Linux) the
-    // runtime provides no parent/neutral culture fallback, so the applied culture must exactly
-    // match one of these names; MatchSupportedLanguage maps an OS/CLI locale onto the right entry.
+    // The UI languages dotnetup ships satellite resources for. In invariant mode the runtime
+    // provides no parent/neutral culture fallback, so the applied culture must exactly match one
+    // of these names; MatchSupportedLanguage maps an OS/CLI locale onto the right entry.
     // Keep in sync with the Strings.*.xlf files — DotnetupUILanguageTests enforces this.
     private static readonly string[] s_supportedUILanguages =
     [
@@ -46,6 +48,10 @@ internal static class DotnetupUILanguage
 
     /// <summary>The UI languages dotnetup ships localized resources for (satellite culture names).</summary>
     internal static IReadOnlyList<string> SupportedUILanguages => s_supportedUILanguages;
+
+    // Windows and macOS run non-invariant (they ship globalization in-box); every other platform
+    // runs invariant. Mirrors the InvariantGlobalization condition in dotnetup.csproj.
+    internal static bool PlatformRunsInvariant => !OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS();
 
     /// <summary>
     /// Detects the user's UI language and applies it to the current process so localized
@@ -69,16 +75,17 @@ internal static class DotnetupUILanguage
     {
         // Windows and macOS run non-invariant: the runtime initialized CurrentUICulture from the
         // OS and CultureInfo's parent fallback works, so only the explicit CLI override is applied.
-        if (!OperatingSystem.IsLinux())
+        if (!PlatformRunsInvariant)
         {
             return UILanguageOverride.GetOverriddenUILanguage();
         }
 
-        // Linux runs invariant: there is no parent/neutral fallback, so the applied culture must
-        // exactly match a shipped satellite. Resolve the desired locale with the same override
-        // resolver as the rest of the .NET CLI (DOTNET_CLI_UI_LANGUAGE > VSLANG), else the POSIX
-        // environment, then map it onto a satellite. (A VSLANG LCID cannot be turned into a named
-        // culture in invariant mode, so it resolves to empty and falls through to the environment.)
+        // Invariant platforms (Linux, etc.): there is no parent/neutral fallback, so the applied
+        // culture must exactly match a shipped satellite. Resolve the desired locale with the same
+        // override resolver as the rest of the .NET CLI (DOTNET_CLI_UI_LANGUAGE > VSLANG), else the
+        // POSIX environment, then map it onto a satellite. (A VSLANG LCID cannot be turned into a
+        // named culture in invariant mode, so it resolves to empty and falls through to the
+        // environment.)
         string? desired = UILanguageOverride.GetOverriddenUILanguage()?.Name;
         if (string.IsNullOrWhiteSpace(desired))
         {

--- a/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
+++ b/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+/// <summary>
+/// Resolves and applies the user's UI language for dotnetup.
+///
+/// dotnetup is published with <c>InvariantGlobalization=true</c> only on Linux, where libicu is
+/// not guaranteed to be present (running non-invariant there crashes on startup with
+/// "Couldn't find a valid ICU package"). Windows and macOS ship globalization in-box, so the
+/// binary runs non-invariant there and the runtime initializes
+/// <see cref="CultureInfo.CurrentUICulture"/> from the operating system automatically.
+///
+/// This type therefore:
+/// <list type="bullet">
+/// <item>Applies the standard .NET CLI overrides (<c>DOTNET_CLI_UI_LANGUAGE</c> / <c>VSLANG</c>)
+/// on every platform, since the runtime never honors those automatically.</item>
+/// <item>Detects the OS locale from the POSIX environment on Linux only, the single platform
+/// where invariant mode suppresses the runtime's own detection.</item>
+/// </list>
+/// On Linux the project also sets <c>PredefinedCulturesOnly=false</c> so the detected culture can
+/// be created by name (it carries invariant formatting data but retains its name, which is what
+/// drives satellite-resource lookup).
+/// </summary>
+internal static class DotnetupUILanguage
+{
+    // POSIX precedence for the message/UI locale: LC_ALL overrides everything, then the
+    // message category, then LANG as the catch-all default.
+    private static readonly string[] s_posixLocaleVariables = ["LC_ALL", "LC_MESSAGES", "LANG"];
+
+    /// <summary>
+    /// Detects the user's UI language and applies it to the current process so localized
+    /// resources resolve.
+    /// </summary>
+    public static void Setup()
+    {
+        CultureInfo? uiCulture = ResolveUICulture();
+        if (uiCulture is not null)
+        {
+            CultureInfo.CurrentUICulture = uiCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = uiCulture;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the UI culture to apply, or <c>null</c> when there is no explicit override and the
+    /// running platform's runtime has already initialized the UI culture (Windows/macOS), or none
+    /// could be determined.
+    /// </summary>
+    internal static CultureInfo? ResolveUICulture()
+    {
+        // Explicit override (DOTNET_CLI_UI_LANGUAGE > VSLANG) applies on every platform.
+        CultureInfo? overridden = UILanguageOverride.GetOverriddenUILanguage();
+        if (overridden is not null)
+        {
+            return overridden;
+        }
+
+        // Only Linux runs invariant, so it is the only platform where the runtime did not already
+        // pick up the OS locale. Windows and macOS leave CurrentUICulture as the runtime set it.
+        return OperatingSystem.IsLinux() ? CreateCulture(GetUnixLocaleName()) : null;
+    }
+
+    private static string? GetUnixLocaleName()
+    {
+        foreach (string variable in s_posixLocaleVariables)
+        {
+            string? value = Environment.GetEnvironmentVariable(variable);
+            if (!string.IsNullOrEmpty(value))
+            {
+                return NormalizePosixLocale(value);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts a POSIX locale string (e.g. <c>fr_FR.UTF-8@euro</c>) into a .NET culture name
+    /// (<c>fr-FR</c>). Returns <c>null</c> for the C/POSIX locales, which map to invariant.
+    /// </summary>
+    internal static string? NormalizePosixLocale(string value)
+    {
+        // Strip the encoding (".UTF-8") and modifier ("@euro") suffixes.
+        int encodingIndex = value.IndexOf('.', StringComparison.Ordinal);
+        if (encodingIndex >= 0)
+        {
+            value = value[..encodingIndex];
+        }
+
+        int modifierIndex = value.IndexOf('@', StringComparison.Ordinal);
+        if (modifierIndex >= 0)
+        {
+            value = value[..modifierIndex];
+        }
+
+        if (value.Length == 0
+            || value.Equals("C", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("POSIX", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return value.Replace('_', '-');
+    }
+
+    private static CultureInfo? CreateCulture(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        try
+        {
+            return new CultureInfo(name);
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
+++ b/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
@@ -80,7 +80,7 @@ internal static class DotnetupUILanguage
         // environment, then map it onto a satellite. (A VSLANG LCID cannot be turned into a named
         // culture in invariant mode, so it resolves to empty and falls through to the environment.)
         string? desired = UILanguageOverride.GetOverriddenUILanguage()?.Name;
-        if (string.IsNullOrEmpty(desired))
+        if (string.IsNullOrWhiteSpace(desired))
         {
             desired = GetUnixLocaleName();
         }

--- a/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
+++ b/src/Installer/dotnetup.Library/DotnetupUILanguage.cs
@@ -17,12 +17,15 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 ///
 /// This type therefore:
 /// <list type="bullet">
-/// <item>Applies the standard .NET CLI overrides (<c>DOTNET_CLI_UI_LANGUAGE</c> / <c>VSLANG</c>)
-/// on every platform, since the runtime never honors those automatically.</item>
-/// <item>Detects the OS locale from the POSIX environment on Linux only, the single platform
-/// where invariant mode suppresses the runtime's own detection.</item>
+/// <item>On Windows/macOS, applies only the standard .NET CLI override
+/// (<c>DOTNET_CLI_UI_LANGUAGE</c> / <c>VSLANG</c>), since the runtime already initialized the UI
+/// culture and <see cref="CultureInfo"/>'s parent fallback works.</item>
+/// <item>On Linux, where invariant mode disables both the runtime's OS-locale detection and
+/// <see cref="CultureInfo.Parent"/> fallback, resolves the desired locale (override, else the
+/// POSIX environment) and maps it onto an exact shipped satellite culture via
+/// <see cref="MatchSupportedLanguage"/>.</item>
 /// </list>
-/// On Linux the project also sets <c>PredefinedCulturesOnly=false</c> so the detected culture can
+/// On Linux the project also sets <c>PredefinedCulturesOnly=false</c> so the matched culture can
 /// be created by name (it carries invariant formatting data but retains its name, which is what
 /// drives satellite-resource lookup).
 /// </summary>
@@ -31,6 +34,18 @@ internal static class DotnetupUILanguage
     // POSIX precedence for the message/UI locale: LC_ALL overrides everything, then the
     // message category, then LANG as the catch-all default.
     private static readonly string[] s_posixLocaleVariables = ["LC_ALL", "LC_MESSAGES", "LANG"];
+
+    // The UI languages dotnetup ships satellite resources for. In invariant mode (Linux) the
+    // runtime provides no parent/neutral culture fallback, so the applied culture must exactly
+    // match one of these names; MatchSupportedLanguage maps an OS/CLI locale onto the right entry.
+    // Keep in sync with the Strings.*.xlf files — DotnetupUILanguageTests enforces this.
+    private static readonly string[] s_supportedUILanguages =
+    [
+        "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant"
+    ];
+
+    /// <summary>The UI languages dotnetup ships localized resources for (satellite culture names).</summary>
+    internal static IReadOnlyList<string> SupportedUILanguages => s_supportedUILanguages;
 
     /// <summary>
     /// Detects the user's UI language and applies it to the current process so localized
@@ -47,22 +62,110 @@ internal static class DotnetupUILanguage
     }
 
     /// <summary>
-    /// Resolves the UI culture to apply, or <c>null</c> when there is no explicit override and the
-    /// running platform's runtime has already initialized the UI culture (Windows/macOS), or none
-    /// could be determined.
+    /// Resolves the UI culture to apply, or <c>null</c> to leave the existing default in place
+    /// (no shipped language matched, or Windows/macOS where the runtime already initialized it).
     /// </summary>
     internal static CultureInfo? ResolveUICulture()
     {
-        // Explicit override (DOTNET_CLI_UI_LANGUAGE > VSLANG) applies on every platform.
-        CultureInfo? overridden = UILanguageOverride.GetOverriddenUILanguage();
-        if (overridden is not null)
+        // Windows and macOS run non-invariant: the runtime initialized CurrentUICulture from the
+        // OS and CultureInfo's parent fallback works, so only the explicit CLI override is applied.
+        if (!OperatingSystem.IsLinux())
         {
-            return overridden;
+            return UILanguageOverride.GetOverriddenUILanguage();
         }
 
-        // Only Linux runs invariant, so it is the only platform where the runtime did not already
-        // pick up the OS locale. Windows and macOS leave CurrentUICulture as the runtime set it.
-        return OperatingSystem.IsLinux() ? CreateCulture(GetUnixLocaleName()) : null;
+        // Linux runs invariant: there is no parent/neutral fallback, so the applied culture must
+        // exactly match a shipped satellite. Resolve the desired locale with the same override
+        // resolver as the rest of the .NET CLI (DOTNET_CLI_UI_LANGUAGE > VSLANG), else the POSIX
+        // environment, then map it onto a satellite. (A VSLANG LCID cannot be turned into a named
+        // culture in invariant mode, so it resolves to empty and falls through to the environment.)
+        string? desired = UILanguageOverride.GetOverriddenUILanguage()?.Name;
+        if (string.IsNullOrEmpty(desired))
+        {
+            desired = GetUnixLocaleName();
+        }
+
+        return CreateCulture(MatchSupportedLanguage(desired));
+    }
+
+    /// <summary>
+    /// Maps a BCP-47 culture name (e.g. <c>fr-FR</c>, <c>zh-CN</c>) onto the closest shipped UI
+    /// language, emulating the specific→neutral resource fallback that invariant mode disables.
+    /// Returns the matched satellite culture name, or <c>null</c> when none is shipped.
+    /// </summary>
+    internal static string? MatchSupportedLanguage(string? cultureName)
+    {
+        if (string.IsNullOrEmpty(cultureName))
+        {
+            return null;
+        }
+
+        foreach (string candidate in GetFallbackCandidates(cultureName))
+        {
+            foreach (string supported in s_supportedUILanguages)
+            {
+                if (string.Equals(candidate, supported, StringComparison.OrdinalIgnoreCase))
+                {
+                    return supported;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Yields candidate culture names from most to least specific: the name as given, the
+    /// script-qualified form for Chinese (whose satellites are script- rather than region-based),
+    /// then the bare language. ResourceManager would normally walk this chain via
+    /// <see cref="CultureInfo.Parent"/>, but that chain collapses straight to invariant in
+    /// invariant mode, so it is reconstructed here.
+    /// </summary>
+    private static IEnumerable<string> GetFallbackCandidates(string cultureName)
+    {
+        yield return cultureName;
+
+        string[] parts = cultureName.Split('-');
+        string language = parts[0];
+
+        if (string.Equals(language, "zh", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return $"zh-{GetChineseScript(parts)}";
+        }
+
+        if (parts.Length > 1)
+        {
+            yield return language;
+        }
+    }
+
+    /// <summary>
+    /// Determines the Chinese script (<c>Hans</c>/<c>Hant</c>) for a <c>zh*</c> culture: an
+    /// explicit script subtag wins, otherwise it is inferred from the region, defaulting to
+    /// Simplified.
+    /// </summary>
+    private static string GetChineseScript(string[] parts)
+    {
+        // The script subtag, when present, is the second BCP-47 subtag (e.g. zh-Hant, zh-Hant-TW).
+        if (parts.Length > 1)
+        {
+            if (string.Equals(parts[1], "Hans", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Hans";
+            }
+
+            if (string.Equals(parts[1], "Hant", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Hant";
+            }
+        }
+
+        string region = parts.Length > 1 ? parts[^1].ToUpperInvariant() : string.Empty;
+        return region switch
+        {
+            "TW" or "HK" or "MO" => "Hant",
+            _ => "Hans",
+        };
     }
 
     private static string? GetUnixLocaleName()

--- a/src/Installer/dotnetup.Library/Program.cs
+++ b/src/Installer/dotnetup.Library/Program.cs
@@ -18,6 +18,9 @@ public class DotnetupProgram
 {
     public static int Main(string[] args)
     {
+        // Apply the user's UI language before any output (honors DOTNET_CLI_UI_LANGUAGE/VSLANG, and
+        // on Linux—where dotnetup runs invariant—detects the OS locale the runtime cannot).
+        DotnetupUILanguage.Setup();
         // Handle --debug flag using the standard .NET SDK pattern
         // This is DEBUG-only and removes the --debug flag from args
         DotnetupDebugHelper.HandleDebugSwitch(ref args);

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -29,16 +29,16 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <!-- Globalization: only Linux lacks a guaranteed libicu, so build invariant there to avoid a
-       startup crash ("Couldn't find a valid ICU package"). Windows and macOS ship globalization
-       in-box (and NativeAOT uses the OS ICU there rather than bundling data), so they run
-       non-invariant and the runtime initializes the UI culture from the OS automatically.
-       PredefinedCulturesOnly is relaxed in invariant mode so DotnetupUILanguage can create the
-       detected culture by name for localized resource lookup.
-       Keyed off TargetOS rather than the RID so source-build's non-portable RIDs (e.g.
-       fedora.36-x64) are still recognized as Linux. -->
+  <!-- Globalization: build invariant by default so the NativeAOT binary has no dependency on
+       libicu and cannot crash on startup with "Couldn't find a valid ICU package". Only Windows
+       and macOS are known to ship globalization in-box (and NativeAOT uses the OS ICU there rather
+       than bundling data), so opt those back into full globalization; every other OS (Linux —
+       including musl/Alpine — FreeBSD, etc.) stays invariant. PredefinedCulturesOnly is relaxed
+       in invariant mode so DotnetupUILanguage can create the detected culture by name for localized
+       resource lookup. -->
   <PropertyGroup>
-    <InvariantGlobalization Condition="'$(TargetOS)' == 'linux'">true</InvariantGlobalization>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantGlobalization Condition="'$(OSName)' == 'win' or '$(OSName)' == 'osx'">false</InvariantGlobalization>
     <PredefinedCulturesOnly Condition="'$(InvariantGlobalization)' == 'true'">false</PredefinedCulturesOnly>
   </PropertyGroup>
 

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -29,6 +29,17 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Globalization: only Linux lacks a guaranteed libicu, so build invariant there to avoid a
+       startup crash ("Couldn't find a valid ICU package"). Windows and macOS ship globalization
+       in-box (and NativeAOT uses the OS ICU there rather than bundling data), so they run
+       non-invariant and the runtime initializes the UI culture from the OS automatically.
+       PredefinedCulturesOnly is relaxed in invariant mode so DotnetupUILanguage can create the
+       detected culture by name for localized resource lookup. -->
+  <PropertyGroup>
+    <InvariantGlobalization Condition="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifier)', '').StartsWith('linux'))">true</InvariantGlobalization>
+    <PredefinedCulturesOnly Condition="'$(InvariantGlobalization)' == 'true'">false</PredefinedCulturesOnly>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifier)', '').StartsWith('osx'))">
     <!-- Suppress macOS NativeAOT debug-info generation to avoid .pcm module-cache errors.
          The runtime's static archives (libSystem.Native.a, etc.) embed clang module-debug

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -34,9 +34,11 @@
        in-box (and NativeAOT uses the OS ICU there rather than bundling data), so they run
        non-invariant and the runtime initializes the UI culture from the OS automatically.
        PredefinedCulturesOnly is relaxed in invariant mode so DotnetupUILanguage can create the
-       detected culture by name for localized resource lookup. -->
+       detected culture by name for localized resource lookup.
+       Keyed off TargetOS rather than the RID so source-build's non-portable RIDs (e.g.
+       fedora.36-x64) are still recognized as Linux. -->
   <PropertyGroup>
-    <InvariantGlobalization Condition="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifier)', '').StartsWith('linux'))">true</InvariantGlobalization>
+    <InvariantGlobalization Condition="'$(TargetOS)' == 'linux'">true</InvariantGlobalization>
     <PredefinedCulturesOnly Condition="'$(InvariantGlobalization)' == 'true'">false</PredefinedCulturesOnly>
   </PropertyGroup>
 

--- a/test/dotnetup.Tests/DotnetupUILanguageTests.cs
+++ b/test/dotnetup.Tests/DotnetupUILanguageTests.cs
@@ -133,12 +133,12 @@ public class DotnetupUILanguageOverrideTests : IDisposable
     }
 
     [Fact]
-    public void ResolveUICulture_HonorsDotnetCliUiLanguageOffLinux()
+    public void ResolveUICulture_AppliesOverrideAsIsOnNonInvariantPlatforms()
     {
         // On Windows/macOS dotnetup runs non-invariant and the override is applied as-is (the
-        // runtime's parent fallback resolves resources). On Linux it is instead mapped onto a
-        // shipped satellite, which is covered by MatchSupportedLanguage tests.
-        if (OperatingSystem.IsLinux())
+        // runtime's parent fallback resolves resources). On invariant platforms it is instead
+        // mapped onto a shipped satellite, which the next test covers.
+        if (DotnetupUILanguage.PlatformRunsInvariant)
         {
             return;
         }
@@ -149,11 +149,11 @@ public class DotnetupUILanguageOverrideTests : IDisposable
     }
 
     [Fact]
-    public void ResolveUICulture_MapsOverrideToSatelliteOnLinux()
+    public void ResolveUICulture_MapsOverrideToSatelliteOnInvariantPlatforms()
     {
-        // On Linux the override is resolved with the same code as the rest of the .NET CLI and then
-        // mapped onto a shipped satellite (fr-FR -> fr). Off Linux it is applied as-is (above).
-        if (!OperatingSystem.IsLinux())
+        // On invariant platforms (Linux, etc.) the override is resolved with the same code as the
+        // rest of the .NET CLI and then mapped onto a shipped satellite (fr-FR -> fr).
+        if (!DotnetupUILanguage.PlatformRunsInvariant)
         {
             return;
         }
@@ -164,11 +164,11 @@ public class DotnetupUILanguageOverrideTests : IDisposable
     }
 
     [Fact]
-    public void ResolveUICulture_WithoutOverride_DefersToRuntimeOffLinux()
+    public void ResolveUICulture_WithoutOverride_DefersToRuntimeOnNonInvariantPlatforms()
     {
         // On Windows and macOS the runtime already initialized CurrentUICulture from the OS, so
         // ResolveUICulture returns null to leave it untouched.
-        if (OperatingSystem.IsLinux())
+        if (DotnetupUILanguage.PlatformRunsInvariant)
         {
             return;
         }

--- a/test/dotnetup.Tests/DotnetupUILanguageTests.cs
+++ b/test/dotnetup.Tests/DotnetupUILanguageTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.DotNet.Tools.Bootstrapper;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
+
+public class DotnetupUILanguageTests
+{
+    [Theory]
+    [InlineData("fr_FR.UTF-8", "fr-FR")]
+    [InlineData("fr_FR.UTF-8@euro", "fr-FR")]
+    [InlineData("de_DE@euro", "de-DE")]
+    [InlineData("pt_BR.UTF-8", "pt-BR")]
+    [InlineData("ja_JP.eucJP", "ja-JP")]
+    [InlineData("en_US", "en-US")]
+    [InlineData("zh_CN", "zh-CN")]
+    public void NormalizePosixLocale_StripsEncodingAndModifier(string posix, string expected)
+    {
+        DotnetupUILanguage.NormalizePosixLocale(posix).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("C")]
+    [InlineData("c")]
+    [InlineData("POSIX")]
+    [InlineData("posix")]
+    [InlineData("")]
+    [InlineData(".UTF-8")]
+    public void NormalizePosixLocale_ReturnsNullForInvariantLocales(string posix)
+    {
+        DotnetupUILanguage.NormalizePosixLocale(posix).Should().BeNull();
+    }
+}
+
+[Collection("DotnetupEnvironmentMutationTests")]
+public class DotnetupUILanguageOverrideTests : IDisposable
+{
+    private const string DotnetCliUiLanguage = "DOTNET_CLI_UI_LANGUAGE";
+    private const string VsLang = "VSLANG";
+
+    private readonly string? _originalDotnetCliUiLanguage;
+    private readonly string? _originalVsLang;
+
+    public DotnetupUILanguageOverrideTests()
+    {
+        _originalDotnetCliUiLanguage = Environment.GetEnvironmentVariable(DotnetCliUiLanguage);
+        _originalVsLang = Environment.GetEnvironmentVariable(VsLang);
+
+        Environment.SetEnvironmentVariable(DotnetCliUiLanguage, null);
+        Environment.SetEnvironmentVariable(VsLang, null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(DotnetCliUiLanguage, _originalDotnetCliUiLanguage);
+        Environment.SetEnvironmentVariable(VsLang, _originalVsLang);
+    }
+
+    [Fact]
+    public void ResolveUICulture_HonorsDotnetCliUiLanguage()
+    {
+        Environment.SetEnvironmentVariable(DotnetCliUiLanguage, "fr-FR");
+
+        CultureInfo? uiCulture = DotnetupUILanguage.ResolveUICulture();
+
+        uiCulture!.Name.Should().Be("fr-FR");
+    }
+
+    [Fact]
+    public void ResolveUICulture_WithoutOverride_DefersToRuntimeOffLinux()
+    {
+        // On Windows and macOS dotnetup runs non-invariant, so the runtime already initialized the
+        // UI culture; ResolveUICulture returns null to leave it untouched. (On Linux it detects
+        // from the environment, which is machine-dependent and not asserted here.)
+        if (OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        DotnetupUILanguage.ResolveUICulture().Should().BeNull();
+    }
+}

--- a/test/dotnetup.Tests/DotnetupUILanguageTests.cs
+++ b/test/dotnetup.Tests/DotnetupUILanguageTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using Microsoft.DotNet.Tools.Bootstrapper;
 using Xunit;
 
@@ -33,6 +35,77 @@ public class DotnetupUILanguageTests
     {
         DotnetupUILanguage.NormalizePosixLocale(posix).Should().BeNull();
     }
+
+    // Representative locale -> shipped satellite culture. The neutral cases (e.g. fr-FR -> fr)
+    // and the Chinese script cases (zh-CN -> zh-Hans) exercise the fallback that invariant mode
+    // would otherwise break. SupportedLanguageCases_CoverEverySupportedLanguage asserts there is
+    // a case here for every language we localize for.
+    public static IEnumerable<object[]> SupportedLanguageCases() =>
+    [
+        ["cs-CZ", "cs"],
+        ["de-DE", "de"],
+        ["es-ES", "es"],
+        ["fr-FR", "fr"],
+        ["it-IT", "it"],
+        ["ja-JP", "ja"],
+        ["ko-KR", "ko"],
+        ["pl-PL", "pl"],
+        ["pt-BR", "pt-BR"],
+        ["ru-RU", "ru"],
+        ["tr-TR", "tr"],
+        ["zh-CN", "zh-Hans"],
+        ["zh-TW", "zh-Hant"],
+        // Additional fallback / script cases.
+        ["fr", "fr"],
+        ["zh-SG", "zh-Hans"],
+        ["zh-HK", "zh-Hant"],
+        ["zh-Hant", "zh-Hant"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(SupportedLanguageCases))]
+    public void MatchSupportedLanguage_MapsToShippedSatellite(string input, string expected)
+    {
+        DotnetupUILanguage.MatchSupportedLanguage(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("en")]
+    [InlineData("nl-NL")]
+    [InlineData("pt-PT")]
+    [InlineData("pt")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MatchSupportedLanguage_ReturnsNullForUnsupported(string? input)
+    {
+        DotnetupUILanguage.MatchSupportedLanguage(input).Should().BeNull();
+    }
+
+    [Fact]
+    public void SupportedLanguageCases_CoverEverySupportedLanguage()
+    {
+        IEnumerable<string> covered = SupportedLanguageCases().Select(c => (string)c[1]).Distinct();
+
+        covered.Should().BeEquivalentTo(
+            DotnetupUILanguage.SupportedUILanguages,
+            "every shipped UI language needs a representative MatchSupportedLanguage test case");
+    }
+
+    [Fact]
+    public void SupportedUILanguages_MatchesShippedSatelliteResources()
+    {
+        // Discover the satellite resource cultures actually emitted next to the test, so adding or
+        // removing a Strings.*.xlf without updating SupportedUILanguages (and its mapping rules)
+        // fails this test.
+        IEnumerable<string> shipped = Directory.EnumerateDirectories(AppContext.BaseDirectory)
+            .Where(directory => File.Exists(Path.Combine(directory, "dotnetup.Library.resources.dll")))
+            .Select(directory => Path.GetFileName(directory));
+
+        shipped.Should().BeEquivalentTo(
+            DotnetupUILanguage.SupportedUILanguages,
+            "DotnetupUILanguage.SupportedUILanguages must stay in sync with the shipped Strings.*.xlf satellites");
+    }
 }
 
 [Collection("DotnetupEnvironmentMutationTests")]
@@ -60,21 +133,41 @@ public class DotnetupUILanguageOverrideTests : IDisposable
     }
 
     [Fact]
-    public void ResolveUICulture_HonorsDotnetCliUiLanguage()
+    public void ResolveUICulture_HonorsDotnetCliUiLanguageOffLinux()
     {
+        // On Windows/macOS dotnetup runs non-invariant and the override is applied as-is (the
+        // runtime's parent fallback resolves resources). On Linux it is instead mapped onto a
+        // shipped satellite, which is covered by MatchSupportedLanguage tests.
+        if (OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
         Environment.SetEnvironmentVariable(DotnetCliUiLanguage, "fr-FR");
 
-        CultureInfo? uiCulture = DotnetupUILanguage.ResolveUICulture();
+        DotnetupUILanguage.ResolveUICulture()!.Name.Should().Be("fr-FR");
+    }
 
-        uiCulture!.Name.Should().Be("fr-FR");
+    [Fact]
+    public void ResolveUICulture_MapsOverrideToSatelliteOnLinux()
+    {
+        // On Linux the override is resolved with the same code as the rest of the .NET CLI and then
+        // mapped onto a shipped satellite (fr-FR -> fr). Off Linux it is applied as-is (above).
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(DotnetCliUiLanguage, "fr-FR");
+
+        DotnetupUILanguage.ResolveUICulture()!.Name.Should().Be("fr");
     }
 
     [Fact]
     public void ResolveUICulture_WithoutOverride_DefersToRuntimeOffLinux()
     {
-        // On Windows and macOS dotnetup runs non-invariant, so the runtime already initialized the
-        // UI culture; ResolveUICulture returns null to leave it untouched. (On Linux it detects
-        // from the environment, which is machine-dependent and not asserted here.)
+        // On Windows and macOS the runtime already initialized CurrentUICulture from the OS, so
+        // ResolveUICulture returns null to leave it untouched.
         if (OperatingSystem.IsLinux())
         {
             return;


### PR DESCRIPTION
Hopefully a better fix for the same problem discussed in #54660

Copilot generated description:

### Problem

`dotnetup` is published as a NativeAOT executable. On Linux, the .NET runtime requires ICU (`libicu`) for globalization. ICU is not guaranteed to be present on every Linux distro/container, and when it is missing dotnetup crashes immediately on startup, before it can do anything useful:

```
Process terminated. Couldn't find a valid ICU package installed on the system.
```

### Approach

Rather than probe for ICU at install time, remove the dependency where it is a problem and keep full globalization where ICU is guaranteed:

- **Linux** → build with `InvariantGlobalization=true`. The binary no longer depends on `libicu`, so the startup crash cannot happen.
- **Windows / macOS** → keep running **non-invariant**. Both ship globalization in-box, and NativeAOT uses the OS ICU there (no bundled ICU data, so no size cost), so the runtime initializes the UI culture from the OS automatically.

Invariant mode disables the runtime's automatic OS-locale detection, so dotnetup sets the UI culture itself via a new `DotnetupUILanguage` helper:

- Honors the standard .NET CLI overrides — `DOTNET_CLI_UI_LANGUAGE`, then `VSLANG` — on **every** platform (the runtime never applies these automatically; this matches the rest of the .NET CLI).
- On **Linux only**, detects the OS locale from the POSIX environment (`LC_ALL` > `LC_MESSAGES` > `LANG`), normalizing e.g. `fr_FR.UTF-8@euro` to `fr-FR` and mapping `C`/`POSIX` to invariant.
- On Windows/macOS, does nothing beyond the override — the runtime already set `CurrentUICulture` from the OS.

Only `CurrentUICulture` is set: in invariant mode all formatting is invariant regardless, and dotnetup formats with `CultureInfo.InvariantCulture` explicitly, so the UI culture (which selects localized resources) is the only one that matters. On Linux the project also sets `PredefinedCulturesOnly=false` so the detected culture can be created by name (it carries invariant formatting data but retains its name, which drives satellite-resource lookup).

### Changes

| File | Change |
| --- | --- |
| `src/Installer/dotnetup/dotnetup.csproj` | `InvariantGlobalization=true` + `PredefinedCulturesOnly=false`, conditioned on a Linux RID. |
| `src/Installer/dotnetup.Library/DotnetupUILanguage.cs` | New helper that resolves and applies the UI language (CLI overrides everywhere; POSIX OS detection on Linux). |
| `src/Installer/dotnetup.Library/Program.cs` | Call `DotnetupUILanguage.Setup()` first thing in `Main`. |
| `test/dotnetup.Tests/DotnetupUILanguageTests.cs` | Tests for POSIX locale normalization and override resolution. |

### Notes / follow-ups

- This makes dotnetup's CLI-language behavior consistent with the rest of the .NET CLI; users can force a language with `DOTNET_CLI_UI_LANGUAGE`.
- Localizing third-party UI text (e.g. System.CommandLine's help banner) would additionally require those components' satellite resources to be published; dotnetup's own `Strings` resources are already published per-RID.
- The Linux invariant build could not be AOT-linked locally on a Windows dev box; the Linux native compile is exercised by CI's Linux leg.
