### PR TITLE
Migrate Microsoft.DotNet.HotReload.Client.Tests to MSTest.Sdk

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -4,6 +4,7 @@
 
   <ItemGroup>
     <!--Test dependencies-->
+    <PackageVersion Include="Combinatorial.MSTest" Version="2.0.0" />
     <PackageVersion Include="DiffPlex" Version="1.8.0" />
     <PackageVersion Include="FakeItEasy" Version="8.0.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />

--- a/global.json
+++ b/global.json
@@ -25,6 +25,7 @@
     "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26303.111",
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Build.Traversal": "4.1.82",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4",
+    "MSTest.Sdk": "4.3.0-preview.26307.5"
   }
 }

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -11,14 +11,31 @@
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(UsingMSTestSdk)' != 'true'">
+  <!-- FluentAssertions namespace is provided by the AwesomeAssertions package (kept by name
+       for backward compat). For xUnit test projects it comes transitively through the
+       Microsoft.NET.TestFramework project reference; for MSTest.Sdk projects we add the
+       PackageReference below. The global using is therefore shared by both. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' OR '$(UsingMSTestSdk)' == 'true'">
     <Using Include="FluentAssertions" />
+  </ItemGroup>
+
+  <!-- TestFramework helper namespaces and the Xunit using are xUnit-only: MSTest.Sdk projects
+       in this repo do not reference Microsoft.NET.TestFramework, so a global using for those
+       namespaces would fail with CS0246. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(UsingMSTestSdk)' != 'true'">
     <Using Include="Microsoft.NET.TestFramework" />
     <Using Include="Microsoft.NET.TestFramework.Assertions" />
     <Using Include="Microsoft.NET.TestFramework.Commands" />
     <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <!-- AwesomeAssertions package reference for MSTest.Sdk projects. xUnit projects pick it up
+       transitively from the Microsoft.NET.TestFramework project reference and so do not need
+       it here. -->
+  <ItemGroup Condition="'$(UsingMSTestSdk)' == 'true'">
+    <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
   <Import Project="..\Directory.Build.targets" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,14 +4,14 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(UseMSTestSdk)' != 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(UsingMSTestSdk)' != 'true'">
     <TestRunnerName>XUnitV3</TestRunnerName>
     <OutputType>Exe</OutputType>
     <!-- Set this to true for test project only because test assets contains .editorconfig file -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(UseMSTestSdk)' != 'true'">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(UsingMSTestSdk)' != 'true'">
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.NET.TestFramework" />
     <Using Include="Microsoft.NET.TestFramework.Assertions" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,14 +4,14 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(UseMSTestSdk)' != 'true'">
     <TestRunnerName>XUnitV3</TestRunnerName>
     <OutputType>Exe</OutputType>
     <!-- Set this to true for test project only because test assets contains .editorconfig file -->
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(UseMSTestSdk)' != 'true'">
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.NET.TestFramework" />
     <Using Include="Microsoft.NET.TestFramework.Assertions" />

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -170,6 +170,12 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
             string driver = $"{PathToDotnet}";
 
+            // True when the test project is a Microsoft.Testing.Platform (MTP) project that
+            // must be invoked via 'dotnet exec <dll>' with MTP-native CLI rather than the
+            // VSTest-style 'dotnet test <dll>' command.
+            xunitProject.TryGetMetadata("IsMTPProject", out string isMTPProjectMetadata);
+            bool isMTPProject = string.Equals(isMTPProjectMetadata, "true", StringComparison.OrdinalIgnoreCase);
+
             // netfx tests should only run on Windows full framework for testing VS scenarios
             // These tests have to be executed slightly differently and we give them a different Identity so ADO can tell them apart
             var runtimeTargetFrameworkParsed = NuGetFramework.Parse(runtimeTargetFramework);
@@ -227,8 +233,41 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 // On macOS, ad-hoc sign the test exe with get-task-allow entitlement so createdump can attach via task_for_pid for crash dumps.
                 string codesignPrefix = IsPosixShell && TargetRid.StartsWith("osx") ? $"codesign -s - -f --entitlements $HELIX_CORRELATION_PAYLOAD/t/helix-debug-entitlements.plist {exeName} && " : "";
 
-                string command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                          $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout 60m {testFilter} {enableDiagLogging} {arguments}";
+                string command;
+                if (isMTPProject)
+                {
+                    // Microsoft.Testing.Platform (MTP) projects (MSTest.Sdk-based) ship as a
+                    // self-contained executable with no testhost.dll, so 'dotnet test <dll>' fails.
+                    // Invoke the test assembly directly via 'dotnet exec' and use MTP-native CLI:
+                    //   --filter                replaces VSTest --filter (same MSTest filter syntax)
+                    //   --results-directory     same as VSTest
+                    //   --report-trx            replaces '--logger trx' (requires Microsoft.Testing.Extensions.TrxReport)
+                    //   --diagnostic            replaces VSTest '-d <log>'
+                    // Note: --logger "console;verbosity=detailed" and --blame-hang* have no direct MTP
+                    // equivalent in the MSTest.Sdk default extension set; the Helix work-item timeout
+                    // (XUnitWorkItemTimeout / HELIX_WORK_ITEM_TIMEOUT) still terminates runaway runs.
+                    string envPrefix;
+                    if (IsPosixShell)
+                    {
+                        envPrefix = $"HELIX_WORK_ITEM_TIMEOUT={timeout} ";
+                    }
+                    else
+                    {
+                        envPrefix = $"set HELIX_WORK_ITEM_TIMEOUT={timeout}&& ";
+                    }
+
+                    string diagArg = IsPosixShell
+                        ? "--diagnostic --diagnostic-output-directory $HELIX_WORKITEM_UPLOAD_ROOT"
+                        : "--diagnostic --diagnostic-output-directory %HELIX_WORKITEM_UPLOAD_ROOT%";
+
+                    command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{driver} exec {assemblyName} " +
+                              $"--results-directory .{Path.DirectorySeparatorChar} --report-trx {testFilter} {diagArg}";
+                }
+                else
+                {
+                    command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout 60m {testFilter} {enableDiagLogging} {arguments}";
+                }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");
 

--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -176,6 +176,13 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             xunitProject.TryGetMetadata("IsMTPProject", out string isMTPProjectMetadata);
             bool isMTPProject = string.Equals(isMTPProjectMetadata, "true", StringComparison.OrdinalIgnoreCase);
 
+            // True when the Microsoft.Testing.Extensions.TrxReport extension is loaded on the
+            // project. MSTest.Sdk enables it by default; xUnit v3 MTP projects do not bundle
+            // it unless added explicitly. Passing '--report-trx' to an MTP host without the
+            // extension fails with an 'unknown argument' error, so only emit it when known safe.
+            xunitProject.TryGetMetadata("EnableTrxReport", out string enableTrxReportMetadata);
+            bool enableTrxReport = string.Equals(enableTrxReportMetadata, "true", StringComparison.OrdinalIgnoreCase);
+
             // netfx tests should only run on Windows full framework for testing VS scenarios
             // These tests have to be executed slightly differently and we give them a different Identity so ADO can tell them apart
             var runtimeTargetFrameworkParsed = NuGetFramework.Parse(runtimeTargetFramework);
@@ -241,7 +248,10 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     // Invoke the test assembly directly via 'dotnet exec' and use MTP-native CLI:
                     //   --filter                replaces VSTest --filter (same MSTest filter syntax)
                     //   --results-directory     same as VSTest
