### PR TITLE
Migrate MergeConfigurationProperties to IMultiThreadableTask

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
+++ b/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
@@ -113,9 +113,6 @@ public class MergeConfigurationProperties : Task, IMultiThreadableTask
             // We can be more lenient here and fallback to the project reference ItemSpec if not present.
             referenceMetadata = !string.IsNullOrEmpty(referenceMetadata) ? referenceMetadata : projectReference.ItemSpec;
             var configurationFullPath = configuration.GetMetadata("FullPath");
-            // Absolutize via TaskEnvironment so the path is resolved against the project directory, not the process CWD.
-            // Path.GetFullPath on an already-absolute path is safe (no CWD lookup) and resolves ".." segments
-            // to match the old Path.GetFullPath(referenceMetadata) canonical form.
             var projectReferenceFullPath = Path.GetFullPath((string)TaskEnvironment.GetAbsolutePath(referenceMetadata));
             var matchPath = string.Equals(
                 configurationFullPath,

--- a/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
+++ b/src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs
@@ -10,7 +10,8 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public class MergeConfigurationProperties : Task
+[MSBuildMultiThreadableTask]
+public class MergeConfigurationProperties : Task, IMultiThreadableTask
 {
     [Required]
     public ITaskItem[] CandidateConfigurations { get; set; }
@@ -20,6 +21,8 @@ public class MergeConfigurationProperties : Task
 
     [Output]
     public ITaskItem[] ProjectConfigurations { get; set; }
+
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     public override bool Execute()
     {
@@ -110,7 +113,10 @@ public class MergeConfigurationProperties : Task
             // We can be more lenient here and fallback to the project reference ItemSpec if not present.
             referenceMetadata = !string.IsNullOrEmpty(referenceMetadata) ? referenceMetadata : projectReference.ItemSpec;
             var configurationFullPath = configuration.GetMetadata("FullPath");
-            var projectReferenceFullPath = Path.GetFullPath(referenceMetadata);
+            // Absolutize via TaskEnvironment so the path is resolved against the project directory, not the process CWD.
+            // Path.GetFullPath on an already-absolute path is safe (no CWD lookup) and resolves ".." segments
+            // to match the old Path.GetFullPath(referenceMetadata) canonical form.
+            var projectReferenceFullPath = Path.GetFullPath((string)TaskEnvironment.GetAbsolutePath(referenceMetadata));
             var matchPath = string.Equals(
                 configurationFullPath,
                 projectReferenceFullPath,

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
@@ -19,6 +19,14 @@ public class MergeConfigurationPropertiesMultiThreadingTest
     [Fact]
     public void ResolvesProjectReferencePathRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
     {
+        // Scope of this test: verify that the *ProjectReferences* side of the path-equality check
+        // in FindMatchingProject is rooted against TaskEnvironment.ProjectDirectory rather than the
+        // process current directory. The *CandidateConfigurations* side (configuration.GetMetadata("FullPath"))
+        // is intentionally passed as an already-absolute path here — that mirrors what MSBuild's
+        // well-known %(FullPath) modifier produces in MT mode (it resolves against the per-task
+        // AsyncLocal working directory, not the process CWD) and is also what the equality check
+        // requires in order to compare against the OS-canonical form on the other side.
+        //
         // Layout (must place the two roots in different subtrees so a relative
         // "../reference/myRcl.csproj" produces *different* absolute paths
         // depending on which root it is resolved against):

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Moq;
+
+namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
+
+// Test parallelization is disabled assembly-wide via
+// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
+// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
+// process-CWD mutation this test performs.
+public class MergeConfigurationPropertiesMultiThreadingTest
+{
+    [Fact]
+    public void ResolvesProjectReferencePathRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
+    {
+        // Layout (must place the two roots in different subtrees so a relative
+        // "../reference/myRcl.csproj" produces *different* absolute paths
+        // depending on which root it is resolved against):
+        //   <testRoot>/project/                 <-- TaskEnvironment.ProjectDirectory
+        //   <testRoot>/project/../reference/    <-- candidate's real location
+        //   <testRoot>/decoy/spawn/             <-- process CWD (the "decoy")
+        //   <testRoot>/decoy/reference/         <-- where the old CWD-based
+        //                                            Path.GetFullPath would point
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(MergeConfigurationPropertiesMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "decoy", "spawn");
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(spawnDir);
+
+        var relativeProjectReference = Path.Combine("..", "reference", "myRcl.csproj");
+
+        // Candidate FullPath represents what MSBuild's well-known FullPath modifier
+        // would produce in MT mode: the path resolved against the project directory.
+        var candidateAbsolutePath = Path.GetFullPath(Path.Combine(projectDir, relativeProjectReference));
+
+        // Sanity: the decoy CWD would produce a *different* absolute path for the
+        // same relative input — that is what proves the equality check is using
+        // the right root.
+        var decoyAbsolutePath = Path.GetFullPath(Path.Combine(spawnDir, relativeProjectReference));
+        candidateAbsolutePath.Should().NotBe(decoyAbsolutePath,
+            "the test setup must place project and decoy in different parents so the migration is actually exercised");
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new MergeConfigurationProperties
+            {
+                BuildEngine = buildEngine.Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                CandidateConfigurations = new[] { CreateCandidateProjectConfiguration(candidateAbsolutePath) },
+                ProjectReferences = new[]
+                {
+                    CreateProjectReference(
+                        project: Path.Combine("..", "myRcl", "myRcl.csproj"),
+                        // Relative MSBuildSourceProjectFile — the task must resolve
+                        // this against the TaskEnvironment.ProjectDirectory, not
+                        // against Environment.CurrentDirectory.
+                        msBuildSourceProjectFile: relativeProjectReference,
+                        undefineProperties: "TargetFramework;RuntimeIdentifier")
+                }
+            };
+
+            var result = task.Execute();
+
+            result.Should().BeTrue("the task must find the project reference by absolutizing against the project directory, not the process CWD");
+            errorMessages.Should().BeEmpty();
+            task.ProjectConfigurations.Should().HaveCount(1);
+            task.ProjectConfigurations[0].GetMetadata("Source").Should().Be("myRcl");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    private static ITaskItem CreateCandidateProjectConfiguration(string project)
+    {
+        return new TaskItem(project, new Dictionary<string, string>
+        {
+            ["AdditionalPublishProperties"] = "",
+            ["GetBuildAssetsTargets"] = "GetCurrentProjectBuildStaticWebAssetItems",
+            ["GetPublishAssetsTargets"] = "ComputeReferencedStaticWebAssetsPublishManifest;GetCurrentProjectPublishStaticWebAssetItems",
+            ["Version"] = "2",
+            ["AdditionalBuildProperties"] = "",
+            ["Source"] = "myRcl",
+            ["AdditionalPublishPropertiesToRemove"] = "",
+            ["AdditionalBuildPropertiesToRemove"] = "",
+        });
+    }
+
+    private static ITaskItem CreateProjectReference(
+        string project,
+        string msBuildSourceProjectFile,
+        string undefineProperties = "")
+    {
+        return new TaskItem(project, new Dictionary<string, string>
+        {
+            ["MSBuildSourceProjectFile"] = msBuildSourceProjectFile,
+            ["UndefineProperties"] = undefineProperties,
+            ["SetConfiguration"] = "",
+            ["SetPlatform"] = "",
+            ["SetTargetFramework"] = "",
+            ["GlobalPropertiesToRemove"] = "",
+        });
+    }
+}


### PR DESCRIPTION
Migrates `MergeConfigurationProperties` (`src/StaticWebAssetsSdk/Tasks/MergeConfigurationProperties.cs`) to `IMultiThreadableTask` so MSBuild's multithreaded mode bypasses the per-task TaskHost wrapper.

Fixes https://github.com/dotnet/msbuild/issues/14028

## Perfstar regression (14d, Windows, paired MT vs non-MT, p50 sum across iterations)

| Target | non-MT (ms) | MT (ms) | Δ (ms) | Δ (%) |
|---|---:|---:|---:|---:|
| `ResolveReferencedProjectsStaticWebAssetsConfiguration` | 685 | 22,572 | **+21,887** | **+3,195 %** |

## Changes

- `[MSBuildMultiThreadableTask]` + implements `IMultiThreadableTask` with default `TaskEnvironment.Fallback`.
- Replaces `Path.GetFullPath(referenceMetadata)` (resolves against process CWD, unsafe in MT) with `Path.GetFullPath((string)TaskEnvironment.GetAbsolutePath(referenceMetadata))`. `TaskEnvironment.GetAbsolutePath` roots the path against the project directory; the outer `Path.GetFullPath` then canonicalizes `..` segments to preserve the prior comparison semantics with `configuration.GetMetadata("FullPath")`.

## Compatibility sins audit (per migration skill)

- Sin 1 (output contamination): no `[Output]` property assigned from an `AbsolutePath`.
- Sin 2 (error-message inflation): no log message uses the absolutized path.
- Sin 3 (`??` swallowing exceptions): no new null-coalescing introduced.
- Sin 4 (try/catch scope): the `Path.GetFullPath` call is inside the existing try block; the catch only logs `ex`, not the path.
- Sin 5 (canonicalization): `configurationFullPath` from MSBuild's `FullPath` metadata is canonical; wrapping `GetAbsolutePath` with `Path.GetFullPath` preserves canonical form for the equality check.
- Sin 6 (exception type): `GetAbsolutePath("")` throws `ArgumentException`. `referenceMetadata` is guaranteed non-empty here (the preceding line falls back to `projectReference.ItemSpec`, and MSBuild rejects empty ItemSpecs upstream).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
