### PR TITLE
Migrate GenerateStaticWebAssetEndpointsPropsFile

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
@@ -91,7 +91,7 @@ public class GenerateStaticWebAssetEndpointsPropsFile : Task, IMultiThreadableTa
 
     private void WriteFile(byte[] data)
     {
-        AbsolutePath targetPropsFilePath = TaskEnvironment.GetAbsolutePath(TargetPropsFilePath);
+        var targetPropsFilePath = string.IsNullOrWhiteSpace(TargetPropsFilePath) ? TargetPropsFilePath : TaskEnvironment.GetAbsolutePath(TargetPropsFilePath).Value;
         var dataHash = ComputeHash(data);
         var fileExists = File.Exists(targetPropsFilePath);
         var existingFileHash = fileExists ? ComputeHash(File.ReadAllBytes(targetPropsFilePath)) : "";

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
@@ -9,7 +9,8 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public class GenerateStaticWebAssetEndpointsPropsFile : Task
+[MSBuildMultiThreadableTask]
+public class GenerateStaticWebAssetEndpointsPropsFile : Task, IMultiThreadableTask
 {
     [Required]
     public string TargetPropsFilePath { get; set; }
@@ -22,10 +23,12 @@ public class GenerateStaticWebAssetEndpointsPropsFile : Task
     [Required]
     public ITaskItem[] StaticWebAssetEndpoints { get; set; }
 
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public override bool Execute()
     {
         var endpoints = StaticWebAssetEndpoint.FromItemGroup(StaticWebAssetEndpoints);
-        var assets = StaticWebAsset.ToAssetDictionary(StaticWebAssets);
+        var assets = StaticWebAsset.ToAssetDictionary(StaticWebAssets, TaskEnvironment);
         if (!ValidateArguments(endpoints, assets))
         {
             return false;
@@ -88,19 +91,20 @@ public class GenerateStaticWebAssetEndpointsPropsFile : Task
 
     private void WriteFile(byte[] data)
     {
+        AbsolutePath targetPropsFilePath = TaskEnvironment.GetAbsolutePath(TargetPropsFilePath);
         var dataHash = ComputeHash(data);
-        var fileExists = File.Exists(TargetPropsFilePath);
-        var existingFileHash = fileExists ? ComputeHash(File.ReadAllBytes(TargetPropsFilePath)) : "";
+        var fileExists = File.Exists(targetPropsFilePath);
+        var existingFileHash = fileExists ? ComputeHash(File.ReadAllBytes(targetPropsFilePath)) : "";
 
         if (!fileExists)
         {
             Log.LogMessage(MessageImportance.Low, $"Creating file '{TargetPropsFilePath}' does not exist.");
-            File.WriteAllBytes(TargetPropsFilePath, data);
+            File.WriteAllBytes(targetPropsFilePath, data);
         }
         else if (!string.Equals(dataHash, existingFileHash, StringComparison.Ordinal))
         {
             Log.LogMessage(MessageImportance.Low, $"Updating '{TargetPropsFilePath}' file because the hash '{dataHash}' is different from existing file hash '{existingFileHash}'.");
-            File.WriteAllBytes(TargetPropsFilePath, data);
+            File.WriteAllBytes(targetPropsFilePath, data);
         }
         else
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -160,6 +160,53 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
         errorMessages[0].Should().Be($"""The asset file '{Path.GetFullPath(Path.Combine("wwwroot", "js", "sample.js"))}' specified in the endpoint '{Path.Combine("js","sample.js").Replace('\\', '/')}' does not exist.""");
     }
 
+    [Fact]
+    public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory()
+    {
+        WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
+        {
+            // Arrange
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new GenerateStaticWebAssetEndpointsPropsFile
+            {
+                BuildEngine = buildEngine.Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                StaticWebAssets =
+                [
+                    CreateStaticWebAsset(
+                        Path.Combine("wwwroot", "js", "sample.js"),
+                        "MyLibrary",
+                        "Discovered",
+                        Path.Combine("js", "sample.js"),
+                        "All",
+                        "All")
+                ],
+                StaticWebAssetEndpoints =
+                [
+                    CreateStaticWebAssetEndpoint(
+                        Path.Combine("js", "sample.js").Replace('\\', '/'),
+                        Path.Combine("wwwroot", "js", "sample.js"))
+                ],
+                PackagePathPrefix = "staticwebassets",
+                TargetPropsFilePath = "endpoints.props",
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().BeTrue();
+            errorMessages.Should().BeEmpty();
+            new FileInfo(Path.Combine(projectDir, "endpoints.props")).Should().Exist(
+                "a relative TargetPropsFilePath must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD");
+            File.Exists(Path.Combine(spawnDir, "endpoints.props")).Should().BeFalse();
+        });
+    }
+
     private static ITaskItem CreateStaticWebAsset(
         string itemSpec,
         string sourceId,
@@ -213,5 +260,29 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
             EndpointProperties = properties ?? [],
             Selectors = responseSelector ?? []
         }.ToTaskItem();
+    }
+
+    private static void WithDecoyCwdAndProjectDirectory(Action<string, string> body)
+    {
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(GenerateStaticWebAssetEndpointsPropsFileTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "decoy", "spawn");
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(spawnDir);
+
+        var originalCwd = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+            body(projectDir, spawnDir);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCwd);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes dotnet/msbuild#14058

## Migrate `GenerateStaticWebAssetEndpointsPropsFile` to multithreaded task support

### Summary

Migrates the `GenerateStaticWebAssetEndpointsPropsFile` task to be compatible with
MSBuild's multithreaded execution model, where tasks can't rely on
process-global state like the current working directory.

### Changes

- Annotated the task with `[MSBuildMultiThreadableTask]` and implemented `IMultiThreadableTask`
  with `TaskEnvironment = TaskEnvironment.Fallback`.
- Passed `TaskEnvironment` into `StaticWebAsset.ToAssetDictionary()` so relative
  path metadata is absolutized against the project directory instead of the process CWD.
- Absolutized `TargetPropsFilePath` before file system operations while preserving
  the original value in log messages.
- Added a focused unit test verifying a relative `TargetPropsFilePath` is resolved
  from the project directory.

This follows the established Static Web Assets migration pattern used by
`ComputeEndpointsForReferenceStaticWebAssets` and `StaticWebAssetsGeneratePackagePropsFile`.

### Compatibility notes

No observable behavior change for existing callers:

- `TargetPropsFilePath`, `StaticWebAssets`, and `StaticWebAssetEndpoints` are `[Required]`.
- The task has no `[Output]` properties, so no absolutized path can leak into task outputs.
- Log messages continue to use the original `TargetPropsFilePath` value.
- `StaticWebAsset.ToAssetDictionary(..., TaskEnvironment)` preserves asset identity keys,
  so endpoint-to-asset lookup behavior remains unchanged.
- No new path canonicalization is introduced for dictionary keys or user-visible values.

### Validation

- Built `src/StaticWebAssetsSdk/Tasks/Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj`
- Built `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj`
- Ran `GenerateStaticWebAssetEndpointsPropsFileTest` with the repo-local dotnet test runner