### PR TITLE
Migrate MSI and misc test projects to MSTest.Sdk on MTP

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -245,7 +245,11 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 {
                     // Microsoft.Testing.Platform (MTP) projects (MSTest.Sdk-based) ship as a
                     // self-contained executable with no testhost.dll, so 'dotnet test <dll>' fails.
-                    // Invoke the test assembly directly via 'dotnet exec' and use MTP-native CLI:
+                    // .NET (Core) targets are invoked via 'dotnet exec <dll>'; .NET Framework targets
+                    // are native Windows executables with no runtimeconfig.json, so 'dotnet exec' fails
+                    // (the host treats them as self-contained .NET Core apps and cannot find
+                    // hostpolicy.dll) -- those must be launched as the '.exe' directly.
+                    // Either way we use the MTP-native CLI:
                     //   --filter                replaces VSTest --filter (same MSTest filter syntax)
                     //   --results-directory     same as VSTest
                     //   --report-trx            replaces '--logger trx' -- only emitted when the
@@ -275,7 +279,13 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
                     string trxArg = enableTrxReport ? "--report-trx " : "";
 
-                    command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{driver} exec {assemblyName} " +
+                    // .NET Framework apphosts (TargetPath is the '.exe') run directly; .NET (Core)
+                    // assemblies (TargetPath is the '.dll') run via 'dotnet exec'.
+                    string mtpLauncher = runtimeTargetFrameworkParsed.Framework == ".NETFramework"
+                        ? assemblyName
+                        : $"{driver} exec {assemblyName}";
+
+                    command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{mtpLauncher} " +
                               $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg}";
                 }
                 else

--- a/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
@@ -2,18 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
+#pragma warning disable MSTESTEXP // TestContext.Current is experimental
 
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Net.WebSockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 
 namespace Aspire.Tools.Service.UnitTests;
 
-public class AspireServerServiceTests(ITestOutputHelper output)
+[TestClass]
+public class AspireServerServiceTests
 {
+    public TestContext TestContext { get; set; }
+
     private const string Project1Path = @"c:\test\Projects\project1.csproj";
     private const int ProcessId = 34213;
     private const string DcpId = "myid";
@@ -31,7 +36,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         env = new List<EnvVar> { new EnvVar { Name = "var1", Value = "value1" } }
     };
 
