### PR TITLE
Migrate sdk-tasks.Tests, trustedroots.Tests and Microsoft.DotNet.MSBuildSdkResolver.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnEnvironmentForResolution.cs
@@ -3,13 +3,14 @@
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenAnEnvironmentForResolution : SdkTest
     {
-        public GivenAnEnvironmentForResolution(ITestOutputHelper log) : base(log)
+        public GivenAnEnvironmentForResolution() : base()
         {
         }
 
-        [Fact]
+        [TestMethod]
         public void ItIgnoresInvalidPath()
         {
             Func<string, string> getPathEnvVarFunc = (string var) => { return $"{Directory.GetCurrentDirectory()}Dir{Path.GetInvalidPathChars().First()}Name"; };
@@ -18,7 +19,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             pathResult.Should().BeNull();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotReturnNullDotnetRootOnExtraPathSeparator()
         {
             File.Create(Path.Combine(Directory.GetCurrentDirectory(), "dotnet.exe")).Close();
@@ -27,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Should().NotBeNullOrWhiteSpace();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotMistakeDotnetPrefixedProcessForDotnetHost()
         {
             // Use separate directories for the dotnet host and the dotnet-prefixed process

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -7,29 +7,30 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.DotNetSdkResolver;
 using Microsoft.DotNet.MSBuildSdkResolver;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: DoNotParallelize]
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenAnMSBuildSdkResolver : SdkTest
     {
         private const string DotnetHostExperimentalKey = "DOTNET_EXPERIMENTAL_HOST_PATH";
         private const string MSBuildTaskHostRuntimeVersion = "SdkResolverMSBuildTaskHostRuntimeVersion";
 
-        public GivenAnMSBuildSdkResolver(ITestOutputHelper logger) : base(logger)
+        public GivenAnMSBuildSdkResolver() : base()
         {
         }
 
-        [Fact]
+        [TestMethod]
         public void ItHasCorrectNameAndPriority()
         {
             var resolver = new DotNetMSBuildSdkResolver();
 
-            Assert.Equal(5000, resolver.Priority);
-            Assert.Equal("Microsoft.DotNet.MSBuildSdkResolver", resolver.Name);
+            Assert.AreEqual(5000, resolver.Priority);
+            Assert.AreEqual("Microsoft.DotNet.MSBuildSdkResolver", resolver.Name);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItDoesNotFindMSBuildSdkThatIsMissingFromLocatedNETCoreSdk()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -50,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().NotBeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItFindsTheVersionSpecifiedInGlobalJson()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -74,9 +75,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
         public void ItUsesProjectDirectoryIfSolutionFilePathIsNullOrWhitespace(string? solutionFilePath)
         {
             const string version = "99.0.0";
@@ -99,11 +100,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Theory]
-        [InlineData(null, null)]
-        [InlineData("", null)]
-        [InlineData("", "")]
-        [InlineData(null, "")]
+        [TestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("", "")]
+        [DataRow(null, "")]
         public void ItUsesCurrentDirectoryIfSolutionFilePathAndProjectFilePathIsNullOrWhitespace(string? solutionFilePath, string? projectFilePath)
         {
             const string version = "99.0.0";
@@ -126,7 +127,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullIfTheVersionFoundDoesNotSatisfyTheMinVersion()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -147,7 +148,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().Contain(string.Format(Strings.NETCoreSDKSmallerThanMinimumRequestedVersion, "99.99.99", "999.99.99"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullWhenTheSDKRequiresAHigherVersionOfMSBuildThanAnyOneAvailable()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -173,9 +174,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().Contain(string.Format(Strings.MSBuildSmallerThanMinimumVersion, "99.99.99", "2.0", "1.0"));
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItReturnsHighestSdkAvailableThatIsCompatibleWithMSBuild(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviews.ToString())
@@ -219,7 +220,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenALocalSdkIsResolvedItReturnsHostFromThatSDKInsteadOfAmbientGlobalSdk()
         {
             // create a test that sets up a TestEnvironment with
@@ -254,9 +255,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.PropertiesToAdd[DotnetHostExperimentalKey].Should().Be(localDotnetBinary);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItDoesNotReturnHighestSdkAvailableThatIsCompatibleWithMSBuildWhenVersionInGlobalJsonCannotBeFoundOutsideOfVisualStudio(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, callingMethod: "ItDoesNotReturnHighest___", identifier: disallowPreviews.ToString())
@@ -291,9 +292,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().NotBeEmpty();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItReturnsHighestSdkAvailableThatIsCompatibleWithMSBuildWhenVersionInGlobalJsonCannotBeFoundAndRunningInVisualStudio(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, callingMethod: "ItReturnsHighest___", identifier: disallowPreviews.ToString())
@@ -342,7 +343,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullWhenTheDefaultVSRequiredSDKVersionIsHigherThanTheSDKVersionAvailable()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -364,7 +365,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().Contain(string.Format(Strings.NETCoreSDKSmallerThanMinimumVersionRequiredByVisualStudio, "1.0.1", "1.0.4"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsNullWhenTheTheVSRequiredSDKVersionIsHigherThanTheSDKVersionAvailable()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -387,7 +388,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().Contain(string.Format(Strings.NETCoreSDKSmallerThanMinimumVersionRequiredByVisualStudio, "1.0.1", "2.0.0"));
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsTheVersionIfItIsEqualToTheMinVersionAndTheVSDefinedMinVersion()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -409,7 +410,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItReturnsTheVersionIfItIsHigherThanTheMinVersionAndTheVSDefinedMinVersion()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -431,9 +432,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItDisallowsPreviewsBasedOnDefault(bool disallowPreviewsByDefault)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviewsByDefault.ToString());
@@ -458,9 +459,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void ItDisallowsPreviewsBasedOnFile(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviews.ToString());
@@ -486,7 +487,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItObservesChangesToVSSettingsFile()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -535,7 +536,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             Check(disallowPreviews: false, message: "file deleted to return to default");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItAllowsPreviewWhenGlobalJsonHasPreviewIrrespectiveOfSetting()
         {
             var environment = new TestEnvironment(TestAssetsManager);
@@ -560,7 +561,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void ItRespectsAmbientVSSettings()
         {
             // When run in test explorer in VS, this will actually locate the settings for the current VS instance
@@ -589,7 +590,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             result.Errors.Should().BeNullOrEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenTemplateLocatorItCanResolveSdkVersion()
         {
             var environment = new TestEnvironment(TestAssetsManager);

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenThatIWantToCompareSemanticVersions.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenThatIWantToCompareSemanticVersions.cs
@@ -7,22 +7,23 @@ using Microsoft.DotNet.MSBuildSdkResolver;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenThatWeWantToCompareFXVersions
     {
-        [Theory]
-        [InlineData("2.0.0", "1.0.0", 1)]
-        [InlineData("1.1.0", "1.0.0", 1)]
-        [InlineData("1.0.1", "1.0.0", 1)]
-        [InlineData("1.0.0", "1.0.0-pre", 1)]
-        [InlineData("1.0.0-pre+2", "1.0.0-pre+1", 0)]
-        [InlineData("1.0.0", "2.0.0", -1)]
-        [InlineData("1.0.0", "1.1.0", -1)]
-        [InlineData("1.0.0", "1.0.1", -1)]
-        [InlineData("1.0.0-pre", "1.0.0", -1)]
-        [InlineData("1.0.0-pre+1", "1.0.0-pre+2", 0)]
-        [InlineData("1.2.3", "1.2.3", 0)]
-        [InlineData("1.2.3-pre", "1.2.3-pre", 0)]
-        [InlineData("1.2.3-pre+1", "1.2.3-pre+1", 0)]
+        [TestMethod]
+        [DataRow("2.0.0", "1.0.0", 1)]
+        [DataRow("1.1.0", "1.0.0", 1)]
+        [DataRow("1.0.1", "1.0.0", 1)]
+        [DataRow("1.0.0", "1.0.0-pre", 1)]
+        [DataRow("1.0.0-pre+2", "1.0.0-pre+1", 0)]
+        [DataRow("1.0.0", "2.0.0", -1)]
+        [DataRow("1.0.0", "1.1.0", -1)]
+        [DataRow("1.0.0", "1.0.1", -1)]
+        [DataRow("1.0.0-pre", "1.0.0", -1)]
+        [DataRow("1.0.0-pre+1", "1.0.0-pre+2", 0)]
+        [DataRow("1.2.3", "1.2.3", 0)]
+        [DataRow("1.2.3-pre", "1.2.3-pre", 0)]
+        [DataRow("1.2.3-pre+1", "1.2.3-pre+1", 0)]
         public void OneFXVersionIsBiggerThanTheOther(string s1, string s2, int expectedResult)
         {
             FXVersion fxVersion1;
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             public bool Same;
         };
 
-        [Fact]
+        [TestMethod]
         public void OrderingMatchesSemVer200Rules()
         {
             TestCase[] orderedCases = new TestCase[]

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenThatWeWantToParseSemanticVersions.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenThatWeWantToParseSemanticVersions.cs
@@ -7,74 +7,75 @@ using Microsoft.DotNet.MSBuildSdkResolver;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenThatWeWantToParseFXVersions
     {
-        [Theory]
-        [InlineData("")]
-        [InlineData("1")]
-        [InlineData("1.1")]
-        [InlineData("A.1.1")]
-        [InlineData("1.A.1")]
-        [InlineData("1.1.A")]
-        [InlineData("1A.1.1")]
-        [InlineData("1.1A.1")]
-        [InlineData("1.1.1A")]
-        [InlineData("1.1.1-")]
-        [InlineData("1.1.1-.")]
-        [InlineData("1.1.1-A.")]
-        [InlineData("1.1.1-A.B.")]
-        [InlineData("1.1.1-.+id")]
-        [InlineData("1.1.1-A.+id")]
-        [InlineData("1.1.1-A.B.+id")]
-        [InlineData("1.1.1-A.B+id.")]
-        [InlineData("01.1.1")]
-        [InlineData("1.01.1")]
-        [InlineData("1.1.01")]
-        [InlineData("1.1.1-01.B")]
-        [InlineData("1.1.1-A.01")]
-        [InlineData("00.1.1")]
-        [InlineData("1.00.1")]
-        [InlineData("1.1.00")]
-        [InlineData("1.1.1-00.B")]
-        [InlineData("1.1.1-A.00")]
-        [InlineData("1.1.1+")]
-        [InlineData("1.1.1-A+")]
-        [InlineData("1.1.1-A*B")]
-        [InlineData("1.1.1-A/B")]
-        [InlineData("1.1.1-A:B")]
-        [InlineData("1.1.1-A^B")]
-        [InlineData("1.1.1-A|B")]
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("1")]
+        [DataRow("1.1")]
+        [DataRow("A.1.1")]
+        [DataRow("1.A.1")]
+        [DataRow("1.1.A")]
+        [DataRow("1A.1.1")]
+        [DataRow("1.1A.1")]
+        [DataRow("1.1.1A")]
+        [DataRow("1.1.1-")]
+        [DataRow("1.1.1-.")]
+        [DataRow("1.1.1-A.")]
+        [DataRow("1.1.1-A.B.")]
+        [DataRow("1.1.1-.+id")]
+        [DataRow("1.1.1-A.+id")]
+        [DataRow("1.1.1-A.B.+id")]
+        [DataRow("1.1.1-A.B+id.")]
+        [DataRow("01.1.1")]
+        [DataRow("1.01.1")]
+        [DataRow("1.1.01")]
+        [DataRow("1.1.1-01.B")]
+        [DataRow("1.1.1-A.01")]
+        [DataRow("00.1.1")]
+        [DataRow("1.00.1")]
+        [DataRow("1.1.00")]
+        [DataRow("1.1.1-00.B")]
+        [DataRow("1.1.1-A.00")]
+        [DataRow("1.1.1+")]
+        [DataRow("1.1.1-A+")]
+        [DataRow("1.1.1-A*B")]
+        [DataRow("1.1.1-A/B")]
+        [DataRow("1.1.1-A:B")]
+        [DataRow("1.1.1-A^B")]
+        [DataRow("1.1.1-A|B")]
         public void ReturnsFalseGivenInvalidVersion(string s1)
         {
             FXVersion fxVersion;
             FXVersion.TryParse(s1, out fxVersion).Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData("1.0.0-0.3.7", 1, 0, 0, "-0.3.7", "")]
-        [InlineData("1.0.0-alpha", 1, 0, 0, "-alpha", "")]
-        [InlineData("1.0.0-alpha+001", 1, 0, 0, "-alpha", "+001")]
-        [InlineData("1.0.0-alpha.1", 1, 0, 0, "-alpha.1", "")]
-        [InlineData("1.0.0-alpha.beta", 1, 0, 0, "-alpha.beta", "")]
-        [InlineData("1.0.0-beta", 1, 0, 0, "-beta", "")]
-        [InlineData("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, "-beta", "+exp.sha.5114f85")]
-        [InlineData("1.0.0-beta.2", 1, 0, 0, "-beta.2", "")]
-        [InlineData("1.0.0-beta.11", 1, 0, 0, "-beta.11", "")]
-        [InlineData("1.0.0-rc.1", 1, 0, 0, "-rc.1", "")]
-        [InlineData("1.0.0-x.7.z.92", 1, 0, 0, "-x.7.z.92", "")]
-        [InlineData("1.0.0", 1, 0, 0, "", "")]
-        [InlineData("1.0.0+20130313144700", 1, 0, 0, "", "+20130313144700")]
-        [InlineData("1.9.0-9", 1, 9, 0, "-9", "")]
-        [InlineData("1.9.0-10", 1, 9, 0, "-10", "")]
-        [InlineData("1.9.0-1A", 1, 9, 0, "-1A", "")]
-        [InlineData("1.9.0", 1, 9, 0, "", "")]
-        [InlineData("1.10.0", 1, 10, 0, "", "")]
-        [InlineData("1.11.0", 1, 11, 0, "", "")]
-        [InlineData("2.0.0", 2, 0, 0, "", "")]
-        [InlineData("2.1.0", 2, 1, 0, "", "")]
-        [InlineData("2.1.1", 2, 1, 1, "", "")]
-        [InlineData("4.6.0-preview.19064.1", 4, 6, 0, "-preview.19064.1", "")]
-        [InlineData("4.6.0-preview1-27018-01", 4, 6, 0, "-preview1-27018-01", "")]
+        [TestMethod]
+        [DataRow("1.0.0-0.3.7", 1, 0, 0, "-0.3.7", "")]
+        [DataRow("1.0.0-alpha", 1, 0, 0, "-alpha", "")]
+        [DataRow("1.0.0-alpha+001", 1, 0, 0, "-alpha", "+001")]
+        [DataRow("1.0.0-alpha.1", 1, 0, 0, "-alpha.1", "")]
+        [DataRow("1.0.0-alpha.beta", 1, 0, 0, "-alpha.beta", "")]
+        [DataRow("1.0.0-beta", 1, 0, 0, "-beta", "")]
+        [DataRow("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, "-beta", "+exp.sha.5114f85")]
+        [DataRow("1.0.0-beta.2", 1, 0, 0, "-beta.2", "")]
+        [DataRow("1.0.0-beta.11", 1, 0, 0, "-beta.11", "")]
+        [DataRow("1.0.0-rc.1", 1, 0, 0, "-rc.1", "")]
+        [DataRow("1.0.0-x.7.z.92", 1, 0, 0, "-x.7.z.92", "")]
+        [DataRow("1.0.0", 1, 0, 0, "", "")]
+        [DataRow("1.0.0+20130313144700", 1, 0, 0, "", "+20130313144700")]
+        [DataRow("1.9.0-9", 1, 9, 0, "-9", "")]
+        [DataRow("1.9.0-10", 1, 9, 0, "-10", "")]
+        [DataRow("1.9.0-1A", 1, 9, 0, "-1A", "")]
+        [DataRow("1.9.0", 1, 9, 0, "", "")]
+        [DataRow("1.10.0", 1, 10, 0, "", "")]
+        [DataRow("1.11.0", 1, 11, 0, "", "")]
+        [DataRow("2.0.0", 2, 0, 0, "", "")]
+        [DataRow("2.1.0", 2, 1, 0, "", "")]
+        [DataRow("2.1.1", 2, 1, 1, "", "")]
+        [DataRow("4.6.0-preview.19064.1", 4, 6, 0, "-preview.19064.1", "")]
+        [DataRow("4.6.0-preview1-27018-01", 4, 6, 0, "-preview1-27018-01", "")]
         public void ReturnsCorrectFXVersion(string s1, int major, int minor, int patch, string pre, string build)
         {
             FXVersion fxVersion;
@@ -89,42 +90,42 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fxVersion.Build.Should().Be(build);
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsNullWhenNoMajorSeparatorIsFound()
         {
             FXVersion fxVersion;
             FXVersion.TryParse("1", out fxVersion).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsNullWhenMajorPortionIsNotANumber()
         {
             FXVersion fxVersion;
             FXVersion.TryParse("a.0.0", out fxVersion).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsNullWhenNoMinorSeparatorIsFound()
         {
             FXVersion fxVersion;
             FXVersion.TryParse("1.0", out fxVersion).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsNullWhenMinorPortionIsNotANumber()
         {
             FXVersion fxVersion;
             FXVersion.TryParse("1.a.0", out fxVersion).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsNullWhenPatchPortionIsNotANumber()
         {
             FXVersion fxVersion;
             FXVersion.TryParse("1.0.a", out fxVersion).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsFXVersionWhenOnlyMajorMinorPatchIsFound()
         {
             FXVersion fxVersion;
@@ -137,7 +138,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fxVersion.Patch.Should().Be(3);
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsFXVersionWhenOnlyMajorMinorPatchAndPreIsFound()
         {
             FXVersion fxVersion;
@@ -151,7 +152,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fxVersion.Pre.Should().Be("-pre");
         }
 
-        [Fact]
+        [TestMethod]
         public void ReturnsFXVersionWhenMajorMinorPatchAndPreAndBuildIsFound()
         {
             FXVersion fxVersion;

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -1,14 +1,15 @@
-﻿<Project>
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <!-- This project's tests rely on global process state, so disable parallelization
+         (the repo default is MethodLevel). [assembly: DoNotParallelize] enforces serial execution. -->
+    <MSTestParallelizeScope></MSTestParallelizeScope>
     <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass.
          Disabling this project as references are not building in this case. -->
@@ -35,7 +36,11 @@
     </ProjectReference>
 
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,7 +50,5 @@
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
   </ItemGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/test/sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -1,13 +1,14 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests
 {
-    public class CalculateTemplateVersionsTests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class CalculateTemplateVersionsTests : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("3.1.0");
@@ -18,7 +19,7 @@ namespace Microsoft.CoreSdkTasks.Tests
             result.MajorMinorPatchVersion.Should().Be("3.1.1");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("3.0.0-alpha.1.20071.6");
@@ -28,7 +29,7 @@ namespace Microsoft.CoreSdkTasks.Tests
             result.MajorMinorPatchVersion.Should().Be("3.0.1");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("5.1.0");
@@ -39,7 +40,7 @@ namespace Microsoft.CoreSdkTasks.Tests
             result.MajorMinorPatchVersion.Should().Be("5.1.0");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
             var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6");

--- a/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
+++ b/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
@@ -7,10 +7,11 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class CopyPreservingRelativeSymlinksTests : SdkTest
 {
 #if !NETFRAMEWORK
-    [Fact]
+    [TestMethod]
     public void ItCopiesRegularFiles()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -29,7 +30,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         task.CopiedFiles.Should().HaveCount(1);
     }
 
-    [Fact]
+    [TestMethod]
     public void ItPreservesRelativeSymbolicLinks()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -57,7 +58,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         destInfo.LinkTarget.Should().Be("target.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItPreservesRelativeSymbolicLinksWithPathTraversal()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -90,7 +91,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         destInfo.LinkTarget.Should().Be("../target.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItCopiesMixedFilesAndSymlinks()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -126,7 +127,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         new FileInfo(destSymlink).LinkTarget.Should().Be("target.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItCreatesDestinationDirectories()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -143,7 +144,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         File.Exists(destFile).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItOverwritesExistingFiles()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -161,7 +162,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         File.ReadAllText(destFile).Should().Be("new content");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItOverwritesExistingSymlinkWithRegularFile()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -186,7 +187,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         File.ReadAllText(destFile).Should().Be("regular content");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItOverwritesExistingRegularFileWithSymlink()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -212,7 +213,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         destInfo.LinkTarget.Should().Be("target.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItFailsWhenSymlinkTargetIsOutsideCopyScope()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -236,7 +237,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         task.Execute().Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItSucceedsWhenSymlinkTargetIsWithinCopyScope()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -261,7 +262,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         new FileInfo(destSymlink).LinkTarget.Should().Be("target.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItFailsWhenSourceFileDoesNotExist()
     {
         var (_, destDir) = CreateSourceAndDestDirs();
@@ -273,7 +274,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         task.Execute().Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItFailsWhenSourceAndDestinationCountMismatch()
     {
         var (sourceDir, destDir) = CreateSourceAndDestDirs();
@@ -290,7 +291,7 @@ public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTes
         task.Execute().Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItSucceedsWithEmptySourceFiles()
     {
         var task = CreateTask([], []);

--- a/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
+++ b/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Build.Tasks;
@@ -300,9 +301,9 @@ public class CopyPreservingRelativeSymlinksTests : SdkTest
         task.CopiedFiles.Should().BeEmpty();
     }
 
-    private (string sourceDir, string destDir) CreateSourceAndDestDirs()
+    private (string sourceDir, string destDir) CreateSourceAndDestDirs([CallerMemberName] string testName = "")
     {
-        var testDir = TestAssetsManager.CreateTestDirectory().Path;
+        var testDir = TestAssetsManager.CreateTestDirectory(testName).Path;
         var sourceDir = Path.Combine(testDir, "source");
         var destDir = Path.Combine(testDir, "dest");
         Directory.CreateDirectory(sourceDir);

--- a/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
+++ b/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
@@ -7,10 +7,11 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class DeduplicateAssembliesWithLinksTests : SdkTest
 {
 #if !NETFRAMEWORK
-    [Fact]
+    [TestMethod]
     public void WhenDuplicatesExistItCreatesHardLinks()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -48,7 +49,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         inode2.Should().Be(inode3);
     }
 
-    [Fact]
+    [TestMethod]
     public void WhenDuplicatesExistItCreatesSymbolicLinks()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -77,7 +78,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         symlinksCreated.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItSelectsMasterByDepthThenAlphabetically()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -118,7 +119,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         GetInode(nestedFile).Should().Be(primaryInode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ItOnlyDeduplicatesAssemblies()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -168,7 +169,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         json1Inode.Should().NotBe(json2Inode);
     }
 
-    [Fact]
+    [TestMethod]
     public void WhenLayoutDirectoryDoesNotExistItFails()
     {
         var nonExistentDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -179,7 +180,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         result.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void ItHandlesMultipleDuplicateGroups()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -221,7 +222,7 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         inodeUnique.Should().NotBe(inodeB1);
     }
 
-    [Fact]
+    [TestMethod]
     public void ItCreatesRelativeSymbolicLinks()
     {
         var layoutDir = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/sdk-tasks.Tests/FilterItemsByDuplicateHashTests.cs
+++ b/test/sdk-tasks.Tests/FilterItemsByDuplicateHashTests.cs
@@ -7,10 +7,11 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class FilterItemsByDuplicateHashTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class FilterItemsByDuplicateHashTests : SdkTest
 {
 #if !NETFRAMEWORK
-    [Fact]
+    [TestMethod]
     public void UnmatchedFilesContainsOnlyCandidatesNotInReference()
     {
         var testDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -34,7 +35,7 @@ public class FilterItemsByDuplicateHashTests(ITestOutputHelper log) : SdkTest(lo
         task.UnmatchedFiles[0].ItemSpec.Should().Be(candUnique);
     }
 
-    [Fact]
+    [TestMethod]
     public void MatchingIsByContentNotByFileName()
     {
         var testDir = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/sdk-tasks.Tests/GenerateDefaultRuntimeFrameworkVersionTests.cs
+++ b/test/sdk-tasks.Tests/GenerateDefaultRuntimeFrameworkVersionTests.cs
@@ -1,17 +1,18 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests
 {
-    public class GenerateDefaultRuntimeFrameworkVersionTests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GenerateDefaultRuntimeFrameworkVersionTests : SdkTest
     {
-        [Theory]
-        [InlineData("3.0.0-rtm", "3.0.0-rtm")]
-        [InlineData("3.1.0", "3.1.0")]
-        [InlineData("10.3.10", "10.3.0")]
-        [InlineData("1.1.10-prerelease", "1.1.0")]
+        [TestMethod]
+        [DataRow("3.0.0-rtm", "3.0.0-rtm")]
+        [DataRow("3.1.0", "3.1.0")]
+        [DataRow("10.3.10", "10.3.0")]
+        [DataRow("1.1.10-prerelease", "1.1.0")]
         public void ItGeneratesDefaultVersionBasedOnRuntimePackVersion(string runtimePackVersion, string defaultRuntimeFrameworkVersion)
         {
             var generateTask = new GenerateDefaultRuntimeFrameworkVersion()

--- a/test/sdk-tasks.Tests/PublishMutationUtilitiesTests.cs
+++ b/test/sdk-tasks.Tests/PublishMutationUtilitiesTests.cs
@@ -5,7 +5,8 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class PublishMutationUtilitiesTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class PublishMutationUtilitiesTests : SdkTest
 {
     private const string SampleDepsJson = """
         {
@@ -26,7 +27,7 @@ public class PublishMutationUtilitiesTests(ITestOutputHelper log) : SdkTest(log)
         }
         """;
 
-    [Fact]
+    [TestMethod]
     public void ItRenamesEntryPointLibrary()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -40,7 +41,7 @@ public class PublishMutationUtilitiesTests(ITestOutputHelper log) : SdkTest(log)
         result.Should().NotContain("OldApp/1.0.0");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItRemovesEntryPointLibraryWhenNewNameIsNull()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -54,7 +55,7 @@ public class PublishMutationUtilitiesTests(ITestOutputHelper log) : SdkTest(log)
         result.Should().NotContain("NewApp");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItPreservesVersionInRenamedLibrary()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/sdk-tasks.Tests/RemoveAssetFromDepsPackagesTests.cs
+++ b/test/sdk-tasks.Tests/RemoveAssetFromDepsPackagesTests.cs
@@ -5,7 +5,8 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class RemoveAssetFromDepsPackagesTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class RemoveAssetFromDepsPackagesTests : SdkTest
 {
     private const string SampleDepsJson = """
         {
@@ -25,7 +26,7 @@ public class RemoveAssetFromDepsPackagesTests(ITestOutputHelper log) : SdkTest(l
         }
         """;
 
-    [Fact]
+    [TestMethod]
     public void ItRemovesSpecificAssetFromDeps()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -39,7 +40,7 @@ public class RemoveAssetFromDepsPackagesTests(ITestOutputHelper log) : SdkTest(l
         result.Should().Contain("MyApp.dll");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItRemovesWildcardSection()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -53,7 +54,7 @@ public class RemoveAssetFromDepsPackagesTests(ITestOutputHelper log) : SdkTest(l
         result.Should().Contain("runtime");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItDoesNotModifyFileWhenAssetNotFound()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/sdk-tasks.Tests/UpdateRuntimeConfigTests.cs
+++ b/test/sdk-tasks.Tests/UpdateRuntimeConfigTests.cs
@@ -6,9 +6,10 @@ using Microsoft.DotNet.Build.Tasks;
 
 namespace Microsoft.CoreSdkTasks.Tests;
 
-public class UpdateRuntimeConfigTests(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class UpdateRuntimeConfigTests : SdkTest
 {
-    [Fact]
+    [TestMethod]
     public void ItUpdatesSingleFrameworkVersion()
     {
     var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -39,7 +40,7 @@ public class UpdateRuntimeConfigTests(ITestOutputHelper log) : SdkTest(log)
         result.Should().Contain("\"name\": \"Microsoft.NETCore.App\"");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItUpdatesMultipleFrameworkVersions()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;
@@ -80,7 +81,7 @@ public class UpdateRuntimeConfigTests(ITestOutputHelper log) : SdkTest(log)
         result.Should().NotContain("\"1.0.0\"");
     }
 
-    [Fact]
+    [TestMethod]
     public void ItPreservesUnknownFrameworks()
     {
       var dir = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
+++ b/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
@@ -1,14 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Tasks\sdk-tasks\sdk-tasks.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
   </ItemGroup>
 
 </Project>

--- a/test/trustedroots.Tests/GivenCodeSigningCtlFile.cs
+++ b/test/trustedroots.Tests/GivenCodeSigningCtlFile.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.DotNet.Tests
 {
+    [TestClass]
     public class GivenCodeSigningCtlFile : CtlFileTests
     {
         private static IReadOnlySet<string> s_fingerprints = null;
@@ -16,35 +17,35 @@ namespace Microsoft.DotNet.Tests
             LazyInitializer.EnsureInitialized(ref s_fingerprints, ref s_lockObject, Initialize);
         }
 
-        [Theory]
-        [InlineData("063e4afac491dfd332f3089b8542e94617d893d7fe944e10a7937ee29d9693c0")]  // CN=Chambers of Commerce Root - 2008, O=AC Camerfirma S.A., SERIALNUMBER=A82743287, L=Madrid (see current address at www.camerfirma.com/address), C=EU
-        [InlineData("2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c")]  // CN=VeriSign Universal Root Certification Authority, OU="(c) 2008 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
-        [InlineData("2e7bf16cc22485a7bbe2aa8696750761b0ae39be3b2fe9d0cc6d4ef73491425c")]  // CN=SSL.com EV Root Certification Authority RSA R2, O=SSL Corporation, L=Houston, S=Texas, C=US
-        [InlineData("3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")]  // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-        [InlineData("43df5774b03e7fef5fe40d931a7bedf1bb2e6b42738c4e6d3841103d3aa7f339")]  // CN=Entrust Root Certification Authority - G2, OU="(c) 2009 Entrust, Inc. - for authorized use only", OU=See www.entrust.net/legal-terms, O="Entrust, Inc.", C=US
-        [InlineData("45140b3247eb9cc8c5b4f0d7b53091f73292089e6e5a63e2749dd3aca9198eda")]  // CN=Go Daddy Root Certificate Authority - G2, O="GoDaddy.com, Inc.", L=Scottsdale, S=Arizona, C=US
-        [InlineData("4b03f45807ad70f21bfc2cae71c9fde4604c064cf5ffb686bae5dbaad7fdd34c")]  // CN=thawte Primary Root CA - G3, OU="(c) 2008 thawte, Inc. - For authorized use only", OU=Certification Services Division, O="thawte, Inc.", C=US
-        [InlineData("52f0e1c4e58ec629291b60317f074671b85d7ea80d5b07273463534b32b40234")]  // CN=COMODO RSA Certification Authority, O=COMODO CA Limited, L=Salford, S=Greater Manchester, C=GB
-        [InlineData("5367f20c7ade0e2bca790915056d086b720c33c1fa2a2661acf787e3292e1270")]  // CN=Microsoft Identity Verification Root Certificate Authority 2020, O=Microsoft Corporation, C=US
-        [InlineData("552f7bdcf1a7af9e6ce672017f4f12abf77240c78e761ac203d1d9d20ac89988")]  // CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, C=US
-        [InlineData("5c58468d55f58e497e743982d2b50010b6d165374acf83a7d4a32db768c4408e")]  // CN=Certum Trusted Network CA, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
-        [InlineData("5d56499be4d2e08bcfcad08a3e38723d50503bde706948e42f55603019e528ae")]  // CN=IdenTrust Commercial Root CA 1, O=IdenTrust, C=US
-        [InlineData("7353b6d6c2d6da4247773f3f07d075decb5134212bead0928ef1f46115260941")]  // CN=DigiCert CS RSA4096 Root G5, O="DigiCert, Inc.", C=US
-        [InlineData("7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf")]  // CN=DigiCert High Assurance EV Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-        [InlineData("7b9d553e1c92cb6e8803e137f4f287d4363757f5d44b37d52f9fca22fb97df86")]  // CN=GlobalSign Code Signing Root R45, O=GlobalSign nv-sa, C=BE
-        [InlineData("7e76260ae69a55d3f060b0fd18b2a8c01443c87b60791030c9fa0b0585101a38")]  // CN=Sectigo Public Code Signing Root R46, O=Sectigo Limited, C=GB
-        [InlineData("85666a562ee0be5ce925c1d8890a6f76a87ec16d4d7d5f29ea7419cf20123b69")]  // CN=SSL.com Root Certification Authority RSA, O=SSL Corporation, L=Houston, S=Texas, C=US
-        [InlineData("85a0dd7dd720adb7ff05f83d542b209dc7ff4528f7d677b18389fea5e5c49e86")]  // CN=QuoVadis Root CA 2, O=QuoVadis Limited, C=BM
-        [InlineData("8d722f81a9c113c0791df136a2966db26c950a971db46b4199f4ea54b78bfb9f")]  // CN=thawte Primary Root CA, OU="(c) 2006 thawte, Inc. - For authorized use only", OU=Certification Services Division, O="thawte, Inc.", C=US
-        [InlineData("9acfab7e43c8d880d06b262a94deeee4b4659989c3d0caf19baf6405e41ab7df")]  // CN=VeriSign Class 3 Public Primary Certification Authority - G5, OU="(c) 2006 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
-        [InlineData("b676f2eddae8775cd36cb0f63cd1d4603961f49e6265ba013a2f0307b6d0b804")]  // CN=Certum Trusted Network CA 2, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
-        [InlineData("bfff8fd04433487d6a8aa60c1a29767a9fc2bbb05e420f713a13b992891d3893")]  // CN=GDCA TrustAUTH R5 ROOT, O="GUANG DONG CERTIFICATE AUTHORITY CO.,LTD.", C=CN
-        [InlineData("c3846bf24b9e93ca64274c0ec67c1ecc5e024ffcacd2d74019350e81fe546ae4")]  // OU=Go Daddy Class 2 Certification Authority, O="The Go Daddy Group, Inc.", C=US
-        [InlineData("c766a9bef2d4071c863a31aa4920e813b2d198608cb7b7cfe21143b836df09ea")]  // CN=StartCom Certification Authority, OU=Secure Digital Certificate Signing, O=StartCom Ltd., C=IL
-        [InlineData("cbb522d7b7f127ad6a0113865bdf1cd4102e7d0759af635a7cf4720dc963c53b")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3
-        [InlineData("d7a7a0fb5d7e2731d771e9484ebcdef71d5f0c3e0a2948782bc83ee0ea699ef4")]  // CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, S=Greater Manchester, C=GB
-        [InlineData("e793c9b02fd8aa13e21c31228accb08119643b749c898964b1746d46c3d4cbd2")]  // CN=USERTrust RSA Certification Authority, O=The USERTRUST Network, L=Jersey City, S=New Jersey, C=US
-        [InlineData("ebd41040e4bb3ec742c9e381d31ef2a41a48b6685c96e7cef3c1df6cd4331c99")]  // CN=GlobalSign Root CA, OU=Root CA, O=GlobalSign nv-sa, C=BE
+        [TestMethod]
+        [DataRow("063e4afac491dfd332f3089b8542e94617d893d7fe944e10a7937ee29d9693c0")]  // CN=Chambers of Commerce Root - 2008, O=AC Camerfirma S.A., SERIALNUMBER=A82743287, L=Madrid (see current address at www.camerfirma.com/address), C=EU
+        [DataRow("2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c")]  // CN=VeriSign Universal Root Certification Authority, OU="(c) 2008 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
+        [DataRow("2e7bf16cc22485a7bbe2aa8696750761b0ae39be3b2fe9d0cc6d4ef73491425c")]  // CN=SSL.com EV Root Certification Authority RSA R2, O=SSL Corporation, L=Houston, S=Texas, C=US
+        [DataRow("3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")]  // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+        [DataRow("43df5774b03e7fef5fe40d931a7bedf1bb2e6b42738c4e6d3841103d3aa7f339")]  // CN=Entrust Root Certification Authority - G2, OU="(c) 2009 Entrust, Inc. - for authorized use only", OU=See www.entrust.net/legal-terms, O="Entrust, Inc.", C=US
+        [DataRow("45140b3247eb9cc8c5b4f0d7b53091f73292089e6e5a63e2749dd3aca9198eda")]  // CN=Go Daddy Root Certificate Authority - G2, O="GoDaddy.com, Inc.", L=Scottsdale, S=Arizona, C=US
+        [DataRow("4b03f45807ad70f21bfc2cae71c9fde4604c064cf5ffb686bae5dbaad7fdd34c")]  // CN=thawte Primary Root CA - G3, OU="(c) 2008 thawte, Inc. - For authorized use only", OU=Certification Services Division, O="thawte, Inc.", C=US
+        [DataRow("52f0e1c4e58ec629291b60317f074671b85d7ea80d5b07273463534b32b40234")]  // CN=COMODO RSA Certification Authority, O=COMODO CA Limited, L=Salford, S=Greater Manchester, C=GB
+        [DataRow("5367f20c7ade0e2bca790915056d086b720c33c1fa2a2661acf787e3292e1270")]  // CN=Microsoft Identity Verification Root Certificate Authority 2020, O=Microsoft Corporation, C=US
+        [DataRow("552f7bdcf1a7af9e6ce672017f4f12abf77240c78e761ac203d1d9d20ac89988")]  // CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, C=US
+        [DataRow("5c58468d55f58e497e743982d2b50010b6d165374acf83a7d4a32db768c4408e")]  // CN=Certum Trusted Network CA, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
+        [DataRow("5d56499be4d2e08bcfcad08a3e38723d50503bde706948e42f55603019e528ae")]  // CN=IdenTrust Commercial Root CA 1, O=IdenTrust, C=US
+        [DataRow("7353b6d6c2d6da4247773f3f07d075decb5134212bead0928ef1f46115260941")]  // CN=DigiCert CS RSA4096 Root G5, O="DigiCert, Inc.", C=US
+        [DataRow("7431e5f4c3c1ce4690774f0b61e05440883ba9a01ed00ba6abd7806ed3b118cf")]  // CN=DigiCert High Assurance EV Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+        [DataRow("7b9d553e1c92cb6e8803e137f4f287d4363757f5d44b37d52f9fca22fb97df86")]  // CN=GlobalSign Code Signing Root R45, O=GlobalSign nv-sa, C=BE
+        [DataRow("7e76260ae69a55d3f060b0fd18b2a8c01443c87b60791030c9fa0b0585101a38")]  // CN=Sectigo Public Code Signing Root R46, O=Sectigo Limited, C=GB
+        [DataRow("85666a562ee0be5ce925c1d8890a6f76a87ec16d4d7d5f29ea7419cf20123b69")]  // CN=SSL.com Root Certification Authority RSA, O=SSL Corporation, L=Houston, S=Texas, C=US
+        [DataRow("85a0dd7dd720adb7ff05f83d542b209dc7ff4528f7d677b18389fea5e5c49e86")]  // CN=QuoVadis Root CA 2, O=QuoVadis Limited, C=BM
+        [DataRow("8d722f81a9c113c0791df136a2966db26c950a971db46b4199f4ea54b78bfb9f")]  // CN=thawte Primary Root CA, OU="(c) 2006 thawte, Inc. - For authorized use only", OU=Certification Services Division, O="thawte, Inc.", C=US
+        [DataRow("9acfab7e43c8d880d06b262a94deeee4b4659989c3d0caf19baf6405e41ab7df")]  // CN=VeriSign Class 3 Public Primary Certification Authority - G5, OU="(c) 2006 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
+        [DataRow("b676f2eddae8775cd36cb0f63cd1d4603961f49e6265ba013a2f0307b6d0b804")]  // CN=Certum Trusted Network CA 2, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
+        [DataRow("bfff8fd04433487d6a8aa60c1a29767a9fc2bbb05e420f713a13b992891d3893")]  // CN=GDCA TrustAUTH R5 ROOT, O="GUANG DONG CERTIFICATE AUTHORITY CO.,LTD.", C=CN
+        [DataRow("c3846bf24b9e93ca64274c0ec67c1ecc5e024ffcacd2d74019350e81fe546ae4")]  // OU=Go Daddy Class 2 Certification Authority, O="The Go Daddy Group, Inc.", C=US
+        [DataRow("c766a9bef2d4071c863a31aa4920e813b2d198608cb7b7cfe21143b836df09ea")]  // CN=StartCom Certification Authority, OU=Secure Digital Certificate Signing, O=StartCom Ltd., C=IL
+        [DataRow("cbb522d7b7f127ad6a0113865bdf1cd4102e7d0759af635a7cf4720dc963c53b")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3
+        [DataRow("d7a7a0fb5d7e2731d771e9484ebcdef71d5f0c3e0a2948782bc83ee0ea699ef4")]  // CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, S=Greater Manchester, C=GB
+        [DataRow("e793c9b02fd8aa13e21c31228accb08119643b749c898964b1746d46c3d4cbd2")]  // CN=USERTrust RSA Certification Authority, O=The USERTRUST Network, L=Jersey City, S=New Jersey, C=US
+        [DataRow("ebd41040e4bb3ec742c9e381d31ef2a41a48b6685c96e7cef3c1df6cd4331c99")]  // CN=GlobalSign Root CA, OU=Root CA, O=GlobalSign nv-sa, C=BE
         public void File_contains_certificates_used_in_NuGet_org_package_signatures(string expectedFingerprint)
         {
             VerifyCertificateExists(s_fingerprints, expectedFingerprint);

--- a/test/trustedroots.Tests/GivenNuGetPackagingDllAndBundleLayout.cs
+++ b/test/trustedroots.Tests/GivenNuGetPackagingDllAndBundleLayout.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Tests
     /// NuGet.Packaging.dll and the trustedroots bundle directory remain co-located in the SDK layout.
     /// Do not move either without coordinating with the NuGet team (https://github.com/NuGet/Home).
     /// </summary>
+    [TestClass]
     public class GivenNuGetPackagingDllAndBundleLayout : SdkTest
     {
         private const string ContractViolationMessage =
@@ -18,13 +19,12 @@ namespace Microsoft.DotNet.Tests
 
         private readonly string _sdkFolder;
 
-        public GivenNuGetPackagingDllAndBundleLayout(ITestOutputHelper log)
-            : base(log)
+        public GivenNuGetPackagingDllAndBundleLayout()
         {
             _sdkFolder = SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest;
         }
 
-        [Fact]
+        [TestMethod]
         public void NuGetPackagingDllIsCoLocatedWithTrustedRootsBundles()
         {
             string nugetPackagingDll = Path.Combine(_sdkFolder, "NuGet.Packaging.dll");

--- a/test/trustedroots.Tests/GivenTimestampingCtlFile.cs
+++ b/test/trustedroots.Tests/GivenTimestampingCtlFile.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.DotNet.Tests
 {
+    [TestClass]
     public class GivenTimestampingCtlFile : CtlFileTests
     {
         private static IReadOnlySet<string> s_fingerprints = null;
@@ -16,25 +17,25 @@ namespace Microsoft.DotNet.Tests
             LazyInitializer.EnsureInitialized(ref s_fingerprints, ref s_lockObject, Initialize);
         }
 
-        [Theory]
-        [InlineData("2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c")]  // CN=VeriSign Universal Root Certification Authority, OU="(c) 2008 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
-        [InlineData("2cabeafe37d06ca22aba7391c0033d25982952c453647349763a3ab5ad6ccf69")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R6
-        [InlineData("2ce1cb0bf9d2f9e102993fbe215152c3b2dd0cabde1c68e5319b839154dbb7f5")]  // CN=Starfield Root Certificate Authority - G2, O="Starfield Technologies, Inc.", L=Scottsdale, S=Arizona, C=US
-        [InlineData("3b222e566711e992300dc0b15ab9473dafdef8c84d0cef7d3317b4c1821d1436")]  // CN=SwissSign Platinum CA - G2, O=SwissSign AG, C=CH
-        [InlineData("3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")]  // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
-        [InlineData("43df5774b03e7fef5fe40d931a7bedf1bb2e6b42738c4e6d3841103d3aa7f339")]  // CN=Entrust Root Certification Authority - G2, OU="(c) 2009 Entrust, Inc. - for authorized use only", OU=See www.entrust.net/legal-terms, O="Entrust, Inc.", C=US
-        [InlineData("5367f20c7ade0e2bca790915056d086b720c33c1fa2a2661acf787e3292e1270")]  // CN=Microsoft Identity Verification Root Certificate Authority 2020, O=Microsoft Corporation, C=US
-        [InlineData("5c58468d55f58e497e743982d2b50010b6d165374acf83a7d4a32db768c4408e")]  // CN=Certum Trusted Network CA, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
-        [InlineData("5d56499be4d2e08bcfcad08a3e38723d50503bde706948e42f55603019e528ae")]  // CN=IdenTrust Commercial Root CA 1, O=IdenTrust, C=US
-        [InlineData("6dc47172e01cbcb0bf62580d895fe2b8ac9ad4f873801e0c10b9c837d21eb177")]  // CN=Entrust.net Certification Authority (2048), OU=(c) 1999 Entrust.net Limited, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), O=Entrust.net
-        [InlineData("6fff78e400a70c11011cd85977c459fb5af96a3df0540820d0f4b8607875e58f")]  // CN=UTN-USERFirst-Object, OU=http://www.usertrust.com, O=The USERTRUST Network, L=Salt Lake City, S=UT, C=US
-        [InlineData("85666a562ee0be5ce925c1d8890a6f76a87ec16d4d7d5f29ea7419cf20123b69")]  // CN=SSL.com Root Certification Authority RSA, O=SSL Corporation, L=Houston, S=Texas, C=US
-        [InlineData("8a866fd1b276b57e578e921c65828a2bed58e9f2f288054134b7f1f4bfc9cc74")]  // CN=QuoVadis Root CA 1 G3, O=QuoVadis Limited, C=BM
-        [InlineData("a45ede3bbbf09c8ae15c72efc07268d693a21c996fd51e67ca079460fd6d8873")]  // CN=QuoVadis Root Certification Authority, OU=Root Certification Authority, O=QuoVadis Limited, C=BM
-        [InlineData("cbb522d7b7f127ad6a0113865bdf1cd4102e7d0759af635a7cf4720dc963c53b")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3
-        [InlineData("d7a7a0fb5d7e2731d771e9484ebcdef71d5f0c3e0a2948782bc83ee0ea699ef4")]  // CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, S=Greater Manchester, C=GB
-        [InlineData("e793c9b02fd8aa13e21c31228accb08119643b749c898964b1746d46c3d4cbd2")]  // CN=USERTrust RSA Certification Authority, O=The USERTRUST Network, L=Jersey City, S=New Jersey, C=US
-        [InlineData("ebd41040e4bb3ec742c9e381d31ef2a41a48b6685c96e7cef3c1df6cd4331c99")]  // CN=GlobalSign Root CA, OU=Root CA, O=GlobalSign nv-sa, C=BE
+        [TestMethod]
+        [DataRow("2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c")]  // CN=VeriSign Universal Root Certification Authority, OU="(c) 2008 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network, O="VeriSign, Inc.", C=US
+        [DataRow("2cabeafe37d06ca22aba7391c0033d25982952c453647349763a3ab5ad6ccf69")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R6
+        [DataRow("2ce1cb0bf9d2f9e102993fbe215152c3b2dd0cabde1c68e5319b839154dbb7f5")]  // CN=Starfield Root Certificate Authority - G2, O="Starfield Technologies, Inc.", L=Scottsdale, S=Arizona, C=US
+        [DataRow("3b222e566711e992300dc0b15ab9473dafdef8c84d0cef7d3317b4c1821d1436")]  // CN=SwissSign Platinum CA - G2, O=SwissSign AG, C=CH
+        [DataRow("3e9099b5015e8f486c00bcea9d111ee721faba355a89bcf1df69561e3dc6325c")]  // CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
+        [DataRow("43df5774b03e7fef5fe40d931a7bedf1bb2e6b42738c4e6d3841103d3aa7f339")]  // CN=Entrust Root Certification Authority - G2, OU="(c) 2009 Entrust, Inc. - for authorized use only", OU=See www.entrust.net/legal-terms, O="Entrust, Inc.", C=US
+        [DataRow("5367f20c7ade0e2bca790915056d086b720c33c1fa2a2661acf787e3292e1270")]  // CN=Microsoft Identity Verification Root Certificate Authority 2020, O=Microsoft Corporation, C=US
+        [DataRow("5c58468d55f58e497e743982d2b50010b6d165374acf83a7d4a32db768c4408e")]  // CN=Certum Trusted Network CA, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
+        [DataRow("5d56499be4d2e08bcfcad08a3e38723d50503bde706948e42f55603019e528ae")]  // CN=IdenTrust Commercial Root CA 1, O=IdenTrust, C=US
+        [DataRow("6dc47172e01cbcb0bf62580d895fe2b8ac9ad4f873801e0c10b9c837d21eb177")]  // CN=Entrust.net Certification Authority (2048), OU=(c) 1999 Entrust.net Limited, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), O=Entrust.net
+        [DataRow("6fff78e400a70c11011cd85977c459fb5af96a3df0540820d0f4b8607875e58f")]  // CN=UTN-USERFirst-Object, OU=http://www.usertrust.com, O=The USERTRUST Network, L=Salt Lake City, S=UT, C=US
+        [DataRow("85666a562ee0be5ce925c1d8890a6f76a87ec16d4d7d5f29ea7419cf20123b69")]  // CN=SSL.com Root Certification Authority RSA, O=SSL Corporation, L=Houston, S=Texas, C=US
+        [DataRow("8a866fd1b276b57e578e921c65828a2bed58e9f2f288054134b7f1f4bfc9cc74")]  // CN=QuoVadis Root CA 1 G3, O=QuoVadis Limited, C=BM
+        [DataRow("a45ede3bbbf09c8ae15c72efc07268d693a21c996fd51e67ca079460fd6d8873")]  // CN=QuoVadis Root Certification Authority, OU=Root Certification Authority, O=QuoVadis Limited, C=BM
+        [DataRow("cbb522d7b7f127ad6a0113865bdf1cd4102e7d0759af635a7cf4720dc963c53b")]  // CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3
+        [DataRow("d7a7a0fb5d7e2731d771e9484ebcdef71d5f0c3e0a2948782bc83ee0ea699ef4")]  // CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, S=Greater Manchester, C=GB
+        [DataRow("e793c9b02fd8aa13e21c31228accb08119643b749c898964b1746d46c3d4cbd2")]  // CN=USERTrust RSA Certification Authority, O=The USERTRUST Network, L=Jersey City, S=New Jersey, C=US
+        [DataRow("ebd41040e4bb3ec742c9e381d31ef2a41a48b6685c96e7cef3c1df6cd4331c99")]  // CN=GlobalSign Root CA, OU=Root CA, O=GlobalSign nv-sa, C=BE
         public void File_contains_certificates_used_in_NuGet_org_package_signatures(string expectedFingerprint)
         {
             VerifyCertificateExists(s_fingerprints, expectedFingerprint);

--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -1,16 +1,17 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
     <CanRunTestAsTool>false</CanRunTestAsTool>
     <OutputPath>$(TestHostFolder)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

Covers three small projects. Microsoft.DotNet.MSBuildSdkResolver.Tests disables parallelization ([assembly: DoNotParallelize] + empty MSTestParallelizeScope) to preserve the previous xUnit CollectionBehavior(DisableTestParallelization = true).

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
