### PR TITLE
Migrate Microsoft.DotNet.Cli.Utils.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/ArgumentEscaperTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/ArgumentEscaperTests.cs
@@ -3,21 +3,22 @@
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class ArgumentEscaperTests
     {
-        [Theory]
-        [InlineData(new[] { "one", "two", "three" }, "one two three")]
-        [InlineData(new[] { "line1\nline2", "word1\tword2" }, "\"line1\nline2\" \"word1\tword2\"")]
-        [InlineData(new[] { "with spaces" }, "\"with spaces\"")]
-        [InlineData(new[] { @"with\backslash" }, @"with\backslash")]
-        [InlineData(new[] { @"""quotedwith\backslash""" }, @"\""quotedwith\backslash\""")]
-        [InlineData(new[] { @"C:\Users\" }, @"C:\Users\")]
-        [InlineData(new[] { @"C:\Program Files\dotnet\" }, @"""C:\Program Files\dotnet\\""")]
-        [InlineData(new[] { @"backslash\""preceedingquote" }, @"backslash\\\""preceedingquote")]
-        [InlineData(new[] { @""" hello """ }, @"""\"" hello \""""")]
+        [TestMethod]
+        [DataRow(new[] { "one", "two", "three" }, "one two three")]
+        [DataRow(new[] { "line1\nline2", "word1\tword2" }, "\"line1\nline2\" \"word1\tword2\"")]
+        [DataRow(new[] { "with spaces" }, "\"with spaces\"")]
+        [DataRow(new[] { @"with\backslash" }, @"with\backslash")]
+        [DataRow(new[] { @"""quotedwith\backslash""" }, @"\""quotedwith\backslash\""")]
+        [DataRow(new[] { @"C:\Users\" }, @"C:\Users\")]
+        [DataRow(new[] { @"C:\Program Files\dotnet\" }, @"""C:\Program Files\dotnet\\""")]
+        [DataRow(new[] { @"backslash\""preceedingquote" }, @"backslash\\\""preceedingquote")]
+        [DataRow(new[] { @""" hello """ }, @"""\"" hello \""""")]
         public void EscapesArgumentsForProcessStart(string[] args, string expected)
         {
-            Assert.Equal(expected, ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
+            Assert.AreEqual(expected, ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/BlockingMemoryStreamTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/BlockingMemoryStreamTests.cs
@@ -3,12 +3,13 @@
 
 namespace Microsoft.DotNet.Cli.Utils
 {
+    [TestClass]
     public class BlockingMemoryStreamTests
     {
         /// <summary>
         /// Tests reading a bigger buffer than what is available.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ReadBiggerBuffer()
         {
             using (var stream = new BlockingMemoryStream())
@@ -17,17 +18,17 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 byte[] buffer = new byte[10];
                 int count = stream.Read(buffer, 0, buffer.Length);
-                Assert.Equal(3, count);
-                Assert.Equal(1, buffer[0]);
-                Assert.Equal(2, buffer[1]);
-                Assert.Equal(3, buffer[2]);
+                Assert.AreEqual(3, count);
+                Assert.AreEqual(1, buffer[0]);
+                Assert.AreEqual(2, buffer[1]);
+                Assert.AreEqual(3, buffer[2]);
             }
         }
 
         /// <summary>
         /// Tests reading smaller buffers than what is available.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void ReadSmallerBuffers()
         {
             using (var stream = new BlockingMemoryStream())
@@ -38,32 +39,32 @@ namespace Microsoft.DotNet.Cli.Utils
                 byte[] buffer = new byte[3];
 
                 int count = stream.Read(buffer, 0, buffer.Length);
-                Assert.Equal(3, count);
-                Assert.Equal(1, buffer[0]);
-                Assert.Equal(2, buffer[1]);
-                Assert.Equal(3, buffer[2]);
+                Assert.AreEqual(3, count);
+                Assert.AreEqual(1, buffer[0]);
+                Assert.AreEqual(2, buffer[1]);
+                Assert.AreEqual(3, buffer[2]);
 
                 count = stream.Read(buffer, 0, buffer.Length);
-                Assert.Equal(1, count);
-                Assert.Equal(4, buffer[0]);
+                Assert.AreEqual(1, count);
+                Assert.AreEqual(4, buffer[0]);
 
                 count = stream.Read(buffer, 0, buffer.Length);
-                Assert.Equal(3, count);
-                Assert.Equal(5, buffer[0]);
-                Assert.Equal(6, buffer[1]);
-                Assert.Equal(7, buffer[2]);
+                Assert.AreEqual(3, count);
+                Assert.AreEqual(5, buffer[0]);
+                Assert.AreEqual(6, buffer[1]);
+                Assert.AreEqual(7, buffer[2]);
 
                 count = stream.Read(buffer, 0, buffer.Length);
-                Assert.Equal(2, count);
-                Assert.Equal(8, buffer[0]);
-                Assert.Equal(9, buffer[1]);
+                Assert.AreEqual(2, count);
+                Assert.AreEqual(8, buffer[0]);
+                Assert.AreEqual(9, buffer[1]);
             }
         }
 
         /// <summary>
         /// Tests reading will block until the stream is written to.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void TestReadBlocksUntilWrite()
         {
             using (var stream = new BlockingMemoryStream())
@@ -77,10 +78,10 @@ namespace Microsoft.DotNet.Cli.Utils
                     readerThreadExecuting.Set();
                     int count = stream.Read(buffer, 0, buffer.Length);
 
-                    Assert.Equal(3, count);
-                    Assert.Equal(1, buffer[0]);
-                    Assert.Equal(2, buffer[1]);
-                    Assert.Equal(3, buffer[2]);
+                    Assert.AreEqual(3, count);
+                    Assert.AreEqual(1, buffer[0]);
+                    Assert.AreEqual(2, buffer[1]);
+                    Assert.AreEqual(3, buffer[2]);
 
                     readerThreadSuccessful = true;
                 })
@@ -92,16 +93,16 @@ namespace Microsoft.DotNet.Cli.Utils
                 // ensure the thread is executing
                 readerThreadExecuting.WaitOne();
 
-                Assert.True(readerThread.IsAlive);
+                Assert.IsTrue(readerThread.IsAlive);
 
                 // give it a little while to ensure it is blocking
                 Thread.Sleep(10);
-                Assert.True(readerThread.IsAlive);
+                Assert.IsTrue(readerThread.IsAlive);
 
                 stream.Write(new byte[] { 1, 2, 3 }, 0, 3);
 
-                Assert.True(readerThread.Join(1000));
-                Assert.True(readerThreadSuccessful);
+                Assert.IsTrue(readerThread.Join(1000));
+                Assert.IsTrue(readerThreadSuccessful);
             }
         }
     }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/BuiltInCommandTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/BuiltInCommandTests.cs
@@ -5,13 +5,14 @@
 
 namespace Microsoft.DotNet.Cli.Utils
 {
+    [TestClass]
     public class BuiltInCommandTests
     {
         /// <summary>
         /// Tests that BuiltInCommand.Execute returns the correct exit code and a
         /// valid StartInfo FileName and Arguments.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void TestExecute()
         {
             Func<string[], int> testCommand = args => args.Length;
@@ -20,16 +21,16 @@ namespace Microsoft.DotNet.Cli.Utils
             var builtInCommand = new BuiltInCommand("fakeCommand", testCommandArgs, testCommand, new TestBuiltInCommandEnvironment());
             CommandResult result = builtInCommand.Execute();
 
-            Assert.Equal(testCommandArgs.Length, result.ExitCode);
-            Assert.Equal(new Muxer().MuxerPath, result.StartInfo.FileName);
-            Assert.Equal("fakeCommand 1 2", result.StartInfo.Arguments);
+            Assert.AreEqual(testCommandArgs.Length, result.ExitCode);
+            Assert.AreEqual(new Muxer().MuxerPath, result.StartInfo.FileName);
+            Assert.AreEqual("fakeCommand 1 2", result.StartInfo.Arguments);
         }
 
         /// <summary>
         /// Tests that BuiltInCommand.Execute raises the OnOutputLine and OnErrorLine
         /// the correct number of times and with the correct content.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void TestOnOutputLines()
         {
             const int exitCode = 29;
@@ -60,11 +61,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (onOutputLineCallCount == 1)
                     {
-                        Assert.Equal($"firstsecond", line);
+                        Assert.AreEqual($"firstsecond", line);
                     }
                     else
                     {
-                        Assert.Equal($"third", line);
+                        Assert.AreEqual($"third", line);
                     }
                 })
                 .OnErrorLine(line =>
@@ -73,18 +74,18 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (onErrorLineCallCount == 1)
                     {
-                        Assert.Equal($"fourth", line);
+                        Assert.AreEqual($"fourth", line);
                     }
                     else
                     {
-                        Assert.Equal($"fifth", line);
+                        Assert.AreEqual($"fifth", line);
                     }
                 })
                 .Execute();
 
-            Assert.Equal(exitCode, result.ExitCode);
-            Assert.Equal(2, onOutputLineCallCount);
-            Assert.Equal(2, onErrorLineCallCount);
+            Assert.AreEqual(exitCode, result.ExitCode);
+            Assert.AreEqual(2, onOutputLineCallCount);
+            Assert.AreEqual(2, onErrorLineCallCount);
         }
 
         private class TestBuiltInCommandEnvironment : IBuiltInCommandEnvironment

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/DangerousFileDetectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/DangerousFileDetectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -9,18 +9,20 @@ using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class DangerousFileDetectorTests : SdkTest
     {
         private const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
 
-        public DangerousFileDetectorTests(ITestOutputHelper log) : base(log)
+        public DangerousFileDetectorTests()
         {
         }
 
 #if NETCOREAPP
         [SupportedOSPlatform("windows")]
 #endif
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItShouldDetectFileWithMarkOfTheWeb()
         {
             var testFile = Path.Combine(TestAssetsManager.CreateTestDirectory().Path, Path.GetRandomFileName());
@@ -42,7 +44,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenThereIsNoFileItReturnsFalse()
         {
             var testFile = Path.Combine(TestAssetsManager.CreateTestDirectory().Path, Path.GetRandomFileName());
@@ -50,7 +52,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             new DangerousFileDetector().IsDangerous(testFile).Should().BeFalse();
         }
 
-        [UnixOnlyFact]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
         public void WhenRunOnNonWindowsReturnFalse()
         {
             var testFile = Path.Combine(TestAssetsManager.CreateTestDirectory().Path, Path.GetRandomFileName());

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
@@ -8,21 +8,24 @@ using Microsoft.Win32;
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
 #pragma warning disable CA1416
+    [TestClass]
     public class DependencyProviderTests
     {
-        [WindowsOnlyTheory]
-        [InlineData(false, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_CURRENT_USER")]
-        [InlineData(true, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_LOCAL_MACHINE")]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_CURRENT_USER")]
+        [DataRow(true, "NET.CORE.SDK,v6.0", @"SOFTWARE\Classes\Installer\Dependencies\NET.CORE.SDK,v6.0\Dependents", "HKEY_LOCAL_MACHINE")]
         public void ProviderProperties(bool allUsers, string providerKeyName, string expectedDependentsKeyPath, string expectedBaseKeyName)
         {
             DependencyProvider dep = new(providerKeyName, allUsers);
 
-            Assert.Equal(expectedDependentsKeyPath, dep.DependentsKeyPath);
-            Assert.Equal(expectedBaseKeyName, dep.BaseKey.Name);
-            Assert.Equal(providerKeyName, dep.ProviderKeyName);
+            Assert.AreEqual(expectedDependentsKeyPath, dep.DependentsKeyPath);
+            Assert.AreEqual(expectedBaseKeyName, dep.BaseKey.Name);
+            Assert.AreEqual(providerKeyName, dep.ProviderKeyName);
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItCanAddDependents()
         {
             // We cannot create per-machine entries unless the tests run elevated. The results are the
@@ -32,12 +35,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             try
             {
                 // We should not have any dependents
-                Assert.Empty(dep.Dependents);
+                Assert.IsEmpty(dep.Dependents);
 
                 dep.AddDependent("Microsoft.NET.SDK,v6.0.100");
 
-                Assert.Single(dep.Dependents);
-                Assert.Equal("Microsoft.NET.SDK,v6.0.100", dep.Dependents.First());
+                Assert.ContainsSingle(dep.Dependents);
+                Assert.AreEqual("Microsoft.NET.SDK,v6.0.100", dep.Dependents.First());
             }
             finally
             {
@@ -45,7 +48,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItCanFindVisualStudioDependents()
         {
             DependencyProvider dep = new(".NET_SDK_TEST_PROVIDER_KEY", allUsers: false);
@@ -53,12 +57,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             try
             {
                 // We should not have any dependents
-                Assert.Empty(dep.Dependents);
+                Assert.IsEmpty(dep.Dependents);
 
                 // Write the VS dependents key
                 dep.AddDependent(DependencyProvider.VisualStudioDependentKeyName);
 
-                Assert.True(dep.HasVisualStudioDependency);
+                Assert.IsTrue(dep.HasVisualStudioDependency);
             }
             finally
             {
@@ -66,7 +70,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItWillNotRemoveTheProviderIfOtherDependentsExist()
         {
             DependencyProvider dep = new(".NET_SDK_TEST_PROVIDER_KEY", allUsers: false);
@@ -77,11 +82,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 dep.AddDependent(DependencyProvider.VisualStudioDependentKeyName);
                 dep.AddDependent("Microsoft.NET.SDK,v6.0.100");
 
-                Assert.Equal(2, dep.Dependents.Count());
+                Assert.HasCount(2, dep.Dependents);
 
                 dep.RemoveDependent("Microsoft.NET.SDK,v6.0.100", removeProvider: true);
 
-                Assert.True(dep.HasVisualStudioDependency);
+                Assert.IsTrue(dep.HasVisualStudioDependency);
             }
             finally
             {
@@ -89,7 +94,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItReturnsNullIfProductCodeDoesNotExist()
         {
             string providerKeyName = "Microsoft.NET.Test.Pack";
@@ -98,7 +104,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             try
             {
-                Assert.Null(dep.ProductCode);
+                Assert.IsNull(dep.ProductCode);
             }
             finally
             {
@@ -106,7 +112,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItCanRetrieveTheProductCodeFromTheProviderKey()
         {
             string providerKeyName = "Microsoft.NET.Test.Pack";
@@ -117,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             try
             {
-                Assert.Equal(productCode, dep.ProductCode);
+                Assert.AreEqual(productCode, dep.ProductCode);
             }
             finally
             {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/DotDefaultPathCorrectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/DotDefaultPathCorrectorTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Cli.Utils
 {
+    [TestClass]
     public class DotDefaultPathCorrectorTests
     {
-        [Fact]
+        [TestMethod]
         public void ItCanCorrectDotDefaultPath()
         {
             var existingPath = @"C:\Users\myname\AppData\Local\Microsoft\WindowsApps;C:\Users\myname\.dotnet\tools";
@@ -13,21 +14,21 @@ namespace Microsoft.DotNet.Cli.Utils
             correctPath.Should().Be(@"%USERPROFILE%\AppData\Local\Microsoft\WindowsApps");
         }
 
-        [Fact]
+        [TestMethod]
         public void ItCanTellNoCorrectionNeeded()
         {
             var existingPath = @"C:\Users\myname\AppData\Local\Microsoft\WindowsApps;";
             DotDefaultPathCorrector.NeedCorrection(existingPath, out string _).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenEmptyItCanTellNoCorrectionNeeded()
         {
             var existingPath = "";
             DotDefaultPathCorrector.NeedCorrection(existingPath, out string _).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenSubsequencePathItCanCorrectDotDefaultPath()
         {
             var existingPath =
@@ -36,7 +37,7 @@ namespace Microsoft.DotNet.Cli.Utils
             correctPath.Should().Be(@"%USERPROFILE%\AppData\Local\Microsoft\WindowsApps;%USERPROFILE%\other");
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenSubsequencePathWithExtraFormatItCanCorrectDotDefaultPath()
         {
             var existingPath =
@@ -45,14 +46,14 @@ namespace Microsoft.DotNet.Cli.Utils
             correctPath.Should().Be(@"%USERPROFILE%\AppData\Local\Microsoft\WindowsApps;%USERPROFILE%\other");
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenNoToolPathItCanTellNoCorrectionNeeded()
         {
             var existingPath = @"C:\Users\myname\AppData\Local\Microsoft\WindowsApps;C:\Users\myname\other";
             DotDefaultPathCorrector.NeedCorrection(existingPath, out string _).Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void Given2InstallationItCanCorrectDotDefaultPath()
         {
             var existingPath = @"C:\Users\user1\AppData\Local\Microsoft\WindowsApps;C:\Users\user2\AppData\otherapp;C:\Users\user1\.dotnet\tools;C:\Users\user2\.dotnet\tools";

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAFrameworkDependencyFile.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAFrameworkDependencyFile.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenAFrameworkDependencyFile
     {
         private readonly IReadOnlyList<RuntimeFallbacks> _testRuntimeGraph;
@@ -22,7 +23,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             };
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRid()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -36,7 +37,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRid2()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -50,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersAndCurrentRuntimeIdentifierIsNullReturnsFalse()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRidWithCasingPreserved()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -76,7 +77,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("Win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersWithDuplicationItOutMostFitRid()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -90,7 +91,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralCompatibleRuntimeIdentifiersAndDuplicationItOutMostFitRidWithCasingPreservedTheFirstIsFavorited()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -104,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("Win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenPassSeveralNonCompatibleRuntimeIdentifiersItReturnsFalse()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -116,7 +117,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCurrentRuntimeIdentifierIsNotSupportedItUsesAlternative()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
@@ -130,7 +131,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             mostFitRid.Should().Be("win");
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenCurrentRuntimeIdentifierIsNotSupportedSoIsTheAlternativeItReturnsFalse()
         {
             FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAppThrowingException.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAppThrowingException.cs
@@ -3,13 +3,15 @@
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class GivenAppThrowingException : SdkTest
     {
-        public GivenAppThrowingException(ITestOutputHelper log) : base(log)
+        public GivenAppThrowingException()
         {
         }
 
-        [RequiresSpecificFrameworkFact("netcoreapp1.1")]
+        [TestMethod]
+        [RequiresSpecificFramework("netcoreapp1.1")]
         public void ItShowsStackTraceWhenRun()
         {
             var root = TestAssetsManager.CopyTestAsset("AppThrowingException", testAssetSubdirectory: TestAssetSubdirectories.NonRestoredTestProjects)
@@ -29,7 +31,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                          .And.HaveStdErrContaining(msg2);
         }
 
-        [RequiresSpecificFrameworkFact("netcoreapp1.1")]
+        [TestMethod]
+        [RequiresSpecificFramework("netcoreapp1.1")]
         public void ItShowsStackTraceWhenRunAsTool()
         {
             var root = TestAssetsManager.CopyTestAsset("AppThrowingException", testAssetSubdirectory: TestAssetSubdirectories.NonRestoredTestProjects)

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -1,14 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
   <!-- Windows-only test files that reference types excluded on non-Windows -->

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/MockFileSystemTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/MockFileSystemTests.cs
@@ -6,11 +6,12 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class MockFileSystemTests
     {
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DirectoryExistsShouldCountTheSameNameFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -21,9 +22,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.Exists(nestedFilePath).Should().BeFalse();
         }
 
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DifferentDirectorySeparatorShouldBeSameFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -35,9 +37,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists($"{directory}/filename").Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDirectoryExistsShouldCreateEmptyFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -49,9 +51,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists(nestedFilePath).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDirectoryDoesNotExistsCreateEmptyFileShouldThrow(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -64,9 +66,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DirectoryExistsWithRelativePathShouldCountTheSameNameFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -77,9 +79,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists(Path.Combine(directory, "file")).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WithRelativePathShouldCreateDirectory(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -90,9 +92,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.Exists(Path.Combine(directory, "dir")).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void ShouldCreateDirectory(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -102,9 +104,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.Exists(directory).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CreateDirectoryWhenExistsShouldNotThrow(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -115,9 +117,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().NotThrow();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CreateDirectoryWhenExistsSameNameFileShouldThrow(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -130,9 +132,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<IOException>();
         }
 
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DirectoryDoesNotExistShouldThrow(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -143,9 +146,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<DirectoryNotFoundException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void FileReadAllTextWhenExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -157,9 +160,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.ReadAllText(path).Should().Be(content);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void FileThrowsWhenTryToReadNonExistFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -170,9 +173,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void FileThrowsWhenTryToReadADictionary(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -185,9 +188,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void FileOpenReadWhenExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -211,9 +214,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fullString.Should().StartWith(content);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void MoveFileWhenBothSourceAndDestinationExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -228,9 +231,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists(destinationFile).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void MoveFileThrowsWhenSourceDoesNotExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -244,9 +247,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void MoveFileThrowsWhenSourceIsADirectory(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -261,9 +264,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void MoveFileThrowsWhenDestinationDirectoryDoesNotExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -279,9 +282,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .And.Message.Should().Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CopyFileWhenBothSourceAndDestinationDirectoryExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -295,9 +298,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.ReadAllText(sourceFile).Should().Be(fileSystem.File.ReadAllText(destinationFile));
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CopyFileThrowsWhenSourceDoesNotExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -310,9 +313,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<FileNotFoundException>().And.Message.Should().Contain("Could not find file");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CopyFileThrowsWhenSourceIsADirectory(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -326,9 +329,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<UnauthorizedAccessException>().And.Message.Should().Contain("Access to the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CopyFileThrowsWhenDestinationDirectoryDoesNotExist(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -343,9 +346,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .And.Message.Should().Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void CopyFileThrowsWhenDestinationExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -361,9 +364,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .And.Message.Should().Contain("already exists");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DeleteFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -376,9 +379,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists(file).Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DeleteFileShouldNotThrowWhenFileDoesNotExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -393,9 +396,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         // https://github.com/dotnet/corefx/issues/32110
         // It behaves differently on Windows Vs Non Windows
         // Use Windows behavior since it is more strict
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void DeleteFileShouldNotThrowWhenDirectoryDoesNotExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -407,9 +411,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<DirectoryNotFoundException>().And.Message.Should().Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void EnumerateAllFilesThrowsWhenDirectoryDoesNotExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -422,9 +426,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void EnumerateAllFilesThrowsWhenPathIsAFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -440,9 +444,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<IOException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenEmptyEnumerateAllFiles(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -453,9 +457,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.EnumerateFiles(emptyDirectory).Should().BeEmpty();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenFilesExistEnumerateAllFiles(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -473,9 +477,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void EnumerateFileSystemEntriesThrowsWhenDirectoryDoesNotExists(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -488,9 +492,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void EnumerateFileSystemEntriesThrowsWhenPathIsAFile(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -506,9 +510,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<IOException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenEmptyEnumerateFileSystemEntries(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -519,9 +523,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.EnumerateFileSystemEntries(emptyDirectory).Should().BeEmpty();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenFilesExistEnumerateFileSystemEntries(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -541,11 +545,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.EnumerateFileSystemEntries(testDirectory).Should().Contain(nestedDirectoryPath);
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
+        [TestMethod]
+        [DataRow(false, false)]
+        [DataRow(false, true)]
+        [DataRow(true, true)]
+        [DataRow(true, false)]
         public void WhenDirectoryExistsItDeleteDirectory(bool testMockBehaviorIsInSync, bool recursive)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -557,11 +561,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.Directory.Exists(testDirectory).Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
+        [TestMethod]
+        [DataRow(false, false)]
+        [DataRow(false, true)]
+        [DataRow(true, true)]
+        [DataRow(true, false)]
         public void WhenDirectoryDoesNotExistsDirectoryDeleteThrows(bool testMockBehaviorIsInSync, bool recursive)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -573,11 +577,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
+        [TestMethod]
+        [DataRow(false, false)]
+        [DataRow(false, true)]
+        [DataRow(true, true)]
+        [DataRow(true, false)]
         public void WhenDirectoryPathIsAFileDirectoryDeleteThrows(bool testMockBehaviorIsInSync, bool recursive)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -589,9 +593,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             action.Should().Throw<IOException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDirectoryPathHasAFileAndNonRecursiveDirectoryDeleteThrows(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -608,9 +612,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             action.Should().Throw<IOException>().And.Message.Should().Contain("not empty");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDirectoryPathHasAFileAndRecursiveItDeletes(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -625,9 +629,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenItMovesDirectory(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -647,9 +651,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             fileSystem.File.Exists(Path.Combine(testDestinationDirectoryPath, nestedFilePath)).Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenSourcePathDoesNotExistsDirectoryMoveThrows(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -663,9 +667,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Contain("Could not find a part of the path");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDestinationDirectoryPathExistsDirectoryMoveThrows(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -680,9 +684,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<IOException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenDestinationDirectoryPathIsAFileDirectoryMoveThrows(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);
@@ -697,9 +701,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             a.Should().Throw<IOException>();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void WhenSourceAndDestinationPathIsTheSameDirectoryMoveThrows(bool testMockBehaviorIsInSync)
         {
             IFileSystem fileSystem = SetupSubjectFileSystem(testMockBehaviorIsInSync);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/NuGetTransientErrorDetectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/NuGetTransientErrorDetectorTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class NuGetTransientErrorDetectorTests
     {
-        [Fact]
+        [TestMethod]
         public void Error1()
         {
             string input =
@@ -63,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             NuGetTransientErrorDetector.IsTransientError(input).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void Error2()
         {
             string input =
@@ -81,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             NuGetTransientErrorDetector.IsTransientError(input).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void Error3()
         {
             string input =
@@ -100,7 +101,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             NuGetTransientErrorDetector.IsTransientError(input).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public void NoTransientError()
         {
             string input =

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/PathUtilityTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/PathUtilityTests.cs
@@ -3,40 +3,44 @@
 
 namespace Microsoft.DotNet.Cli.Utils
 {
+    [TestClass]
     public class PathUtilityTests
     {
         /// <summary>
         /// Tests that PathUtility.GetRelativePath treats drive references as case insensitive on Windows.
         /// </summary>
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void GetRelativePathWithCaseInsensitiveDrives()
         {
-            Assert.Equal(@"bar\", PathUtility.GetRelativePath(@"C:\foo\", @"C:\foo\bar\"));
-            Assert.Equal(@"Bar\Baz\", PathUtility.GetRelativePath(@"c:\foo\", @"C:\Foo\Bar\Baz\"));
-            Assert.Equal(@"baz\Qux\", PathUtility.GetRelativePath(@"C:\fOO\bar\", @"c:\foo\BAR\baz\Qux\"));
-            Assert.Equal(@"d:\foo\", PathUtility.GetRelativePath(@"C:\foo\", @"d:\foo\"));
+            Assert.AreEqual(@"bar\", PathUtility.GetRelativePath(@"C:\foo\", @"C:\foo\bar\"));
+            Assert.AreEqual(@"Bar\Baz\", PathUtility.GetRelativePath(@"c:\foo\", @"C:\Foo\Bar\Baz\"));
+            Assert.AreEqual(@"baz\Qux\", PathUtility.GetRelativePath(@"C:\fOO\bar\", @"c:\foo\BAR\baz\Qux\"));
+            Assert.AreEqual(@"d:\foo\", PathUtility.GetRelativePath(@"C:\foo\", @"d:\foo\"));
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void GetRelativePathForFilePath()
         {
-            Assert.Equal(
+            Assert.AreEqual(
                 $@"mytool\1.0.1\mytool\1.0.1\tools\{ToolsetInfo.CurrentTargetFramework}\any\mytool.dll",
                 PathUtility.GetRelativePath(
                     @"C:\Users\myuser\.dotnet\tools\mytool.exe",
                     $@"C:\Users\myuser\.dotnet\tools\mytool\1.0.1\mytool\1.0.1\tools\{ToolsetInfo.CurrentTargetFramework}\any\mytool.dll"));
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void GetRelativePathRequireTrailingSlashForDirectoryPath()
         {
-            Assert.NotEqual(
+            Assert.AreNotEqual(
                 $@"mytool\1.0.1\mytool\1.0.1\tools\{ToolsetInfo.CurrentTargetFramework}\any\mytool.dll",
                 PathUtility.GetRelativePath(
                     @"C:\Users\myuser\.dotnet\tools",
                     $@"C:\Users\myuser\.dotnet\tools\mytool\1.0.1\mytool\1.0.1\tools\{ToolsetInfo.CurrentTargetFramework}\any\mytool.dll"));
 
-            Assert.Equal(
+            Assert.AreEqual(
                 $@"mytool\1.0.1\mytool\1.0.1\tools\{ToolsetInfo.CurrentTargetFramework}\any\mytool.dll",
                 PathUtility.GetRelativePath(
                     @"C:\Users\myuser\.dotnet\tools\",
@@ -46,11 +50,12 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <summary>
         /// Tests that PathUtility.RemoveExtraPathSeparators works correctly with drive references on Windows.
         /// </summary>
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void RemoveExtraPathSeparatorsWithDrives()
         {
-            Assert.Equal(@"c:\foo\bar\baz\", PathUtility.RemoveExtraPathSeparators(@"c:\\\foo\\\\bar\baz\\"));
-            Assert.Equal(@"D:\QUX\", PathUtility.RemoveExtraPathSeparators(@"D:\\\\\QUX\"));
+            Assert.AreEqual(@"c:\foo\bar\baz\", PathUtility.RemoveExtraPathSeparators(@"c:\\\foo\\\\bar\baz\\"));
+            Assert.AreEqual(@"D:\QUX\", PathUtility.RemoveExtraPathSeparators(@"D:\\\\\QUX\"));
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/ProcessExtensionsTests.cs
@@ -12,9 +12,11 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 #if NET
     [SupportedOSPlatform("windows")]
 #endif
+    [TestClass]
     public class ProcessExtensionsTests
     {
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void ItReturnsTheParentProcessId()
         {
             int expectedParentProcessId = Process.GetCurrentProcess().Id;
@@ -27,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             int ppid = parentProcess.Id;
             childProcess.Kill();
 
-            Assert.Equal(expectedParentProcessId, ppid);
+            Assert.AreEqual(expectedParentProcessId, ppid);
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/RuntimeEnvironmentTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/RuntimeEnvironmentTests.cs
@@ -1,50 +1,54 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class RuntimeEnvironmentTests : SdkTest
     {
-        public RuntimeEnvironmentTests(ITestOutputHelper log) : base(log)
+        public RuntimeEnvironmentTests()
         {
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void VerifyWindows()
         {
-            Assert.Equal(Platform.Windows, RuntimeEnvironment.OperatingSystemPlatform);
-            Assert.Equal("Windows", RuntimeEnvironment.OperatingSystem);
+            Assert.AreEqual(Platform.Windows, RuntimeEnvironment.OperatingSystemPlatform);
+            Assert.AreEqual("Windows", RuntimeEnvironment.OperatingSystem);
 
             Version osVersion = Version.Parse(RuntimeEnvironment.OperatingSystemVersion);
             Version expectedOSVersion = Environment.OSVersion.Version;
 
             // 3 parts of the version should be supplied for Windows
-            Assert.Equal(expectedOSVersion.Major, osVersion.Major);
-            Assert.Equal(expectedOSVersion.Minor, osVersion.Minor);
-            Assert.Equal(expectedOSVersion.Build, osVersion.Build);
-            Assert.Equal(-1, osVersion.Revision);
+            Assert.AreEqual(expectedOSVersion.Major, osVersion.Major);
+            Assert.AreEqual(expectedOSVersion.Minor, osVersion.Minor);
+            Assert.AreEqual(expectedOSVersion.Build, osVersion.Build);
+            Assert.AreEqual(-1, osVersion.Revision);
         }
 
-        [MacOsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.OSX)]
         public void VerifyMacOs()
         {
-            Assert.Equal(Platform.Darwin, RuntimeEnvironment.OperatingSystemPlatform);
-            Assert.Equal("Mac OS X", RuntimeEnvironment.OperatingSystem);
+            Assert.AreEqual(Platform.Darwin, RuntimeEnvironment.OperatingSystemPlatform);
+            Assert.AreEqual("Mac OS X", RuntimeEnvironment.OperatingSystem);
 
             Version osVersion = Version.Parse(RuntimeEnvironment.OperatingSystemVersion);
             Version expectedOSVersion = Environment.OSVersion.Version;
 
             // 2 parts of the version should be supplied for macOS
-            Assert.Equal(expectedOSVersion.Major, osVersion.Major);
-            Assert.Equal(expectedOSVersion.Minor, osVersion.Minor);
-            Assert.Equal(-1, osVersion.Build);
-            Assert.Equal(-1, osVersion.Revision);
+            Assert.AreEqual(expectedOSVersion.Major, osVersion.Major);
+            Assert.AreEqual(expectedOSVersion.Minor, osVersion.Minor);
+            Assert.AreEqual(-1, osVersion.Build);
+            Assert.AreEqual(-1, osVersion.Revision);
         }
 
-        [LinuxOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Linux)]
         public void VerifyLinux()
         {
-            Assert.Equal(Platform.Linux, RuntimeEnvironment.OperatingSystemPlatform);
+            Assert.AreEqual(Platform.Linux, RuntimeEnvironment.OperatingSystemPlatform);
 
             var osRelease = File.ReadAllLines("/etc/os-release");
             string id = osRelease
@@ -52,13 +56,13 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Substring("ID=".Length)
                 .Trim('\"', '\'')
                 .ToLowerInvariant();
-            Assert.Equal(id, RuntimeEnvironment.OperatingSystem.ToLowerInvariant());
+            Assert.AreEqual(id, RuntimeEnvironment.OperatingSystem.ToLowerInvariant());
 
             string version = osRelease
                 .First(line => line.StartsWith("VERSION_ID=", StringComparison.OrdinalIgnoreCase))
                 .Substring("VERSION_ID=".Length)
                 .Trim('\"', '\'');
-            Assert.Equal(version, RuntimeEnvironment.OperatingSystemVersion);
+            Assert.AreEqual(version, RuntimeEnvironment.OperatingSystemVersion);
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,9 +7,10 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace StreamForwarderTests
 {
+    [TestClass]
     public class StreamForwarderTests : SdkTest
     {
-        public StreamForwarderTests(ITestOutputHelper log) : base(log)
+        public StreamForwarderTests()
         {
         }
 
@@ -34,16 +35,16 @@ namespace StreamForwarderTests
             }
         }
 
-        [Theory]
-        [InlineData("123")]
-        [InlineData("123\n")]
+        [TestMethod]
+        [DataRow("123")]
+        [DataRow("123\n")]
         public void TestNoForwardingNoCapture(string inputStr)
         {
             TestCapturingAndForwardingHelper(ForwardOptions.None, inputStr, null, new string[0]);
         }
 
-        [Theory]
-        [MemberData(nameof(ForwardingTheoryVariations))]
+        [TestMethod]
+        [DynamicData(nameof(ForwardingTheoryVariations))]
         public void TestForwardingOnly(string inputStr, string[] expectedWrites)
         {
             for (int i = 0; i < expectedWrites.Length; ++i)
@@ -54,8 +55,8 @@ namespace StreamForwarderTests
             TestCapturingAndForwardingHelper(ForwardOptions.WriteLine, inputStr, null, expectedWrites);
         }
 
-        [Theory]
-        [MemberData(nameof(ForwardingTheoryVariations))]
+        [TestMethod]
+        [DynamicData(nameof(ForwardingTheoryVariations))]
         public void TestCaptureOnly(string inputStr, string[] expectedWrites)
         {
             for (int i = 0; i < expectedWrites.Length; ++i)
@@ -68,8 +69,8 @@ namespace StreamForwarderTests
             TestCapturingAndForwardingHelper(ForwardOptions.Capture, inputStr, expectedCaptured, new string[0]);
         }
 
-        [Theory]
-        [MemberData(nameof(ForwardingTheoryVariations))]
+        [TestMethod]
+        [DynamicData(nameof(ForwardingTheoryVariations))]
         public void TestCaptureAndForwardingTogether(string inputStr, string[] expectedWrites)
         {
             for (int i = 0; i < expectedWrites.Length; ++i)
@@ -104,10 +105,10 @@ namespace StreamForwarderTests
             }
 
             forwarder.Read(new StringReader(str));
-            Assert.Equal(expectedWrites, writes);
+            writes.Should().Equal(expectedWrites);
 
             var captured = forwarder.CapturedOutput;
-            Assert.Equal(expectedCaptured, captured);
+            Assert.AreEqual(expectedCaptured, captured);
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
@@ -6,13 +6,13 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
     [TestClass]
     public class TypoCorrectionTests
     {
-        [DataRow("wbe", "web|webapp|wpf|install|uninstall", "web|wpf", "Levanshtein algorithm")]
+        [DataRow("wbe", "web|webapp|wpf|install|uninstall", "web|wpf", "Levenshtein algorithm")]
         [DataRow("uninstal", "web|webapp|install|uninstall", "uninstall|install", "StartsWith & Contains")]
         [DataRow("console", "web|webapp|install|uninstall", "", "No matches")]
-        [DataRow("blazor", "razor|pazor|blazorweb|blazorservice|uninstall|pizor", "blazorweb|blazorservice|razor|pazor", "StartsWith & Levanshtein algorithm")]
-        [DataRow("blazor", "razor|pazor|pazors", "razor|pazor", "Levanshtein algorithm with shortest distance filtering")]
-        [DataRow("con", "lacon|test|consoleweb|precon|uninstall|ponsole|pons", "consoleweb|lacon|precon|pons", "StartsWith & Contains & Levanshtein algorithm")]
-        [DataRow("c", "lacon|test|consoleweb|preconsole|uninstall|ponsole|pons|ccs", "consoleweb|ccs", "StartsWith & Levanshtein algorithm")]
+        [DataRow("blazor", "razor|pazor|blazorweb|blazorservice|uninstall|pizor", "blazorweb|blazorservice|razor|pazor", "StartsWith & Levenshtein algorithm")]
+        [DataRow("blazor", "razor|pazor|pazors", "razor|pazor", "Levenshtein algorithm with shortest distance filtering")]
+        [DataRow("con", "lacon|test|consoleweb|precon|uninstall|ponsole|pons", "consoleweb|lacon|precon|pons", "StartsWith & Contains & Levenshtein algorithm")]
+        [DataRow("c", "lacon|test|consoleweb|preconsole|uninstall|ponsole|pons|ccs", "consoleweb|ccs", "StartsWith & Levenshtein algorithm")]
         [DataRow("c", "peacon|lecture|beacon", "", "No matches due to Contains restriction on input length")]
         [DataRow(
             "eac",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/TypoCorrectionTests.cs
@@ -3,27 +3,28 @@
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
+    [TestClass]
     public class TypoCorrectionTests
     {
-        [InlineData("wbe", "web|webapp|wpf|install|uninstall", "web|wpf", "Levanshtein algorithm")]
-        [InlineData("uninstal", "web|webapp|install|uninstall", "uninstall|install", "StartsWith & Contains")]
-        [InlineData("console", "web|webapp|install|uninstall", "", "No matches")]
-        [InlineData("blazor", "razor|pazor|blazorweb|blazorservice|uninstall|pizor", "blazorweb|blazorservice|razor|pazor", "StartsWith & Levanshtein algorithm")]
-        [InlineData("blazor", "razor|pazor|pazors", "razor|pazor", "Levanshtein algorithm with shortest distance filtering")]
-        [InlineData("con", "lacon|test|consoleweb|precon|uninstall|ponsole|pons", "consoleweb|lacon|precon|pons", "StartsWith & Contains & Levanshtein algorithm")]
-        [InlineData("c", "lacon|test|consoleweb|preconsole|uninstall|ponsole|pons|ccs", "consoleweb|ccs", "StartsWith & Levanshtein algorithm")]
-        [InlineData("c", "peacon|lecture|beacon", "", "No matches due to Contains restriction on input length")]
-        [InlineData(
+        [DataRow("wbe", "web|webapp|wpf|install|uninstall", "web|wpf", "Levanshtein algorithm")]
+        [DataRow("uninstal", "web|webapp|install|uninstall", "uninstall|install", "StartsWith & Contains")]
+        [DataRow("console", "web|webapp|install|uninstall", "", "No matches")]
+        [DataRow("blazor", "razor|pazor|blazorweb|blazorservice|uninstall|pizor", "blazorweb|blazorservice|razor|pazor", "StartsWith & Levanshtein algorithm")]
+        [DataRow("blazor", "razor|pazor|pazors", "razor|pazor", "Levanshtein algorithm with shortest distance filtering")]
+        [DataRow("con", "lacon|test|consoleweb|precon|uninstall|ponsole|pons", "consoleweb|lacon|precon|pons", "StartsWith & Contains & Levanshtein algorithm")]
+        [DataRow("c", "lacon|test|consoleweb|preconsole|uninstall|ponsole|pons|ccs", "consoleweb|ccs", "StartsWith & Levanshtein algorithm")]
+        [DataRow("c", "peacon|lecture|beacon", "", "No matches due to Contains restriction on input length")]
+        [DataRow(
             "eac",
             "peac|lect|beac|zeac|dect|meac|qeac|aect|oeac|xeac|necte|geacy|gueac",
             "peac|beac|zeac|meac|qeac|oeac|xeac|geacy|gueac|lect",
             "Contains due to max number of suggestions restriction")]
-        [InlineData(
+        [DataRow(
             "eacy",
             "eacyy|eacyl|eacys|eacyt|eacyp|eacyzz|eacyqwe|eacyasd|eacyaa|eacynbv|eacyrfd|peacy|peacp",
             "eacyy|eacyl|eacys|eacyt|eacyp|eacyzz|eacyaa|eacyqwe|eacyasd|eacynbv",
             "StartsWith due to max number of suggestions restriction")]
-        [Theory]
+        [TestMethod]
         public void TypoCorrection_BasicTest(string token, string possibleTokens, string expectedTokens, string checkedScenario)
         {
             TypoCorrection.GetSimilarTokens(possibleTokens.Split('|'), token)

--- a/test/Microsoft.NET.TestFramework.MSTest/InternalsVisibleToAttributes.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/InternalsVisibleToAttributes.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+// The runner-agnostic sources (e.g. Mock/FileSystemMockBuilder) link-shared from the legacy
+// Microsoft.NET.TestFramework expose internal members to a handful of test projects. The legacy
+// grants live in Attributes/InternalsVisibleToAttributes.cs, which this project intentionally
+// excludes from the link-share, so the grants are mirrored here for the MSTest-flavored assembly.
+[assembly: InternalsVisibleTo("dotnet.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: InternalsVisibleTo("Microsoft.DotNet.PackageInstall.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Cli.Utils.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

Also adds InternalsVisibleTo grants to Microsoft.NET.TestFramework.MSTest so migrated projects can use internal test helpers such as FileSystemMockBuilder. Windows/Linux/Unix-only facts become [OSCondition] composition.

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
