### PR TITLE
Add Native AOT support for tool list --local, tool run, tool uninstall --local, and tool search

### DIFF
--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -148,4 +148,34 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\BundledTargetFramework.cs" Link="BundledTargetFramework.cs" />
   </ItemGroup>
 
+  <!--
+    'dotnet tool' command (AOT-capable subset): the parser plus the real implementations of the
+    local 'tool list'/'tool uninstall', 'tool run', and 'tool search'. The shared manifest/package
+    and command-resolution infrastructure is already linked above (for AOT tool resolution); this
+    group adds only the pieces unique to running these subcommands in-process. The global/tool-path
+    variants and install/update/restore/execute fall back to the managed CLI and are not linked.
+  -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\PrintableTable.cs" Link="PrintableTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\ToolCommandParser.cs" Link="Commands\Tool\ToolCommandParser.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Common\ToolManifestFinderExtensions.cs" Link="Commands\Tool\Common\ToolManifestFinderExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\List\ToolListLocalCommand.cs" Link="Commands\Tool\List\ToolListLocalCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\List\ToolListJsonHelper.cs" Link="Commands\Tool\List\ToolListJsonHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Uninstall\ToolUninstallLocalCommand.cs" Link="Commands\Tool\Uninstall\ToolUninstallLocalCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Run\ToolRunCommand.cs" Link="Commands\Tool\Run\ToolRunCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Search\ToolSearchCommand.cs" Link="Commands\Tool\Search\ToolSearchCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Search\SearchResultPrinter.cs" Link="Commands\Tool\Search\SearchResultPrinter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Tool\Search\NugetSearchSerializables.cs" Link="Commands\Tool\Search\NugetSearchSerializables.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\AuthorsConverter.cs" Link="NugetSearch\AuthorsConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\INugetToolSearchApiRequest.cs" Link="NugetSearch\INugetToolSearchApiRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiParameter.cs" Link="NugetSearch\NugetSearchApiParameter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiRequestException.cs" Link="NugetSearch\NugetSearchApiRequestException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiResultDeserializer.cs" Link="NugetSearch\NugetSearchApiResultDeserializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetToolSearchApiRequest.cs" Link="NugetSearch\NugetToolSearchApiRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiSerializable\NugetSearchApiAuthorsSerializable.cs" Link="NugetSearch\NugetSearchApiSerializable\NugetSearchApiAuthorsSerializable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiSerializable\NugetSearchApiContainerSerializable.cs" Link="NugetSearch\NugetSearchApiSerializable\NugetSearchApiContainerSerializable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiSerializable\NugetSearchApiPackageSerializable.cs" Link="NugetSearch\NugetSearchApiSerializable\NugetSearchApiPackageSerializable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetSearch\NugetSearchApiSerializable\NugetSearchApiVersionSerializable.cs" Link="NugetSearch\NugetSearchApiSerializable\NugetSearchApiVersionSerializable.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Cli/dotnet/Commands/Tool/ToolCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Tool/ToolCommandParser.cs
@@ -2,15 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+#if !CLI_AOT
 using Microsoft.DotNet.Cli.Commands.Tool.Execute;
 using Microsoft.DotNet.Cli.Commands.Tool.Install;
-using Microsoft.DotNet.Cli.Commands.Tool.List;
 using Microsoft.DotNet.Cli.Commands.Tool.Restore;
+using Microsoft.DotNet.Cli.Commands.Tool.Update;
+using Microsoft.DotNet.Cli.Extensions;
+#endif
+using Microsoft.DotNet.Cli.Commands.Tool.List;
 using Microsoft.DotNet.Cli.Commands.Tool.Run;
 using Microsoft.DotNet.Cli.Commands.Tool.Search;
 using Microsoft.DotNet.Cli.Commands.Tool.Uninstall;
-using Microsoft.DotNet.Cli.Commands.Tool.Update;
-using Microsoft.DotNet.Cli.Extensions;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool;
 
