### PR TITLE
Preserve whitespace-path throw in StaticWebAsset.NormalizeContentRootPath

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -1098,7 +1098,12 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     public static string NormalizeContentRootPath(string path) => NormalizeContentRootPath(path, TaskEnvironment.Fallback);
 
     public static string NormalizeContentRootPath(string path, TaskEnvironment env)
-        => Path.GetFullPath(string.IsNullOrEmpty(path) ? path : env.GetAbsolutePath(path)) +
+        // For null/empty/whitespace paths we deliberately call Path.GetFullPath on the raw value
+        // rather than routing it through env.GetAbsolutePath. This preserves the pre-multithreading
+        // behavior: such inputs resolve against the legacy base (and on Windows whitespace-only paths
+        // still throw, since Path.GetFullPath trims trailing whitespace to an empty path) instead of
+        // being silently resolved into the project directory.
+        => Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? path : env.GetAbsolutePath(path)) +
         // We need to do .ToString because there is no EndsWith overload for chars in .NET Framework
         (path.EndsWith(Path.DirectorySeparatorChar.ToString()), path.EndsWith(Path.AltDirectorySeparatorChar.ToString())) switch
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
@@ -217,6 +218,41 @@ public class StaticWebAssetTaskEnvironmentTests
 
             asset.ContentRoot.Should().Be(absoluteContentRoot + Path.DirectorySeparatorChar);
             asset.RelatedAsset.Should().Be(absoluteRelatedAsset);
+        });
+    }
+
+    [Fact]
+    public void NormalizeContentRootPath_WithWhitespacePath_PreservesLegacyBehavior_DoesNotResolveAgainstProjectDirectory()
+    {
+        WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
+        {
+            var env = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir);
+            const string whitespace = "   ";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Before the multithreading migration the raw whitespace path flowed straight into
+                // Path.GetFullPath, which on Windows trims the trailing whitespace to an empty path
+                // and throws. Routing it through env.GetAbsolutePath first would instead silently
+                // resolve it to the project directory, masking the invalid input. Guarding on
+                // IsNullOrWhiteSpace preserves the original throw.
+                Action act = () => StaticWebAsset.NormalizeContentRootPath(whitespace, env);
+
+                act.Should().Throw<ArgumentException>(
+                    "a whitespace-only path is invalid on Windows and must keep throwing as it did before the migration");
+            }
+            else
+            {
+                // On Unix whitespace is a legal path segment, so Path.GetFullPath does not throw.
+                // It must still resolve against the legacy base (the process CWD) exactly like the
+                // parameterless overload, rather than being silently re-rooted to the project directory.
+                var result = StaticWebAsset.NormalizeContentRootPath(whitespace, env);
+
+                result.Should().Be(StaticWebAsset.NormalizeContentRootPath(whitespace),
+                    "whitespace paths must keep their pre-migration resolution and not be re-rooted to the project directory");
+                result.Should().StartWith(spawnDir);
+                result.Should().NotStartWith(projectDir);
+            }
         });
     }
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
@@ -6,7 +6,6 @@
 using Microsoft.AspNetCore.StaticWebAssets.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
@@ -221,38 +220,36 @@ public class StaticWebAssetTaskEnvironmentTests
         });
     }
 
