### PR TITLE
Retry transient in-box SDK resolution failures in tests

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class TransientSdkResolutionErrorDetectorTests
+    {
+        [Fact]
+        public void TransientInBoxSdkResolutionFailureIsDetected()
+        {
+            string input =
+                "/datadisks/disk1/work/99FC086F/p/d/sdk/11.0.100-ci/Sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.props(20,3): " +
+                "error : Could not resolve SDK \"Microsoft.NET.Sdk.StaticWebAssets\". Exactly one of the probing " +
+                "messages below indicates why we could not resolve the SDK.\r\n" +
+                "Sdk.props(20,3): error :   SDK resolver \"Microsoft.DotNet.MSBuildWorkloadSdkResolver\" returned null.\r\n" +
+                "Sdk.props(20,3): error :   The NuGetSdkResolver did not resolve this SDK because there was no version " +
+                "specified in the project or global.json.\r\n" +
+                "Sdk.props(20,11): error MSB4236: The SDK 'Microsoft.NET.Sdk.StaticWebAssets' specified could not be " +
+                "found. [/work/InstantiatePr.csproj]";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeTrue();
+        }
+
+        [Fact]
+        public void NullInputIsNotTransient()
+        {
+            TransientSdkResolutionErrorDetector.IsTransientError(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SuccessfulBuildIsNotTransient()
+        {
+            string input =
+                "  Determining projects to restore...\r\n" +
+                "  Restored /work/InstantiatePr.csproj (in 131 ms).\r\n" +
+                "  InstantiatePr -> /work/bin/Debug/net11.0/InstantiatePr.dll\r\n" +
+                "Build succeeded.\r\n    0 Warning(s)\r\n    0 Error(s)";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
+        }
+
+        [Fact]
+        public void MissingVersionedSdkWithoutResolverNullIsNotTransient()
+        {
+            // A genuinely missing, version-specified SDK is a deterministic failure (no workload resolver
+            // "returned null" deferral), so it must not be treated as transient.
+            string input =
+                "error MSB4236: The SDK 'Contoso.Custom.Sdk' specified could not be found. [/work/project.csproj]";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
@@ -46,5 +46,17 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 "error MSB4236: The SDK 'Contoso.Custom.Sdk' specified could not be found. [/work/project.csproj]";
             TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
         }
+
+        [Fact]
+        public void OtherResolverReturningNullIsNotTransient()
+        {
+            // A "returned null" message from a different resolver must not trigger a retry: only the in-box
+            // workload resolver deferral (Microsoft.DotNet.MSBuildWorkloadSdkResolver) is the transient flake.
+            string input =
+                "Sdk.props(20,3): error :   SDK resolver \"Contoso.CustomSdkResolver\" returned null.\r\n" +
+                "Sdk.props(20,11): error MSB4236: The SDK 'Microsoft.NET.Sdk.StaticWebAssets' specified could not be " +
+                "found. [/work/InstantiatePr.csproj]";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
+        }
     }
 }

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -165,7 +165,8 @@ namespace Microsoft.NET.TestFramework.Commands
                 return false;
             }
 
-            return !NuGetTransientErrorDetector.IsTransientError(result.StdOut);
+            return !NuGetTransientErrorDetector.IsTransientError(result.StdOut)
+                && !TransientSdkResolutionErrorDetector.IsTransientError(result.StdOut);
         }
 
         public virtual CommandResult Execute(IEnumerable<string> args)

--- a/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
+++ b/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.TestFramework
+{
+    /// <summary>
+    /// Detects transient failures to resolve an in-box .NET SDK (for example
+    /// <c>Microsoft.NET.Sdk.StaticWebAssets</c> imported by the Razor SDK).
+    /// </summary>
+    /// <remarks>
+    /// Under heavy parallel I/O (many concurrent <c>dotnet build</c>/<c>dotnet new</c> invocations sharing a single
+    /// SDK-under-test) the MSBuild default SDK resolver intermittently fails to probe the
+    /// <c>Sdks/&lt;name&gt;/Sdk</c> folder, producing an <c>MSB4236</c> "could not be found" error even though the
+    /// SDK is present on disk. These failures are not deterministic and succeed when retried, so they are treated as
+    /// transient for the purposes of <see cref="Commands.TestCommand"/> retry logic. A genuinely missing SDK still
+    /// fails after the retries are exhausted.
+    /// </remarks>
+    public static class TransientSdkResolutionErrorDetector
+    {
+        public static bool IsTransientError(string? errorMessage)
+        {
+            if (errorMessage is null)
+            {
+                return false;
+            }
+
+            // The combination below is specific to the transient in-box SDK resolution flake:
+            //   - MSB4236 is raised for an SDK that "could not be found",
+            //   - for an in-box SDK in the Microsoft.NET.Sdk family, and
+            //   - after the .NET SDK workload resolver deferred resolution by returning null.
+            // Requiring all three avoids retrying legitimate failures such as a NuGet-versioned SDK that is
+            // intentionally absent.
+            return errorMessage.Contains("MSB4236")
+                && errorMessage.Contains("Microsoft.NET.Sdk")
+                && errorMessage.Contains("returned null");
+        }
+    }
+}

