### PR TITLE
Reduce sdk-build job timeout from 150 to 50 minutes

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -15,7 +15,7 @@ parameters:
   testRunnerAdditionalArguments: ''
   enableSbom: true
   populateInternalRuntimeVariables: false
-  timeoutInMinutes: 150
+  timeoutInMinutes: 50
   ### ENV VARS ###
   testFullMSBuild: false
   runAoTTests: false


### PR DESCRIPTION
Now that tests are queued to Helix rather than run inline, the build legs complete much faster. The previous 150-minute timeout wastes significant compute when a job hangs (e.g. [build 1462067](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1462067) where a macOS job hung for the full 150 minutes on SDK install).

## Analysis

Sampled 7 recent successful PR builds (definition 101) and measured build leg durations (excluding Dotnet-Format Integration Tests):

| Job | Min | Avg | Max |
|-----|-----|-----|-----|
| TestBuild: macOS (arm64) | 24.1 | 34.8 | **39.9** |
| AoT: macOS (arm64) | 24.3 | 26.7 | 29.0 |
| TestBuild: windows (x64) | 21.7 | 23.2 | 27.8 |
| FullFramework: windows (x64) | 22.0 | 23.3 | 25.6 |
| TestBuild: linux (x64) | 16.8 | 17.3 | 18.1 |
| AoT: windows (x64) | 15.3 | 16.3 | 18.5 |
| TestBuild: linux (arm64) | 10.1 | 10.4 | 10.6 |

The worst-case observed is ~40 minutes (macOS arm64 TestBuild). A 50-minute timeout provides ~25% headroom above the observed maximum while cutting wasted compute by ~67% when hangs occur.