### PR TITLE
Use MSBuild SHA instead of VMR SHA but keep both

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/DotnetVersionFile.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/DotnetVersionFile.cs
@@ -11,6 +11,8 @@ public class DotnetVersionFile
 
     public string? CommitSha { get; init; }
 
+    public string? VmrCommitSha { get; init; }
+
     public string? BuildNumber { get; init; }
 
     public string? FullNugetVersion { get; init; }
@@ -58,6 +60,10 @@ public class DotnetVersionFile
                 else if (index == 4)
                 {
                     SdkFeatureBand = line;
+                }
+                else if (index == 5)
+                {
+                    VmrCommitSha = line.Length >= 10 ? line.Substring(0, 10) : line;
                 }
                 else
                 {

--- a/src/Cli/dotnet/ParserOptionActions.cs
+++ b/src/Cli/dotnet/ParserOptionActions.cs
@@ -149,6 +149,10 @@ internal class PrintInfoAction(Option<bool> option) : InvocableOptionAction(opti
         Reporter.Output.WriteLine($"{LocalizableStrings.DotNetSdkInfoLabel}");
         Reporter.Output.WriteLine($" Version:           {Product.Version}");
         Reporter.Output.WriteLine($" Commit:            {commitSha}");
+        if (!string.IsNullOrEmpty(versionFile.VmrCommitSha) && versionFile.VmrCommitSha != versionFile.CommitSha)
+        {
+            Reporter.Output.WriteLine($" VMR Commit:        {versionFile.VmrCommitSha}");
+        }
 #if !CLI_AOT
         // Workload and MSBuild version reporting are not AOT-compatible yet (they pull in the
         // workload manager and MSBuild forwarding machinery), so they are omitted from the AOT build.

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -30,13 +30,23 @@
   </Target>
 
   <Target Name="PublishVersionFile">
+    <PropertyGroup>
+      <!-- When building from the VMR, SourceRevisionId is the VMR commit. Prefer the original
+           product-repo (dotnet/sdk) commit so the SDK commit reported by the CLI maps back to
+           this repository. Falls back to SourceRevisionId for standalone builds. -->
+      <_SdkRevisionId Condition="'$(RepoOriginalSourceRevisionId)' != ''">$(RepoOriginalSourceRevisionId)</_SdkRevisionId>
+      <_SdkRevisionId Condition="'$(_SdkRevisionId)' == ''">$(SourceRevisionId)</_SdkRevisionId>
+      <!-- In VMR builds, also record the VMR commit as a trailing line so it remains available. -->
+      <_VmrRevisionSuffix Condition="'$(RepoOriginalSourceRevisionId)' != '' and '$(SourceRevisionId)' != ''">;$(SourceRevisionId)</_VmrRevisionSuffix>
+    </PropertyGroup>
+
     <WriteLinesToFile File="$(OutputPath).toolsetversion"
-                      Lines="$(SourceRevisionId);$(Version);$(TargetRid)"
+                      Lines="$(_SdkRevisionId);$(Version);$(TargetRid)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
     <WriteLinesToFile File="$(OutputPath).version"
-                      Lines="$(SourceRevisionId);$(Version);$(TargetRid);$(FullNugetVersion);$(SdkFeatureBand)"
+                      Lines="$(_SdkRevisionId);$(Version);$(TargetRid);$(FullNugetVersion);$(SdkFeatureBand)$(_VmrRevisionSuffix)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
   </Target>


### PR DESCRIPTION
Related to dotnet/msbuild#13832 (SDK-side follow-up; companion to the MSBuild change)

### Context
When the SDK is built in the VMR (dotnet/dotnet), the commit written into the SDK's `.version`
file (via `$(SourceRevisionId)`) is the **VMR** commit, not the dotnet/sdk commit. That commit is
what `dotnet --info` reports as `Commit:`, so it can't be traced back to dotnet/sdk source.

The VMR already passes the original product-repo commit to the per-repo build as
`RepoOriginalSourceRevisionId`. This change surfaces that commit as the primary SDK commit and keeps
the VMR commit as secondary info — mirroring the MSBuild banner change for the same issue.

### Changes Made
- `src/Layout/redist/targets/GenerateLayout.targets`: the commit written to `.version` and
  `.toolsetversion` (line 1) now prefers `RepoOriginalSourceRevisionId`, falling back to
  `SourceRevisionId` for standalone builds. In VMR builds the VMR commit is appended to `.version`
  as a trailing line so it remains available.
- `src/Cli/Microsoft.DotNet.Cli.CoreUtils/DotnetVersionFile.cs`: parse the optional trailing line
  into a new `VmrCommitSha` property (the parser previously stopped after index 4, so standalone
  builds are unaffected).
- `src/Cli/dotnet/ParserOptionActions.cs`: `dotnet --info` prints a secondary `VMR Commit:` line
  when it differs from the primary `Commit:`.

### Testing
- Standalone build: `.version` is unchanged (5 lines, line 1 = `SourceRevisionId`) and `dotnet --info`
  shows no `VMR Commit:` line — byte-for-byte identical to today.
- Simulated VMR build (`/p:RepoOriginalSourceRevisionId=aaaa…`):
  - `.version` line 1 = the source-repo commit, with the real source revision appended as a 6th line.
  - `dotnet --info` renders:
    - ` Commit:            aaaaaaaaaa`
    - ` VMR Commit:        db0a641af6`
- Existing CLI tests are unaffected (the only test touching this asserts the `Commit:` label is
  present, not its value).

### Notes
- The `MSBuild version:` line in `dotnet --info` already reads `ProjectCollection.DisplayVersion`
  (`MSBuildForwardingAppWithoutLogging.cs`), so it leads with the MSBuild source commit automatically
  once the corresponding MSBuild change (dotnet/msbuild#13832) flows in — no SDK change needed for it.
- `.version` gains the trailing VMR line only in VMR builds; line-indexed readers (host, VS) read the
  earlier lines and ignore it, so this is backward compatible.
- The `Commit:` / `VMR Commit:` labels are hardcoded English, consistent with the existing `--info`
  field labels (only the section headers are localized), so no `.resx`/`.xlf` change is needed.
- Depends on the VMR supplying `RepoOriginalSourceRevisionId` to the per-repo build (already the case).