@@ -18,8 +20,31 @@ internal static class ToolCommandParser
 {
     public static void ConfigureCommand(ToolCommandDefinition command)
     {
-        command.SetAction(parseResult => parseResult.HandleMissingCommand());
+#if CLI_AOT
+        // bare `dotnet tool` needs the full help output, which falls back to the managed CLI.
+        command.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
 
+        // Only the local `list`/`uninstall`, `run`, and `search` paths run in AOT. The
+        // `--global`/`--tool-path` variants and `install`/`update`/`restore`/`execute` depend on
+        // NuGet package install/restore infrastructure that isn't AOT-ready, so they throw
+        // CommandNotAvailableInAotException; NativeEntryPoint catches it and hosts the managed CLI.
+        command.ListCommand.SetAction(parseResult =>
+            command.ListCommand.LocationOptions.IsGlobalOrToolPath(parseResult)
+                ? throw new CommandNotAvailableInAotException()
+                : new ToolListLocalCommand(parseResult).Execute());
+        command.UninstallCommand.SetAction(parseResult =>
+            command.UninstallCommand.LocationOptions.IsGlobalOrToolPath(parseResult)
+                ? throw new CommandNotAvailableInAotException()
+                : new ToolUninstallLocalCommand(parseResult).Execute());
+        command.RunCommand.SetAction(parseResult => new ToolRunCommand(parseResult).Execute());
+        command.SearchCommand.SetAction(parseResult => new ToolSearchCommand(parseResult).Execute());
+
+        command.InstallCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
+        command.UpdateCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
+        command.RestoreCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
+        command.ExecuteCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
+#else
+        command.SetAction(parseResult => parseResult.HandleMissingCommand());
         command.InstallCommand.SetAction(parseResult => new ToolInstallCommand(parseResult).Execute());
         command.UninstallCommand.SetAction(parseResult => new ToolUninstallCommand(parseResult).Execute());
         command.UpdateCommand.SetAction(parseResult => new ToolUpdateCommand(parseResult).Execute());
@@ -28,5 +53,6 @@ internal static class ToolCommandParser
         command.SearchCommand.SetAction(parseResult => new ToolSearchCommand(parseResult).Execute());
         command.RestoreCommand.SetAction(parseResult => new ToolRestoreCommand(parseResult).Execute());
         command.ExecuteCommand.SetAction(parseResult => new ToolExecuteCommand(parseResult).Execute());
+#endif
     }
 }

--- a/src/Cli/dotnet/Commands/Tool/ToolCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Tool/ToolCommandParser.cs
@@ -21,13 +21,12 @@ internal static class ToolCommandParser
     public static void ConfigureCommand(ToolCommandDefinition command)
     {
 #if CLI_AOT
-        // bare `dotnet tool` needs the full help output, which falls back to the managed CLI.
-        command.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
-
-        // Only the local `list`/`uninstall`, `run`, and `search` paths run in AOT. The
-        // `--global`/`--tool-path` variants and `install`/`update`/`restore`/`execute` depend on
-        // NuGet package install/restore infrastructure that isn't AOT-ready, so they throw
-        // CommandNotAvailableInAotException; NativeEntryPoint catches it and hosts the managed CLI.
+        // ConfigureAotActions already set every `tool` subcommand (and the bare `tool` command) to
+        // throw CommandNotAvailableInAotException by default, so we only override the paths that run
+        // in AOT. Only the local `list`/`uninstall`, `run`, and `search` paths are AOT-capable; the
+        // `--global`/`--tool-path` variants and `install`/`update`/`restore`/`execute` keep the
+        // default fallback because they depend on NuGet package install/restore infrastructure that
+        // isn't AOT-ready. NativeEntryPoint catches the exception and hosts the managed CLI.
         command.ListCommand.SetAction(parseResult =>
             command.ListCommand.LocationOptions.IsGlobalOrToolPath(parseResult)
                 ? throw new CommandNotAvailableInAotException()
@@ -38,11 +37,6 @@ internal static class ToolCommandParser
                 : new ToolUninstallLocalCommand(parseResult).Execute());
         command.RunCommand.SetAction(parseResult => new ToolRunCommand(parseResult).Execute());
         command.SearchCommand.SetAction(parseResult => new ToolSearchCommand(parseResult).Execute());
-
-        command.InstallCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
-        command.UpdateCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
-        command.RestoreCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
-        command.ExecuteCommand.SetAction((Func<ParseResult, int>)(_ => throw new CommandNotAvailableInAotException()));
 #else
         command.SetAction(parseResult => parseResult.HandleMissingCommand());
         command.InstallCommand.SetAction(parseResult => new ToolInstallCommand(parseResult).Execute());

--- a/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
@@ -5,8 +5,13 @@
 
 using System.Collections.Specialized;
 using System.Web;
+#if CLI_AOT
+using System.Text.Json;
+using System.Text.Json.Serialization;
+#else
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+#endif
 
 namespace Microsoft.DotNet.Cli.NugetSearch;
 
@@ -79,6 +84,73 @@ internal class NugetToolSearchApiRequest : INugetToolSearchApiRequest
     }
 
     // More detail on this API https://github.com/dotnet/sdk/issues/12038
