### PR TITLE
Fix dotnetup official builds

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -228,10 +228,33 @@ jobs:
       continueOnError: true
       condition: always()
 
+    # Publish the leg's Shipping packages as a <JobName>_Assets pipeline artifact, but only when
+    # there's something to publish. A scoped build (e.g. the dotnetup build, which builds only
+    # dotnetup via /p:Projects) produces no Shipping packages, and 1ES.PublishPipelineArtifact
+    # fails hard on a missing targetPath (it doesn't honor continueOnError there), so guard the
+    # step on the directory actually containing files.
+    - ${{ if eq(parameters.pool.os, 'windows') }}:
+      - powershell: |
+          $dir = "$(Build.SourcesDirectory)/artifacts/packages/$(buildConfiguration)/Shipping"
+          $hasAssets = (Test-Path $dir) -and ((Get-ChildItem -Path $dir -File -Recurse -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0)
+          Write-Host "##vso[task.setvariable variable=HasBuiltAssets]$($hasAssets.ToString().ToLowerInvariant())"
+        displayName: 🟣 Check for built assets
+        condition: not(canceled())
+    - ${{ else }}:
+      - bash: |
+          dir="$(Build.SourcesDirectory)/artifacts/packages/$(buildConfiguration)/Shipping"
+          if [ -d "$dir" ] && [ -n "$(find "$dir" -type f -print -quit)" ]; then
+            echo "##vso[task.setvariable variable=HasBuiltAssets]true"
+          else
+            echo "##vso[task.setvariable variable=HasBuiltAssets]false"
+          fi
+        displayName: 🟣 Check for built assets
+        condition: not(canceled())
+
     - task: ${{ parameters.oneESCompat.publishTaskPrefix }}PublishPipelineArtifact@1
       displayName: 🟣 Publish Built Assets
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/packages/$(buildConfiguration)/Shipping
         artifactName: $(System.PhaseName)_Assets
       continueOnError: true
-      condition: not(canceled())
+      condition: and(not(canceled()), eq(variables['HasBuiltAssets'], 'true'))

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -23,6 +23,9 @@ parameters:
   targetArchitecture: x64
   publishArgument: ''
   signArgument: ''
+  # MSBuild /p:Projects argument used to scope the build to specific projects (e.g. a .slnf).
+  # Defaults to empty, which builds the repo's default solution.
+  projectsArgument: ''
   pgoInstrument: false
   enableDefaultArtifacts: false
   runtimeIdentifier: linux-x64
@@ -94,6 +97,7 @@ jobs:
           -configuration $(buildConfiguration)
           ${{ parameters.publishArgument }}
           ${{ parameters.signArgument }}
+          ${{ parameters.projectsArgument }}
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }}
           /p:TargetArchitecture=${{ parameters.targetArchitecture }}
           /p:PgoInstrument=${{ parameters.pgoInstrument }}
@@ -117,6 +121,7 @@ jobs:
           -configuration $(buildConfiguration) \
           ${{ parameters.publishArgument }} \
           ${{ parameters.signArgument }} \
+          ${{ parameters.projectsArgument }} \
           /p:EnableDefaultArtifacts=${{ parameters.enableDefaultArtifacts }} \
           /p:TargetArchitecture=${{ parameters.targetArchitecture }} \
           /p:PgoInstrument=${{ parameters.pgoInstrument }} \


### PR DESCRIPTION
It looks like since we merged main into release/dnup (#54586), the official dotnetup builds have been failing.  That means recent fixes such as #54733 and #54694 haven't been published.

- Fixes YAML so that the project argument is correctly forwarded.  Without this, we were unintentionally building the whole sdk.slnx in the dotnetup pipeline, and hitting a signing error with xUnit v3
- Skips Publish Build Assets task if there are no assets to publish, which is now the case on our MacOS legs

@MichaelSimons In the release/dnup branch, we were hitting issues where xUnit v3 libraries were making their way into the list of assemblies to sign, and were failing.  You may want to verify whether this is happening on main and if there are any signing issues there.