### PR TITLE
Migrate ReadStaticWebAssetsManifestFile

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ReadStaticWebAssetsManifestFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ReadStaticWebAssetsManifestFile.cs
@@ -29,16 +29,7 @@ public class ReadStaticWebAssetsManifestFile : Task, IMultiThreadableTask
 
     public override bool Execute()
     {
-        AbsolutePath manifestPath;
-        try
-        {
-            manifestPath = TaskEnvironment.GetAbsolutePath(ManifestPath);
-        }
-        catch (ArgumentException)
-        {
-            Log.LogError($"Manifest file at '{ManifestPath}' not found.");
-            return false;
-        }
+        string manifestPath = string.IsNullOrEmpty(ManifestPath) ? ManifestPath : TaskEnvironment.GetAbsolutePath(ManifestPath);
 
         if (!File.Exists(manifestPath))
         {

--- a/src/StaticWebAssetsSdk/Tasks/ReadStaticWebAssetsManifestFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ReadStaticWebAssetsManifestFile.cs
@@ -7,7 +7,8 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public class ReadStaticWebAssetsManifestFile : Task
+[MSBuildMultiThreadableTask]
+public class ReadStaticWebAssetsManifestFile : Task, IMultiThreadableTask
 {
     [Required]
     public string ManifestPath { get; set; }
@@ -24,9 +25,22 @@ public class ReadStaticWebAssetsManifestFile : Task
     [Output]
     public ITaskItem[] ReferencedProjectsConfiguration { get; set; }
 
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
     public override bool Execute()
     {
-        if (!File.Exists(ManifestPath))
+        AbsolutePath manifestPath;
+        try
+        {
+            manifestPath = TaskEnvironment.GetAbsolutePath(ManifestPath);
+        }
+        catch (ArgumentException)
+        {
+            Log.LogError($"Manifest file at '{ManifestPath}' not found.");
+            return false;
+        }
+
+        if (!File.Exists(manifestPath))
         {
             Log.LogError($"Manifest file at '{ManifestPath}' not found.");
             return false;
@@ -34,7 +48,7 @@ public class ReadStaticWebAssetsManifestFile : Task
 
         try
         {
-            var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(ManifestPath));
+            var manifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(manifestPath));
 
             Assets = manifest.Assets?.Select(a => a.ToTaskItem()).ToArray() ?? [];
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Moq;
+
+namespace Microsoft.AspNetCore.Razor.Tasks;
+
+// Test parallelization is disabled assembly-wide via
+// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
+// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
+// process-CWD mutation this test performs.
+public class ReadStaticWebAssetsManifestFileMultiThreadingTest
+{
+    [Fact]
+    public void ReadsManifestRelativeToTaskEnvironmentProjectDirectory()
+    {
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(ReadStaticWebAssetsManifestFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "spawn");
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(spawnDir);
+
+        // Same relative file name in both directories, but with different content so the
+        // source of the read is unambiguous. If the task resolved against the process CWD
+        // (the decoy) instead of the TaskEnvironment.ProjectDirectory, it would read the
+        // decoy manifest and surface "DecoyClassLib".
+        File.WriteAllText(Path.Combine(projectDir, "manifest.json"), ManifestWithDiscoveryPatternSource("ProjectClassLib"));
+        File.WriteAllText(Path.Combine(spawnDir, "manifest.json"), ManifestWithDiscoveryPatternSource("DecoyClassLib"));
+
+        var currentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var buildEngine = new Mock<IBuildEngine>();
+            var task = new ReadStaticWebAssetsManifestFile
+            {
+                BuildEngine = buildEngine.Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                ManifestPath = "manifest.json"
+            };
+
+            task.Execute().Should().BeTrue();
+
+            task.DiscoveryPatterns.Length.Should().Be(1);
+            task.DiscoveryPatterns[0].GetMetadata(nameof(StaticWebAssetsDiscoveryPattern.Source))
+                .Should().Be("ProjectClassLib", "the manifest should be read from the project dir, not the process CWD");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(currentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    private static string ManifestWithDiscoveryPatternSource(string source) => $@"{{
+  ""Version"": 1,
+  ""Hash"": ""__hash__"",
+  ""Source"": ""{source}"",
+  ""BasePath"": ""_content/{source}"",
+  ""Mode"": ""Default"",
+  ""ManifestType"": ""Build"",
+  ""ReferencedProjectsConfiguration"": [ ],
+  ""DiscoveryPatterns"": [
+    {{
+      ""Name"": ""{source}\\wwwroot"",
+      ""Source"": ""{source}"",
+      ""ContentRoot"": ""{source}/wwwroot"",
+      ""BasePath"": ""_content/{source}"",
+      ""Pattern"": ""**""
+    }}
+  ],
+  ""Assets"": [],
+  ""Endpoints"": []
+}}";
+}

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
@@ -349,6 +349,33 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
         }
 
         [Fact]
+        public void ReturnsErrorwhenManifestPathIsEmpty()
+        {
+            var errorMessages = new List<string>();
+            var buildEngine = new Mock<IBuildEngine>();
+            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+            var task = new ReadStaticWebAssetsManifestFile
+            {
+                BuildEngine = buildEngine.Object,
+                ManifestPath = ""
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            result.Should().Be(false);
+            errorMessages.Count.Should().Be(1);
+            errorMessages[0].Should().Be("Manifest file at '' not found.");
+            task.Assets.Should().BeNull();
+            task.Endpoints.Should().BeNull();
+            task.DiscoveryPatterns.Should().BeNull();
+            task.ReferencedProjectsConfiguration.Should().BeNull();
+        }
+
+        [Fact]
         public void ReturnsErrorwhenManifestIsMalformed()
         {
             var errorMessages = new List<string>();

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
         }
 
         [Fact]
-        public void ReturnsErrorwhenManifestPathIsEmpty()
+        public void ReturnsErrorWhenManifestPathIsEmpty()
         {
             var errorMessages = new List<string>();
             var buildEngine = new Mock<IBuildEngine>();


### PR DESCRIPTION
Fixes dotnet/msbuild#14060

### Context

Migrates `ReadStaticWebAssetsManifestFile` to support MSBuild multithreaded task execution. The task reads the static web assets manifest from disk, so it needs to avoid resolving relative paths against process-wide current directory state.

### Changes Made

- Added `[MSBuildMultiThreadableTask]` to `ReadStaticWebAssetsManifestFile`.
- Implemented `IMultiThreadableTask` and initialized `TaskEnvironment` with `TaskEnvironment.Fallback`.
- Absolutized `ManifestPath` with `TaskEnvironment.GetAbsolutePath()` before file system access.
- Preserved existing missing-manifest behavior and error text for valid missing paths and empty/invalid paths.
- Added a focused regression test for empty manifest path handling.

### Testing

- Built `D:\msbuild\src\ThreadSafeTaskAnalyzer\ThreadSafeTaskAnalyzer.csproj`.
- Ran the thread-safe task analyzer against `src\StaticWebAssetsSdk\Tasks\Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj`.
  - No analyzer diagnostics for `ReadStaticWebAssetsManifestFile`.
  - The project still reports unrelated diagnostics in other task files.
- Built `src\StaticWebAssetsSdk\Tasks\Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj`.
- Ran focused tests:
  - `Microsoft.NET.Sdk.StaticWebAssets.Tests.ReadStaticWebAssetsManifestFileTest`
  - Result: 8 passed, 0 failed.
