### PR TITLE
Migrate ApplyJsModules to IMultiThreadableTask

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/JSModules/ApplyJsModules.cs
+++ b/src/StaticWebAssetsSdk/Tasks/JSModules/ApplyJsModules.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
+[MSBuildMultiThreadableTask]
 public class ApplyJsModules : Task
 {
     [Required]


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/14053
Migrate ApplyJsModules to IMultiThreadableTask 