### PR TITLE
Migrate MSI and misc test projects to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGetDependsOnNETStandardMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ReferencePath_IsResolvedRelativeToProjectDirectory()
         {
             using var env = new TaskTestEnvironment();
@@ -35,9 +36,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "the assembly at the relative path (resolved via TaskEnvironment) references System.Runtime");
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void DependsOnNETStandard_IsConsistent_RegardlessOfCwd(bool useDifferentCwd)
         {
             // Use the test assembly itself as input — it references System.Runtime.

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardTask.cs
@@ -8,9 +8,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    public class GivenAGetDependsOnNETStandardTask(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenAGetDependsOnNETStandardTask : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void CanCheckThisAssembly()
         {
             var thisAssemblyPath = typeof(GivenAGetDependsOnNETStandardTask).GetTypeInfo().Assembly.Location;
@@ -26,7 +27,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.DependsOnNETStandard.Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void CanCheckThisAssemblyByHintPath()
         {
             var thisAssemblyPath = typeof(GivenAGetDependsOnNETStandardTask).GetTypeInfo().Assembly.Location;
@@ -50,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.DependsOnNETStandard.Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsFalseForNonPE()
         {
             string testFile = $"testFile.{nameof(GivenAGetDependsOnNETStandardTask)}.{nameof(ReturnsFalseForNonPE)}.txt";
@@ -75,7 +76,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsFalseForNativeLibrary()
         {
             var corelibLocation = typeof(object).GetTypeInfo().Assembly.Location;
@@ -102,7 +103,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void SucceedsOnMissingFileReturnsFalse()
         {
             var missingFile = $"{nameof(SucceedsOnMissingFileReturnsFalse)}.shouldNotExist.dll";
@@ -119,7 +120,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             ((MockBuildEngine)task.BuildEngine).Warnings.Count.Should().Be(0);
         }
 
-        [Fact]
+        [TestMethod]
         public void SucceedsWithWarningOnLockedFile()
         {
             var testDir = TestAssetsManager.CreateTestDirectory();

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenANETBuildExtensionsError.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenANETBuildExtensionsError.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenANETBuildExtensionsError
     {
-        [Fact]
+        [TestMethod]
         public void It_is_compiled_with_extensions_specific_name()
         {
             // Regression test for https://github.com/dotnet/sdk/issues/2061

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
@@ -1,13 +1,10 @@
-﻿<Project>
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
@@ -22,7 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tasks\Microsoft.NET.Build.Extensions.Tasks\Microsoft.NET.Build.Extensions.Tasks.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,8 +28,7 @@
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\MockTaskItem.cs" />
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\TaskEnvironmentHelper.cs" />
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\TaskTestEnvironment.cs" />
+    <Using Include="Microsoft.NET.TestFramework" />
   </ItemGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/test/Microsoft.NET.Build.Tasks.Tests/AssemblyAttributes.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/AssemblyAttributes.cs
@@ -1,8 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-// Several tests in this assembly mutate the process-wide current working directory to verify
-// that SDK tasks resolve relative paths through TaskEnvironment instead of Environment.CurrentDirectory
-// (see Given*MultiThreading*.cs and GivenATaskEnvironmentDefault.cs). Disable xUnit parallelization
-// at the assembly level so concurrent tests do not observe each other's CWD writes.
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GetPublishItemsOutputGroupOutputsTests.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GetPublishItemsOutputGroupOutputsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         // The logic is cross platform but the test path examples are all in Windows
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         public void It_can_expand_OutputPath()
         {
             var task = new GetPublishItemsOutputGroupOutputs

--- a/test/Microsoft.NET.Build.Tasks.Tests/GetPublishItemsOutputGroupOutputsTests.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GetPublishItemsOutputGroupOutputsTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GetPublishItemsOutputGroupOutputsTests
     {
         private readonly MockTaskItem _apphost
@@ -24,7 +25,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
 
         // The logic is cross platform but the test path examples are all in Windows
-        [WindowsOnlyFact]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void It_can_expand_OutputPath()
         {
             var task = new GetPublishItemsOutputGroupOutputs

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAAllowEmptyTelemetry.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAAllowEmptyTelemetry.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAAllowEmptyTelemetry
     {
         private static ITaskItem CreateHashItem(string key, string? value = null, bool? hash = null)
@@ -20,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             return item;
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenInvokeWithoutValueItSendValueAsNull()
         {
             var engine = new MockBuildEngine5();
@@ -41,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             engine.Log.Should().Contain("'Property2' = 'null'");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenInvokeWithDuplicatedEventDataItKeepsTheLastOne()
         {
             var engine = new MockBuildEngine5();
@@ -64,7 +65,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             engine.Log.Should().Contain("4ADE3D2622CA400B8B95A039DF540037");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenInvokeWithNoEventDataItSendsEvents()
         {
             var engine = new MockBuildEngine5();
@@ -82,7 +83,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             engine.Log.Should().NotContain("Property"); // shouldn't have any logged properties since none were supplied
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenHashIsRequestedValueIsHashed()
         {
             var engine = new MockBuildEngine5();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForDuplicateFrameworkReferences.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForDuplicateFrameworkReferences.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckForDuplicateFrameworkReferences
     {
-        [Fact]
+        [TestMethod]
         public void DetectsDuplicates()
         {
             var task = new CheckForDuplicateFrameworkReferences
@@ -33,7 +34,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().HaveCount(1);
         }
 
-        [Fact]
+        [TestMethod]
         public void NoDuplicates_NoOutput()
         {
             var task = new CheckForDuplicateFrameworkReferences
@@ -58,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void NullFrameworkReferences_Succeeds()
         {
             var task = new CheckForDuplicateFrameworkReferences
@@ -73,7 +74,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyArray_Succeeds()
         {
             var task = new CheckForDuplicateFrameworkReferences
@@ -88,7 +89,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyItemSpec_HandlesGracefully()
         {
             var task = new CheckForDuplicateFrameworkReferences
@@ -112,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToRemove.Should().HaveCount(1, "the implicit duplicate with empty ItemSpec should be removed");
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativePathItemSpec_PreservesFormat()
         {
             const string relativePathSpec = "some/relative/path.dll";
@@ -144,7 +145,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "output ItemSpec must preserve the exact input format without path normalization");
         }
 
-        [Fact]
+        [TestMethod]
         public void MultipleExplicitDuplicates_LogsError()
         {
             var engine = new MockBuildEngine();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForDuplicateItems.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForDuplicateItems.cs
@@ -8,9 +8,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckForDuplicateItems
     {
-        [Fact]
+        [TestMethod]
         public void CheckForNoDuplicateItems()
         {
             var compile = new[]
@@ -34,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.DeduplicatedItems.Length.Should().Be(0);
         }
 
-        [Fact]
+        [TestMethod]
         public void CheckForDuplicateItems()
         {
             var compile = new[]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForImplicitPackageReferenceOverrides.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForImplicitPackageReferenceOverrides.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckForImplicitPackageReferenceOverrides
     {
-        [Fact]
+        [TestMethod]
         public void DetectsOverrides()
         {
             var task = new CheckForImplicitPackageReferenceOverrides
@@ -32,7 +33,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().HaveCount(1, "the explicit item is re-added with AllowExplicitVersion");
         }
 
-        [Fact]
+        [TestMethod]
         public void NullPackageReferenceItems_Throws()
         {
             var task = new CheckForImplicitPackageReferenceOverrides
@@ -46,7 +47,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             act.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyArray_Succeeds()
         {
             var task = new CheckForImplicitPackageReferenceOverrides
@@ -61,7 +62,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyItemSpec_HandlesGracefully()
         {
             var task = new CheckForImplicitPackageReferenceOverrides
@@ -86,7 +87,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ItemsToAdd.Should().HaveCount(1, "the explicit item should be re-added");
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativePathItemSpec_PreservesFormat()
         {
             const string pathLikeSpec = "some/path/Newtonsoft.Json";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferences.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferences.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckForUnsupportedWinMDReferences
     {
-        [Fact]
+        [TestMethod]
         public void NoReferences_Succeeds()
         {
             var task = new CheckForUnsupportedWinMDReferences
@@ -20,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.Execute().Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void NullReferencePaths_Throws()
         {
             var task = new CheckForUnsupportedWinMDReferences
@@ -34,7 +35,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             act.Should().Throw<NullReferenceException>();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyItemSpec_HandlesGracefully()
         {
             var task = new CheckForUnsupportedWinMDReferences
@@ -51,7 +52,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.Execute().Should().BeTrue("empty ItemSpec has no .winmd extension");
         }
 
-        [Fact]
+        [TestMethod]
         public void WinMDExtensionOnly_LogsError()
         {
             var task = new CheckForUnsupportedWinMDReferences
@@ -68,7 +69,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.Execute().Should().BeFalse("a bare .winmd reference triggers an error");
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativePathItemSpec_HandlesCorrectly()
         {
             const string relativeWinmdPath = "subfolder/something.winmd";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void RelativeManagedReferencePath_ResolvesFromTaskEnvironment()
         {
             using var tte = new TaskTestEnvironment();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckIfPackageReferenceShouldBeFrameworkReference.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckIfPackageReferenceShouldBeFrameworkReference.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACheckIfPackageReferenceShouldBeFrameworkReference
     {
-        [Fact]
+        [TestMethod]
         public void MatchingPackage_ShouldRemoveAndAdd()
         {
             var task = new CheckIfPackageReferenceShouldBeFrameworkReference
@@ -27,7 +28,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ShouldAddFrameworkReference.Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void FrameworkAlreadyExists_ShouldNotAdd()
         {
             var task = new CheckIfPackageReferenceShouldBeFrameworkReference
@@ -50,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ShouldAddFrameworkReference.Should().BeFalse("framework reference already exists");
         }
 
-        [Fact]
+        [TestMethod]
         public void NoMatch_ShouldDoNothing()
         {
             var task = new CheckIfPackageReferenceShouldBeFrameworkReference
@@ -70,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ShouldAddFrameworkReference.Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyItemSpec_HandlesGracefully()
         {
             var task = new CheckIfPackageReferenceShouldBeFrameworkReference
@@ -90,7 +91,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ShouldAddFrameworkReference.Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyArrays_Succeeds()
         {
             var task = new CheckIfPackageReferenceShouldBeFrameworkReference
@@ -107,7 +108,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ShouldAddFrameworkReference.Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativePathItemSpec_MatchesCorrectly()
         {
             const string pathLikeSpec = "some/path/Microsoft.AspNetCore.All";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACollatePackageDownloads.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACollatePackageDownloads.cs
@@ -115,7 +115,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         // Backslash is only a path separator on Windows. On Linux, TaskItem normalizes '\' to '/'.
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         public void PathItemSpec_PreservesBackslashOnWindows()
         {
             var pathSpec = "packages\\NuGet.Common";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACollatePackageDownloads.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACollatePackageDownloads.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACollatePackageDownloads
     {
-        [Fact]
+        [TestMethod]
         public void GroupsVersions()
         {
             var task = new CollatePackageDownloads
@@ -29,7 +30,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             nugetCommon!.GetMetadata("Version").Should().Contain("[5.0.0]").And.Contain("[6.0.0]");
         }
 
-        [Fact]
+        [TestMethod]
         public void SingleVersion()
         {
             var task = new CollatePackageDownloads
@@ -46,7 +47,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackageDownloads[0].GetMetadata("Version").Should().Be("[1.0.0]");
         }
 
-        [Fact]
+        [TestMethod]
         public void NullPackages_Throws()
         {
             var task = new CollatePackageDownloads
@@ -59,7 +60,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             act.Should().Throw<ArgumentNullException>();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyArray_Succeeds()
         {
             var task = new CollatePackageDownloads
@@ -72,7 +73,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackageDownloads.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void EmptyItemSpec_HandlesGracefully()
         {
             var task = new CollatePackageDownloads
@@ -90,8 +91,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackageDownloads[0].GetMetadata("Version").Should().Be("[1.0.0]");
         }
 
-        [Theory]
-        [InlineData("packages/NuGet.Common")]
+        [TestMethod]
+        [DataRow("packages/NuGet.Common")]
         public void PathItemSpec_PreservesFormat(string pathSpec)
         {
             var task = new CollatePackageDownloads
@@ -113,7 +114,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         // Backslash is only a path separator on Windows. On Linux, TaskItem normalizes '\' to '/'.
-        [WindowsOnlyFact]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void PathItemSpec_PreservesBackslashOnWindows()
         {
             var pathSpec = "packages\\NuGet.Common";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACompilationOptionsConverter.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACompilationOptionsConverter.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenACompilationOptionsConverter
     {
         private static MethodInfo s_convertFromMethod = typeof(GenerateDepsFile)
@@ -17,8 +18,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             .GetType("Microsoft.NET.Build.Tasks.CompilationOptionsConverter")
             .GetMethod("ConvertFrom");
 
-        [Theory]
-        [MemberData(nameof(CompilerOptionsData))]
+        [TestMethod]
+        [DynamicData(nameof(CompilerOptionsData))]
         public void ItConvertsFromITaskItemsCorrectly(ITaskItem taskItem, CompilationOptions expectedOptions)
         {
             CompilationOptions resultOptions = (CompilationOptions)s_convertFromMethod.Invoke(null, new object[] { taskItem });

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAConflictResolver.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAConflictResolver.cs
@@ -10,9 +10,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAConflictResolver
     {
-        [Fact]
+        [TestMethod]
         public void ItemsWithDifferentKeysDontConflict()
         {
             var item1 = new MockConflictItem("System.Ben");
@@ -24,7 +25,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenOnlyOneItemExistsAWinnerCannotBeDetermined()
         {
             var item1 = new MockConflictItem() { Exists = false };
@@ -36,7 +37,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenNeitherItemExistsAWinnerCannotBeDetermined()
         {
             var item1 = new MockConflictItem() { Exists = false, AssemblyVersion = new Version("1.0.0.0") };
@@ -48,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenAnItemDoesntExistButDoesNotConflictWithAnythingItIsNotReported()
         {
             var result = GetConflicts(
@@ -61,7 +62,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndDontHaveAssemblyVersionsTheFileVersionIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { AssemblyVersion = null, FileVersion = new Version("1.0.0.0") };
@@ -74,7 +75,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndOnlyOneHasAnAssemblyVersionAWinnerCannotBeDetermined()
         {
             var item1 = new MockConflictItem() { AssemblyVersion = new Version("1.0.0.0") };
@@ -86,7 +87,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndAssemblyVersionsMatchTheFileVersionIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { FileVersion = new Version("3.0.0.0") };
@@ -99,7 +100,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictTheAssemblyVersionIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { AssemblyVersion = new Version("1.0.0.0") };
@@ -112,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndDontHaveFileVersionsThePackageRankIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { FileVersion = null, PackageId = "Package3" };
@@ -125,7 +126,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndOnlyOneHasAFileVersionAWinnerCannotBeDetermined()
         {
             var item1 = new MockConflictItem() { FileVersion = null };
@@ -137,7 +138,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndFileVersionsMatchThePackageRankIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { PackageId = "Package2" };
@@ -150,7 +151,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictTheFileVersionIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { FileVersion = new Version("2.0.0.0") };
@@ -163,7 +164,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndDontHaveAPackageRankTheItemTypeIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { PackageId = "Unranked1", ItemType = ConflictItemType.Platform };
@@ -175,7 +176,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndOnlyOneHasAPackageRankItWins()
         {
             var item1 = new MockConflictItem() { PackageId = "Unranked1" };
@@ -187,7 +188,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndPackageRanksMatchTheItemTypeIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { PackageId = "Package1", ItemType = ConflictItemType.Reference };
@@ -199,7 +200,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictThePackageRankIsUsedToResolveTheConflict()
         {
             var item1 = new MockConflictItem() { PackageId = "Package1" };
@@ -212,13 +213,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Theory]
-        [InlineData(new[] { 1, 1, 2 }, 2)]
-        [InlineData(new[] { 1, 2, 1 }, 1)]
-        [InlineData(new[] { 2, 1, 1 }, 0)]
-        [InlineData(new[] { 1, 1, 2, 1, 2, 2, 3 }, 6)]
-        [InlineData(new[] { 1, 1, 2, 3, 1, 2, 2 }, 3)]
-        [InlineData(new[] { 3, 1, 1, 2, 1, 2, 2 }, 0)]
+        [TestMethod]
+        [DataRow(new[] { 1, 1, 2 }, 2)]
+        [DataRow(new[] { 1, 2, 1 }, 1)]
+        [DataRow(new[] { 2, 1, 1 }, 0)]
+        [DataRow(new[] { 1, 1, 2, 1, 2, 2, 3 }, 6)]
+        [DataRow(new[] { 1, 1, 2, 3, 1, 2, 2 }, 3)]
+        [DataRow(new[] { 3, 1, 1, 2, 1, 2, 2 }, 0)]
         public void ItemsWithNoWinnerWillCountAsConflictsIfAnotherItemWins(int[] versions, int winnerIndex)
         {
             var items = versions.Select(v => new MockConflictItem() { FileVersion = new Version(v, 0, 0, 0) })
@@ -230,7 +231,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItemsWithNoWinnerWillBeUnresolvedIfAnotherItemLoses()
         {
             int[] versions = new[]
@@ -249,7 +250,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEquivalentTo(new[] { items[0], items[1] });
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndBothArePlatformItemsTheConflictCannotBeResolved()
         {
             var item1 = new MockConflictItem() { ItemType = ConflictItemType.Platform };
@@ -261,7 +262,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAndNeitherArePlatformItemsTheConflictCannotBeResolved()
         {
             var item1 = new MockConflictItem() { ItemType = ConflictItemType.Reference };
@@ -273,7 +274,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(item1, item2);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenItemsConflictAPlatformItemWins()
         {
             var item1 = new MockConflictItem() { ItemType = ConflictItemType.Reference };
@@ -285,7 +286,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCommitWinnerIsFalseOnlyTheFirstResolvedConflictIsReported()
         {
             var committedItem = new MockConflictItem() { AssemblyVersion = new Version("2.0.0.0") };
@@ -300,7 +301,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCommitWinnerIsFalseAndThereIsNoWinnerEachUnresolvedConflictIsReported()
         {
             var committedItem = new MockConflictItem();
@@ -315,7 +316,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().Equal(committedItem, uncommittedItem1, uncommittedItem2, uncommittedItem3);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCommitWinnerIsFalseMultipleConflictsAreReportedIfTheCommittedItemWins()
         {
             var committedItem = new MockConflictItem() { AssemblyVersion = new Version("4.0.0.0") };
@@ -330,7 +331,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCommitWinnerIsFalseConflictsWithDifferentKeysAreReported()
         {
             var committedItem1 = new MockConflictItem("System.Ben") { AssemblyVersion = new Version("2.0.0.0") };
@@ -347,7 +348,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPackageOverridesAreSpecifiedTheyAreUsed()
         {
             var systemItem1 = new MockConflictItem("System.Ben") { PackageId = "System.Ben", PackageVersion = new NuGetVersion("4.3.0") };
@@ -372,7 +373,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             result.UnresolvedConflicts.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenAHigherPackageIsUsedPackageOverrideLoses()
         {
             var platformItem1 = new MockConflictItem("System.Ben") { PackageId = "Platform", PackageVersion = new NuGetVersion("2.0.0") };

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
@@ -16,13 +16,14 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenADependencyContextBuilder
     {
         /// <summary>
         /// Tests that DependencyContextBuilder generates DependencyContexts correctly.
         /// </summary>
-        [Theory]
-        [MemberData(nameof(ProjectData))]
+        [TestMethod]
+        [DynamicData(nameof(ProjectData))]
         public void ItBuildsDependencyContextsFromProjectLockFiles(
             string mainProjectName,
             string mainProjectVersion,
@@ -171,7 +172,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesntCreateReferenceAssembliesWhenNoCompilationOptions()
         {
             DependencyContext dependencyContext = BuildDependencyContextWithReferenceAssemblies(useCompilationOptions: false);
@@ -188,7 +189,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesntCreateKeepUnneededRuntimeReferences()
         {
             DependencyContext dependencyContext = BuildDependencyContextWithReferenceAssemblies(useCompilationOptions: false);
@@ -197,7 +198,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries[0].Name.Should().Be("simple.dependencies"); // This is the entrypoint
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesReferenceAndPackageReferenceNameCollisions()
         {
             DependencyContext dependencyContext = BuildDependencyContextWithReferenceAssemblies(useCompilationOptions: true);
@@ -213,7 +214,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Contain(c => c.Name == "System.Collections.NonGeneric.Reference.Reference" && c.Type == "referenceassembly");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesProjectNameMatchingDirectReferenceAssemblyName()
         {
             // Regression test: if the main project name matches a dependency reference assembly name
@@ -346,9 +347,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Build();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void DirectReferenceToPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources([], [], ["System.A"], dllReference);
@@ -356,9 +357,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Count.Should().Be(1);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void IndirectReferenceToPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -369,9 +370,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Should().Contain(x => x.Name.Equals("System.A"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void PackageWithNoAssetsReferencesPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -382,9 +383,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Count.Should().Be(1);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void PackageWithNoAssetsReferencesPackageWithAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -397,9 +398,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Should().Contain(x => x.Name.Equals("System.B"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void PackageWithNoAssetsReferencesPackageReferencesByOtherPackage(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()
@@ -412,9 +413,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Should().Contain(x => x.Name.Equals("System.B"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void PackageWithNoAssetsReferencesPackageWithAssetsWithOtherReferencer(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()
@@ -429,9 +430,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             dependencyContext.RuntimeLibraries.Should().Contain(x => x.Name.Equals("System.B"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void TwoPackagesWithNoAssetsReferencePackageWithAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()
@@ -532,7 +533,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     generateXmlDocumentation: true);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItCanGenerateTheRuntimeFallbackGraph()
         {
             string mainProjectName = "simple.dependencies";
@@ -586,7 +587,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             CheckRuntimeFallbacks("unrelated_os-unknown_arch", 0);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIncludesLocalPathForResolvedNuGetFiles()
         {
             string mainProjectName = "simple.dependencies";
@@ -702,7 +703,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 $"resource assemblies should have item with LocalPath={resourceWithCustomSubPath.PathInPackage} and Path={resourceWithCustomSubPath.DestinationSubPath}");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIncludesLocalPathForReferences()
         {
             string mainProjectName = "simple.dependencies";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAFrameworkPackages.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAFrameworkPackages.cs
@@ -15,6 +15,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// exercise the method in isolation (the early-out guards, the missing-folder branch, and a successful
     /// PackageOverrides.txt load) rather than only through <see cref="GetPackagesToPrune"/>.
     /// </summary>
+    [TestClass]
     public class GivenAFrameworkPackages
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";
@@ -29,7 +30,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         private static AbsolutePath AbsolutePathFor(string path) =>
             TaskEnvironmentHelper.CreateForTest(Path.GetTempPath()).GetAbsolutePath(path);
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullWhenFrameworkIsNotANetCoreAppPack()
         {
             // null framework and non-.NETCoreApp frameworks both short-circuit to null.
@@ -41,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().BeNull("only .NETCoreApp frameworks have targeting pack data");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullWhenTargetingPackFolderDoesNotExist()
         {
             var missingRoot = Path.Combine(Path.GetTempPath(), "fp-missing-" + Guid.NewGuid().ToString("N"));
@@ -50,7 +51,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().BeNull("a non-existent targeting pack folder yields no packages");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItLoadsPackageOverridesFromTargetingPack()
         {
             var root = Path.Combine(Path.GetTempPath(), "fp-" + Guid.NewGuid().ToString("N"));

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -5,14 +5,9 @@
 
 using System.Runtime.CompilerServices;
 using FluentAssertions;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [CollectionDefinition(nameof(CwdSensitiveCollection), DisableParallelization = true)]
-    public sealed class CwdSensitiveCollection
-    {
-    }
 
     /// <summary>
     /// Behavioral tests for <see cref="GenerateBundle"/>'s migration to <c>IMultiThreadableTask</c>.
@@ -27,7 +22,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// location different from the <c>TaskEnvironment.ProjectDirectory</c> so a bug that fell
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
-    [Collection(nameof(CwdSensitiveCollection))]
+    [TestClass]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();
@@ -41,7 +36,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             Directory.CreateDirectory(_tempRoot);
         }
 
-        [Fact]
+        [TestMethod]
         public void ResolveOutputDir_RoutesRelativePathThroughTaskEnvironment_NotProcessCwd()
         {
             string projectDir = CreateTempDirectory("proj");
@@ -61,9 +56,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "relative OutputDir must not leak the process CWD into the resolved path");
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
         public void ResolveOutputDir_DefaultsToProjectDirectory_WhenOutputDirIsNullOrEmpty(string outputDir)
         {
             string projectDir = CreateTempDirectory("proj");

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -3,13 +3,13 @@
 
 using FluentAssertions;
 using Microsoft.Build.Framework;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGenerateClsidMapMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItProducesSameErrorsInMultiProcessAndMultiThreadedEnvironments()
         {
             // In multi-process mode, each task runs in its own process where CWD == projectDir
@@ -67,7 +67,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItProducesSameClsidMapInMultiProcessAndMultiThreadedEnvironments()
         {
             // Same pattern but with a valid .NET assembly to test the success path.

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -9,22 +9,16 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [CollectionDefinition(nameof(GenerateDepsFileCwdSensitiveCollection), DisableParallelization = true)]
-    public sealed class GenerateDepsFileCwdSensitiveCollection
-    {
-    }
-
-    [Collection(nameof(GenerateDepsFileCwdSensitiveCollection))]
+    [TestClass]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {
         private readonly List<string> _tempDirs = new();
         private readonly string _originalCwd = Directory.GetCurrentDirectory();
 
-        [Fact]
+        [TestMethod]
         public void ProjectAndDepsFilePathsAreResolvedThroughTaskEnvironment()
         {
             string projectDir = CreateTestProjectDirectory();
@@ -47,7 +41,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "FilesWritten should preserve the caller's original relative output path");
         }
 
-        [Fact]
+        [TestMethod]
         public void AssetsAndRuntimeGraphPathsAreResolvedThroughTaskEnvironment()
         {
             string projectDir = CreateTestProjectDirectory();
@@ -77,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "deps file should not be written under the process CWD");
         }
 
-        [Fact]
+        [TestMethod]
         public void SatelliteAssemblyTargetPathFlowsVerbatimToDepsJsonResources()
         {
             // Encodes the contract that AssemblySatelliteAssemblies metadata is passed through

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -4,13 +4,13 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItWritesRuntimeConfigViaTaskEnvironment()
         {
             // Create a temp directory to act as a fake project dir (different from CWD).
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItBehavesSameWithEmptyAssetsFilePathInBothEnvironments()
         {
             // When AssetsFilePath = "", the task enters the else branch (not null)
@@ -172,9 +172,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             return (result, engine, caught);
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow(null)]
         public void ItBehavesSameWithEmptyOrNullRuntimeConfigPathInBothEnvironments(string? runtimeConfigPath)
         {
             // WriteRuntimeConfig calls TaskEnvironment.GetAbsolutePath(RuntimeConfigPath).
@@ -232,7 +232,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void UserRuntimeConfigProducesSameOutputInBothEnvironments()
         {
             // AddUserRuntimeOptions calls TaskEnvironment.GetAbsolutePath(UserRuntimeConfig).
@@ -300,7 +300,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void UserRuntimeConfigWithNonexistentFileProducesSameOutputInBothEnvironments()
         {
             // When UserRuntimeConfig points to a file that doesn't exist,

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGenerateRuntimeConfigurationFiles
     {
         private readonly string _runtimeConfigPath;
@@ -27,7 +28,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItCanGenerateWithoutAssetFile()
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
@@ -67,7 +68,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             File.Exists(_runtimeConfigDevPath).Should().BeFalse("No nuget involved, so no extra probing path");
         }
 
-        [Fact]
+        [TestMethod]
         public void Given3RuntimeFrameworksItCanGenerateWithoutAssetFile()
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
@@ -127,7 +128,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     "There is no Microsoft.NETCore.App. And it is under frameworkS.");
         }
 
-        [Fact]
+        [TestMethod]
         public void Given2RuntimeFrameworksItCanGenerateWithoutAssetFile()
         {
             var task = new TestableGenerateRuntimeConfigurationFiles
@@ -174,7 +175,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                     "There is no Microsoft.NETCore.App.");
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenTargetMonikerItGeneratesShortName()
         {
             var task = new TestableGenerateRuntimeConfigurationFiles

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFile.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFile.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGenerateToolsSettingsFile
     {
         private XDocument _generatedDocument = null;
@@ -16,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 commandRunner: null, runtimeIdentifier: null, toolPackageId: "mytool", toolPackageVersion: "1.0.0", Array.Empty<ITaskItem>());
         }
 
-        [Fact]
+        [TestMethod]
         public void It_puts_command_name_in_correct_place_of_the_file()
         {
             _generatedDocument
@@ -28,7 +29,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().Be("mytool");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_puts_entryPoint_in_correct_place_of_the_file()
         {
             _generatedDocument
@@ -40,7 +41,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().Be("tool.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_puts_runner_as_dotnet()
         {
             _generatedDocument
@@ -52,7 +53,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().Be("dotnet");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_puts_format_version_in_correct_place_of_the_file()
         {
             _generatedDocument

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateToolsSettingsFileMultiThreading.cs
@@ -3,13 +3,13 @@
 
 using FluentAssertions;
 using Microsoft.Build.Framework;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGenerateToolsSettingsFileMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItSavesFileRelativeToTaskEnvironmentProjectDir()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "gtsf-test-" + Guid.NewGuid().ToString("N"));

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetAssemblyAttributesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetAssemblyAttributesMultiThreading.cs
@@ -3,13 +3,13 @@
 
 using FluentAssertions;
 using Microsoft.Build.Framework;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGetAssemblyAttributesMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItResolvesRelativePathsViaTaskEnvironment()
         {
             // Create a temp directory to act as a fake project dir (different from CWD)

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackageDirectoryMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAGetPackageDirectoryMultiThreading
     {
         // When the caller passes a relative PackageFolders
@@ -13,11 +14,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         // [Output] items' PackageDirectory metadata. The relative prefix is substituted back into
         // NuGet's absolutized result via string surgery, so this exercises that surgery across a
         // range of folder shapes (nested, forward slashes, trailing separators).
-        [Theory]
-        [InlineData("packages")]               // flat relative folder
-        [InlineData("nested/packages")]        // nested with forward slash
-        [InlineData("a/b/c/packages")]         // deeply nested
-        [InlineData("packages/")]              // trailing separator
+        [TestMethod]
+        [DataRow("packages")]               // flat relative folder
+        [DataRow("nested/packages")]        // nested with forward slash
+        [DataRow("a/b/c/packages")]         // deeply nested
+        [DataRow("packages/")]              // trailing separator
         public void PackageDirectoryMetadata_PreservesRelativeFolderShape_WhenInputIsRelative(string relativeFolder)
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "gpd-rel-" + Guid.NewGuid().ToString("N"));
@@ -73,7 +74,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         // empty user-package-folder is tolerated by NuGet's VersionFolderPathResolver (it stores
         // the empty string and probes harmlessly fail), so the task must still reach NuGet and
         // resolve packages from the remaining (valid) fallback folders.
-        [Fact]
+        [TestMethod]
         public void EmptyPackageFolderEntry_DoesNotThrow_AndValidFallbackResolves()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "gpd-empty-" + Guid.NewGuid().ToString("N"));
@@ -116,7 +117,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         // Happy-path regression guard: when all PackageFolders are already absolute (the realistic
         // production case), the migration must produce the same absolute PackageDirectory metadata
         // it would have pre-migration, and must NOT root anything against TaskEnvironment.ProjectDirectory.
-        [Fact]
+        [TestMethod]
         public void AbsolutePackageFolders_ProduceAbsoluteMetadata_AndDoNotLeakProjectDirectory()
         {
             var packagesDir = Path.Combine(Path.GetTempPath(), "gpd-abs-pkgs-" + Guid.NewGuid().ToString("N"));

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -13,6 +13,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// the task reads the on-disk data from the right place even when the process
     /// current working directory differs from the project directory.
     /// </summary>
+    [TestClass]
     public class GivenAGetPackagesToPrune
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";
@@ -44,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             };
         }
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesPrunePackageDataRootRelativeToTaskEnvironmentProjectDirectory()
         {
             using var env = new TaskTestEnvironment();
@@ -64,7 +65,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Which.ItemSpec.Should().Be("Newtonsoft.Json");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesTargetingPackRootsRelativeToTaskEnvironmentProjectDirectory()
         {
             using var env = new TaskTestEnvironment();
@@ -95,7 +96,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Which.ItemSpec.Should().Be("Newtonsoft.Json");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIgnoresEmptyTargetingPackRootEntries()
         {
             using var env = new TaskTestEnvironment();
@@ -117,7 +118,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Which.ItemSpec.Should().Be("Newtonsoft.Json");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotReuseCachedDataForDifferentResolvedTargetingPackRoots()
         {
             using var env = new TaskTestEnvironment();
@@ -154,7 +155,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "different resolved targeting pack roots must not collide in the build-wide cache");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReusesCachedDataForIdenticalInputs()
         {
             using var env = new TaskTestEnvironment();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenALogger.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenALogger.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenALogger
     {
         private sealed class TestLogger : Logger
@@ -13,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             protected override void LogCore(in Message message) => Messages.Add(message);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItLogsWarnings()
         {
             var logger = new TestLogger();
@@ -26,7 +27,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new Message(MessageLevel.Warning, "Goodbye, cruel world.", code: "NETSDK4567"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItLogsErrors()
         {
             var logger = new TestLogger();
@@ -37,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new Message(MessageLevel.Error, "Uh oh! :(", code: "NETSDK9898"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItLogsMessages()
         {
             var logger = new TestLogger();
@@ -54,7 +55,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 new Message(MessageLevel.HighImportance, "High importance"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIndicatesIfErrorsWereLogged()
         {
             var logger = new TestLogger();
@@ -79,7 +80,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             logger.HasLoggedErrors.Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItEnforcesErrorCodesInDebug()
         {
             var logger = new TestLogger();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPackageOverrideResolver.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPackageOverrideResolver.cs
@@ -10,9 +10,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAPackageOverrideResolver
     {
-        [Fact]
+        [TestMethod]
         public void ItMergesPackageOverridesUsingHighestVersion()
         {
             ITaskItem[] packageOverrides = new[]
@@ -29,27 +30,27 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var resolver = new PackageOverrideResolver<MockConflictItem>(packageOverrides);
 
-            Assert.Single(resolver.PackageOverrides);
+            Assert.ContainsSingle(resolver.PackageOverrides);
 
             PackageOverride packageOverride = resolver.PackageOverrides["Platform"];
-            Assert.Equal(5, packageOverride.OverriddenPackages.Count);
-            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Ben"]);
-            Assert.Equal(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Immo"]);
-            Assert.Equal(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Livar"]);
-            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Dave"]);
-            Assert.Equal(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Nick"]);
+            Assert.HasCount(5, packageOverride.OverriddenPackages);
+            Assert.AreEqual(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Ben"]);
+            Assert.AreEqual(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Immo"]);
+            Assert.AreEqual(new NuGetVersion(4, 3, 0), packageOverride.OverriddenPackages["System.Livar"]);
+            Assert.AreEqual(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Dave"]);
+            Assert.AreEqual(new NuGetVersion(4, 2, 0), packageOverride.OverriddenPackages["System.Nick"]);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesNullITaskItemArray()
         {
             var resolver = new PackageOverrideResolver<MockConflictItem>(null);
 
-            Assert.Null(resolver.PackageOverrides);
-            Assert.Null(resolver.Resolve(new MockConflictItem(), new MockConflictItem()));
+            Assert.IsNull(resolver.PackageOverrides);
+            Assert.IsNull(resolver.Resolve(new MockConflictItem(), new MockConflictItem()));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesNullPackageIds()
         {
             ITaskItem[] packageOverrides = new[]
@@ -62,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var resolver = new PackageOverrideResolver<MockConflictItem>(packageOverrides);
 
-            Assert.NotNull(resolver.PackageOverrides);
+            Assert.IsNotNull(resolver.PackageOverrides);
 
             var packageItem = new MockConflictItem("System.Eric")
             {
@@ -79,8 +80,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ItemType = ConflictItemType.Platform
             };
 
-            Assert.Null(resolver.Resolve(packageItem, platformItem));
-            Assert.Null(resolver.Resolve(platformItem, packageItem));
+            Assert.IsNull(resolver.Resolve(packageItem, platformItem));
+            Assert.IsNull(resolver.Resolve(platformItem, packageItem));
 
             var packageItem2 = new MockConflictItem("System.Eric")
             {
@@ -90,8 +91,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ItemType = ConflictItemType.Reference
             };
 
-            Assert.Null(resolver.Resolve(packageItem2, platformItem));
-            Assert.Null(resolver.Resolve(platformItem, packageItem2));
+            Assert.IsNull(resolver.Resolve(packageItem2, platformItem));
+            Assert.IsNull(resolver.Resolve(platformItem, packageItem2));
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRid.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRid.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAPickBestRid
     {
         private const string RuntimeGraphContent = @"{
@@ -37,7 +38,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }";
 
-        [Fact]
+        [TestMethod]
         public void ItPicksBestMatchingRid()
         {
             var runtimeGraphPath = Path.GetTempFileName();
@@ -62,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItPicksBestMatchingRidFallback()
         {
             var runtimeGraphPath = Path.GetTempFileName();
@@ -87,7 +88,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItPicksBestMatchingRidAnyFallback()
         {
             var runtimeGraphPath = Path.GetTempFileName();
@@ -112,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesNonExistentRuntimeGraphFile()
         {
             var task = new PickBestRid
@@ -132,7 +133,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             buildEngine.Errors[0].Message.Should().Contain("does not exist");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesUnknownTargetRid()
         {
             var runtimeGraphPath = Path.GetTempFileName();
@@ -162,7 +163,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHandlesNoSupportedRidsMatch()
         {
             var runtimeGraphPath = Path.GetTempFileName();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphContent = @"{
@@ -16,7 +17,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }";
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesRelativeRuntimeGraphPathAgainstProjectDirectory()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-relpath-" + Guid.NewGuid().ToString("N"));
@@ -53,7 +54,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void MissingFileErrorContainsOriginalRelativePathNotAbsolutized()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "pickbestrid-err-" + Guid.NewGuid().ToString("N"));
@@ -86,9 +87,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
         public void EmptyRuntimeGraphPathLogsMissingFileError(string? runtimeGraphPath)
         {
             var mockEngine = new MockBuildEngine();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAProcessFrameworkReferencesTaskEnvironment.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAProcessFrameworkReferencesTaskEnvironment.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAProcessFrameworkReferencesTaskEnvironment
     {
         private const string MinimalRuntimeGraph = """
@@ -20,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
             """;
 
-        [Fact]
+        [TestMethod]
         public void Execute_WithRelativeTargetingPackRoot_DoesNotAbsolutizeOutputMetadata()
         {
             var testRoot = CreateTestRoot();
@@ -51,7 +52,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void Execute_WithRelativeWorkloadPackRoot_DoesNotAbsolutizeOutputMetadata()
         {
             var testRoot = CreateTestRoot();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAProduceContentsAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAProduceContentsAssetsTask.cs
@@ -7,9 +7,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAProduceContentsAssetsTask
     {
-        [Fact]
+        [TestMethod]
         public void ItProcessesContentFiles()
         {
             // sample data
@@ -55,7 +56,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ProcessedContentItems.Count().Should().Be(0); // buildAction = none
         }
 
-        [Fact]
+        [TestMethod]
         public void ItOutputsFileWritesForProcessedContent()
         {
             // sample data
@@ -108,7 +109,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.CopyLocalItems.Count().Should().Be(0);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItOutputsCopyLocalItems()
         {
             // sample data
@@ -187,7 +188,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             copyLocalItems.Where(t => t.ItemSpec.EndsWith(contentFiles[3])).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItOutputsContentItemsWithActiveBuildAction()
         {
             // sample data
@@ -265,7 +266,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             contentItems.Where(t => t.ItemSpec.EndsWith(contentFiles[3])).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItCanOutputOnlyPreprocessedItems()
         {
             // sample data
@@ -345,7 +346,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             copyLocalItems.Where(t => t.ItemSpec.EndsWith(contentFiles[3])).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIgnoresProjectLanguageIfCodeLanguageIsOnlyAny()
         {
             // sample data
@@ -384,7 +385,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             contentItems.All(t => t.GetMetadata(MetadataKeys.NuGetPackageVersion) == packageVersion).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItProcessesOnlyProjectLanguageIfPresent()
         {
             // sample data
@@ -428,7 +429,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             contentItems.First().GetMetadata(MetadataKeys.NuGetPackageVersion).Should().Be(packageVersion);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItProcessesOnlyAnyItemsIfProjectLanguageNotPresent()
         {
             // sample data

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAProjectContext.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAProjectContext.cs
@@ -8,9 +8,10 @@ using NuGet.ProjectModel;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAProjectContext
     {
-        [Fact]
+        [TestMethod]
         public void ItComputesExcludeFromPublishList()
         {
             LockFile lockFile = TestLockFiles.GetLockFile("dependencies.withgraphs");

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenARemoveDuplicatePackageReferences.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenARemoveDuplicatePackageReferences.cs
@@ -7,6 +7,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenARemoveDuplicatePackageReferenceTask
     {
         private static ITaskItem[] GetPackageRefItems(List<PackageIdentity> packages)
@@ -14,7 +15,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 itemSpec: kvp.Id,
                 metadata: new Dictionary<string, string> { { "Version", kvp.Version.ToString() } })).ToArray();
 
-        [Fact]
+        [TestMethod]
         public void RemoveDuplicatePackageReference()
         {
             var knownpackage = new List<PackageIdentity>();
@@ -30,7 +31,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var packagelistWithoutDups = new HashSet<PackageIdentity>(knownpackage);
 
-            Assert.True(knownpackage.Count() > packagelistWithoutDups.Count());
+            Assert.IsGreaterThan(packagelistWithoutDups.Count(), knownpackage.Count());
 
             // execute task
             var task = new RemoveDuplicatePackageReferences()

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -9,21 +9,16 @@ using System.IO;
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [CollectionDefinition(GivenAResolveAppHostsMultiThreading.CollectionName, DisableParallelization = true)]
-    public sealed class ResolveAppHostsCurrentDirectoryCollection
-    {
-    }
 
     /// <summary>
     /// Tests for ResolveAppHosts multi-threading support.
     /// Verifies TaskEnvironment-based path resolution against ProjectDirectory (not process CWD)
     /// and that output metadata preserves the original path form.
     /// </summary>
-    [Collection(CollectionName)]
+    [TestClass]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {
         internal const string CollectionName = "ResolveAppHosts current directory tests";
@@ -49,7 +44,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             DeleteDirectory(_decoyDir);
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativeTargetingPackRoot_OutputMetadataRemainsRelative()
         {
             string relativePackRoot = "packs";
@@ -76,7 +71,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             AssertRelativePackMetadata(task.IjwHost, expectedPackDir, "ijwhost.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void Execute_DoesNotMutateProcessCurrentDirectory()
         {
             string relativePackRoot = "packs";
@@ -98,7 +93,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "ResolveAppHosts must not mutate process current directory");
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativeTargetingPackRoot_ResolvedAgainstProjectDirectory_NotCwd()
         {
             string relativePackRoot = "packs";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -6,9 +6,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolvePackageAssetsMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItResolvesCacheFilePathViaTaskEnvironment()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "rpa-test-" + Guid.NewGuid().ToString("N"));
@@ -54,7 +55,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void OutputMatchesBetweenSingleAndMultiProcessMode()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "rpa-parity-" + Guid.NewGuid().ToString("N"));
@@ -135,7 +136,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void OutputPaths_AreNotAbsolutized_ByTaskEnvironment()
         {
             var projectDir = Path.Combine(Path.GetTempPath(), "rpa-noabs-" + Guid.NewGuid().ToString("N"));

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsTask.cs
@@ -9,9 +9,10 @@ using static Microsoft.NET.Build.Tasks.ResolvePackageAssets;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolvePackageAssetsTask
     {
-        [Fact]
+        [TestMethod]
         public void ItHashesAllParameters()
         {
             IEnumerable<PropertyInfo> inputProperties;
@@ -23,11 +24,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 oldHash = task.HashSettings();
             }
-            catch (ArgumentNullException)
+            catch (ArgumentNullException ex)
             {
-                Assert.Fail("HashSettings is likely not correctly handling null value of one or more optional task parameters");
-
-                throw; // unreachable
+                throw new InvalidOperationException("HashSettings is likely not correctly handling null value of one or more optional task parameters", ex);
             }
 
             foreach (var property in inputProperties)
@@ -60,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotHashDesignTimeBuild()
         {
             var task = InitializeTask(out _);
@@ -77,7 +76,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 because: $"{nameof(task.DesignTimeBuild)} should not be included in hash.");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_does_not_error_on_duplicate_package_names()
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
@@ -155,9 +154,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
   }
 }".Replace("`", "\"").Replace("{tfm}", tfm).Replace("{locale}", locale);
 
-        [InlineData("net7.0", true)]
-        [InlineData("net6.0", false)]
-        [Theory]
+        [DataRow("net7.0", true)]
+        [DataRow("net6.0", false)]
+        [TestMethod]
         public void It_warns_on_invalid_culture_codes_of_resources(string tfm, bool shouldHaveWarnings)
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
@@ -178,9 +177,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         }
 
-        [InlineData("net7.0", true)]
-        [InlineData("net6.0", false)]
-        [Theory]
+        [DataRow("net7.0", true)]
+        [DataRow("net6.0", false)]
+        [TestMethod]
         public void It_warns_on_incorrectly_cased_culture_codes_of_resources(string tfm, bool shouldHaveWarnings)
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
@@ -231,4 +230,3 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
     }
 }
-

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesMultiThreading.cs
@@ -4,14 +4,14 @@
 using FluentAssertions;
 using Microsoft.Build.Framework;
 using NuGet.ProjectModel;
-using Xunit;
 using static Microsoft.NET.Build.Tasks.UnitTests.LockFileSnippets;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolvePackageDependenciesMultiThreading
     {
-        [Fact]
+        [TestMethod]
         public void ItResolvesProjectReferencePathsViaTaskEnvironment()
         {
             // Create a temp directory to act as a fake project dir (different from CWD).

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
@@ -10,14 +10,15 @@ using static Microsoft.NET.Build.Tasks.UnitTests.LockFileSnippets;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolvePackageDependenciesTask
     {
         private static readonly string _drivePrefix = OperatingSystem.IsWindows() ? "C:" : "";
         private static readonly string _packageRoot = (_drivePrefix + "\\root\\packages").Replace('\\', Path.DirectorySeparatorChar);
         private static readonly string _projectPath = (_drivePrefix + "\\root\\anypath\\solutiondirectory\\myprojectdir\\myproject.csproj").Replace('\\', Path.DirectorySeparatorChar);
 
-        [Theory]
-        [MemberData(nameof(ItemCounts))]
+        [TestMethod]
+        [DynamicData(nameof(ItemCounts))]
         public void ItRaisesLockFileToMSBuildItems(string projectName, int[] counts)
         {
             var task = GetExecutedTaskFromPrefix(projectName, out _);
@@ -47,9 +48,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Theory]
-        [InlineData("dotnet.new")]
-        [InlineData("simple.dependencies")]
+        [TestMethod]
+        [DataRow("dotnet.new")]
+        [DataRow("simple.dependencies")]
         public void ItAssignsTypeMetaDataToEachDefinition(string projectName)
         {
             var task = GetExecutedTaskFromPrefix(projectName, out _);
@@ -62,9 +63,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             allTyped(task.TargetDefinitions).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData("dotnet.new")]
-        [InlineData("simple.dependencies")]
+        [TestMethod]
+        [DataRow("dotnet.new")]
+        [DataRow("simple.dependencies")]
         public void ItAssignsValidParentTargetsAndPackages(string projectName)
         {
             LockFile lockFile;
@@ -89,9 +90,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             allValidParentPackage(task.FileDependencies).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData("dotnet.new")]
-        [InlineData("simple.dependencies")]
+        [TestMethod]
+        [DataRow("dotnet.new")]
+        [DataRow("simple.dependencies")]
         public void ItAssignsValidTopLevelDependencies(string projectName)
         {
             LockFile lockFile;
@@ -112,7 +113,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().OnlyContain(p => allProjectDeps.Any(dep => dep.IndexOf(p) != -1));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsExpectedTopLevelDependencies()
         {
             string lockFileContent = CreateLockFileSnippet(
@@ -140,9 +141,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItAssignsDiagnosticLevel(bool useAlias)
         {
             const string target1 = ".NETCoreApp,Version=v1.0";
@@ -184,7 +185,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             defs["LibC/1.2.3"].Single().GetMetadata(MetadataKeys.DiagnosticLevel).Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsExpectedTopLevelDependenciesFromAllTargets()
         {
             string targetLibD = CreateTargetLibrary("LibD/1.2.3", "package",
@@ -229,7 +230,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsTargetDefinitionMetadata()
         {
             string lockFileContent = CreateLockFileSnippet(
@@ -260,7 +261,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             target.GetMetadata(MetadataKeys.Type).Should().Be("target");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsPackageDefinitionMetadata()
         {
             // project lib
@@ -310,7 +311,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsPackageDependenciesMetadata()
         {
             // project lib
@@ -352,7 +353,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().OnlyContain(s => s == "netcoreapp1.0");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsFileDefinitionMetadata()
         {
             var expectedTypes = new Dictionary<string, string>()
@@ -399,7 +400,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAssignsFileDependenciesMetadata()
         {
             var expectedFileGroups = new Dictionary<string, string>()
@@ -455,7 +456,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItRaisesAssetPropertiesToFileDependenciesMetadata()
         {
             string lockFileContent = CreateLockFileSnippet(
@@ -495,7 +496,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             fileDeps.First().GetMetadata("copyToOutput").Should().Be("false");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItExcludesPlaceholderFiles()
         {
             string targetLibC = CreateTargetLibrary("LibC/1.2.3", "package",
@@ -535,7 +536,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAddsAnalyzerMetadataAndFileDependencies()
         {
             string projectLanguage = "VB";
@@ -604,7 +605,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItFiltersAnalyzersByProjectLanguage()
         {
             string projectLanguage = "C#";
@@ -695,7 +696,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItUsesResolvedPackageVersionFromSameTarget()
         {
             string targetLibC = CreateTargetLibrary("LibC/1.2.3", "package",
@@ -738,7 +739,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .First().Should().Be("Dep.Lib.Chi/4.1.0");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItMarksTransitiveProjectReferences()
         {
             // --------------------------------------------------------------------------
@@ -808,7 +809,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             others.Where(t => t.ItemSpec == "ProjF/1.0.0").Count().Should().Be(1);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotThrowOnCrossTargetingWithTargetPlatforms()
         {
             string lockFileContent = CreateCrossTargetingLockFileSnippet(

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -5,11 +5,9 @@ using FluentAssertions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
-
-[Collection(nameof(CwdSensitiveCollection))]
+[TestClass]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {
     private readonly string _originalCwd = Directory.GetCurrentDirectory();
@@ -27,7 +25,7 @@ public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
     /// pointing at a manifest that exists relative to the project directory but not the
     /// CWD: if path resolution were CWD-based, the task would log CouldNotLoadPlatformManifest.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PlatformManifest_ResolvesRelativePathAgainstProjectDir()
     {
         var projectDir = CreateTempDir();
@@ -66,7 +64,7 @@ public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
         conflict.GetMetadata(nameof(ConflictItemType)).Should().Be(ConflictItemType.CopyLocal.ToString());
     }
 
-    [Fact]
+    [TestMethod]
     public void PlatformManifest_EmptyPathLogsAndSkips()
     {
         var projectDir = CreateTempDir();
@@ -85,7 +83,7 @@ public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
     /// TargetFrameworkDirectories with a relative ItemSpec must preserve the pre-migration
     /// behavior: the derived FrameworkList.xml path is invalid because it is not rooted.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void TargetFrameworkDirectories_RelativePathLogsNotRootedOriginalPath()
     {
         var projectDir = CreateTempDir();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -7,13 +7,11 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {
-        public GivenAResolveRuntimePackAssetsTask(ITestOutputHelper log) : base(log)
-        {
-        }
 
-        [Fact]
+        [TestMethod]
         public void ItFiltersSatelliteResources()
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory().Path;
@@ -51,7 +49,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimePackAssets.FirstOrDefault().ItemSpec.Should().Contain(expectedResource);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesRelativePackageDirectoryAgainstProjectDirectory()
         {
             //  TaskTestEnvironment points the injected TaskEnvironment at ProjectDirectory while
@@ -95,7 +93,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "the resolved asset path must not leak the process working directory");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesAbsolutePackageDirectoryIndependentlyOfCwd()
         {
             using var testEnv = new TaskTestEnvironment();
@@ -132,7 +130,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimePackAssets[0].ItemSpec.Should().Be(testEnv.GetProjectPath("runtimepack/runtimes/a.dll"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItResolvesAnEmptyFilePathToTheRuntimePackRoot()
         {
             //  Pre-migration the asset path was built with Path.Combine(runtimePackRoot, Path), and

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveTargetingPackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveTargetingPackAssetsTask.cs
@@ -10,14 +10,11 @@ using static Microsoft.NET.Build.Tasks.ResolveTargetingPackAssets;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenAResolveTargetingPackAssetsTask : SdkTest
     {
-        public GivenAResolveTargetingPackAssetsTask(ITestOutputHelper log)
-            : base(log)
-        {
-        }
 
-        [Fact]
+        [TestMethod]
         public void Given_ResolvedTargetingPacks_with_valid_PATH_in_PlatformManifest_It_resolves_TargetingPack()
         {
             ResolveTargetingPackAssets task = InitializeMockTargetingPackAssetsDirectory(out string mockPackageDirectory);
@@ -45,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 because: "There should be a cache entry for the overall lookup and for the specific targeting pack");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_Uses_Multiple_Frameworks()
         {
             ResolveTargetingPackAssets task = InitializeMockTargetingPackAssetsDirectory(out string mockPackageDirectory);
@@ -66,7 +63,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Fact]
+        [TestMethod]
         public void Given_Passing_ResolvedTargetingPacks_It_Passes_Again_With_Cached_Results()
         {
             ResolveTargetingPackAssets task1 = InitializeMockTargetingPackAssetsDirectory(out string packageDirectory);
@@ -93,7 +90,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 because: "the cache keys should match");
         }
 
-        [Fact]
+        [TestMethod]
         public void Given_Passing_ResolvedTargetingPacks_A_Different_Language_Parses_Again()
         {
             ResolveTargetingPackAssets task1 = InitializeMockTargetingPackAssetsDirectory(out string packageDirectory);
@@ -176,7 +173,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
   <File Type=""Analyzer"" Language=""vb"" Path=""analyzers/dotnet/vb/vbAnalyzer.dll"" PublicKeyToken=""null"" AssemblyName=""vbAnalyzer"" AssemblyVersion=""10.0.18362.3"" FileVersion=""10.0.18362.3"" />
 </FileList>";
 
-        [Fact]
+        [TestMethod]
         public void CachingBehaviorIsControlledByTaskEnvironment()
         {
             ResolveTargetingPackAssets taskNoCaching = InitializeMockTargetingPackAssetsDirectory(out string mockPackageDirectory);
@@ -194,7 +191,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "caching should be enabled when DOTNETSDK_ALLOW_TARGETING_PACK_CACHING!=0 in TaskEnvironment");
         }
 
-        [Fact]
+        [TestMethod]
         public void RelativeTargetingPackPathsResolveAgainstTaskEnvironmentProjectDirectoryAndArePreservedInOutputs()
         {
             string projectDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -227,7 +224,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().OnlyContain(path => !Path.IsPathRooted(path));
         }
 
-        [Fact]
+        [TestMethod]
         public void SharedCacheKeepsIdenticalRelativeTargetingPackPathsIsolatedByProjectDirectory()
         {
             string firstProjectDir = TestAssetsManager.CreateTestDirectory(identifier: "first").Path;
@@ -278,7 +275,7 @@ $@"<FileList Name=""{assemblyName}"">
   <File Type=""Managed"" Path=""lib/{assemblyName}.dll"" PublicKeyToken=""null"" AssemblyName=""{assemblyName}"" AssemblyVersion=""1.0.0.0"" FileVersion=""1.0.0.0"" />
 </FileList>";
 
-        [Fact]
+        [TestMethod]
         public void It_Hashes_All_Inputs()
         {
             IEnumerable<PropertyInfo> inputProperties;
@@ -290,11 +287,9 @@ $@"<FileList Name=""{assemblyName}"">
             {
                 oldHash = task.GetInputs().CacheKey();
             }
-            catch (ArgumentNullException)
+            catch (ArgumentNullException ex)
             {
-                Assert.Fail(nameof(StronglyTypedInputs) + " is likely not correctly handling null value of one or more optional task parameters");
-
-                throw; // unreachable
+                throw new InvalidOperationException(nameof(StronglyTypedInputs) + " is likely not correctly handling null value of one or more optional task parameters", ex);
             }
 
             foreach (var property in inputProperties)
@@ -359,8 +354,8 @@ $@"<FileList Name=""{assemblyName}"">
             return task;
         }
 
-        [Fact]
-        public static void It_Hashes_All_Inputs_To_FrameworkList()
+        [TestMethod]
+        public void It_Hashes_All_Inputs_To_FrameworkList()
         {
             var constructor = typeof(FrameworkListDefinition).GetConstructors().Single();
 
@@ -404,8 +399,8 @@ $@"<FileList Name=""{assemblyName}"">
             }
         }
 
-        [Fact]
-        public static void StronglyTypedInputs_Includes_All_Inputs_In_CacheKey()
+        [TestMethod]
+        public void StronglyTypedInputs_Includes_All_Inputs_In_CacheKey()
         {
             StronglyTypedInputs defaultObject = new(
                 frameworkReferences: DefaultFrameworkReferences(),
@@ -545,4 +540,3 @@ $@"<FileList Name=""{assemblyName}"">
         };
     }
 }
-

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenASelectRuntimeIdentifierSpecificItems.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenASelectRuntimeIdentifierSpecificItems.cs
@@ -6,9 +6,10 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenASelectRuntimeIdentifierSpecificItems
     {
-        [Fact]
+        [TestMethod]
         public void ItSelectsCompatibleItems()
         {
             // Arrange
@@ -41,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.SelectedItems.Should().NotContain(i => i.ItemSpec == "Item2"); // win-x64
         }
 
-        [Fact]
+        [TestMethod]
         public void ItSelectsItemsWithExactMatch()
         {
             // Arrange
@@ -69,7 +70,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.SelectedItems[0].ItemSpec.Should().Be("Item1");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItSkipsItemsWithoutRuntimeIdentifierMetadata()
         {
             // Arrange
@@ -98,7 +99,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.SelectedItems[0].ItemSpec.Should().Be("Item1");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItUsesCustomRuntimeIdentifierMetadata()
         {
             // Arrange
@@ -124,7 +125,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.SelectedItems[0].ItemSpec.Should().Be("Item1");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsEmptyArrayWhenNoItemsProvided()
         {
             // Arrange

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskBase.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenATaskBase
     {
         private sealed class TestTask : TaskBase
@@ -12,7 +13,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             protected override void ExecuteCore() { }
         }
 
-        [Fact]
+        [TestMethod]
         public void ItRoutesLogMessagesToMSBuild()
         {
             var task = new TestTask();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Build.Framework;
-using Xunit;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
@@ -20,9 +19,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// <see cref="TaskEnvironment"/>. Tasks default to <see cref="TaskEnvironment.Fallback"/>
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
+    [TestClass]
     public class GivenATaskEnvironmentDefault
     {
-        [Fact]
+        [TestMethod]
         public void NewTaskInstance_HasNonNullTaskEnvironment_EqualToFallback()
         {
             var task = new GenerateClsidMap();
@@ -32,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "the default should be the shared Fallback singleton (live process state) for backwards compatibility");
         }
 
-        [Fact]
+        [TestMethod]
         public void Fallback_GetAbsolutePath_ResolvesAgainstLiveCwd()
         {
             var task = new GenerateClsidMap();
@@ -59,7 +59,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void DifferentTaskInstances_ShareTheFallbackSingleton()
         {
             var a = new GenerateClsidMap();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAnAssetsFileResolver.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAnAssetsFileResolver.cs
@@ -13,10 +13,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// <summary>
     /// Tests that AssetsFileResolver resolves files correctly.
     /// </summary>
+    [TestClass]
     public class GivenAnAssetsFileResolver
     {
-        [Theory]
-        [MemberData(nameof(ProjectData))]
+        [TestMethod]
+        [DynamicData(nameof(ProjectData))]
         public void ItResolvesAssembliesFromProjectLockFiles(string projectName, string runtime, object[] expectedResolvedFiles)
         {
             LockFile lockFile = TestLockFiles.GetLockFile(projectName);
@@ -35,8 +36,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .BeEquivalentTo(expectedResolvedFiles);
         }
 
-        [Theory]
-        [MemberData(nameof(ProjectData1))]
+        [TestMethod]
+        [DynamicData(nameof(ProjectData1))]
         public void ItResolvesAssembliesFromProjectLockFilesWithStoreLayout(string projectName, string runtime, object[] expectedResolvedFiles)
         {
             LockFile lockFile = TestLockFiles.GetLockFile(projectName);

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -17,15 +17,15 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// These tests create files in a "project" directory, then verify task behavior by
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
+[TestClass]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;
-    private readonly ITestOutputHelper _output;
+    public TestContext TestContext { get; set; }
 
-    public GivenTasksUseAbsolutePaths(ITestOutputHelper output)
+    public GivenTasksUseAbsolutePaths()
     {
         _env = new TaskTestEnvironment();
-        _output = output;
     }
 
     public void Dispose()
@@ -35,18 +35,18 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region Infrastructure Verification Tests
 
-    [Fact]
+    [TestMethod]
     public void TestEnvironment_ProjectAndSpawnDirectories_AreDifferent()
     {
         _env.ProjectDirectory.Should().NotBe(_env.SpawnDirectory);
         Directory.Exists(_env.ProjectDirectory).Should().BeTrue();
         Directory.Exists(_env.SpawnDirectory).Should().BeTrue();
 
-        _output.WriteLine($"Project directory: {_env.ProjectDirectory}");
-        _output.WriteLine($"Spawn directory: {_env.SpawnDirectory}");
+        TestContext.WriteLine($"Project directory: {_env.ProjectDirectory}");
+        TestContext.WriteLine($"Spawn directory: {_env.SpawnDirectory}");
     }
 
-    [Fact]
+    [TestMethod]
     public void TestEnvironment_DemonstratesPathDifference()
     {
         var projectFile = _env.CreateProjectFile("test.txt", "content");
@@ -58,15 +58,15 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         File.Exists(correctPath).Should().BeTrue("file was created in project directory");
         File.Exists(incorrectPath).Should().BeFalse("file should not exist in spawn directory");
 
-        _output.WriteLine($"Correct path (in project): {correctPath}");
-        _output.WriteLine($"Incorrect path (in spawn): {incorrectPath}");
+        TestContext.WriteLine($"Correct path (in project): {correctPath}");
+        TestContext.WriteLine($"Incorrect path (in spawn): {incorrectPath}");
     }
 
     #endregion
 
     #region AllowEmptyTelemetry - No File I/O
 
-    [Fact]
+    [TestMethod]
     public void AllowEmptyTelemetry_NoFileIO_ShouldSucceed()
     {
         var task = new AllowEmptyTelemetry
@@ -82,7 +82,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region CheckForTargetInAssetsFile
 
-    [Fact]
+    [TestMethod]
     public void CheckForTargetInAssetsFile_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         var assetsContent = @"{
@@ -116,7 +116,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region GenerateRuntimeConfigurationFiles
 
-    [Fact]
+    [TestMethod]
     public void GenerateRuntimeConfigurationFiles_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         _env.CreateProjectDirectory("obj");
@@ -152,7 +152,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region GenerateToolsSettingsFile
 
-    [Fact]
+    [TestMethod]
     public void GenerateToolsSettingsFile_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         _env.CreateProjectDirectory("obj");
@@ -180,7 +180,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region GetAssemblyAttributes
 
-    [Fact]
+    [TestMethod]
     public void GetAssemblyAttributes_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         _env.CreateProjectDirectory("obj");
@@ -205,7 +205,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region ResolvePackageAssets
 
-    [Fact]
+    [TestMethod]
     public void ResolvePackageAssets_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         var assetsContent = @"{
@@ -238,8 +238,8 @@ public class GivenTasksUseAbsolutePaths : IDisposable
             DefaultImplicitPackages = ""
         };
 
-        _output.WriteLine($"Current directory: {Environment.CurrentDirectory}");
-        _output.WriteLine($"Project directory: {_env.ProjectDirectory}");
+        TestContext.WriteLine($"Current directory: {Environment.CurrentDirectory}");
+        TestContext.WriteLine($"Project directory: {_env.ProjectDirectory}");
 
         var result = task.Execute();
 
@@ -250,7 +250,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region ResolvePackageDependencies
 
-    [Fact]
+    [TestMethod]
     public void ResolvePackageDependencies_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         var assetsContent = @"{
@@ -284,7 +284,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region SelectRuntimeIdentifierSpecificItems
 
-    [Fact]
+    [TestMethod]
     public void SelectRuntimeIdentifierSpecificItems_WithRelativePaths_ShouldResolveFromProjectDirectory()
     {
         var runtimeGraphContent = @"{
@@ -318,7 +318,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         task.SelectedItems[0].ItemSpec.Should().Be("Item1");
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectRuntimeIdentifierSpecificItems_IgnoresDecoyRuntimeGraphInCwd()
     {
         // Correct graph (project dir): linux-x64 imports linux, so an item with RID "linux" is compatible.
@@ -367,7 +367,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region ResolveOverlappingItemGroupConflicts
 
-    [Fact]
+    [TestMethod]
     public void ResolveOverlappingItemGroupConflicts_WithRelativeHintPaths_ShouldResolveFromProjectDirectory()
     {
         const string winnerPath = "libs/winner.dll";
@@ -399,7 +399,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         task.RemovedItemGroup2[0]!.GetMetadata("HintPath").Should().Be(loserPath, "outputs should preserve original metadata");
     }
 
-    [Fact]
+    [TestMethod]
     public void AbsoluteHintPaths_AreLeftUnchanged()
     {
         var winnerPath = _env.CreateProjectFile("libs/winner.dll", string.Empty);
@@ -428,7 +428,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         task.RemovedItemGroup2[0]!.GetMetadata("HintPath").Should().Be(loserPath, "outputs should preserve original (absolute) metadata");
     }
 
-    [Fact]
+    [TestMethod]
     public void ConflictItem_WithoutTaskEnvironment_ShouldKeepExistingRelativePathBehavior()
     {
         const string existingPath = "libs/existing.dll";
@@ -445,7 +445,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         conflictItem.DisplayName.Should().Be($"CopyLocal:{existingPath}", "display strings should not be absolutized");
     }
 
-    [Fact]
+    [TestMethod]
     public void ConflictItem_WithTaskEnvironment_ExistsResolvesRelativePathToProjectDirectory()
     {
         const string relativePath = "libs/existing.dll";
@@ -461,7 +461,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
             "Exists must resolve the relative HintPath against the TaskEnvironment's project directory, not the process CWD");
     }
 
-    [Fact]
+    [TestMethod]
     public void ConflictItem_WithTaskEnvironment_FileVersionReadsFileViaProjectDirectory()
     {
         // Copy a real managed assembly (this test assembly) into the project directory so
@@ -486,7 +486,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
             "FileVersion must be obtainable via TaskEnvironment-resolved path even when the process CWD is wrong");
     }
 
-    [Fact]
+    [TestMethod]
     public void ConflictItem_WithTaskEnvironment_SourcePathAndDisplayNamePreserveOriginalRelativePath()
     {
         const string relativePath = "libs/existing.dll";
@@ -508,7 +508,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
             "DisplayName is used in diagnostics and must not leak the absolutized path");
     }
 
-    [Fact]
+    [TestMethod]
     public void ConflictItem_WithTaskEnvironment_HonorsMetadataAndDoesNotAccessFile()
     {
         // Point at a file that does NOT exist anywhere; if anything other than Exists touches the
@@ -548,7 +548,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
     #region Demonstration: Absolute vs Relative Paths
 
-    [Fact]
+    [TestMethod]
     public void AbsolutePath_AlwaysPointsToCorrectFile()
     {
         var content = "test content";
@@ -559,11 +559,11 @@ public class GivenTasksUseAbsolutePaths : IDisposable
         var readContent = File.ReadAllText(absolutePath);
         readContent.Should().Be(content);
 
-        _output.WriteLine($"Absolute path: {absolutePath}");
-        _output.WriteLine($"Successfully read file content: {readContent}");
+        TestContext.WriteLine($"Absolute path: {absolutePath}");
+        TestContext.WriteLine($"Successfully read file content: {readContent}");
     }
 
-    [Fact]
+    [TestMethod]
     public void MockTaskEnvironment_ResolvesRelativeToProjectDirectory()
     {
         var content = "test content";
@@ -577,7 +577,7 @@ public class GivenTasksUseAbsolutePaths : IDisposable
 
         File.Exists(resolvedPath).Should().BeTrue();
 
-        _output.WriteLine($"TaskEnvironment resolved: {resolvedPath}");
+        TestContext.WriteLine($"TaskEnvironment resolved: {resolvedPath}");
     }
 
     #endregion

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;
-    public TestContext TestContext { get; set; }
+    public TestContext TestContext { get; set; } = null!;
 
     public GivenTasksUseAbsolutePaths()
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeHaveErrorCodes.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeHaveErrorCodes.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenThatWeHaveErrorCodes
     {
         private const int _firstCode = 1001;
@@ -52,7 +53,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             "ILLinkOptimizedAssemblies"
         };
 
-        [Fact]
+        [TestMethod]
         public void ThereAreNoGapsDuplicatesOrIncorrectlyFormattedCodes()
         {
             var codes = new HashSet<int>(_deletedCodes);
@@ -92,7 +93,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void ResxIsCommentedWithCorrectStrBegin()
         {
             var resxPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Strings.resx");

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGenerateSupportedTargetFrameworkAlias.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenThatWeWantToGenerateSupportedTargetFrameworkAlias
     {
         private static List<(string targetFrameworkMoniker, string displayName)> MockSupportedTargetFramework = new()
@@ -20,7 +21,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 ( ".NETFramework,Version=v4.8", ".NET Framework 4.8"),
             };
 
-        [Fact]
+        [TestMethod]
         public void It_generates_supported_net_standard_target_framework_alias_items()
         {
             var targetFrameworkMoniker = ".NETStandard,Version=v2.1";
@@ -31,7 +32,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Fact]
+        [TestMethod]
         public void It_generates_supported_net_framework_target_framework_alias_items()
         {
             var targetFrameworkMoniker = ".NETFramework,Version=v4.8.1";
@@ -42,10 +43,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Theory]
-        [InlineData(".NETCoreApp,Version=v3.1")]
-        [InlineData(".NETCoreApp,Version=v5.0")]
-        [InlineData(".NETCoreApp,Version=v6.0")]
+        [TestMethod]
+        [DataRow(".NETCoreApp,Version=v3.1")]
+        [DataRow(".NETCoreApp,Version=v5.0")]
+        [DataRow(".NETCoreApp,Version=v6.0")]
         public void It_generates_supported_net_core_target_framework_alias_items(string targetFrameworkMoniker)
         {
             RunTask(targetFrameworkMoniker, targetPlatformMoniker: string.Empty, UseWpf: false, UseWindowsForms: false, expectedResult: new List<(string, string)>
@@ -57,10 +58,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Theory]
-        [InlineData(".NETCoreApp,Version=v5.0", "Windows,Version=7.0")]
-        [InlineData(".netcoreapp,version=v5.0", "windows,version=7.0")]
-        [InlineData(".NETCoreApp,Version=v6.0", "Windows,Version=7.0")]
+        [TestMethod]
+        [DataRow(".NETCoreApp,Version=v5.0", "Windows,Version=7.0")]
+        [DataRow(".netcoreapp,version=v5.0", "windows,version=7.0")]
+        [DataRow(".NETCoreApp,Version=v6.0", "Windows,Version=7.0")]
         public void It_generates_supported_target_framework_alias_items_when_targeting_windows(string targetFrameworkMoniker, string targetPlatformMoniker)
         {
             RunTask(targetFrameworkMoniker, targetPlatformMoniker, UseWpf: false, UseWindowsForms: false, expectedResult: new List<(string, string)>
@@ -72,13 +73,13 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 });
         }
 
-        [Theory]
-        [InlineData(".NETCoreApp,Version=v5.0", "", true, false)]
-        [InlineData(".NETCoreApp,Version=v5.0", "", false, true)]
-        [InlineData(".NETCoreApp,Version=v5.0", "Windows,Version=7.0", true, false)]
-        [InlineData(".NETCoreApp,Version=v5.0", "Windows,Version=7.0", false, true)]
-        [InlineData(".NETCoreApp,Version=v3.1", "", true, false)]
-        [InlineData(".NETCoreApp,Version=v3.1", "", false, true)]
+        [TestMethod]
+        [DataRow(".NETCoreApp,Version=v5.0", "", true, false)]
+        [DataRow(".NETCoreApp,Version=v5.0", "", false, true)]
+        [DataRow(".NETCoreApp,Version=v5.0", "Windows,Version=7.0", true, false)]
+        [DataRow(".NETCoreApp,Version=v5.0", "Windows,Version=7.0", false, true)]
+        [DataRow(".NETCoreApp,Version=v3.1", "", true, false)]
+        [DataRow(".NETCoreApp,Version=v3.1", "", false, true)]
         public void It_generates_supported_target_framework_alias_items_when_using_wpf_or_winforms(string targetFrameworkMoniker, string targetPlatformMoniker, bool UseWpf, bool UseWindowsForms)
         {
             RunTask(targetFrameworkMoniker, targetPlatformMoniker, UseWpf, UseWindowsForms, expectedResult: new List<(string, string)>

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     {
 
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItShouldIgnoreAllDependenciesWithTypeNotEqualToPackageOrUnresolved()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -45,7 +45,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItShouldIdentifyDefaultImplicitPackages()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -81,7 +81,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItShouldOnlyReturnPackagesInTheSpecifiedTarget()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -349,7 +349,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [OSCondition(OperatingSystems.Windows)]
         [DataRow("latestNet")]
         [DataRow("net6.0")]
         public void ItShouldOnlyReturnTopLevelPackages(string alias)

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenThatWeWantToGetDependenciesViaDesignTimeBuild.cs
@@ -6,13 +6,12 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenThatWeWantToGetDependenciesViaDesignTimeBuild : SdkTest
     {
-        public GivenThatWeWantToGetDependenciesViaDesignTimeBuild(ITestOutputHelper log) : base(log)
-        {
-        }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ItShouldIgnoreAllDependenciesWithTypeNotEqualToPackageOrUnresolved()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -31,7 +30,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute();
 
-            Assert.Equal(2, task.PackageDependenciesDesignTime.Count());
+            Assert.HasCount(2, task.PackageDependenciesDesignTime);
 
             // Verify only
             // top.package1 is type 'package'
@@ -39,13 +38,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             //
             // top.package3 is type 'unknown'. Should not appear in the list
             var item1 = task.PackageDependenciesDesignTime[0];
-            Assert.Equal("top.package1/1.0.0", item1.ItemSpec);
+            Assert.AreEqual("top.package1/1.0.0", item1.ItemSpec);
 
             var item2 = task.PackageDependenciesDesignTime[1];
-            Assert.Equal("top.package2/1.0.0", item2.ItemSpec);
+            Assert.AreEqual("top.package2/1.0.0", item2.ItemSpec);
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ItShouldIdentifyDefaultImplicitPackages()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -64,23 +64,24 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             task.Execute();
 
-            Assert.Equal(3, task.PackageDependenciesDesignTime.Count());
+            Assert.HasCount(3, task.PackageDependenciesDesignTime);
 
             // Verify implicit packages
             var item1 = task.PackageDependenciesDesignTime[0];
-            Assert.Equal("top.package1/1.0.0", item1.ItemSpec);
-            Assert.Equal("False", item1.GetMetadata(MetadataKeys.IsImplicitlyDefined));
+            Assert.AreEqual("top.package1/1.0.0", item1.ItemSpec);
+            Assert.AreEqual("False", item1.GetMetadata(MetadataKeys.IsImplicitlyDefined));
 
             var item2 = task.PackageDependenciesDesignTime[1];
-            Assert.Equal("top.package2/1.0.0", item2.ItemSpec);
-            Assert.Equal("True", item2.GetMetadata(MetadataKeys.IsImplicitlyDefined));
+            Assert.AreEqual("top.package2/1.0.0", item2.ItemSpec);
+            Assert.AreEqual("True", item2.GetMetadata(MetadataKeys.IsImplicitlyDefined));
 
             var item3 = task.PackageDependenciesDesignTime[2];
-            Assert.Equal("top.package3/1.0.0", item3.ItemSpec);
-            Assert.Equal("True", item3.GetMetadata(MetadataKeys.IsImplicitlyDefined));
+            Assert.AreEqual("top.package3/1.0.0", item3.ItemSpec);
+            Assert.AreEqual("True", item3.GetMetadata(MetadataKeys.IsImplicitlyDefined));
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ItShouldOnlyReturnPackagesInTheSpecifiedTarget()
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -340,16 +341,17 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.TargetFramework = "net6.0";
             task.Execute();
 
-            Assert.Single(task.PackageDependenciesDesignTime);
+            Assert.ContainsSingle(task.PackageDependenciesDesignTime);
 
             // Verify top packages in target
             var item1 = task.PackageDependenciesDesignTime[0];
-            Assert.Equal("top.package1/1.0.0", item1.ItemSpec);
+            Assert.AreEqual("top.package1/1.0.0", item1.ItemSpec);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("latestNet")]
-        [InlineData("net6.0")]
+        [TestMethod]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [DataRow("latestNet")]
+        [DataRow("net6.0")]
         public void ItShouldOnlyReturnTopLevelPackages(string alias)
         {
             var testRoot = TestAssetsManager.CreateTestDirectory().Path;
@@ -366,19 +368,19 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.Execute();
 
             // Verify all top packages are listed here
-            Assert.Equal(3, task.PackageDependenciesDesignTime.Count());
+            Assert.HasCount(3, task.PackageDependenciesDesignTime);
 
             var item1 = task.PackageDependenciesDesignTime[0];
-            Assert.Equal("top.package1/1.0.0", item1.ItemSpec);
-            Assert.Equal("Error", item1.GetMetadata("DiagnosticLevel"));
+            Assert.AreEqual("top.package1/1.0.0", item1.ItemSpec);
+            Assert.AreEqual("Error", item1.GetMetadata("DiagnosticLevel"));
 
             var item2 = task.PackageDependenciesDesignTime[1];
-            Assert.Equal("top.package2/1.0.0", item2.ItemSpec);
-            Assert.Equal(string.Empty, item2.GetMetadata("DiagnosticLevel"));
+            Assert.AreEqual("top.package2/1.0.0", item2.ItemSpec);
+            Assert.AreEqual(string.Empty, item2.GetMetadata("DiagnosticLevel"));
 
             var item3 = task.PackageDependenciesDesignTime[2];
-            Assert.Equal("top.package3/1.0.0", item3.ItemSpec);
-            Assert.Equal("Warning", item3.GetMetadata("DiagnosticLevel"));
+            Assert.AreEqual("top.package3/1.0.0", item3.ItemSpec);
+            Assert.AreEqual("Warning", item3.GetMetadata("DiagnosticLevel"));
         }
 
         /// <summary>
@@ -694,4 +696,3 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
     }
 }
-

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenUnresolvedSDKProjectItemsAndImplicitPackages.cs
@@ -5,9 +5,10 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenUnresolvedSDKProjectItemsAndImplicitPackages
     {
-        [Fact]
+        [TestMethod]
         public void ItShouldCombineSdkReferencesWithImplicitPackageReferences()
         {
             // Arrange 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenWriteAppConfigWithSupportedRuntimeTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenWriteAppConfigWithSupportedRuntimeTask.cs
@@ -7,9 +7,10 @@ using NuGet.Frameworks;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class GivenWriteAppConfigWithSupportedRuntimeTask
     {
-        [Fact]
+        [TestMethod]
         public void It_creates_startup_and_supportedRuntime_node_when_there_is_not_any()
         {
             var doc =
@@ -25,7 +26,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().Contain(e => e.Name.LocalName == "supportedRuntime");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_creates_supportedRuntime_node_when_there_is_startup()
         {
             var doc =
@@ -41,7 +42,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Should().Contain(e => e.Name.LocalName == "supportedRuntime");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_does_not_change_supportedRuntime_node_when_there_is_supportedRuntime()
         {
             var doc =
@@ -66,10 +67,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
         // intersection of https://docs.microsoft.com/en-us/nuget/reference/target-frameworks
         // and https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/startup/supportedruntime-element#version
-        [Theory]
-        [InlineData(".NETFramework", "v1.1", "v1.1.4322")]
-        [InlineData(".NETFramework", "v2.0", "v2.0.50727")]
-        [InlineData(".NETFramework", "v3.5", "v2.0.50727")]
+        [TestMethod]
+        [DataRow(".NETFramework", "v1.1", "v1.1.4322")]
+        [DataRow(".NETFramework", "v2.0", "v2.0.50727")]
+        [DataRow(".NETFramework", "v3.5", "v2.0.50727")]
         public void It_generate_correct_version_and_sku_for_below40(
             string targetFrameworkIdentifier,
             string targetFrameworkVersion,
@@ -91,16 +92,16 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             supportedRuntime.Attribute("sku").Should().BeNull();
         }
 
-        [Theory]
-        [InlineData(".NETFramework", "v4.5", "v4.0", ".NETFramework,Version=v4.5")]
-        [InlineData(".NETFramework", "v4.5.1", "v4.0", ".NETFramework,Version=v4.5.1")]
-        [InlineData(".NETFramework", "v4.5.2", "v4.0", ".NETFramework,Version=v4.5.2")]
-        [InlineData(".NETFramework", "v4.6", "v4.0", ".NETFramework,Version=v4.6")]
-        [InlineData(".NETFramework", "v4.6.1", "v4.0", ".NETFramework,Version=v4.6.1")]
-        [InlineData(".NETFramework", "v4.6.2", "v4.0", ".NETFramework,Version=v4.6.2")]
-        [InlineData(".NETFramework", "v4.7", "v4.0", ".NETFramework,Version=v4.7")]
-        [InlineData(".NETFramework", "v4.7.1", "v4.0", ".NETFramework,Version=v4.7.1")]
-        [InlineData(".NETFramework", "v4.7.2", "v4.0", ".NETFramework,Version=v4.7.2")]
+        [TestMethod]
+        [DataRow(".NETFramework", "v4.5", "v4.0", ".NETFramework,Version=v4.5")]
+        [DataRow(".NETFramework", "v4.5.1", "v4.0", ".NETFramework,Version=v4.5.1")]
+        [DataRow(".NETFramework", "v4.5.2", "v4.0", ".NETFramework,Version=v4.5.2")]
+        [DataRow(".NETFramework", "v4.6", "v4.0", ".NETFramework,Version=v4.6")]
+        [DataRow(".NETFramework", "v4.6.1", "v4.0", ".NETFramework,Version=v4.6.1")]
+        [DataRow(".NETFramework", "v4.6.2", "v4.0", ".NETFramework,Version=v4.6.2")]
+        [DataRow(".NETFramework", "v4.7", "v4.0", ".NETFramework,Version=v4.7")]
+        [DataRow(".NETFramework", "v4.7.1", "v4.0", ".NETFramework,Version=v4.7.1")]
+        [DataRow(".NETFramework", "v4.7.2", "v4.0", ".NETFramework,Version=v4.7.2")]
         public void It_generate_correct_version_and_sku_for_above40(
             string targetFrameworkIdentifier,
             string targetFrameworkVersion,
@@ -123,8 +124,8 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             supportedRuntime.Should().HaveAttribute("sku", expectedSku);
         }
 
-        [Theory]
-        [InlineData(".NETFramework", "v4.0", "Client", "v4.0", ".NETFramework,Version=v4.0,Profile=Client")]
+        [TestMethod]
+        [DataRow(".NETFramework", "v4.0", "Client", "v4.0", ".NETFramework,Version=v4.0,Profile=Client")]
         public void It_generate_correct_version_and_sku_and_profile(
             string targetFrameworkIdentifier,
             string targetFrameworkVersion,
@@ -151,9 +152,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             supportedRuntime.Should().HaveAttribute("sku", expectedSku);
         }
 
-        [Theory]
-        [InlineData("net999")]
-        [InlineData("netstandard20")]
+        [TestMethod]
+        [DataRow("net999")]
+        [DataRow("netstandard20")]
         public void It_does_not_generate_version_and_sku_for_non_supported(string targetframework)
         {
             var targetFrameworkParsed = NuGetFramework.Parse(targetframework);

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -1,13 +1,10 @@
-﻿<Project>
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
@@ -29,11 +26,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tasks\Microsoft.NET.Build.Tasks\Microsoft.NET.Build.Tasks.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="**\*.cs" />
+    <Using Include="Microsoft.NET.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +39,5 @@
     <None Include="LockFiles\*.project.lock.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\src\Tasks\Common\Resources\Strings.resx" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
+    [TestClass]
     public class ProcessFrameworkReferencesTests
     {
         // Shared runtime graph templates
@@ -240,9 +241,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public string? NETCoreSdkPortableRuntimeIdentifier { get; set; }
         }
 
-        [Theory]
-        [InlineData(false)] // Without target platform
-        [InlineData(true)]  // With target platform
+        [TestMethod]
+        [DataRow(false)] // Without target platform
+        [DataRow(true)]  // With target platform
         public void It_resolves_AspNetCore_FrameworkReferences(bool withTargetPlatform)
         {
             var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", 
@@ -271,7 +272,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimeFrameworks[0].GetMetadata(MetadataKeys.Version).Should().Be("1.9.5");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_does_not_resolve_FrameworkReferences_if_targetframework_doesnt_match()
         {
             var aspNetCoreRef = CreateKnownFrameworkReference("Microsoft.AspNetCore.App", "netcoreapp3.0", "1.9.5");
@@ -292,7 +293,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimeFrameworks.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void Given_KnownFrameworkReferences_with_RuntimePackAlwaysCopyLocal_It_resolves_FrameworkReferences()
         {
             var windowsSDKRef = CreateKnownFrameworkReference("Microsoft.Windows.SDK.NET.Ref", 
@@ -340,7 +341,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             runtimePack.GetMetadata(MetadataKeys.RuntimePackAlwaysCopyLocal).Should().Be("true");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_resolves_self_contained_FrameworkReferences_to_download()
         {
             var config = new TaskConfiguration
@@ -376,7 +377,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void Given_reference_to_NETCoreApp_It_should_not_resolve_runtime_pack()
         {
             var config = new TaskConfiguration
@@ -410,12 +411,12 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref", "should not resolve runtime pack for Microsoft.NETCore.App");
         }
 
-        [Theory]
-        [InlineData(null, new[] { "win-x64", "win-x86", "linux-x64" }, "Multiple RuntimeIdentifiers without RuntimeIdentifier")]
-        [InlineData("", new[] { "win-x64", "linux-x64" }, "Empty RuntimeIdentifier with RuntimeIdentifiers")]
-        [InlineData("any", new[] { "win-x64" }, "Any RID with RuntimeIdentifiers")]
-        [InlineData(null, new string[0], "No RuntimeIdentifier with empty RuntimeIdentifiers")]
-        [InlineData(null, null, "No RuntimeIdentifier with null RuntimeIdentifiers")]
+        [TestMethod]
+        [DataRow(null, new[] { "win-x64", "win-x86", "linux-x64" }, "Multiple RuntimeIdentifiers without RuntimeIdentifier")]
+        [DataRow("", new[] { "win-x64", "linux-x64" }, "Empty RuntimeIdentifier with RuntimeIdentifiers")]
+        [DataRow("any", new[] { "win-x64" }, "Any RID with RuntimeIdentifiers")]
+        [DataRow(null, new string[0], "No RuntimeIdentifier with empty RuntimeIdentifiers")]
+        [DataRow(null, null, "No RuntimeIdentifier with null RuntimeIdentifiers")]
         public void It_processes_various_RuntimeIdentifier_scenarios(string? runtimeIdentifier, string[]? runtimeIdentifiers, string scenario)
         {
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net5.0", "5.0.0",
@@ -449,7 +450,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void It_processes_RuntimeIdentifiers_with_AlwaysCopyLocal_and_no_RuntimeIdentifier()
         {
             var config = new TaskConfiguration
@@ -478,7 +479,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.RuntimePacks[0].ItemSpec.Should().Be("Microsoft.Windows.SDK.NET.Ref");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_real_world_ridless_scenario_with_aot_and_trimming()
         {
             // This test reproduces the exact scenario from the reported issue
@@ -562,7 +563,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec.Contains("Microsoft.DotNet.ILCompiler"), "Should include AOT compiler tooling");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_AOT_properties_without_failure()
         {
             var config = new TaskConfiguration
@@ -591,7 +592,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.linux-x64");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_trimming_scenarios()
         {
             var config = new TaskConfiguration
@@ -618,7 +619,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.win-x64");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_combined_publish_properties()
         {
             var config = new TaskConfiguration
@@ -648,7 +649,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackagesToDownload.Should().Contain(p => p.ItemSpec == "Microsoft.NETCore.App.Runtime.osx-arm64");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_mobile_iOS_framework_references()
         {
             // Create compatible framework references with correct target framework
@@ -681,11 +682,11 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.TargetingPacks.Should().Contain(p => p.GetMetadata(MetadataKeys.NuGetPackageId) == "Microsoft.iOS.Ref");
         }
 
-        [Theory]
-        [InlineData(true, true, true, "All analyzers enabled")]
-        [InlineData(true, true, false, "AOT and Trim analyzers only")]
-        [InlineData(false, false, true, "SingleFile analyzer only")]
-        [InlineData(true, false, false, "AOT analyzer only")]
+        [TestMethod]
+        [DataRow(true, true, true, "All analyzers enabled")]
+        [DataRow(true, true, false, "AOT and Trim analyzers only")]
+        [DataRow(false, false, true, "SingleFile analyzer only")]
+        [DataRow(true, false, false, "AOT analyzer only")]
         public void It_handles_analyzer_combinations(bool aotAnalyzer, bool trimAnalyzer, bool singleFileAnalyzer, string scenario)
         {
             var config = new TaskConfiguration
@@ -712,10 +713,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.PackagesToDownload.Should().NotBeNull();
         }
 
-        [Theory]
-        [InlineData("Android", "34.0", "android-arm64")]
-        [InlineData("macOS", "14.0", "osx-arm64")]
-        [InlineData("Windows", "10.0.19041.0", "win-x64")]
+        [TestMethod]
+        [DataRow("Android", "34.0", "android-arm64")]
+        [DataRow("macOS", "14.0", "osx-arm64")]
+        [DataRow("Windows", "10.0.19041.0", "win-x64")]
         public void It_handles_different_target_platforms(string platformId, string platformVersion, string runtimeId)
         {
             var platformFrameworkRef = CreateKnownFrameworkReference($"Microsoft.{platformId}", "net8.0", "8.0.0",
@@ -756,7 +757,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.TargetingPacks.Should().NotBeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void It_resolves_runtime_packs_for_SelfContained_deployment()
         {
             // This test validates the "good" behavior from good-processframeworkreferences-selfcontained.txt
@@ -826,7 +827,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             task.ImplicitPackageReferences.Should().Contain(p => p.ItemSpec == "Microsoft.NET.ILLink.Tasks");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_resolves_runtime_packs_for_PublishTrimmed_without_SelfContained()
         {
             // This test validates that PublishTrimmed should trigger runtime pack resolution
@@ -897,14 +898,14 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 "ILLink pack should be included for PublishTrimmed");
         }
 
-        [Theory]
-        [InlineData(true, false, false, false, "SelfContained only")]
-        [InlineData(false, true, false, false, "PublishTrimmed only")]
-        [InlineData(false, false, true, false, "PublishReadyToRun only")]
-        [InlineData(false, false, false, true, "PublishAot only")]
-        [InlineData(true, true, false, false, "SelfContained + PublishTrimmed")]
-        [InlineData(true, false, true, false, "SelfContained + PublishReadyToRun")]
-        [InlineData(false, true, true, false, "PublishTrimmed + PublishReadyToRun")]
+        [TestMethod]
+        [DataRow(true, false, false, false, "SelfContained only")]
+        [DataRow(false, true, false, false, "PublishTrimmed only")]
+        [DataRow(false, false, true, false, "PublishReadyToRun only")]
+        [DataRow(false, false, false, true, "PublishAot only")]
+        [DataRow(true, true, false, false, "SelfContained + PublishTrimmed")]
+        [DataRow(true, false, true, false, "SelfContained + PublishReadyToRun")]
+        [DataRow(false, true, true, false, "PublishTrimmed + PublishReadyToRun")]
         public void It_resolves_runtime_packs_for_various_publish_scenarios(
             bool selfContained, bool publishTrimmed, bool publishReadyToRun, bool publishAot, string scenario)
         {
@@ -955,7 +956,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 $"Should have runtime pack in output for scenario: {scenario}");
         }
 
-        [Fact]
+        [TestMethod]
         public void It_handles_complex_cross_compilation_RuntimeIdentifiers()
         {
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net8.0", "8.0.0",
@@ -988,10 +989,10 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             }
         }
 
-        [Theory]
-        [InlineData(null, "linux-x64")]
-        [InlineData("linux-x64", "linux-x64")]
-        [InlineData(NonPortableRid, NonPortableRid)]
+        [TestMethod]
+        [DataRow(null, "linux-x64")]
+        [DataRow("linux-x64", "linux-x64")]
+        [DataRow(NonPortableRid, NonPortableRid)]
         public void It_selects_correct_ILCompiler_based_on_RuntimeIdentifier(string? runtimeIdentifier, string expectedILCompilerRid)
         {
             var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App", "net10.0", "10.0.1",

--- a/test/Microsoft.NET.TestFramework.MSTest/AspNetSdkTest.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/AspNetSdkTest.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.NET.TestFramework;
+
+[TestCategory("AspNetCore")]
+public abstract class AspNetSdkTest : SdkTest
+{
+    public readonly string? DefaultTfm;
+    public const string WasmBootConfigFileName = "dotnet.js";
+
+#if !GENERATE_MSBUILD_LOGS
+    public static bool GenerateMSbuildLogs = true;
+#else
+    public static bool GenerateMSbuildLogs = bool.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_GENERATE_BINLOG"), out var result) && result || Debugger.IsAttached;
+#endif
+
+    private bool _generateMSbuildLogs = GenerateMSbuildLogs;
+
+    protected AspNetSdkTest()
+    {
+        var assembly = Assembly.GetCallingAssembly();
+        var testAssemblyMetadata = assembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+        DefaultTfm = testAssemblyMetadata.SingleOrDefault(a => a.Key == "AspNetTestTfm")?.Value;
+    }
+
+    public TestAsset CreateAspNetSdkTestAsset(
+        string testAsset,
+        [CallerMemberName] string callerName = "",
+        string subdirectory = "",
+        string? overrideTfm = null,
+        string? identifier = null)
+    {
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset, callingMethod: callerName, testAssetSubdirectory: subdirectory, identifier: identifier)
+            .WithSource()
+            .WithProjectChanges(project =>
+            {
+                var targetFramework = project.Descendants()
+                   .SingleOrDefault(e => e.Name.LocalName == "TargetFramework");
+                if (targetFramework?.Value == "$(AspNetTestTfm)")
+                {
+                    targetFramework.Value = overrideTfm ?? DefaultTfm ?? string.Empty;
+                    targetFramework.AddAfterSelf(new XElement("StaticWebAssetsFingerprintContent", "false"));
+                    targetFramework.AddAfterSelf(new XElement("AttachWeakETagToCompressedAssetsDuringDevelopment", "false"));
+                }
+                var targetFrameworks = project.Descendants()
+                    .SingleOrDefault(e => e.Name.LocalName == "TargetFrameworks");
+                if (targetFrameworks != null)
+                {
+                    targetFrameworks.Value = targetFrameworks.Value.Replace("$(AspNetTestTfm)", overrideTfm ?? DefaultTfm);
+                    targetFrameworks.AddAfterSelf(new XElement("StaticWebAssetsFingerprintContent", "false"));
+                    targetFrameworks.AddAfterSelf(new XElement("AttachWeakETagToCompressedAssetsDuringDevelopment", "false"));
+                }
+            });
+
+        foreach (string assetPath in Directory.EnumerateFiles(Path.Combine(TestAssetsManager.TestAssetsRoot, "WasmOverride")))
+            File.Copy(assetPath, Path.Combine(projectDirectory.Path, Path.GetFileName(assetPath)));
+
+        return projectDirectory;
+    }
+
+    public TestAsset CreateMultitargetAspNetSdkTestAsset(
+        string testAsset,
+        [CallerMemberName] string callerName = "",
+        string subdirectory = "",
+        string? overrideTfm = null,
+        string? identifier = null)
+    {
+        var projectDirectory = TestAssetsManager
+            .CopyTestAsset(testAsset, callingMethod: callerName, testAssetSubdirectory: subdirectory, identifier: identifier)
+            .WithSource()
+            .WithProjectChanges(project =>
+            {
+                var targetFramework = project.Descendants()
+                   .Single(e => e.Name.LocalName == "TargetFrameworks");
+                targetFramework.Value = targetFramework.Value.Replace("$(AspNetTestTfm)", overrideTfm ?? DefaultTfm);
+            });
+        return projectDirectory;
+    }
+
+    protected virtual RestoreCommand CreateRestoreCommand(TestAsset asset, string? relativePathToProject = null)
+    {
+        var restore = new RestoreCommand(asset, relativePathToProject);
+        restore.WithWorkingDirectory(asset.TestRoot);
+        ApplyDefaults(restore);
+        return restore;
+    }
+
+    protected virtual BuildCommand CreateBuildCommand(TestAsset asset, string? relativePathToProject = null)
+    {
+        var build = new BuildCommand(asset, relativePathToProject);
+        build.WithWorkingDirectory(asset.TestRoot);
+        ApplyDefaults(build);
+
+        return build;
+    }
+
+    protected virtual RebuildCommand CreateRebuildCommand(TestAsset asset, string? relativePathToProject = null)
+    {
+        var rebuild = new RebuildCommand(Log, asset.Path, relativePathToProject);
+        rebuild.WithWorkingDirectory(asset.TestRoot);
+        ApplyDefaults(rebuild);
+
+        return rebuild;
+    }
+
+    protected virtual PackCommand CreatePackCommand(TestAsset asset, string? relativePathToProject = null)
+    {
+        var pack = new PackCommand(asset, relativePathToProject);
+        pack.WithWorkingDirectory(asset.TestRoot);
+        ApplyDefaults(pack);
+
+        return pack;
+    }
+
+    protected virtual PublishCommand CreatePublishCommand(TestAsset asset, string? relativePathToProject = null)
+    {
+        var publish = new PublishCommand(asset, relativePathToProject);
+        publish.WithWorkingDirectory(asset.TestRoot);
+        ApplyDefaults(publish);
+
+        return publish;
+    }
+
+    protected virtual CommandResult ExecuteCommand(TestCommand command, params string[] arguments)
+    {
+        ValidateIndividualArgumentsContainNoSpaces(arguments);
+
+        if (_generateMSbuildLogs)
+        {
+            var i = 0;
+            for (i = 0; command.WorkingDirectory is not null && File.Exists(Path.Combine(command.WorkingDirectory, $"msbuild{i}.binlog")) && i < 20; i++) { }
+            var log = $"msbuild{i}.binlog";
+
+            return command.Execute([$"/bl:{log}", .. arguments]);
+        }
+        else
+        {
+            return command.Execute(arguments);
+        }
+    }
+
+    protected virtual CommandResult ExecuteCommandWithoutRestore(MSBuildCommand command, params string[] arguments)
+    {
+        ValidateIndividualArgumentsContainNoSpaces(arguments);
+
+        if (_generateMSbuildLogs)
+        {
+            var i = 0;
+            for (i = 0; command.WorkingDirectory is not null && File.Exists(Path.Combine(command.WorkingDirectory, $"msbuild{i}.binlog")) && i < 20; i++) { }
+            var log = $"msbuild{i}.binlog";
+            return command.ExecuteWithoutRestore([$"/bl:{log}", .. arguments]);
+        }
+        else
+        {
+            return command.ExecuteWithoutRestore(arguments);
+        }
+    }
+
+    private void ValidateIndividualArgumentsContainNoSpaces(string[] arguments)
+    {
+        foreach (var argument in arguments)
+        {
+            if (argument.Contains(' '))
+            {
+                throw new ArgumentException($"Individual arguments should not contain spaces to avoid quoting issues when passing to msbuild, pass them as separate array elements instead. Argument: {argument}");
+            }
+        }
+    }
+
+    private void ApplyDefaults(MSBuildCommand command)
+    {
+        if (GetNuGetCachePath() is { } cache)
+        {
+            command.WithEnvironmentVariable("NUGET_PACKAGES", cache);
+            command.WithEnvironmentVariable("AspNetNugetIsolationPath", cache);
+            command.WithEnvironmentVariable("RestorePackagesPath", cache);
+        }
+    }
+
+    protected virtual string? GetNuGetCachePath() => null;
+}

--- a/test/Microsoft.NET.TestFramework.MSTest/ConditionalTestAttributes.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/ConditionalTestAttributes.cs
@@ -1,0 +1,278 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.NET.TestFramework;
+
+[Flags]
+public enum TestPlatforms
+{
+    Windows = 1,
+    Linux = 2,
+    OSX = 4,
+    FreeBSD = 8,
+    Any = Windows | Linux | OSX | FreeBSD,
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class CoreMSBuildOnlyAttribute : ConditionBaseAttribute
+{
+    public CoreMSBuildOnlyAttribute()
+        : base(ConditionMode.Include)
+    {
+        IgnoreMessage = "This test requires Core MSBuild to run";
+    }
+
+    public override string GroupName => nameof(CoreMSBuildOnlyAttribute);
+
+    public override bool IsConditionMet => !SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild;
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class FullMSBuildOnlyAttribute : ConditionBaseAttribute
+{
+    public FullMSBuildOnlyAttribute()
+        : base(ConditionMode.Include)
+    {
+        IgnoreMessage = "This test requires Full MSBuild to run";
+    }
+
+    public override string GroupName => nameof(FullMSBuildOnlyAttribute);
+
+    public override bool IsConditionMet => SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild;
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class CoreMSBuildAndWindowsOnlyAttribute : ConditionBaseAttribute
+{
+    public CoreMSBuildAndWindowsOnlyAttribute()
+        : base(ConditionMode.Include)
+    {
+        IgnoreMessage = "This test requires Core MSBuild and Windows to run";
+    }
+
+    public override string GroupName => nameof(CoreMSBuildAndWindowsOnlyAttribute);
+
+    public override bool IsConditionMet =>
+        !SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild
+            && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class MacOsOnlyAttribute : ConditionBaseAttribute
+{
+    public MacOsOnlyAttribute()
+        : base(ConditionMode.Include)
+    {
+        IgnoreMessage = "This test requires macos to run";
+    }
+
+    public override string GroupName => nameof(MacOsOnlyAttribute);
+
+    public override bool IsConditionMet => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class PlatformSpecificAttribute : ConditionBaseAttribute
+{
+    private const Architecture NoArchitectureFilter = (Architecture)(-1);
+
+    private readonly TestPlatforms _platforms;
+    private readonly TestPlatforms _skipPlatforms;
+    private readonly Architecture _architecture;
+    private readonly Architecture _skipArchitecture;
+    private readonly string? _skipReason;
+
+    public PlatformSpecificAttribute(
+        TestPlatforms platforms = TestPlatforms.Any,
+        TestPlatforms skipPlatforms = 0,
+        Architecture architecture = NoArchitectureFilter,
+        Architecture skipArchitecture = NoArchitectureFilter,
+        string? skipReason = null)
+        : base(ConditionMode.Include)
+    {
+        _platforms = platforms;
+        _skipPlatforms = skipPlatforms;
+        _architecture = architecture;
+        _skipArchitecture = skipArchitecture;
+        _skipReason = skipReason;
+        IgnoreMessage = "This test is not supported on this platform.";
+    }
+
+    public override string GroupName => nameof(PlatformSpecificAttribute);
+
+    public override bool IsConditionMet
+    {
+        get
+        {
+            if (EvaluateSkip(_platforms, _skipPlatforms, _architecture, _skipArchitecture, _skipReason) is { } skip)
+            {
+                IgnoreMessage = skip;
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    private static string? EvaluateSkip(
+        TestPlatforms platforms,
+        TestPlatforms skipPlatforms,
+        Architecture architecture,
+        Architecture skipArchitecture,
+        string? skipReason)
+    {
+        if (!PlatformsMatchCurrentOS(platforms))
+        {
+            return "This test is not supported on this platform.";
+        }
+
+        if (architecture != NoArchitectureFilter && RuntimeInformation.ProcessArchitecture != architecture)
+        {
+            return $"This test is not supported on {RuntimeInformation.ProcessArchitecture} architecture.";
+        }
+
+        bool skipPlatformMatches = skipPlatforms != 0 && PlatformsMatchCurrentOS(skipPlatforms);
+        bool skipArchMatches = skipArchitecture != NoArchitectureFilter && RuntimeInformation.ProcessArchitecture == skipArchitecture;
+
+        if (skipPlatforms != 0 && skipArchitecture != NoArchitectureFilter)
+        {
+            if (skipPlatformMatches && skipArchMatches)
+            {
+                return skipReason ?? "Test skipped on this platform and architecture.";
+            }
+        }
+        else if (skipPlatformMatches)
+        {
+            return skipReason ?? "Test skipped on this platform.";
+        }
+        else if (skipArchMatches)
+        {
+            return skipReason ?? "Test skipped on this architecture.";
+        }
+
+        return null;
+    }
+
+    private static bool PlatformsMatchCurrentOS(TestPlatforms platforms) =>
+        (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            || (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            || (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            || (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
+}
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RequiresMSBuildVersionAttribute : ConditionBaseAttribute
+{
+    private readonly string _version;
+
+    public RequiresMSBuildVersionAttribute(string version)
+        : base(ConditionMode.Include)
+    {
+        _version = version;
+        IgnoreMessage = $"This test requires MSBuild version {version} to run";
+    }
+
+    public string? Reason { get; set; }
+
+    public override string GroupName => nameof(RequiresMSBuildVersionAttribute);
+
+    public override bool IsConditionMet => IsRequiredMSBuildVersionAvailable(_version);
+
+    private bool IsRequiredMSBuildVersionAvailable(string version)
+    {
+        if (!Version.TryParse(SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version? msbuildVersion))
+        {
+            IgnoreMessage = $"Failed to determine the version of MSBuild ({SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+            return false;
+        }
+        if (!Version.TryParse(version, out Version? requiredVersion))
+        {
+            IgnoreMessage = $"Failed to determine the version required by this test ({version}).";
+            return false;
+        }
+        if (requiredVersion > msbuildVersion)
+        {
+            IgnoreMessage = $"This test requires MSBuild version {version} to run (using {SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+            return false;
+        }
+
+        return true;
+    }
+}
+
+#if NETCOREAPP
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RequiresSpecificFrameworkAttribute : ConditionBaseAttribute
+{
+    private readonly string _framework;
+
+    public RequiresSpecificFrameworkAttribute(string framework)
+        : base(ConditionMode.Include)
+    {
+        _framework = framework;
+        IgnoreMessage = $"This test requires a shared framework that isn't present: {framework}";
+    }
+
+    public override string GroupName => nameof(RequiresSpecificFrameworkAttribute);
+
+    public override bool IsConditionMet => EnvironmentInfo.SupportsTargetFramework(_framework);
+}
+
+#endif
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class WindowsOnlyRequiresMSBuildVersionAttribute : ConditionBaseAttribute
+{
+    private readonly string _version;
+
+    public WindowsOnlyRequiresMSBuildVersionAttribute(string version)
+        : base(ConditionMode.Include)
+    {
+        _version = version;
+        IgnoreMessage = "This test requires Windows to run";
+    }
+
+    public string? Reason { get; set; }
+
+    public override string GroupName => nameof(WindowsOnlyRequiresMSBuildVersionAttribute);
+
+    public override bool IsConditionMet
+    {
+        get
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IgnoreMessage = "This test requires Windows to run";
+                return false;
+            }
+
+            return IsRequiredMSBuildVersionAvailable(_version);
+        }
+    }
+
+    private bool IsRequiredMSBuildVersionAvailable(string version)
+    {
+        if (!Version.TryParse(SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version? msbuildVersion))
+        {
+            IgnoreMessage = $"Failed to determine the version of MSBuild ({SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+            return false;
+        }
+        if (!Version.TryParse(version, out Version? requiredVersion))
+        {
+            IgnoreMessage = $"Failed to determine the version required by this test ({version}).";
+            return false;
+        }
+        if (requiredVersion > msbuildVersion)
+        {
+            IgnoreMessage = $"This test requires MSBuild version {version} to run (using {SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/test/Microsoft.NET.TestFramework.MSTest/ConditionalTestAttributes.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/ConditionalTestAttributes.cs
@@ -7,15 +7,17 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.NET.TestFramework;
 
-[Flags]
-public enum TestPlatforms
-{
-    Windows = 1,
-    Linux = 2,
-    OSX = 4,
-    FreeBSD = 8,
-    Any = Windows | Linux | OSX | FreeBSD,
-}
+// NOTE: Operating-system gating is intentionally NOT reimplemented here. MSTest ships
+// [OSCondition(OperatingSystems.Windows | OperatingSystems.OSX | ...)] (with
+// ConditionMode.Include/Exclude), which already covers it. Because MSTest combines
+// condition attributes that have different GroupNames with AND, an OS requirement can be
+// composed with the conditions below, for example:
+//   [TestMethod, OSCondition(OperatingSystems.Windows), CoreMSBuildOnly]            // Core MSBuild on Windows
+//   [TestMethod, OSCondition(OperatingSystems.Windows), RequiresMSBuildVersion("17.0")]
+//   [TestMethod, OSCondition(OperatingSystems.OSX)]                                  // macOS only
+//   [TestMethod, OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]          // everything except macOS
+// Only conditions that MSTest does not already provide (MSBuild flavor/version, shared
+// framework availability, and process architecture) are defined here.
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 public sealed class CoreMSBuildOnlyAttribute : ConditionBaseAttribute
@@ -45,123 +47,33 @@ public sealed class FullMSBuildOnlyAttribute : ConditionBaseAttribute
     public override bool IsConditionMet => SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild;
 }
 
+/// <summary>
+/// Restricts a test to the specified process architecture(s). Compose with
+/// <c>[OSCondition(...)]</c> for OS gating. Use <see cref="ConditionMode.Exclude"/> to skip
+/// the listed architectures instead of requiring them.
+/// </summary>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class CoreMSBuildAndWindowsOnlyAttribute : ConditionBaseAttribute
+public sealed class ArchitectureConditionAttribute : ConditionBaseAttribute
 {
-    public CoreMSBuildAndWindowsOnlyAttribute()
-        : base(ConditionMode.Include)
+    private readonly Architecture[] _architectures;
+
+    public ArchitectureConditionAttribute(params Architecture[] architectures)
+        : this(ConditionMode.Include, architectures)
     {
-        IgnoreMessage = "This test requires Core MSBuild and Windows to run";
     }
 
-    public override string GroupName => nameof(CoreMSBuildAndWindowsOnlyAttribute);
-
-    public override bool IsConditionMet =>
-        !SdkTestContext.Current.ToolsetUnderTest.ShouldUseFullFrameworkMSBuild
-            && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-}
-
-[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class MacOsOnlyAttribute : ConditionBaseAttribute
-{
-    public MacOsOnlyAttribute()
-        : base(ConditionMode.Include)
+    public ArchitectureConditionAttribute(ConditionMode mode, params Architecture[] architectures)
+        : base(mode)
     {
-        IgnoreMessage = "This test requires macos to run";
+        _architectures = architectures;
+        IgnoreMessage = mode == ConditionMode.Include
+            ? $"This test is only supported on architecture(s): {string.Join(", ", architectures)}"
+            : $"This test is not supported on architecture(s): {string.Join(", ", architectures)}";
     }
 
-    public override string GroupName => nameof(MacOsOnlyAttribute);
+    public override string GroupName => nameof(ArchitectureConditionAttribute);
 
-    public override bool IsConditionMet => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-}
-
-[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class PlatformSpecificAttribute : ConditionBaseAttribute
-{
-    private const Architecture NoArchitectureFilter = (Architecture)(-1);
-
-    private readonly TestPlatforms _platforms;
-    private readonly TestPlatforms _skipPlatforms;
-    private readonly Architecture _architecture;
-    private readonly Architecture _skipArchitecture;
-    private readonly string? _skipReason;
-
-    public PlatformSpecificAttribute(
-        TestPlatforms platforms = TestPlatforms.Any,
-        TestPlatforms skipPlatforms = 0,
-        Architecture architecture = NoArchitectureFilter,
-        Architecture skipArchitecture = NoArchitectureFilter,
-        string? skipReason = null)
-        : base(ConditionMode.Include)
-    {
-        _platforms = platforms;
-        _skipPlatforms = skipPlatforms;
-        _architecture = architecture;
-        _skipArchitecture = skipArchitecture;
-        _skipReason = skipReason;
-        IgnoreMessage = "This test is not supported on this platform.";
-    }
-
-    public override string GroupName => nameof(PlatformSpecificAttribute);
-
-    public override bool IsConditionMet
-    {
-        get
-        {
-            if (EvaluateSkip(_platforms, _skipPlatforms, _architecture, _skipArchitecture, _skipReason) is { } skip)
-            {
-                IgnoreMessage = skip;
-                return false;
-            }
-
-            return true;
-        }
-    }
-
-    private static string? EvaluateSkip(
-        TestPlatforms platforms,
-        TestPlatforms skipPlatforms,
-        Architecture architecture,
-        Architecture skipArchitecture,
-        string? skipReason)
-    {
-        if (!PlatformsMatchCurrentOS(platforms))
-        {
-            return "This test is not supported on this platform.";
-        }
-
-        if (architecture != NoArchitectureFilter && RuntimeInformation.ProcessArchitecture != architecture)
-        {
-            return $"This test is not supported on {RuntimeInformation.ProcessArchitecture} architecture.";
-        }
-
-        bool skipPlatformMatches = skipPlatforms != 0 && PlatformsMatchCurrentOS(skipPlatforms);
-        bool skipArchMatches = skipArchitecture != NoArchitectureFilter && RuntimeInformation.ProcessArchitecture == skipArchitecture;
-
-        if (skipPlatforms != 0 && skipArchitecture != NoArchitectureFilter)
-        {
-            if (skipPlatformMatches && skipArchMatches)
-            {
-                return skipReason ?? "Test skipped on this platform and architecture.";
-            }
-        }
-        else if (skipPlatformMatches)
-        {
-            return skipReason ?? "Test skipped on this platform.";
-        }
-        else if (skipArchMatches)
-        {
-            return skipReason ?? "Test skipped on this architecture.";
-        }
-
-        return null;
-    }
-
-    private static bool PlatformsMatchCurrentOS(TestPlatforms platforms) =>
-        (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            || (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            || (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            || (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
+    public override bool IsConditionMet => Array.IndexOf(_architectures, RuntimeInformation.ProcessArchitecture) >= 0;
 }
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
@@ -224,55 +136,3 @@ public sealed class RequiresSpecificFrameworkAttribute : ConditionBaseAttribute
 }
 
 #endif
-
-[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class WindowsOnlyRequiresMSBuildVersionAttribute : ConditionBaseAttribute
-{
-    private readonly string _version;
-
-    public WindowsOnlyRequiresMSBuildVersionAttribute(string version)
-        : base(ConditionMode.Include)
-    {
-        _version = version;
-        IgnoreMessage = "This test requires Windows to run";
-    }
-
-    public string? Reason { get; set; }
-
-    public override string GroupName => nameof(WindowsOnlyRequiresMSBuildVersionAttribute);
-
-    public override bool IsConditionMet
-    {
-        get
-        {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                IgnoreMessage = "This test requires Windows to run";
-                return false;
-            }
-
-            return IsRequiredMSBuildVersionAvailable(_version);
-        }
-    }
-
-    private bool IsRequiredMSBuildVersionAvailable(string version)
-    {
-        if (!Version.TryParse(SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion, out Version? msbuildVersion))
-        {
-            IgnoreMessage = $"Failed to determine the version of MSBuild ({SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
-            return false;
-        }
-        if (!Version.TryParse(version, out Version? requiredVersion))
-        {
-            IgnoreMessage = $"Failed to determine the version required by this test ({version}).";
-            return false;
-        }
-        if (requiredVersion > msbuildVersion)
-        {
-            IgnoreMessage = $"This test requires MSBuild version {version} to run (using {SdkTestContext.Current.ToolsetUnderTest.MSBuildVersion}).";
-            return false;
-        }
-
-        return true;
-    }
-}

--- a/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/AspireServerServiceTests.cs
@@ -2,18 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
+#pragma warning disable MSTESTEXP // TestContext.Current is experimental
 
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Net.WebSockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 
 namespace Aspire.Tools.Service.UnitTests;
 
-public class AspireServerServiceTests(ITestOutputHelper output)
+[TestClass]
+public class AspireServerServiceTests
 {
+    public TestContext TestContext { get; set; }
+
     private const string Project1Path = @"c:\test\Projects\project1.csproj";
     private const int ProcessId = 34213;
     private const string DcpId = "myid";
@@ -31,7 +36,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         env = new List<EnvVar> { new EnvVar { Name = "var1", Value = "value1" } }
     };
 
-    [Fact]
+    [TestMethod]
     public async Task SessionStarted_Test()
     {
         var mocks = new Mocks();
@@ -53,15 +58,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         var result = await notificationTask.Task;
 
-        Assert.Equal(ProcessId, result.PID);
-        Assert.Equal("1", result.SessionId);
+        Assert.AreEqual(ProcessId, result.PID);
+        Assert.AreEqual("1", result.SessionId);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SessionEndedAsync_Test()
     {
         var mocks = new Mocks();
@@ -84,16 +89,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         await server.NotifySessionEndedAsync(DcpId, "1", ProcessId, 130, CancellationToken.None);
 
         var result = await sessionEndNotificationTask.Task;
-        Assert.Equal(ProcessId, result.Pid);
-        Assert.Equal("1", result.SessionId);
-        Assert.Equal(130, result.ExitCode);
+        Assert.AreEqual(ProcessId, result.Pid);
+        Assert.AreEqual("1", result.SessionId);
+        Assert.AreEqual(130, result.ExitCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_Success()
     {
         var mocks = new Mocks();
@@ -107,17 +112,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
 
         HttpResponseMessage response;
-        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+        Assert.AreEqual($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_WithNullArgs_PassesThroughNullArgs()
     {
         var mocks = new Mocks();
@@ -131,17 +136,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
 
         HttpResponseMessage response;
-        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project2SessionRequest, TestContext.Current.CancellationToken);
+        response = await client.PutAsJsonAsync(VersionedSessionUrl, Project2SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.Equal($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+        Assert.AreEqual($"{client.BaseAddress}run_session/2", response.Headers.Location.AbsoluteUri);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_Success_ThenStopProcessRequest()
     {
         var mocks = new Mocks();
@@ -156,23 +161,23 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
 
         // Now send a stop session
-        response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         // Validate NoContent response if session not found
-        response = await client.DeleteAsync(RunSessionRequest.Url + "/3", TestContext.Current.CancellationToken);
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        response = await client.DeleteAsync(RunSessionRequest.Url + "/3", TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailedToLaunchProject()
     {
         var mocks = new Mocks();
@@ -185,17 +190,17 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
-        Assert.Equal("{\"error\":{\"message\":\"Launch project failed\"}}", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.AreEqual("application/json; charset=utf-8", response.Content.Headers.ContentType.ToString());
+        Assert.AreEqual("{\"error\":{\"message\":\"Launch project failed\"}}", await response.Content.ReadAsStringAsync(TestContext.CancellationToken));
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -206,15 +211,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_FailWrongUrl()
     {
         var mocks = new Mocks();
@@ -224,16 +229,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PutAsJsonAsync("/run_badurl", Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PutAsJsonAsync("/run_badurl", Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
 
         await server.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LaunchProject_NotAPUTRequest()
     {
         var mocks = new Mocks();
@@ -243,16 +248,16 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = aspireServer.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.PostAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.Current.CancellationToken);
+        var response = await client.PostAsJsonAsync(VersionedSessionUrl, Project1SessionRequest, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
 
         await aspireServer.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StopSession_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -263,15 +268,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.Current.CancellationToken);
+        var response = await client.DeleteAsync(RunSessionRequest.Url + "/2", TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Info_Success()
     {
         var mocks = new Mocks();
@@ -281,15 +286,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var tokens = server.GetServerVariables();
         using HttpClient client = GetHttpClient(tokens);
 
-        var response = await client.GetAsync(InfoResponse.Url, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(InfoResponse.Url, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Info_FailNoBearerToken()
     {
         var mocks = new Mocks();
@@ -300,15 +305,15 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         using HttpClient client = GetHttpClient(tokens);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "badToken");
 
-        var response = await client.GetAsync(InfoResponse.Url, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(InfoResponse.Url, TestContext.CancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
 
         await server.DisposeAsync();
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SendLogMessageAsync_Test()
     {
         var mocks = new Mocks();
@@ -330,14 +335,14 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         var result = await notificationTask.Task;
 
-        Assert.Equal("My Message", result.LogMessage);
-        Assert.False(result.IsStdErr);
+        Assert.AreEqual("My Message", result.LogMessage);
+        Assert.IsFalse(result.IsStdErr);
         await aspireServer.DisposeAsync();
 
         mocks.Verify();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetEnvironmentForOrchestrator_Tests()
     {
         var mocks = new Mocks();
@@ -347,13 +352,13 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         // First time should create a key
         var envVars = server.GetServerConnectionEnvironment();
 
-        Assert.Equal(3, envVars.Count);
+        Assert.HasCount(3, envVars);
         var token = envVars[1];
-        Assert.NotNull(token.Value);
+        Assert.IsNotNull(token.Value);
 
         // Should return the same
         envVars = server.GetServerConnectionEnvironment();
-        Assert.Equal(token, envVars[1]);
+        Assert.AreEqual(token, envVars[1]);
 
         mocks.Verify();
     }
@@ -365,14 +370,20 @@ public class AspireServerServiceTests(ITestOutputHelper output)
 
         using var ws = new ClientWebSocket();
         ws.Options.SetRequestHeader("Authorization", $"Bearer {tokens.bearerToken}");
+        Exception connectException = null;
         try
         {
-            await ws.ConnectAsync(new Uri($"wss://{tokens.serverAddress}{RunSessionRequest.Url}{SessionNotification.Url}"), httpClient, TestContext.Current.CancellationToken);
+            await ws.ConnectAsync(new Uri($"wss://{tokens.serverAddress}{RunSessionRequest.Url}{SessionNotification.Url}"), httpClient, TestContext.CancellationToken);
         }
         catch (Exception ex)
         {
-            Assert.Fail("Could not connect to session update endpoint: " + ex.ToString());
             connected.SetResult(false);
+            connectException = ex;
+        }
+
+        if (connectException is not null)
+        {
+            Assert.Fail("Could not connect to session update endpoint: " + connectException.ToString());
             return;
         }
 
@@ -381,25 +392,32 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         while (ws.State == WebSocketState.Open)
         {
             string message;
+            bool connectionClosed = false;
             try
             {
                 (message, var messageType) = await GetSocketMsgAsync(ws);
 
                 if (messageType == WebSocketMessageType.Close)
                 {
-                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, TestContext.Current.CancellationToken);
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, TestContext.CancellationToken);
                     return;
                 }
             }
             catch
             {
                 // This is expected if the connection is closed
-                Assert.Equal(WebSocketState.Closed, ws.State);
+                connectionClosed = true;
+                message = null;
+            }
+
+            if (connectionClosed)
+            {
+                Assert.AreEqual(WebSocketState.Closed, ws.State);
                 return;
             }
 
             var notification = JsonSerializer.Deserialize<SessionNotification>(message, AspireServerService.JsonSerializerOptions);
-            Assert.NotNull(notification);
+            Assert.IsNotNull(notification);
 
             SessionNotification value = notification.NotificationType switch
             {
@@ -409,7 +427,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
                 _ => throw new InvalidOperationException($"Unexpected {notification.NotificationType}")
             };
 
-            Assert.NotNull(value);
+            Assert.IsNotNull(value);
             callback.Invoke(value);
         }
     }
@@ -440,7 +458,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
     private async Task<(string, WebSocketMessageType)> GetSocketMsgAsync(ClientWebSocket client)
     {
         var rcvBuffer = new ArraySegment<byte>(new byte[2048]);
-        WebSocketReceiveResult rcvResult = await client.ReceiveAsync(rcvBuffer, TestContext.Current.CancellationToken);
+        WebSocketReceiveResult rcvResult = await client.ReceiveAsync(rcvBuffer, TestContext.CancellationToken);
         if (rcvResult.MessageType == WebSocketMessageType.Text)
         {
             byte[] msgBytes = rcvBuffer.Skip(rcvBuffer.Offset).Take(rcvResult.Count).ToArray();
@@ -457,7 +475,7 @@ public class AspireServerServiceTests(ITestOutputHelper output)
         var aspireServer = new AspireServerService(serverEvents.Object, displayName: "Test server",
             line =>
             {
-                output.WriteLine(line);
+                TestContext.WriteLine(line);
                 Debug.WriteLine(line);
             });
 

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -1,24 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
-    <OutputType>Exe</OutputType>
-    <EnableDefaultScopedCssItems>false</EnableDefaultScopedCssItems>
-
-    <!-- Suppress pack warnings for this test project. Microsoft.NET.Sdk.Web defaults 
-         WarnOnPackingNonPackableProject=true, but test projects have IsPackable=false by default,
-         which would generate warnings/errors during pack operations that we want to suppress. -->
-    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.DotNet.HotReload.Test.Utilities\AssertEx.cs" Link="Utilities\AssertEx.cs" />
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Import Project="..\..\src\Dotnet.Watch\AspireService\Microsoft.WebTools.AspireService.projitems" Label="Shared" />

--- a/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
+++ b/test/Microsoft.WebTools.AspireService.Tests/RunSessionRequestTests.cs
@@ -3,13 +3,12 @@
 
 #nullable disable
 
-using Microsoft.DotNet.Watch.UnitTests;
-
 namespace Aspire.Tools.Service.UnitTests;
 
+[TestClass]
 public class RunSessionRequestTests
 {
-    [Fact]
+    [TestMethod]
     public void RunSessionRequest_ToProjectLaunchRequest()
     {
         var request = new RunSessionRequest()
@@ -36,21 +35,21 @@ public class RunSessionRequestTests
 
         var info = request.ToProjectLaunchInformation();
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "--someArg"
         ], info.Arguments);
 
-        AssertEx.SequenceEqual(
+        Assert.AreSequenceEqual(
         [
             "var1='value1'",
             "var2='value2'",
             "var3=''"
         ], info.Environment.Select(e => $"{e.Key}='{e.Value}'"));
 
-        Assert.Equal(@"c:\test\Projects\project1.csproj", info.ProjectPath);
-        Assert.True(info.Debug);
-        Assert.Equal("specificProfileName", info.LaunchProfile);
-        Assert.True(info.DisableLaunchProfile);
+        Assert.AreEqual(@"c:\test\Projects\project1.csproj", info.ProjectPath);
+        Assert.IsTrue(info.Debug);
+        Assert.AreEqual("specificProfileName", info.LaunchProfile);
+        Assert.IsTrue(info.DisableLaunchProfile);
     }
 }

--- a/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Manual.Tests/Microsoft.Win32.Msi.Manual.Tests.csproj
@@ -12,15 +12,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" />
   </ItemGroup>
-
-  <!-- Global usings removal -->
-  <!-- See: https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#using -->
-  <ItemGroup>
-    <Using Remove="Microsoft.NET.TestFramework" />
-    <Using Remove="Microsoft.NET.TestFramework.Assertions" />
-    <Using Remove="Microsoft.NET.TestFramework.Commands" />
-    <Using Remove="Microsoft.NET.TestFramework.ProjectConstruction" />
-    <Using Remove="Microsoft.NET.TestFramework.Utilities" />
-    <Using Remove="Xunit" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.Win32.Msi.Tests/EventArgsTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/EventArgsTests.cs
@@ -3,27 +3,30 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class EventArgsTests
     {
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItParsesProgressMessageFields()
         {
             ProgressEventArgs e = new("1: 2 2: 4 3: 6 4: 9", InstallMessage.PROGRESS, 0);
 
-            Assert.Equal(4, e.Fields.Length);
-            Assert.Equal(2, e.Fields[0]);
-            Assert.Equal(ProgressType.ProgressReport, e.ProgressType);
+            Assert.HasCount(4, e.Fields);
+            Assert.AreEqual(2, e.Fields[0]);
+            Assert.AreEqual(ProgressType.ProgressReport, e.ProgressType);
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItParsesActionStartMessageFields()
         {
             ActionStartEventArgs e = new("Action 20:08:24: ProcessComponents. Updating component registration",
                 InstallMessage.ACTIONSTART, 0);
 
-            Assert.Equal("20:08:24", e.ActionTime);
-            Assert.Equal("ProcessComponents", e.ActionName);
-            Assert.Equal("Updating component registration", e.ActionDescription);
+            Assert.AreEqual("20:08:24", e.ActionTime);
+            Assert.AreEqual("ProcessComponents", e.ActionName);
+            Assert.AreEqual("Updating component registration", e.ActionDescription);
         }
     }
 }

--- a/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
@@ -9,6 +9,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Win32.Msi.Tests/WindowsInstallerExceptionTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/WindowsInstallerExceptionTests.cs
@@ -3,11 +3,13 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class WindowsInstallerExceptionTests
     {
-        [WindowsOnlyTheory]
-        [InlineData(Error.ACCESS_DENIED, "Access is denied")]
-        [InlineData(Error.INSTALL_PACKAGE_OPEN_FAILED, "This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package")]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(Error.ACCESS_DENIED, "Access is denied")]
+        [DataRow(Error.INSTALL_PACKAGE_OPEN_FAILED, "This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package")]
         public void ItContainsValidErrorMessage(uint errorCode, string expectedMessage)
         {
             WindowsInstallerException e = new(unchecked((int)errorCode));

--- a/test/Microsoft.Win32.Msi.Tests/WindowsInstallerTests.cs
+++ b/test/Microsoft.Win32.Msi.Tests/WindowsInstallerTests.cs
@@ -3,26 +3,29 @@
 
 namespace Microsoft.Win32.Msi.Tests
 {
+    [TestClass]
     public class WindowsInstallerTests
     {
-        [WindowsOnlyTheory]
-        [InlineData("", "", Error.INVALID_PARAMETER)]
-        [InlineData("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", "ProductVersion", Error.UNKNOWN_PRODUCT)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("", "", Error.INVALID_PARAMETER)]
+        [DataRow("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", "ProductVersion", Error.UNKNOWN_PRODUCT)]
         public void InstallProductReturnsAnError(string productCode, string property, uint expectedError)
         {
             uint error = WindowsInstaller.GetProductInfo(productCode, property, out string propertyValue);
 
-            Assert.Equal(error, expectedError);
+            Assert.AreEqual(expectedError, error);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("", InstallState.INVALIDARG)]
-        [InlineData("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", InstallState.UNKNOWN)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("", InstallState.INVALIDARG)]
+        [DataRow("{807215B4-F42F-4E5F-BFEE-9817D7F2CEA5}", InstallState.UNKNOWN)]
         public void QueryProductStateReturnsAnError(string productCode, InstallState expectedState)
         {
             InstallState state = WindowsInstaller.QueryProduct(productCode);
 
-            Assert.Equal(state, expectedState);
+            Assert.AreEqual(expectedState, state);
         }
     }
 }

--- a/test/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.Integration.Tests/GivenDotnetInvokesMSBuild.cs
@@ -3,19 +3,16 @@
 
 namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
 {
+    [TestClass]
     public class GivenDotnetInvokesMSBuild : SdkTest
     {
-        public GivenDotnetInvokesMSBuild(ITestOutputHelper log) : base(log)
-        {
-        }
-
-        [Theory]
-        [InlineData("build")]
-        [InlineData("clean")]
-        [InlineData("msbuild")]
-        [InlineData("pack")]
-        [InlineData("publish")]
-        [InlineData("test")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("clean")]
+        [DataRow("msbuild")]
+        [DataRow("pack")]
+        [DataRow("publish")]
+        [DataRow("test")]
         public void When_dotnet_command_invokes_msbuild_Then_env_vars_and_m_are_passed(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -27,11 +24,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .Should().Pass();
         }
 
-        [Theory]
-        [InlineData("build")]
-        [InlineData("msbuild")]
-        [InlineData("pack")]
-        [InlineData("publish")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("msbuild")]
+        [DataRow("pack")]
+        [DataRow("publish")]
         public void When_dotnet_command_invokes_msbuild_with_no_args_verbosity_is_set_to_minimum(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -48,11 +45,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                      .And.Contain("Message with high importance", "Because high importance messages are shown on minimum verbosity");
         }
 
-        [Theory]
-        [InlineData("build")]
-        [InlineData("clean")]
-        [InlineData("pack")]
-        [InlineData("publish")]
+        [TestMethod]
+        [DataRow("build")]
+        [DataRow("clean")]
+        [DataRow("pack")]
+        [DataRow("publish")]
         public void When_dotnet_command_invokes_msbuild_with_diag_verbosity_Then_arg_is_passed(string command)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration", identifier: command)
@@ -69,7 +66,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.StdOut.Should().Contain("Message with low importance");
         }
 
-        [Fact]
+        [TestMethod]
         public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_minimum()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")
@@ -83,7 +80,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.StdOut.Should().Contain("Message with high importance");
         }
 
-        [Fact]
+        [TestMethod]
         public void When_dotnet_msbuild_command_is_invoked_with_non_msbuild_switch_Then_it_fails()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")
@@ -96,7 +93,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
             cmd.ExitCode.Should().NotBe(0);
         }
 
-        [Fact]
+        [TestMethod]
         public void When_MSBuildSDKsPath_is_set_by_env_var_then_it_is_not_overridden()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildIntegration")

--- a/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
+++ b/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
@@ -1,18 +1,20 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="MSTest.Sdk">
+
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
-  </PropertyGroup>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
-  <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Migrates the MSI and miscellaneous test projects from xUnit to `MSTest.Sdk` on Microsoft.Testing.Platform (MTP), following the established repo pattern.

Projects:
- `Microsoft.Win32.Msi.Tests`
- `Microsoft.Win32.Msi.Manual.Tests`
- `msbuild.Integration.Tests`
- `Microsoft.WebTools.AspireService.Tests`

Part of the xUnit -> MSTest migration effort. Each project builds cleanly.

> Note: this overlaps with #54882 which covers the same four projects.