### PR TITLE
Migrate Microsoft.DotNet.TemplateLocator.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
+++ b/test/Microsoft.DotNet.TemplateLocator.Tests/GivenAnTemplateLocator.cs
@@ -5,13 +5,14 @@ using Microsoft.DotNet.DotNetSdkResolver;
 
 namespace Microsoft.DotNet.TemplateLocator.Tests
 {
+    [TestClass]
     public class GivenAnTemplateLocator : SdkTest
     {
         private readonly TemplateLocator _resolver;
         private readonly string _manifestDirectory;
         private readonly string _fakeDotnetRootDirectory;
 
-        public GivenAnTemplateLocator(ITestOutputHelper logger) : base(logger)
+        public GivenAnTemplateLocator()
         {
             _resolver = new TemplateLocator(Environment.GetEnvironmentVariable, null, VSSettings.Ambient, null, null);
             _fakeDotnetRootDirectory =
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void ItShouldReturnListOfTemplates()
         {
             Directory.CreateDirectory(Path.Combine(_manifestDirectory, "Android"));
@@ -49,7 +50,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
             result.Should().HaveCount(1);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenNoSdkToBondItShouldReturnEmpty()
         {
             Directory.CreateDirectory(Path.Combine(_manifestDirectory, "Android"));
@@ -60,7 +61,7 @@ namespace Microsoft.DotNet.TemplateLocator.Tests
             result.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenNoManifestDirectoryItShouldReturnEmpty()
         {
             var fakeDotnetRootDirectory =

--- a/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
+++ b/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
@@ -6,7 +6,6 @@
     <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass. -->
     <TargetFrameworks Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildPass)' != '2'">$(SdkTargetFramework)</TargetFrameworks>
-    <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 
     <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests
@@ -18,7 +17,11 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.TemplateLocator\Microsoft.DotNet.TemplateLocator.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.DotNet.SdkResolver\Microsoft.DotNet.SdkResolver.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration. Migrates `Microsoft.DotNet.TemplateLocator.Tests` to `MSTest.Sdk` on Microsoft.Testing.Platform, following the same pattern as the other migration PRs (builds on the foundation from #54845).

- `Microsoft.NET.Sdk` -> `MSTest.Sdk`; `Microsoft.NET.TestFramework` project reference -> `Microsoft.NET.TestFramework.MSTest`; removed `OutputType=Exe`; added the `Microsoft.NET.TestFramework` global using.
- `[Fact]` -> `[TestMethod]`, `[TestClass]` added; removed the `ITestOutputHelper` constructor injection (base `SdkTest` is now parameterless).

Builds clean for the SDK target framework.