### PR TITLE
Migrate EndToEnd.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/EndToEnd.Tests/EndToEnd.Tests.csproj
+++ b/test/EndToEnd.Tests/EndToEnd.Tests.csproj
@@ -1,19 +1,24 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
+    <!-- These tests rely on global process state, so run serially ([assembly: DoNotParallelize]). -->
+    <MSTestParallelizeScope></MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+  </ItemGroup>
+
 </Project>

--- a/test/EndToEnd.Tests/GivenDotNetLinuxInstallers.cs
+++ b/test/EndToEnd.Tests/GivenDotNetLinuxInstallers.cs
@@ -6,12 +6,13 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests;
 
-public class GivenDotNetLinuxInstallers(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class GivenDotNetLinuxInstallers : SdkTest
 {
     private static readonly string[] ExcludedDebSuffixes = ["-newkey"];
     private static readonly string[] ExcludedRpmSuffixes = ["-newkey", "-azl"];
 
-    [Fact]
+    [TestMethod]
     public void ItHasExpectedDependencies()
     {
         var installerFile = Environment.GetEnvironmentVariable("SDK_INSTALLER_FILE");
@@ -77,7 +78,7 @@ public class GivenDotNetLinuxInstallers(ITestOutputHelper log) : SdkTest(log)
                 .And.HaveStdOutMatching(@"dotnet-runtime-\d+(\.\d+){2} >= \d+(\.\d+){2}")
                 .And.HaveStdOutMatching(@"aspnetcore-store-\d+(\.\d+){2} >= \d+(\.\d+){2}");
 
-    [Fact]
+    [TestMethod]
     public void DebPackagePreservesSymbolicLinks() =>
         FileLinkHelpers.VerifyInstallerSymlinks(
             OSPlatform.Linux,
@@ -106,7 +107,7 @@ public class GivenDotNetLinuxInstallers(ITestOutputHelper log) : SdkTest(log)
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void RpmPackagePreservesSymbolicLinks() =>
         FileLinkHelpers.VerifyInstallerSymlinks(
             OSPlatform.Linux,

--- a/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
+++ b/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
@@ -6,9 +6,10 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests;
 
-public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class GivenDotNetMacInstallers : SdkTest
 {
-    [Fact]
+    [TestMethod]
     public void PkgPackagePreservesSymbolicLinks() =>
         FileLinkHelpers.VerifyInstallerSymlinks(
             OSPlatform.OSX,

--- a/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -1,15 +1,17 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: DoNotParallelize]
 
 namespace EndToEnd.Tests
 {
-    public class GivenDotNetUsesMSBuild(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenDotNetUsesMSBuild : SdkTest
     {
-        [RequiresMSBuildVersionFact("17.0.0.32901")]
+        [TestMethod]
+        [RequiresMSBuildVersion("17.0.0.32901")]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             string projectDirectory = TestAssetsManager.CreateTestDirectory().Path;
@@ -42,7 +44,8 @@ namespace EndToEnd.Tests
         }
 
         //  https://github.com/dotnet/sdk/issues/49665
-        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.OSX)]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
         public void ItCanRunToolsInACSProj()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildTestApp")
@@ -76,7 +79,8 @@ namespace EndToEnd.Tests
 
         //  https://github.com/dotnet/sdk/issues/49665
         //  Failed to load /private/tmp/helix/working/A452091E/p/d/shared/Microsoft.NETCore.App/9.0.0/libhostpolicy.dylib, error: dlopen(/private/tmp/helix/working/A452091E/p/d/shared/Microsoft.NETCore.App/9.0.0/libhostpolicy.dylib, 0x0001): tried: '/private/tmp/helix/working/A452091E/p/d/shared/Microsoft.NETCore.App/9.0.0/libhostpolicy.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), 
-        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.OSX)]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
         public void ItCanRunToolsThatPrefersTheCliRuntimeEvenWhenTheToolItselfDeclaresADifferentRuntime()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("MSBuildTestApp")

--- a/test/EndToEnd.Tests/GivenDotnetUsesDotnetTools.cs
+++ b/test/EndToEnd.Tests/GivenDotnetUsesDotnetTools.cs
@@ -1,11 +1,12 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace EndToEnd.Tests
 {
-    public class GivenDotnetUsesDotnetTools(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenDotnetUsesDotnetTools : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void ThenOneDotnetToolsCanBeCalled()
         {
             new DotnetCommand(Log)

--- a/test/EndToEnd.Tests/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd.Tests/GivenFrameworkDependentApps.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -9,10 +9,11 @@ using NuGet.Versioning;
 
 namespace EndToEnd.Tests
 {
-    public class GivenFrameworkDependentApps(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenFrameworkDependentApps : SdkTest
     {
-        [Theory]
-        [ClassData(typeof(SupportedNetCoreAppVersions))]
+        [TestMethod]
+        [DynamicData(nameof(SupportedNetCoreAppVersions.TestData), typeof(SupportedNetCoreAppVersions))]
         public void ItDoesNotRollForwardToTheLatestVersionOfNetCore(string minorVersion)
         {
             if (minorVersion == "3.0" || minorVersion == "3.1" || minorVersion == "5.0" || minorVersion == "6.0" || minorVersion == "7.0" || minorVersion == "8.0" || minorVersion == "9.0" || minorVersion == "10.0" || minorVersion == "11.0")
@@ -23,8 +24,8 @@ namespace EndToEnd.Tests
             ItDoesNotRollForwardToTheLatestVersion(TestProjectCreator.NETCorePackageName, minorVersion);
         }
 
-        [Theory]
-        [ClassData(typeof(SupportedAspNetCoreVersions))]
+        [TestMethod]
+        [DynamicData(nameof(SupportedAspNetCoreVersions.TestData), typeof(SupportedAspNetCoreVersions))]
         public void ItDoesNotRollForwardToTheLatestVersionOfAspNetCoreApp(string minorVersion)
         {
             if (minorVersion == "3.0" || minorVersion == "3.1" || minorVersion == "5.0" || minorVersion == "6.0" || minorVersion == "7.0" || minorVersion == "8.0" || minorVersion == "9.0" || minorVersion == "10.0" || minorVersion == "11.0")
@@ -35,8 +36,8 @@ namespace EndToEnd.Tests
             ItDoesNotRollForwardToTheLatestVersion(TestProjectCreator.AspNetCoreAppPackageName, minorVersion);
         }
 
-        [Theory]
-        [ClassData(typeof(SupportedAspNetCoreAllVersions))]
+        [TestMethod]
+        [DynamicData(nameof(SupportedAspNetCoreAllVersions.TestData), typeof(SupportedAspNetCoreAllVersions))]
         public void ItDoesNotRollForwardToTheLatestVersionOfAspNetCoreAll(string minorVersion) => ItDoesNotRollForwardToTheLatestVersion(TestProjectCreator.AspNetCoreAllPackageName, minorVersion);
 
         internal void ItDoesNotRollForwardToTheLatestVersion(string packageName, string minorVersion)

--- a/test/EndToEnd.Tests/GivenNetFrameworkSupportsNetStandard2.cs
+++ b/test/EndToEnd.Tests/GivenNetFrameworkSupportsNetStandard2.cs
@@ -1,11 +1,13 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace EndToEnd.Tests
 {
-    public class GivenNetFrameworkSupportsNetStandard2(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenNetFrameworkSupportsNetStandard2 : SdkTest
     {
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void Anet462ProjectCanReferenceANETStandardProject()
         {
             var _testInstance = TestAssetsManager

--- a/test/EndToEnd.Tests/GivenSdkArchives.cs
+++ b/test/EndToEnd.Tests/GivenSdkArchives.cs
@@ -6,9 +6,10 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests;
 
-public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
+[TestClass]
+public class GivenSdkArchives : SdkTest
 {
-    [Fact]
+    [TestMethod]
     public void ItHasDeduplicatedAssemblies()
     {
         // Find and extract archive

--- a/test/EndToEnd.Tests/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd.Tests/GivenSelfContainedAppsRollForward.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,9 +7,10 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests
 {
-    public partial class GivenSelfContainedAppsRollForward(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public partial class GivenSelfContainedAppsRollForward : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void WeCoverLatestNetCoreAppRollForward()
         {
             //  Run "dotnet new console", get TargetFramework property, and make sure it's covered in SupportedNetCoreAppVersions
@@ -35,7 +36,7 @@ namespace EndToEnd.Tests
                 "of .NET Core created by \"dotnet new\"");
         }
 
-        [Fact]
+        [TestMethod]
         public void WeCoverLatestAspNetCoreAppRollForward()
         {
             var directory = TestAssetsManager.CreateTestDirectory();

--- a/test/EndToEnd.Tests/GivenUsingDefaultRuntimeFrameworkVersions.cs
+++ b/test/EndToEnd.Tests/GivenUsingDefaultRuntimeFrameworkVersions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -8,14 +8,15 @@ using NuGet.Versioning;
 
 namespace EndToEnd.Tests
 {
-    public partial class GivenUsingDefaultRuntimeFrameworkVersions(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public partial class GivenUsingDefaultRuntimeFrameworkVersions : SdkTest
     {
         private static readonly IEnumerable<string> frameworks = new string[] {"Microsoft.NETCore.App", "Microsoft.WindowsDesktop.App",
             "Microsoft.WindowsDesktop.App.WPF", "Microsoft.WindowsDesktop.App.WindowsForms", "Microsoft.AspNetCore.App" };
 
         private static readonly IEnumerable<string> versions = SupportedNetCoreAppVersions.Versions.Where(version => NuGetVersion.Parse(version).Major >= 3);
 
-        [Fact]
+        [TestMethod]
         public void DefaultRuntimeVersionsAreUpToDate()
         {
             var outputFile = "resolvedVersions.txt";

--- a/test/EndToEnd.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/test/EndToEnd.Tests/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,9 +7,12 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests
 {
-    public class GivenWeWantToRequireWindowsForDesktopApps(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenWeWantToRequireWindowsForDesktopApps : SdkTest
     {
-        [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD, Skip = "https://github.com/dotnet/sdk/issues/42230")]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+        [Ignore("https://github.com/dotnet/sdk/issues/42230")]
         public void It_does_not_download_desktop_targeting_packs_on_unix()
         {
             var testProjectCreator = new TestProjectCreator()
@@ -29,7 +32,8 @@ namespace EndToEnd.Tests
             Directory.Exists(packagesPath).Should().BeFalse(packagesPath + " should not exist");
         }
 
-        [PlatformSpecificFact(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD)]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
         public void It_does_not_download_desktop_runtime_packs_on_unix()
         {
             const string Rid = "win-x64";

--- a/test/EndToEnd.Tests/GivenWindowsApp.cs
+++ b/test/EndToEnd.Tests/GivenWindowsApp.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,18 +7,20 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests
 {
-    public class GivenWindowsApp(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class GivenWindowsApp : SdkTest
     {
-        [WindowsOnlyTheory]
-        [InlineData("10.0.17763.0")]
-        [InlineData("10.0.18362.0")]
-        [InlineData("10.0.19041.0")]
-        [InlineData("10.0.20348.0")]
-        [InlineData("10.0.22000.0")]
-        [InlineData("10.0.22621.0")]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("10.0.17763.0")]
+        [DataRow("10.0.18362.0")]
+        [DataRow("10.0.19041.0")]
+        [DataRow("10.0.20348.0")]
+        [DataRow("10.0.22000.0")]
+        [DataRow("10.0.22621.0")]
         // Skipped due to: https://github.com/dotnet/sdk/pull/42090/files#r1680016439
-        //[InlineData("10.0.26100.0")]
-        [InlineData("10.0.22621.0", "34")]
+        //[DataRow("10.0.26100.0")]
+        [DataRow("10.0.22621.0", "34")]
         public void ItCanBuildAndRun(string targetPlatformVersion, string packageVersion = "")
         {
             var testInstance = TestAssetsManager

--- a/test/EndToEnd.Tests/ProjectBuildTests.cs
+++ b/test/EndToEnd.Tests/ProjectBuildTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,9 +7,10 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests
 {
-    public class ProjectBuildTests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class ProjectBuildTests : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             var directory = TestAssetsManager.CreateTestDirectory();
@@ -51,7 +52,7 @@ namespace EndToEnd.Tests
             binDirectory.Should().NotHaveFilesMatching("*.dll", SearchOption.AllDirectories);
         }
 
-        [Fact]
+        [TestMethod]
         public void ItCanRunAnAppUsingTheWebSdk()
         {
             var directory = TestAssetsManager.CreateTestDirectory();
@@ -81,9 +82,9 @@ namespace EndToEnd.Tests
                 .Execute().Should().Pass().And.HaveStdOutContaining("Hello, World!");
         }
 
-        [Theory]
-        [InlineData("current", true)]
-        [InlineData("current", false)]
+        [TestMethod]
+        [DataRow("current", true)]
+        [DataRow("current", false)]
         public void ItCanPublishArm64Winforms(string targetFramework, bool selfContained)
         {
             var directory = TestAssetsManager.CreateTestDirectory();
@@ -120,9 +121,10 @@ namespace EndToEnd.Tests
             selfContainedPublishDir.Should().HaveFilesMatching($"{new DirectoryInfo(directory.Path).Name}.dll", SearchOption.TopDirectoryOnly);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("current", true)]
-        [InlineData("current", false)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow("current", true)]
+        [DataRow("current", false)]
         public void ItCanPublishArm64Wpf(string targetFramework, bool selfContained)
         {
             var directory = TestAssetsManager.CreateTestDirectory();
@@ -159,26 +161,26 @@ namespace EndToEnd.Tests
             selfContainedPublishDir.Should().HaveFilesMatching($"{new DirectoryInfo(directory.Path).Name}.dll", SearchOption.TopDirectoryOnly);
         }
 
-        [Theory]
+        [TestMethod]
         // microsoft.dotnet.common.projectemplates templates
-        [InlineData("console")]
-        [InlineData("console", "C#")]
-        [InlineData("console", "VB")]
-        [InlineData("console", "F#")]
-        [InlineData("classlib")]
-        [InlineData("classlib", "C#")]
-        [InlineData("classlib", "VB")]
-        [InlineData("classlib", "F#")]
-        [InlineData("mstest")]
-        [InlineData("nunit")]
-        [InlineData("web")]
-        [InlineData("mvc")]
+        [DataRow("console")]
+        [DataRow("console", "C#")]
+        [DataRow("console", "VB")]
+        [DataRow("console", "F#")]
+        [DataRow("classlib")]
+        [DataRow("classlib", "C#")]
+        [DataRow("classlib", "VB")]
+        [DataRow("classlib", "F#")]
+        [DataRow("mstest")]
+        [DataRow("nunit")]
+        [DataRow("web")]
+        [DataRow("mvc")]
         public void ItCanBuildTemplates(string templateName, string language = "") => TestTemplateCreateAndBuild(templateName, language: language);
 
         /// <summary>
         /// The test checks if dotnet new shows curated list correctly after the SDK installation and template insertion.
         /// </summary>
-        [Fact]
+        [TestMethod]
         public void DotnetNewShowsCuratedListCorrectly()
         {
             string locale = Thread.CurrentThread.CurrentUICulture.Name;
@@ -212,14 +214,14 @@ namespace EndToEnd.Tests
                 .And.HaveStdOutMatching(expectedOutput);
         }
 
-        [Theory]
+        [TestMethod]
         // microsoft.dotnet.common.itemtemplates templates
-        [InlineData("globaljson")]
-        [InlineData("nugetconfig")]
-        [InlineData("webconfig")]
-        [InlineData("gitignore")]
-        [InlineData("tool-manifest")]
-        [InlineData("sln")]
+        [DataRow("globaljson")]
+        [DataRow("nugetconfig")]
+        [DataRow("webconfig")]
+        [DataRow("gitignore")]
+        [DataRow("tool-manifest")]
+        [DataRow("sln")]
         public void ItCanCreateItemTemplate(string templateName)
         {
             var directory = TestAssetsManager.CreateTestDirectory(identifier: templateName);
@@ -234,8 +236,8 @@ namespace EndToEnd.Tests
 
             //check if the template created files
             var directoryInfo = new DirectoryInfo(directory.Path);
-            Assert.True(directoryInfo.Exists);
-            Assert.True(directoryInfo.EnumerateFileSystemInfos().Any());
+            Assert.IsTrue(directoryInfo.Exists);
+            Assert.IsNotEmpty(directoryInfo.EnumerateFileSystemInfos());
 
             // delete test directory for some tests so we aren't leaving behind non-compliant nuget files
             if (templateName.Equals("nugetconfig"))
@@ -244,18 +246,18 @@ namespace EndToEnd.Tests
             }
         }
 
-        [Theory]
+        [TestMethod]
         // microsoft.dotnet.common.itemtemplates templates
-        [InlineData("class")]
-        [InlineData("struct")]
-        [InlineData("enum")]
-        [InlineData("record")]
-        [InlineData("interface")]
-        [InlineData("class", "C#")]
-        [InlineData("class", "VB")]
-        [InlineData("struct", "VB")]
-        [InlineData("enum", "VB")]
-        [InlineData("interface", "VB")]
+        [DataRow("class")]
+        [DataRow("struct")]
+        [DataRow("enum")]
+        [DataRow("record")]
+        [DataRow("interface")]
+        [DataRow("class", "C#")]
+        [DataRow("class", "VB")]
+        [DataRow("struct", "VB")]
+        [DataRow("enum", "VB")]
+        [DataRow("interface", "VB")]
         public void ItCanCreateItemTemplateWithProjectRestriction(string templateName, string language = "")
         {
             var languageExtensionMap = new Dictionary<string, string>()
@@ -282,66 +284,66 @@ namespace EndToEnd.Tests
 
             //check if the template created files
             var directoryInfo = new DirectoryInfo(directory.Path);
-            Assert.True(directoryInfo.Exists);
-            Assert.True(directoryInfo.EnumerateFileSystemInfos().Any());
-            Assert.True(directoryInfo.File($"{expectedItemName}.{languageExtensionMap[language]}") != null);
+            Assert.IsTrue(directoryInfo.Exists);
+            Assert.IsNotEmpty(directoryInfo.EnumerateFileSystemInfos());
+            Assert.IsNotNull(directoryInfo.File($"{expectedItemName}.{languageExtensionMap[language]}"));
         }
 
-        [Theory]
-        [InlineData("wpf")]
-        [InlineData("winforms")]
+        [TestMethod]
+        [DataRow("wpf")]
+        [DataRow("winforms")]
         public void ItCanBuildDesktopTemplates(string templateName) => TestTemplateCreateAndBuild(templateName);
 
-        [Theory]
-        [InlineData("wpf")]
+        [TestMethod]
+        [DataRow("wpf")]
         public void ItCanBuildDesktopTemplatesSelfContained(string templateName) => TestTemplateCreateAndBuild(templateName, selfContained: true);
 
-        [Theory]
-        [InlineData("web")]
-        [InlineData("console")]
+        [TestMethod]
+        [DataRow("web")]
+        [DataRow("console")]
         public void ItCanBuildTemplatesSelfContained(string templateName) => TestTemplateCreateAndBuild(templateName, selfContained: true);
 
         /// <summary>
         /// The test checks if the template creates the template for correct framework by default.
         /// For .NET 6 the templates should create the projects targeting net6.0
         /// </summary>
-        [Theory]
-        [InlineData("console")]
-        [InlineData("console", "C#")]
-        [InlineData("console", "VB")]
-        [InlineData("console", "F#")]
-        [InlineData("classlib")]
-        [InlineData("classlib", "C#")]
-        [InlineData("classlib", "VB")]
-        [InlineData("classlib", "F#")]
-        [InlineData("worker")]
-        [InlineData("worker", "C#")]
-        [InlineData("worker", "F#")]
-        [InlineData("mstest")]
-        [InlineData("mstest", "C#")]
-        [InlineData("mstest", "VB")]
-        [InlineData("mstest", "F#")]
-        [InlineData("nunit")]
-        [InlineData("nunit", "C#")]
-        [InlineData("nunit", "VB")]
-        [InlineData("nunit", "F#")]
-        [InlineData("xunit")]
-        [InlineData("xunit", "C#")]
-        [InlineData("xunit", "VB")]
-        [InlineData("xunit", "F#")]
+        [TestMethod]
+        [DataRow("console")]
+        [DataRow("console", "C#")]
+        [DataRow("console", "VB")]
+        [DataRow("console", "F#")]
+        [DataRow("classlib")]
+        [DataRow("classlib", "C#")]
+        [DataRow("classlib", "VB")]
+        [DataRow("classlib", "F#")]
+        [DataRow("worker")]
+        [DataRow("worker", "C#")]
+        [DataRow("worker", "F#")]
+        [DataRow("mstest")]
+        [DataRow("mstest", "C#")]
+        [DataRow("mstest", "VB")]
+        [DataRow("mstest", "F#")]
+        [DataRow("nunit")]
+        [DataRow("nunit", "C#")]
+        [DataRow("nunit", "VB")]
+        [DataRow("nunit", "F#")]
+        [DataRow("xunit")]
+        [DataRow("xunit", "C#")]
+        [DataRow("xunit", "VB")]
+        [DataRow("xunit", "F#")]
         // Skip = "https://github.com/dotnet/sdk/issues/53791"
-        //[InlineData("blazorwasm")]
-        [InlineData("web")]
-        [InlineData("web", "C#")]
-        [InlineData("web", "F#")]
-        [InlineData("mvc")]
-        [InlineData("mvc", "C#")]
-        [InlineData("mvc", "F#")]
-        [InlineData("webapi")]
-        [InlineData("webapi", "C#")]
-        [InlineData("webapi", "F#")]
-        [InlineData("webapp")]
-        [InlineData("razorclasslib")]
+        //[DataRow("blazorwasm")]
+        [DataRow("web")]
+        [DataRow("web", "C#")]
+        [DataRow("web", "F#")]
+        [DataRow("mvc")]
+        [DataRow("mvc", "C#")]
+        [DataRow("mvc", "F#")]
+        [DataRow("webapi")]
+        [DataRow("webapi", "C#")]
+        [DataRow("webapi", "F#")]
+        [DataRow("webapp")]
+        [DataRow("razorclasslib")]
         public void ItCanCreateAndBuildTemplatesWithDefaultFramework(string templateName, string language = "")
         {
             string framework = DetectExpectedDefaultFramework(templateName);
@@ -352,28 +354,28 @@ namespace EndToEnd.Tests
         /// The test checks if the template creates the template for correct framework by default.
         /// For .NET 6 the templates should create the projects targeting net6.0.
         /// </summary>
-        [Theory]
-        [InlineData("wpf")]
-        [InlineData("wpf", "C#")]
-        [InlineData("wpf", "VB")]
-        [InlineData("wpflib")]
-        [InlineData("wpflib", "C#")]
-        [InlineData("wpflib", "VB")]
-        [InlineData("wpfcustomcontrollib")]
-        [InlineData("wpfcustomcontrollib", "C#")]
-        [InlineData("wpfcustomcontrollib", "VB")]
-        [InlineData("wpfusercontrollib")]
-        [InlineData("wpfusercontrollib", "C#")]
-        [InlineData("wpfusercontrollib", "VB")]
-        [InlineData("winforms")]
-        [InlineData("winforms", "C#")]
-        [InlineData("winforms", "VB")]
-        [InlineData("winformslib")]
-        [InlineData("winformslib", "C#")]
-        [InlineData("winformslib", "VB")]
-        [InlineData("winformscontrollib")]
-        [InlineData("winformscontrollib", "C#")]
-        [InlineData("winformscontrollib", "VB")]
+        [TestMethod]
+        [DataRow("wpf")]
+        [DataRow("wpf", "C#")]
+        [DataRow("wpf", "VB")]
+        [DataRow("wpflib")]
+        [DataRow("wpflib", "C#")]
+        [DataRow("wpflib", "VB")]
+        [DataRow("wpfcustomcontrollib")]
+        [DataRow("wpfcustomcontrollib", "C#")]
+        [DataRow("wpfcustomcontrollib", "VB")]
+        [DataRow("wpfusercontrollib")]
+        [DataRow("wpfusercontrollib", "C#")]
+        [DataRow("wpfusercontrollib", "VB")]
+        [DataRow("winforms")]
+        [DataRow("winforms", "C#")]
+        [DataRow("winforms", "VB")]
+        [DataRow("winformslib")]
+        [DataRow("winformslib", "C#")]
+        [DataRow("winformslib", "VB")]
+        [DataRow("winformscontrollib")]
+        [DataRow("winformscontrollib", "C#")]
+        [DataRow("winformscontrollib", "VB")]
         public void ItCanCreateAndBuildTemplatesWithDefaultFramework_Windows(string templateName, string language = "")
         {
             string framework = DetectExpectedDefaultFramework(templateName);
@@ -385,8 +387,8 @@ namespace EndToEnd.Tests
         /// The test checks if the template creates the template for correct framework by default.
         /// For .NET 6 the templates should create the projects targeting net6.0.
         /// </summary>
-        [Theory]
-        [InlineData("grpc")]
+        [TestMethod]
+        [DataRow("grpc")]
         public void ItCanCreateAndBuildTemplatesWithDefaultFramework_DisableBuildOnLinuxMusl(string templateName)
         {
             string framework = DetectExpectedDefaultFramework(templateName);
@@ -438,7 +440,7 @@ namespace EndToEnd.Tests
                 //check if MSBuild TargetFramework property for *proj is set to expected framework
                 var projectXml = GetProjectXml();
                 XNamespace ns = projectXml.Root.Name.Namespace;
-                Assert.Equal(framework, projectXml.Root.Element(ns + "PropertyGroup").Element(ns + "TargetFramework").Value);
+                Assert.AreEqual(framework, projectXml.Root.Element(ns + "PropertyGroup").Element(ns + "TargetFramework").Value);
             }
 
             bool needsEnableWindowsTargeting = false;

--- a/test/EndToEnd.Tests/Utilities/FileLinkHelpers.cs
+++ b/test/EndToEnd.Tests/Utilities/FileLinkHelpers.cs
@@ -88,7 +88,7 @@ internal static class FileLinkHelpers
 
         log.WriteLine($"Found {symlinkPaths.Count} symbolic links in {contextName}");
 
-        Assert.True(symlinkPaths.Count > MinExpectedDeduplicatedLinks,
+        Assert.IsGreaterThan(MinExpectedDeduplicatedLinks, symlinkPaths.Count,
             $"Expected more than {MinExpectedDeduplicatedLinks} symbolic links in {contextName}, but found only {symlinkPaths.Count}. " +
             "This suggests deduplication did not run correctly.");
 
@@ -109,7 +109,7 @@ internal static class FileLinkHelpers
             }
         }
 
-        Assert.Empty(absoluteSymlinks);
+        Assert.IsEmpty(absoluteSymlinks);
         log.WriteLine($"Verified all {symlinkPaths.Count} symbolic links use relative paths");
     }
 
@@ -140,7 +140,7 @@ internal static class FileLinkHelpers
 
         log.WriteLine($"Found {hardlinkedFiles.Count} hardlinked files in {contextName}");
 
-        Assert.True(hardlinkedFiles.Count > MinExpectedDeduplicatedLinks,
+        Assert.IsGreaterThan(MinExpectedDeduplicatedLinks, hardlinkedFiles.Count,
             $"Expected more than {MinExpectedDeduplicatedLinks} hardlinked files in {contextName}, but found only {hardlinkedFiles.Count}. " +
             "This suggests deduplication did not run correctly.");
 

--- a/test/EndToEnd.Tests/Utilities/SupportedNetCoreAppVersions.cs
+++ b/test/EndToEnd.Tests/Utilities/SupportedNetCoreAppVersions.cs
@@ -19,6 +19,7 @@ namespace EndToEnd.Tests.Utilities
     {
         public IEnumerator<object[]> GetEnumerator() => Versions.Select(version => new object[] { version }).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public static IEnumerable<object[]> TestData => Versions.Select(version => new object[] { version });
         public static IEnumerable<string> Versions => new[]
         {
             "1.0",
@@ -64,6 +65,8 @@ namespace EndToEnd.Tests.Utilities
         public IEnumerator<object[]> GetEnumerator() => Versions.Select(version => new object[] { version }).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        public static IEnumerable<object[]> TestData => Versions.Select(version => new object[] { version });
+
         public static IEnumerable<string> Versions =>
             SupportedNetCoreAppVersions.Versions.Except(new List<string>() { "1.0", "1.1", "2.0" });
     }
@@ -72,6 +75,8 @@ namespace EndToEnd.Tests.Utilities
     {
         public IEnumerator<object[]> GetEnumerator() => Versions.Select(version => new object[] { version }).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public static IEnumerable<object[]> TestData => Versions.Select(version => new object[] { version });
 
         public static IEnumerable<string> Versions =>
             SupportedAspNetCoreVersions.Versions.Where(v => new Version(v).Major < 3);

--- a/test/EndToEnd.Tests/ValidateInsertedManifests.cs
+++ b/test/EndToEnd.Tests/ValidateInsertedManifests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,9 +7,10 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace EndToEnd.Tests
 {
-    public class ValidateInsertedManifests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class ValidateInsertedManifests : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void ManifestReaderCanReadManifests()
         {
             var sdkManifestDir = Path.Combine(Path.GetDirectoryName(SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath), "sdk-manifests");

--- a/test/EndToEnd.Tests/VersionTests.cs
+++ b/test/EndToEnd.Tests/VersionTests.cs
@@ -1,13 +1,14 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 
 namespace EndToEnd.Tests
 {
-    public class VersionTests(ITestOutputHelper log) : SdkTest(log)
+    [TestClass]
+    public class VersionTests : SdkTest
     {
-        [Fact]
+        [TestMethod]
         public void DotnetVersionReturnsCorrectVersion()
         {
             var result = new DotnetCommand(Log).Execute("--version");


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

[ClassData] sources become static TestData members consumed via [DynamicData]; [PlatformSpecificFact] become [OSCondition] composition; the assembly runs serially via [DoNotParallelize].

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
