### PR TITLE
Use truncating logger by default for all tests

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -20,6 +20,15 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public List<string> EnvironmentToRemove { get; } = new List<string>();
 
+        /// <summary>
+        /// When true, the full command output is echoed to <see cref="Log"/> instead of being capped by a
+        /// <see cref="TruncatingTestOutputHelper"/>. Leave false (the default) so a single very verbose
+        /// command (e.g. <c>dotnet test -v diag</c>) can't flood xUnit's IPC channel and trigger a
+        /// spurious hang-dump timeout. Set it (or call <see cref="WithoutTruncatedOutputLogging"/>) for
+        /// tests that need the complete output in the test log.
+        /// </summary>
+        public bool DisableTruncatedOutputLogging { get; set; }
+
         //  These only work via Execute(), not when using GetProcessStartInfo()
         public Action<string> CommandOutputHandler { get; set; }
         public Action<Process> ProcessStartedHandler { get; set; }
@@ -58,6 +67,16 @@ namespace Microsoft.NET.TestFramework.Commands
         public TestCommand WithTraceOutput()
         {
             WithEnvironmentVariable("DOTNET_CLI_VSTEST_TRACE", "1");
+            return this;
+        }
+
+        /// <summary>
+        /// Opts this command out of bounded output logging so the complete command output is echoed to
+        /// <see cref="Log"/>. See <see cref="DisableTruncatedOutputLogging"/>.
+        /// </summary>
+        public TestCommand WithoutTruncatedOutputLogging()
+        {
+            DisableTruncatedOutputLogging = true;
             return this;
         }
 
@@ -132,7 +151,20 @@ namespace Microsoft.NET.TestFramework.Commands
 
             var result = ((Command)command).Execute(ProcessStartedHandler);
 
-            LogCommandResult(Log, result);
+            // By default, cap how much of the (potentially enormous) command output is echoed to the test
+            // log so a single very verbose command (e.g. `dotnet test -v diag`) can't flush hundreds of
+            // megabytes over the test host's IPC channel and trigger a spurious hang-dump timeout. The full
+            // StdOut/StdErr remain on the returned CommandResult; only the log echo is bounded. Tests that
+            // need the complete output in the log can opt out with WithoutTruncatedOutputLogging().
+            if (DisableTruncatedOutputLogging)
+            {
+                LogCommandResult(Log, result);
+            }
+            else
+            {
+                using var truncatingLog = new TruncatingTestOutputHelper(Log);
+                LogCommandResult(truncatingLog, result);
+            }
 
             return result;
         }

--- a/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
+++ b/test/Microsoft.NET.TestFramework/TruncatingTestOutputHelper.cs
@@ -12,10 +12,22 @@ namespace Microsoft.NET.TestFramework
     /// individual lines can be arbitrarily long.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This is useful for commands that intentionally produce an enormous amount of output (for example
     /// <c>dotnet test -v diag</c>). Echoing every line to xUnit's output buffer can flush hundreds of
     /// megabytes over the test host's single IPC channel when the test completes, which is enough to
     /// starve the blame hang-dump collector's inactivity timer and trigger a spurious timeout.
+    /// </para>
+    /// <para>
+    /// Tail eviction is line-oriented: whole buffered lines (oldest first) are dropped to stay within
+    /// <c>maxTailCharacters</c>, so the retained tail is rounded to line boundaries rather than an exact
+    /// character count. To avoid the degenerate case where a short final line would otherwise evict a
+    /// much larger immediately-preceding line (collapsing the tail to almost nothing), the single oldest
+    /// line that straddles the budget boundary is trimmed from its front instead of dropped — its
+    /// trailing (most recent) portion is kept. A single <see cref="WriteLine(string)"/> larger than the
+    /// tail budget likewise keeps only its final <c>maxTailCharacters</c> characters. The net effect is
+    /// that the tail always retains close to <c>maxTailCharacters</c> of the most recent output.
+    /// </para>
     /// </remarks>
     public sealed class TruncatingTestOutputHelper : ITestOutputHelper, IDisposable
     {
@@ -26,7 +38,7 @@ namespace Microsoft.NET.TestFramework
         private readonly int _maxHeadCharacters;
         private readonly int _maxTailCharacters;
         private readonly object _lock = new();
-        private readonly Queue<string> _tail = new();
+        private readonly LinkedList<string> _tail = new();
 
         private int _headCharactersWritten;
         private bool _headFull;
@@ -93,15 +105,35 @@ namespace Microsoft.NET.TestFramework
                 message = message.Substring(message.Length - _maxTailCharacters);
             }
 
