### PR TITLE
Fix solution file discovery to prefer local .slnx over ancestor .sln in post-actions

### DIFF
--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -47,7 +47,7 @@ internal class DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, 
             directory = Path.GetDirectoryName(directory);
         }
 
-        return []
+        return [];
     }
 
     // The project files to add are a subset of the primary outputs, specifically the primary outputs indicated by the primaryOutputIndexes post action argument (semicolon separated)

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -20,8 +20,30 @@ internal class DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, 
 
     internal static IReadOnlyList<string> FindSolutionFilesAtOrAbovePath(IPhysicalFileSystem fileSystem, string outputBasePath)
     {
-        var slnFiles = FileFindHelpers.FindFilesAtOrAbovePath(fileSystem, outputBasePath, "*.sln");
-        return slnFiles.Count > 0 ? slnFiles : FileFindHelpers.FindFilesAtOrAbovePath(fileSystem, outputBasePath, "*.slnx");
+        // Search for .sln and .slnx at each directory level before traversing to parent.
+        // At each level, .sln is preferred over .slnx.
+        // This prevents finding stray .sln files in ancestor directories when the intended
+        // .slnx file exists in the output directory (which can happen with parallel test runs).
+        string? directory = fileSystem.DirectoryExists(outputBasePath) ? outputBasePath : Path.GetDirectoryName(outputBasePath);
+        do
+        {
+            var slnFiles = fileSystem.EnumerateFileSystemEntries(directory!, "*.sln", SearchOption.TopDirectoryOnly).ToList();
+            if (slnFiles.Count > 0)
+            {
+                return slnFiles;
+            }
+
+            var slnxFiles = fileSystem.EnumerateFileSystemEntries(directory!, "*.slnx", SearchOption.TopDirectoryOnly).ToList();
+            if (slnxFiles.Count > 0)
+            {
+                return slnxFiles;
+            }
+
+            directory = Path.GetPathRoot(directory) != directory ? Directory.GetParent(directory!)?.FullName : null;
+        }
+        while (directory != null);
+
+        return [];
     }
 
     // The project files to add are a subset of the primary outputs, specifically the primary outputs indicated by the primaryOutputIndexes post action argument (semicolon separated)

--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -25,25 +25,29 @@ internal class DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, 
         // This prevents finding stray .sln files in ancestor directories when the intended
         // .slnx file exists in the output directory (which can happen with parallel test runs).
         string? directory = fileSystem.DirectoryExists(outputBasePath) ? outputBasePath : Path.GetDirectoryName(outputBasePath);
-        do
+        while (!string.IsNullOrEmpty(directory))
         {
-            var slnFiles = fileSystem.EnumerateFileSystemEntries(directory!, "*.sln", SearchOption.TopDirectoryOnly).ToList();
+            var slnFiles = fileSystem.EnumerateFileSystemEntries(directory, "*.sln", SearchOption.TopDirectoryOnly).ToList();
             if (slnFiles.Count > 0)
             {
                 return slnFiles;
             }
 
-            var slnxFiles = fileSystem.EnumerateFileSystemEntries(directory!, "*.slnx", SearchOption.TopDirectoryOnly).ToList();
+            var slnxFiles = fileSystem.EnumerateFileSystemEntries(directory, "*.slnx", SearchOption.TopDirectoryOnly).ToList();
             if (slnxFiles.Count > 0)
             {
                 return slnxFiles;
             }
 
-            directory = Path.GetPathRoot(directory) != directory ? Directory.GetParent(directory!)?.FullName : null;
-        }
-        while (directory != null);
+            if (Path.GetPathRoot(directory) == directory)
+            {
+                break;
+            }
 
-        return [];
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        return []
     }
 
     // The project files to add are a subset of the primary outputs, specifically the primary outputs indicated by the primaryOutputIndexes post action argument (semicolon separated)

--- a/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
@@ -61,6 +61,29 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.Equal(slnFileFullPath, solutionFiles[0]);
         }
 
