### PR TITLE
Migrate StaticWebAssetsGeneratePackManifest

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackManifest.cs
@@ -10,7 +10,8 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 
-public class StaticWebAssetsGeneratePackManifest : Task
+[MSBuildMultiThreadableTask]
+public class StaticWebAssetsGeneratePackManifest : Task, IMultiThreadableTask
 {
     // Since the manifest is only used at build time, it's ok for it to use the relaxed
     // json escaping (which is also what MVC uses by default) and to produce indented output
@@ -31,6 +32,8 @@ public class StaticWebAssetsGeneratePackManifest : Task
 
     [Required]
     public string ManifestPath { get; set; }
+
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     public override bool Execute()
     {
@@ -69,27 +72,28 @@ public class StaticWebAssetsGeneratePackManifest : Task
             ElementsToRemove = [.. AdditionalElementsToRemoveFromPacking.Select(e => e.ItemSpec).OrderBy(id => id)]
         };
 
-        PersistManifest(manifest);
+        string manifestPath = string.IsNullOrEmpty(ManifestPath) ? ManifestPath : TaskEnvironment.GetAbsolutePath(ManifestPath);
+        PersistManifest(manifest, manifestPath);
 
         return !Log.HasLoggedErrors;
     }
 
-    private void PersistManifest(StaticWebAssetsPackManifest manifest)
+    private void PersistManifest(StaticWebAssetsPackManifest manifest, string manifestPath)
     {
         var data = JsonSerializer.SerializeToUtf8Bytes(manifest, ManifestSerializationOptions);
         var dataHash = ComputeHash(data);
-        var fileExists = File.Exists(ManifestPath);
-        var existingManifestHash = fileExists ? ComputeHash(File.ReadAllBytes(ManifestPath)) : "";
+        var fileExists = File.Exists(manifestPath);
+        var existingManifestHash = fileExists ? ComputeHash(File.ReadAllBytes(manifestPath)) : "";
 
         if (!fileExists)
         {
             Log.LogMessage(MessageImportance.Low, $"Creating manifest because manifest file '{ManifestPath}' does not exist.");
-            File.WriteAllBytes(ManifestPath, data);
+            File.WriteAllBytes(manifestPath, data);
         }
         else if (!string.Equals(dataHash, existingManifestHash, StringComparison.Ordinal))
         {
             Log.LogMessage(MessageImportance.Low, $"Updating manifest because manifest version '{dataHash}' is different from existing manifest hash '{existingManifestHash}'.");
-            File.WriteAllBytes(ManifestPath, data);
+            File.WriteAllBytes(manifestPath, data);
         }
         else
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.AspNetCore.StaticWebAssets.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Moq;
+
+namespace Microsoft.AspNetCore.Razor.Tasks;
+
+// Test parallelization is disabled assembly-wide via
+// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
+// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
+// process-CWD mutation these tests perform.
+public class StaticWebAssetsGeneratePackManifestMultiThreadingTest
+{
+    [Fact]
+    public void WritesManifestRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
+    {
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackManifestMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "spawn");
+        var relativeManifestPath = Path.Combine("obj", "staticwebassets.pack.json");
+        Directory.CreateDirectory(Path.Combine(projectDir, "obj"));
+        Directory.CreateDirectory(Path.Combine(spawnDir, "obj"));
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var task = new StaticWebAssetsGeneratePackManifest
+            {
+                BuildEngine = new Mock<IBuildEngine>().Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                Assets = [CreateAsset("wwwroot/css/site.css", "css/site.css")],
+                AdditionalPackageFiles = [],
+                ManifestPath = relativeManifestPath
+            };
+
+            task.Execute().Should().BeTrue();
+
+            var expectedPath = Path.Combine(projectDir, relativeManifestPath);
+            File.Exists(expectedPath).Should().BeTrue("the manifest should be written under the project dir, not the process CWD");
+
+            var incorrectPath = Path.Combine(spawnDir, relativeManifestPath);
+            File.Exists(incorrectPath).Should().BeFalse();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolvesExistingManifestCheckRelativeToProjectDirectory_NotProcessCurrentDirectory()
+    {
+        // Verifies that the File.Exists/File.ReadAllBytes change-detection probe in PersistManifest
+        // is rooted against TaskEnvironment.ProjectDirectory rather than the process CWD. A decoy
+        // manifest is planted in the process CWD at the same relative path. If the task read that
+        // decoy as the "existing" manifest, it would either overwrite the decoy or skip writing the
+        // project-dir file. The correct behavior is to ignore the decoy entirely: create the manifest
+        // under the project dir and leave the decoy untouched.
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackManifestMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "spawn");
+        var relativeManifestPath = Path.Combine("obj", "staticwebassets.pack.json");
+        Directory.CreateDirectory(Path.Combine(projectDir, "obj"));
+        Directory.CreateDirectory(Path.Combine(spawnDir, "obj"));
+
+        const string decoyContents = "DECOY - must not be read or overwritten";
+        var decoyPath = Path.Combine(spawnDir, relativeManifestPath);
+        File.WriteAllText(decoyPath, decoyContents);
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var task = new StaticWebAssetsGeneratePackManifest
+            {
+                BuildEngine = new Mock<IBuildEngine>().Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                Assets = [CreateAsset("wwwroot/css/site.css", "css/site.css")],
+                AdditionalPackageFiles = [],
+                ManifestPath = relativeManifestPath
+            };
+
+            task.Execute().Should().BeTrue();
+
+            var expectedPath = Path.Combine(projectDir, relativeManifestPath);
+            File.Exists(expectedPath).Should().BeTrue("the existence probe must target the project dir, find nothing, and create the manifest there");
+
+            File.ReadAllText(decoyPath).Should().Be(decoyContents, "the decoy in the process CWD must be neither read nor overwritten");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void WritesManifestToAbsoluteManifestPath_WhenProcessCurrentDirectoryDiffers()
+    {
+        var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackManifestMultiThreadingTest), Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(testRoot, "project");
+        var spawnDir = Path.Combine(testRoot, "spawn");
+        Directory.CreateDirectory(Path.Combine(projectDir, "obj"));
+        Directory.CreateDirectory(spawnDir);
+        var absoluteManifestPath = Path.Combine(projectDir, "obj", "staticwebassets.pack.json");
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(spawnDir);
+
+            var task = new StaticWebAssetsGeneratePackManifest
+            {
+                BuildEngine = new Mock<IBuildEngine>().Object,
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+                Assets = [CreateAsset("wwwroot/css/site.css", "css/site.css")],
+                AdditionalPackageFiles = [],
+                ManifestPath = absoluteManifestPath
+            };
+
+            task.Execute().Should().BeTrue();
+
+            File.Exists(absoluteManifestPath).Should().BeTrue("an absolute manifest path must pass through unchanged regardless of the process CWD");
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    private static ITaskItem CreateAsset(string itemSpec, string targetPath)
+    {
+        return new TaskItem(itemSpec, new Dictionary<string, string>
+        {
+            ["TargetPath"] = targetPath
+        });
+    }
+}


### PR DESCRIPTION
Fixes dotnet/msbuild#14063

### Context

Migrates `StaticWebAssetsGeneratePackManifest` to support MSBuild multithreaded task execution. The task reads an existing pack manifest from disk for change-detection and writes the manifest back out, so it must avoid resolving the relative `ManifestPath` against process-wide current directory state.

### Changes Made

- Added `[MSBuildMultiThreadableTask]` to `StaticWebAssetsGeneratePackManifest`.
- Implemented `IMultiThreadableTask` and initialized `TaskEnvironment` with `TaskEnvironment.Fallback`.
- Absolutized `ManifestPath` with `TaskEnvironment.GetAbsolutePath()` before any file system access (`File.Exists`, `File.ReadAllBytes`, `File.WriteAllBytes`), guarding empty/null inputs to preserve the existing `[Required]` semantics.
- Preserved existing log/error message text by keeping the original `ManifestPath` value in all `Log.LogMessage` calls (only the file I/O uses the absolutized path), so user-facing output is unchanged.
- Left the `[Output]`-free, early-return (`Assets.Length == 0`) behavior intact.
- Added focused regression tests for relative-path resolution.

### Testing

- Built `src\StaticWebAssetsSdk\Tasks\Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj` (via the test project) — 0 warnings, 0 errors.
- Added and ran focused tests in `Microsoft.NET.Sdk.StaticWebAssets.Tests.StaticWebAssetsGeneratePackManifestMultiThreadingTest`:
  - `WritesManifestRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory` — manifest is written under the project directory, not the process CWD.
  - `ResolvesExistingManifestCheckRelativeToProjectDirectory_NotProcessCurrentDirectory` — the existing-manifest probe targets the project directory; a decoy manifest planted in the CWD is neither read nor overwritten.
  - `WritesManifestToAbsoluteManifestPath_WhenProcessCurrentDirectoryDiffers` — absolute paths pass through unchanged regardless of CWD.
  - Result: 3 passed, 0 failed.