### PR TITLE
CA1873: Fix log level comparison

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLogging.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/AvoidPotentiallyExpensiveCallWhenLogging.cs
@@ -82,7 +82,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
                 // Check if the log level exceeds the configured maximum threshold.
                 if (logLevel != LogLevelPassedAsParameter &&
-                    logLevel < LogLevelCritical &&
+                    logLevel <= LogLevelCritical &&
                     logLevel > ParseLogLevel(context.Options.GetStringOptionValue(EditorConfigOptionNames.MaxLogLevel, Rule, invocation.Syntax.SyntaxTree, context.Compilation)))
                 {
                     return;


### PR DESCRIPTION
Using the < operator here inadvertantly prevents critical log messages from ever being excluded from the expensive call analysis based on the `max_log_level` option.

The goal of this condition is to skip analysis if the logging statement uses a level higher than `max_log_level`. If the level is critical and `max_log_level` is lower than that, it must be true, so it needs to be a "less than or equal to" comparison.