### PR TITLE
Migrate Microsoft.DotNet.PackageInstall.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -45,8 +45,6 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         //  https://github.com/dotnet/sdk/issues/49665
         //  The tool does not support the current architecture or operating system (osx-arm64). Supported runtimes: win-x64 win-x86 osx-x64 linux-x64 linux-musl-x64
-        //  https://github.com/dotnet/sdk/issues/49665
-        //  The tool does not support the current architecture or operating system (osx-arm64). Supported runtimes: win-x64 win-x86 osx-x64 linux-x64 linux-musl-x64
         [TestMethod]
         [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
         public void InstallAndRunNativeAotGlobalTool()

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -8,17 +8,15 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
-    [Collection(nameof(TestToolBuilderCollection))]
+    [DoNotParallelize]
+    [TestClass]
     public class EndToEndToolTests : SdkTest
     {
-        private readonly TestToolBuilder ToolBuilder;
+        private static readonly TestToolBuilder ToolBuilder = TestToolBuilder.SharedInstance.Value;
 
-        public EndToEndToolTests(ITestOutputHelper log, TestToolBuilder toolBuilder) : base(log)
-        {
-            ToolBuilder = toolBuilder;
-        }
+        public EndToEndToolTests() { }
 
-        [Fact]
+        [TestMethod]
         public void InstallAndRunToolGlobal()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings();
@@ -47,7 +45,10 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         //  https://github.com/dotnet/sdk/issues/49665
         //  The tool does not support the current architecture or operating system (osx-arm64). Supported runtimes: win-x64 win-x86 osx-x64 linux-x64 linux-musl-x64
-        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.OSX)]
+        //  https://github.com/dotnet/sdk/issues/49665
+        //  The tool does not support the current architecture or operating system (osx-arm64). Supported runtimes: win-x64 win-x86 osx-x64 linux-x64 linux-musl-x64
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
         public void InstallAndRunNativeAotGlobalTool()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -78,7 +79,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdOutContaining("Hello Tool!");
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallAndRunToolLocal()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings();
@@ -110,7 +111,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         //  https://github.com/dotnet/sdk/issues/49665
         //  The tool does not support the current architecture or operating system (osx-arm64). Supported runtimes: win-x64 win-x86 osx-x64 linux-x64 linux-musl-x64
-        [PlatformSpecificFact(TestPlatforms.Any & ~TestPlatforms.OSX)]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
         public void InstallAndRunNativeAotLocalTool()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -144,7 +146,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         }
 
 
-        [Fact]
+        [TestMethod]
         public void PackagesMultipleToolsWithASingleInvocation()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -173,7 +175,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             foundRids.Should().BeEquivalentTo(expectedRids, "The top-level package should declare all of the RIDs for the tools it contains");
         }
 
-        [Fact]
+        [TestMethod]
         public void PackagesMultipleTrimmedToolsWithASingleInvocation()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -203,7 +205,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             foundRids.Should().BeEquivalentTo(expectedRids, "The top-level package should declare all of the RIDs for the tools it contains");
         }
 
-        [Fact]
+        [TestMethod]
         public void PackagesFrameworkDependentRidSpecificPackagesCorrectly()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -232,7 +234,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             foundRids.Should().BeEquivalentTo(expectedRids, "The top-level package should declare all of the RIDs for the tools it contains");
         }
 
-        [Fact]
+        [TestMethod]
         public void PackageToolWithAnyRid()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -268,9 +270,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.Satisfy<string>(SupportAllOfTheseRuntimes([.. expectedRids, "any"]));
         }
 
-        [Theory]
-        [InlineData("exec")]
-        [InlineData("dnx")]
+        [TestMethod]
+        [DataRow("exec")]
+        [DataRow("dnx")]
         public void InstallAndRunToolFromAnyRid(string command)
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -299,9 +301,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdOutContaining("Hello Tool!");
         }
 
-        [Theory]
-        [InlineData("exec")]
-        [InlineData("dnx")]
+        [TestMethod]
+        [DataRow("exec")]
+        [DataRow("dnx")]
         public void InstallAndRunToolFromAnyRidWhenOtherRidsArePresentButIncompatible(string command)
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -334,9 +336,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdOutContaining("Hello Tool!");
         }
 