-    [Fact]
+    [TestMethod]
     public async Task SessionStarted_Test()
     {
         var mocks = new Mocks();
@@ -53,15 +58,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         var result = await notificationTask.Task;
 
-        Assert.Equal(ProcessId, result.PID);
-        Assert.Equal("1", result.SessionId);
+        Assert.AreEqual(ProcessId, result.PID);
+        Assert.AreEqual("1", result.SessionId);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SessionEndedAsync_Test()
     {
         var mocks = new Mocks();
@@ -84,16 +89,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         await server.NotifySessionEndedAsync(DcpId, "1", ProcessId, 130, CancellationToken.None);
 
         var result = await sessionEndNotificationTask.Task;
-        Assert.Equal(ProcessId, result.Pid);
-        Assert.Equal("1", result.SessionId);
-        Assert.Equal(130, result.ExitCode);
+        Assert.AreEqual(ProcessId, result.Pid);
+        Assert.AreEqual("1", result.SessionId);
+        Assert.AreEqual(130, result.ExitCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_Success()
     {
         var mocks = new Mocks();
@@ -107,17 +112,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
 
         HttpResponseMessage response;
-        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+        Assert.AreEqual($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_WithNullArgs_PassesThroughNullArgs()
     {
         var mocks = new Mocks();
@@ -131,17 +136,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
 
         HttpResponseMessage response;
-        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project2SessionRequest, TestContext.Current.CancellationToken);
+        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project2SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+        Assert.AreEqual($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_Success_ThenStopProcessRequest()
     {
         var mocks = new Mocks();
@@ -156,23 +161,23 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
 
         // Now send a stop session
-        response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         // Validate NoContent response if session not found
-        response = await client.DeleteAsync(RunSessionRequest.Url + "/3", TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        response = await client.DeleteAsync(RunSessionRequest.Url + "/3", TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailedToLaunchProject()
     {
         var mocks = new Mocks();
@@ -185,17 +190,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
-        Assert.Equal("{\"error\":{\"message\":\"Launch project failed\"}}", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.AreEqual("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
+        Assert.AreEqual("{\"error\":{\"message\":\"Launch project failed\"}}", await response.Content.ReadAsStringAsync(TestContext.CancellationToken));
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -206,15 +211,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailWrongUrl()
     {
         var mocks = new Mocks();
@@ -224,16 +229,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync("/run_badurl", Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync("/run_badurl", Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_NotAPUTRequest()
     {
         var mocks = new Mocks();
@@ -243,16 +248,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = aspireServer.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PostAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PostAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
 
         await aspireServer.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StopSession_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -263,15 +268,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.Current.CancellationToken);
+        var response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Info_Success()
     {
         var mocks = new Mocks();
@@ -281,15 +286,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.GetAsync(InfoResponse.Url, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(InfoResponse.Url, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Info_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -300,15 +305,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.GetAsync(InfoResponse.Url, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(InfoResponse.Url, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SendLogMessageAsync_Test()
     {
         var mocks = new Mocks();
@@ -330,14 +335,14 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         var result = await notificationTask.Task;
 
-        Assert.Equal("My Message", result.LogMessage);
-        Assert.False(result.IsStdErr);
+        Assert.AreEqual("My Message", result.LogMessage);
+        Assert.IsFalse(result.IsStdErr);
         await aspireServer.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetEnvironmentForOrchestrator_Tests()
     {
         var mocks = new Mocks();
@@ -347,13 +352,13 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         // First time should create a key
         var envVars = server.GetServerConnectionEnvironment();
 
-        Assert.Equal(3, envVars.Count);
+        Assert.HasCount(3, envVars);
         var token = envVars[1];
-        Assert.NotNull(token.Value);
+        Assert.IsNotNull(token.Value);
 
         // Should return the same
         envVars = server.GetServerConnectionEnvironment();
-        Assert.Equal(token, envVars[1]);
+        Assert.AreEqual(token, envVars[1]);
 
         mocks.Verify();
     }
@@ -365,14 +370,20 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         using var ws = new ClientWebSocket();
         ws.Options.SetRequestHeader("Authorization", $"Bearer {tokens.bearerToken}");
+        Exception connectException = null;
         try
         {
-            await ws.ConnectAsync(new Uri($"wss://{tokens.serverAddress}{RunSessionRequest.Url}{SessionNotification.Url}"), httpClient, TestContext.Current.CancellationToken);
+            await ws.ConnectAsync(new Uri($"wss://{tokens.serverAddress}{RunSessionRequest.Url}{SessionNotification.Url}"), httpClient, TestContext.CancellationToken);
         }
         catch (Exception ex)
         {
-            Assert.Fail("Could not connect to session update endpoint: " + ex.ToString());
             connected.SetResult(false);
+            connectException = ex;
+        }
+
+        if (connectException is not null)
+        {
+            Assert.Fail("Could not connect to session update endpoint: " + connectException.ToString());
             return;
         }
 
@@ -381,25 +392,32 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         while (ws.State == WebSocketState.Open)
         {
             string message;
+            bool connectionClosed = false;
             try
             {
                 (message, var messageType) = await GetSocketMsgAsync(ws);
 
                 if (messageType == WebSocketMessageType.Close)
                 {
-                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, TestContext.Current.CancellationToken);
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, TestContext.CancellationToken);
                     return;
                 }
             }
             catch
             {
                 // This is expected if the connection is closed
-                Assert.Equal(WebSocketState.Closed, ws.State);
+                connectionClosed = true;
+                message = null;
+            }
+
+            if (connectionClosed)
+            {
+                Assert.AreEqual(WebSocketState.Closed, ws.State);
                 return;
             }
 
             var notification = JsonSerializer.Deserialize<SessionNotification>(message, AspireServerService.JsonSerializerOptions);
-            Assert.NotNull(notification);
+            Assert.IsNotNull(notification);
 
             SessionNotification value = notification.NotificationType switch
             {
@@ -409,7 +427,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
                 _ => throw new InvalidOperationException($"Unexpected {notification.NotificationType}")
             };
 
-            Assert.NotNull(value);
+            Assert.IsNotNull(value);
             callback.Invoke(value);
         }
     }
@@ -440,7 +458,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
     private async Task<(string, WebSocketMessageType)> GetSocketMsgAsync(ClientWebSocket client)
     {
         var rcvBuffer = new ArraySegment<byte>(new byte[2048]);
-        WebSocketReceiveResult rcvResult = await client.ReceiveAsync(rcvBuffer, TestContext.Current.CancellationToken);
+        WebSocketReceiveResult rcvResult = await client.ReceiveAsync(rcvBuffer, TestContext.CancellationToken);
         if (rcvResult.MessageType == WebSocketMessageType.Text)
         {
             byte[] msgBytes = rcvBuffer.Skip(rcvBuffer.Offset).Take(rcvResult.Count).ToArray();
@@ -457,7 +475,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var aspireServer = new AspireServerService(serverEvents.Object, displayName: "Test server",
             line =>
             {
-                output.WriteLine(line);
+                TestContext.WriteLine(line);
                 Debug.WriteLine(line);
             });
 

--- a/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
-#pragma warning disable MSTESTEXP // TestContext.Current is experimental
 
 using System.Diagnostics;
 using System.Net;
@@ -481,7 +480,7 @@ public class AspireServerServiceTests
 
         if (waitForListening)
         {
-            await aspireServer.WaitForListeningAsync();
+            await aspireServer.WaitForListeningAsync(TestContext.CancellationToken);
         }
 
         return aspireServer;
@@ -550,12 +549,12 @@ public class AspireServerServiceTests
 
 internal static class AspireServerServiceExtensions
 {
-    public static async Task WaitForListeningAsync(this AspireServerService aspireServer)
+    public static async Task WaitForListeningAsync(this AspireServerService aspireServer, CancellationToken cancellationToken)
     {
         string serverAddress = aspireServer.GetServerVariables().serverAddress;
 
         // We need to wait on the port being available
-        await Helpers.CanConnectToPortAsync(new Uri($"http://{serverAddress}"), 5000, TestContext.Current.CancellationToken);
+        await Helpers.CanConnectToPortAsync(new Uri($"http://{serverAddress}"), 5000, cancellationToken);
 
     }
 

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -1,24 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
-    <OutputType>Exe</OutputType>
-    <EnableDefaultScopedCssItems>false</EnableDefaultScopedCssItems>
-
-    <!-- Suppress pack warnings for this test project. Microsoft.NET.Sdk.Web defaults 
-         WarnOnPackingNonPackableProject=true, but test projects have IsPackable=false by default,
-         which would generate warnings/errors during pack operations that we want to suppress. -->
-    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.DotNet.HotReload.Test.Utilities\AssertEx.cs" Link="Utilities\AssertEx.cs" />
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Import Project="..\..\src\Dotnet.Watch\AspireService\Microsoft.WebTools.AspireService.projitems" Label="Shared" />

--- a/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
@@ -3,13 +3,12 @@
 
 #nullable disable
 
-using Microsoft.DotNet.Watch.UnitTests;
-
 namespace Aspire.Tools.Service.UnitTests;
 
+[TestClass]
 public class RunSessionRequestTests
 {
-    [Fact]
+    [TestMethod]
     public void RunSessionRequest_ToProjectLaunchRequest()
     {
         var request = new RunSessionRequest()
@@ -36,21 +35,21 @@ public class RunSessionRequestTests
 
         var info = request.ToProjectLaunchInformation();
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "--someArg"
         ], info.Arguments);
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "var1='value1'",
             "var2='value2'",
             "var3=''"
         ], info.Environment.Select(e => $"{e.Key}='{e.Value}'"));
 
-        Assert.Equal(@"c:\test\Projects\project1.csproj", info.ProjectPath);
-        Assert.True(info.Debug);
-        Assert.Equal("specificProfileName", info.LaunchProfile);
-        Assert.True(info.DisableLaunchProfile);
+        Assert.AreEqual(@"c:\test\Projects\project1.csproj", info.ProjectPath);
+        Assert.IsTrue(info.Debug);
+        Assert.AreEqual("specificProfileName", info.LaunchProfile);
+        Assert.IsTrue(info.DisableLaunchProfile);
     }
 }

--- a/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
@@ -12,15 +12,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" />
   </ItemGroup>
-
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-    <Using Remove="Xunit" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.Win32.Msi.Tests/EventArgsTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/EventArgsTests.cs
@@ -3,27 +3,30 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class EventArgsTests
     {
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItParsesProgressMessageFields()
         {
             ProgressEventArgs e = new("1: 2 2: 4 3: 6 4: 9", InstallMessage.PROGRESS, 0);
 
-            Assert.Equal(4, e.Fields.Length);
-            Assert.Equal(2, e.Fields[0]);
-            Assert.Equal(ProgressType.ProgressReport, e.ProgressType);
+            Assert.HasCount(4, e.Fields);
+            Assert.AreEqual(2, e.Fields[0]);
+            Assert.AreEqual(ProgressType.ProgressReport, e.ProgressType);
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItParsesActionStartMessageFields()
         {
             ActionStartEventArgs e = new("Action 20:08:24: ProcessComponents. Updating component registration",
                 InstallMessage.ACTIONSTART, 0);
 
-            Assert.Equal("20:08:24", e.ActionTime);
-            Assert.Equal("ProcessComponents", e.ActionName);
-            Assert.Equal("Updating component registration", e.ActionDescription);
+            Assert.AreEqual("20:08:24", e.ActionTime);
+            Assert.AreEqual("ProcessComponents", e.ActionName);
+            Assert.AreEqual("Updating component registration", e.ActionDescription);
         }
     }
 }

--- a/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
@@ -9,6 +9,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Win32.Msi.Tests/WindowsInstallerExceptionTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/WindowsInstallerExceptionTests.cs
@@ -3,11 +3,13 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class WindowsInstallerExceptionTests
     {
-        [WindowsOnlyTheory]
-        [InlineData(Error.ACCESS_DENIED, "Access is denied")]
-        [InlineData(Error.INSTALL_PACKAGE_OPEN_FAILED, "This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package")]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(Error.ACCESS_DENIED, "Access is denied")]
+        [DataRow(Error.INSTALL_PACKAGE_OPEN_FAILED, "This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package")]
         public void ItContainsValidErrorMessage(uint errorCode, string expectedMessage)
         {
             WindowsInstallerException e = new(unchecked((int)errorCode));

--- a/test/Microsoft.Win32.Msi.Tests/WindowsInstallerTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/WindowsInstallerTests.cs
@@ -3,26 +3,29 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class WindowsInstallerTests
     {
-        [WindowsOnlyTheory]
-        [InlineData("", "", Error.INVALID_PARAMETER)]
-        [InlineData("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", "ProductVersion", Error.UNKNOWN_PRODUCT)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("", "", Error.INVALID_PARAMETER)]
+        [DataRow("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", "ProductVersion", Error.UNKNOWN_PRODUCT)]
         public void InstallProductReturnsAnError(string productCode, string property, uint expectedError)
         {
             uint error = WindowsInstaller.GetProductInfo(productCode, property, out string propertyValue);
 
-            Assert.Equal(error, expectedError);
+            Assert.AreEqual(expectedError, error);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("", InstallState.INVALIDARG)]
-        [InlineData("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", InstallState.UNKNOWN)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("", InstallState.INVALIDARG)]
+        [DataRow("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", InstallState.UNKNOWN)]
         public void QueryProductStateReturnsAnError(string productCode, InstallState expectedState)
         {
             InstallState state = WindowsInstaller.QueryProduct(productCode);
 
-            Assert.Equal(state, expectedState);
+            Assert.AreEqual(expectedState, state);
         }
     }
 }

--- a/test/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
@@ -3,19 +3,16 @@
 
 namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
 {
+    [TestClass]
     public class GivenDotnetInvokesMSBuild : SdkTest
     {
-        public GivenDotnetInvokesMSBuild(ITestOutputHelper log) : base(log)
-        {
-        }
-
-        [Theory]
-        [InlineData("build")]
-        [InlineData("clean")]
-        [InlineData("msbuild")]
-        [InlineData("pack")]
-        [InlineData("publish")]
-        [InlineData("test")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("clean")]
+        [DataRow("msbuild")]
+        [DataRow("pack")]
+        [DataRow("publish")]
+        [DataRow("test")]
         public void When_dotnet_command_invokes_msbuild_Then_env_vars_and_m_are_passed(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -27,11 +24,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .Should().Pass();
         }
 
-        [Theory]
-        [InlineData("build")]
-        [InlineData("msbuild")]
-        [InlineData("pack")]
-        [InlineData("publish")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("msbuild")]
+        [DataRow("pack")]
+        [DataRow("publish")]
         public void When_dotnet_command_invokes_msbuild_with_no_args_verbosity_is_set_to_minimum(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -48,11 +45,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                      .And.Contain("Message with high importance", "Because high importance messages are shown on minimum verbosity");
         }
 
-        [Theory]
-        [InlineData("build")]
-        [InlineData("clean")]
-        [InlineData("pack")]
-        [InlineData("publish")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("clean")]
+        [DataRow("pack")]
+        [DataRow("publish")]
         public void When_dotnet_command_invokes_msbuild_with_diag_verbosity_Then_arg_is_passed(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -69,7 +66,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.StdOut.Should().Contain("Message with low importance");
         }
 
-        [Fact]
+        [TestMethod]
         public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_minimum()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")
@@ -83,7 +80,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.StdOut.Should().Contain("Message with high importance");
         }
 
-        [Fact]
+        [TestMethod]
         public void When_dotnet_msbuild_command_is_invoked_with_non_msbuild_switch_Then_it_fails()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")
@@ -96,7 +93,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.ExitCode.Should().NotBe(0);
         }
 
-        [Fact]
+        [TestMethod]
         public void When_MSBuildSDKsPath_is_set_by_env_var_then_it_is_not_overridden()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")

--- a/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
+++ b/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
@@ -1,18 +1,20 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="MSTest.Sdk">
+
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
-  </PropertyGroup>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
-  <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Migrates the MSI and miscellaneous test projects from xUnit to `MSTest.Sdk` on Microsoft.Testing.Platform (MTP), following the established repo pattern.

Projects:
- `Microsoft.Win32.Msi.Tests`
- `Microsoft.Win32.Msi.Manual.Tests`
- `msbuild.Integration.Tests`
- `Microsoft.WebTools.AspireService.Tests`

Part of the xUnit -> MSTest migration effort. Each project builds cleanly; tests were not run as part of this change.