### PR TITLE
[clr-ios] Keep R2R IL bodies in Debug for Apple mobile RIDs

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripDebugInfo>
 
-    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripILBodies>
+    <PublishReadyToRunStripILBodies Condition="'$(PublishReadyToRunStripILBodies)' == '' and '$(DebuggerSupport)' != 'true' and '$(Configuration)' != 'Debug' and '$(_IsIOSLikeRid)' == 'true'">true</PublishReadyToRunStripILBodies>
 
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>


### PR DESCRIPTION
## Description

Follow-up to #54529. That PR stopped stripping R2R debug and inlining info in `Debug`/`DebuggerSupport` builds for Apple mobile RIDs, but `PublishReadyToRunStripILBodies` still defaulted to `true`, so crossgen2 kept passing `--strip-il-bodies` and dropped the IL method bodies from the R2R image. Apple mobile has no JIT, so methods that fall back to the CoreCLR interpreter and the debugger both need those IL bodies. 