-        [Theory]
-        [InlineData("exec")]
-        [InlineData("dnx")]
+        [TestMethod]
+        [DataRow("exec")]
+        [DataRow("dnx")]
         public void ToolExecSucceedsWhenToolIsInLocalManifestButNotRestored(string command)
         {
             // Regression test: 'dotnet tool exec' and 'dnx' should succeed even when the tool is
@@ -383,7 +385,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdOutContaining("Hello Tool!");
         }
 
-        [Fact]
+        [TestMethod]
         public void StripsPackageTypesFromInnerToolPackages()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -417,7 +419,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             foundRids.Should().BeEquivalentTo(expectedRids, "The top-level package should declare all of the RIDs for the tools it contains");
         }
 
-        [Fact]
+        [TestMethod]
         public void MixedPackageTypesBuildInASingleBatchSuccessfully()
         {
             var toolSettings = new TestToolBuilder.TestToolSettings()
@@ -565,7 +567,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallToolWithHigherFrameworkAsGlobalToolShowsAppropriateError()
         {
             var toolPackagesPath = CreateNet99ToolPackage();
@@ -582,7 +584,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdErrContaining(".NET 99");
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallToolWithHigherFrameworkAsLocalToolShowsAppropriateError()
         {
             var toolPackagesPath = CreateNet99ToolPackage();
@@ -606,7 +608,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .And.HaveStdErrContaining(".NET 99");
         }
 
-        [Fact]
+        [TestMethod]
         public void RunToolWithHigherFrameworkUsingDnxShowsAppropriateError()
         {
             var toolPackagesPath = CreateNet99ToolPackage();

--- a/test/Microsoft.DotNet.PackageInstall.Tests/LocalToolsResolverCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/LocalToolsResolverCacheTests.cs
@@ -10,11 +10,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class LocalToolsResolverCacheTests : SdkTest
     {
-        public LocalToolsResolverCacheTests(ITestOutputHelper log) : base(log)
-        {
-        }
+        public LocalToolsResolverCacheTests() { }
 
         private static
             (DirectoryPath nuGetGlobalPackagesFolder,
@@ -33,7 +32,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             return (nuGetGlobalPackagesFolder, localToolsResolverCache);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenExecutableIdentifierItCanSaveAndCannotLoadWithMismatches()
         {
             (DirectoryPath nuGetGlobalPackagesFolder, LocalToolsResolverCache localToolsResolverCache) = Setup();
@@ -73,7 +72,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .Should().BeFalse();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenExecutableIdentifierItCanSaveAndLoad()
         {
             (DirectoryPath nuGetGlobalPackagesFolder, LocalToolsResolverCache localToolsResolverCache) = Setup();
@@ -107,7 +106,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             tool2.Should().BeEquivalentTo(restoredCommands[1]);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenExecutableIdentifierItCanSaveMultipleSameAndLoadContainsOnlyOne()
         {
             (DirectoryPath nuGetGlobalPackagesFolder, LocalToolsResolverCache localToolsResolverCache) = Setup();
@@ -147,7 +146,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             tool2.Should().BeEquivalentTo(restoredCommands[1]);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenExecutableIdentifierItCanSaveMultipleVersionAndLoad()
         {
             (DirectoryPath nuGetGlobalPackagesFolder, LocalToolsResolverCache localToolsResolverCache) = Setup();
@@ -197,7 +196,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             tool2Newer.Should().BeEquivalentTo(restoredCommandsNewer[1]);
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenTheCacheIsCorruptedByAppendingLineItShouldLoadAsEmpty()
         {
             WhenTheCacheIsCorruptedItShouldLoadAsEmpty(
@@ -207,7 +206,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             );
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenTheCacheIsCorruptedByNotAJsonItShouldLoadAsEmpty()
         {
             WhenTheCacheIsCorruptedItShouldLoadAsEmpty(
@@ -219,7 +218,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             );
         }
 
-        [Fact]
+        [TestMethod]
         public void WhenTheCacheIsCorruptedItShouldNotAffectNextSaveAndLoad()
         {
             IFileSystem fileSystem = new FileSystemMockBuilder().UseCurrentSystemTemporaryDirectory().Build();

--- a/test/Microsoft.DotNet.PackageInstall.Tests/LockFileMatcherTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/LockFileMatcherTests.cs
@@ -6,16 +6,17 @@ using NuGet.ProjectModel;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class LockFileMatcherTests
     {
-        [Theory]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "tool.dll", true)]
-        [InlineData($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "subDirectory/tool.dll", true)]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/win-x64/tool.dll", "tool.dll", true)]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "subDirectory/tool.dll", true)]
-        [InlineData($"libs/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "tool.dll", false)]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}1/any/subDirectory/tool.dll", "tool.dll", false)]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "subDirectory/subDirectory/subDirectory/subDirectory/subDirectory/tool.dll", false)]
+        [TestMethod]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "tool.dll", true)]
+        [DataRow($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "subDirectory/tool.dll", true)]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/win-x64/tool.dll", "tool.dll", true)]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "subDirectory/tool.dll", true)]
+        [DataRow($"libs/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "tool.dll", false)]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}1/any/subDirectory/tool.dll", "tool.dll", false)]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "subDirectory/subDirectory/subDirectory/subDirectory/subDirectory/tool.dll", false)]
         public void MatchesEntryPointTests(string pathInLockFileItem, string targetRelativeFilePath, bool shouldMatch)
         {
             LockFileMatcher.MatchesFile(new LockFileItem(pathInLockFileItem), targetRelativeFilePath)
@@ -23,11 +24,11 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         }
 
 
-        [Theory]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "", true)]
-        [InlineData($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "subDirectory", true)]
-        [InlineData($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "sub", false)]
-        [InlineData($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "any/subDirectory", false)]
+        [TestMethod]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/any/tool.dll", "", true)]
+        [DataRow($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "subDirectory", true)]
+        [DataRow($@"tools\{ToolsetInfo.CurrentTargetFramework}\any\subDirectory\tool.dll", "sub", false)]
+        [DataRow($"tools/{ToolsetInfo.CurrentTargetFramework}/any/subDirectory/tool.dll", "any/subDirectory", false)]
         public void MatchesDirectoryPathTests(
             string pathInLockFileItem,
             string targetRelativeFilePath,

--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -1,14 +1,11 @@
-﻿<Project>
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
 
@@ -16,8 +13,31 @@
     <ProjectReference Include="..\..\src\Cli\dotnet\dotnet.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.ComponentMocks\Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj" />
+    <!-- Suppress the old xUnit TestFramework that ComponentMocks brings in transitively;
+         Microsoft.NET.TestFramework.MSTest link-shares the same runner-agnostic types. -->
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- Remove the old xUnit TestFramework from the C# compiler reference list to avoid
+       CS0433 duplicate-type conflicts with Microsoft.NET.TestFramework.MSTest. -->
+  <Target Name="RemoveConflictingTestFrameworkReference"
+          AfterTargets="ResolveAssemblyReferences"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)"
+                     Condition="'%(Filename)' == 'Microsoft.NET.TestFramework' AND '%(Extension)' == '.dll'" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
   </ItemGroup>
 
   <ItemGroup>
@@ -175,6 +195,5 @@
     <Copy SourceFiles="@(TestAssetLocalNugetFeed)" DestinationFiles="@(TestAssetLocalNugetFeed->'$(PublishDir)\TestAssetLocalNugetFeed\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -15,20 +15,22 @@
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
     <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.ComponentMocks\Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj" />
-    <!-- Suppress the old xUnit TestFramework that ComponentMocks brings in transitively;
-         Microsoft.NET.TestFramework.MSTest link-shares the same runner-agnostic types. -->
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj"
-                      ReferenceOutputAssembly="false" />
+    <!-- ComponentMocks is compiled against the old xUnit Microsoft.NET.TestFramework and needs it at
+         runtime. Reference it directly so it flows into the runtime closure (output + deps.json). It is
+         removed from the C# compiler references below to avoid CS0433 duplicate-type conflicts with
+         Microsoft.NET.TestFramework.MSTest, which link-shares the same runner-agnostic types. -->
+    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
   </ItemGroup>
 
-  <!-- Remove the old xUnit TestFramework from the C# compiler reference list to avoid
-       CS0433 duplicate-type conflicts with Microsoft.NET.TestFramework.MSTest. -->
+  <!-- Remove the old xUnit TestFramework from the C# compiler reference list (compile only) to avoid
+       CS0433 duplicate-type conflicts with Microsoft.NET.TestFramework.MSTest. The assembly remains in
+       the runtime closure so ComponentMocks can load it at runtime. -->
   <Target Name="RemoveConflictingTestFrameworkReference"
-          AfterTargets="ResolveAssemblyReferences"
+          AfterTargets="FindReferenceAssembliesForReferences"
           BeforeTargets="CoreCompile">
     <ItemGroup>
-      <ReferencePath Remove="@(ReferencePath)"
-                     Condition="'%(Filename)' == 'Microsoft.NET.TestFramework' AND '%(Extension)' == '.dll'" />
+      <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)"
+                                      Condition="'%(Filename)' == 'Microsoft.NET.TestFramework' AND '%(Extension)' == '.dll'" />
     </ItemGroup>
   </Target>
 

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageDownloaderFactoryTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageDownloaderFactoryTests.cs
@@ -9,16 +9,15 @@ using NuGet.Common;
 
 namespace Microsoft.DotNet.PackageInstall.Tests;
 
+[TestClass]
 public class NuGetPackageDownloaderFactoryTests : SdkTest
 {
-    public NuGetPackageDownloaderFactoryTests(ITestOutputHelper log) : base(log)
-    {
-    }
+    public NuGetPackageDownloaderFactoryTests() { }
 
     private static DirectoryPath GetTempDir() =>
         new(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
 
-    [Fact]
+    [TestMethod]
     public void CreateForWorkloads_ReturnsNonNullDownloader()
     {
         var tempDir = GetTempDir();
@@ -31,7 +30,7 @@ public class NuGetPackageDownloaderFactoryTests : SdkTest
         downloader.Should().BeOfType<NuGetPackageDownloader>();
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateForWorkloads_WithAllParameters_ReturnsConfiguredDownloader()
     {
         var tempDir = GetTempDir();
@@ -50,7 +49,7 @@ public class NuGetPackageDownloaderFactoryTests : SdkTest
         downloader.Should().NotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateForWorkloads_DefaultsSourceMappingToTrue()
     {
         // The factory method defaults shouldUsePackageSourceMapping to true,
@@ -65,7 +64,7 @@ public class NuGetPackageDownloaderFactoryTests : SdkTest
         downloader.Should().NotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WhenVerifyRequestedButPlatformUnsupported_LogsMessage()
     {
         // On non-Windows, requesting verification without the env var should log a message.

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerExtractTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerExtractTests.cs
@@ -10,13 +10,12 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class NuGetPackageInstallerExtractTests : SdkTest
     {
-        public NuGetPackageInstallerExtractTests(ITestOutputHelper log) : base(log)
-        {
-        }
+        public NuGetPackageInstallerExtractTests() { }
 
-        [Fact]
+        [TestMethod]
         public async Task ItCanExtractNugetPackage()
         {
             string packageId = "Newtonsoft.Json";
@@ -37,7 +36,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             extractedFiles.Should().BeEquivalentTo(result);
         }
 
-        [UnixOnlyFact]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
         public void ItCanGetAllFilesNeedToSetExecutablePermission()
         {
             NuGetTestLogger logger = new(Log);
@@ -61,7 +61,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 "file without extension under tools folder");
         }
 
-        [UnixOnlyFact]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
         public void GivenPackageNotInAllowListItCannotGetAllFilesNeedToSetExecutablePermission()
         {
             NuGetTestLogger logger = new(Log);

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageInstallerTests.cs
@@ -18,6 +18,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class NuGetPackageInstallerTests : SdkTest
     {
         private const string TestPackageVersion = "1.0.4";
@@ -31,7 +32,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         private readonly string _testTargetframework = BundledTargetFramework.GetTargetFrameworkMoniker();
         private readonly NuGetTestLogger _logger;
 
-        public NuGetPackageInstallerTests(ITestOutputHelper log) : base(log)
+        public NuGetPackageInstallerTests()
         {
             _tempDirectory = GetUniqueTempProjectPathEachTest();
             _logger = new NuGetTestLogger();
@@ -43,12 +44,12 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     restoreActionConfig: new RestoreActionConfig(NoCache: true), timer: () => ExponentialRetry.Timer(ExponentialRetry.TestingIntervals), shouldUsePackageSourceMapping: true);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenNoFeedInstallFailsWithException() =>
-            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
+            await Assert.ThrowsExactlyAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(TestPackageId, new NuGetVersion(TestPackageVersion)));
 
-        [Fact]
+        [TestMethod]
         public async Task GivenASourceInstallSucceeds()
         {
             string packagePath = await _installer.DownloadPackageAsync(
@@ -59,20 +60,20 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             packagePath.Should().Contain(_tempDirectory.Value, "Package should be downloaded to the input folder");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenAFailedSourceItShouldError()
         {
             DirectoryPath nonExistFeed =
                 new DirectoryPath(Path.GetTempPath()).WithSubDirectories(Path.GetRandomFileName());
 
-            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
+            await Assert.ThrowsExactlyAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),
                     new PackageSourceLocation(sourceFeedOverrides: new[] { nonExistFeed.Value })));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenAFailedSourceAndIgnoreFailedSourcesItShouldNotThrowFatalProtocolException()
         {
             var installer =
@@ -82,7 +83,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             // should not throw FatalProtocolException
             // when there is at least one valid source, it should pass.
             // but it is hard to set up that in unit test
-            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
+            await Assert.ThrowsExactlyAsync<NuGetPackageNotFoundException>(() =>
                 installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),
@@ -92,7 +93,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                     })));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenNugetConfigInstallSucceeds()
         {
             FilePath nugetConfigPath = GenerateRandomNugetConfigFilePath();
@@ -106,7 +107,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenAValidNugetConfigAndFailedSourceItShouldError()
         {
             DirectoryPath nonExistFeed =
@@ -117,7 +118,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             WriteNugetConfigFileToPointToTheFeed(fileSystem, validNugetConfigPath);
 
             // "source" option will override everything like nuget.config just like "dotner restore --source ..."
-            await Assert.ThrowsAsync<NuGetPackageNotFoundException>(() =>
+            await Assert.ThrowsExactlyAsync<NuGetPackageNotFoundException>(() =>
                 _installer.DownloadPackageAsync(
                     TestPackageId,
                     new NuGetVersion(TestPackageVersion),
@@ -125,7 +126,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                         sourceFeedOverrides: new[] { nonExistFeed.Value })));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenAConfigFileRootDirectoryPackageInstallSucceedsViaFindingNugetConfigInParentDir()
         {
             FilePath nugetConfigPath = GenerateRandomNugetConfigFilePath();
@@ -142,7 +143,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenNoPackageVersionItCanInstallLatestVersionOfPackage()
         {
             NuGetVersion packageVersion = null;
@@ -154,7 +155,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenARelativeSourcePathInstallSucceeds()
         {
             new RunExeCommand(Log, "dotnet", "nuget", "locals", "all", "--list")
@@ -171,7 +172,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             packagePath.Should().Contain(_tempDirectory.Value, "Package should be downloaded to the input folder");
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenNoPackageSourceMappingItShouldError()
         {
             string testFeed = GetTestLocalFeedPath();
@@ -200,7 +201,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             (await downloadAction.Should().ThrowAsync<NuGetPackageInstallerException>()).And.Message.Should().Contain(string.Format(CliStrings.FailedToFindSourceUnderPackageSourceMapping, TestPackageId));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task GivenPackageSourceMappingFeedNotFoundItShouldError()
         {
             string testFeed = GetTestLocalFeedPath();
@@ -229,7 +230,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             (await downloadAction.Should().ThrowAsync<NuGetPackageInstallerException>()).And.Message.Should().Contain(string.Format(CliStrings.FailedToMapSourceUnderPackageSourceMapping, TestPackageId));
         }
 
-        [Fact]
+        [TestMethod]
         public async Task WhenPassedIncludePreviewItInstallSucceeds()
         {
             string getTestLocalFeedPath = GetTestLocalFeedPath();
@@ -244,7 +245,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 "Package should download higher package version");
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenPackageOverrideSourceWithCredentialsNugetFeedReturnsSelectedSource()
         {
             PackageSource source = new PackageSource("NuGet")
@@ -259,7 +260,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             selectedSources.Should().HaveCount(1).And.Contain(x => x.Credentials != null);
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public async Task GivenANonSignedSdkItShouldPrintMessageOnce()
         {
             BufferedReporter bufferedReporter = new();
@@ -283,7 +285,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public async Task GivenANonSignedSdkItShouldNotPrintMessageInQuiet()
         {
             BufferedReporter bufferedReporter = new BufferedReporter();
@@ -305,7 +308,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             File.Exists(packagePath).Should().BeTrue();
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         // https://aka.ms/netsdkinternal-certificate-rotate
         public void ItShouldHaveUpdateToDateCertificateSha()
         {
@@ -350,7 +354,8 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void GivenFirstPartyPackageItShouldReturnTrue()
         {
             var iosSamplePackage = DownloadSamplePackage(new PackageId("Microsoft.iOS.Ref"));
@@ -423,7 +428,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         private static string GetTestLocalFeedPath() =>
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestAssetLocalNugetFeed");
 
-        [Fact]
+        [TestMethod]
         public async Task RejectsAdditionalSourceFeedsWhenMappingActive()
         {
             var mappingRules = new Dictionary<string, IReadOnlyList<string>>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/TestToolBuilder.cs
@@ -3,16 +3,8 @@
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
-    [CollectionDefinition(nameof(TestToolBuilderCollection))]
-    public class TestToolBuilderCollection : ICollectionFixture<TestToolBuilder>
-    {
-        // This class is intentionally left empty.
-    }
-
-
     //  This class is responsible for creating test dotnet tool packages.  We don't want every test to have to create it's own tool package, as that could slow things down quite a bit.
-    //  So this class handles creating each tool package once.  To use it, add it as a constructor parameter to your test class.  You will also need to add [Collection(nameof(TestToolBuilderCollection))]
-    //  to your test class to ensure that only one test at a time uses this class.  xUnit will give you an error if you forget to add the collection attribute but do add the constructor parameter.
+    //  So this class handles creating each tool package once.
     //
     //  The TestToolBuilder class uses a common folder to store all the tool package projects and their built nupkgs.  When CreateTestTool is called, it will compare the contents of the project
     //  in the common folder to the contents of the project that is being requested.  If there are any differences, it will re-create the project and build it again.  It will also delete the package from the
@@ -22,6 +14,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
     //  For local testing, you may need to delete the artifacts\tmp\Debug\testing\TestTools folder if the SDK changes in a way that affects the built package.
     public class TestToolBuilder
     {
+        public static readonly Lazy<TestToolBuilder> SharedInstance = new(() => new TestToolBuilder());
         public class TestToolSettings
         {
             public string ToolPackageId { get; set; } = "TestTool";

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolConfigurationDeserializerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolConfigurationDeserializerTests.cs
@@ -6,9 +6,10 @@ using Microsoft.DotNet.Cli.ToolPackage;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class ToolConfigurationDeserializerTests
     {
-        [Fact]
+        [TestMethod]
         public void GivenXmlPathItShouldGetToolConfiguration()
         {
             ToolConfiguration toolConfiguration = ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsGolden.xml");
@@ -17,7 +18,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             toolConfiguration.ToolAssemblyEntryPoint.Should().Be("console.dll");
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenMalformedPathItThrows()
         {
             Action a = () => ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMalformed.xml");
@@ -26,7 +27,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .Contain(string.Format(CliStrings.ToolSettingsInvalidXml, string.Empty));
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenMissingContentItThrows()
         {
             Action a = () => ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMissing.xml");
@@ -35,7 +36,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .Contain(CliStrings.ToolSettingsMissingCommandName);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenMissingVersionItHasWarningReflectIt()
         {
             ToolConfiguration toolConfiguration = ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMissingVersion.xml");
@@ -43,7 +44,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             toolConfiguration.Warnings.First().Should().Be(CliStrings.FormatVersionIsMissing);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenMajorHigherVersionItHasWarningReflectIt()
         {
             ToolConfiguration toolConfiguration = ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsMajorHigherVersion.xml");
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             toolConfiguration.Warnings.First().Should().Be(CliStrings.FormatVersionIsHigher);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenMinorHigherVersionItHasNoWarning()
         {
             ToolConfiguration toolConfiguration = ToolConfigurationDeserializer.Deserialize("DotnetToolSettingsGolden.xml");
@@ -59,7 +60,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             toolConfiguration.Warnings.Should().BeEmpty();
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenInvalidCharAsFileNameItThrows()
         {
             var invalidCommandName = "na\0me";
@@ -73,7 +74,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                         string.Join(", ", Path.GetInvalidFileNameChars().Select(c => $"'{c}'"))));
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenALeadingDotAsFileNameItThrows()
         {
             var invalidCommandName = ".mytool";

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
@@ -34,12 +34,22 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void Dispose() => Environment.SetEnvironmentVariable(_PATH_VAR_NAME, _originalPath);
     }
 
-    [Collection(nameof(TestToolBuilderCollection))]
-    public class ToolPackageDownloaderTests : SdkTest, IClassFixture<DotnetEnvironmentTestFixture>
+    [DoNotParallelize]
+    [TestClass]
+    public class ToolPackageDownloaderTests : SdkTest
     {
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        private static DotnetEnvironmentTestFixture _envFixture;
+        private static readonly TestToolBuilder ToolBuilder = TestToolBuilder.SharedInstance.Value;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext _) => _envFixture = new DotnetEnvironmentTestFixture();
+
+        [ClassCleanup]
+        public static void ClassCleanup() => _envFixture?.Dispose();
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -60,9 +70,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenNugetConfigInstallSucceedsInTransaction(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -90,9 +100,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenNugetConfigInstallCreatesAnAssetFile(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -128,9 +138,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAConfigFileRootDirectoryPackageInstallSucceedsViaFindingNugetConfigInParentDir(
             bool testMockBehaviorIsInSync)
         {
@@ -155,9 +165,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAllButNoPackageVersionItReturnLatestStableVersion(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -172,13 +182,13 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             package.OriginalVersion.Should().Be(TestPackageVersion);
         }
 
-        [Theory]
-        [InlineData(false, "1.0.0-rc*", TestPackageVersion)]
-        [InlineData(true, "1.0.0-rc*", TestPackageVersion)]
-        [InlineData(false, "1.*", TestPackageVersion)]
-        [InlineData(true, "1.*", TestPackageVersion)]
-        [InlineData(false, TestPackageVersion, TestPackageVersion)]
-        [InlineData(true, TestPackageVersion, TestPackageVersion)]
+        [TestMethod]
+        [DataRow(false, "1.0.0-rc*", TestPackageVersion)]
+        [DataRow(true, "1.0.0-rc*", TestPackageVersion)]
+        [DataRow(false, "1.*", TestPackageVersion)]
+        [DataRow(true, "1.*", TestPackageVersion)]
+        [DataRow(false, TestPackageVersion, TestPackageVersion)]
+        [DataRow(true, TestPackageVersion, TestPackageVersion)]
         public void GivenASpecificVersionGetCorrectVersion(bool testMockBehaviorIsInSync, string requestedVersion, string expectedVersion)
         {
 
@@ -198,9 +208,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             package.OriginalVersion.Should().Be(expectedVersion);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAllButNoPackageVersionItCanInstallThePackage(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -220,9 +230,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAllButNoTargetFrameworkItCanDownloadThePackage(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -241,9 +251,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenASourceInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -265,9 +275,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenARelativeSourcePathInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             //  CI seems to be getting an old version of the global.tool.console.demo package which targets .NET Core 2.1.  This may fix that
@@ -299,9 +309,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAUriSourceInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             //  CI seems to be getting an old version of the global.tool.console.demo package which targets .NET Core 2.1.  This may fix that
@@ -326,9 +336,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAEmptySourceAndNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -352,9 +362,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenFailureAfterRestoreInstallWillRollback(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -389,9 +399,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             AssertInstallRollBack(fileSystem, store);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenSecondInstallInATransactionTheFirstInstallShouldRollback(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -438,9 +448,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             AssertInstallRollBack(fileSystem, store);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenFailureWhenInstallLocalToolsItWillRollbackPackageVersion(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -503,9 +513,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .BeFalse();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenSecondInstallOfLocalToolItShouldNotThrowException(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -542,9 +552,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             a();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenSecondInstallWithoutATransactionTheFirstShouldNotRollback(bool testMockBehaviorIsInSync)
         {
             new RunExeCommand(Log, "dotnet", "nuget", "locals", "all", "--list")
@@ -598,9 +608,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
                 .BeEmpty();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAnInstalledPackageUninstallRemovesThePackage(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -625,9 +635,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             storeQuery.EnumeratePackages().Should().BeEmpty();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAnInstalledPackageUninstallRollsbackWhenTransactionFails(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -661,9 +671,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAnInstalledPackageUninstallRemovesThePackageWhenTransactionCommits(
             bool testMockBehaviorIsInSync)
         {
@@ -694,9 +704,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             storeQuery.EnumeratePackages().Should().BeEmpty();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAPackageNameWithDifferentCaseItCanInstallThePackage(bool testMockBehaviorIsInSync)
         {
             var (store, storeQuery, downloader, uninstaller, reporter, fileSystem, testDir) = Setup(
@@ -715,7 +725,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [Fact]
+        [TestMethod]
         public void GivenARootWithNonAsciiCharacterInstallSucceeds()
         {
             var surrogate = char.ConvertFromUtf32(int.Parse("2A601", NumberStyles.HexNumber));
@@ -751,9 +761,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         }
 
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
         // repro https://github.com/dotnet/cli/issues/9409
         public void GivenAComplexVersionRangeInstallSucceeds(bool testMockBehaviorIsInSync)
         {
@@ -778,9 +788,10 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             uninstaller.Uninstall(package.PackageDirectory);
         }
 
-        [UnixOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         // repro https://github.com/dotnet/cli/issues/10101
         public void GivenAPackageWithCasingAndenUSPOSIXInstallSucceeds(bool testMockBehaviorIsInSync)
         {
@@ -959,14 +970,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         private static readonly IEnumerable<NuGetFramework> TestFrameworks = new NuGetFramework[] { NuGetFramework.Parse(ToolPackageDownloaderMock2.DefaultTargetFramework) };
         private static readonly VerbosityOptions TestVerbosity = new VerbosityOptions();
 
-        private readonly TestToolBuilder ToolBuilder;
+        public ToolPackageDownloaderTests() { }
 
-        public ToolPackageDownloaderTests(ITestOutputHelper log, TestToolBuilder toolBuilder) : base(log)
-        {
-            ToolBuilder = toolBuilder;
-        }
-
-        [Fact]
+        [TestMethod]
         public void GivenAToolWithHigherFrameworkItShowsAppropriateErrorMessage()
         {
             // Create a mock tool package with net99.0 framework to simulate a tool requiring a higher .NET version

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -14,6 +14,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [DoNotParallelize]
     [TestClass]
     public class ToolPackageInstallToManagedLocationInstaller : SdkTest
     {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -14,15 +14,15 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class ToolPackageInstallToManagedLocationInstaller : SdkTest
     {
-        public ToolPackageInstallToManagedLocationInstaller(ITestOutputHelper log) : base(log)
-        {
-        }
+        public ToolPackageInstallToManagedLocationInstaller() { }
 
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             string testDirectory = TestAssetsManager.CreateTestDirectory(identifier: testMockBehaviorIsInSync.ToString()).Path;
@@ -64,9 +64,10 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             }
         }
 
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenNugetConfigVersionRangeInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             string testDirectory = TestAssetsManager.CreateTestDirectory(identifier: testMockBehaviorIsInSync.ToString()).Path;

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
@@ -15,6 +15,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [DoNotParallelize]
     [TestClass]
     public class ToolPackageUninstallerTests : SdkTest
     {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
@@ -15,11 +15,13 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class ToolPackageUninstallerTests : SdkTest
     {
-        [WindowsOnlyTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        [DataRow(false)]
+        [DataRow(true)]
         public void GivenAnInstalledPackageUninstallRemovesThePackage(bool testMockBehaviorIsInSync)
         {
             var source = GetTestLocalFeedPath();
@@ -123,8 +125,6 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         private const string TestPackageVersion = "1.0.4";
         private static readonly PackageId TestPackageId = new("global.tool.console.demo.with.shim");
         private static readonly VerbosityOptions TestVerbosity = new VerbosityOptions();
-        public ToolPackageUninstallerTests(ITestOutputHelper log) : base(log)
-        {
-        }
+        public ToolPackageUninstallerTests() { }
     }
 }

--- a/test/Microsoft.DotNet.PackageInstall.Tests/UnixFilePermissionsTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/UnixFilePermissionsTests.cs
@@ -5,9 +5,10 @@ using Microsoft.DotNet.Cli.NugetPackageDownloader;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class UnixFilePermissionsTests
     {
-        [Fact]
+        [TestMethod]
         public void GivenXmlPathItShouldDeserialize()
         {
             var fileList = FileList.Deserialize("UnixFilePermissionsSample.xml");

--- a/test/Microsoft.NET.TestFramework.MSTest/InternalsVisibleToAttributes.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/InternalsVisibleToAttributes.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+// The runner-agnostic sources (e.g. Mock/FileSystemMockBuilder) link-shared from the legacy
+// Microsoft.NET.TestFramework expose internal members to a handful of test projects. The legacy
+// grants live in Attributes/InternalsVisibleToAttributes.cs, which this project intentionally
+// excludes from the link-share, so the grants are mirrored here for the MSTest-flavored assembly.
+[assembly: InternalsVisibleTo("dotnet.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: InternalsVisibleTo("Microsoft.DotNet.PackageInstall.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: InternalsVisibleTo("Microsoft.DotNet.Cli.Utils.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

Collection/class fixtures (TestToolBuilder, DotnetEnvironmentTestFixture) become a shared static Lazy / [ClassInitialize] with [DoNotParallelize] to preserve serialization. Includes the InternalsVisibleTo grant this project needs and a target to strip the old xUnit framework dll pulled transitively by ComponentMocks.

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
