### PR TITLE
Migrate FilterStaticWebAssetGroups

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/FilterStaticWebAssetGroups.cs
+++ b/src/StaticWebAssetsSdk/Tasks/FilterStaticWebAssetGroups.cs
@@ -11,8 +11,12 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 // When SkipDeferred=true (first pass / pre-filter), groups marked Deferred are skipped.
 // When SkipDeferred=false (final pass), all groups must be concrete — an error is raised
 // if any group is still marked Deferred.
-public class FilterStaticWebAssetGroups : Task
+[MSBuildMultiThreadableTask]
+public class FilterStaticWebAssetGroups : Task, IMultiThreadableTask
 {
+    /// <inheritdoc/>
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     [Required]
     public ITaskItem[] Assets { get; set; }
 
@@ -66,7 +70,7 @@ public class FilterStaticWebAssetGroups : Task
             }
         }
 
-        var parsedAssets = StaticWebAsset.FromTaskItemGroup(Assets);
+        var parsedAssets = StaticWebAsset.FromTaskItemGroup(Assets, TaskEnvironment);
         var (_, excludedAssetFiles) = StaticWebAsset.FilterByGroup(parsedAssets, groups, SkipDeferred, Source);
 
         // Null out excluded entries in-place — MSBuild ignores null ITaskItem[] entries,

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/FilterStaticWebAssetGroupsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/FilterStaticWebAssetGroupsTest.cs
@@ -127,6 +127,26 @@ public class FilterStaticWebAssetGroupsTest : IDisposable
     }
 
     [Fact]
+    public void CascadingExclusion_RelatedAssetPathResolvedAgainstTaskEnvironment()
+    {
+        var primary = CreateAssetItem("server.js", "MyLib", "ServerRendering=true");
+        var related = CreateRelatedAssetItem("server.js.gz", "server.js.gz", "MyLib", primary, relatedAsset: "server.js");
+
+        var primaryEndpoint = CreateEndpointItem("server.js", primary.ItemSpec);
+        var relatedEndpoint = CreateEndpointItem("server.js.gz", related.ItemSpec);
+
+        var (task, result) = ExecuteFilterTask(
+            new[] { primary, related },
+            new[] { primaryEndpoint, relatedEndpoint },
+            new[] { CreateGroup("ServerRendering", "false", "MyLib") },
+            taskEnvironment: TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(_tempDir));
+
+        result.Should().BeTrue();
+        task.FilteredAssets.Where(a => a != null).Should().HaveCount(0, "the related asset path should resolve against the project directory");
+        task.SurvivingEndpoints.Should().HaveCount(0);
+    }
+
+    [Fact]
     public void EndpointsFiltered_ForExcludedAssets()
     {
         var includedAsset = CreateAssetItem("app.js", "MyLib", "");
@@ -203,11 +223,13 @@ public class FilterStaticWebAssetGroupsTest : IDisposable
         ITaskItem[] assets,
         ITaskItem[] endpoints,
         ITaskItem[] groups = null,
-        bool skipDeferred = false)
+        bool skipDeferred = false,
+        TaskEnvironment taskEnvironment = null)
     {
         var task = new FilterStaticWebAssetGroups
         {
             BuildEngine = _buildEngine.Object,
+            TaskEnvironment = taskEnvironment ?? TaskEnvironment.Fallback,
             Assets = assets,
             Endpoints = endpoints,
             SkipDeferred = skipDeferred,
@@ -217,7 +239,7 @@ public class FilterStaticWebAssetGroupsTest : IDisposable
         return (task, result);
     }
 
-    private ITaskItem CreateRelatedAssetItem(string fileName, string relativePath, string sourceId, ITaskItem primaryAsset, string traitName = "Content-Encoding", string traitValue = "gzip")
+    private ITaskItem CreateRelatedAssetItem(string fileName, string relativePath, string sourceId, ITaskItem primaryAsset, string traitName = "Content-Encoding", string traitValue = "gzip", string relatedAsset = null)
     {
         var filePath = Path.Combine(_tempDir, fileName);
         if (!File.Exists(filePath))
@@ -235,7 +257,7 @@ public class FilterStaticWebAssetGroupsTest : IDisposable
             ["AssetKind"] = "All",
             ["AssetMode"] = "All",
             ["AssetRole"] = "Alternative",
-            ["RelatedAsset"] = primaryAsset.ItemSpec,
+            ["RelatedAsset"] = relatedAsset ?? primaryAsset.ItemSpec,
             ["AssetTraitName"] = traitName,
             ["AssetTraitValue"] = traitValue,
             ["AssetGroups"] = "",


### PR DESCRIPTION
Fixes dotnet/msbuild#14057
## Migrate `FilterStaticWebAssetGroups` to multithreaded task support

### Summary
Makes `FilterStaticWebAssetGroups` compatible with MSBuild's multithreaded execution model, where tasks can't rely on process-global state like the current working directory.

### Changes
- Annotated with `[MSBuildMultiThreadableTask]` and implemented `IMultiThreadableTask` (`TaskEnvironment = TaskEnvironment.Fallback`).
- Passed `TaskEnvironment` into `StaticWebAsset.FromTaskItemGroup()` so relative path metadata (`ContentRoot`, `RelatedAsset`) is absolutized against the project directory instead of the process CWD — the task's only env-sensitive operation.

Follows the existing `ComputeEndpointsForReferenceStaticWebAssets` migration pattern.

### Compatibility notes
- `Assets`/`Endpoints` are `[Required]` — no null/empty edge case.
- Endpoint flow is pure pass-through (endpoints never mutated; `ToTaskItem()` returns the original item), so no `TaskEnvironment` needed there.
- `excludedAssetFiles` uses `asset.Identity` (well-known `FullPath`), which `Normalize(env)` doesn't touch — endpoint matching unaffected.
- No `[Output]` or error message carries an absolutized path; no `??`/try-catch semantics changed.

### Validation
- Source + test projects build clean (0 errors).
- Existing `FilterStaticWebAssetGroupsTest` covers inclusion, exclusion, cascading exclusion, deferred handling, and endpoint filtering.
- MSBuild **ThreadSafeTaskAnalyzer**: **0** `MSBuildTask0001`–`0005` diagnostics on this task (0 transitive). Analyzer confirmed working — 80 diagnostics on other unmigrated tasks, 0 crashes.