-            _tail.Enqueue(message);
+            _tail.AddLast(message);
             _tailCharacters += message.Length;
 
-            while (_tailCharacters > _maxTailCharacters && _tail.Count > 1)
+            // Evict the oldest content to stay within the tail budget. Whole lines are dropped while a
+            // whole line can be removed without going under budget. The single oldest line that straddles
+            // the boundary is trimmed from its front (keeping its most recent, trailing portion) rather
+            // than dropped, so a short final line can never discard a much larger recent line and leave
+            // the tail nearly empty.
+            while (_tailCharacters > _maxTailCharacters && _tail.Count > 0)
             {
-                string dropped = _tail.Dequeue();
-                _tailCharacters -= dropped.Length;
-                _omittedCharacters += dropped.Length;
-                _omittedLines++;
+                string oldest = _tail.First!.Value;
+                int overBy = _tailCharacters - _maxTailCharacters;
+
+                if (oldest.Length <= overBy)
+                {
+                    _tail.RemoveFirst();
+                    _tailCharacters -= oldest.Length;
+                    _omittedCharacters += oldest.Length;
+                    _omittedLines++;
+                }
+                else
+                {
+                    // Dropping this whole line would remove more than necessary, discarding recent
+                    // output. Trim just its leading (oldest) characters instead.
+                    _tail.First.Value = oldest.Substring(overBy);
+                    _tailCharacters -= overBy;
+                    _omittedCharacters += overBy;
+                    break;
+                }
             }
         }
 
@@ -129,7 +161,7 @@ namespace Microsoft.NET.TestFramework
 
                 _flushed = true;
 