+#if CLI_AOT
+    // NuGet.Protocol's service-index resolution isn't AOT-compatible, so under AOT we read the
+    // service index directly over HTTP and select the SearchQueryService endpoint using
+    // System.Text.Json source generation. Failures are translated into NugetSearchApiRequestException
+    // (a GracefulException) with the same retriable/non-retriable messaging as GetResult.
+    private static async Task<Uri> DomainAndPath()
+    {
+        const string serviceIndexUrl = "https://api.nuget.org/v3/index.json";
+        const string searchQueryServiceType = "SearchQueryService/3.5.0";
+
+        using var httpClient = new HttpClient();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient.GetAsync(serviceIndexUrl, cancellation.Token);
+        }
+        catch (Exception e) when (e is HttpRequestException or OperationCanceledException)
+        {
+            // Transient network failures (DNS, connection refused, timeout) are retriable.
+            throw new NugetSearchApiRequestException(
+                string.Format(
+                    CliStrings.RetriableNugetSearchFailure,
+                    serviceIndexUrl, e.Message, "N/A"));
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
+            {
+                throw new NugetSearchApiRequestException(
+                    string.Format(
+                        CliStrings.RetriableNugetSearchFailure,
+                        serviceIndexUrl, response.ReasonPhrase, response.StatusCode));
+            }
+
+            throw new NugetSearchApiRequestException(
+                string.Format(
+                    CliStrings.NonRetriableNugetSearchFailure,
+                    serviceIndexUrl, response.ReasonPhrase, response.StatusCode));
+        }
+
+        var indexJson = await response.Content.ReadAsStringAsync(cancellation.Token);
+
+        NugetServiceIndex index;
+        try
+        {
+            index = JsonSerializer.Deserialize(indexJson, NugetServiceIndexJsonSerializerContext.Default.NugetServiceIndex);
+        }
+        catch (JsonException e)
+        {
+            throw new NugetSearchApiRequestException(
+                string.Format(
+                    CliStrings.NonRetriableNugetSearchFailure,
+                    serviceIndexUrl, e.Message, response.StatusCode));
+        }
+
+        var resource = index?.Resources?.FirstOrDefault(r => r.Type == searchQueryServiceType)
+            ?? throw new NugetSearchApiRequestException(
+                string.Format(
+                    CliStrings.NonRetriableNugetSearchFailure,
+                    serviceIndexUrl, $"{searchQueryServiceType} not found in service index", response.StatusCode));
+
+        return new Uri(resource.Id);
+    }
+#else
     private static async Task<Uri> DomainAndPath()
     {
         var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
@@ -86,4 +158,25 @@ internal class NugetToolSearchApiRequest : INugetToolSearchApiRequest
         var uris = resource.GetServiceEntryUris("SearchQueryService/3.5.0");
         return uris[0];
     }
+#endif
 }
