### PR TITLE
Fix GivenThatWeWantToUseFrameworkRoslyn tests

### DIFF
--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToUseFrameworkRoslyn.cs
@@ -47,45 +47,6 @@ namespace Microsoft.NET.Restore.Tests
         }
 
         [FullMSBuildOnlyFact]
-        public void It_downloads_Microsoft_Net_Compilers_Toolset_Framework_when_MSBuild_is_torn()
-        {
-            const string testProjectName = "NetCoreApp";
-            var project = new TestProject
-            {
-                Name = testProjectName,
-                TargetFrameworks = "net6.0",
-            };
-
-            // simulate mismatched MSBuild versions
-            project.AdditionalProperties.Add("_IsDisjointMSBuildVersion", "true");
-
-            // avoid opt in to RoslynCompilerType=Core
-            string[] args = ["-p:DOTNET_HOST_PATH=", "-p:DOTNET_EXPERIMENTAL_HOST_PATH="];
-
-            var testAsset = _testAssetsManager
-                .CreateTestProject(project);
-
-            NuGetConfigWriter.Write(testAsset.Path, SdkTestContext.Current.TestPackages);
-
-            var customPackagesDir = Path.Combine(testAsset.Path, "nuget-packages");
-
-            testAsset.GetRestoreCommand(Log, relativePath: testProjectName)
-                .WithEnvironmentVariable("NUGET_PACKAGES", customPackagesDir)
-                .Execute(args).Should().Pass();
-
-            var toolsetPackageDir = Path.Combine(customPackagesDir, "microsoft.net.sdk.compilers.toolset");
-
-            Assert.True(Directory.Exists(toolsetPackageDir));
-
-            var toolsetPackageVersion = Directory.EnumerateDirectories(toolsetPackageDir).Should().ContainSingle().Subject;
-
-            new BuildCommand(testAsset)
-                .WithEnvironmentVariable("NUGET_PACKAGES", customPackagesDir)
-                .Execute(args).Should().Pass().And
-                .HaveStdOutContaining(Path.Combine(toolsetPackageDir, toolsetPackageVersion, "csc.exe") + " /noconfig");
-        }
-
-        [FullMSBuildOnlyFact]
         public void It_throws_a_warning_when_adding_the_PackageReference_directly()
         {
             const string testProjectName = "NetCoreApp";
@@ -144,11 +105,7 @@ namespace Microsoft.NET.Restore.Tests
                 TargetFrameworks = "net6.0",
             };
 
-            // simulate mismatched MSBuild versions
-            project.AdditionalProperties.Add("_IsDisjointMSBuildVersion", "true");
-
-            // avoid opt in to RoslynCompilerType=Core
-            string[] args = ["-p:DOTNET_HOST_PATH=", "-p:DOTNET_EXPERIMENTAL_HOST_PATH="];
+            project.AdditionalProperties.Add("BuildWithNetFrameworkHostedCompiler", "true");
 
             var testAsset = _testAssetsManager
                 .CreateTestProject(project);
@@ -159,7 +116,7 @@ namespace Microsoft.NET.Restore.Tests
 
             var command = (MSBuildCommand)new MSBuildCommand(testAsset, "Restore;Build")
                 .WithEnvironmentVariable("NUGET_PACKAGES", customPackagesDir);
-            command.ExecuteWithoutRestore(args)
+            command.ExecuteWithoutRestore()
                 .Should().Pass().And.HaveStdOutContaining("NETSDK1221");
 
             // The package is downloaded, but the targets cannot find the path to it
@@ -183,9 +140,7 @@ namespace Microsoft.NET.Restore.Tests
                 WorkingDirectory = Path.Combine(testAsset.Path, "FxWpf")
             };
 
-            // simulate mismatched MSBuild versions via _IsDisjointMSBuildVersion
-            // avoid opt in to RoslynCompilerType=Core by unsetting DOTNET_HOST_PATH and DOTNET_EXPERIMENTAL_HOST_PATH
-            buildCommand.Execute("-p:_IsDisjointMSBuildVersion=true", "-p:DOTNET_HOST_PATH=", "-p:DOTNET_EXPERIMENTAL_HOST_PATH=")
+            buildCommand.Execute("-p:BuildWithNetFrameworkHostedCompiler=true")
                 .Should().Pass().And.NotHaveStdOutContaining("NETSDK1221");
 
             Assert.True(File.Exists(Path.Combine(testAsset.Path, "obj", "net472", "MainWindow.g.cs")));


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/54828.