### PR TITLE
Guard against null/whitespace BuildTargetPath in StaticWebAssetsGeneratePackagePropsFile

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackagePropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackagePropsFile.cs
@@ -24,7 +24,7 @@ public class StaticWebAssetsGeneratePackagePropsFile : Task, IMultiThreadableTas
 
     public override bool Execute()
     {
-        AbsolutePath buildTargetPath = TaskEnvironment.GetAbsolutePath(BuildTargetPath);
+        var buildTargetPath = string.IsNullOrWhiteSpace(BuildTargetPath) ? BuildTargetPath : TaskEnvironment.GetAbsolutePath(BuildTargetPath).Value;
 
         var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"));
         var elements = (AdditionalImports ?? []).Select(e => e.ItemSpec).Prepend(PropsFileImport)


### PR DESCRIPTION
## Summary

Adds a null/whitespace guard around `TaskEnvironment.GetAbsolutePath(BuildTargetPath)` in `StaticWebAssetsGeneratePackagePropsFile`, mirroring the pattern already used in the sibling task `GenerateStaticWebAssetsPropsFile` (#54789).

## Background

`BuildTargetPath` is annotated `[Required]`. However, MSBuild's `[Required]` attribute only validates **presence** (that the property setter was invoked), **not** that the value is meaningful. A whitespace-only value such as `"   "` therefore passes required-parameter validation and reaches the task body.

Before this task was migrated to `IMultiThreadableTask`, a whitespace value would have been handled by the old process-relative path logic. After the migration, the value flows into `TaskEnvironment.GetAbsolutePath(...)`, which internally constructs an `AbsolutePath`. The `AbsolutePath` constructor only rejects `null`/empty (`ArgumentException.ThrowIfNullOrEmpty`) and combines the value with `ProjectDirectory` via `Path.Combine`, so a whitespace value is silently turned into a nonsensical path like `<ProjectDirectory>\   ` that later fails at `File.WriteAllBytes` with a confusing `DirectoryNotFoundException`.

## Change

```csharp
var buildTargetPath = string.IsNullOrWhiteSpace(BuildTargetPath)
    ? BuildTargetPath
    : TaskEnvironment.GetAbsolutePath(BuildTargetPath).Value;
```

When `BuildTargetPath` is null or whitespace, the original value is passed through unchanged instead of being resolved against the project directory, keeping this task consistent with `GenerateStaticWebAssetsPropsFile`.

## Notes

- No behavior change for valid inputs: a real `BuildTargetPath` is still resolved against `TaskEnvironment.ProjectDirectory` exactly as before.
- Verified the `Microsoft.NET.Sdk.StaticWebAssets.Tasks` project builds cleanly for both `net11.0` and `net472`.