+
+#if CLI_AOT
+internal sealed class NugetServiceIndex
+{
+    [JsonPropertyName("resources")]
+    public NugetServiceResource[] Resources { get; set; }
+}
+
+internal sealed class NugetServiceResource
+{
+    [JsonPropertyName("@id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("@type")]
+    public string Type { get; set; }
+}
+
+[JsonSerializable(typeof(NugetServiceIndex))]
+internal partial class NugetServiceIndexJsonSerializerContext : JsonSerializerContext;
+#endif

--- a/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
+++ b/src/Cli/dotnet/NugetSearch/NugetToolSearchApiRequest.cs
@@ -111,44 +111,58 @@ internal class NugetToolSearchApiRequest : INugetToolSearchApiRequest
                     serviceIndexUrl, e.Message, "N/A"));
         }
 
-        if (!response.IsSuccessStatusCode)
+        using (response)
         {
-            if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
+            if (!response.IsSuccessStatusCode)
             {
+                if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
+                {
+                    throw new NugetSearchApiRequestException(
+                        string.Format(
+                            CliStrings.RetriableNugetSearchFailure,
+                            serviceIndexUrl, response.ReasonPhrase, response.StatusCode));
+                }
+
                 throw new NugetSearchApiRequestException(
                     string.Format(
-                        CliStrings.RetriableNugetSearchFailure,
+                        CliStrings.NonRetriableNugetSearchFailure,
                         serviceIndexUrl, response.ReasonPhrase, response.StatusCode));
             }
 
-            throw new NugetSearchApiRequestException(
-                string.Format(
-                    CliStrings.NonRetriableNugetSearchFailure,
-                    serviceIndexUrl, response.ReasonPhrase, response.StatusCode));
+            var indexJson = await response.Content.ReadAsStringAsync(cancellation.Token);
+
+            NugetServiceIndex index;
+            try
+            {
+                index = JsonSerializer.Deserialize(indexJson, NugetServiceIndexJsonSerializerContext.Default.NugetServiceIndex);
+            }
+            catch (JsonException e)
+            {
+                throw new NugetSearchApiRequestException(
+                    string.Format(
+                        CliStrings.NonRetriableNugetSearchFailure,
+                        serviceIndexUrl, e.Message, response.StatusCode));
+            }
+
+            var resource = index?.Resources?.FirstOrDefault(r => r.Type == searchQueryServiceType)
+                ?? throw new NugetSearchApiRequestException(
+                    string.Format(
+                        CliStrings.NonRetriableNugetSearchFailure,
+                        serviceIndexUrl, $"{searchQueryServiceType} not found in service index", response.StatusCode));
+
+            // The service index is server-supplied, so don't trust the URL to be well-formed.
+            try
+            {
+                return new Uri(resource.Id);
+            }
+            catch (Exception e) when (e is UriFormatException or ArgumentException)
+            {
+                throw new NugetSearchApiRequestException(
+                    string.Format(
+                        CliStrings.NonRetriableNugetSearchFailure,
+                        serviceIndexUrl, $"{searchQueryServiceType} returned a malformed URL: {e.Message}", response.StatusCode));
+            }
         }
-
-        var indexJson = await response.Content.ReadAsStringAsync(cancellation.Token);
-
-        NugetServiceIndex index;
-        try
-        {
-            index = JsonSerializer.Deserialize(indexJson, NugetServiceIndexJsonSerializerContext.Default.NugetServiceIndex);
-        }
-        catch (JsonException e)
-        {
-            throw new NugetSearchApiRequestException(
-                string.Format(
-                    CliStrings.NonRetriableNugetSearchFailure,
-                    serviceIndexUrl, e.Message, response.StatusCode));
-        }
-
-        var resource = index?.Resources?.FirstOrDefault(r => r.Type == searchQueryServiceType)
-            ?? throw new NugetSearchApiRequestException(
-                string.Format(
-                    CliStrings.NonRetriableNugetSearchFailure,
-                    serviceIndexUrl, $"{searchQueryServiceType} not found in service index", response.StatusCode));
-
-        return new Uri(resource.Id);
     }
 #else
     private static async Task<Uri> DomainAndPath()

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -15,6 +15,7 @@ using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Commands.NuGet;
 using Microsoft.DotNet.Cli.Commands.Solution;
 using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Tool;
 using Microsoft.DotNet.Cli.Commands.VSTest;
 using Microsoft.DotNet.Cli.Commands.Workload.Search;
 using Microsoft.DotNet.Cli.Extensions;
