### PR TITLE
Fix cmd parse error in Helix Node.js PATH setup on Windows

### DIFF
--- a/build/SetupHelixEnvironment.cmd
+++ b/build/SetupHelixEnvironment.cmd
@@ -58,5 +58,5 @@ dotnet nuget list source --configfile %TestExecutionDirectory%\nuget.config
 REM Install Node.js if version is specified (needed for TypeScript compilation tests)
 if "%DOTNET_SDK_TEST_NODE_VERSION%" NEQ "" (
     PowerShell -ExecutionPolicy ByPass -File "%HELIX_CORRELATION_PAYLOAD%\t\InstallNode.ps1" %DOTNET_SDK_TEST_NODE_VERSION%
-    if exist "%HELIX_CORRELATION_PAYLOAD%\t\nodejs\node.exe" set PATH=%HELIX_CORRELATION_PAYLOAD%\t\nodejs;%PATH%
+    if exist "%HELIX_CORRELATION_PAYLOAD%\t\nodejs\node.exe" set "PATH=%HELIX_CORRELATION_PAYLOAD%\t\nodejs;%PATH%"
 )


### PR DESCRIPTION
## Problem

PR #52302 (`Add TypeScript Static Web Assets integration`) added a Node.js install step to `build/SetupHelixEnvironment.cmd`:

```cmd
if "%DOTNET_SDK_TEST_NODE_VERSION%" NEQ "" (
    PowerShell ... InstallNode.ps1 %DOTNET_SDK_TEST_NODE_VERSION%
    if exist "...\nodejs\node.exe" set PATH=...;%PATH%
)
```

`DOTNET_SDK_TEST_NODE_VERSION` is set unconditionally on every Windows leg (`NodeVersion=22.22.3` in `test/UnitTests.proj`). On Windows `%PATH%` contains `C:\Program Files (x86)\...`; the `)` in `(x86)` prematurely closes the parenthesized `if` block during cmd parsing, producing:

```
\Microsoft was unexpected at this time.
```

Every Windows Helix work item then exits with code 255. This broke **all** Windows CI on `main` starting with #52302, and is what blocks PR #54859 (and every other open PR) on the Windows test legs.

## Fix

Quote the assignment — `set "PATH=...;%PATH%"` — so the parentheses in the expanded value are treated literally and no longer terminate the block. Verified with a local cmd repro: the unquoted form fails with `... was unexpected at this time.`; the quoted form parses cleanly and prepends `nodejs` to `PATH` while preserving `Program Files (x86)`.

Unblocks #54859.
