### PR TITLE
Allow comments and trailing commas in launchSettings.json profile parsing

### DIFF
--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileJsonSerializerContext.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileJsonSerializerContext.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.ProjectTools;
 
+[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)]
 [JsonSerializable(typeof(ProjectLaunchProfile))]
 [JsonSerializable(typeof(ExecutableLaunchProfile))]
 internal partial class LaunchProfileJsonSerializerContext : JsonSerializerContext;

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -84,6 +84,50 @@ public class LaunchSettingsParserTests
     }
 
     [Fact]
+    public void CommentsAndTrailingCommas_Executable()
+    {
+        var parser = ExecutableLaunchProfileParser.Instance;
+
+        var result = parser.ParseProfile("path", "name", """
+            {
+                // line comment
+                "commandName": "Executable",
+                "executablePath": "executable", /* block comment */
+                "environmentVariables": {
+                    "VAR1": "VALUE1", // trailing comma below
+                },
+            }
+            """);
+
+        Assert.True(result.Successful);
+        var model = Assert.IsType<ExecutableLaunchProfile>(result.Profile);
+        Assert.Equal("executable", model.ExecutablePath);
+        Assert.Equal([("VAR1", "VALUE1")], model.EnvironmentVariables.Select(e => (e.Key, e.Value)));
+    }
+
+    [Fact]
+    public void CommentsAndTrailingCommas_Project()
+    {
+        var parser = ProjectLaunchProfileParser.Instance;
+
+        var result = parser.ParseProfile("path", "name", """
+            {
+                // line comment
+                "commandName": "Project",
+                "commandLineArgs": "arg1", /* block comment */
+                "environmentVariables": {
+                    "VAR1": "VALUE1", // trailing comma below
+                },
+            }
+            """);
+
+        Assert.True(result.Successful);
+        var model = Assert.IsType<ProjectLaunchProfile>(result.Profile);
+        Assert.Equal("arg1", model.CommandLineArgs);
+        Assert.Equal([("VAR1", "VALUE1")], model.EnvironmentVariables.Select(e => (e.Key, e.Value)));
+    }
+
+    [Fact]
     public void EnvironmentVariableExpansion_Executable()
     {
         var root = Path.GetTempPath();


### PR DESCRIPTION
Fixes #54155 (and unblocks microsoft/testfx#7952).

### Problem
`dotnet run` fails to read a `launchSettings.json` that contains JSON comments or trailing commas:

```
The launch profile "(Default)" could not be applied.
An error was encountered when reading '...launchSettings.json': '/' is invalid after a value. ...
```

### Root cause
`LaunchSettings.ReadProfileSettingsFromFile` parses the whole file with a `JsonDocument` configured with `JsonCommentHandling.Skip` / `AllowTrailingCommas = true`, then hands the selected profile's **raw text** (`JsonElement.GetRawText()`, which still contains any comments) to the source-generated `ProjectLaunchProfileParser` / `ExecutableLaunchProfileParser`. Those deserializers used `LaunchProfileJsonSerializerContext` with no comment/trailing-comma handling, so they throw.

This is a regression introduced when profile parsing moved to source-generated deserialization.

### Fix
Add `[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)]` to `LaunchProfileJsonSerializerContext`, matching the top-level `JsonDocument` options and the `dotnet-watch` launch settings reader.

### Tests
Added regression tests `CommentsAndTrailingCommas_Executable` / `CommentsAndTrailingCommas_Project` to `LaunchSettingsParserTests`. All `LaunchSettingsParserTests` pass locally.