@@ -49,7 +50,6 @@ using Microsoft.DotNet.Cli.Commands.Restore;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Run.Api;
 using Microsoft.DotNet.Cli.Commands.Sdk;
-using Microsoft.DotNet.Cli.Commands.Tool;
 using Microsoft.DotNet.Cli.Commands.Tool.Store;
 using Microsoft.DotNet.Cli.Commands.Workload;
 #endif
@@ -201,6 +201,11 @@ public static class Parser
         // fallback defaults above. SolutionCommandParser is AOT-aware: it keeps real implementations
         // for `sln list`/`migrate`/`remove` and falls back for `sln` and `sln add`.
         SolutionCommandParser.ConfigureCommand(rootCommand.SolutionCommand);
+
+        // ToolCommandParser is AOT-aware: it keeps real implementations for the local `tool list`/
+        // `tool uninstall`, `tool run`, and `tool search`, and falls back to the managed CLI for the
+        // global/tool-path variants and for install/update/restore/execute.
+        ToolCommandParser.ConfigureCommand(rootCommand.ToolCommand);
 
         rootCommand.VersionOption.Action = new PrintVersionAction(rootCommand.VersionOption);
         rootCommand.InfoOption.Action = new PrintInfoAction(rootCommand.InfoOption);

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -246,6 +246,52 @@ public class AotParserTests
         Assert.Contains("Usage:", stdout);
     }
 
+    [Theory]
+    [InlineData("tool list")]
+    [InlineData("tool list --local")]
+    [InlineData("tool run mytool")]
+    [InlineData("tool uninstall mypackage")]
+    [InlineData("tool search mysearchterm")]
+    public void ParseAotToolCommand_HasNoErrors(string commandLine)
+    {
+        // The AOT-capable `tool` subcommands (local list/uninstall, run, search) parse cleanly
+        // because their real implementations are linked into the AOT CLI.
+        var result = Parser.Parse(commandLine.Split(' '));
+        Assert.Empty(result.Errors);
+    }
+
+    [Theory]
+    [InlineData("tool list")]
+    [InlineData("tool list --local")]
+    public void InvokeAotToolListCommand_ExecutesWithoutManagedFallback(string commandLine)
+    {
+        // `tool list` is AOT-capable: the real ToolListLocalCommand is linked in. It succeeds even
+        // when no manifest is present (empty output), so invoking it should return 0 rather than
+        // throw CommandNotAvailableInAotException. This catches mis-wired actions that parse-only
+        // tests would miss.
+        var (exitCode, _, _) = InvokeWithCapture(commandLine.Split(' '));
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData("tool list --global")]                  // global list dispatches to managed CLI
+    [InlineData("tool list --tool-path somepath")]      // tool-path list dispatches to managed CLI
+    [InlineData("tool uninstall mypackage --global")]   // global uninstall dispatches to managed CLI
+    [InlineData("tool install mypackage")]              // install is not AOT-capable
+    [InlineData("tool update mypackage")]               // update is not AOT-capable
+    [InlineData("tool restore")]                        // restore is not AOT-capable
+    [InlineData("tool execute dotnetsay")]              // execute is not AOT-capable
+    public void InvokeManagedOnlyToolCommand_FallsBackToManaged(string commandLine)
+    {
+        // The global/tool-path variants and install/update/restore depend on NuGet package
+        // install/restore infrastructure that isn't AOT-ready, so they must signal a managed
+        // fallback via CommandNotAvailableInAotException rather than execute.
+        var result = Parser.Parse(commandLine.Split(' '));
+        Assert.Empty(result.Errors);
+        Assert.Throws<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
+    }
+
     /// <summary>
     ///  Invokes the AOT parser and captures output.
     ///  Uses BufferedReporter for Reporter.Output (used by --version, --info)


### PR DESCRIPTION
> **Stacked on #54810** (`baronfel/tool-resolution-aot`). This PR targets that branch so the diff under review is just the `dotnet tool` subcommand wiring. #54810 already makes tool-command **resolution/invocation** AOT-able (and links the shared manifest/package + command-resolution sources, grants `InternalsVisibleTo` for `IFileSystem`, and gates `IProject`/MSBuild off the AOT path); this PR builds on that to run the subcommands in-process. Once #54810 merges, this can be retargeted to `main`.