--- a/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
+++ b/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
@@ -27,11 +27,14 @@ namespace Microsoft.NET.TestFramework
             // The combination below is specific to the transient in-box SDK resolution flake:
             //   - MSB4236 is raised for an SDK that "could not be found",
             //   - for an in-box SDK in the Microsoft.NET.Sdk family, and
-            //   - after the .NET SDK workload resolver deferred resolution by returning null.
-            // Requiring all three avoids retrying legitimate failures such as a NuGet-versioned SDK that is
-            // intentionally absent.
+            //   - after the .NET SDK workload resolver (Microsoft.DotNet.MSBuildWorkloadSdkResolver) deferred
+            //     resolution by returning null.
+            // Keying on the specific resolver name (rather than a bare "returned null" substring) avoids
+            // accidental retries when some other resolver emits a similar message, and requiring all three
+            // avoids retrying legitimate failures such as a NuGet-versioned SDK that is intentionally absent.
             return errorMessage.Contains("MSB4236")
                 && errorMessage.Contains("Microsoft.NET.Sdk")
+                && errorMessage.Contains("Microsoft.DotNet.MSBuildWorkloadSdkResolver")
                 && errorMessage.Contains("returned null");
         }
     }

--- a/test/dotnet-new.IntegrationTests/WebProjectsTests.cs
+++ b/test/dotnet-new.IntegrationTests/WebProjectsTests.cs
@@ -43,7 +43,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             string workingDir = Path.Combine(_fixture.BaseWorkingDirectory, testName);
             Directory.CreateDirectory(workingDir);
 
-            new DotnetNewCommand(_log, args)
+            // Run instantiation without the implicit post-action restore: that restore is redundant with the
+            // explicit DotnetRestoreCommand below, and its transient in-box SDK resolution failures surface as
+            // stderr while 'dotnet new' still exits 0, which cannot be retried at the command level. The explicit
+            // restore and build (which retry transient SDK resolution failures) provide the actual coverage.
+            new DotnetNewCommand(_log, [.. args, "--no-restore"])
                 .WithCustomHive(_fixture.HomeDirectory)
                 .WithWorkingDirectory(workingDir)
                 .Execute()


### PR DESCRIPTION
## Problem

Many SDK integration tests (EndToEnd, dotnet-new) randomly fail while building Razor-based templates with:

```
error : Could not resolve SDK "Microsoft.NET.Sdk.StaticWebAssets". ...
error :   SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
error MSB4236: The SDK 'Microsoft.NET.Sdk.StaticWebAssets' specified could not be found.
```

Under heavy parallel I/O (many concurrent `dotnet build`/`dotnet new` sharing one SDK-under-test), MSBuild's default SDK resolver intermittently fails to probe the in-box `Sdks/<name>/Sdk` folder even though it is present. The `...WorkloadSdkResolver returned null` line is benign (that resolver correctly defers in-box SDKs to the default resolver). The failure is non-deterministic and succeeds on retry.

The repo already mitigates such transient flakes via `TestCommand` retry (e.g. #54800, `NuGetTransientErrorDetector`), but in-box SDK-resolution failures weren't recognized as transient.

## Changes

- **`TransientSdkResolutionErrorDetector`** (new): matches the transient in-box resolution signature (`MSB4236` + `Microsoft.NET.Sdk` + `returned null`), specific enough to avoid retrying genuinely-missing versioned SDKs.
- **`TestCommand.ShouldStopRetry`**: also consults the new detector, so the existing `ExecuteWithRetry` (3x) retries these failures. Covers commands that exit non-zero (e.g. the EndToEnd `dotnet build`).
- **`WebProjectsTests.AllWebProjectsRestoreAndBuild`**: instantiate with `--no-restore`. The implicit post-action restore flakes the same way, but `dotnet new` still exits 0 (error only on stderr), which cannot be retried at the command level. The explicit `dotnet restore`/`dotnet build` that follow provide the coverage and are retryable.
- Unit tests for the new detector.

## Verification

- All affected projects build with `-warnaserror` (0 warnings/errors).
- `dotnet format --verify-no-changes` clean.
- New detector tests pass (4/4).