+        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/49923
+        public void AddProjectToSolutionPostActionPrefersLocalSlnxOverParentSln()
+        {
+            string parentPath = _engineEnvironmentSettings.GetTempVirtualizedPath();
+            _engineEnvironmentSettings.Host.VirtualizeDirectory(parentPath);
+            EnsureParentDirectoriesExist(parentPath);
+
+            string childPath = Path.Combine(parentPath, "output");
+            _engineEnvironmentSettings.Host.FileSystem.CreateDirectory(childPath);
+
+            // Place a .sln in the parent (simulating another test's stray file)
+            string parentSlnFile = Path.Combine(parentPath, "Stray.sln");
+            _engineEnvironmentSettings.Host.FileSystem.WriteAllText(parentSlnFile, string.Empty);
+
+            // Place a .slnx in the child (the intended solution file)
+            string childSlnxFile = Path.Combine(childPath, "MySolution.slnx");
+            _engineEnvironmentSettings.Host.FileSystem.WriteAllText(childSlnxFile, string.Empty);
+
+            IReadOnlyList<string> solutionFiles = DotnetSlnPostActionProcessor.FindSolutionFilesAtOrAbovePath(_engineEnvironmentSettings.Host.FileSystem, childPath);
+            Assert.Single(solutionFiles);
+            Assert.Equal(childSlnxFile, solutionFiles[0]);
+        }
+
         [Fact(DisplayName = nameof(AddProjectToSolutionPostActionFindsOneProjectToAdd))]
         public void AddProjectToSolutionPostActionFindsOneProjectToAdd()
         {


### PR DESCRIPTION
## Summary

When `dotnet new` runs the "add project to solution" post-action, it searches for a solution file starting from the output directory and walking up the parent hierarchy. Previously, the search looked for `*.sln` across the **entire** ancestor chain first, and only fell back to `*.slnx` if no `.sln` was found anywhere. This meant a `.slnx` in the output directory would be ignored if any `.sln` existed in an ancestor directory.

Since `dotnet new sln` now creates `.slnx` files by default, this caused incorrect behavior: the post-action would target an unrelated `.sln` in a parent directory instead of the intended local `.slnx`.

## Fix

Changed `FindSolutionFilesAtOrAbovePath` to search for both `.sln` and `.slnx` at **each directory level** before traversing to the parent, while still preferring `.sln` over `.slnx` within the same directory.

## Observable difference

| Scenario | Old behavior | New behavior |
|----------|-------------|-------------|
| `.slnx` in output dir, `.sln` in ancestor dir | Finds the **ancestor's `.sln`** (ignores local `.slnx`) | Finds the **local `.slnx`** ✅ |
| `.sln` in output dir only | Same — finds it | Same |
| `.slnx` in output dir only, no `.sln` anywhere | Same — finds it | Same |
| `.sln` and `.slnx` in same dir | Same — prefers `.sln` | Same |

## The one scenario that changes

A user runs `dotnet new <template>` in a directory that has a `.slnx` file, but an ancestor directory also has a `.sln` file. Previously, the project would be added to the **ancestor's `.sln`**. Now it's added to the **local `.slnx`**.

A user with a `.slnx` in their working directory almost certainly intends for the new project to be added there, not to some unrelated `.sln` higher up the tree. The old behavior was an unintended consequence of the two-pass search approach when `.slnx` support was added.

## Discovery

This was discovered via intermittent CI test failures where a stray `.sln` file in the Helix temp directory hierarchy was found by the ancestor search, causing the post-action to target a file that was subsequently deleted by another parallel test:
- [Build 1466643](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1466643)
- [Build 1466026](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1466026&view=ms.vss-test-web.build-test-results-tab&runId=40527762&resultId=113154)

## Test

Added `AddProjectToSolutionPostActionPrefersLocalSlnxOverParentSln` — a regression test that places a `.sln` in a parent directory and a `.slnx` in the output directory, verifying the local `.slnx` is found.