### PR TITLE
Migrate dotnet-MsiInstallation.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -12,11 +12,12 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
     [DoNotParallelize]
     public class VMTestBase : SdkTest, IDisposable
     {
-        internal VirtualMachine VM { get; }
+        private VirtualMachine _vm;
+
+        internal VirtualMachine VM => _vm ??= new VirtualMachine(Log);
 
         public VMTestBase()
         {
-            VM = new VirtualMachine(Log);
             _sdkInstallerVersion = new Lazy<string>(() =>
             {
                 if (!string.IsNullOrEmpty(VM.VMTestSettings.SdkInstallerVersion))
@@ -51,7 +52,7 @@ namespace Microsoft.DotNet.MsiInstallerTests.Framework
 
         public virtual void Dispose()
         {
-            VM.Dispose();
+            _vm?.Dispose();
         }
 
         protected virtual bool NeedsIncludePreviews => false;

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -9,12 +9,12 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
-    [Collection("VM Tests")]
+    [DoNotParallelize]
     public class VMTestBase : SdkTest, IDisposable
     {
         internal VirtualMachine VM { get; }
 
-        public VMTestBase(ITestOutputHelper log) : base(log)
+        public VMTestBase()
         {
             VM = new VirtualMachine(Log);
             _sdkInstallerVersion = new Lazy<string>(() =>

--- a/test/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/MsiInstallerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {
+    [TestClass]
     public class WorkloadTests : VMTestBase
     {
         const string RollbackRC1 = """
@@ -45,7 +46,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 }
                 """;
 
-        public WorkloadTests(ITestOutputHelper log) : base(log)
+        public WorkloadTests()
         {
         }
 
@@ -69,7 +70,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             return ApplyManifests(Rollback8_0_101, "8.0.101");
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWasm()
         {
             InstallSdk();
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             InstallWorkload("wasm-tools", skipManifestUpdate: true);
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallAndroid()
         {
             InstallSdk();
@@ -89,7 +90,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             InstallWorkload("android", skipManifestUpdate: true);
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallAndroidAndWasm()
         {
             InstallSdk();
@@ -101,7 +102,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             InstallWorkload("wasm-tools", skipManifestUpdate: true);
         }
 
-        [Fact]
+        [TestMethod]
         public void SdkInstallation()
         {
             var command = VM.CreateRunCommand("dotnet", "--version");
@@ -146,7 +147,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
 
-        [Fact]
+        [TestMethod]
         public void WorkloadInstallationAndGarbageCollection()
         {
             InstallSdk();
@@ -180,7 +181,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
         //  Fixed by https://github.com/dotnet/installer/pull/18266
-        [Fact]
+        [TestMethod]
         public void InstallStateShouldBeRemovedOnSdkUninstall()
         {
             InstallSdk();
@@ -193,7 +194,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             VM.GetRemoteFile(installStatePath).Should().NotExist();
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateWithRollback()
         {
             InstallSdk();
@@ -208,7 +209,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .NotHaveStdOutContaining("Installing");
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWithRollback()
         {
             InstallSdk();
@@ -222,7 +223,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             TestWasmWorkload();
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallShouldNotUpdatePinnedRollback()
         {
             InstallSdk();
@@ -234,7 +235,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(workloadVersion);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateShouldUndoPinnedRollback()
         {
             InstallSdk();
@@ -249,19 +250,19 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void ShouldNotShowRebootMessage()
         {
             throw new NotImplementedException();
         }
 
-        [Fact]
+        [TestMethod]
         public void ApplyRollbackShouldNotUpdateAdvertisingManifests()
         {
             throw new NotImplementedException();
         }
 
-        [Fact]
+        [TestMethod]
         public void TestAspire()
         {
             InstallSdk();

--- a/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
@@ -10,7 +10,8 @@ namespace Microsoft.DotNet.MsiInstallerTests
     [TestClass]
     public class VSWorkloadTests : VMTestBase
     {
-        public VSWorkloadTests()
+        [TestInitialize]
+        public void Initialize()
         {
             VM.SetCurrentState("Install VS 17.10 Preview 6");
             DeployStage2Sdk();

--- a/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/VSWorkloadTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,15 +7,16 @@ using Microsoft.DotNet.MsiInstallerTests.Framework;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {
+    [TestClass]
     public class VSWorkloadTests : VMTestBase
     {
-        public VSWorkloadTests(ITestOutputHelper log) : base(log)
+        public VSWorkloadTests()
         {
             VM.SetCurrentState("Install VS 17.10 Preview 6");
             DeployStage2Sdk();
         }
 
-        [Fact]
+        [TestMethod]
         public void WorkloadListShowsVSInstalledWorkloads()
         {
             var result = VM.CreateRunCommand("dotnet", "workload", "list")
@@ -27,7 +28,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             result.Should().HaveStdOutContaining("aspire");
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdatesAreAdvertisedForVSInstalledWorkloads()
         {
             AddNuGetSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json");

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -11,13 +11,14 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {
+    [TestClass]
     public class WorkloadSetTests : WorkloadSetTestsBase
     {
-        public WorkloadSetTests(ITestOutputHelper log) : base(log)
+        public WorkloadSetTests()
         {
         }
 
-        [Fact]
+        [TestMethod]
         public void DoesNotUseWorkloadSetsByDefault()
         {
             InstallSdk();
@@ -42,7 +43,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateWithWorkloadSets()
         {
             InstallSdk();
@@ -67,7 +68,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateInWorkloadSetModeWithNoAvailableWorkloadSet()
         {
             InstallSdk();
@@ -87,13 +88,13 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(updatedWorkloadVersion);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateToSpecificWorkloadSetVersion()
         {
             UpdateToWorkloadSetVersion(WorkloadSetVersion1);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateToPreviousBandWorkloadSetVersion()
         {
             UpdateToWorkloadSetVersion(WorkloadSetPreviousBandVersion);
@@ -134,7 +135,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateToUnavailableWorkloadSetVersion()
         {
             string unavailableWorkloadSetVersion = "8.0.300-preview.test.42";
@@ -160,7 +161,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
 
-        [Fact]
+        [TestMethod]
         public void UpdateWorkloadSetWithoutAvailableManifests()
         {
             InstallSdk();
@@ -183,7 +184,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateToWorkloadSetVersionWithManifestsNotAvailable()
         {
             InstallSdk();
@@ -204,7 +205,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(workloadVersionBeforeUpdate);
         }
 
-        [Fact]
+        [TestMethod]
         public void UpdateShouldNotPinWorkloadSet()
         {
             InstallSdk();
@@ -229,14 +230,16 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/46905")]
+        [TestMethod]
+        [Ignore("https://github.com/dotnet/sdk/issues/46905")]
         public void WorkloadSetInstallationRecordIsWrittenCorrectly()
         {
             //  Should the workload set version or the package version be used in the registry?
             throw new NotImplementedException();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/sdk/issues/46905")]
+        [TestMethod]
+        [Ignore("https://github.com/dotnet/sdk/issues/46905")]
         public void TurnOffWorkloadSetUpdateMode()
         {
             //  If you have a workload set installed and then turn off workload set update mode, what should happen?
@@ -245,7 +248,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             throw new NotImplementedException();
         }
 
-        [Fact]
+        [TestMethod]
         public void GarbageCollectWorkloadSets()
         {
             InstallSdk();
@@ -306,7 +309,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
         //  Note: this may fail due to https://github.com/dotnet/sdk/issues/43876
-        [Fact]
+        [TestMethod]
         public void FinalizerUninstallsWorkloadSets()
         {
             UpdateWithWorkloadSets();
@@ -323,7 +326,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
         //  Note: this may fail for rtm-branded non-stabilized SDKs: https://github.com/dotnet/sdk/issues/43890
-        [Fact]
+        [TestMethod]
         public void WorkloadSearchVersion()
         {
             InstallSdk();

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -8,9 +8,10 @@ using Microsoft.NET.Sdk.WorkloadManifestReader;
 
 namespace Microsoft.DotNet.MsiInstallerTests
 {
+    [TestClass]
     public class WorkloadSetTests2 : WorkloadSetTestsBase
     {
-        public WorkloadSetTests2(ITestOutputHelper log) : base(log)
+        public WorkloadSetTests2()
         {
         }
 
@@ -45,7 +46,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             AddNuGetSource(@"C:\SdkTesting\workloadsets", SdkTestingDirectory);
         }
 
-        [Fact]
+        [TestMethod]
         public void RestoreWorkloadSetViaGlobalJson()
         {
             InstallSdk();
@@ -66,9 +67,9 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
         }
 
-        [Theory]
-        [InlineData("update")]
-        [InlineData("install")]
+        [TestMethod]
+        [DataRow("update")]
+        [DataRow("install")]
         public void UseGlobalJsonToSpecifyWorkloadSet(string command)
         {
             SetupWorkloadSetInGlobalJson(out var originalRollback);
@@ -78,7 +79,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetRollback(SdkTestingDirectory).Should().NotBe(originalRollback);
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWithGlobalJsonAndSkipManifestUpdate()
         {
             SetupWorkloadSetInGlobalJson(out var originalRollback);
@@ -90,7 +91,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .And.HaveStdErrContaining(Path.Combine(SdkTestingDirectory, "global.json"));
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWithVersionAndSkipManifestUpdate()
         {
             InstallSdk();
@@ -101,7 +102,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
                 .And.HaveStdErrContaining("--sdk-version");
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWithVersionWhenPinned()
         {
             InstallSdk();
@@ -122,7 +123,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
             GetWorkloadVersion().Should().Be(WorkloadSetVersion2);
         }
 
-        [Fact]
+        [TestMethod]
         public void InstallWithGlobalJsonWhenPinned()
         {
             SetupWorkloadSetInGlobalJson(out var originalRollback);
@@ -147,7 +148,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
 
         }
 
-        [Fact]
+        [TestMethod]
         public void DotnetInfoWithGlobalJson()
         {
             InstallSdk();
@@ -158,9 +159,9 @@ namespace Microsoft.DotNet.MsiInstallerTests
             SetupWorkloadSetInGlobalJson(out _);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public void UpdateDoesNotTryToInstallOlderWorkloadSet(bool usePreview)
         {
             if (NeedsIncludePreviews && usePreview)

--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTestsBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         protected string WorkloadSetPreviousBandVersion => _testWorkloadSetVersions.Value.GetValueOrDefault("previousbandversion", "8.0.204");
 
         protected override bool NeedsIncludePreviews => bool.Parse(_testWorkloadSetVersions.Value.GetValueOrDefault("needsIncludePreviews", "false"));
-        public WorkloadSetTestsBase(ITestOutputHelper log) : base(log)
+        public WorkloadSetTestsBase()
         {
             _testWorkloadSetVersions = new Lazy<Dictionary<string, string>>(() =>
             {

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -1,19 +1,16 @@
-﻿<Project>
+﻿<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\dotnet-MsiInstallation.Tests.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-
   <PropertyGroup>
-    <OutputType Condition="'$(TargetOS)' == 'windows'">Exe</OutputType>
-    <OutputType Condition="'$(TargetOS)' != 'windows'">Library</OutputType>
     <!-- Use plain TFM on non-Windows so NuGet restore can evaluate the project -->
     <TargetFramework Condition="'$(TargetOS)' == 'windows'">$(SdkTargetFramework)-windows</TargetFramework>
     <TargetFramework Condition="'$(TargetOS)' != 'windows'">$(SdkTargetFramework)</TargetFramework>
     <!-- Disable test infrastructure on non-Windows so it doesn't inject usings/entry points -->
+    <IsTestApplication Condition="'$(TargetOS)' != 'windows'">false</IsTestApplication>
     <IsTestProject Condition="'$(TargetOS)' != 'windows'">false</IsTestProject>
     <IsUnitTestProject Condition="'$(TargetOS)' != 'windows'">false</IsUnitTestProject>
   </PropertyGroup>
@@ -37,11 +34,17 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <ProjectReference Include="..\..\src\Cli\dotnet\dotnet.csproj" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+  </ItemGroup>
 
   <!-- Remove ALL compile items and global usings added by test infrastructure (must be after Sdk.targets) -->
   <ItemGroup Condition="'$(TargetOS)' != 'windows'">


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

Preserves the Windows-only test-app behaviour (non-Windows builds as a plain library via IsTestApplication=false); the [Collection] VM serialization becomes [DoNotParallelize] (inherited by the derived test classes).

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
