### PR TITLE
Fix telemetry init crash in NativeAOT dotnet muxer on macOS

### DIFF
--- a/src/Cli/dotnet-aot/NativeEntryPoint.cs
+++ b/src/Cli/dotnet-aot/NativeEntryPoint.cs
@@ -43,19 +43,31 @@ static unsafe partial class NativeEntryPoint
         string hostPath, string dotnetRoot, string sdkDir,
         string hostfxrPath, string[] args)
     {
-        DateTime preTelemetry = DateTime.UtcNow;
-        // Initialize OTel telemetry (mirrors managed Program.cs setup).
-        var telemetryClient = new TelemetryClient(sessionId: null);
-        DateTime postTelemetry = DateTime.UtcNow;
-        var mainActivity = Activities.Source.StartActivity("native-entrypoint", TelemetryClient.ActivityKind, TelemetryClient.ParentActivityContext);
-
-        // Backdate the activity start to process start time for accurate timing.
-        if (mainActivity is not null)
+        // Telemetry is best-effort and must never prevent the CLI from running. Initializing
+        // it can fail on some layouts (e.g. the NativeAOT muxer cannot resolve the crypto
+        // native library used to hash telemetry properties on macOS - see dotnet/sdk#54544),
+        // so swallow any failure here and continue to the actual command.
+        Activity? mainActivity = null;
+        try
         {
-            mainActivity.SetStartTime(Process.GetCurrentProcess().StartTime.ToUniversalTime());
-            using var telemetryActivity = Activities.Source.StartActivity("aot-telemetry-setup");
-            telemetryActivity?.SetStartTime(preTelemetry);
-            telemetryActivity?.SetEndTime(postTelemetry);
+            DateTime preTelemetry = DateTime.UtcNow;
+            // Initialize OTel telemetry (mirrors managed Program.cs setup).
+            var telemetryClient = new TelemetryClient(sessionId: null);
+            DateTime postTelemetry = DateTime.UtcNow;
+            mainActivity = Activities.Source.StartActivity("native-entrypoint", TelemetryClient.ActivityKind, TelemetryClient.ParentActivityContext);
+
+            // Backdate the activity start to process start time for accurate timing.
+            if (mainActivity is not null)
+            {
+                mainActivity.SetStartTime(Process.GetCurrentProcess().StartTime.ToUniversalTime());
+                using var telemetryActivity = Activities.Source.StartActivity("aot-telemetry-setup");
+                telemetryActivity?.SetStartTime(preTelemetry);
+                telemetryActivity?.SetEndTime(postTelemetry);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to initialize telemetry in the native entry point: {ex}");
         }
 
         int exitCode = 1;


### PR DESCRIPTION
## Problem

The NativeAOT `dotnet` muxer (`NativeEntryPoint.ExecuteCore`) initializes the `TelemetryClient` **before** the main `try` block:

```csharp
var telemetryClient = new TelemetryClient(sessionId: null);   // unconditional, outside try
```

When telemetry is enabled (the default in official builds), the ctor computes common properties via `Sha256Hasher.Hash` → `SHA256.HashData` → P/Invoke `Interop.AppleCrypto.DigestOneShot`. On macOS the AOT muxer cannot resolve `libSystem.Security.Cryptography.Native.Apple`: it probes the SDK root and `/usr/lib`, but the dylib only ships under `shared/Microsoft.NETCore.App/<ver>/`. The resulting `DllNotFoundException` is unhandled (it's before the `try`), so the process aborts:

```
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'libSystem.Security.Cryptography.Native.Apple' ...
   at Interop.AppleCrypto.DigestOneShot(...)
   at System.Security.Cryptography.HashStatic`1.HashData(...)
   at Microsoft.DotNet.Utilities.Sha256Hasher.Hash(String)
   at Microsoft.DotNet.Cli.Telemetry.TelemetryCommonProperties.GetTelemetryCommonProperties(String)
   at Microsoft.DotNet.Cli.Telemetry.TelemetryClient..ctor(String, IEnvironmentProvider)
   at Microsoft.DotNet.Cli.NativeEntryPoint.ExecuteCore(...)
Fatal error. Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code.
```

Related to #54544

### Repro (osx-arm64, SDK 11.0.100-preview.6.26310.110)

```
$ ./dotnet --version
Unhandled exception. System.DllNotFoundException: ... 'libSystem.Security.Cryptography.Native.Apple' ...
Abort trap: 6   # exit 134

$ DOTNET_CLI_TELEMETRY_OPTOUT=1 ./dotnet --version
11.0.100-preview.6.26310.110   # exit 0
```