### PR TITLE
migrate ResolveStaticWebAssetsEmbeddedProjectConfiguration

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ResolveStaticWebAssetsEmbeddedProjectConfiguration.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 // We filter the build configurations in cross targeting to reflect the dependencies between
 // TFMs, and we avoid building them in the multi-targeted build.
 
+[MSBuildMultiThreadableTask]
 public class ResolveStaticWebAssetsEmbeddedProjectConfiguration : Task
 {
     [Required]


### PR DESCRIPTION
Fixes dotnet/msbuild#14062

### Context

`ResolveStaticWebAssetsEmbeddedProjectConfiguration` can run under MSBuild's multithreaded task scheduler because it only transforms task item metadata in memory and does not use file I/O, environment state, process state, or current-directory-dependent APIs.

### Changes Made

- Added `[MSBuildMultiThreadableTask]` to `ResolveStaticWebAssetsEmbeddedProjectConfiguration`.

### Testing

- Built `src/StaticWebAssetsSdk/Tasks/Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj` — succeeded.