### PR TITLE
Use StaticWebAsset.NormalizeContentRootPath TaskEnvironment overload in CollectStaticWebAssetsToCopy

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
+++ b/src/StaticWebAssetsSdk/Tasks/CollectStaticWebAssetsToCopy.cs
@@ -25,8 +25,7 @@ public class CollectStaticWebAssetsToCopy : Task, IMultiThreadableTask
     public override bool Execute()
     {
         var copyToOutputFolder = new List<ITaskItem>();
-        var normalizedOutputPath = StaticWebAsset.NormalizeContentRootPath(
-            string.IsNullOrEmpty(OutputPath) ? OutputPath : TaskEnvironment.GetAbsolutePath(OutputPath).Value);
+        var normalizedOutputPath = StaticWebAsset.NormalizeContentRootPath(OutputPath, TaskEnvironment);
         try
         {
             foreach (var asset in StaticWebAsset.FromTaskItemGroup(Assets, TaskEnvironment))


### PR DESCRIPTION
Follow-up to #54621.

Veronika ([review comment](https://github.com/dotnet/sdk/pull/54621#discussion_r0)) noted that we already have a `StaticWebAsset.NormalizeContentRootPath(string path, TaskEnvironment env)` overload, so the call site doesn't need to inline the `TaskEnvironment.GetAbsolutePath` resolution.

This simplifies:
```csharp
var normalizedOutputPath = StaticWebAsset.NormalizeContentRootPath(
    string.IsNullOrEmpty(OutputPath) ? OutputPath : TaskEnvironment.GetAbsolutePath(OutputPath).Value);
```
to:
```csharp
var normalizedOutputPath = StaticWebAsset.NormalizeContentRootPath(OutputPath, TaskEnvironment);
```

The overload performs the exact same null/empty guard and `GetAbsolutePath` resolution internally, so behavior is unchanged.

### Validation
- `./.dotnet/dotnet build src/StaticWebAssetsSdk/Tasks/Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj -c Debug`