### PR TITLE
Add WithRetryOnExitCode to TestCommand for transient file lock failures

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -10,6 +10,7 @@ namespace Microsoft.NET.TestFramework.Commands
     public abstract class TestCommand
     {
         private readonly Dictionary<string, string> _environment = [];
+        private readonly HashSet<int> _retryOnExitCodes = [];
         private bool _doNotEscapeArguments;
         public ITestOutputHelper Log { get; }
         public string? WorkingDirectory { get; set; }
@@ -85,6 +86,16 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public TestCommand WithCulture(string locale) => WithEnvironmentVariable(UILanguageOverride.DOTNET_CLI_UI_LANGUAGE, locale);
 
+        /// <summary>
+        /// Configures the command to retry when the specified exit code is returned.
+        /// Useful for transient errors like file locks from background processes.
+        /// </summary>
+        public TestCommand WithRetryOnExitCode(int exitCode)
+        {
+            _retryOnExitCodes.Add(exitCode);
+            return this;
+        }
+
         public TestCommand WithTraceOutput()
         {
             WithEnvironmentVariable("DOTNET_CLI_VSTEST_TRACE", "1");
@@ -135,18 +146,23 @@ namespace Microsoft.NET.TestFramework.Commands
             IEnumerable<string> enumerableArgs = args;
             return ExecuteWithRetry(
                     action: () => Execute(enumerableArgs),
-                    shouldStopRetry: SuccessOrNotTransientRestoreError,
+                    shouldStopRetry: ShouldStopRetry,
                     maxRetryCount: 3,
                     timer: () => Timer(Intervals),
-                    taskDescription: "Run command while retry transient restore error")
+                    taskDescription: "Run command while retry transient error")
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        private static bool SuccessOrNotTransientRestoreError(CommandResult result)
+        private bool ShouldStopRetry(CommandResult result)
         {
             if (result.ExitCode == 0)
             {
                 return true;
+            }
+
+            if (_retryOnExitCodes.Contains(result.ExitCode))
+            {
+                return false;
             }
 
             return !NuGetTransientErrorDetector.IsTransientError(result.StdOut);

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -87,7 +87,7 @@ namespace Microsoft.NET.TestFramework.Commands
         public TestCommand WithCulture(string locale) => WithEnvironmentVariable(UILanguageOverride.DOTNET_CLI_UI_LANGUAGE, locale);
 
         /// <summary>
-        /// Configures the command to retry when the specified exit code is returned.
+        /// Configures the command to retry when the specified exit code is returned (only when executing via Execute()/Execute(params string[])).
         /// Useful for transient errors like file locks from background processes.
         /// </summary>
         public TestCommand WithRetryOnExitCode(int exitCode)

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -149,7 +149,7 @@ namespace Microsoft.NET.TestFramework.Commands
                     shouldStopRetry: ShouldStopRetry,
                     maxRetryCount: 3,
                     timer: () => Timer(Intervals),
-                    taskDescription: "Run command while retry transient error")
+                    taskDescription: "Run command while retrying transient errors")
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 

--- a/test/dotnet-new.IntegrationTests/DotnetNewInstantiateTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewInstantiateTests.cs
@@ -110,6 +110,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             Utils.CommandResult forceCommandResult = new DotnetNewCommand(_log, "console", "--no-restore", "--force")
                 .WithCustomHive(_fixture.HomeDirectory)
                 .WithWorkingDirectory(workingDirectory)
+                .WithRetryOnExitCode(100)
                 .Execute();
 
             forceCommandResult.Should()


### PR DESCRIPTION
## Summary

Adds a `WithRetryOnExitCode(int exitCode)` fluent API to the `TestCommand` base class, allowing any integration test to opt into retry when a specific exit code is returned. This is used to fix the intermittent `CanOverwriteFilesWithForce` test failure.

## Problem

The `DotnetNewInstantiateTests.CanOverwriteFilesWithForce` test intermittently fails with exit code 100 ("Failed to create template") due to transient file locks from background processes (antivirus, indexers, etc.) preventing overwrite of `.csproj` files. This has been observed on both Windows and Linux:

- Build [1465471](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1465471) (Linux x64, Jun 15)
- Build [1456514](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1456514) (Windows, Jun 9)

## Solution

- Added `WithRetryOnExitCode(int exitCode)` to `TestCommand`, which leverages the existing `ExponentialRetry` infrastructure (immediate → 5s → 50s, max 3 retries).
- Refactored the retry stop-predicate from a static method (`SuccessOrNotTransientRestoreError`) to an instance method (`ShouldStopRetry`) that also checks the configurable exit code set.
- Applied `.WithRetryOnExitCode(100)` to the `--force` command in `CanOverwriteFilesWithForce`.

## Testing

- `CanOverwriteFilesWithForce` passes locally.
- The retry API is generic and can be reused for other intermittent test failures.