### PR TITLE
Adjust CI build timeouts: 60m default, 90m macOS x64

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -83,6 +83,7 @@ stages:
           vmImage: macOS-latest
           os: macOS
         helixTargetQueue: osx.15.amd64.open
+        timeoutInMinutes: 90
         macOSJobParameterSets:
         - categoryName: TestBuild
           runtimeIdentifier: osx-x64

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -15,7 +15,7 @@ parameters:
   testRunnerAdditionalArguments: ''
   enableSbom: true
   populateInternalRuntimeVariables: false
-  timeoutInMinutes: 50
+  timeoutInMinutes: 60
   ### ENV VARS ###
   testFullMSBuild: false
   runAoTTests: false


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/sdk/pull/54752. I forgot the slowness and variability of the x64 Mac legs which only run in CI. Also giving the other legs a little more breathing room.

- Default timeout: 50m → 60m
- macOS x64 (CI-only): 90m