### PR TITLE
Fix flaky SubLevelCommandNameShouldBeSentToTelemetry test on macOS

### DIFF
--- a/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
@@ -57,7 +58,17 @@ public class TelemetryFilterTests : SdkTest
         // other tests that may have dynamically added template names (e.g. "console")
         // as subcommands to the static Parser.RootCommand's "new" command.
         // See InstantiateCommand.ExecuteAsync which mutates the static parser tree.
-        var parseResult = new DotNetCommandDefinition().Parse(["new", "console"], Parser.ParserConfiguration);
+        var rootCommand = new DotNetCommandDefinition();
+        // Remove the built-in VersionOption that conflicts with the SDK's custom --version option.
+        // In production, Parser.NormalizeRootOptions handles this, but it's private.
+        for (int i = rootCommand.Options.Count - 1; i >= 0; i--)
+        {
+            if (rootCommand.Options[i] is VersionOption)
+            {
+                rootCommand.Options.RemoveAt(i);
+            }
+        }
+        var parseResult = rootCommand.Parse(["new", "console"], Parser.ParserConfiguration);
         TelemetryEventEntry.SendFiltered(parseResult);
         _fakeTelemetry
             .LogEntries.Should()

--- a/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Utilities;
@@ -52,7 +53,11 @@ public class TelemetryFilterTests : SdkTest
     [Fact]
     public void SubLevelCommandNameShouldBeSentToTelemetry()
     {
-        var parseResult = Parser.Parse(["new", "console"]);
+        // Use a fresh DotNetCommandDefinition to avoid test pollution from
+        // other tests that may have dynamically added template names (e.g. "console")
+        // as subcommands to the static Parser.RootCommand's "new" command.
+        // See InstantiateCommand.ExecuteAsync which mutates the static parser tree.
+        var parseResult = new DotNetCommandDefinition().Parse(["new", "console"], Parser.ParserConfiguration);
         TelemetryEventEntry.SendFiltered(parseResult);
         _fakeTelemetry
             .LogEntries.Should()


### PR DESCRIPTION
## Summary

Fixes #54746

The `SubLevelCommandNameShouldBeSentToTelemetry` test was intermittently failing on the macOS arm64 CI leg (`osx.15.arm64.open`).

## Root Cause

`InstantiateCommand.ExecuteAsync` dynamically adds template names (e.g., "console") as subcommands to the static `Parser.RootCommand`'s `NewCommand`. This mutation persists for the process lifetime. When another test in the same xUnit process triggers template instantiation before this test runs, "console" becomes a registered subcommand — causing System.CommandLine to classify it as `TokenType.Command` instead of `TokenType.Argument`. The `AllowListToSendVerbSecondVerbFirstArgument` telemetry rule then reports `subcommand="CONSOLE", argument=""` instead of the expected `argument="CONSOLE"`.

The intermittent nature is due to non-deterministic xUnit test ordering, which varies by platform/scheduler.

## Fix

Parse against a fresh `DotNetCommandDefinition()` instance instead of the static `Parser.RootCommand` singleton. This guarantees the parser tree has not been mutated by prior template instantiations.

## Testing

- Build verified locally
- The fix ensures deterministic behavior regardless of test execution order