### PR TITLE
Migrate API compatibility test projects to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
-    <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
-    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +12,7 @@
     <!-- Build-ordering dependencies on the tools and tasks under test. ReferenceOutputAssembly="false" so we don't take a compile-time dependency on netcore-only types; SetTargetFramework pins both inner builds to consume the netcore TFM since these projects are netcore-only. -->
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Task\Microsoft.DotNet.ApiCompat.Task.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=$(NetMinimum)" />
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompat.Tool\Microsoft.DotNet.ApiCompat.Tool.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=$(NetMinimum)" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
   <!-- Stage the apicompat CLI binary closure under tools\Microsoft.DotNet.ApiCompat.Tool\ so the
@@ -32,5 +30,13 @@
                CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
 
 </Project>

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidateAssembliesTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidateAssembliesTargetIntegrationTests.cs
@@ -1,13 +1,14 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
 {
-    public class ValidateAssembliesTargetIntegrationTests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class ValidateAssembliesTargetIntegrationTests() : SdkTest()
     {
         private const string TestAssetName = "ApiCompatValidateAssembliesTestProject";
 
-        [Fact]
+        [TestMethod]
         public void ValidateAssemblies_NoBreakingChanges_Succeeds()
         {
             // Build the asset twice with the same source to produce a "contract" DLL and an "implementation" DLL
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             result.StdOut.Should().NotContain("error CP0002");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidateAssemblies_BreakingChange_FailsWithCP0002()
         {
             // Contract has Goodbye(string); implementation removes it via -p:ForceBreakingChange=true.
@@ -45,7 +46,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .And.Contain("Goodbye");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidateAssemblies_StrictMode_FailsOnAddition()
         {
             // Implementation adds Welcome(string) (-p:AddNewMember=true). Without strict mode, ApiCompat tolerates additions.
@@ -66,7 +67,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .And.Contain("Welcome");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidateAssemblies_GeneratesAndConsumesSuppressionFile()
         {
             // 1) Generate a suppression file for the breaking change.

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,13 +7,11 @@ using Microsoft.DotNet.PackageValidation;
 
 namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
 {
+    [TestClass]
     public class ValidatePackageTargetIntegrationTests : SdkTest
     {
-        public ValidatePackageTargetIntegrationTests(ITestOutputHelper log) : base(log)
-        {
-        }
 
-        [Fact]
+        [TestMethod]
         public void InvalidPackage()
         {
             var testAsset = TestAssetsManager
@@ -24,11 +22,11 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .Execute($"-p:ForceValidationProblem=true");
 
             // No failures while running the package validation on a simple assembly.
-            Assert.Equal(1, result.ExitCode);
-            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeAPINotInCore()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.AreEqual(1, result.ExitCode);
+            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeAPINotInCore()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetRunsSuccessfully()
         {
             var testAsset = TestAssetsManager
@@ -39,10 +37,10 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .Execute();
 
             // No failures while running the package validation on a simple assembly.
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineCheck()
         {
             var testAsset = TestAssetsManager
@@ -52,17 +50,17 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
 
             string packageValidationBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
             // No failures while running the package validation on a simple assembly.
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetRunsSuccessfullyWithBaselineVersion()
         {
             var testAsset = TestAssetsManager
@@ -72,16 +70,16 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
 
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselineVersion=1.0.0;PackageValidationBaselineName=PackageValidationTestProject");
 
             // No failures while running the package validation on a simple assembly.
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetFailsWithBaselineVersion()
         {
             var testAsset = TestAssetsManager
@@ -91,18 +89,18 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
 
             string packageValidationBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;AddBreakingChange=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
-            Assert.Equal(1, result.ExitCode);
-            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/net8.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
-            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.AreEqual(1, result.ExitCode);
+            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/net8.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll");
+            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetWithIncorrectBaselinePackagePath()
         {
             var testAsset = TestAssetsManager
@@ -113,16 +111,16 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
 
-            Assert.Equal(1, result.ExitCode);
-            Assert.Contains(string.Format(Resources.NonExistentPackagePath, nonExistentPackageBaselinePath), result.StdOut);
+            Assert.AreEqual(1, result.ExitCode);
+            Assert.Contains(result.StdOut, string.Format(Resources.NonExistentPackagePath, nonExistentPackageBaselinePath));
 
             // Disables package baseline validation.
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;DisablePackageBaselineValidation=true;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetFailsWithBaselineVersionInStrictMode()
         {
             var testAsset = TestAssetsManager
@@ -132,18 +130,18 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
 
             string packageValidationBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;ForceStrictModeBaselineValidationProblem=true;EnableStrictModeForBaselineValidation=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
-            Assert.Equal(1, result.ExitCode);
-            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/net8.0/PackageValidationTestProject.dll but not on [Baseline] lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
-            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.AreEqual(1, result.ExitCode);
+            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/net8.0/PackageValidationTestProject.dll but not on [Baseline] lib/net8.0/PackageValidationTestProject.dll");
+            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageTargetSucceedsWithBaselineVersionNotInStrictMode()
         {
             var testAsset = TestAssetsManager
@@ -153,13 +151,13 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
             var result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageOutputPath={testAsset.TestRoot}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
 
             string packageValidationBaselinePath = Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.1.0.0.nupkg");
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
                 .Execute($"-p:PackageVersion=2.0.0;ForceStrictModeBaselineValidationProblem=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
-            Assert.Equal(0, result.ExitCode);
+            Assert.AreEqual(0, result.ExitCode);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Task/ValidatePackageTargetIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
 
             // No failures while running the package validation on a simple assembly.
             Assert.AreEqual(1, result.ExitCode);
-            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeAPINotInCore()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll");
+            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeAPINotInCore()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
         [TestMethod]
@@ -96,8 +96,8 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .Execute($"-p:PackageVersion=2.0.0;AddBreakingChange=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
             Assert.AreEqual(1, result.ExitCode);
-            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/net8.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll");
-            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll");
+            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/net8.0/PackageValidationTestProject.dll but not on lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiNotInLatestVersion()' exists on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll but not on lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
         [TestMethod]
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .Execute($"-p:PackageVersion=2.0.0;PackageValidationBaselinePath={nonExistentPackageBaselinePath}");
 
             Assert.AreEqual(1, result.ExitCode);
-            Assert.Contains(result.StdOut, string.Format(Resources.NonExistentPackagePath, nonExistentPackageBaselinePath));
+            Assert.Contains(string.Format(Resources.NonExistentPackagePath, nonExistentPackageBaselinePath), result.StdOut);
 
             // Disables package baseline validation.
             result = new PackCommand(Log, Path.Combine(testAsset.TestRoot, "PackageValidationTestProject.csproj"))
@@ -137,8 +137,8 @@ namespace Microsoft.DotNet.ApiCompat.Task.IntegrationTests
                 .Execute($"-p:PackageVersion=2.0.0;ForceStrictModeBaselineValidationProblem=true;EnableStrictModeForBaselineValidation=true;PackageValidationBaselinePath={packageValidationBaselinePath}");
 
             Assert.AreEqual(1, result.ExitCode);
-            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/net8.0/PackageValidationTestProject.dll but not on [Baseline] lib/net8.0/PackageValidationTestProject.dll");
-            Assert.Contains(result.StdOut, "error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll");
+            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/net8.0/PackageValidationTestProject.dll but not on [Baseline] lib/net8.0/PackageValidationTestProject.dll", result.StdOut);
+            Assert.Contains("error CP0002: Member 'void PackageValidationTestProject.Program.SomeApiOnlyInLatestVersion()' exists on lib/netstandard2.0/PackageValidationTestProject.dll but not on [Baseline] lib/netstandard2.0/PackageValidationTestProject.dll", result.StdOut);
         }
 
         [TestMethod]

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Utils;
@@ -10,15 +10,12 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
     /// <c>dotnet exec Microsoft.DotNet.ApiCompat.Tool.dll</c> with command-line arguments and
     /// asserting on the exit code and stdout, exactly as a customer would.
     /// </summary>
+    [TestClass]
     public class ApiCompatToolIntegrationTests : SdkTest
     {
         private const string TestAssetName = "ApiCompatValidateAssembliesTestProject";
 
-        public ApiCompatToolIntegrationTests(ITestOutputHelper log) : base(log)
-        {
-        }
-
-        [Fact] 
+        [TestMethod] 
         public void ApiCompatTool_AssembliesIdentical_ExitsZero()
         {
             string assembly = BuildAsset(nameof(ApiCompatTool_AssembliesIdentical_ExitsZero), forceBreakingChange: false);
@@ -28,7 +25,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             result.Should().Pass();
         }
 
-        [Fact] 
+        [TestMethod] 
         public void ApiCompatTool_BreakingChange_ReportsCP0002()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_BreakingChange_ReportsCP0002)}_left", forceBreakingChange: false);
@@ -42,7 +39,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
                 .And.Contain("Goodbye");
         }
 
-        [Fact] 
+        [TestMethod] 
         public void ApiCompatTool_SuppressionFile_RoundTrip()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_SuppressionFile_RoundTrip)}_left", forceBreakingChange: false);
@@ -71,7 +68,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             consumeResult.StdOut.Should().NotContain("error CP0002");
         }
 
-        [Fact] 
+        [TestMethod] 
         public void ApiCompatTool_PackageMode_DetectsRemovedApi()
         {
             // Pack the existing PackageValidationTestProject twice to produce two .nupkg files

--- a/test/Microsoft.DotNet.ApiCompat.IntegrationTests/ToolPaths.cs
+++ b/test/Microsoft.DotNet.ApiCompat.IntegrationTests/ToolPaths.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.ApiCompat.IntegrationTests

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/CompatDifferenceTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/CompatDifferenceTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests
 {
+    [TestClass]
     public class CompatDifferenceTests
     {
         public static IEnumerable<object[]> CompatDifferencesData =>
@@ -22,22 +23,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
                 }
             };
 
-        [Theory]
-        [MemberData(nameof(CompatDifferencesData))]
+        [TestMethod]
+        [DynamicData(nameof(CompatDifferencesData))]
         public void PropertiesAreCorrect(MetadataInformation left, MetadataInformation right, string diagId, string message, string memberId, DifferenceType type)
         {
             CompatDifference difference = new(left, right, diagId, message, type, memberId);
-            Assert.Equal(left, difference.Left);
-            Assert.Equal(right, difference.Right);
-            Assert.Equal(diagId, difference.DiagnosticId);
-            Assert.Equal(message, difference.Message);
-            Assert.Equal(memberId, difference.ReferenceId);
-            Assert.Equal(type, difference.Type);
+            Assert.AreEqual(left, difference.Left);
+            Assert.AreEqual(right, difference.Right);
+            Assert.AreEqual(diagId, difference.DiagnosticId);
+            Assert.AreEqual(message, difference.Message);
+            Assert.AreEqual(memberId, difference.ReferenceId);
+            Assert.AreEqual(type, difference.Type);
 
-            Assert.Equal($"{diagId} : {message}", difference.ToString());
+            Assert.AreEqual($"{diagId} : {message}", difference.ToString());
         }
 
-        [Fact]
+        [TestMethod]
         public void IsEquatableWorksAsExpected()
         {
             CompatDifference difference = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:Foo");
@@ -47,13 +48,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             CompatDifference differentMemberId = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:FooBar");
             CompatDifference differentMessage = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, "Hello", DifferenceType.Removed, "T:Foo");
 
-            Assert.False(difference.Equals(null));
-            Assert.True(difference.Equals(otherEqual));
-            Assert.True(difference.Equals((object)otherEqual));
-            Assert.False(difference.Equals(differentDiagId));
-            Assert.False(difference.Equals(differentType));
-            Assert.False(difference.Equals(differentMemberId));
-            Assert.True(difference.Equals(differentMessage));
+            Assert.IsFalse(difference.Equals(null));
+            Assert.IsTrue(difference.Equals(otherEqual));
+            Assert.IsTrue(difference.Equals((object)otherEqual));
+            Assert.IsFalse(difference.Equals(differentDiagId));
+            Assert.IsFalse(difference.Equals(differentType));
+            Assert.IsFalse(difference.Equals(differentMemberId));
+            Assert.IsTrue(difference.Equals(differentMessage));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
@@ -7,11 +7,12 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests
 {
+    [TestClass]
     public class CustomSideNameTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
 
-        [Fact]
+        [TestMethod]
         public void CustomSideNameAreNotSpecified()
         {
             string leftSyntax = @"
@@ -39,11 +40,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             AssertNames(differences.First(), expectedLeftName, expectedRightName);
         }
 
-        [Fact]
+        [TestMethod]
         public void CustomSideNamesAreUsed()
         {
             string leftSyntax = @"
@@ -73,16 +74,16 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             AssertNames(differences.First(), left.MetadataInformation.DisplayString, right.MetadataInformation.DisplayString);
 
             // Use the single assembly override
             differences = differ.GetDifferences(left, right);
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             AssertNames(differences.First(), left.MetadataInformation.DisplayString, right.MetadataInformation.DisplayString);
         }
 
-        [Fact]
+        [TestMethod]
         public void CustomSideNamesAreUsedStrictMode()
         {
             string leftSyntax = @"
@@ -112,11 +113,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             AssertNames(differences.First(), left.MetadataInformation.DisplayString, right.MetadataInformation.DisplayString, leftFirst: false);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsMetadataInformationIsUsedAsName()
         {
             string leftSyntax = @"
@@ -195,7 +196,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Equal(right.Count, differences.Count());
+            Assert.HasCount(right.Count, differences);
             foreach (CompatDifference difference in differences)
             {
                 AssertNames(difference, difference.Left.AssemblyId, difference.Right.AssemblyId);
@@ -211,13 +212,13 @@ namespace CompatTests
             string right = " " + expectedRightName;
             if (leftFirst)
             {
-                Assert.Contains(left + " ", message);
-                Assert.EndsWith(right, message);
+                Assert.Contains(message, left + " ");
+                Assert.EndsWith(message, right);
             }
             else
             {
-                Assert.Contains(right + " ", message);
-                Assert.EndsWith(left, message);
+                Assert.Contains(message, right + " ");
+                Assert.EndsWith(message, left);
             }
         }
     }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/CustomSideNameTests.cs
@@ -212,13 +212,13 @@ namespace CompatTests
             string right = " " + expectedRightName;
             if (leftFirst)
             {
-                Assert.Contains(message, left + " ");
-                Assert.EndsWith(message, right);
+                Assert.Contains(left + " ", message);
+                Assert.EndsWith(right, message);
             }
             else
             {
-                Assert.Contains(message, right + " ");
-                Assert.EndsWith(message, left);
+                Assert.Contains(right + " ", message);
+                Assert.EndsWith(left, message);
             }
         }
     }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionEngineTests.cs
@@ -7,9 +7,10 @@ using System.Xml.Serialization;
 
 namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 {
+    [TestClass]
     public class SuppressionEngineTests
     {
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_AddSuppression_AddingTwiceDoesntThrow()
         {
             SuppressionEngine suppressionEngine = new();
@@ -18,38 +19,38 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             suppressionEngine.AddSuppression(suppression);
             suppressionEngine.AddSuppression(suppression);
 
-            Assert.Single(suppressionEngine.Suppressions);
+            Assert.ContainsSingle(suppressionEngine.Suppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_IsErrorSuppressed_CanParseInputSuppressionFile()
         {
             TestSuppressionEngine suppressionEngine = new();
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
             // Parsed the right amount of suppressions
-            Assert.Equal(9, suppressionEngine.BaselineSuppressions.Count);
+            Assert.HasCount(9, suppressionEngine.BaselineSuppressions);
 
-            Assert.True(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "lib/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
-            Assert.True(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".netframework,Version=v4.8")));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression(string.Empty, string.Empty)));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".netframework,Version=v4.8", "lib/net6.0/mylib.dll")));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".NETStandard,Version=v2.0")));
-            Assert.True(suppressionEngine.IsErrorSuppressed(new Suppression("CP123", "T:myValidation.Class1", isBaselineSuppression: true)));
-            Assert.False(suppressionEngine.IsErrorSuppressed(new Suppression("CP123", "T:myValidation.Class1", isBaselineSuppression: false)));
-            Assert.True(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
+            Assert.IsTrue(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "lib/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
+            Assert.IsTrue(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".netframework,Version=v4.8")));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression(string.Empty, string.Empty)));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".netframework,Version=v4.8", "lib/net6.0/mylib.dll")));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression("PKV004", ".NETStandard,Version=v2.0")));
+            Assert.IsTrue(suppressionEngine.IsErrorSuppressed(new Suppression("CP123", "T:myValidation.Class1", isBaselineSuppression: true)));
+            Assert.IsFalse(suppressionEngine.IsErrorSuppressed(new Suppression("CP123", "T:myValidation.Class1", isBaselineSuppression: false)));
+            Assert.IsTrue(suppressionEngine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/netstandard2.0/tempValidation.dll", "lib/net6.0/tempValidation.dll")));
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_LoadFiles_ThrowsIfFileDoesNotExist()
         {
             SuppressionEngine suppressionEngine = new();
-            Assert.Throws<FileNotFoundException>(() => suppressionEngine.LoadSuppressions("AFileThatDoesNotExist.xml"));
+            Assert.ThrowsExactly<FileNotFoundException>(() => suppressionEngine.LoadSuppressions("AFileThatDoesNotExist.xml"));
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_WriteSuppressionsToFile_SuppressionsRoundTrip()
         {
             string output = string.Empty;
@@ -64,15 +65,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
             var (suppressionFileUpdated, writtenSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true);
 
-            Assert.True(suppressionFileUpdated);
-            Assert.NotEmpty(writtenSuppressions);
+            Assert.IsTrue(suppressionFileUpdated);
+            Assert.IsNotEmpty(writtenSuppressions);
 
             // Trimming away the comment as the serializer doesn't preserve them.
             string expectedSuppressionFile = TestSuppressionEngine.DefaultSuppressionFile.Replace(TestSuppressionEngine.SuppressionFileComment, string.Empty);
-            Assert.Equal(expectedSuppressionFile.Trim(), output.Trim(), ignoreCase: true);
+            Assert.AreEqual(expectedSuppressionFile.Trim(), output.Trim(), ignoreCase: true);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_GetUnnecessarySuppressions_NotEmptyWithUnnecessarySuppressions()
         {
             TestSuppressionEngine suppressionEngine = new();
@@ -80,20 +81,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 
             IReadOnlyCollection<Suppression> unnecessarySuppressions = suppressionEngine.GetUnnecessarySuppressions();
 
-            Assert.NotEmpty(unnecessarySuppressions);
+            Assert.IsNotEmpty(unnecessarySuppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_BaselineSuppressions_NotEmptyWithUnnecessarySuppressions()
         {
             TestSuppressionEngine suppressionEngine = new();
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
-            Assert.Empty(suppressionEngine.Suppressions);
-            Assert.NotEmpty(suppressionEngine.BaselineSuppressions);
+            Assert.IsEmpty(suppressionEngine.Suppressions);
+            Assert.IsNotEmpty(suppressionEngine.BaselineSuppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_WriteSuppressionsToFile_ReturnsEmptyWithAllUnnecessarySuppressions()
         {
             TestSuppressionEngine suppressionEngine = new();
@@ -103,11 +104,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 
             var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath);
 
-            Assert.True(suppressionFileUpdated);
-            Assert.Empty(updatedSuppressions);
+            Assert.IsTrue(suppressionFileUpdated);
+            Assert.IsEmpty(updatedSuppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_WriteSuppressionsToFile_UnnecessarySuppressionsOmitted()
         {
             Suppression usedSuppression = new("CP0001", "T:A", "lib/netstandard1.3/tempValidation.dll", "lib/netstandard1.3/tempValidation.dll");
@@ -135,22 +136,22 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName(), "DummyFile.xml");
             var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath);
 
-            Assert.True(suppressionFileUpdated);
-            Assert.Equal([usedSuppression], updatedSuppressions);
+            Assert.IsTrue(suppressionFileUpdated);
+            Assert.AreSequenceEqual([usedSuppression], updatedSuppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_WriteSuppressionsToFile_ReturnsEmptyWithEmptyFilePath()
         {
             EmptyTestSuppressionEngine suppressionEngine = new();
-            Assert.Empty(suppressionEngine.Suppressions);
+            Assert.IsEmpty(suppressionEngine.Suppressions);
 
             var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(string.Empty, preserveUnnecessarySuppressions: true);
-            Assert.False(suppressionFileUpdated);
-            Assert.Empty(updatedSuppressions);
+            Assert.IsFalse(suppressionFileUpdated);
+            Assert.IsEmpty(updatedSuppressions);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_IsErrorSuppressed_SupportsGlobalSuppressions()
         {
             SuppressionEngine engine = new();
@@ -159,29 +160,29 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             engine.AddSuppression(new Suppression("CP0001", "T:A.B", isBaselineSuppression: true));
             engine.AddSuppression(new Suppression("CP0001", "T:A.C"));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
 
             // Engine has a suppression with no target. Should be treated globally for any target with that left and right.
             engine.AddSuppression(new Suppression("CP0003", null, "ref/net6.0/myleft.dll", "lib/net6.0/myright.dll", isBaselineSuppression: false));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.B", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.B", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
 
             // Engine has a suppression with no diagnostic id and target. Should be treated globally for any diagnostic id and target with that left and right.
             engine.AddSuppression(new Suppression(string.Empty, null, "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: false));
             engine.AddSuppression(new Suppression(string.Empty, null, "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: true));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: false)));
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: true)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: false)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0009", "T:A.B.C.D.E", "ref/net8.0/left.dll", "lib/net8.0/left.dll", isBaselineSuppression: true)));
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_BaseliningNewErrorsDoesNotOverrideSuppressions()
         {
             using Stream stream = new MemoryStream();
@@ -193,7 +194,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             });
             suppressionEngine.LoadSuppressions("NonExistentFile.xml");
 
-            Assert.Equal(9, suppressionEngine.BaselineSuppressions.Count);
+            Assert.HasCount(9, suppressionEngine.BaselineSuppressions);
 
             Suppression newSuppression = new("CP0002", "F:MyNs.Class1.Field");
             suppressionEngine.AddSuppression(newSuppression);
@@ -202,38 +203,38 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 
             var (suppressionFileUpdated, updatedSuppressions) = suppressionEngine.WriteSuppressionsToFile(filePath, preserveUnnecessarySuppressions: true);
 
-            Assert.True(suppressionFileUpdated);
-            Assert.NotEmpty(updatedSuppressions);
+            Assert.IsTrue(suppressionFileUpdated);
+            Assert.IsNotEmpty(updatedSuppressions);
 
             XmlSerializer xmlSerializer = new(typeof(Suppression[]), new XmlRootAttribute("Suppressions"));
             Suppression[] deserializedSuppressions = xmlSerializer.Deserialize(stream) as Suppression[];
-            Assert.Equal(10, deserializedSuppressions.Length);
+            Assert.HasCount(10, deserializedSuppressions);
 
-            Assert.Equal(new Suppression("CP0001")
+            Assert.AreEqual(new Suppression("CP0001")
             {
                 Target = "T:A",
                 Left = "lib/netstandard1.3/tempValidation.dll",
                 Right = "lib/netstandard1.3/tempValidation.dll"
             }, deserializedSuppressions[0]);
 
-            Assert.Equal(newSuppression, deserializedSuppressions[4]);
+            Assert.AreEqual(newSuppression, deserializedSuppressions[4]);
         }
 
-        [Fact]
+        [TestMethod]
         public void SuppressionEngine_IsErrorSuppressed_NoWarnIsHonored()
         {
             SuppressionEngine engine = new(noWarn: "CP0001;CP0003;CP1111");
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP1110", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP1110", "T:A.B", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP1000", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0001", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: false)));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP1000", "T:A.C", "ref/net6.0/myLib.dll", "lib/net6.0/myLib.dll", isBaselineSuppression: true)));
 
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.B", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.True(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
-            Assert.False(engine.IsErrorSuppressed(new Suppression("CP1232", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.B", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.C", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsTrue(engine.IsErrorSuppressed(new Suppression("CP0003", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll")));
+            Assert.IsFalse(engine.IsErrorSuppressed(new Suppression("CP1232", "T:A.D", "ref/net6.0/myLeft.dll", "lib/net6.0/myRight.dll", isBaselineSuppression: true)));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Logging/SuppressionTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
 {
+    [TestClass]
     public class SuppressionTests
     {
         public static IEnumerable<object[]> GetEqualData()
@@ -34,26 +35,26 @@ namespace Microsoft.DotNet.ApiCompatibility.Logging.Tests
             yield return new object[] { new Suppression("PK004") { Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll" }, new Suppression("PK004") { Target = "A.B", Left = "ref/net6.0/myLib.dll", Right = "lib/net6.0/myLib.dll", IsBaselineSuppression = true } };
         }
 
-        [Theory]
-        [MemberData(nameof(GetEqualData))]
+        [TestMethod]
+        [DynamicData(nameof(GetEqualData))]
         public void CheckSuppressionsAreEqual(Suppression suppression, Suppression other)
         {
-            Assert.True(suppression.Equals(other));
-            Assert.True(other.Equals(suppression));
+            Assert.IsTrue(suppression.Equals(other));
+            Assert.IsTrue(other.Equals(suppression));
         }
 
-        [Theory]
-        [MemberData(nameof(GetDifferentData))]
+        [TestMethod]
+        [DynamicData(nameof(GetDifferentData))]
         public void CheckSuppressionsAreNotEqual(Suppression suppression, Suppression other)
         {
-            Assert.False(suppression.Equals(other));
-            Assert.False(other.Equals(suppression));
+            Assert.IsFalse(suppression.Equals(other));
+            Assert.IsFalse(other.Equals(suppression));
         }
 
-        [Fact]
+        [TestMethod]
         public void CheckSuppressionIsNotEqualWithNull()
         {
-            Assert.False(new Suppression("PK0004").Equals(null));
+            Assert.IsFalse(new Suppression("PK0004").Equals(null));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/AssemblyMapperTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/AssemblyMapperTests.cs
@@ -11,9 +11,10 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 {
+    [TestClass]
     public class AssemblyMapperTests
     {
-        [Fact]
+        [TestMethod]
         public void AssemblyMapper_Ctor_PropertiesSet()
         {
             IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
@@ -23,20 +24,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 
             AssemblyMapper assemblyMapper = new(ruleRunner, mapperSettings, rightSetSize, assemblySetMapper);
 
-            Assert.Null(assemblyMapper.Left);
-            Assert.Equal(mapperSettings, assemblyMapper.Settings);
-            Assert.Equal(rightSetSize, assemblyMapper.Right.Length);
-            Assert.Equal(assemblySetMapper, assemblyMapper.ContainingAssemblySet);
+            Assert.IsNull(assemblyMapper.Left);
+            Assert.AreEqual(mapperSettings, assemblyMapper.Settings);
+            Assert.HasCount(rightSetSize, assemblyMapper.Right);
+            Assert.AreEqual(assemblySetMapper, assemblyMapper.ContainingAssemblySet);
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblyMapper_GetNamespacesWithoutLeftAndRight_EmptyResult()
         {
             AssemblyMapper assemblyMapper = new(Mock.Of<IRuleRunner>(), Mock.Of<IMapperSettings>(), rightSetSize: 1);
-            Assert.Empty(assemblyMapper.GetNamespaces());
+            Assert.IsEmpty(assemblyMapper.GetNamespaces());
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblyMapper_GetNamespaces_ReturnsExpected()
         {
             string leftSyntax = @"
@@ -73,9 +74,9 @@ namespace AssemblyMapperTestNamespace3
 
             IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
 
-            Assert.Equal(3, namespaceMappers.Count());
-            Assert.Equal(new string[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", null }, namespaceMappers.Select(n => n.Left?.Name));
-            Assert.Equal(new string[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", "AssemblyMapperTestNamespace3" }, namespaceMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+            Assert.HasCount(3, namespaceMappers);
+            Assert.AreSequenceEqual(new string[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", null }, namespaceMappers.Select(n => n.Left?.Name));
+            Assert.AreSequenceEqual(new string[] { "AssemblyMapperTestNamespace1", "AssemblyMapperTestNamespace2", "AssemblyMapperTestNamespace3" }, namespaceMappers.SelectMany(n => n.Right).Select(r => r?.Name));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/AssemblySetMapperTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/AssemblySetMapperTests.cs
@@ -10,9 +10,10 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 {
+    [TestClass]
     public class AssemblySetMapperTests
     {
-        [Fact]
+        [TestMethod]
         public void AssemblySetMapper_Ctor_PropertiesSet()
         {
             IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
@@ -21,21 +22,21 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 
             AssemblySetMapper assemblySetMapper = new(ruleRunner, mapperSettings, rightSetSize);
 
-            Assert.Null(assemblySetMapper.Left);
-            Assert.Equal(mapperSettings, assemblySetMapper.Settings);
-            Assert.Equal(rightSetSize, assemblySetMapper.Right.Length);
-            Assert.Equal(0, assemblySetMapper.AssemblyCount);
+            Assert.IsNull(assemblySetMapper.Left);
+            Assert.AreEqual(mapperSettings, assemblySetMapper.Settings);
+            Assert.HasCount(rightSetSize, assemblySetMapper.Right);
+            Assert.AreEqual(0, assemblySetMapper.AssemblyCount);
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblySetMapper_GetAssembliesWithoutLeftAndRight_EmptyResult()
         {
             AssemblySetMapper assemblySetMapper = new(Mock.Of<IRuleRunner>(), Mock.Of<IMapperSettings>(), rightSetSize: 1);
-            Assert.Empty(assemblySetMapper.GetAssemblies());
-            Assert.Equal(0, assemblySetMapper.AssemblyCount);
+            Assert.IsEmpty(assemblySetMapper.GetAssemblies());
+            Assert.AreEqual(0, assemblySetMapper.AssemblyCount);
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblySetMapper_GetAssemblies_ReturnsExpected()
         {
             string[] leftSyntaxes = new[]
@@ -121,12 +122,12 @@ namespace NamespaceInAssemblyD
             assemblySetMapper.AddElement(right1, ElementSide.Right);
             assemblySetMapper.AddElement(right2, ElementSide.Right, 1);
 
-            Assert.Equal(0, assemblySetMapper.AssemblyCount);
+            Assert.AreEqual(0, assemblySetMapper.AssemblyCount);
             IEnumerable<IAssemblyMapper> assemblyMappers = assemblySetMapper.GetAssemblies();
-            Assert.Equal(4, assemblySetMapper.AssemblyCount);
+            Assert.AreEqual(4, assemblySetMapper.AssemblyCount);
 
-            Assert.Equal(4, assemblyMappers.Count());
-            Assert.Equal(new string[] {
+            Assert.HasCount(4, assemblyMappers);
+            Assert.AreSequenceEqual(new string[] {
                     nameof(AssemblySetMapper_GetAssemblies_ReturnsExpected) + "-0",
                     nameof(AssemblySetMapper_GetAssemblies_ReturnsExpected) + "-1",
                     nameof(AssemblySetMapper_GetAssemblies_ReturnsExpected) + "-2",
@@ -142,8 +143,8 @@ namespace NamespaceInAssemblyD
             {
                 string expectedAssemblyName = nameof(AssemblySetMapper_GetAssemblies_ReturnsExpected) + $"-{counter}";
 
-                Assert.Equal(2, assemblyMapper.Right.Length);
-                Assert.True(assemblyMapper.Right.All(r => r?.Element.Name == expectedAssemblyName));
+                Assert.HasCount(2, assemblyMapper.Right);
+                Assert.IsTrue(assemblyMapper.Right.All(r => r?.Element.Name == expectedAssemblyName));
 
                 counter++;
             }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/MemberMapperTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/MemberMapperTests.cs
@@ -7,9 +7,10 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 {
+    [TestClass]
     public class MemberMapperTests
     {
-        [Fact]
+        [TestMethod]
         public void MemberMapper_Ctor_PropertiesSet()
         {
             IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
@@ -19,10 +20,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 
             MemberMapper memberMapper = new(ruleRunner, mapperSettings, rightSetSize, containingType);
 
-            Assert.Null(memberMapper.Left);
-            Assert.Equal(mapperSettings, memberMapper.Settings);
-            Assert.Equal(rightSetSize, memberMapper.Right.Length);
-            Assert.Equal(containingType, memberMapper.ContainingType);
+            Assert.IsNull(memberMapper.Left);
+            Assert.AreEqual(mapperSettings, memberMapper.Settings);
+            Assert.HasCount(rightSetSize, memberMapper.Right);
+            Assert.AreEqual(containingType, memberMapper.ContainingType);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/NamespaceMapperTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/NamespaceMapperTests.cs
@@ -11,9 +11,10 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 {
+    [TestClass]
     public class NamespaceMapperTests
     {
-        [Fact]
+        [TestMethod]
         public void NamespaceMapper_Ctor_PropertiesSet()
         {
             IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
@@ -23,20 +24,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 
             NamespaceMapper namespaceMapper = new(ruleRunner, mapperSettings, rightSetSize, assemblyMapper);
 
-            Assert.Null(namespaceMapper.Left);
-            Assert.Equal(mapperSettings, namespaceMapper.Settings);
-            Assert.Equal(rightSetSize, namespaceMapper.Right.Length);
-            Assert.Equal(assemblyMapper, namespaceMapper.ContainingAssembly);
+            Assert.IsNull(namespaceMapper.Left);
+            Assert.AreEqual(mapperSettings, namespaceMapper.Settings);
+            Assert.HasCount(rightSetSize, namespaceMapper.Right);
+            Assert.AreEqual(assemblyMapper, namespaceMapper.ContainingAssembly);
         }
 
-        [Fact]
+        [TestMethod]
         public void NamespaceMapper_GetTypesWithoutLeftAndRight_EmptyResult()
         {
             NamespaceMapper namespaceMapper = new(Mock.Of<IRuleRunner>(), Mock.Of<IMapperSettings>(), rightSetSize: 1, Mock.Of<IAssemblyMapper>());
-            Assert.Empty(namespaceMapper.GetTypes());
+            Assert.IsEmpty(namespaceMapper.GetTypes());
         }
 
-        [Fact]
+        [TestMethod]
         public void NamespaceMapper_GetTypes_ReturnsExpected()
         {
             string leftSyntax = @"
@@ -61,13 +62,13 @@ namespace NamespaceMapper
             assemblyMapper.AddElement(right, ElementSide.Right);
 
             IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
-            Assert.Single(namespaceMappers);
+            Assert.ContainsSingle(namespaceMappers);
 
             IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
-            Assert.Equal(2, typeMappers.Count());
+            Assert.HasCount(2, typeMappers);
 
-            Assert.Equal(new string[] { "A", null }, typeMappers.Select(n => n.Left?.Name));
-            Assert.Equal(new string[] { "A", "B" }, typeMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+            Assert.AreSequenceEqual(new string[] { "A", null }, typeMappers.Select(n => n.Left?.Name));
+            Assert.AreSequenceEqual(new string[] { "A", "B" }, typeMappers.SelectMany(n => n.Right).Select(r => r?.Name));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/TypeMapperTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Mapping/TypeMapperTests.cs
@@ -11,9 +11,10 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 {
+    [TestClass]
     public class TypeMapperTests
     {
-        [Fact]
+        [TestMethod]
         public void TypeMapper_Ctor_PropertiesSet()
         {
             IRuleRunner ruleRunner = Mock.Of<IRuleRunner>();
@@ -25,28 +26,28 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests.Mapping
 
             TypeMapper typeMapper = new(ruleRunner, mapperSettings, rightSetSize, containingNamespace, containingType);
 
-            Assert.Null(typeMapper.Left);
-            Assert.Equal(mapperSettings, typeMapper.Settings);
-            Assert.Equal(rightSetSize, typeMapper.Right.Length);
-            Assert.Equal(containingNamespace, typeMapper.ContainingNamespace);
-            Assert.Equal(containingType, typeMapper.ContainingType);
+            Assert.IsNull(typeMapper.Left);
+            Assert.AreEqual(mapperSettings, typeMapper.Settings);
+            Assert.HasCount(rightSetSize, typeMapper.Right);
+            Assert.AreEqual(containingNamespace, typeMapper.ContainingNamespace);
+            Assert.AreEqual(containingType, typeMapper.ContainingType);
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeMapper_GetNestedTypesWithoutLeftAndRight_EmptyResult()
         {
             TypeMapper typeMapper = new(Mock.Of<IRuleRunner>(), Mock.Of<IMapperSettings>(), rightSetSize: 1, Mock.Of<INamespaceMapper>());
-            Assert.Empty(typeMapper.GetNestedTypes());
+            Assert.IsEmpty(typeMapper.GetNestedTypes());
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeMapper_GetMembersWithoutLeftAndRight_EmptyResult()
         {
             TypeMapper typeMapper = new(Mock.Of<IRuleRunner>(), Mock.Of<IMapperSettings>(), rightSetSize: 1, Mock.Of<INamespaceMapper>());
-            Assert.Empty(typeMapper.GetMembers());
+            Assert.IsEmpty(typeMapper.GetMembers());
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeMapper_GetNestedTypes_ReturnsExpected()
         {
             string leftSyntax = @"
@@ -73,19 +74,19 @@ public class A
             assemblyMapper.AddElement(right, ElementSide.Right);
 
             IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
-            Assert.Single(namespaceMappers);
+            Assert.ContainsSingle(namespaceMappers);
 
             IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
-            Assert.Single(typeMappers);
+            Assert.ContainsSingle(typeMappers);
 
             IEnumerable<ITypeMapper> nestedTypeMappers = typeMappers.Single().GetNestedTypes();
 
-            Assert.Equal(3, nestedTypeMappers.Count());
-            Assert.Equal(new string[] { "B", "C", null }, nestedTypeMappers.Select(n => n.Left?.Name));
-            Assert.Equal(new string[] { "B", "C", "D" }, nestedTypeMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+            Assert.HasCount(3, nestedTypeMappers);
+            Assert.AreSequenceEqual(new string[] { "B", "C", null }, nestedTypeMappers.Select(n => n.Left?.Name));
+            Assert.AreSequenceEqual(new string[] { "B", "C", "D" }, nestedTypeMappers.SelectMany(n => n.Right).Select(r => r?.Name));
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeMapper_GetMembers_ReturnsExpected()
         {
             string leftSyntax = @"
@@ -114,19 +115,19 @@ public class A
             assemblyMapper.AddElement(right, ElementSide.Right);
 
             IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
-            Assert.Single(namespaceMappers);
+            Assert.ContainsSingle(namespaceMappers);
 
             IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
-            Assert.Single(typeMappers);
+            Assert.ContainsSingle(typeMappers);
 
             IEnumerable<IMemberMapper> memberMappers = typeMappers.Single().GetMembers();
 
-            Assert.Equal(4, memberMappers.Count());
-            Assert.Equal(new string[] { ".ctor", "B", "C", null }, memberMappers.Select(n => n.Left?.Name));
-            Assert.Equal(new string[] { ".ctor", "B", "C", "D" }, memberMappers.SelectMany(n => n.Right).Select(r => r?.Name));
+            Assert.HasCount(4, memberMappers);
+            Assert.AreSequenceEqual(new string[] { ".ctor", "B", "C", null }, memberMappers.Select(n => n.Left?.Name));
+            Assert.AreSequenceEqual(new string[] { ".ctor", "B", "C", "D" }, memberMappers.SelectMany(n => n.Right).Select(r => r?.Name));
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeMapper_GetMembersAndGetNestedTypesWithOnlyEffectivelySealedMembersAndTypes_ReturnsEmpty()
         {
             string leftSyntax = @"
@@ -154,16 +155,16 @@ public class A
             assemblyMapper.AddElement(right, ElementSide.Right);
 
             IEnumerable<INamespaceMapper> namespaceMappers = assemblyMapper.GetNamespaces();
-            Assert.Single(namespaceMappers);
+            Assert.ContainsSingle(namespaceMappers);
 
             IEnumerable<ITypeMapper> typeMappers = namespaceMappers.Single().GetTypes();
-            Assert.Single(typeMappers);
+            Assert.ContainsSingle(typeMappers);
 
             IEnumerable<IMemberMapper> memberMappers = typeMappers.Single().GetMembers();
-            Assert.Empty(memberMappers);
+            Assert.IsEmpty(memberMappers);
 
             IEnumerable<ITypeMapper> nestedTypeMappers = typeMappers.Single().GetNestedTypes();
-            Assert.Empty(nestedTypeMappers);
+            Assert.IsEmpty(nestedTypeMappers);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +15,15 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.ApiCompatibility\Microsoft.DotNet.ApiCompatibility.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class AssemblyIdentityMustMatchTests
     {
         private static readonly SuppressibleTestLog s_log = new();
@@ -30,8 +31,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             122, 189, 56, 195, 25, 62, 141, 151, 88, 234, 231, 156
         };
 
-        [Fact]
-        public static void AssemblyNamesDoNotMatch()
+        [TestMethod]
+        public void AssemblyNamesDoNotMatch()
         {
             IAssemblySymbol left = CSharpCompilation.Create("AssemblyA").Assembly;
             IAssemblySymbol right = CSharpCompilation.Create("AssemblyB").Assembly;
@@ -39,12 +40,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, "AssemblyB, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First());
+            Assert.AreEqual(expected, differences.First());
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblyCultureMustBeCompatible()
         {
             string leftSyntax = "";
@@ -53,18 +54,18 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
 
-            Assert.Equal(string.Empty, leftSymbol.Identity.CultureName);
-            Assert.Equal("de", rightSymbol.Identity.CultureName);
+            Assert.AreEqual(string.Empty, leftSymbol.Identity.CultureName);
+            Assert.AreEqual("de", rightSymbol.Identity.CultureName);
 
             ApiComparer differ = new(s_ruleFactory);
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, $"{leftSymbol.Name}, Version=0.0.0.0, Culture=de, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First());
+            Assert.AreEqual(expected, differences.First());
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblyVersionMustBeCompatible()
         {
             string leftSyntax = "[assembly: System.Reflection.AssemblyVersionAttribute(\"2.0.0.0\")]";
@@ -73,19 +74,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
 
-            Assert.Equal(new Version(2, 0, 0, 0), leftSymbol.Identity.Version);
-            Assert.Equal(new Version(0, 0, 0, 0), rightSymbol.Identity.Version);
+            Assert.AreEqual(new Version(2, 0, 0, 0), leftSymbol.Identity.Version);
+            Assert.AreEqual(new Version(0, 0, 0, 0), rightSymbol.Identity.Version);
 
             ApiComparer differ = new(s_ruleFactory);
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
 
             // right assembly should have same or higher version than left
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, $"{rightSymbol.Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First());
+            Assert.AreEqual(expected, differences.First());
         }
 
-        [Fact]
+        [TestMethod]
         public void AssemblyVersionMustBeStrictlyCompatible()
         {
             string leftSyntax = "[assembly: System.Reflection.AssemblyVersionAttribute(\"1.0.0.0\")]";
@@ -94,27 +95,27 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
 
-            Assert.Equal(new Version(1, 0, 0, 0), leftSymbol.Identity.Version);
-            Assert.Equal(new Version(2, 0, 0, 0), rightSymbol.Identity.Version);
+            Assert.AreEqual(new Version(1, 0, 0, 0), leftSymbol.Identity.Version);
+            Assert.AreEqual(new Version(2, 0, 0, 0), rightSymbol.Identity.Version);
 
             // Compatible assembly versions
             ApiComparer differ = new(s_ruleFactory);
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
 
             differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
 
             // Not strictly compatible
             differences = differ.GetDifferences(leftSymbol, rightSymbol);
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
 
             CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, $"{leftSymbol.Name}, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First());
+            Assert.AreEqual(expected, differences.First());
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void AssemblyKeyTokenMustBeCompatible(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -122,19 +123,19 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax, publicKey: _publicKey);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax, publicKey: _publicKey);
 
-            Assert.Equal(_publicKey, leftSymbol.Identity.PublicKey);
-            Assert.Equal(_publicKey, rightSymbol.Identity.PublicKey);
+            Assert.AreSequenceEqual(_publicKey, leftSymbol.Identity.PublicKey);
+            Assert.AreSequenceEqual(_publicKey, rightSymbol.Identity.PublicKey);
 
             // public key tokens must match
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: strictMode));
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void LeftAssemblyKeyTokenNull(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -142,27 +143,27 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax, publicKey: _publicKey);
 
-            Assert.False(leftSymbol.Identity.HasPublicKey);
-            Assert.Equal(_publicKey, rightSymbol.Identity.PublicKey);
+            Assert.IsFalse(leftSymbol.Identity.HasPublicKey);
+            Assert.AreSequenceEqual(_publicKey, rightSymbol.Identity.PublicKey);
 
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: strictMode));
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
 
             if (strictMode)
             {
-                Assert.Single(differences);
+                Assert.ContainsSingle(differences);
                 CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, $"{rightSymbol.Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-                Assert.Equal(expected, differences.First());
+                Assert.AreEqual(expected, differences.First());
             }
             else
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void RightAssemblyKeyTokenNull(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -170,20 +171,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             IAssemblySymbol leftSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax, publicKey: _publicKey);
             IAssemblySymbol rightSymbol = SymbolFactory.GetAssemblyFromSyntax(syntax);
 
-            Assert.Equal(_publicKey, leftSymbol.Identity.PublicKey);
-            Assert.False(rightSymbol.Identity.HasPublicKey);
+            Assert.AreSequenceEqual(_publicKey, leftSymbol.Identity.PublicKey);
+            Assert.IsFalse(rightSymbol.Identity.HasPublicKey);
 
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: strictMode));
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftSymbol, rightSymbol);
 
-            Assert.Single(differences);
+            Assert.ContainsSingle(differences);
             CompatDifference expected = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.AssemblyIdentityMustMatch, string.Empty, DifferenceType.Changed, $"{leftSymbol.Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.Equal(expected, differences.First());
+            Assert.AreEqual(expected, differences.First());
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void RetargetableFlagSet(bool strictMode)
         {
             string syntax = @"
@@ -200,14 +201,14 @@ using System.Reflection;
             IAssemblySymbol leftSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(leftAssembly);
             IAssemblySymbol rightSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(rightAssembly);
 
-            Assert.True(leftSymbol.Identity.IsRetargetable);
-            Assert.True(rightSymbol.Identity.IsRetargetable);
-            Assert.False(rightSymbol.Identity.HasPublicKey);
-            Assert.Equal(_publicKey, leftSymbol.Identity.PublicKey);
+            Assert.IsTrue(leftSymbol.Identity.IsRetargetable);
+            Assert.IsTrue(rightSymbol.Identity.IsRetargetable);
+            Assert.IsFalse(rightSymbol.Identity.HasPublicKey);
+            Assert.AreSequenceEqual(_publicKey, leftSymbol.Identity.PublicKey);
 
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: strictMode));
 
-            Assert.Empty(differ.GetDifferences(leftSymbol, rightSymbol));
+            Assert.IsEmpty(differ.GetDifferences(leftSymbol, rightSymbol));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class AttributesMustMatchTests
     {
         /*
@@ -1318,9 +1319,9 @@ new CompatDifference[] {
             }
         };
 
-        [Theory]
-        [MemberData(nameof(TypesCases))]
-        [MemberData(nameof(MembersCases))]
+        [TestMethod]
+        [DynamicData(nameof(TypesCases))]
+        [DynamicData(nameof(MembersCases))]
         public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             using TempDirectory root = new();
@@ -1333,11 +1334,11 @@ new CompatDifference[] {
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
 
-        [Theory]
-        [MemberData(nameof(StrictMode))]
+        [TestMethod]
+        [DynamicData(nameof(StrictMode))]
         public void EnsureStrictModeReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             using TempDirectory root = new();
@@ -1350,10 +1351,10 @@ new CompatDifference[] {
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
 
-        [Fact]
+        [TestMethod]
         public void TestExclusionsFilteredOut()
         {
             using TempDirectory root = new();
@@ -1399,10 +1400,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Empty(actual);
+            Assert.IsEmpty(actual);
         }
 
-        [Fact]
+        [TestMethod]
         public void AttributesExcludedButMembersValidated()
         {
             using TempDirectory root = new();
@@ -1449,7 +1450,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right).ToArray();
 
-            Assert.Equal(new[]
+            Assert.AreSequenceEqual(new[]
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.FooAttribute.X"),
             }, actual);

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddAbstractMemberTests.cs
@@ -9,12 +9,13 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotAddAbstractMemberTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotAddAbstractMember(settings, context));
 
-        [Theory]
-        [MemberData(nameof(AddedAbstractMemberIsReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(AddedAbstractMemberIsReportedData))]
         public void AddedAbstractMemberIsReported(string leftSyntax, string rightSyntax, bool includeInternals)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -27,11 +28,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAbstractMember, string.Empty, DifferenceType.Added, "M:CompatTests.First.SecondAbstract")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Theory]
-        [MemberData(nameof(AddedAbstractMemberNoVisibleConstructorData))]
+        [TestMethod]
+        [DynamicData(nameof(AddedAbstractMemberNoVisibleConstructorData))]
         public void AddedAbstractMemberNoVisibleConstructor(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -40,11 +41,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Theory]
-        [MemberData(nameof(AddedToUnsealedTypeInRightNotReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(AddedToUnsealedTypeInRightNotReportedData))]
         public void AddedToUnsealedTypeInRightNotReported(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -53,10 +54,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void StrictModeRuleIsNotExecuted()
         {
             object[] syntaxes = AddedAbstractMemberIsReportedData().First();
@@ -71,11 +72,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             foreach (CompatDifference difference in differences)
             {
-                Assert.NotEqual(DiagnosticIds.CannotAddAbstractMember, difference.DiagnosticId);
+                Assert.AreNotEqual(DiagnosticIds.CannotAddAbstractMember, difference.DiagnosticId);
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsAreReported()
         {
             string leftSyntax = @"
@@ -153,7 +154,7 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right[1].MetadataInformation, DiagnosticIds.CannotAddAbstractMember, string.Empty, DifferenceType.Added, "M:CompatTests.First.FirstNested.SecondNested.SomeAbstractMethod"),
                 new CompatDifference(left.MetadataInformation, right[2].MetadataInformation, DiagnosticIds.CannotAddAbstractMember, string.Empty, DifferenceType.Added, "M:CompatTests.First.FirstNested.FirstNestedAbstract"),
             };
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
         public static IEnumerable<object[]> AddedToUnsealedTypeInRightNotReportedData()

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddMemberToInterfaceTests.cs
@@ -7,11 +7,12 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotAddMemberToInterfaceTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotAddMemberToInterface(settings, context));
 
-        [Fact]
+        [TestMethod]
         public void AddedMembersAreReported()
         {
             string leftSyntax = @"
@@ -52,11 +53,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "P:CompatTests.IFoo.MyPropertyWithoutDefaultImplementation"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "E:CompatTests.IFoo.MyEventWithoutImplementation"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Theory]
-        [MemberData(nameof(NoDifferencesShouldBeReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(NoDifferencesShouldBeReportedData))]
         public void NoDifferencesShouldBeReported(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -65,10 +66,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void StrictModeRuleShouldNotRun()
         {
             string leftSyntax = @"
@@ -106,11 +107,11 @@ namespace CompatTests
 
             foreach (CompatDifference difference in differences)
             {
-                Assert.NotEqual(DiagnosticIds.CannotAddMemberToInterface, difference.DiagnosticId);
+                Assert.AreNotEqual(DiagnosticIds.CannotAddMemberToInterface, difference.DiagnosticId);
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsAreReported()
         {
             string leftSyntax = @"
@@ -192,7 +193,7 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right[2].MetadataInformation, DiagnosticIds.CannotAddMemberToInterface, string.Empty, DifferenceType.Added, "M:CompatTests.IFoo.MyOtherMethod"),
             };
 
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
         public static IEnumerable<object[]> NoDifferencesShouldBeReportedData()

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotAddOrRemoveVirtualKeywordTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotAddOrRemoveVirtualKeywordTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotAddOrRemoveVirtualKeyword(settings, context));
@@ -180,11 +181,11 @@ namespace CompatTests {{
             };
         }
 
-        [Theory]
-        [MemberData(nameof(RemovedCases))]
-        [MemberData(nameof(AddedCases))]
-        [MemberData(nameof(AddedCasesStrictMode))]
-        public static void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, bool strictMode, CompatDifference[] expected)
+        [TestMethod]
+        [DynamicData(nameof(RemovedCases))]
+        [DynamicData(nameof(AddedCases))]
+        [DynamicData(nameof(AddedCasesStrictMode))]
+        public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, bool strictMode, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
@@ -192,11 +193,11 @@ namespace CompatTests {{
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void EnsureNoCrashWhenMembersDoNotExist()
+        [TestMethod]
+        public void EnsureNoCrashWhenMembersDoNotExist()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -225,13 +226,13 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.F"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
         // Don't run this test on .NET Framework, because default interface methods weren't introduced until C# 8.
 #if !NETFRAMEWORK
-        [Fact]
-        public static void EnsureDiagnosticWhenAddingSealedToInterfaceMember()
+        [TestMethod]
+        public void EnsureDiagnosticWhenAddingSealedToInterfaceMember()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -255,7 +256,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Equal(new CompatDifference[]
+            Assert.AreSequenceEqual(new CompatDifference[]
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddSealedToInterfaceMember, string.Empty, DifferenceType.Added, "M:CompatTests.First.F")
             }, differences);

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeGenericConstraintsTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeGenericConstraintsTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotChangeGenericConstraintsTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotChangeGenericConstraints(settings, context));
@@ -210,8 +211,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             },
         };
 
-        [Theory]
-        [MemberData(nameof(TestCases))]
+        [TestMethod]
+        [DynamicData(nameof(TestCases))]
         public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -220,11 +221,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
 
-        [Theory]
-        [MemberData(nameof(StrictMode))]
+        [TestMethod]
+        [DynamicData(nameof(StrictMode))]
         public void EnsureDiagnosticIsReportedInStrictMode(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -235,7 +236,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotChangeVisibilityTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotChangeVisibilityTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotChangeVisibility(settings, context));
@@ -378,8 +379,8 @@ new CompatDifference[] {}
             },
         };
 
-        [Theory]
-        [MemberData(nameof(TestCases))]
+        [TestMethod]
+        [DynamicData(nameof(TestCases))]
         public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -388,11 +389,11 @@ new CompatDifference[] {}
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
 
-        [Theory]
-        [MemberData(nameof(StrictMode))]
+        [TestMethod]
+        [DynamicData(nameof(StrictMode))]
         public void EnsureDiagnosticIsReportedInStrictMode(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -403,11 +404,11 @@ new CompatDifference[] {}
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
 
-        [Theory]
-        [MemberData(nameof(NoInternals))]
+        [TestMethod]
+        [DynamicData(nameof(NoInternals))]
         public void EnsureReportedInStrictModeWithoutInternalSymbols(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -418,7 +419,7 @@ new CompatDifference[] {}
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
@@ -83,8 +83,8 @@ namespace CompatTests
             };
             Assert.AreSequenceEqual(expected, differences);
 
-            Assert.Contains(differences.ElementAt(0).Message, "CompatTests.FirstBase");
-            Assert.Contains(differences.ElementAt(1).Message, "CompatTests.IFirstInterface");
+            Assert.Contains("CompatTests.FirstBase", differences.ElementAt(0).Message);
+            Assert.Contains("CompatTests.IFirstInterface", differences.ElementAt(1).Message);
         }
 
         [TestMethod]
@@ -163,8 +163,8 @@ namespace CompatTests
             string firstMessage = differences[0].Message;
             string secondMessage = differences[1].Message;
 
-            Assert.Contains(firstMessage, "CompatTests.FirstBase");
-            Assert.Contains(secondMessage, "CompatTests.IFirstInterface");
+            Assert.Contains("CompatTests.FirstBase", firstMessage);
+            Assert.Contains("CompatTests.IFirstInterface", secondMessage);
 
             Assert.IsGreaterThan(firstMessage.IndexOf("left"), firstMessage.IndexOf("right"));
             Assert.IsGreaterThan(firstMessage.IndexOf("left"), secondMessage.IndexOf("right"));

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
@@ -7,11 +7,12 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotRemoveBaseTypeOrInterfaceTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotRemoveBaseTypeOrInterface(settings, context));
 
-        [Fact]
+        [TestMethod]
         public void PromotedBaseClassOrInterfaceIsNotReported()
         {
             string leftSyntax = @"
@@ -45,10 +46,10 @@ namespace CompatTests
 
             ApiComparer differ = new(s_ruleFactory);
 
-            Assert.Empty(differ.GetDifferences(left, right));
+            Assert.IsEmpty(differ.GetDifferences(left, right));
         }
 
-        [Fact]
+        [TestMethod]
         public void RemovedInterfaceAndBaseClassAreReported()
         {
             string leftSyntax = @"
@@ -80,15 +81,15 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveBaseType, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveBaseInterface, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
 
-            Assert.Contains("CompatTests.FirstBase", differences.ElementAt(0).Message);
-            Assert.Contains("CompatTests.IFirstInterface", differences.ElementAt(1).Message);
+            Assert.Contains(differences.ElementAt(0).Message, "CompatTests.FirstBase");
+            Assert.Contains(differences.ElementAt(1).Message, "CompatTests.IFirstInterface");
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void RemovedInternalInterfaceIsReportedWhenIncludeInternals(bool includeInternals)
         {
             string leftSyntax = @"
@@ -119,15 +120,15 @@ namespace CompatTests
                 {
                     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveBaseInterface, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
                 };
-                Assert.Equal(expected, differences);
+                Assert.AreSequenceEqual(expected, differences);
             }
             else
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void RemovedFromLeftReportedOnStrictMode()
         {
             string leftSyntax = @"
@@ -157,21 +158,21 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveBaseType, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveBaseInterface, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
 
             string firstMessage = differences[0].Message;
             string secondMessage = differences[1].Message;
 
-            Assert.Contains("CompatTests.FirstBase", firstMessage);
-            Assert.Contains("CompatTests.IFirstInterface", secondMessage);
+            Assert.Contains(firstMessage, "CompatTests.FirstBase");
+            Assert.Contains(secondMessage, "CompatTests.IFirstInterface");
 
-            Assert.True(firstMessage.IndexOf("right") > firstMessage.IndexOf("left"));
-            Assert.True(secondMessage.IndexOf("right") > firstMessage.IndexOf("left"));
+            Assert.IsGreaterThan(firstMessage.IndexOf("left"), firstMessage.IndexOf("right"));
+            Assert.IsGreaterThan(firstMessage.IndexOf("left"), secondMessage.IndexOf("right"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void SameOnBothSidesDoesNotFail(bool strictMode)
         {
             string leftSyntax = @"
@@ -205,10 +206,10 @@ namespace CompatTests
 
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: strictMode));
 
-            Assert.Empty(differ.GetDifferences(left, right));
+            Assert.IsEmpty(differ.GetDifferences(left, right));
         }
 
-        [Fact]
+        [TestMethod]
         public void MultiRightReportsRightDifferences()
         {
             string leftSyntax = @"
@@ -275,10 +276,10 @@ namespace CompatTests
                 new CompatDifference(leftContainer.MetadataInformation, right[2].MetadataInformation, DiagnosticIds.CannotRemoveBaseInterface, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
             };
 
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MembersPushedDownToNewBaseNotReported()
         {
             string leftSyntax = @"
@@ -332,7 +333,7 @@ namespace CompatTests
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer differ = new(s_ruleFactory);
 
-            Assert.Empty(differ.GetDifferences(left, right));
+            Assert.IsEmpty(differ.GetDifferences(left, right));
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
@@ -7,12 +7,13 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class CannotSealTypeTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotSealType(settings, context));
 
-        [Theory]
-        [MemberData(nameof(SealNonInheritableTypeNotReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(SealNonInheritableTypeNotReportedData))]
         public void SealNonInheritableTypeNotReported(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -23,12 +24,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 
             foreach (CompatDifference difference in differences)
             {
-                Assert.NotEqual(DiagnosticIds.CannotSealType, difference.DiagnosticId);
+                Assert.AreNotEqual(DiagnosticIds.CannotSealType, difference.DiagnosticId);
             }
         }
 
-        [Theory]
-        [MemberData(nameof(SealInheritableTypeReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(SealInheritableTypeReportedData))]
         public void SealInheritableTypeReported(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -41,9 +42,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
             Assert.Contains(difference, differences);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void SealInheritableTypeInternalsVisibleReported(bool includeInternals)
         {
             string leftSyntax = @"
@@ -72,7 +73,7 @@ namespace CompatTests
 
             if (!includeInternals)
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
             else
             {
@@ -81,12 +82,12 @@ namespace CompatTests
                      CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotSealType, string.Empty, DifferenceType.Changed, "T:CompatTests.First")
                 };
 
-                Assert.Equal(expected, differences);
+                Assert.AreSequenceEqual(expected, differences);
             }
 
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsAreReportedCorrectly()
         {
             string leftSyntax = @"
@@ -144,10 +145,10 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.ElementAt(3).MetadataInformation, DiagnosticIds.CannotSealType, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
                 new CompatDifference(left.MetadataInformation, right.ElementAt(3).MetadataInformation, DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.#ctor"),
             };
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsNoDifferences()
         {
             string leftSyntax = @"
@@ -192,11 +193,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(leftContainer, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Theory]
-        [MemberData(nameof(StrictModeSealedLeftIsReportedData))]
+        [TestMethod]
+        [DynamicData(nameof(StrictModeSealedLeftIsReportedData))]
         public void StrictModeSealedLeftIsReported(string leftSyntax, string rightSyntax)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -207,7 +208,7 @@ namespace CompatTests
 
             CompatDifference expectedDifference = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotSealType, string.Empty, DifferenceType.Changed, "T:CompatTests.First");
             Assert.Contains(expectedDifference, differences);
-            Assert.True(differences[0].Message.IndexOf("left") < differences[0].Message.IndexOf("right"));
+            Assert.IsLessThan(differences[0].Message.IndexOf("right"), differences[0].Message.IndexOf("left"));
         }
 
         public static IEnumerable<object[]> StrictModeSealedLeftIsReportedData()

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/EnumsMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/EnumsMustMatchTests.cs
@@ -7,12 +7,13 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class EnumsMustMatchTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new EnumsMustMatch(settings, context));
 
-        [Fact]
-        public static void DifferencesReported()
+        [TestMethod]
+        public void DifferencesReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -47,11 +48,11 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.EnumValuesMustMatch, string.Empty, DifferenceType.Changed, "F:CompatTests.First.A"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void RemovedEnum()
+        [TestMethod]
+        public void RemovedEnum()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -83,11 +84,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.NotEmpty(differences);
+            Assert.IsNotEmpty(differences);
         }
 
-        [Fact]
-        public static void AddedEnum()
+        [TestMethod]
+        public void AddedEnum()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -118,11 +119,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
-        public static void BackingStoreChanged()
+        [TestMethod]
+        public void BackingStoreChanged()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -156,7 +157,7 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.EnumTypesMustMatch, string.Empty, DifferenceType.Changed, "T:CompatTests.First"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
@@ -7,12 +7,13 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class MembersMustExistTests_Strict
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
 
-        [Fact]
-        public static void MissingMembersOnLeftAreReported()
+        [TestMethod]
+        public void MissingMembersOnLeftAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -55,11 +56,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.remove_ShouldReportMissingEvent(CompatTests.EventHandler)"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.ReportMissingField"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void HiddenMemberInRightIsNotReported()
+        [TestMethod]
+        public void HiddenMemberInRightIsNotReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -99,11 +100,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
-        public static void MultipleOverridesMissingInLeftAreReported()
+        [TestMethod]
+        public void MultipleOverridesMissingInLeftAreReported()
         {
             string rightSyntax = @"
 namespace CompatTests
@@ -140,13 +141,13 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.String)"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.Int32,System.String)"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
         {
             string rightSyntax = @"
 namespace CompatTests
@@ -190,16 +191,16 @@ namespace CompatTests
                     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MultipleOverrides(System.String,System.Int32,System.Int32)"),
                     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.set_InternalProperty(System.Int32)"),
                 };
-                Assert.Equal(expected, differences);
+                Assert.AreSequenceEqual(expected, differences);
             }
             else
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
         }
 
-        [Fact]
-        public static void MissingMembersOnBothSidesAreReported()
+        [TestMethod]
+        public void MissingMembersOnBothSidesAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -232,11 +233,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.MissingMethodRight"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "M:CompatTests.First.MissingMethodLeft(System.String,System.String)"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingMembersOnLeftAreReported()
+        [TestMethod]
+        public void MultipleRightsMissingMembersOnLeftAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -329,11 +330,11 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.ElementAt(0).MetadataInformation, DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.FirstNested.SecondNested.ThirdNested.MyField"),
                 new CompatDifference(left.MetadataInformation, right.ElementAt(1).MetadataInformation, DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.FirstNested.SecondNested.ThirdNested.MyField"),
             };
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
-        [Fact]
-        public static void MissingMembersOnEnumReported()
+        [TestMethod]
+        public void MissingMembersOnEnumReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -372,7 +373,7 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.F"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Added, "F:CompatTests.First.E"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -7,12 +7,13 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class MembersMustExistTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
 
-        [Fact]
-        public static void MissingMembersAreReported()
+        [TestMethod]
+        public void MissingMembersAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -56,11 +57,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "F:CompatTests.First.ReportMissingField"),
             };
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void HiddenMemberInLeftIsNotReported()
+        [TestMethod]
+        public void HiddenMemberInLeftIsNotReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -100,11 +101,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(new[] { left }, new[] { right });
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
-        public static void MultipleOverridesAreReported()
+        [TestMethod]
+        public void MultipleOverridesAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -142,13 +143,13 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.MultipleOverrides(System.String,System.Int32,System.String)"),
             };
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -191,16 +192,16 @@ namespace CompatTests
                     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.set_InternalProperty(System.Int32)"),
                 };
 
-                Assert.Equal(expected, differences);
+                Assert.AreSequenceEqual(expected, differences);
             }
             else
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
         }
 
-        [Fact]
-        public static void MembersWithDifferentNullableAnnotationsNoErrors()
+        [TestMethod]
+        public void MembersWithDifferentNullableAnnotationsNoErrors()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -226,11 +227,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
-        public static void ParametersWithDifferentModifiersNoErrors()
+        [TestMethod]
+        public void ParametersWithDifferentModifiersNoErrors()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -258,11 +259,11 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
-        public static void ParametersWithDifferentModifiersReportedWhenMissing()
+        [TestMethod]
+        public void ParametersWithDifferentModifiersReportedWhenMissing()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -297,11 +298,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.MyRefMethod(System.String@)"),
             };
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingMembersAreReported()
+        [TestMethod]
+        public void MultipleRightsMissingMembersAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -394,11 +395,11 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.ElementAt(2).MetadataInformation, DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.FirstNested.SecondNested.MyMethod"),
             };
 
-            Assert.Equal(expectedDiffs, differences);
+            Assert.AreSequenceEqual(expectedDiffs, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsNoDifferencesReported()
+        [TestMethod]
+        public void MultipleRightsNoDifferencesReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -428,10 +429,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void ParameterlessConstructorRemovalIsReported()
         {
             string leftSyntax = @"
@@ -461,10 +462,10 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.#ctor")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void NumericPtrNotFlagged()
         {
             string leftSyntax = @"
@@ -495,10 +496,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void ThisExtensionMethodModifierRemovalFlagged()
         {
             string leftSyntax = @"
@@ -525,14 +526,14 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Equal(new[]
+            Assert.AreSequenceEqual(new[]
             {
                 // The call to GetDocumentationCommentId doesn't return a string that includes the "this" keyword.
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "M:CompatTests.First.F(System.String)")
             }, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MemberTypesChangeFlagged()
         {
             string leftSyntax = @"
@@ -573,7 +574,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Equal(new[]
+            Assert.AreSequenceEqual(new[]
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.MemberMustExist, string.Empty, DifferenceType.Removed, "F:CompatTests.First.S"),
                 // CompatTests.First.Prop.set isn't reported as the return types match: 'void'.

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/ParameterNamesCannotChangeTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/ParameterNamesCannotChangeTests.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class ParameterNamesCannotChangeTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new CannotChangeParameterName(settings, context));
@@ -81,8 +82,8 @@ namespace CompatTests
             }
         };
 
-        [Theory]
-        [MemberData(nameof(TestCases))]
+        [TestMethod]
+        [DynamicData(nameof(TestCases))]
         public void EnsureDiagnosticIsReported(string leftSyntax, string rightSyntax, CompatDifference[] expected)
         {
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
@@ -91,7 +92,7 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> actual = differ.GetDifferences(left, right);
 
-            Assert.Equal(expected, actual);
+            Assert.AreSequenceEqual(expected, actual);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.Strict.cs
@@ -7,11 +7,12 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class TypeMustExistTests_Strict
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
 
-        [Fact]
+        [TestMethod]
         public void MissingPublicTypesInLeftAreReported()
         {
             string leftSyntax = @"
@@ -47,10 +48,10 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.MyRecord"),
 #endif
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingTypeFromTypeForwardOnLeftIsReported()
         {
             string forwardedTypeSyntax = @"
@@ -82,10 +83,10 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.ForwardedTestType")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeForwardExistsOnBothNoWarn()
         {
             string forwardedTypeSyntax = @"
@@ -106,10 +107,10 @@ namespace CompatTests
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
             ApiComparer differ = new(s_ruleFactory, new ApiComparerSettings(strictMode: true));
 
-            Assert.Empty(differ.GetDifferences(left, right));
+            Assert.IsEmpty(differ.GetDifferences(left, right));
         }
 
-        [Fact]
+        [TestMethod]
         public void DifferenceIsIgnoredForMemberOnRight()
         {
             string leftSyntax = @"
@@ -145,11 +146,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.Fourth"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.MyEnum")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MissingNestedTypeOnLeftIsReported()
+        [TestMethod]
+        public void MissingNestedTypeOnLeftIsReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -182,11 +183,11 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.First.FirstNested"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void TypesMissingOnBothSidesAreReported()
+        [TestMethod]
+        public void TypesMissingOnBothSidesAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -211,11 +212,11 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.LeftType"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.RightType"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingTypesOnLeftAreReported()
+        [TestMethod]
+        public void MultipleRightsMissingTypesOnLeftAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -257,11 +258,11 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.ElementAt(1).MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.Second"),
                 new CompatDifference(left.MetadataInformation, right.ElementAt(2).MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.Third"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingNestedTypesOnLeftAreReported()
+        [TestMethod]
+        public void MultipleRightsMissingNestedTypesOnLeftAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -322,10 +323,10 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.First().MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.First.FirstNested.SecondNested.ThirdNested"),
             };
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsMissingTypeForwardInLeftIsReported()
         {
             string forwardedTypeSyntax = @"
@@ -355,7 +356,7 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right.First().MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.ForwardedTestType"),
                 new CompatDifference(left.MetadataInformation, right.ElementAt(2).MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:CompatTests.ForwardedTestType"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
@@ -7,11 +7,12 @@ using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
 {
+    [TestClass]
     public class TypeMustExistTests
     {
         private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
 
-        [Fact]
+        [TestMethod]
         public void MissingPublicTypesInRightAreReported()
         {
             string leftSyntax = @"
@@ -50,10 +51,10 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyRecord"),
 #endif
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeInDifferentNamespaces()
         {
             string leftSyntax = @"
@@ -79,10 +80,10 @@ namespace B.B
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:A.B.C"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void NestedTypeVsNamespaces()
         {
             string leftSyntax = @"
@@ -108,10 +109,10 @@ public class A
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:A.B"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingTypeFromTypeForwardIsReported()
         {
             string forwardedTypeSyntax = @"
@@ -143,10 +144,10 @@ namespace CompatTests
             {
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.ForwardedTestType")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void TypeForwardExistsOnBoth()
         {
             string forwardedTypeSyntax = @"
@@ -167,10 +168,10 @@ namespace CompatTests
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntaxWithReferences(syntax, references);
             ApiComparer differ = new(s_ruleFactory);
 
-            Assert.Empty(differ.GetDifferences(left, right));
+            Assert.IsEmpty(differ.GetDifferences(left, right));
         }
 
-        [Fact]
+        [TestMethod]
         public void RecordsAreMappedCorrectly()
         {
             string leftSyntax = @"
@@ -206,12 +207,12 @@ namespace CompatTests
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.Fourth"),
                 CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.MyEnum")
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void InternalTypesAreIgnoredWhenSpecified(bool includeInternalSymbols)
         {
             string leftSyntax = @"
@@ -235,7 +236,7 @@ namespace CompatTests
 
             if (!includeInternalSymbols)
             {
-                Assert.Empty(differences);
+                Assert.IsEmpty(differences);
             }
             else
             {
@@ -243,14 +244,14 @@ namespace CompatTests
                 {
                     CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.InternalType")
                 };
-                Assert.Equal(expected, differences);
+                Assert.AreSequenceEqual(expected, differences);
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void MissingNestedTypeIsReported(bool includeInternalSymbols)
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void MissingNestedTypeIsReported(bool includeInternalSymbols)
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -295,11 +296,11 @@ namespace CompatTests
                 );
             }
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingTypesReported()
+        [TestMethod]
+        public void MultipleRightsMissingTypesReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -340,11 +341,11 @@ namespace CompatTests
                     new CompatDifference(left.MetadataInformation, right[1].MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.First"),
                     new CompatDifference(left.MetadataInformation, right[2].MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.Second"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsMissingNestedTypesAreReported()
+        [TestMethod]
+        public void MultipleRightsMissingNestedTypesAreReported()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -417,11 +418,11 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right[2].MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.First.FirstNested.SecondNested"),
                 new CompatDifference(left.MetadataInformation, right[3].MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.First"),
             };
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
 
-        [Fact]
-        public static void MultipleRightsNoDifferences()
+        [TestMethod]
+        public void MultipleRightsNoDifferences()
         {
             string leftSyntax = @"
 namespace CompatTests
@@ -449,10 +450,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsTypeForwardExistsOnAll()
         {
             string forwardedTypeSyntax = @"
@@ -473,10 +474,10 @@ namespace CompatTests
 
             IEnumerable<CompatDifference> differences = differ.GetDifferences(left, right);
 
-            Assert.Empty(differences);
+            Assert.IsEmpty(differences);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleRightsMissingTypeForwardIsReported()
         {
             string forwardedTypeSyntax = @"
@@ -502,7 +503,7 @@ namespace CompatTests
                 new CompatDifference(left.MetadataInformation, right[1].MetadataInformation, DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:CompatTests.ForwardedTestType"),
             };
 
-            Assert.Equal(expected, differences);
+            Assert.AreSequenceEqual(expected, differences);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatOptionsTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatOptionsTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 {
+    [TestClass]
     public class ApiCompatOptionsTests
     {
-        [Fact]
+        [TestMethod]
         public void Ctor_ValidArguments_PropertiesSet()
         {
             bool enableStrictMode = true;
@@ -13,8 +14,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 
             ApiCompatRunnerOptions options = new(enableStrictMode, isBaselineComparison);
 
-            Assert.Equal(enableStrictMode, options.EnableStrictMode);
-            Assert.Equal(isBaselineComparison, options.IsBaselineComparison);
+            Assert.AreEqual(enableStrictMode, options.EnableStrictMode);
+            Assert.AreEqual(isBaselineComparison, options.IsBaselineComparison);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 {
+    [TestClass]
     public class ApiCompatRunnerTests
     {
         private static ApiCompatRunner MockApiCompatRunner(MetadataInformation left = default,
@@ -54,7 +55,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
                 assemblyLoaderFactoryMock.Object);
         }
 
-        [Fact]
+        [TestMethod]
         public void EnqueueWorkItem_NoDuplicateLeftsForDifferentRights_SingleLeftWithMultipleRights()
         {
             ApiCompatRunner apiCompatRunner = MockApiCompatRunner();
@@ -66,11 +67,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right1));
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right2));
 
-            Assert.Single(apiCompatRunner.WorkItems);
-            Assert.Equal(2, apiCompatRunner.WorkItems.First().Right.Count);
+            Assert.ContainsSingle(apiCompatRunner.WorkItems);
+            Assert.HasCount(2, apiCompatRunner.WorkItems.First().Right);
         }
 
-        [Fact]
+        [TestMethod]
         public void EnqueueWorkItem_NoDuplicateRightsForSpecificLeft_SingleRight()
         {
             ApiCompatRunner apiCompatRunner = MockApiCompatRunner();
@@ -81,11 +82,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right));
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right));
 
-            Assert.Single(apiCompatRunner.WorkItems);
-            Assert.Single(apiCompatRunner.WorkItems.First().Right);
+            Assert.ContainsSingle(apiCompatRunner.WorkItems);
+            Assert.ContainsSingle(apiCompatRunner.WorkItems.First().Right);
         }
 
-        [Fact]
+        [TestMethod]
         public void EnqueueWorkItem_DifferentAssemblies_EqualNumberOfWorkItems()
         {
             ApiCompatRunner apiCompatRunner = MockApiCompatRunner();
@@ -97,20 +98,20 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left1, new ApiCompatRunnerOptions(), right));
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left2, new ApiCompatRunnerOptions(), right));
 
-            Assert.Equal(2, apiCompatRunner.WorkItems.Count());
+            Assert.HasCount(2, apiCompatRunner.WorkItems);
         }
 
-        [Fact]
+        [TestMethod]
         public void ExecuteWorkItems_NoWorkItemsEnqueued_EmptyWorkItems()
         {
             ApiCompatRunner apiCompatRunner = MockApiCompatRunner();
 
-            Assert.Empty(apiCompatRunner.WorkItems);
+            Assert.IsEmpty(apiCompatRunner.WorkItems);
             apiCompatRunner.ExecuteWorkItems();
-            Assert.Empty(apiCompatRunner.WorkItems);
+            Assert.IsEmpty(apiCompatRunner.WorkItems);
         }
 
-        [Fact]
+        [TestMethod]
         public void ExecuteWorkItems_WorkItemsEnqueued_EmptyWorkItems()
         {
             MetadataInformation left = new("A.dll", @"lib\netstandard2.0\A.dll", references: new string[] { @"ref\net6.0\System.Runtime.dll", @"ref\net6.0\System.Collections.dll" });
@@ -121,7 +122,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, options, right));
             apiCompatRunner.ExecuteWorkItems();
 
-            Assert.Empty(apiCompatRunner.WorkItems);
+            Assert.IsEmpty(apiCompatRunner.WorkItems);
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatWorkItemTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatWorkItemTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 {
+    [TestClass]
     public class ApiCompatWorkItemTests
     {
-        [Fact]
+        [TestMethod]
         public void Ctor_ValidArguments_PropertiesSet()
         {
             ApiCompatRunnerOptions apiCompatOptions = new(enableStrictMode: true, isBaselineComparison: true);
@@ -14,13 +15,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 
             ApiCompatRunnerWorkItem workItem = new(left, apiCompatOptions, right);
 
-            Assert.Equal(new MetadataInformation[] { left }, workItem.Left);
-            Assert.Equal(apiCompatOptions, workItem.Options);
-            Assert.Single(workItem.Right);
-            Assert.Equal(new MetadataInformation[] { right }, workItem.Right[0]);
+            Assert.AreSequenceEqual(new MetadataInformation[] { left }, workItem.Left);
+            Assert.AreEqual(apiCompatOptions, workItem.Options);
+            Assert.ContainsSingle(workItem.Right);
+            Assert.AreSequenceEqual(new MetadataInformation[] { right }, workItem.Right[0]);
         }
 
-        [Fact]
+        [TestMethod]
         public void Equals_SameWorkItems_IsEqual()
         {
             ApiCompatRunnerOptions apiCompatOptions = new(enableStrictMode: true, isBaselineComparison: true);
@@ -30,12 +31,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             ApiCompatRunnerWorkItem workItem1 = new(left, apiCompatOptions, right);
             ApiCompatRunnerWorkItem workItem2 = new(left, apiCompatOptions, right);
 
-            Assert.True(workItem1.Equals((object)workItem2));
-            Assert.True(workItem1.Equals(workItem2));
-            Assert.True(workItem1 == workItem2);
+            Assert.IsTrue(workItem1.Equals((object)workItem2));
+            Assert.IsTrue(workItem1.Equals(workItem2));
+            Assert.IsTrue(workItem1 == workItem2);
         }
 
-        [Fact]
+        [TestMethod]
         public void Equals_DifferentWorkItems_NotEqual()
         {
             ApiCompatRunnerOptions apiCompatOptions1 = new(enableStrictMode: true, isBaselineComparison: true);
@@ -48,12 +49,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             ApiCompatRunnerWorkItem workItem1 = new(left1, apiCompatOptions1, right1);
             ApiCompatRunnerWorkItem workItem2 = new(left2, apiCompatOptions2, right2);
 
-            Assert.False(workItem1.Equals((object)workItem2));
-            Assert.False(workItem1.Equals(workItem2));
-            Assert.True(workItem1 != workItem2);
+            Assert.IsFalse(workItem1.Equals((object)workItem2));
+            Assert.IsFalse(workItem1.Equals(workItem2));
+            Assert.IsTrue(workItem1 != workItem2);
         }
 
-        [Fact]
+        [TestMethod]
         public void GetHashCode_SameWorkItems_Equal()
         {
             ApiCompatRunnerOptions apiCompatOptions = new(enableStrictMode: true, isBaselineComparison: true);
@@ -63,10 +64,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             ApiCompatRunnerWorkItem workItem1 = new(left, apiCompatOptions, right);
             ApiCompatRunnerWorkItem workItem2 = new(left, apiCompatOptions, right);
 
-            Assert.Equal(workItem1.GetHashCode(), workItem2.GetHashCode());
+            Assert.AreEqual(workItem1.GetHashCode(), workItem2.GetHashCode());
         }
 
-        [Fact]
+        [TestMethod]
         public void GetHashCode_DifferentWorkItems_NotEqual()
         {
             ApiCompatRunnerOptions apiCompatOptions1 = new(enableStrictMode: true, isBaselineComparison: true);
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             ApiCompatRunnerWorkItem workItem1 = new(left1, apiCompatOptions1, right1);
             ApiCompatRunnerWorkItem workItem2 = new(left2, apiCompatOptions2, right2);
 
-            Assert.NotEqual(workItem1.GetHashCode(), workItem2.GetHashCode());
+            Assert.AreNotEqual(workItem1.GetHashCode(), workItem2.GetHashCode());
         }
     }
 }

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/SuppressibleTestLog.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/SuppressibleTestLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.ApiCompatibility.Logging;

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/TheoryData.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/TheoryData.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    public class TheoryData<T1, T2, T3> : List<object[]>
+    {
+        public void Add(T1 item1, T2 item2, T3 item3) => Add([item1!, item2!, item3!]);
+    }
+}

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
@@ -11,9 +11,9 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
 {
+    [TestClass]
     public class AssemblySymbolLoaderTests : SdkTest
     {
-        public AssemblySymbolLoaderTests(ITestOutputHelper log) : base(log) { }
 
         private const string SimpleAssemblySourceContents = @"
 namespace MyNamespace
@@ -87,26 +87,28 @@ namespace MyNamespace
 
         private TestAssetInfo GetSimpleTestAsset() => TestAssetCache.Instance.GetSimpleAsset(TestAssetsManager);
 
-        [Fact]
+        [TestMethod]
         public void LoadAssembly_Throws()
         {
             TestLog log = new();
             AssemblySymbolLoader loader = new(log);
-            Assert.Throws<FileNotFoundException>(() => loader.LoadAssembly(Guid.NewGuid().ToString("N").Substring(0, 8)));
+            Assert.ThrowsExactly<FileNotFoundException>(() => loader.LoadAssembly(Guid.NewGuid().ToString("N").Substring(0, 8)));
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadAssemblyFromSourceFiles_Throws()
         {
             TestLog log = new();
             AssemblySymbolLoader loader = new(log);
             IEnumerable<string> paths = new[] { Guid.NewGuid().ToString("N") };
-            Assert.Throws<FileNotFoundException>(() => loader.LoadAssemblyFromSourceFiles(paths, "assembly1", Array.Empty<string>()));
-            Assert.Throws<ArgumentNullException>("filePaths", () => loader.LoadAssemblyFromSourceFiles(Array.Empty<string>(), "assembly1", Array.Empty<string>()));
-            Assert.Throws<ArgumentNullException>("assemblyName", () => loader.LoadAssemblyFromSourceFiles(paths, null, Array.Empty<string>()));
+            Assert.ThrowsExactly<FileNotFoundException>(() => loader.LoadAssemblyFromSourceFiles(paths, "assembly1", Array.Empty<string>()));
+            ArgumentNullException filePathsException = Assert.ThrowsExactly<ArgumentNullException>(() => loader.LoadAssemblyFromSourceFiles(Array.Empty<string>(), "assembly1", Array.Empty<string>()));
+            Assert.AreEqual("filePaths", filePathsException.ParamName);
+            ArgumentNullException assemblyNameException = Assert.ThrowsExactly<ArgumentNullException>(() => loader.LoadAssemblyFromSourceFiles(paths, null, Array.Empty<string>()));
+            Assert.AreEqual("assemblyName", assemblyNameException.ParamName);
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadMatchingAssemblies_Throws()
         {
             TestLog log = new();
@@ -114,10 +116,10 @@ namespace MyNamespace
             IEnumerable<string> paths = new[] { Guid.NewGuid().ToString("N") };
             IAssemblySymbol assembly = SymbolFactory.GetAssemblyFromSyntax("namespace MyNamespace { class Foo { } }");
 
-            Assert.Throws<FileNotFoundException>(() => loader.LoadMatchingAssemblies(new[] { assembly }, paths));
+            Assert.ThrowsExactly<FileNotFoundException>(() => loader.LoadMatchingAssemblies(new[] { assembly }, paths));
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadMatchingAssembliesWarns()
         {
             IAssemblySymbol assembly = SymbolFactory.GetAssemblyFromSyntax("namespace MyNamespace { class Foo { } }");
@@ -126,13 +128,13 @@ namespace MyNamespace
             TestLog log = new();
             AssemblySymbolLoader loader = new(log);
             IEnumerable<IAssemblySymbol> symbols = loader.LoadMatchingAssemblies(new[] { assembly }, paths);
-            Assert.Empty(symbols);
-            Assert.True(log.HasLoggedWarnings);
+            Assert.IsEmpty(symbols);
+            Assert.IsTrue(log.HasLoggedWarnings);
             List<string> expected = [ $"{AssemblySymbolLoader.AssemblyNotFoundErrorCode} Could not find matching assembly: '{assembly.Identity.GetDisplayName()}' in any of the search directories." ];
-            Assert.Equal(expected, log.Warnings, StringComparer.CurrentCultureIgnoreCase);
+            Assert.AreSequenceEqual(expected, log.Warnings, StringComparer.CurrentCultureIgnoreCase);
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadMatchingAssembliesSameIdentitySucceeds()
         {
             string assemblyName = nameof(LoadMatchingAssembliesSameIdentitySucceeds);
@@ -156,13 +158,13 @@ namespace MyNamespace
             AssemblySymbolLoader loader = new(log);
             IEnumerable<IAssemblySymbol> matchingAssemblies = loader.LoadMatchingAssemblies(new[] { fromAssembly }, new[] { outputDirectory });
 
-            Assert.Single(matchingAssemblies);
-            Assert.False(log.HasLoggedWarnings);
+            Assert.ContainsSingle(matchingAssemblies);
+            Assert.IsFalse(log.HasLoggedWarnings);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void LoadMatchingAssemblies_DifferentIdentity(bool validateIdentities)
         {
             var assetInfo = GetSimpleTestAsset();
@@ -174,27 +176,27 @@ namespace MyNamespace
 
             if (validateIdentities)
             {
-                Assert.Empty(matchingAssemblies);
-                Assert.True(log.HasLoggedWarnings);
+                Assert.IsEmpty(matchingAssemblies);
+                Assert.IsTrue(log.HasLoggedWarnings);
                 List<string> expected = [$"{AssemblySymbolLoader.AssemblyNotFoundErrorCode} Could not find matching assembly: '{fromAssembly.Identity.GetDisplayName()}' in any of the search directories."];
-                Assert.Equal(expected, log.Warnings, StringComparer.CurrentCultureIgnoreCase);
+                Assert.AreSequenceEqual(expected, log.Warnings, StringComparer.CurrentCultureIgnoreCase);
             }
             else
             {
-                Assert.Single(matchingAssemblies);
-                Assert.False(log.HasLoggedWarnings);
-                Assert.NotEqual(fromAssembly.Identity, matchingAssemblies.FirstOrDefault().Identity);
+                Assert.ContainsSingle(matchingAssemblies);
+                Assert.IsFalse(log.HasLoggedWarnings);
+                Assert.AreNotEqual(fromAssembly.Identity, matchingAssemblies.FirstOrDefault().Identity);
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadsSimpleAssemblyFromDirectory()
         {
             var assetInfo = GetSimpleTestAsset();
             TestLog log = new();
             AssemblySymbolLoader loader = new(log);
             IEnumerable<IAssemblySymbol> symbols = loader.LoadAssemblies(assetInfo.OutputDirectory);
-            Assert.Single(symbols);
+            Assert.ContainsSingle(symbols);
 
             IEnumerable<ITypeSymbol> types = symbols.FirstOrDefault()
                 .GlobalNamespace
@@ -202,11 +204,11 @@ namespace MyNamespace
                 .FirstOrDefault((n) => n.Name == "MyNamespace")
                 .GetTypeMembers();
 
-            Assert.Single(types);
-            Assert.Equal("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
+            Assert.ContainsSingle(types);
+            Assert.AreEqual("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadSimpleAssemblyFullPath()
         {
             var assetInfo = GetSimpleTestAsset();
@@ -219,11 +221,11 @@ namespace MyNamespace
                 .FirstOrDefault((n) => n.Name == "MyNamespace")
                 .GetTypeMembers();
 
-            Assert.Single(types);
-            Assert.Equal("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
+            Assert.ContainsSingle(types);
+            Assert.AreEqual("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadsMultipleAssembliesFromDirectory()
         {
             TestProject first = new("LoadsMultipleAssembliesFromDirectory_First")
@@ -249,17 +251,17 @@ namespace MyNamespace
             AssemblySymbolLoader loader = new(log);
             IEnumerable<IAssemblySymbol> symbols = loader.LoadAssemblies(outputDirectory);
 
-            Assert.Equal(2, symbols.Count());
+            Assert.HasCount(2, symbols);
 
             IEnumerable<string> expected = new[] { "LoadsMultipleAssembliesFromDirectory_First", "LoadsMultipleAssembliesFromDirectory_Second" };
             IEnumerable<string> actual = symbols.Select(a => a.Name).OrderBy(a => a, StringComparer.Ordinal);
 
-            Assert.Equal(expected, actual, StringComparer.Ordinal);
+            Assert.AreSequenceEqual(expected, actual, StringComparer.Ordinal);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void LoadAssemblyResolveReferences_WarnsWhenEnabled(bool resolveReferences)
         {
             var assetInfo = GetSimpleTestAsset();
@@ -272,7 +274,7 @@ namespace MyNamespace
             {
                 // Temporarily downgrade assembly reference load warnings to messages: https://github.com/dotnet/sdk/issues/46236
 
-                // Assert.True(log.HasLoggedWarnings);
+                // Assert.IsTrue(log.HasLoggedWarnings);
 
                 // string expectedReference = "System.Runtime.dll";
 
@@ -281,18 +283,18 @@ namespace MyNamespace
                 //     expectedReference = "mscorlib.dll";
                 // }
 
-                // Assert.Single(log.Warnings);
+                // Assert.ContainsSingle(log.Warnings);
                 // Assert.Matches($"CP1002.*?'{Regex.Escape(expectedReference)}'.*?'{Regex.Escape(assemblyPath)}'.*", log.Warnings.Single());
 
-                Assert.Empty(log.Warnings);
+                Assert.IsEmpty(log.Warnings);
             }
             else
             {
-                Assert.Empty(log.Warnings);
+                Assert.IsEmpty(log.Warnings);
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadAssembliesShouldResolveReferencesNoWarnings()
         {
             var assetInfo = GetSimpleTestAsset();
@@ -303,14 +305,14 @@ namespace MyNamespace
             loader.AddReferenceSearchPaths(Path.GetFullPath(typeof(string).Assembly.Location));
             loader.LoadAssembly(Path.Combine(assetInfo.OutputDirectory, assetInfo.TestAsset.TestProject.Name + ".dll"));
 
-            Assert.Empty(log.Warnings);
+            Assert.IsEmpty(log.Warnings);
 
             // Ensure we loaded more than one assembly since resolveReferences was set to true.
             Dictionary<string, MetadataReference> loadedAssemblies = (Dictionary<string, MetadataReference>)typeof(AssemblySymbolLoader)?.GetField("_loadedAssemblies", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(loader);
-            Assert.True(loadedAssemblies != null && loadedAssemblies.Count > 1);
+            Assert.IsTrue(loadedAssemblies != null && loadedAssemblies.Count > 1);
         }
 
-        [Fact]
+        [TestMethod]
         public void LoadAssemblyFromStreamNoWarns()
         {
             var assetInfo = GetSimpleTestAsset();
@@ -320,19 +322,19 @@ namespace MyNamespace
             using FileStream stream = File.OpenRead(Path.Combine(assetInfo.OutputDirectory, testProject.Name + ".dll"));
             IAssemblySymbol symbol = loader.LoadAssembly(testProject.Name, stream);
 
-            Assert.False(log.HasLoggedWarnings);
-            Assert.Equal(testProject.Name, symbol.Name, StringComparer.Ordinal);
+            Assert.IsFalse(log.HasLoggedWarnings);
+            Assert.AreEqual(testProject.Name, symbol.Name);
 
             IEnumerable<ITypeSymbol> types = symbol.GlobalNamespace
                 .GetNamespaceMembers()
                 .FirstOrDefault((n) => n.Name == "MyNamespace")
                 .GetTypeMembers();
 
-            Assert.Single(types);
-            Assert.Equal("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
+            Assert.ContainsSingle(types);
+            Assert.AreEqual("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
         }
 
-        [Fact]
+        [TestMethod]
         public void TestCreateFromFiles()
         {
             var assetInfo = GetSimpleTestAsset();
@@ -343,7 +345,7 @@ namespace MyNamespace
                 assemblyReferencesPaths: [],
                 assembliesToExclude: [assetInfo.TestAsset.TestProject.Name + ".dll"]);
 
-            Assert.Single(symbols);
+            Assert.ContainsSingle(symbols);
 
             IEnumerable<ITypeSymbol> types = symbols.FirstOrDefault().Value
                 .GlobalNamespace
@@ -351,11 +353,11 @@ namespace MyNamespace
                 .FirstOrDefault((n) => n.Name == "MyNamespace")
                 .GetTypeMembers();
 
-            Assert.Single(types);
-            Assert.Equal("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
+            Assert.ContainsSingle(types);
+            Assert.AreEqual("MyNamespace.MyClass", types.FirstOrDefault().ToDisplayString());
         }
 
-        [Fact]
+        [TestMethod]
         public void TestCreateFromFilesExcludeAssembly()
         {
             var assetInfo = GetSimpleTestAsset();
@@ -366,7 +368,7 @@ namespace MyNamespace
                 assemblyReferencesPaths: [],
                 assembliesToExclude: [assetInfo.TestAsset.TestProject.Name]);
 
-            Assert.Empty(symbols);
+            Assert.IsEmpty(symbols);
         }
 
         private static CommandResult BuildTestAsset(TestAsset testAsset, out string outputDirectory)

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
@@ -1,14 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Compatibility\Microsoft.DotNet.ApiSymbolExtensions\Microsoft.DotNet.ApiSymbolExtensions.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe);
 
-            Assert.Empty(compilation.GetDiagnostics());
+            Assert.IsEmpty(compilation.GetDiagnostics());
 
             string assemblyDir = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid().ToString("D").Substring(0, 4)}-{assemblyName}");
             Directory.CreateDirectory(assemblyDir);
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
 
-            Assert.Empty(compilation.GetDiagnostics());
+            Assert.IsEmpty(compilation.GetDiagnostics());
 
             MemoryStream stream = new();
             compilation.Emit(stream);
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe);
 
-            Assert.Empty(compilation.GetDiagnostics());
+            Assert.IsEmpty(compilation.GetDiagnostics());
 
             return compilation.Assembly;
         }
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
 
             compilation = compilation.AddReferences(compilationWithReferences.ToMetadataReference());
 
-            Assert.Empty(compilation.GetDiagnostics());
+            Assert.IsEmpty(compilation.GetDiagnostics());
 
             return compilation.Assembly;
         }

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe);
 
-            Assert.IsEmpty(compilation.GetDiagnostics());
+            AssertNoDiagnostics(compilation);
 
             string assemblyDir = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid().ToString("D").Substring(0, 4)}-{assemblyName}");
             Directory.CreateDirectory(assemblyDir);
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
 
-            Assert.IsEmpty(compilation.GetDiagnostics());
+            AssertNoDiagnostics(compilation);
 
             MemoryStream stream = new();
             compilation.Emit(stream);
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
         {
             CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe);
 
-            Assert.IsEmpty(compilation.GetDiagnostics());
+            AssertNoDiagnostics(compilation);
 
             return compilation.Assembly;
         }
@@ -72,9 +72,19 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
 
             compilation = compilation.AddReferences(compilationWithReferences.ToMetadataReference());
 
-            Assert.IsEmpty(compilation.GetDiagnostics());
+            AssertNoDiagnostics(compilation);
 
             return compilation.Assembly;
+        }
+
+        private static void AssertNoDiagnostics(CSharpCompilation compilation)
+        {
+            ImmutableArray<Diagnostic> diagnostics = compilation.GetDiagnostics();
+            if (!diagnostics.IsEmpty)
+            {
+                throw new InvalidOperationException(
+                    $"Expected no compilation diagnostics but found:{Environment.NewLine}{string.Join(Environment.NewLine, diagnostics)}");
+            }
         }
 
         private static CSharpCompilation CreateCSharpCompilationFromSyntax(string syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -8,35 +8,37 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
+[TestClass]
+
 public class SymbolFilterFactoryTests
 {
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void Test_FilterFromFiles(bool includeCustomType)
     {
         Test_FilterFromFiles_Internal(includeCustomType, accessibilitySymbolFilter: null);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void Test_FilterFromFiles_CustomAccessibilityFilter(bool includeCustomType)
     {
         Test_FilterFromFiles_Internal(includeCustomType, new AccessibilitySymbolFilter(includeInternalSymbols: true));
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void Test_FilterFromList(bool includeCustomType)
     {
         Test_FilterFromList_Internal(includeCustomType, accessibilitySymbolFilter: null);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void Test_FilterFromList_WithCustomAccessibilityFilter(bool includeCustomType)
     {
         Test_FilterFromList_Internal(includeCustomType, new AccessibilitySymbolFilter(includeInternalSymbols: true));
@@ -87,27 +89,27 @@ public class SymbolFilterFactoryTests
 
     private void Test_GetFilter_Internal(CompositeSymbolFilter compositeFilter, bool includeCustomType)
     {
-        Assert.NotNull(compositeFilter);
+        Assert.IsNotNull(compositeFilter);
 
-        Assert.Equal(3, compositeFilter.Filters.Count);
+        Assert.HasCount(3, compositeFilter.Filters);
 
         DocIdSymbolFilter docIdFilter = compositeFilter.Filters[0] as DocIdSymbolFilter;
-        Assert.NotNull(docIdFilter);
+        Assert.IsNotNull(docIdFilter);
 
         ImplicitSymbolFilter implicitFilter = compositeFilter.Filters[1] as ImplicitSymbolFilter;
-        Assert.NotNull(implicitFilter);
+        Assert.IsNotNull(implicitFilter);
 
         AccessibilitySymbolFilter accessibilityFilter = compositeFilter.Filters[2] as AccessibilitySymbolFilter;
-        Assert.NotNull(accessibilityFilter);
+        Assert.IsNotNull(accessibilityFilter);
 
         IAssemblySymbol assemblySymbol = SymbolFactory.GetAssemblyFromSyntax(@"
 namespace MyNamespace
 {
     public class MyClass { }
 }");
-        Assert.NotNull(assemblySymbol);
+        Assert.IsNotNull(assemblySymbol);
         INamedTypeSymbol myClass = assemblySymbol.GetTypeByMetadataName("MyNamespace.MyClass");
-        Assert.NotNull(myClass);
-        Assert.Equal(includeCustomType, docIdFilter.Include(myClass));
+        Assert.IsNotNull(myClass);
+        Assert.AreEqual(includeCustomType, docIdFilter.Include(myClass));
     }
 }

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/TestLog.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/TestLog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.ApiSymbolExtensions.Logging;

--- a/test/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworkInPackageValidatorTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/CompatibleFrameworkInPackageValidatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -13,11 +13,9 @@ using Microsoft.DotNet.PackageValidation.Validators;
 
 namespace Microsoft.DotNet.PackageValidation.Tests
 {
+    [TestClass]
     public class CompatibleFrameworkInPackageValidatorTests : SdkTest
     {
-        public CompatibleFrameworkInPackageValidatorTests(ITestOutputHelper log) : base(log)
-        {
-        }
 
         private (SuppressibleTestLog, CompatibleFrameworkInPackageValidator) CreateLoggerAndValidator()
         {
@@ -31,7 +29,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             return (log, validator);
         }
 
-        [Fact]
+        [TestMethod]
         public void CompatibleFrameworksInPackage()
         {
             string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
@@ -56,19 +54,19 @@ namespace PackageValidationTests
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
             Package package = Package.Create(packCommand.GetNuGetPackage(), null);
             (SuppressibleTestLog log, CompatibleFrameworkInPackageValidator validator) = CreateLoggerAndValidator();
 
             validator.Validate(new PackageValidatorOption(package));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             // TODO: add asserts for assembly and header metadata.
             string assemblyName = $"{asset.TestProject.Name}.dll";
             Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/{ToolsetInfo.CurrentTargetFramework}/{assemblyName}", log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleCompatibleFrameworksInPackage()
         {
             string name = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
@@ -97,13 +95,13 @@ namespace PackageValidationTests
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
             Package package = Package.Create(packCommand.GetNuGetPackage(), null);
             (SuppressibleTestLog log, CompatibleFrameworkInPackageValidator validator) = CreateLoggerAndValidator();
 
             validator.Validate(new PackageValidatorOption(package));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             string assemblyName = $"{asset.TestProject.Name}.dll";
             // TODO: add asserts for assembly and header metadata.
             Assert.Contains($"CP0002 Member 'void PackageValidationTests.First.test(string)' exists on lib/netstandard2.0/{assemblyName} but not on lib/netcoreapp3.1/{assemblyName}", log.errors);

--- a/test/Microsoft.DotNet.PackageValidation.Tests/Filtering/TargetFrameworkFilterTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Filtering/TargetFrameworkFilterTests.cs
@@ -6,58 +6,59 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.PackageValidation.Tests.Filtering
 {
+    [TestClass]
     public class TargetFrameworkFilterTests
     {
-        [Theory]
-        [InlineData("net8.0", "net8.0")]
-        [InlineData("net8.0", "net8.0", "net9.0")]
-        [InlineData("net8.0", "net8*")]
-        [InlineData("net80.0", "net8*")]
-        [InlineData("portable-net45+win8+wpa81+wp8", "portable-*")]
-        [InlineData("portable-net45+win8+wpa81+wp8", "portable*")]
+        [TestMethod]
+        [DataRow("net8.0", "net8.0")]
+        [DataRow("net8.0", "net8.0", "net9.0")]
+        [DataRow("net8.0", "net8*")]
+        [DataRow("net80.0", "net8*")]
+        [DataRow("portable-net45+win8+wpa81+wp8", "portable-*")]
+        [DataRow("portable-net45+win8+wpa81+wp8", "portable*")]
         public void IsExcluded_TargetFrameworkFound_ReturnsTrue(string targetFramework, params string[] excludedTargetFrameworks)
         {
             TargetFrameworkFilter targetFrameworkFilter = new(excludedTargetFrameworks);
 
-            Assert.True(targetFrameworkFilter.IsExcluded(targetFramework));
+            Assert.IsTrue(targetFrameworkFilter.IsExcluded(targetFramework));
         }
 
-        [Theory]
-        [InlineData("", "")]
-        [InlineData("net8.0", "*")]
-        [InlineData("net8.0", "net9.0")]
-        [InlineData("net7.0", "net8.0", "net9.0")]
+        [TestMethod]
+        [DataRow("", "")]
+        [DataRow("net8.0", "*")]
+        [DataRow("net8.0", "net9.0")]
+        [DataRow("net7.0", "net8.0", "net9.0")]
         public void IsExcluded_TargetFrameworkNotFound_ReturnsFalse(string targetFramework, params string[] excludedTargetFrameworks)
         {
             TargetFrameworkFilter targetFrameworkFilter = new(excludedTargetFrameworks);
 
-            Assert.False(targetFrameworkFilter.IsExcluded(targetFramework));
+            Assert.IsFalse(targetFrameworkFilter.IsExcluded(targetFramework));
         }
 
-        [Theory]
-        [InlineData("net8.0", "net8.0")]
-        [InlineData("net8.0", "net8.0", "net9.0")]
-        [InlineData("net8.0", "net8*")]
-        [InlineData("net80.0", "net8*")]
+        [TestMethod]
+        [DataRow("net8.0", "net8.0")]
+        [DataRow("net8.0", "net8.0", "net9.0")]
+        [DataRow("net8.0", "net8*")]
+        [DataRow("net80.0", "net8*")]
         public void IsExcluded_NuGetFrameworkFound_ReturnsTrue(string targetFramework, params string[] excludedTargetFrameworks)
         {
             TargetFrameworkFilter targetFrameworkFilter = new(excludedTargetFrameworks);
 
-            Assert.True(targetFrameworkFilter.IsExcluded(NuGetFramework.ParseFolder(targetFramework)));
+            Assert.IsTrue(targetFrameworkFilter.IsExcluded(NuGetFramework.ParseFolder(targetFramework)));
         }
 
-        [Theory]
-        [InlineData("", "")]
-        [InlineData("net8.0", "net9.0")]
-        [InlineData("net7.0", "net8.0", "net9.0")]
+        [TestMethod]
+        [DataRow("", "")]
+        [DataRow("net8.0", "net9.0")]
+        [DataRow("net7.0", "net8.0", "net9.0")]
         public void IsExcluded_NuGetFrameworkNotFound_ReturnsFalse(string targetFramework, params string[] excludedTargetFrameworks)
         {
             TargetFrameworkFilter targetFrameworkFilter = new(excludedTargetFrameworks);
 
-            Assert.False(targetFrameworkFilter.IsExcluded(NuGetFramework.ParseFolder(targetFramework)));
+            Assert.IsFalse(targetFrameworkFilter.IsExcluded(NuGetFramework.ParseFolder(targetFramework)));
         }
 
-        [Fact]
+        [TestMethod]
         public void FoundExcludedTargetFrameworks_FrameworksFound_ReturnsEqual()
         {
             string[] excludedTargetFrameworks = ["netstandard2.0", "net4*"];
@@ -66,13 +67,13 @@ namespace Microsoft.DotNet.PackageValidation.Tests.Filtering
 
             foreach (string targetFramework in targetFrameworks)
             {
-                Assert.True(targetFrameworkFilter.IsExcluded(targetFramework));
+                Assert.IsTrue(targetFrameworkFilter.IsExcluded(targetFramework));
             }
 
-            Assert.Equal(targetFrameworks, targetFrameworkFilter.FoundExcludedTargetFrameworks);
+            Assert.AreSequenceEqual(targetFrameworks, targetFrameworkFilter.FoundExcludedTargetFrameworks);
         }
 
-        [Fact]
+        [TestMethod]
         public void FoundExcludedTargetFrameworks_FrameworksNotFound_ReturnsEmpty()
         {
             string[] excludedTargetFrameworks = ["netstandard2.0", "net4*"];
@@ -81,10 +82,10 @@ namespace Microsoft.DotNet.PackageValidation.Tests.Filtering
 
             foreach (string targetFramework in targetFrameworks)
             {
-                Assert.False(targetFrameworkFilter.IsExcluded(targetFramework));
+                Assert.IsFalse(targetFrameworkFilter.IsExcluded(targetFramework));
             }
 
-            Assert.Empty(targetFrameworkFilter.FoundExcludedTargetFrameworks);
+            Assert.IsEmpty(targetFrameworkFilter.FoundExcludedTargetFrameworks);
         }
     }
 }

--- a/test/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +19,15 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Compatibility\ApiCompat\Microsoft.DotNet.PackageValidation\Microsoft.DotNet.PackageValidation.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -14,11 +14,9 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.PackageValidation.Tests
 {
+    [TestClass]
     public class ValidatePackageInProcessTests : SdkTest
     {
-        public ValidatePackageInProcessTests(ITestOutputHelper log) : base(log)
-        {
-        }
 
         private (SuppressibleTestLog, CompatibleFrameworkInPackageValidator) CreateLoggerAndValidator()
         {
@@ -32,7 +30,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             return (log, validator);
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidatePackageWithReferences()
         {
             string testDependencySource = @"namespace PackageValidationTests { public class IntermediateBaseClass
@@ -51,7 +49,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
             Package package = Package.Create(packCommand.GetNuGetPackage());
             (SuppressibleTestLog log, CompatibleFrameworkInPackageValidator validator) = CreateLoggerAndValidator();
 
@@ -59,7 +57,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             // removed an interface due to it's base class removing that implementation. We validate that APICompat doesn't
             // log errors when not using references.
             validator.Validate(new PackageValidatorOption(package));
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
 
             // Now we do pass in references. With references, ApiCompat should now detect that an interface was removed in a
             // dependent assembly, causing one of our types to stop implementing that assembly. We validate that a CP0008 is logged.
@@ -70,16 +68,16 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             };
             package = Package.Create(packCommand.GetNuGetPackage(), references);
             validator.Validate(new PackageValidatorOption(package));
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
 
             Assert.Contains($"CP0008 Type 'PackageValidationTests.First' does not implement interface 'PackageValidationTests.IBaseInterface' on lib/{ToolsetInfo.CurrentTargetFramework}/{asset.TestProject.Name}.dll but it does on lib/netstandard2.0/{asset.TestProject.Name}.dll", log.errors);
         }
 
-        [Theory]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [TestMethod]
+        [DataRow(false, true)]
+        [DataRow(false, false)]
+        [DataRow(true, false)]
+        [DataRow(true, true)]
         public void ValidateOnlyErrorWhenAReferenceIsRequired(bool createDependencyToDummy, bool useReferences)
         {
             string testDependencyCode = createDependencyToDummy ?
@@ -93,7 +91,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
 
             Dictionary<NuGetFramework, IEnumerable<string>> references = new()
             {
@@ -110,14 +108,14 @@ namespace Microsoft.DotNet.PackageValidation.Tests
             // temporarily downgraded to an informational message (see https://github.com/dotnet/sdk/issues/46236),
             // so no errors or warnings should be produced for any combination in the matrix.
             validator.Validate(new PackageValidatorOption(package));
-            Assert.Empty(log.errors);
-            Assert.DoesNotContain(log.warnings, e => e.Contains("CP1002"));
+            Assert.IsEmpty(log.errors);
+            Assert.IsEmpty(log.warnings.Where(e => e.Contains("CP1002")));
         }
 
-        [Theory]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
+        [TestMethod]
+        [DataRow(false, true, false)]
+        [DataRow(true, false, false)]
+        [DataRow(true, true, true)]
         public void ValidateErrorWhenTypeForwardingReferences(bool useReferences, bool expectCP0001, bool deleteFile)
         {
             string dependencySourceCode = @"namespace PackageValidationTests { public interface ISomeInterface { }
@@ -137,7 +135,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
 
             Dictionary<NuGetFramework, IEnumerable<string>> references = new()
             {
@@ -157,16 +155,16 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
                 Assert.Contains($"CP0001 Type 'PackageValidationTests.MyForwardedType' exists on lib/netstandard2.0/{testProject.Name}.dll but not on lib/{ToolsetInfo.CurrentTargetFramework}/{testProject.Name}.dll", log.errors);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences(bool useReferences)
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}");
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Equal(string.Empty, result.StdErr);
+            Assert.AreEqual(string.Empty, result.StdErr);
 
             Dictionary<NuGetFramework, IEnumerable<string>> references = new()
             {
@@ -178,19 +176,19 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
             validator.Validate(new PackageValidatorOption(package));
 
             if (!useReferences)
-                Assert.DoesNotContain(log.warnings, e => e.Contains("CP1003"));
+                Assert.IsEmpty(log.warnings.Where(e => e.Contains("CP1003")));
             else
-                Assert.Contains(log.warnings, e => e.Contains("CP1003"));
+                Assert.IsNotEmpty(log.warnings.Where(e => e.Contains("CP1003")));
         }
 
-        [Fact]
+        [TestMethod]
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");
             TestAsset asset = TestAssetsManager.CreateTestProject(testProject, testProject.Name);
             PackCommand packCommand = new(Log, Path.Combine(asset.TestRoot, testProject.Name));
             var result = packCommand.Execute();
-            Assert.Empty(result.StdErr);
+            Assert.IsEmpty(result.StdErr);
 
             Dictionary<NuGetFramework, IEnumerable<string>> references = new()
             {
@@ -202,7 +200,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
 
             validator.Validate(new PackageValidatorOption(package));
 
-            Assert.DoesNotContain(log.warnings, e => e.Contains("CP1003"));
+            Assert.IsEmpty(log.warnings.Where(e => e.Contains("CP1003")));
         }
 
         private static TestProject CreateTestProject(string sourceCode, string tfms, IEnumerable<TestProject> referenceProjects = null)

--- a/test/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Validators/BaselinePackageValidatorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.ApiCompatibility.Runner;
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 {
+    [TestClass]
     public class BaselinePackageValidatorTests
     {
         private (SuppressibleTestLog, BaselinePackageValidator) CreateLoggerAndValidator()
@@ -20,7 +21,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
             return (log, validator);
         }
 
-        [Fact]
+        [TestMethod]
         public void TfmDroppedInLatestVersion()
         {
             Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0",
@@ -37,11 +38,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
                 enqueueApiCompatWorkItems: false,
                 baselinePackage: baselinePackage));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.TargetFrameworkDropped + " " + string.Format(Resources.MissingTargetFramework, ".NETStandard,Version=v2.0"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void BaselineFrameworksExcluded()
         {
             Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0",
@@ -61,11 +62,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
                 targetFrameworkFilter: targetFrameworkRegexFilter));
 
             Assert.Contains(string.Format(Resources.BaselineTargetFrameworksIgnored, "netcoreapp3.1"), log.info);
-            Assert.Empty(log.warnings);
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.warnings);
+            Assert.IsEmpty(log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void BaselineFrameworkIgnoredButPresentInCurrentPackage()
         {
             Package baselinePackage = new(string.Empty, "TestPackage", "1.0.0",
@@ -92,7 +93,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
             Assert.Contains(DiagnosticIds.BaselineTargetFrameworkIgnoredButPresentInCurrentPackage + " " +
                 string.Format(Resources.BaselineTargetFrameworkIgnoredButPresentInCurrentPackage, "portable-net45+win8+wp8+wpa81"),
                 log.warnings);
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
         }
     }
 }

--- a/test/Microsoft.DotNet.PackageValidation.Tests/Validators/CompatibleTFMValidatorTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Validators/CompatibleTFMValidatorTests.cs
@@ -8,6 +8,7 @@ using Moq;
 
 namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 {
+    [TestClass]
     public class CompatibleTFMValidatorTests
     {
         private (SuppressibleTestLog, CompatibleTfmValidator) CreateLoggerAndValidator()
@@ -19,7 +20,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
             return (log, validator);
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingRidLessAssetForFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -32,11 +33,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.Single(log.errors);
-            Assert.Equal(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v3.1"), log.errors[0]);
+            Assert.ContainsSingle(log.errors);
+            Assert.AreEqual(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v3.1"), log.errors[0]);
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingAssetForFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -49,11 +50,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETStandard,Version=v2.0"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingRidSpecificAssetForFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -68,12 +69,12 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ".NETCoreApp,Version=v2.0"), log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidSpecificAsset + " " + string.Format(Resources.NoCompatibleRidSpecificRuntimeAsset, ".NETCoreApp,Version=v2.0", "win"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void OnlyRuntimeAssembly()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -85,11 +86,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " + string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void LibAndRuntimeAssembly()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -102,10 +103,10 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void NoCompileTimeAssetForSpecificFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -119,11 +120,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " + string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void NoRuntimeAssetForSpecificFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -136,11 +137,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.CompatibleRuntimeRidLessAsset + " " + string.Format(Resources.NoCompatibleRuntimeAsset, ToolsetInfo.CurrentTargetFramework), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void NoRuntimeSpecificAssetForSpecificFramework()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -155,10 +156,10 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void CompatibleLibAsset()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -171,11 +172,11 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.NotEmpty(log.errors);
+            Assert.IsNotEmpty(log.errors);
             Assert.Contains(DiagnosticIds.ApplicableCompileTimeAsset + " " + string.Format(Resources.NoCompatibleCompileTimeAsset, ".NETStandard,Version=v2.0"), log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void CompatibleRidSpecificAsset()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -189,10 +190,10 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
         }
 
-        [Fact]
+        [TestMethod]
         public void CompatibleFrameworksWithDifferentAssets()
         {
             (SuppressibleTestLog log, CompatibleTfmValidator validator) = CreateLoggerAndValidator();
@@ -207,7 +208,7 @@ namespace Microsoft.DotNet.PackageValidation.Validators.Tests
 
             validator.Validate(new PackageValidatorOption(package, enqueueApiCompatWorkItems: false));
 
-            Assert.Empty(log.errors);
+            Assert.IsEmpty(log.errors);
         }
     }
 }


### PR DESCRIPTION
Migrates the API compatibility test projects from xUnit to `MSTest.Sdk` on Microsoft.Testing.Platform (MTP), following the established repo pattern (`Microsoft.NET.TestFramework.MSTest`, MSTest analyzers, method-level parallelization via `test/Directory.Build.props`).

Projects:
- `Microsoft.DotNet.ApiCompatibility.Tests`
- `Microsoft.DotNet.ApiSymbolExtensions.Tests`
- `Microsoft.DotNet.PackageValidation.Tests`
- `Microsoft.DotNet.ApiCompat.IntegrationTests`

Part of the xUnit -> MSTest migration effort. Each project builds cleanly; tests were not run as part of this change.