### PR TITLE
Derive blame-hang-timeout as a percentage of Helix work item timeout

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -277,8 +277,11 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 }
                 else
                 {
+                    // blame-hang-timeout is set to a % of the Helix work item timeout so that blame can
+                    // collect hang dumps and write the TRX file before Helix hard-kills the process.
+                    var blameHangTimeout = TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.8);
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout 60m {testFilter} {enableDiagLogging} {arguments}";
+                              $"{(XUnitArguments != null ? " " + XUnitArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout {blameHangTimeout.TotalMinutes:0}m {testFilter} {enableDiagLogging} {arguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");


### PR DESCRIPTION
## Summary

The `--blame-hang-timeout` was hardcoded to `60m`, which equals the Helix work item timeout (`XUnitWorkItemTimeout`). This creates a race condition where Helix hard-kills the process (exit code -3) at the same time blame would fire, preventing blame from collecting hang dumps and TRX files. As a result, timed-out work items produce no test logs at all.

## Changes

Instead of hardcoding the blame timeout, derive it as a percentage of the Helix work item timeout (currently 80%). This ensures:

- Blame always fires before the Helix kill, regardless of what the work item timeout is set to
- The two values are inherently linked — changing `XUnitWorkItemTimeout` automatically adjusts the blame timeout
- The percentage is defined in one place, making it easy to tune without hunting for hardcoded values
- For the current 1-hour timeout, this gives a blame-hang-timeout of 48 minutes, leaving 12 minutes for blame to detect hung tests and collect diagnostics

## Root Cause

Observed in builds [1466423](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1466423), [1466026](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1466026), and [1465477](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1465477) on macOS legs — 19-21 work items per build failing with exit code -3 (Helix timeout kill), all with zero blame activity in the logs.