-                if (_omittedLines > 0)
+                if (_omittedCharacters > 0)
                 {
                     _inner.WriteLine($"... [{_omittedLines} lines / {_omittedCharacters} characters of output omitted by {nameof(TruncatingTestOutputHelper)}] ...");
                 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -344,17 +344,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp($"9_{verbosity}");
 
-            // At diagnostic verbosity 'dotnet test -v diag' emits a huge volume of MSBuild output.
-            // Echoing every line to the xUnit ITestOutputHelper makes the test host flush hundreds of
-            // megabytes over its single IPC channel when the test completes, which can starve the blame
-            // hang-dump collector's inactivity timer and trigger a spurious 15-minute timeout. The
-            // assertions below only inspect the captured StdOut, so for the diag case forward just a
-            // bounded head and tail of the output to the log instead of the whole firehose.
-            using var diagOutputLimiter = verbosity == "diag" ? new TruncatingTestOutputHelper(Log) : null;
-            ITestOutputHelper commandLog = diagOutputLimiter ?? Log;
-
             // Call test
-            CommandResult result = new DotnetTestCommand(commandLog, disableNewOutput: true)
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
                                         .WithWorkingDirectory(testProjectDirectory)
                                         .Execute("-v", verbosity);
 

--- a/test/dotnet-test.Tests/TruncatingTestOutputHelperTests.cs
+++ b/test/dotnet-test.Tests/TruncatingTestOutputHelperTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.Test.Tests
+{
+    public class TruncatingTestOutputHelperTests
+    {
+        private sealed class RecordingOutputHelper : ITestOutputHelper
+        {
+            public List<string> Lines { get; } = new();
+
+            public void WriteLine(string message) => Lines.Add(message);
+
+            public void WriteLine(string format, params object[] args) => Lines.Add(string.Format(format, args));
+        }
+
+        private static bool IsOmissionNote(string line) => line.Contains(nameof(TruncatingTestOutputHelper));
+
+        [Fact]
+        public void OutputWithinBudgetIsForwardedUnchanged()
+        {
+            var inner = new RecordingOutputHelper();
+            using (var helper = new TruncatingTestOutputHelper(inner))
+            {
+                helper.WriteLine("first");
+                helper.WriteLine("second");
+            }
+
+            inner.Lines.Should().Equal("first", "second");
+        }
+
+        [Fact]
+        public void MiddleIsDroppedButHeadAndTailArePreserved()
+        {
+            var inner = new RecordingOutputHelper();
+            using (var helper = new TruncatingTestOutputHelper(inner, maxHeadCharacters: 5, maxTailCharacters: 5))
+            {
+                helper.WriteLine("aaaaa"); // fills the head
+                helper.WriteLine("bbbbb"); // middle, should be dropped
+                helper.WriteLine("ccccc"); // most recent, should be kept as tail
+            }
+
+            inner.Lines.First().Should().Be("aaaaa");
+            inner.Lines.Last().Should().Be("ccccc");
+            inner.Lines.Should().ContainSingle(l => IsOmissionNote(l));
+            inner.Lines.Should().NotContain("bbbbb");
+        }
+
+        [Fact]
+        public void TailKeepsRecentContentWhenFinalLineIsTiny()
+        {
+            // Michael Simons' review edge case: a short final line must not evict a much larger
+            // immediately-preceding line and leave the tail with essentially nothing.
+            var inner = new RecordingOutputHelper();
+            using (var helper = new TruncatingTestOutputHelper(inner, maxHeadCharacters: 0, maxTailCharacters: 10))
+            {
+                helper.WriteLine(new string('A', 9));
+                helper.WriteLine("BBB");
+            }
+
+            string tail = string.Concat(inner.Lines.Where(l => !IsOmissionNote(l)));
+            // The retained tail holds the most recent ~10 characters (the trailing 'A's plus "BBB"),
+            // not just the tiny final "BBB" (which is what whole-line eviction would have left).
+            tail.Should().Be(new string('A', 7) + "BBB");
+            tail.Length.Should().Be(10);
+        }
+
+        [Fact]
+        public void SingleMessageLargerThanBudgetForwardsOnlyHeadAndTailPortions()
+        {
+            var inner = new RecordingOutputHelper();
+            using (var helper = new TruncatingTestOutputHelper(inner, maxHeadCharacters: 5, maxTailCharacters: 5))
+            {
+                helper.WriteLine(new string('x', 100));
+            }
+
+            int forwardedCharacters = inner.Lines.Where(l => !IsOmissionNote(l)).Sum(l => l.Length);
+            forwardedCharacters.Should().Be(10); // 5 head + 5 tail, not the whole 100
+            inner.Lines.Should().ContainSingle(l => IsOmissionNote(l));
+        }
+
+        [Fact]
+        public void WriteBufferedTailIsIdempotent()
+        {
+            var inner = new RecordingOutputHelper();
+            var helper = new TruncatingTestOutputHelper(inner, maxHeadCharacters: 0, maxTailCharacters: 5);
+            helper.WriteLine("abcdef"); // 6 chars, trimmed to last 5
+
+            helper.WriteBufferedTail();
+            int countAfterFirstFlush = inner.Lines.Count;
+            helper.WriteBufferedTail();
+
+            inner.Lines.Count.Should().Be(countAfterFirstFlush);
+            inner.Lines.Last().Should().Be("bcdef");
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #54642.  Fixes some issues @MichaelSimons found, and enables the truncating logger for all tests, rather than just the one that I had noticed was timing out due to large logs.