### PR TITLE
Route verbose test output to file to reduce CI log size

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -27,6 +27,16 @@ namespace Microsoft.NET.TestFramework.Commands
         public bool VerboseOutput { get; set; }
 
         /// <summary>
+        /// When true, command output is written to a file on disk instead of the test log
+        /// when the command fails. The file is placed in the Helix upload directory (if
+        /// available) or a temp directory. Use this for tests that intentionally produce
+        /// very large output (e.g., diagnostic verbosity) to avoid bloating CI logs.
+        /// The output is still captured in <see cref="CommandResult.StdOut"/>/<see cref="CommandResult.StdErr"/>
+        /// for assertions.
+        /// </summary>
+        public bool SuppressOutputOnFailure { get; set; }
+
+        /// <summary>
         /// When true, the child process is launched in a new process group so that
         /// console signals (e.g. Ctrl+C) sent to it do not propagate to the test host.
         /// </summary>
@@ -219,18 +229,37 @@ namespace Microsoft.NET.TestFramework.Commands
             // buffering output a second time in memory.
             if (!verboseTestOutput && result.ExitCode != 0)
             {
-                if (!string.IsNullOrEmpty(result.StdOut))
+                if (SuppressOutputOnFailure)
                 {
-                    foreach (var line in result.StdOut.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
-                    {
-                        Log.WriteLine($"》{line}");
-                    }
+                    // Write output to a file instead of the test log to avoid bloating CI logs.
+                    var outputDir = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT")
+                        ?? Path.GetTempPath();
+                    var fileName = $"cmd-output-{Guid.NewGuid():N}.log";
+                    var outputPath = Path.Combine(outputDir, fileName);
+                    File.WriteAllText(outputPath,
+                        $"> {result.StartInfo.FileName} {result.StartInfo.Arguments}{Environment.NewLine}" +
+                        $"Exit code: {result.ExitCode}{Environment.NewLine}{Environment.NewLine}" +
+                        $"=== STDOUT ==={Environment.NewLine}{result.StdOut ?? ""}{Environment.NewLine}{Environment.NewLine}" +
+                        $"=== STDERR ==={Environment.NewLine}{result.StdErr ?? ""}");
+                    int stdOutLines = string.IsNullOrEmpty(result.StdOut) ? 0 : result.StdOut.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
+                    int stdErrLines = string.IsNullOrEmpty(result.StdErr) ? 0 : result.StdErr.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
+                    Log.WriteLine($"  ⚠️ Command failed — output ({stdOutLines} stdout + {stdErrLines} stderr lines) written to: {outputPath}");
                 }
-                if (!string.IsNullOrEmpty(result.StdErr))
+                else
                 {
-                    foreach (var line in result.StdErr.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+                    if (!string.IsNullOrEmpty(result.StdOut))
                     {
-                        Log.WriteLine($"❌{line}");
+                        foreach (var line in result.StdOut.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+                        {
+                            Log.WriteLine($"》{line}");
+                        }
+                    }
+                    if (!string.IsNullOrEmpty(result.StdErr))
+                    {
+                        foreach (var line in result.StdErr.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+                        {
+                            Log.WriteLine($"❌{line}");
+                        }
                     }
                 }
             }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -344,10 +344,15 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
             var testProjectDirectory = CopyAndRestoreVSTestDotNetCoreTestApp([verbosity, shouldShowPassedTests]);
 
-            // Call test
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
-                                        .WithWorkingDirectory(testProjectDirectory)
-                                        .Execute("-v", verbosity);
+            // Call test — suppress output for verbose cases to avoid bloating CI logs
+            // (the "diag" case alone produces ~95,000 lines of MSBuild output).
+            var command = new DotnetTestCommand(Log, disableNewOutput: true)
+                                        .WithWorkingDirectory(testProjectDirectory);
+            if (verbosity is "d" or "diag")
+            {
+                command.SuppressOutputOnFailure = true;
+            }
+            CommandResult result = command.Execute("-v", verbosity);
 
             // Verify
             if (!SdkTestContext.IsLocalized())


### PR DESCRIPTION
## Summary

Follow-up to #54782. Addresses the remaining ~10 MB per shard caused by tests that intentionally invoke MSBuild with diagnostic verbosity.

## Problem

After #54782, three dotnet.Tests.dll shards remained at ~9.5-9.8 MB each. Root cause: ItUsesVerbosityPassedToDefineVerbosityOfConsoleLoggerOfTheTests runs dotnet test -v diag, producing ~95,000 lines of MSBuild output. Since the test expects exit code 1 (intentional failure), the dump-on-failure logic writes all of it to the test log.

## Solution

Added TestCommand.SuppressOutputOnFailure property:
- When set, command output is written to a file on disk instead of the test log on failure
- File goes to HELIX_WORKITEM_UPLOAD_ROOT (available for download) or temp
- CommandResult.StdOut/StdErr remain fully populated for assertions
- Test log shows a one-line pointer to the file location

Applied to the verbosity d and diag cases of the problematic test.

## Expected impact

~19 MB less per PR build run across the affected shards (from ~29 MB to ~10 MB for those 3 shards combined).

## Debugging

If you need the full output locally, set DOTNET_SDK_TEST_VERBOSE=1 to stream everything in real-time, or check the output file on disk / in Helix uploads.