-    [Fact]
-    public void NormalizeContentRootPath_WithWhitespacePath_PreservesLegacyBehavior_DoesNotResolveAgainstProjectDirectory()
+    [WindowsOnlyFact]
+    public void NormalizeContentRootPath_WithWhitespacePath_ThrowsOnWindows()
     {
+        // Pre-migration the raw path went straight into Path.GetFullPath, which trims trailing
+        // whitespace to an empty path and throws. Guarding on IsNullOrWhiteSpace preserves that
+        // instead of silently resolving the invalid path to the project directory.
+        WithDecoyCwdAndProjectDirectory((projectDir, _) =>
+        {
+            var env = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir);
+
+            Action act = () => StaticWebAsset.NormalizeContentRootPath("   ", env);
+
+            act.Should().Throw<ArgumentException>();
+        });
+    }
+
+    [LinuxOnlyFact]
+    public void NormalizeContentRootPath_WithWhitespacePath_ResolvesAgainstCurrentDirectory_NotProjectDirectory()
+    {
+        // On Unix whitespace is a legal path segment, so it must keep resolving against the legacy
+        // base (the process CWD) like the parameterless overload, not be re-rooted to the project dir.
         WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
         {
             var env = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir);
-            const string whitespace = "   ";
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Before the multithreading migration the raw whitespace path flowed straight into
-                // Path.GetFullPath, which on Windows trims the trailing whitespace to an empty path
-                // and throws. Routing it through env.GetAbsolutePath first would instead silently
-                // resolve it to the project directory, masking the invalid input. Guarding on
-                // IsNullOrWhiteSpace preserves the original throw.
-                Action act = () => StaticWebAsset.NormalizeContentRootPath(whitespace, env);
+            var result = StaticWebAsset.NormalizeContentRootPath("   ", env);
 
-                act.Should().Throw<ArgumentException>(
-                    "a whitespace-only path is invalid on Windows and must keep throwing as it did before the migration");
-            }
-            else
-            {
-                // On Unix whitespace is a legal path segment, so Path.GetFullPath does not throw.
-                // It must still resolve against the legacy base (the process CWD) exactly like the
-                // parameterless overload, rather than being silently re-rooted to the project directory.
-                var result = StaticWebAsset.NormalizeContentRootPath(whitespace, env);
-
-                result.Should().Be(StaticWebAsset.NormalizeContentRootPath(whitespace),
-                    "whitespace paths must keep their pre-migration resolution and not be re-rooted to the project directory");
-                result.Should().StartWith(spawnDir);
-                result.Should().NotStartWith(projectDir);
-            }
+            result.Should().Be(StaticWebAsset.NormalizeContentRootPath("   "));
+            result.Should().StartWith(spawnDir);
+            result.Should().NotStartWith(projectDir);
         });
     }
 


### PR DESCRIPTION
Follow-up to #54621.

Veronika ([review comment](https://github.com/dotnet/sdk/pull/54621#discussion_r0)) raised a backwards-compatibility concern about `NormalizeContentRootPath(string path, TaskEnvironment env)`:

> What if path is whitespace? It will return to us project dir and will not throw on getFullPath as it was before migration for whitespace input.

### The regression
Before the multi-threaded migration, the raw path flowed straight into `Path.GetFullPath`. On **Windows**, `Path.GetFullPath("   ")` trims the trailing whitespace to an empty path and throws `ArgumentException`. After the migration the path was first routed through `TaskEnvironment.GetAbsolutePath`, which resolves it against the project directory — so an invalid whitespace `OutputPath`/`ContentRoot` was **silently** turned into the project directory instead of throwing.

### The fix (backwards compatible)
Guard with `string.IsNullOrWhiteSpace` instead of `string.IsNullOrEmpty`:

```csharp
=> Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? path : env.GetAbsolutePath(path)) + ...
```

Whitespace-only inputs now bypass `env.GetAbsolutePath` and flow straight into `Path.GetFullPath`, exactly as before the migration:
- **Windows**: throws `ArgumentException` (invalid path), as it did pre-migration.
- **Unix**: whitespace is a legal path segment, so it resolves against the legacy base (process CWD), not silently against the project directory.

Valid relative paths are unaffected and still resolve against the project directory (MT-safe).

### Test proving the mitigated behavior change
`NormalizeContentRootPath_WithWhitespacePath_PreservesLegacyBehavior_DoesNotResolveAgainstProjectDirectory` runs under a decoy CWD distinct from the project directory and asserts that a whitespace path is not re-rooted to the project directory (throws on Windows; resolves against the CWD on Unix). I verified the test **fails** against the previous `IsNullOrEmpty` implementation and **passes** with this fix.

### Validation
- `./.dotnet/dotnet build test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj -c Debug`
- Ran `*NormalizeContentRootPath*` (4 tests) — all pass; new test fails on the pre-fix code.