-                    //   --report-trx            replaces '--logger trx' (requires Microsoft.Testing.Extensions.TrxReport)
+                    //   --report-trx            replaces '--logger trx' -- only emitted when the
+                    //                           Microsoft.Testing.Extensions.TrxReport extension is
+                    //                           loaded (always true for MSTest.Sdk default profile;
+                    //                           not bundled with xUnit v3 MTP)
                     //   --diagnostic            replaces VSTest '-d <log>'
                     // Note: --logger "console;verbosity=detailed" and --blame-hang* have no direct MTP
                     // equivalent in the MSTest.Sdk default extension set; the Helix work-item timeout
@@ -260,8 +270,10 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                         ? "--diagnostic --diagnostic-output-directory $HELIX_WORKITEM_UPLOAD_ROOT"
                         : "--diagnostic --diagnostic-output-directory %HELIX_WORKITEM_UPLOAD_ROOT%";
 
+                    string trxArg = enableTrxReport ? "--report-trx " : "";
+
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{driver} exec {assemblyName} " +
-                              $"--results-directory .{Path.DirectorySeparatorChar} --report-trx {testFilter} {diagArg}";
+                              $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg}";
                 }
                 else
                 {

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
@@ -319,20 +319,11 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
     //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
     //       time the memory is accessed which triggers the full memory allocation.
     [TestMethod]
+    [OSCondition(OperatingSystems.Windows | OperatingSystems.OSX)]
+    [Is64BitProcessCondition]
     [TestCategory("OuterLoop")]
     public void InvalidAdvance_Large()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            Assert.Inconclusive("This test is constrained to run on Windows and macOS.");
-        }
-
-        if (!Environment.Is64BitProcess)
-        {
-            Assert.Inconclusive("This test requires a 64-bit process.");
-        }
-
         try
         {
             {

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
@@ -480,6 +480,8 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
 [TestClass]
 public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
 {
+    public TestContext TestContext { get; set; } = null!;
+
     protected override void WriteData(IBufferWriter<byte> bufferWriter, int numBytes)
     {
         Span<byte> outputSpan = bufferWriter.GetSpan(numBytes);
@@ -560,7 +562,7 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
         Assert.IsTrue(transient.Span[0] != 0);
         byte expectedFirstByte = transient.Span[0];
 
-        await memStream.WriteAsync(transient.ToArray(), 0, transient.Length, CancellationToken.None);
+        await memStream.WriteAsync(transient.ToArray(), 0, transient.Length, TestContext.CancellationToken);
 
         if (clearContent)
         {

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
@@ -18,7 +18,7 @@ internal static class TestExtensions
 #if NET
     public static ArraySegment<T> GetArraySegment<T>(this ArrayBufferWriter<T> writer, int sizeHint = 0)
     {
-        Assert.True(MemoryMarshal.TryGetArray(writer.GetMemory(sizeHint), out ArraySegment<T> segment));
+        Assert.IsTrue(MemoryMarshal.TryGetArray(writer.GetMemory(sizeHint), out ArraySegment<T> segment));
         return segment;
     }
 #endif
@@ -27,120 +27,125 @@ internal static class TestExtensions
         => segment.Array![segment.Offset + index];
 }
 
+[TestClass]
 public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
 {
-    [Fact]
+    [TestMethod]
     public void ArrayBufferWriter_Ctor()
     {
         {
             var output = new ArrayBufferWriter<T>();
-            Assert.Equal(0, output.FreeCapacity);
-            Assert.Equal(0, output.Capacity);
-            Assert.Equal(0, output.WrittenCount);
-            Assert.True(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-            Assert.True(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+            Assert.AreEqual(0, output.FreeCapacity);
+            Assert.AreEqual(0, output.Capacity);
+            Assert.AreEqual(0, output.WrittenCount);
+            Assert.IsTrue(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+            Assert.IsTrue(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
         }
 
         {
             var output = new ArrayBufferWriter<T>(200);
-            Assert.True(output.FreeCapacity >= 200);
-            Assert.True(output.Capacity >= 200);
-            Assert.Equal(0, output.WrittenCount);
-            Assert.True(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-            Assert.True(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+            Assert.IsTrue(output.FreeCapacity >= 200);
+            Assert.IsTrue(output.Capacity >= 200);
+            Assert.AreEqual(0, output.WrittenCount);
+            Assert.IsTrue(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+            Assert.IsTrue(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
         }
 
         {
             ArrayBufferWriter<T> output = null!;
-            Assert.Null(output);
+            Assert.IsNull(output);
         }
     }
 
-    [Fact]
-    [ActiveIssue("https://github.com/mono/mono/issues/15002", TestRuntimes.Mono)]
+    [TestMethod]
     public void Invalid_Ctor()
     {
-        Assert.Throws<ArgumentException>(() => new ArrayBufferWriter<T>(0));
-        Assert.Throws<ArgumentException>(() => new ArrayBufferWriter<T>(-1));
-        Assert.Throws<OutOfMemoryException>(() => new ArrayBufferWriter<T>(int.MaxValue));
+        if (Type.GetType("Mono.Runtime") is not null)
+        {
+            Assert.Inconclusive("Active issue: https://github.com/mono/mono/issues/15002");
+        }
+
+        Assert.ThrowsExactly<ArgumentException>(() => new ArrayBufferWriter<T>(0));
+        Assert.ThrowsExactly<ArgumentException>(() => new ArrayBufferWriter<T>(-1));
+        Assert.ThrowsExactly<OutOfMemoryException>(() => new ArrayBufferWriter<T>(int.MaxValue));
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear()
     {
         var output = new ArrayBufferWriter<T>(256);
         int previousAvailable = output.FreeCapacity;
         WriteData(output, 2);
-        Assert.True(output.FreeCapacity < previousAvailable);
-        Assert.True(output.WrittenCount > 0);
-        Assert.False(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-        Assert.False(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(output.FreeCapacity < previousAvailable);
+        Assert.IsTrue(output.WrittenCount > 0);
+        Assert.IsFalse(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+        Assert.IsFalse(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
 
         ReadOnlyMemory<T> transientMemory = output.WrittenMemory;
         ReadOnlySpan<T> transientSpan = output.WrittenSpan;
         T t0 = transientMemory.Span[0];
         T t1 = transientSpan[1];
-        Assert.NotEqual(default, t0);
-        Assert.NotEqual(default, t1);
+        Assert.AreNotEqual(default, t0);
+        Assert.AreNotEqual(default, t1);
         output.Clear();
-        Assert.Equal(default, transientMemory.Span[0]);
-        Assert.Equal(default, transientSpan[1]);
+        Assert.AreEqual(default, transientMemory.Span[0]);
+        Assert.AreEqual(default, transientSpan[1]);
 
-        Assert.Equal(0, output.WrittenCount);
-        Assert.True(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-        Assert.True(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.Equal(previousAvailable, output.FreeCapacity);
+        Assert.AreEqual(0, output.WrittenCount);
+        Assert.IsTrue(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+        Assert.IsTrue(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.AreEqual(previousAvailable, output.FreeCapacity);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResetWrittenCount()
     {
         var output = new ArrayBufferWriter<T>(256);
         int previousAvailable = output.FreeCapacity;
         WriteData(output, 2);
-        Assert.True(output.FreeCapacity < previousAvailable);
-        Assert.True(output.WrittenCount > 0);
-        Assert.False(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-        Assert.False(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(output.FreeCapacity < previousAvailable);
+        Assert.IsTrue(output.WrittenCount > 0);
+        Assert.IsFalse(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+        Assert.IsFalse(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
 
         ReadOnlyMemory<T> transientMemory = output.WrittenMemory;
         ReadOnlySpan<T> transientSpan = output.WrittenSpan;
         T t0 = transientMemory.Span[0];
         T t1 = transientSpan[1];
-        Assert.NotEqual(default, t0);
-        Assert.NotEqual(default, t1);
+        Assert.AreNotEqual(default, t0);
+        Assert.AreNotEqual(default, t1);
         output.ResetWrittenCount();
-        Assert.Equal(t0, transientMemory.Span[0]);
-        Assert.Equal(t1, transientSpan[1]);
+        Assert.AreEqual(t0, transientMemory.Span[0]);
+        Assert.AreEqual(t1, transientSpan[1]);
 
-        Assert.Equal(0, output.WrittenCount);
-        Assert.True(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
-        Assert.True(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.Equal(previousAvailable, output.FreeCapacity);
+        Assert.AreEqual(0, output.WrittenCount);
+        Assert.IsTrue(ReadOnlySpan<T>.Empty.SequenceEqual(output.WrittenSpan));
+        Assert.IsTrue(ReadOnlyMemory<T>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.AreEqual(previousAvailable, output.FreeCapacity);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance()
     {
         {
             var output = new ArrayBufferWriter<T>();
             int capacity = output.Capacity;
-            Assert.Equal(capacity, output.FreeCapacity);
+            Assert.AreEqual(capacity, output.FreeCapacity);
             output.Advance(output.FreeCapacity);
-            Assert.Equal(capacity, output.WrittenCount);
-            Assert.Equal(0, output.FreeCapacity);
+            Assert.AreEqual(capacity, output.WrittenCount);
+            Assert.AreEqual(0, output.FreeCapacity);
         }
 
         {
             var output = new ArrayBufferWriter<T>();
             output.Advance(output.Capacity);
-            Assert.Equal(output.Capacity, output.WrittenCount);
-            Assert.Equal(0, output.FreeCapacity);
+            Assert.AreEqual(output.Capacity, output.WrittenCount);
+            Assert.AreEqual(0, output.FreeCapacity);
             int previousCapacity = output.Capacity;
             Span<T> _ = output.GetSpan();
-            Assert.True(output.Capacity > previousCapacity);
+            Assert.IsTrue(output.Capacity > previousCapacity);
         }
 
         {
@@ -148,11 +153,11 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             WriteData(output, 2);
             ReadOnlyMemory<T> previousMemory = output.WrittenMemory;
             ReadOnlySpan<T> previousSpan = output.WrittenSpan;
-            Assert.True(previousSpan.SequenceEqual(previousMemory.Span));
+            Assert.IsTrue(previousSpan.SequenceEqual(previousMemory.Span));
             output.Advance(10);
-            Assert.False(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
-            Assert.False(previousSpan.SequenceEqual(output.WrittenSpan));
-            Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+            Assert.IsFalse(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
+            Assert.IsFalse(previousSpan.SequenceEqual(output.WrittenSpan));
+            Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
         }
 
         {
@@ -161,151 +166,151 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             WriteData(output, 10);
             ReadOnlyMemory<T> previousMemory = output.WrittenMemory;
             ReadOnlySpan<T> previousSpan = output.WrittenSpan;
-            Assert.True(previousSpan.SequenceEqual(previousMemory.Span));
-            Assert.Throws<InvalidOperationException>(() => output.Advance(247));
+            Assert.IsTrue(previousSpan.SequenceEqual(previousMemory.Span));
+            Assert.ThrowsExactly<InvalidOperationException>(() => output.Advance(247));
             output.Advance(10);
-            Assert.False(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
-            Assert.False(previousSpan.SequenceEqual(output.WrittenSpan));
-            Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+            Assert.IsFalse(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
+            Assert.IsFalse(previousSpan.SequenceEqual(output.WrittenSpan));
+            Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void AdvanceZero()
     {
         var output = new ArrayBufferWriter<T>();
         WriteData(output, 2);
-        Assert.Equal(2, output.WrittenCount);
+        Assert.AreEqual(2, output.WrittenCount);
         ReadOnlyMemory<T> previousMemory = output.WrittenMemory;
         ReadOnlySpan<T> previousSpan = output.WrittenSpan;
-        Assert.True(previousSpan.SequenceEqual(previousMemory.Span));
+        Assert.IsTrue(previousSpan.SequenceEqual(previousMemory.Span));
         output.Advance(0);
-        Assert.Equal(2, output.WrittenCount);
-        Assert.True(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(previousSpan.SequenceEqual(output.WrittenSpan));
-        Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+        Assert.AreEqual(2, output.WrittenCount);
+        Assert.IsTrue(previousMemory.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(previousSpan.SequenceEqual(output.WrittenSpan));
+        Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public void InvalidAdvance()
     {
         {
             var output = new ArrayBufferWriter<T>();
-            Assert.Throws<ArgumentException>(() => output.Advance(-1));
-            Assert.Throws<InvalidOperationException>(() => output.Advance(output.Capacity + 1));
+            Assert.ThrowsExactly<ArgumentException>(() => output.Advance(-1));
+            Assert.ThrowsExactly<InvalidOperationException>(() => output.Advance(output.Capacity + 1));
         }
 
         {
             var output = new ArrayBufferWriter<T>();
             WriteData(output, 100);
-            Assert.Throws<InvalidOperationException>(() => output.Advance(output.FreeCapacity + 1));
+            Assert.ThrowsExactly<InvalidOperationException>(() => output.Advance(output.FreeCapacity + 1));
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSpan_DefaultCtor()
     {
         var output = new ArrayBufferWriter<T>();
         var span = output.GetSpan();
-        Assert.Equal(256, span.Length);
+        Assert.AreEqual(256, span.Length);
     }
 
-    [Theory]
-    [MemberData(nameof(SizeHints))]
+    [TestMethod]
+    [DynamicData(nameof(SizeHints))]
     public void GetSpan_DefaultCtor_WithSizeHint(int sizeHint)
     {
         var output = new ArrayBufferWriter<T>();
         var span = output.GetSpan(sizeHint);
-        Assert.Equal(sizeHint <= 256 ? 256 : sizeHint, span.Length);
+        Assert.AreEqual(sizeHint <= 256 ? 256 : sizeHint, span.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSpan_InitSizeCtor()
     {
         var output = new ArrayBufferWriter<T>(100);
         var span = output.GetSpan();
-        Assert.Equal(100, span.Length);
+        Assert.AreEqual(100, span.Length);
     }
 
-    [Theory]
-    [MemberData(nameof(SizeHints))]
+    [TestMethod]
+    [DynamicData(nameof(SizeHints))]
     public void GetSpan_InitSizeCtor_WithSizeHint(int sizeHint)
     {
         {
             var output = new ArrayBufferWriter<T>(256);
             var span = output.GetSpan(sizeHint);
-            Assert.Equal(sizeHint <= 256 ? 256 : sizeHint + 256, span.Length);
+            Assert.AreEqual(sizeHint <= 256 ? 256 : sizeHint + 256, span.Length);
         }
 
         {
             var output = new ArrayBufferWriter<T>(1000);
             var span = output.GetSpan(sizeHint);
-            Assert.Equal(sizeHint <= 1000 ? 1000 : sizeHint + 1000, span.Length);
+            Assert.AreEqual(sizeHint <= 1000 ? 1000 : sizeHint + 1000, span.Length);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetMemory_DefaultCtor()
     {
         var output = new ArrayBufferWriter<T>();
         var memory = output.GetMemory();
-        Assert.Equal(256, memory.Length);
+        Assert.AreEqual(256, memory.Length);
 
         var segment = output.GetArraySegment();
-        Assert.Equal(memory.Length, segment.Count);
+        Assert.AreEqual(memory.Length, segment.Count);
     }
 
-    [Theory]
-    [MemberData(nameof(SizeHints))]
+    [TestMethod]
+    [DynamicData(nameof(SizeHints))]
     public void GetMemory_DefaultCtor_WithSizeHint(int sizeHint)
     {
         var output = new ArrayBufferWriter<T>();
         var memory = output.GetMemory(sizeHint);
-        Assert.Equal(sizeHint <= 256 ? 256 : sizeHint, memory.Length);
+        Assert.AreEqual(sizeHint <= 256 ? 256 : sizeHint, memory.Length);
 
         var segment = output.GetArraySegment(sizeHint);
-        Assert.Equal(memory.Length, segment.Count);
+        Assert.AreEqual(memory.Length, segment.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetMemory_ExceedMaximumBufferSize_WithSmallStartingSize()
     {
         var output = new ArrayBufferWriter<T>(256);
-        Assert.Throws<OutOfMemoryException>(() => output.GetMemory(int.MaxValue));
-        Assert.Throws<OutOfMemoryException>(() => output.GetArraySegment(int.MaxValue));
+        Assert.ThrowsExactly<OutOfMemoryException>(() => output.GetMemory(int.MaxValue));
+        Assert.ThrowsExactly<OutOfMemoryException>(() => output.GetArraySegment(int.MaxValue));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetMemory_InitSizeCtor()
     {
         var output = new ArrayBufferWriter<T>(100);
         var memory = output.GetMemory();
-        Assert.Equal(100, memory.Length);
+        Assert.AreEqual(100, memory.Length);
 
         var segment = output.GetArraySegment();
-        Assert.Equal(memory.Length, segment.Count);
+        Assert.AreEqual(memory.Length, segment.Count);
     }
 
-    [Theory]
-    [MemberData(nameof(SizeHints))]
+    [TestMethod]
+    [DynamicData(nameof(SizeHints))]
     public void GetMemory_InitSizeCtor_WithSizeHint(int sizeHint)
     {
         {
             var output = new ArrayBufferWriter<T>(256);
             var memory = output.GetMemory(sizeHint);
-            Assert.Equal(sizeHint <= 256 ? 256 : sizeHint + 256, memory.Length);
+            Assert.AreEqual(sizeHint <= 256 ? 256 : sizeHint + 256, memory.Length);
 
             var segment = output.GetArraySegment();
-            Assert.Equal(memory.Length, segment.Count);
+            Assert.AreEqual(memory.Length, segment.Count);
         }
 
         {
             var output = new ArrayBufferWriter<T>(1000);
             var memory = output.GetMemory(sizeHint);
-            Assert.Equal(sizeHint <= 1000 ? 1000 : sizeHint + 1000, memory.Length);
+            Assert.AreEqual(sizeHint <= 1000 ? 1000 : sizeHint + 1000, memory.Length);
 
             var segment = output.GetArraySegment();
-            Assert.Equal(memory.Length, segment.Count);
+            Assert.AreEqual(memory.Length, segment.Count);
         }
     }
 
@@ -313,24 +318,34 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
     //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
     //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
     //       time the memory is accessed which triggers the full memory allocation.
-    [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-    [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))]
-    [OuterLoop]
+    [TestMethod]
+    [TestCategory("OuterLoop")]
     public void InvalidAdvance_Large()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Assert.Inconclusive("This test is constrained to run on Windows and macOS.");
+        }
+
+        if (!Environment.Is64BitProcess)
+        {
+            Assert.Inconclusive("This test requires a 64-bit process.");
+        }
+
         try
         {
             {
                 var output = new ArrayBufferWriter<T>(2_000_000_000);
                 WriteData(output, 1_000);
-                Assert.Throws<InvalidOperationException>(() => output.Advance(int.MaxValue));
-                Assert.Throws<InvalidOperationException>(() => output.Advance(2_000_000_000 - 1_000 + 1));
+                Assert.ThrowsExactly<InvalidOperationException>(() => output.Advance(int.MaxValue));
+                Assert.ThrowsExactly<InvalidOperationException>(() => output.Advance(2_000_000_000 - 1_000 + 1));
             }
         }
         catch (OutOfMemoryException) { }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetMemoryAndSpan()
     {
         {
@@ -340,15 +355,15 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             var memory = output.GetMemory();
             var segment = output.GetArraySegment();
             Span<T> memorySpan = memory.Span;
-            Assert.True(span.Length > 0);
-            Assert.Equal(span.Length, memorySpan.Length);
-            Assert.Equal(span.Length, segment.Count);
+            Assert.IsTrue(span.Length > 0);
+            Assert.AreEqual(span.Length, memorySpan.Length);
+            Assert.AreEqual(span.Length, segment.Count);
 
             for (int i = 0; i < span.Length; i++)
             {
-                Assert.Equal(default, span[i]);
-                Assert.Equal(default, memorySpan[i]);
-                Assert.Equal(default, segment.GetItem(i));
+                Assert.AreEqual(default, span[i]);
+                Assert.AreEqual(default, memorySpan[i]);
+                Assert.AreEqual(default, segment.GetItem(i));
             }
         }
 
@@ -357,44 +372,44 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             WriteData(output, 2);
             ReadOnlyMemory<T> writtenSoFarMemory = output.WrittenMemory;
             ReadOnlySpan<T> writtenSoFar = output.WrittenSpan;
-            Assert.True(writtenSoFarMemory.Span.SequenceEqual(writtenSoFar));
+            Assert.IsTrue(writtenSoFarMemory.Span.SequenceEqual(writtenSoFar));
             int previousAvailable = output.FreeCapacity;
             var span = output.GetSpan(500);
-            Assert.True(span.Length >= 500);
-            Assert.True(output.FreeCapacity >= 500);
-            Assert.True(output.FreeCapacity > previousAvailable);
+            Assert.IsTrue(span.Length >= 500);
+            Assert.IsTrue(output.FreeCapacity >= 500);
+            Assert.IsTrue(output.FreeCapacity > previousAvailable);
 
-            Assert.Equal(writtenSoFar.Length, output.WrittenCount);
-            Assert.False(writtenSoFar.SequenceEqual(span.Slice(0, output.WrittenCount)));
+            Assert.AreEqual(writtenSoFar.Length, output.WrittenCount);
+            Assert.IsFalse(writtenSoFar.SequenceEqual(span.Slice(0, output.WrittenCount)));
 
             var memory = output.GetMemory();
             var segment = output.GetArraySegment();
             Span<T> memorySpan = memory.Span;
-            Assert.True(span.Length >= 500);
-            Assert.True(memorySpan.Length >= 500);
-            Assert.Equal(span.Length, memorySpan.Length);
-            Assert.Equal(span.Length, segment.Count);
+            Assert.IsTrue(span.Length >= 500);
+            Assert.IsTrue(memorySpan.Length >= 500);
+            Assert.AreEqual(span.Length, memorySpan.Length);
+            Assert.AreEqual(span.Length, segment.Count);
             for (int i = 0; i < span.Length; i++)
             {
-                Assert.Equal(default, span[i]);
-                Assert.Equal(default, memorySpan[i]);
-                Assert.Equal(default, segment.GetItem(i));
+                Assert.AreEqual(default, span[i]);
+                Assert.AreEqual(default, memorySpan[i]);
+                Assert.AreEqual(default, segment.GetItem(i));
             }
 
             memory = output.GetMemory(500);
             segment = output.GetArraySegment(500);
             memorySpan = memory.Span;
-            Assert.True(memorySpan.Length >= 500);
-            Assert.Equal(span.Length, memorySpan.Length);
+            Assert.IsTrue(memorySpan.Length >= 500);
+            Assert.AreEqual(span.Length, memorySpan.Length);
             for (int i = 0; i < memorySpan.Length; i++)
             {
-                Assert.Equal(default, memorySpan[i]);
-                Assert.Equal(default, segment.GetItem(i));
+                Assert.AreEqual(default, memorySpan[i]);
+                Assert.AreEqual(default, segment.GetItem(i));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSpanShouldAtleastDoubleWhenGrowing()
     {
         var output = new ArrayBufferWriter<T>(256);
@@ -402,13 +417,13 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
         int previousAvailable = output.FreeCapacity;
 
         _ = output.GetSpan(previousAvailable);
-        Assert.Equal(previousAvailable, output.FreeCapacity);
+        Assert.AreEqual(previousAvailable, output.FreeCapacity);
 
         _ = output.GetSpan(previousAvailable + 1);
-        Assert.True(output.FreeCapacity >= previousAvailable * 2);
+        Assert.IsTrue(output.FreeCapacity >= previousAvailable * 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSpanOnlyGrowsAboveThreshold()
     {
         {
@@ -419,7 +434,7 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             for (int i = 0; i < 10; i++)
             {
                 _ = output.GetSpan();
-                Assert.Equal(previousAvailable, output.FreeCapacity);
+                Assert.AreEqual(previousAvailable, output.FreeCapacity);
             }
         }
 
@@ -431,19 +446,19 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
             for (int i = 0; i < 10; i++)
             {
                 _ = output.GetSpan(previousAvailable);
-                Assert.Equal(previousAvailable, output.FreeCapacity);
+                Assert.AreEqual(previousAvailable, output.FreeCapacity);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void InvalidGetMemoryAndSpan()
     {
         var output = new ArrayBufferWriter<T>();
         WriteData(output, 2);
-        Assert.Throws<ArgumentException>(() => output.GetSpan(-1));
-        Assert.Throws<ArgumentException>(() => output.GetMemory(-1));
-        Assert.Throws<ArgumentException>(() => output.GetArraySegment(-1));
+        Assert.ThrowsExactly<ArgumentException>(() => output.GetSpan(-1));
+        Assert.ThrowsExactly<ArgumentException>(() => output.GetMemory(-1));
+        Assert.ThrowsExactly<ArgumentException>(() => output.GetArraySegment(-1));
     }
 
     protected abstract void WriteData(IBufferWriter<T> bufferWriter, int numBytes);
@@ -471,12 +486,13 @@ public abstract class ArrayBufferWriterTests<T> where T : IEquatable<T>
     }
 }
 
+[TestClass]
 public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
 {
     protected override void WriteData(IBufferWriter<byte> bufferWriter, int numBytes)
     {
         Span<byte> outputSpan = bufferWriter.GetSpan(numBytes);
-        Assert.True(outputSpan.Length >= numBytes);
+        Assert.IsTrue(outputSpan.Length >= numBytes);
         var random = new Random(42);
 
         var data = new byte[numBytes];
@@ -486,9 +502,9 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
         bufferWriter.Advance(numBytes);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void WriteAndCopyToStream(bool clearContent)
     {
         System.Buffers.ArrayBufferWriter<byte> output = new();
@@ -496,16 +512,16 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
 
         using MemoryStream memStream = new(100);
 
-        Assert.Equal(100, output.WrittenCount);
+        Assert.AreEqual(100, output.WrittenCount);
 
         ReadOnlySpan<byte> outputSpan = output.WrittenMemory.ToArray();
 
         ReadOnlyMemory<byte> transientMemory = output.WrittenMemory;
         ReadOnlySpan<byte> transientSpan = output.WrittenSpan;
 
-        Assert.True(transientSpan.SequenceEqual(transientMemory.Span));
+        Assert.IsTrue(transientSpan.SequenceEqual(transientMemory.Span));
 
-        Assert.True(transientSpan[0] != 0);
+        Assert.IsTrue(transientSpan[0] != 0);
         byte expectedFirstByte = transientSpan[0];
 
         memStream.Write(transientSpan.ToArray(), 0, transientSpan.Length);
@@ -520,23 +536,23 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
             output.ResetWrittenCount();
         }
 
-        Assert.Equal(expectedFirstByte, transientSpan[0]);
-        Assert.Equal(expectedFirstByte, transientMemory.Span[0]);
+        Assert.AreEqual(expectedFirstByte, transientSpan[0]);
+        Assert.AreEqual(expectedFirstByte, transientMemory.Span[0]);
 
-        Assert.Equal(0, output.WrittenCount);
+        Assert.AreEqual(0, output.WrittenCount);
         byte[] streamOutput = memStream.ToArray();
 
-        Assert.True(ReadOnlyMemory<byte>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(ReadOnlySpan<byte>.Empty.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(ReadOnlyMemory<byte>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(ReadOnlySpan<byte>.Empty.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(output.WrittenSpan.SequenceEqual(output.WrittenMemory.Span));
 
-        Assert.Equal(outputSpan.Length, streamOutput.Length);
-        Assert.True(outputSpan.SequenceEqual(streamOutput));
+        Assert.AreEqual(outputSpan.Length, streamOutput.Length);
+        Assert.IsTrue(outputSpan.SequenceEqual(streamOutput));
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task WriteAndCopyToStreamAsync(bool clearContent)
     {
         System.Buffers.ArrayBufferWriter<byte> output = new();
@@ -544,16 +560,16 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
 
         using MemoryStream memStream = new(100);
 
-        Assert.Equal(100, output.WrittenCount);
+        Assert.AreEqual(100, output.WrittenCount);
 
         ReadOnlyMemory<byte> outputMemory = output.WrittenMemory.ToArray();
 
         ReadOnlyMemory<byte> transient = output.WrittenMemory;
 
-        Assert.True(transient.Span[0] != 0);
+        Assert.IsTrue(transient.Span[0] != 0);
         byte expectedFirstByte = transient.Span[0];
 
-        await memStream.WriteAsync(transient.ToArray(), 0, transient.Length, TestContext.Current.CancellationToken);
+        await memStream.WriteAsync(transient.ToArray(), 0, transient.Length, CancellationToken.None);
 
         if (clearContent)
         {
@@ -565,15 +581,15 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
             output.ResetWrittenCount();
         }
 
-        Assert.True(transient.Span[0] == expectedFirstByte);
+        Assert.IsTrue(transient.Span[0] == expectedFirstByte);
 
-        Assert.Equal(0, output.WrittenCount);
+        Assert.AreEqual(0, output.WrittenCount);
         byte[] streamOutput = memStream.ToArray();
 
-        Assert.True(ReadOnlyMemory<byte>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
-        Assert.True(ReadOnlySpan<byte>.Empty.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(ReadOnlyMemory<byte>.Empty.Span.SequenceEqual(output.WrittenMemory.Span));
+        Assert.IsTrue(ReadOnlySpan<byte>.Empty.SequenceEqual(output.WrittenMemory.Span));
 
-        Assert.Equal(outputMemory.Length, streamOutput.Length);
-        Assert.True(outputMemory.Span.SequenceEqual(streamOutput));
+        Assert.AreEqual(outputMemory.Length, streamOutput.Length);
+        Assert.IsTrue(outputMemory.Span.SequenceEqual(streamOutput));
     }
 }

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/EnvironmentUtilitiesTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/EnvironmentUtilitiesTests.cs
@@ -1,13 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.Watch.UnitTests;
-
 namespace Microsoft.DotNet.HotReload.UnitTests;
 
+[TestClass]
 public class EnvironmentUtilitiesTests
 {
-    [Fact]
+    [TestMethod]
     public void MultipleValues()
     {
         var builder = new Dictionary<string, string>();
@@ -15,10 +14,10 @@ public class EnvironmentUtilitiesTests
         builder.InsertListItem("X", "b", separator: ';');
         builder.InsertListItem("X", "a", separator: ';');
 
-        AssertEx.SequenceEqual([new KeyValuePair<string, string>("X", "b;a")], builder);
+        Assert.AreSequenceEqual([new KeyValuePair<string, string>("X", "b;a")], builder);
     }
 
-    [Fact]
+    [TestMethod]
     public void EmptyValue()
     {
         var builder = new Dictionary<string, string>();
@@ -28,6 +27,6 @@ public class EnvironmentUtilitiesTests
         builder.InsertListItem("X", "b", separator: ';');
         builder.InsertListItem("X", "a", separator: ';');
 
-        AssertEx.SequenceEqual([new KeyValuePair<string, string>("X", "b;a")], builder);
+        Assert.AreSequenceEqual([new KeyValuePair<string, string>("X", "b;a")], builder);
     }
 }

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
@@ -1,6 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <!-- Opts this project out of the xUnit-specific defaults applied by test/Directory.Build.targets.
+         MSTest.Sdk wires up MSTest + Microsoft.Testing.Platform (MTP) itself. -->
+    <UseMSTestSdk>true</UseMSTestSdk>
+
     <!--
       Tests code used in in-proc VS and VS Code.
       Ideally, we would target $(VisualStudioServiceTargetFramework) but Microsoft.NET.TestFramework has dependencies on $(SdkTargetFramework).
@@ -12,12 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.DotNet.HotReload.Test.Utilities\AssertEx.cs" Link="Utilities\AssertEx.cs" />
-    <Compile Include="..\Microsoft.DotNet.HotReload.Test.Utilities\TestLogger.cs" Link="Utilities\TestLogger.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Contracts" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
@@ -25,8 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
-    <PackageReference Include="Xunit.Combinatorial" />
+    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
@@ -1,9 +1,6 @@
-﻿<Project Sdk="MSTest.Sdk">
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
-    <!-- Opts this project out of the xUnit-specific defaults applied by test/Directory.Build.targets.
-         MSTest.Sdk wires up MSTest + Microsoft.Testing.Platform (MTP) itself. -->
-    <UseMSTestSdk>true</UseMSTestSdk>
 
     <!--
       Tests code used in in-proc VS and VS Code.

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/SharedSecretProviderTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/SharedSecretProviderTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.HotReload.UnitTests;
 
+[TestClass]
 public class SharedSecretProviderTests
 {
     private static byte[] GetRandomBytes(int length)
@@ -15,7 +16,7 @@ public class SharedSecretProviderTests
         return result;
     }
 
-    [Fact]
+    [TestMethod]
     public void EncryptDecrypt()
     {
         using var provider = new SharedSecretProvider();
@@ -26,7 +27,7 @@ public class SharedSecretProviderTests
         var publicKey = provider.GetPublicKey();
 
         // Middleware embeds key by in the .js file loaded to the browser:
-        Assert.Equal(publicKey, publicKeyNetfx);
+        Assert.AreEqual(publicKey, publicKeyNetfx);
 
         // The browser generates 32-byte random secret:
         var secret = GetRandomBytes(32);
@@ -40,17 +41,18 @@ public class SharedSecretProviderTests
         // The secret is sent over to the client with every request over WebSocket.
         // The client validates that the secrete matches the one it generated.
         var decrypted = provider.DecryptSecret(encrypted);
-        Assert.Equal(secretBase64, decrypted);
+        Assert.AreEqual(secretBase64, decrypted);
     }
 
     // Equivalent to getSecret function in WebSocketScriptInjection.js:
     public static string GetEncryptedSecret(string key, RSAParameters publicKeyParameters, byte[] secret)
     {
         // Import server key for RSA-OAEP
-        using var rsa = RSA.Create();
 #if NET
+        using var rsa = RSA.Create();
         rsa.ImportSubjectPublicKeyInfo(Convert.FromBase64String(key), out _);
 #else
+        using var rsa = new RSACng();
         rsa.ImportParameters(publicKeyParameters);
 #endif
         // Encrypt using RSA-OAEP

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/StaticWebAssetsManifestTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/StaticWebAssetsManifestTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Watch.UnitTests;
@@ -6,24 +6,27 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.HotReload.UnitTests;
 
-public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
+[TestClass]
+public class StaticWebAssetsManifestTests
 {
+    public TestContext TestContext { get; set; } = default!;
+
     private static MemoryStream CreateStream(string content)
         => new(Encoding.UTF8.GetBytes(content));
 
     private static string GetContentRoot(params string[] segments)
         => (Path.Combine(segments).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar).Replace("\\", "\\\\");
 
-    [Fact]
+    [TestMethod]
     public void TryParse_Empty()
     {
         using var stream = CreateStream("null");
-        var logger = new TestLogger(testOutput);
-        Assert.Null(StaticWebAssetsManifest.TryParse(stream, "file.json", logger));
-        Assert.True(logger.HasError);
+        var logger = new TestLogger(TestContext);
+        Assert.IsNull(StaticWebAssetsManifest.TryParse(stream, "file.json", logger));
+        Assert.IsTrue(logger.HasError);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_MissingContentRoots()
     {
         using var stream = CreateStream("""
@@ -41,12 +44,12 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
-        Assert.Null(StaticWebAssetsManifest.TryParse(stream, "file.json", logger));
-        Assert.True(logger.HasError);
+        var logger = new TestLogger(TestContext);
+        Assert.IsNull(StaticWebAssetsManifest.TryParse(stream, "file.json", logger));
+        Assert.IsTrue(logger.HasError);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_InvalidRootIndex()
     {
         var root = Path.GetTempPath();
@@ -69,20 +72,20 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "[Warning] Failed to parse 'file.json': Invalid value of ContentRootIndex: 1",
         ], logger.GetAndClearMessages());
 
-        Assert.NotNull(manifest);
-        Assert.Empty(manifest.UrlToPathMap);
-        Assert.Empty(manifest.DiscoveryPatterns);
+        Assert.IsNotNull(manifest);
+        Assert.IsEmpty(manifest.UrlToPathMap);
+        Assert.IsEmpty(manifest.DiscoveryPatterns);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_InvalidCharactersInSubPath()
     {
         var root = Path.GetTempPath();
@@ -105,18 +108,18 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
-        Assert.Empty(logger.GetAndClearMessages());
-        Assert.NotNull(manifest);
+        Assert.IsEmpty(logger.GetAndClearMessages());
+        Assert.IsNotNull(manifest);
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             new("site.css", Path.Join(root, "<>.css")),
         ], manifest.UrlToPathMap.OrderBy(e => e.Key));
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_NoChildren()
     {
         var root = Path.GetTempPath();
@@ -133,15 +136,15 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
-        Assert.NotNull(manifest);
-        Assert.False(logger.HasWarning);
-        Assert.Empty(manifest.UrlToPathMap);
-        Assert.Empty(manifest.DiscoveryPatterns);
+        Assert.IsNotNull(manifest);
+        Assert.IsFalse(logger.HasWarning);
+        Assert.IsEmpty(manifest.UrlToPathMap);
+        Assert.IsEmpty(manifest.DiscoveryPatterns);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_TopAsset()
     {
         var root = Path.GetTempPath();
@@ -162,19 +165,19 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "[Warning] Failed to parse 'file.json': Asset has no URL",
         ], logger.GetAndClearMessages());
 
-        Assert.NotNull(manifest);
-        Assert.Empty(manifest.UrlToPathMap);
-        Assert.Empty(manifest.DiscoveryPatterns);
+        Assert.IsNotNull(manifest);
+        Assert.IsEmpty(manifest.UrlToPathMap);
+        Assert.IsEmpty(manifest.DiscoveryPatterns);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_RootIsNotFullPath()
     {
         using var stream = CreateStream("""
@@ -193,15 +196,15 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
-        Assert.True(logger.HasWarning);
-        Assert.NotNull(manifest);
-        Assert.Empty(manifest.UrlToPathMap);
-        Assert.Empty(manifest.DiscoveryPatterns);
+        Assert.IsTrue(logger.HasWarning);
+        Assert.IsNotNull(manifest);
+        Assert.IsEmpty(manifest.UrlToPathMap);
+        Assert.IsEmpty(manifest.DiscoveryPatterns);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_ValidFile()
     {
         var root = Path.GetTempPath();
@@ -317,8 +320,8 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
 
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", NullLogger.Instance);
 
-        Assert.NotNull(manifest);
-        AssertEx.SequenceEqual(
+        Assert.IsNotNull(manifest);
+        Assert.AreSequenceEqual(
         [
             new("_content/Classlib/css/site.css", Path.Combine(root, "Classlib", "wwwroot", "css", "site.css")),
             new("_content/Classlib2/background.png", Path.Combine(root, "Classlib2", "wwwroot", "background.png")),
@@ -329,10 +332,10 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
             new("css/site.css", Path.Combine(root, "Classlib2", "bundles", "css", "site.css")),
         ], manifest.UrlToPathMap.OrderBy(e => e.Key));
 
-        Assert.Empty(manifest.DiscoveryPatterns);
+        Assert.IsEmpty(manifest.DiscoveryPatterns);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryParse_Patterns()
     {
         var root = Path.GetTempPath();
@@ -362,17 +365,17 @@ public class StaticWebAssetsManifestTests(ITestOutputHelper testOutput)
         }
         """);
 
-        var logger = new TestLogger(testOutput);
+        var logger = new TestLogger(TestContext);
         var manifest = StaticWebAssetsManifest.TryParse(stream, "file.json", logger);
-        Assert.False(logger.HasWarning);
-        Assert.NotNull(manifest);
+        Assert.IsFalse(logger.HasWarning);
+        Assert.IsNotNull(manifest);
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             new("site.css", Path.Combine(root, "css", "site.css")),
         ], manifest.UrlToPathMap.OrderBy(e => e.Key));
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             $"{root};**;"
         ], manifest.DiscoveryPatterns.Select(p => $"{p.Directory};{p.Pattern};{p.BaseUrl}"));

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Utilities/Is64BitProcessConditionAttribute.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Utilities/Is64BitProcessConditionAttribute.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.HotReload.UnitTests;
+
+// Skips a test when the current process is not 64-bit.
+//
+// NOTE: this is a hand-rolled, single-purpose ConditionBaseAttribute. xUnit ships a generic
+// [ConditionalFact(typeof(X), nameof(member))] that evaluates an arbitrary static bool member
+// at runtime and skips the test if it returns false. MSTest does not have an equivalent yet
+// (see https://github.com/microsoft/testfx/issues/9070) — once it does, this attribute should
+// be replaced.
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+internal sealed class Is64BitProcessConditionAttribute : ConditionBaseAttribute
+{
+    public Is64BitProcessConditionAttribute()
+        : base(ConditionMode.Include)
+    {
+        IgnoreMessage = "This test requires a 64-bit process.";
+    }
+
+    public override string GroupName => nameof(Is64BitProcessConditionAttribute);
+
+    public override bool IsConditionMet => Environment.Is64BitProcess;
+}

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Utilities/TestLogger.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Utilities/TestLogger.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+internal class TestLogger(TestContext? output = null) : ILogger
+{
+    public readonly object Guard = new();
+    private readonly List<string> _messages = [];
+
+    public Func<LogLevel, bool> IsEnabledImpl = _ => true;
+
+    public bool HasError { get; private set; }
+    public bool HasWarning { get; private set; }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.None)
+        {
+            return;
+        }
+
+        var message = $"[{logLevel}] {formatter(state, exception)}";
+
+        lock (Guard)
+        {
+            HasError |= logLevel is LogLevel.Error or LogLevel.Critical;
+            HasWarning |= logLevel is LogLevel.Warning;
+
+            _messages.Add(message);
+            output?.WriteLine(message);
+        }
+    }
+
+    public ImmutableArray<string> GetAndClearMessages()
+    {
+        lock (Guard)
+        {
+            var result = _messages.ToImmutableArray();
+            _messages.Clear();
+            return result;
+        }
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => throw new NotImplementedException();
+
+    public bool IsEnabled(LogLevel logLevel)
+        => IsEnabledImpl(logLevel);
+}

--- a/test/xunit-runner/XUnitPublish.targets
+++ b/test/xunit-runner/XUnitPublish.targets
@@ -4,6 +4,6 @@
   <!-- Returns 'true' if the project is a Microsoft.Testing.Platform (MTP) project that
        must be invoked via 'dotnet exec' rather than 'dotnet test'. In this repo,
        MSTest.Sdk-based projects ship as MTP self-contained executables and set
-       UseMSTestSdk=true; non-MSTest projects (e.g. xUnit v3) keep using the VSTest path. -->
-  <Target Name="GetIsMTPProject" Returns="$(UseMSTestSdk)" />
+       UsingMSTestSdk=true; non-MSTest projects (e.g. xUnit v3) keep using the VSTest path. -->
+  <Target Name="GetIsMTPProject" Returns="$(UsingMSTestSdk)" />
 </Project>

--- a/test/xunit-runner/XUnitPublish.targets
+++ b/test/xunit-runner/XUnitPublish.targets
@@ -6,4 +6,13 @@
        MSTest.Sdk-based projects ship as MTP self-contained executables and set
        UsingMSTestSdk=true; non-MSTest projects (e.g. xUnit v3) keep using the VSTest path. -->
   <Target Name="GetIsMTPProject" Returns="$(UsingMSTestSdk)" />
+
+  <!-- Returns 'true' when the Microsoft.Testing.Extensions.TrxReport extension is
+       enabled on the project. MSTest.Sdk defaults this to 'true' for the Default and
+       AllMicrosoft extension profiles (see microsoft/testfx Runner/Common.targets);
+       other MTP project types (e.g. xUnit v3 MTP) do not bundle the extension unless
+       added explicitly. The Helix dispatcher uses this to decide whether emitting
+       '--report-trx' on the test command is safe -- passing it to an MTP host without
+       the extension fails with an 'unknown argument' error. -->
+  <Target Name="GetTrxReportEnabled" Returns="$(EnableMicrosoftTestingExtensionsTrxReport)" />
 </Project>

--- a/test/xunit-runner/XUnitPublish.targets
+++ b/test/xunit-runner/XUnitPublish.targets
@@ -11,8 +11,8 @@
        enabled on the project. MSTest.Sdk defaults this to 'true' for the Default and
        AllMicrosoft extension profiles (see microsoft/testfx Runner/Common.targets);
        other MTP project types (e.g. xUnit v3 MTP) do not bundle the extension unless
-       added explicitly. The Helix dispatcher uses this to decide whether emitting
-       '--report-trx' on the test command is safe -- passing it to an MTP host without
+       added explicitly. The Helix dispatcher uses this to decide whether emitting the
+       report-trx switch on the test command is safe; passing it to an MTP host without
        the extension fails with an 'unknown argument' error. -->
   <Target Name="GetTrxReportEnabled" Returns="$(EnableMicrosoftTestingExtensionsTrxReport)" />
 </Project>

--- a/test/xunit-runner/XUnitPublish.targets
+++ b/test/xunit-runner/XUnitPublish.targets
@@ -1,3 +1,9 @@
 <Project>
   <Target Name="PublishWithOutput" DependsOnTargets="Publish" Returns="$([System.IO.Path]::GetFullPath('$(PublishDir)'))" />
+
+  <!-- Returns 'true' if the project is a Microsoft.Testing.Platform (MTP) project that
+       must be invoked via 'dotnet exec' rather than 'dotnet test'. In this repo,
+       MSTest.Sdk-based projects ship as MTP self-contained executables and set
+       UseMSTestSdk=true; non-MSTest projects (e.g. xUnit v3) keep using the VSTest path. -->
+  <Target Name="GetIsMTPProject" Returns="$(UseMSTestSdk)" />
 </Project>

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -79,10 +79,10 @@
 
     <!-- Detect whether the project is a Microsoft.Testing.Platform (MTP) project so the
          Helix work item command can be tailored. MSTest.Sdk-based projects in this repo
-         set UseMSTestSdk=true and ship as MTP self-contained executables (no testhost.dll),
+         set UsingMSTestSdk=true and ship as MTP self-contained executables (no testhost.dll),
          so the standard 'dotnet test <dll>' VSTest invocation does not work for them. -->
     <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetIsMTPProject" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
-      <Output TaskParameter="TargetOutputs" PropertyName="_UseMSTestSdk" />
+      <Output TaskParameter="TargetOutputs" PropertyName="_UsingMSTestSdk" />
     </MSBuild>
 
     <ItemGroup>
@@ -91,7 +91,7 @@
         <TargetPath>$(_TargetPath)</TargetPath>
         <PublishTargetFramework>$(_CurrentPublishTargetFramework)</PublishTargetFramework>
         <RuntimeTargetFramework>$(_CurrentRuntimeTargetFramework)</RuntimeTargetFramework>
-        <IsMTPProject>$(_UseMSTestSdk)</IsMTPProject>
+        <IsMTPProject>$(_UsingMSTestSdk)</IsMTPProject>
       </SDKCustomXUnitProject>
     </ItemGroup>
   </Target>

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -87,7 +87,7 @@
 
     <!-- Detect whether the project has the Microsoft.Testing.Extensions.TrxReport extension
          loaded. MSTest.Sdk enables it by default; other MTP runners (e.g. xUnit v3 MTP) do
-         not, so passing '--report-trx' to those hosts would fail with 'unknown argument'. -->
+         not, so passing the report-trx switch to those hosts would fail with 'unknown argument'. -->
     <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetTrxReportEnabled" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" PropertyName="_EnableTrxReport" />
     </MSBuild>

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -85,6 +85,13 @@
       <Output TaskParameter="TargetOutputs" PropertyName="_UsingMSTestSdk" />
     </MSBuild>
 
+    <!-- Detect whether the project has the Microsoft.Testing.Extensions.TrxReport extension
+         loaded. MSTest.Sdk enables it by default; other MTP runners (e.g. xUnit v3 MTP) do
+         not, so passing '--report-trx' to those hosts would fail with 'unknown argument'. -->
+    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetTrxReportEnabled" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
+      <Output TaskParameter="TargetOutputs" PropertyName="_EnableTrxReport" />
+    </MSBuild>
+
     <ItemGroup>
       <SDKCustomXUnitProject Condition="'%(Identity)' == '$(_CurrentSDKCustomXUnitProject)'">
         <PublishDirectory>$(_PublishOutputDir)</PublishDirectory>
@@ -92,6 +99,7 @@
         <PublishTargetFramework>$(_CurrentPublishTargetFramework)</PublishTargetFramework>
         <RuntimeTargetFramework>$(_CurrentRuntimeTargetFramework)</RuntimeTargetFramework>
         <IsMTPProject>$(_UsingMSTestSdk)</IsMTPProject>
+        <EnableTrxReport>$(_EnableTrxReport)</EnableTrxReport>
       </SDKCustomXUnitProject>
     </ItemGroup>
   </Target>

--- a/test/xunit-runner/XUnitRunner.targets
+++ b/test/xunit-runner/XUnitRunner.targets
@@ -77,12 +77,21 @@
       <Output TaskParameter="TargetOutputs" PropertyName="_TargetPath" />
     </MSBuild>
 
+    <!-- Detect whether the project is a Microsoft.Testing.Platform (MTP) project so the
+         Helix work item command can be tailored. MSTest.Sdk-based projects in this repo
+         set UseMSTestSdk=true and ship as MTP self-contained executables (no testhost.dll),
+         so the standard 'dotnet test <dll>' VSTest invocation does not work for them. -->
+    <MSBuild Projects="$(_CurrentSDKCustomXUnitProject)" Targets="GetIsMTPProject" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomXUnitPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
+      <Output TaskParameter="TargetOutputs" PropertyName="_UseMSTestSdk" />
+    </MSBuild>
+
     <ItemGroup>
       <SDKCustomXUnitProject Condition="'%(Identity)' == '$(_CurrentSDKCustomXUnitProject)'">
         <PublishDirectory>$(_PublishOutputDir)</PublishDirectory>
         <TargetPath>$(_TargetPath)</TargetPath>
         <PublishTargetFramework>$(_CurrentPublishTargetFramework)</PublishTargetFramework>
         <RuntimeTargetFramework>$(_CurrentRuntimeTargetFramework)</RuntimeTargetFramework>
+        <IsMTPProject>$(_UseMSTestSdk)</IsMTPProject>
       </SDKCustomXUnitProject>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
## Summary
- Migrate Microsoft.DotNet.HotReload.Client.Tests to MSTest.Sdk on Microsoft.Testing.Platform.
- Replace xUnit attributes/assertions with MSTest equivalents and project-local TestLogger.
- Preserve net11.0 + net472 multi-targeting.

## Validation
- `Q:\src\sdk\.dotnet\dotnet.exe build test\Microsoft.DotNet.HotReload.Client.Tests\Microsoft.DotNet.HotReload.Client.Tests.csproj --nologo` — 0 warnings, 0 errors.
- `Q:\src\sdk\.dotnet\dotnet.exe exec artifacts\bin\Microsoft.DotNet.HotReload.Client.Tests\Debug\net11.0\Microsoft.DotNet.HotReload.Client.Tests.dll` — 81 passed.
- `artifacts\bin\Microsoft.DotNet.HotReload.Client.Tests\Debug\net472\Microsoft.DotNet.HotReload.Client.Tests.exe` — 81 passed.