## Summary

Enables Native AOT support for the AOT-capable subset of `dotnet tool` subcommands: **local `tool list`**, **local `tool uninstall`**, **`tool run`**, and **`tool search`**.

Following the unified-parser model (#54653), `ToolCommandParser.ConfigureCommand` is shared between the managed and AOT paths via inline `#if CLI_AOT` regions, the AOT CLI links the **real** command implementations, and commands/options that cannot run under AOT throw `CommandNotAvailableInAotException` so `NativeEntryPoint` re-hosts the managed CLI.

## What runs under AOT vs. falls back

| `dotnet tool` invocation | AOT behavior |
| --- | --- |
| `tool list` / `tool list --local` | Runs in AOT (`ToolListLocalCommand`) |
| `tool uninstall <pkg>` (local) | Runs in AOT (`ToolUninstallLocalCommand`) |
| `tool run <cmd>` | Runs in AOT (`ToolRunCommand`) |
| `tool search <term>` | Runs in AOT (HttpClient + STJ source-gen) |
| `tool list --global` / `--tool-path` | Falls back to managed |
| `tool uninstall --global` / `--tool-path` | Falls back to managed |
| bare `tool`, `install`, `update`, `restore`, `execute` | Falls back to managed |

## Changes

- **`ToolCommandParser.cs`** — AOT-aware `ConfigureCommand`. Under `#if CLI_AOT` it only overrides the AOT-capable paths: local `list`/`uninstall` guard on `LocationOptions.IsGlobalOrToolPath` (global/tool-path throw fallback) and `run`/`search` call the real commands. Bare `tool` and `install`/`update`/`restore`/`execute` keep the recursive default fallback already set by `ConfigureAotActions`. The managed `#else` branch is unchanged from before.
- **`NugetToolSearchApiRequest.cs`** — under `#if CLI_AOT`, resolve the NuGet service index with `HttpClient` + a `System.Text.Json` source-generated context instead of NuGet.Protocol. The rest of the search pipeline (STJ deserializer, `PrintableTable`) was already AOT-friendly.
- **`Parser.cs`** — wire `ToolCommandParser.ConfigureCommand` into `ConfigureAotActions`.
- **`AotSourceFiles.props`** — link only the sources unique to running these subcommands in-process (the parser, the four command implementations, `PrintableTable`, and the NuGet search sources); the shared manifest/package and command-resolution infrastructure is already linked by #54810.
- **`AotParserTests.cs`** — parse coverage for the AOT-capable tool commands plus fallback assertions for the managed-only variants.

## Validation

- `dotnet-aot.csproj` and managed `dotnet.csproj`: build with 0 warnings / 0 errors.
- Full Native AOT publish (`-r win-x64`): ILC generates native code with **zero AOT/trim warnings**.
- `AotParserTests`: 38/38 pass (parse + managed-fallback theories, plus an invoke-level assertion that `tool list` executes on the AOT path without falling back).

## Performance

Measured with `eng/gather-otel.ps1` against the locally-built redist `dotnet.exe`, toggling `DOTNET_CLI_ENABLEAOT` (Debug, win-x64). End-to-end wall-clock per invocation:

`dotnet tool list` — fully handled on the AOT fast path (no network):

| | mean | median | min | max |
| --- | --- | --- | --- | --- |
| managed | 378.2 ms | 374.9 ms | 363.8 ms | 417.2 ms |
| AOT | 68.4 ms | 67.6 ms | 64.4 ms | 72.8 ms |

→ **−309.8 ms, 5.5× faster, 81.9% lower latency** (12 timed runs/path, 2 warmups discarded).

`dotnet tool search` exercises the new `HttpClient` + STJ service-index path and returns identical results to the managed path. Its end-to-end time is dominated by NuGet network I/O (~700 ms of service-index + query round-trips), so the ~300 ms startup win is present but not the dominant cost (managed ≈ 875 ms vs AOT ≈ 922 ms mean, within network variance).

