### PR TITLE
Migrate ComputeStaticWebAssetsTargetPaths

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ComputeStaticWebAssetsTargetPaths.cs
@@ -7,7 +7,8 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public class ComputeStaticWebAssetsTargetPaths : Task
+[MSBuildMultiThreadableTask]
+public class ComputeStaticWebAssetsTargetPaths : Task, IMultiThreadableTask
 {
     [Required]
     public ITaskItem[] Assets { get; set; }
@@ -21,6 +22,8 @@ public class ComputeStaticWebAssetsTargetPaths : Task
     [Output]
     public ITaskItem[] AssetsWithTargetPath { get; set; }
 
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public override bool Execute()
     {
         try
@@ -33,7 +36,7 @@ public class ComputeStaticWebAssetsTargetPaths : Task
 
             for (var i = 0; i < Assets.Length; i++)
             {
-                var staticWebAsset = StaticWebAsset.FromTaskItem(Assets[i]);
+                var staticWebAsset = StaticWebAsset.FromTaskItem(Assets[i], TaskEnvironment);
                 var result = staticWebAsset.ToTaskItem();
 
                 var targetPath = staticWebAsset.ComputeTargetPath(

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Moq;
+
+namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
+
+public class ComputeStaticWebAssetsTargetPathsMultiThreadingTest
+{
+    [Fact]
+    public void ResolvesRelativeContentRootAgainstTaskEnvironmentProjectDirectoryNotProcessCurrentDirectory()
+    {
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(ComputeStaticWebAssetsTargetPathsMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "decoy", "spawn");
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(spawnDir);
+
+        const string relativeContentRoot = "wwwroot";
+
+        var projectAbsoluteContentRoot = Path.GetFullPath(Path.Combine(projectDir, relativeContentRoot));
+        var spawnAbsoluteContentRoot = Path.GetFullPath(Path.Combine(spawnDir, relativeContentRoot));
+        projectAbsoluteContentRoot.Should().NotBe(spawnAbsoluteContentRoot,
+            "the test setup must place project and decoy in different parents so a relative path resolves differently against each");
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new ComputeStaticWebAssetsTargetPaths
+            {
+                BuildEngine = buildEngine.Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                Assets = [CreateCandidateWithRelativeContentRoot(Path.Combine(relativeContentRoot, "candidate.js"), relativeContentRoot)],
+                PathPrefix = "wwwroot",
+            };
+
+            var result = task.Execute();
+
+            result.Should().Be(true, "the task must run to completion when TaskEnvironment.ProjectDirectory differs from the process CWD");
+            errorMessages.Should().BeEmpty();
+            task.AssetsWithTargetPath.Should().ContainSingle();
+
+            // The relative ContentRoot must be absolutized against the task's ProjectDirectory,
+            // not the process current working directory (the decoy). This is the multithreaded-safe behavior.
+            var contentRoot = task.AssetsWithTargetPath[0].GetMetadata("ContentRoot");
+            contentRoot.Should().StartWith(projectAbsoluteContentRoot);
+            contentRoot.Should().NotStartWith(spawnAbsoluteContentRoot);
+
+            // The computed TargetPath is unaffected by the ContentRoot resolution.
+            task.AssetsWithTargetPath[0].GetMetadata("TargetPath").Should().Be(Path.Combine("wwwroot", "candidate.js"));
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    private static ITaskItem CreateCandidateWithRelativeContentRoot(string itemSpec, string relativeContentRoot)
+    {
+        // Intentionally skips Normalize() so the relative ContentRoot reaches the task unmodified.
+        var result = new StaticWebAsset()
+        {
+            Identity = Path.GetFullPath(itemSpec),
+            SourceId = "MyPackage",
+            SourceType = "Discovered",
+            ContentRoot = relativeContentRoot,
+            BasePath = "base",
+            RelativePath = "candidate.js",
+            AssetKind = "All",
+            AssetMode = "All",
+            AssetRole = "Primary",
+            RelatedAsset = "",
+            AssetTraitName = "",
+            AssetTraitValue = "",
+            CopyToOutputDirectory = "",
+            CopyToPublishDirectory = "",
+            OriginalItemSpec = itemSpec,
+            // Add these to avoid accessing the disk to compute them
+            Integrity = "integrity",
+            Fingerprint = "fingerprint",
+            FileLength = 10,
+            LastWriteTime = DateTime.UtcNow,
+        };
+
+        return result.ToTaskItem();
+    }
+}

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
@@ -9,6 +9,12 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[CollectionDefinition("ProcessState", DisableParallelization = true)]
+public class ProcessStateCollection
+{
+}
+
+[Collection("ProcessState")]
 public class ComputeStaticWebAssetsTargetPathsMultiThreadingTest
 {
     [Fact]
@@ -65,7 +71,7 @@ public class ComputeStaticWebAssetsTargetPathsMultiThreadingTest
             Directory.SetCurrentDirectory(originalCurrentDirectory);
             if (Directory.Exists(testRoot))
             {
-                Directory.Delete(testRoot, recursive: true);
+                try { Directory.Delete(testRoot, recursive: true); } catch { }
             }
         }
     }


### PR DESCRIPTION
Fixes dotnet/msbuild#14056
## Migrate `ComputeStaticWebAssetsTargetPaths` to multithreaded task support

### Summary
Migrates the `ComputeStaticWebAssetsTargetPaths` task to be compatible with MSBuild's multithreaded execution model, where tasks can't rely on process-global state like the current working directory.

### Changes
- Annotated the task with `[MSBuildMultiThreadableTask]` and implemented `IMultiThreadableTask` (with `TaskEnvironment = TaskEnvironment.Fallback`).
- Passed `TaskEnvironment` into `StaticWebAsset.FromTaskItem()` so relative path metadata (e.g. `ContentRoot`) is absolutized against the project directory instead of the process CWD.
- Added a focused unit test (`ComputeStaticWebAssetsTargetPathsMultiThreadingTest`) verifying the task resolves a **relative** `ContentRoot` from the project directory.

This follows the established `ComputeEndpointsForReferenceStaticWebAssets` migration pattern in this repo.

### Compatibility notes
No observable behavior change for existing callers:
- `Assets` is `[Required]`, so there's no null/empty edge case.
- The `[Output] AssetsWithTargetPath` carries the original `TargetPath`; the computed value is unchanged.
- No error messages use the absolutized path, and no `??`/try-catch semantics changed.
- `FromTaskItem`'s default overload uses `TaskEnvironment.Fallback`, which is pass-through for already-absolute production paths, so existing absolute-path inputs are preserved.

### Validation
- Builds clean (source + test projects).
- All 4 relevant unit tests pass (3 existing regression + 1 new).
- Ran the MSBuild **ThreadSafeTaskAnalyzer**: **0** direct `MSBuildTask0001`–`0004` diagnostics on this task (analyzer confirmed working — diagnostics reported on other unmigrated tasks, 0 crashes).