### PR TITLE
Migrate dotnet-watch.Tests to MSTest.Sdk on MTP

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -148,6 +148,7 @@
     <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.2.4" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
 
+    <PackageVersion Include="xunit.v3.assert" Version="$(XUnitV3Version)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -148,7 +148,6 @@
     <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.2.4" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
 
-    <PackageVersion Include="xunit.v3.assert" Version="$(XUnitV3Version)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" />
   </ItemGroup>
 

--- a/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
@@ -1,13 +1,50 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using System.IO.Pipes;
 using System.Text.Json;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class AspireLauncherIntegrationTests(ITestOutputHelper logger) : WatchSdkTest(logger)
+[TestClass]
+public class AspireLauncherIntegrationTests : MSTestFramework::Microsoft.NET.TestFramework.SdkTest
 {
+    private TestAssetsManager? _testAssetsManager;
+    public TestAssetsManager TestAssets => _testAssetsManager ??= new TestAssetsManager(Logger);
+
+    private DualOutputHelper? _logger;
+    private DualOutputHelper Logger
+        => _logger ??= new DualOutputHelper(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+
+    public new void Log(string message, [System.Runtime.CompilerServices.CallerFilePath] string? testPath = null, [System.Runtime.CompilerServices.CallerLineNumber] int testLine = 0)
+        => Logger.Log(message, testPath, testLine);
+
+    public static void WriteAllText(string path, string text)
+    {
+        using var stream = File.Open(path, FileMode.OpenOrCreate);
+        using (var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(text);
+        }
+
+        stream.SetLength(stream.Position);
+    }
+
+    public void UpdateSourceFile(string path, string text, [System.Runtime.CompilerServices.CallerFilePath] string? testPath = null, [System.Runtime.CompilerServices.CallerLineNumber] int testLine = 0)
+    {
+        var existed = File.Exists(path);
+        WriteAllText(path, text);
+        Log($"File '{path}' " + (existed ? "updated" : "added"), testPath, testLine);
+    }
+
+    public void UpdateSourceFile(string path, Func<string, string> contentTransform, [System.Runtime.CompilerServices.CallerFilePath] string? testPath = null, [System.Runtime.CompilerServices.CallerLineNumber] int testLine = 0)
+        => UpdateSourceFile(path, contentTransform(File.ReadAllText(path, Encoding.UTF8)), testPath, testLine);
+
+    public void UpdateSourceFile(string path)
+        => UpdateSourceFile(path, content => content);
+
     private WatchableApp CreateHostApp()
         => new(
             Logger,
@@ -29,7 +66,8 @@ public class AspireLauncherIntegrationTests(ITestOutputHelper logger) : WatchSdk
             commandName: "resource",
             commandArguments: ["--server", serverPipe]);
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task Host()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -45,7 +83,8 @@ public class AspireLauncherIntegrationTests(ITestOutputHelper logger) : WatchSdk
         await host.WaitUntilOutputContains("Started");
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task ServerAndResources()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppMultiProc")
@@ -112,7 +151,7 @@ public class AspireLauncherIntegrationTests(ITestOutputHelper logger) : WatchSdk
         serviceB.Process.ClearOutput();
 
         using var controlPipe = new NamedPipeServerStream(controlPipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
-        await controlPipe.WaitForConnectionAsync();
+        await controlPipe.WaitForConnectionAsync(TestContext.CancellationToken);
         using var controlPipeWriter = new StreamWriter(controlPipe) { AutoFlush = true };
 
         // restart resource process:

--- a/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireServiceFactoryTests.cs
@@ -5,9 +5,10 @@ using Aspire.Tools.Service;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class AspireServiceFactoryTests
 {
-    [Fact]
+    [TestMethod]
     public void GetRunCommandArguments_Empty()
     {
         var request = new ProjectLaunchRequest()
@@ -24,7 +25,7 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj"], args);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRunCommandArguments_DisableLaunchProfile()
     {
         var request = new ProjectLaunchRequest()
@@ -41,9 +42,9 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj", "--no-launch-profile" ], args);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
     public void GetRunCommandArguments_NoLaunchProfile_HostProfile(string? launchProfile)
     {
         var request = new ProjectLaunchRequest()
@@ -60,9 +61,9 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "H"], args);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
     public void GetRunCommandArguments_DisableLaunchProfile_HostProfile(string? launchProfile)
     {
         var request = new ProjectLaunchRequest()
@@ -79,9 +80,9 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj", "--no-launch-profile"], args);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
     public void GetRunCommandArguments_NoLaunchProfile_NoHostProfile(string? launchProfile)
     {
         var request = new ProjectLaunchRequest()
@@ -97,7 +98,7 @@ public class AspireServiceFactoryTests
 
         AssertEx.SequenceEqual(["--project", "a.csproj"], args);
     }
-    [Fact]
+    [TestMethod]
     public void GetRunCommandArguments_LaunchProfile_NoArgs()
     {
         var request = new ProjectLaunchRequest()
@@ -114,7 +115,7 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P"], args);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRunCommandArguments_LaunchProfile_EmptyArgs()
     {
         var request = new ProjectLaunchRequest()
@@ -131,7 +132,7 @@ public class AspireServiceFactoryTests
         AssertEx.SequenceEqual(["--project", "a.csproj", "--launch-profile", "P", "--no-launch-profile-arguments"], args);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRunCommandArguments_LaunchProfile_NonEmptyArgs()
     {
         var request = new ProjectLaunchRequest()

--- a/test/dotnet-watch.Tests/Aspire/PipeUtilities.cs
+++ b/test/dotnet-watch.Tests/Aspire/PipeUtilities.cs
@@ -29,7 +29,7 @@ internal static class PipeUtilities
                 }
 
                 var value = JsonSerializer.Deserialize<WatchStatusEvent>(line);
-                Assert.NotNull(value);
+                Assert.IsNotNull(value);
 
                 lines.Add(value);
             }

--- a/test/dotnet-watch.Tests/Browser/BrowserLauncherTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserLauncherTests.cs
@@ -3,21 +3,22 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class BrowserLauncherTests
 {
-    [Theory]
-    [InlineData(null, "https://localhost:1234", "https://localhost:1234")]
-    [InlineData(null, "https://localhost:1234/", "https://localhost:1234/")]
-    [InlineData("", "https://localhost:1234", "https://localhost:1234")]
-    [InlineData("   ", "https://localhost:1234", "https://localhost:1234")]
-    [InlineData("", "a/b", "a/b")]
-    [InlineData("x/y", "a/b", "a/b")]
-    [InlineData("a/b?X=1", "https://localhost:1234", "https://localhost:1234/a/b?X=1")]
-    [InlineData("https://localhost:1000/", "https://localhost:1234", "https://localhost:1000/")]
-    [InlineData("https://localhost:1000/a/b", "https://localhost:1234", "https://localhost:1000/a/b")]
-    [InlineData("https://localhost:1000/x/y?z=u", "https://localhost:1234/a?b=c", "https://localhost:1000/x/y?z=u")]
+    [TestMethod]
+    [DataRow(null, "https://localhost:1234", "https://localhost:1234")]
+    [DataRow(null, "https://localhost:1234/", "https://localhost:1234/")]
+    [DataRow("", "https://localhost:1234", "https://localhost:1234")]
+    [DataRow("   ", "https://localhost:1234", "https://localhost:1234")]
+    [DataRow("", "a/b", "a/b")]
+    [DataRow("x/y", "a/b", "a/b")]
+    [DataRow("a/b?X=1", "https://localhost:1234", "https://localhost:1234/a/b?X=1")]
+    [DataRow("https://localhost:1000/", "https://localhost:1234", "https://localhost:1000/")]
+    [DataRow("https://localhost:1000/a/b", "https://localhost:1234", "https://localhost:1000/a/b")]
+    [DataRow("https://localhost:1000/x/y?z=u", "https://localhost:1234/a?b=c", "https://localhost:1000/x/y?z=u")]
     public void GetLaunchUrl(string? profileLaunchUrl, string outputLaunchUrl, string expected)
     {
-        Assert.Equal(expected, BrowserLauncher.GetLaunchUrl(profileLaunchUrl, outputLaunchUrl));
+        Assert.AreEqual(expected, BrowserLauncher.GetLaunchUrl(profileLaunchUrl, outputLaunchUrl));
     }
 }

--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class BrowserRefreshServerTests
 {
     class TestListener : IDisposable
@@ -15,8 +16,21 @@ public class BrowserRefreshServerTests
         }
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(LogLevel.Trace, true)]
+    [DataRow(LogLevel.Trace, false)]
+    [DataRow(LogLevel.Debug, true)]
+    [DataRow(LogLevel.Debug, false)]
+    [DataRow(LogLevel.Information, true)]
+    [DataRow(LogLevel.Information, false)]
+    [DataRow(LogLevel.Warning, true)]
+    [DataRow(LogLevel.Warning, false)]
+    [DataRow(LogLevel.Error, true)]
+    [DataRow(LogLevel.Error, false)]
+    [DataRow(LogLevel.Critical, true)]
+    [DataRow(LogLevel.Critical, false)]
+    [DataRow(LogLevel.None, true)]
+    [DataRow(LogLevel.None, false)]
     public async Task ConfigureLaunchEnvironmentAsync(LogLevel logLevel, bool enableHotReload) 
     {
         var middlewarePath = Path.GetTempPath();
@@ -34,7 +48,7 @@ public class BrowserRefreshServerTests
         var envBuilder = new Dictionary<string, string>();
         server.ConfigureLaunchEnvironment(envBuilder, enableHotReload);
 
-        Assert.True(envBuilder.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
+        Assert.IsTrue(envBuilder.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
 
         var expected = new List<string>()
         {

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -5,9 +5,10 @@ using System.Text.Json;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class BrowserTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task LaunchesBrowserOnStart()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchBrowserLaunchApp")
@@ -24,7 +25,8 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage("https://localhost:5001"));
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task BrowserDiagnostics()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")
@@ -79,7 +81,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             """);
 
         // no other browser message sent:
-        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
+        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
 
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
@@ -103,7 +105,7 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             """);
 
         // no other browser message sent:
-        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
+        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
 
         App.Process.ClearOutput();
 
@@ -121,6 +123,6 @@ public class BrowserTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
             """);
 
         // no other browser message sent:
-        Assert.Equal(2, App.Process.Output.Count(line => line.Contains("🧪")));
+        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
     }
 }

--- a/test/dotnet-watch.Tests/Build/BuildUtilitiesTests.cs
+++ b/test/dotnet-watch.Tests/Build/BuildUtilitiesTests.cs
@@ -3,25 +3,26 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests.Build;
 
+[TestClass]
 public class BuildUtilitiesTests
 {
-    [Theory]
-    [InlineData("-p:P=V", "P", "V")]
-    [InlineData("-p:P==", "P", "=")]
-    [InlineData("-p:P=A=B", "P", "A=B")]
-    [InlineData("-p: P\t = V ", "P", " V ")]
-    [InlineData("-p:P=", "P", "")]
+    [TestMethod]
+    [DataRow("-p:P=V", "P", "V")]
+    [DataRow("-p:P==", "P", "=")]
+    [DataRow("-p:P=A=B", "P", "A=B")]
+    [DataRow("-p: P\t = V ", "P", " V ")]
+    [DataRow("-p:P=", "P", "")]
     public void BuildProperties_Valid(string argValue, string name, string value)
     {
         var properties = BuildUtilities.ParseBuildProperties([argValue]);
         AssertEx.SequenceEqual([(name, value)], properties);
     }
 
-    [Theory]
-    [InlineData("P")]
-    [InlineData("=P3")]
-    [InlineData("=")]
-    [InlineData("==")]
+    [TestMethod]
+    [DataRow("P")]
+    [DataRow("=P3")]
+    [DataRow("=")]
+    [DataRow("==")]
     public void BuildProperties_Invalid(string argValue)
     {
         var properties = BuildUtilities.ParseBuildProperties([argValue]);

--- a/test/dotnet-watch.Tests/Build/EvaluationResultTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationResultTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Graph;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class EvaluationResultTests
 {
     public ProjectGraph CreateGraph(TestDirectory testDir, params (string projectName, string[] targetFrameworks, string[] referencedProjects)[] projects)
@@ -65,9 +66,9 @@ public class EvaluationResultTests
             });
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("net9.0")]
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("net9.0")]
     public void CreateDesignTimeBuildRequests_SingleTfm(string? mainTfm)
     {
         var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
@@ -81,9 +82,9 @@ public class EvaluationResultTests
         AssertEx.SequenceEqual(["main (net9.0)"], requests.Select(r => r.ProjectInstance.GetDisplayName()));
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("net9.0")]
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("net9.0")]
     public void CreateDesignTimeBuildRequests_SingleTfm_WithDependencies(string? mainTfm)
     {
         var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
@@ -102,9 +103,9 @@ public class EvaluationResultTests
         ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("net9.0")]
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("net9.0")]
     public void CreateDesignTimeBuildRequests_SingleTfm_WithMultiTargetedDependencies(string? mainTfm)
     {
         var testDir = TestAssetsManager.CreateTestDirectory(identifiers: [mainTfm]);
@@ -124,7 +125,7 @@ public class EvaluationResultTests
         ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateDesignTimeBuildRequests_MultiTfm_WithDependencies_NoMainTfm()
     {
         var testDir = TestAssetsManager.CreateTestDirectory();
@@ -145,7 +146,7 @@ public class EvaluationResultTests
         ], requests.Select(r => r.ProjectInstance.GetDisplayName()));
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateDesignTimeBuildRequests_MultiTfm_WithDependencies_MainTfm()
     {
         var testDir = TestAssetsManager.CreateTestDirectory();

--- a/test/dotnet-watch.Tests/Build/EvaluationTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationTests.cs
@@ -1,14 +1,22 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class EvaluationTests(ITestOutputHelper output)
+[TestClass]
+public class EvaluationTests
 {
-    private readonly TestLogger _logger = new(output);
-    private readonly TestAssetsManager _testAssets = new(output);
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper? _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private TestLogger? _logger;
+    private TestLogger Logger => _logger ??= new TestLogger(Output);
+    private TestAssetsManager? _testAssets;
+    private TestAssetsManager TestAssets => _testAssets ??= new TestAssetsManager(Output);
 
     private static string InspectPath(string path, string rootDir)
         => path.Substring(rootDir.Length + 1).Replace("\\", "/");
@@ -39,7 +47,7 @@ public class EvaluationTests(ITestOutputHelper output)
         return 1;
         """;
 
-    [Fact]
+    [TestMethod]
     public async Task FindsCustomWatchItems()
     {
         var project = new TestProject("Project1")
@@ -57,7 +65,7 @@ public class EvaluationTests(ITestOutputHelper output)
             }
         };
 
-        var testAsset = _testAssets.CreateTestProject(project)
+        var testAsset = TestAssets.CreateTestProject(project)
             .WithProjectChanges(d => d.Root!.Add(XElement.Parse("""
                 <ItemGroup>
                   <Watch Include="*.js" Exclude="gulpfile.js" />
@@ -75,7 +83,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExcludesDefaultItemsWithWatchFalseMetadata()
     {
         var project = new TestProject("Project1")
@@ -104,7 +112,7 @@ public class EvaluationTests(ITestOutputHelper output)
             }
         };
 
-        var testAsset = _testAssets.CreateTestProject(project);
+        var testAsset = TestAssets.CreateTestProject(project);
 
         await VerifyEvaluation(testAsset,
         [
@@ -117,9 +125,14 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Theory]
-    [CombinatorialData]
-    public async Task StaticAssets(bool isWeb, [CombinatorialValues(true, false, null)] bool? enableStaticWebAssets)
+    [TestMethod]
+    [DataRow(true, true)]
+    [DataRow(true, false)]
+    [DataRow(true, null)]
+    [DataRow(false, true)]
+    [DataRow(false, false)]
+    [DataRow(false, null)]
+    public async Task StaticAssets(bool isWeb, bool? enableStaticWebAssets)
     {
         var project = new TestProject("Project1")
         {
@@ -138,7 +151,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(project, identifier: $"{isWeb}_{enableStaticWebAssets}");
+        var testAsset = TestAssets.CreateTestProject(project, identifier: $"{isWeb}_{enableStaticWebAssets}");
 
         await VerifyEvaluation(testAsset,
             isWeb && enableStaticWebAssets != false ?
@@ -160,7 +173,7 @@ public class EvaluationTests(ITestOutputHelper output)
             suppressStaticWebAssets: enableStaticWebAssets == false);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RazorClassLibrary()
     {
         var projectRcl = new TestProject("RCL")
@@ -197,7 +210,7 @@ public class EvaluationTests(ITestOutputHelper output)
             }
         };
 
-        var testAsset = _testAssets.CreateTestProject(project);
+        var testAsset = TestAssets.CreateTestProject(project);
 
         await VerifyEvaluation(testAsset,
         [
@@ -224,7 +237,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProjectReferences_OneLevel()
     {
         var project2 = new TestProject("Project2")
@@ -243,7 +256,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(project1);
+        var testAsset = TestAssets.CreateTestProject(project1);
 
         await VerifyEvaluation(testAsset, targetFramework: ToolsetInfo.CurrentTargetFramework,
         [
@@ -258,7 +271,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TransitiveProjectReferences_TwoLevels()
     {
         var project3 = new TestProject("Project3")
@@ -283,7 +296,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(project1);
+        var testAsset = TestAssets.CreateTestProject(project1);
 
         await VerifyEvaluation(testAsset, targetFramework: ToolsetInfo.CurrentTargetFramework,
         [
@@ -302,8 +315,9 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task SingleTargetRoot_MultiTargetedDependency(bool specifyTargetFramework)
     {
         var project2 = new TestProject("Project2")
@@ -322,7 +336,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(project1, identifier: specifyTargetFramework.ToString());
+        var testAsset = TestAssets.CreateTestProject(project1, identifier: specifyTargetFramework.ToString());
 
         await VerifyEvaluation(testAsset, specifyTargetFramework ? ToolsetInfo.CurrentTargetFramework : null,
         [
@@ -339,7 +353,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FSharpProjectDependency()
     {
         var projectFS = new TestProject("FSProj")
@@ -366,7 +380,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(projectCS);
+        var testAsset = TestAssets.CreateTestProject(projectCS);
 
         await VerifyEvaluation(testAsset,
         [
@@ -381,7 +395,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VBProjectDependency()
     {
         var projectVB = new TestProject("VB")
@@ -408,7 +422,7 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(projectCS);
+        var testAsset = TestAssets.CreateTestProject(projectCS);
 
         await VerifyEvaluation(testAsset,
         [
@@ -423,7 +437,7 @@ public class EvaluationTests(ITestOutputHelper output)
         ]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProjectReferences_Graph()
     {
         // A->B,F,W(Watch=False)
@@ -434,7 +448,7 @@ public class EvaluationTests(ITestOutputHelper output)
         // G->E
         // W->U
         // Y->B,F,Z
-        var testDirectory = _testAssets.CopyTestAsset("ProjectReferences_Graph")
+        var testDirectory = TestAssets.CopyTestAsset("ProjectReferences_Graph")
             .WithSource()
             .Path;
         var projectA = Path.Combine(testDirectory, "A", "A.csproj");
@@ -442,10 +456,10 @@ public class EvaluationTests(ITestOutputHelper output)
         var options = TestOptions.GetEnvironmentOptions(workingDirectory: testDirectory);
         var processRunner = new ProcessRunner(processCleanupTimeout: TimeSpan.Zero);
 
-        var filesetFactory = new MSBuildFileSetFactory(projectA, targetFramework: null, buildArguments: ["/p:_DotNetWatchTraceOutput=true"], processRunner, _logger, TestOptions.GlobalOptions, options);
+        var filesetFactory = new MSBuildFileSetFactory(projectA, targetFramework: null, buildArguments: ["/p:_DotNetWatchTraceOutput=true"], processRunner, Logger, TestOptions.GlobalOptions, options);
 
         var result = await filesetFactory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
-        Assert.NotNull(result);
+        Assert.IsNotNull(result);
 
         AssertEx.SequenceEqual(
         [
@@ -478,10 +492,10 @@ public class EvaluationTests(ITestOutputHelper output)
                 "'F'",
                 "'G'",
             ],
-            _logger.GetAndClearMessages().Where(m => m.Contains(prefix)).Select(m => m.Trim()[prefix.Length..]).Order());
+            Logger.GetAndClearMessages().Where(m => m.Contains(prefix)).Select(m => m.Trim()[prefix.Length..]).Order());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MsbuildOutput()
     {
         var project2 = new TestProject("Project2")
@@ -500,20 +514,20 @@ public class EvaluationTests(ITestOutputHelper output)
             },
         };
 
-        var testAsset = _testAssets.CreateTestProject(project1);
+        var testAsset = TestAssets.CreateTestProject(project1);
         var project1Path = GetTestProjectPath(testAsset);
 
         var options = TestOptions.GetEnvironmentOptions(workingDirectory: Path.GetDirectoryName(project1Path)!);
         var processRunner = new ProcessRunner(processCleanupTimeout: TimeSpan.Zero);
 
-        var factory = new MSBuildFileSetFactory(project1Path, targetFramework: null, buildArguments: [], processRunner, _logger, TestOptions.GlobalOptions, options);
+        var factory = new MSBuildFileSetFactory(project1Path, targetFramework: null, buildArguments: [], processRunner, Logger, TestOptions.GlobalOptions, options);
         var result = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
-        Assert.Null(result);
+        Assert.IsNull(result);
 
         // note: msbuild prints errors to stdout, we match the pattern and report as error:
         Assert.Contains(
             $"[Error] {project1Path} : error NU1201: Project Project2 is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Project2 supports: netstandard2.1 (.NETStandard,Version=v2.1)",
-            _logger.GetAndClearMessages());
+            Logger.GetAndClearMessages());
     }
 
     private readonly struct ExpectedFile(string path, string? staticAssetUrl = null, bool targetsOnly = false, bool graphOnly = false)
@@ -532,10 +546,10 @@ public class EvaluationTests(ITestOutputHelper output)
         var testDir = testAsset.Path;
         var rootProjectPath = GetTestProjectPath(testAsset);
 
-        output.WriteLine("=== Evaluate using target ===");
+        Output.WriteLine("=== Evaluate using target ===");
         await VerifyTargetsEvaluation();
 
-        output.WriteLine("=== Evaluate using project graph ===");
+        Output.WriteLine("=== Evaluate using project graph ===");
         await VerifyProjectGraphEvaluation();
 
         async Task VerifyTargetsEvaluation()
@@ -543,9 +557,9 @@ public class EvaluationTests(ITestOutputHelper output)
             var options = TestOptions.GetEnvironmentOptions(workingDirectory: testDir) with { TestOutput = testDir };
             var processRunner = new ProcessRunner(processCleanupTimeout: TimeSpan.Zero);
             var buildArguments = targetFramework != null ? new[] { "/p:TargetFramework=" + targetFramework } : [];
-            var factory = new MSBuildFileSetFactory(rootProjectPath, targetFramework: null, buildArguments, processRunner, _logger, TestOptions.GlobalOptions, options);
+            var factory = new MSBuildFileSetFactory(rootProjectPath, targetFramework: null, buildArguments, processRunner, Logger, TestOptions.GlobalOptions, options);
             var targetsResult = await factory.TryCreateAsync(requireProjectGraph: null, CancellationToken.None);
-            Assert.NotNull(targetsResult);
+            Assert.IsNotNull(targetsResult);
 
             var normalizedActual = Inspect(targetsResult.Files);
             var normalizedExpected = expectedFiles.Where(f => !f.GraphOnly).Select(f => (f.Path, f.StaticAssetUrl)).OrderBy(f => f.Path);
@@ -556,7 +570,7 @@ public class EvaluationTests(ITestOutputHelper output)
         {
             // Needs to be executed in dotnet-watch process in order for msbuild to load from the correct location.
 
-            await using var watchableApp = WatchableApp.CreateDotnetWatchApp(output);
+            await using var watchableApp = WatchableApp.CreateDotnetWatchApp(Output);
             var arguments = targetFramework != null ? new[] { "-f", targetFramework } : [];
 
             if (suppressStaticWebAssets)

--- a/test/dotnet-watch.Tests/Build/FileSetSerializerTests.cs
+++ b/test/dotnet-watch.Tests/Build/FileSetSerializerTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 #nullable disable
 
 using System.Runtime.Serialization.Json;
@@ -10,9 +12,14 @@ using Microsoft.NET.Build.Tasks.UnitTests;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class FileSetSerializerTests(ITestOutputHelper output)
+[TestClass]
+public class FileSetSerializerTests
 {
-    private readonly TestAssetsManager _testAssetManager = new (output);
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private TestAssetsManager _testAssetManager;
+    private TestAssetsManager TestAssetManager => _testAssetManager ??= new(Output);
 
     private static string Serialize(MSBuildFileSetResult fileSetResult, Stream stream)
     {
@@ -36,7 +43,7 @@ public class FileSetSerializerTests(ITestOutputHelper output)
         return reader.ReadToEnd();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Roundtrip()
     {
         var result1 = new MSBuildFileSetResult()
@@ -101,10 +108,10 @@ public class FileSetSerializerTests(ITestOutputHelper output)
             """.Replace("\r\n", "\n"), serialized1.Replace("\r\n", "\n"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Task()
     {
-        var dir = _testAssetManager.CreateTestDirectory().Path;
+        var dir = TestAssetManager.CreateTestDirectory().Path;
         var outputPath = Path.Combine(dir, "output.txt");
 
         var engine = new MockBuildEngine();
@@ -150,7 +157,7 @@ public class FileSetSerializerTests(ITestOutputHelper output)
         };
 
         var result = task.Execute();
-        Assert.True(result);
+        Assert.IsTrue(result);
 
         AssertEx.Equal("""
             {

--- a/test/dotnet-watch.Tests/Build/ProjectGraphFactoryTests.cs
+++ b/test/dotnet-watch.Tests/Build/ProjectGraphFactoryTests.cs
@@ -1,20 +1,27 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProjectGraphFactoryTests(ITestOutputHelper output)
+[TestClass]
+public class ProjectGraphFactoryTests
 {
-    private readonly TestAssetsManager _testAssetManager = new(output);
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper? _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private TestAssetsManager? _testAssetManager;
+    private TestAssetsManager TestAssetManager => _testAssetManager ??= new(Output);
     private readonly TestLogger _testLogger = new();
 
-    [Fact]
+    [TestMethod]
     public void RegularProject()
     {
-        var testAsset = _testAssetManager.CopyTestAsset("WatchNoDepsApp")
+        var testAsset = TestAssetManager.CopyTestAsset("WatchNoDepsApp")
             .WithSource();
 
         var projectPath = Path.Combine(testAsset.Path, "WatchNoDepsApp.csproj");
@@ -23,16 +30,16 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         var factory = new ProjectGraphFactory([projectRepr], buildProperties: [], _testLogger, TestOptions.GlobalOptions, TestOptions.GetEnvironmentOptions(asset: testAsset));
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, virtualProjectTargetFramework: null, CancellationToken.None);
-        Assert.NotNull(graph);
+        Assert.IsNotNull(graph);
 
         var root = graph.Graph.GraphRoots.Single();
-        Assert.Equal(projectPath, root.ProjectInstance.FullPath);
+        Assert.AreEqual(projectPath, root.ProjectInstance.FullPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void VirtualProject()
     {
-        var dir = _testAssetManager.CreateTestDirectory().Path;
+        var dir = TestAssetManager.CreateTestDirectory().Path;
 
         var entryPointFilePath = Path.Combine(dir, "App.cs");
         File.WriteAllText(entryPointFilePath, """
@@ -43,16 +50,16 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         var factory = new ProjectGraphFactory([projectRepr], buildProperties: [], _testLogger, TestOptions.GlobalOptions, TestOptions.GetEnvironmentOptions());
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, virtualProjectTargetFramework: null, CancellationToken.None);
-        Assert.NotNull(graph);
+        Assert.IsNotNull(graph);
 
         var root = graph.Graph.GraphRoots.Single();
-        Assert.Equal(VirtualProjectBuilder.GetVirtualProjectPath(entryPointFilePath), root.ProjectInstance.FullPath);
+        Assert.AreEqual(VirtualProjectBuilder.GetVirtualProjectPath(entryPointFilePath), root.ProjectInstance.FullPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void VirtualProject_Error()
     {
-        var dir = _testAssetManager.CreateTestDirectory().Path;
+        var dir = TestAssetManager.CreateTestDirectory().Path;
 
         var entryPointFilePath = Path.Combine(dir, "App.cs");
         File.WriteAllText(entryPointFilePath, """
@@ -63,7 +70,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         var factory = new ProjectGraphFactory([projectRepr], buildProperties: [], _testLogger, TestOptions.GlobalOptions, TestOptions.GetEnvironmentOptions());
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, virtualProjectTargetFramework: null, CancellationToken.None);
-        Assert.Null(graph);
+        Assert.IsNull(graph);
 
         var message = string.Format(FileBasedProgramsResources.InvalidProjectDirective,
             string.Format(FileBasedProgramsResources.CouldNotFindProjectOrDirectory, Path.Combine(dir, "NonExistent.csproj")));
@@ -75,10 +82,10 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         ], _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void VirtualProject_ProjectDirective()
     {
-        var testAsset = _testAssetManager.CopyTestAsset("WatchNoDepsApp")
+        var testAsset = TestAssetManager.CopyTestAsset("WatchNoDepsApp")
             .WithSource();
 
         var projectPath = Path.Combine(testAsset.Path, "WatchNoDepsApp.csproj");
@@ -95,7 +102,7 @@ public class ProjectGraphFactoryTests(ITestOutputHelper output)
         var factory = new ProjectGraphFactory([projectRepr], buildProperties: [], _testLogger, TestOptions.GlobalOptions, TestOptions.GetEnvironmentOptions(asset: testAsset));
 
         var graph = factory.TryLoadProjectGraph(projectGraphRequired: true, virtualProjectTargetFramework: null, CancellationToken.None);
-        Assert.NotNull(graph);
+        Assert.IsNotNull(graph);
 
         AssertEx.SequenceEqual(
             [projectPath, VirtualProjectBuilder.GetVirtualProjectPath(entryPointFilePath)],

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class CommandLineOptionsTests
 {
     private readonly TestLogger _testLogger = new();
@@ -19,11 +20,11 @@ public class CommandLineOptionsTests
         var output = new StringWriter();
         var options = CommandLineOptions.Parse(args, _testLogger, output: output, errorCode: out var errorCode);
 
-        Assert.Equal(expectedMessages, _testLogger.GetAndClearMessages());
+        AssertEx.SequenceEqual(expectedMessages, _testLogger.GetAndClearMessages());
         outputValidator(output.ToString());
 
-        Assert.NotNull(options);
-        Assert.Equal(0, errorCode);
+        Assert.IsNotNull(options);
+        Assert.AreEqual(0, errorCode);
         return options;
     }
 
@@ -33,186 +34,191 @@ public class CommandLineOptionsTests
         var options = CommandLineOptions.Parse(args, _testLogger, output: output, errorCode: out var errorCode);
 
         AssertEx.Equal(expectedErrors, _testLogger.GetAndClearMessages());
-        Assert.Empty(output.ToString());
+        Assert.IsEmpty(output.ToString());
 
-        Assert.Null(options);
-        Assert.NotEqual(0, errorCode);
+        Assert.IsNull(options);
+        Assert.AreNotEqual(0, errorCode);
     }
 
-    [Theory]
-    [InlineData([new[] { "-h" }])]
-    [InlineData([new[] { "-?" }])]
-    [InlineData([new[] { "--help" }])]
-    [InlineData([new[] { "--help", "--bogus" }])]
+    [TestMethod]
+    [DataRow([new[] { "-h" }])]
+    [DataRow([new[] { "-?" }])]
+    [DataRow([new[] { "--help" }])]
+    [DataRow([new[] { "--help", "--bogus" }])]
     public void HelpArgs(string[] args)
     {
         var output = new StringWriter();
         var options = CommandLineOptions.Parse(args, _testLogger, output: output, errorCode: out var errorCode);
-        Assert.Null(options);
-        Assert.Equal(0, errorCode);
+        Assert.IsNull(options);
+        Assert.AreEqual(0, errorCode);
 
-        Assert.Empty(_testLogger.GetAndClearMessages());
+        Assert.IsEmpty(_testLogger.GetAndClearMessages());
         Assert.Contains("Usage:", output.ToString());
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitCommand()
     {
         var options = VerifyOptions([]);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual([], options.CommandArguments);
     }
 
-    [Theory]
-    [InlineData("add")]
-    [InlineData("build")]
-    [InlineData("build-server")]
-    [InlineData("clean")]
-    [InlineData("format")]
-    [InlineData("help")]
-    [InlineData("list")]
-    [InlineData("msbuild")]
-    [InlineData("new")]
-    [InlineData("nuget")]
-    [InlineData("pack")]
-    [InlineData("publish")]
-    [InlineData("remove")]
-    [InlineData("restore")]
-    [InlineData("run")]
-    [InlineData("sdk")]
-    [InlineData("solution")]
-    [InlineData("store")]
-    [InlineData("test")]
-    [InlineData("tool")]
-    [InlineData("vstest")]
-    [InlineData("workload")]
+    [TestMethod]
+    [DataRow("add")]
+    [DataRow("build")]
+    [DataRow("build-server")]
+    [DataRow("clean")]
+    [DataRow("format")]
+    [DataRow("help")]
+    [DataRow("list")]
+    [DataRow("msbuild")]
+    [DataRow("new")]
+    [DataRow("nuget")]
+    [DataRow("pack")]
+    [DataRow("publish")]
+    [DataRow("remove")]
+    [DataRow("restore")]
+    [DataRow("run")]
+    [DataRow("sdk")]
+    [DataRow("solution")]
+    [DataRow("store")]
+    [DataRow("test")]
+    [DataRow("tool")]
+    [DataRow("vstest")]
+    [DataRow("workload")]
     public void ExplicitCommand(string command)
     {
         var options = VerifyOptions([command]);
         var args = options.CommandArguments.ToList();
-        Assert.True(options.IsExplicitCommand);
-        Assert.Equal(command, options.Command.Name);
-        Assert.Empty(args);
+        Assert.IsTrue(options.IsExplicitCommand);
+        Assert.AreEqual(command, options.Command.Name);
+        Assert.IsEmpty(args);
     }
 
-    [Theory]
-    [CombinatorialData]
-    public void WatchOptions_NotPassedThrough(
-        [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
-        bool beforeCommand)
+    [TestMethod]
+    [DataRow("--quiet", true)]
+    [DataRow("--quiet", false)]
+    [DataRow("--verbose", true)]
+    [DataRow("--verbose", false)]
+    [DataRow("--no-hot-reload", true)]
+    [DataRow("--no-hot-reload", false)]
+    [DataRow("--non-interactive", true)]
+    [DataRow("--non-interactive", false)]
+    public void WatchOptions_NotPassedThrough(string option, bool beforeCommand)
     {
         var options = VerifyOptions(beforeCommand ? [option, "test"] : ["test", option]);
-        Assert.Equal("test", options.Command.Name);
+        Assert.AreEqual("test", options.Command.Name);
         AssertEx.SequenceEqual([], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietAndVerbose()
     {
          VerifyErrors(["--quiet", "--verbose"],
             expectedErrors: [$"[Error] {string.Format(Resources.Cannot_specify_both_0_and_1_options, "--quiet", "--verbose")}"]);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_LaunchProfile_Watch()
     {
         var options = VerifyOptions(["-lp", "P", "run"]);
-        Assert.Equal("P", options.LaunchProfileName);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual("P", options.LaunchProfileName);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["-lp", "P"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_LaunchProfile_Run()
     {
         var options = VerifyOptions(["run", "-lp", "P"]);
-        Assert.Equal("P", options.LaunchProfileName);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual("P", options.LaunchProfileName);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["-lp", "P"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_LaunchProfile_Both()
     {
         VerifyErrors(["-lp", "P1", "run", "-lp", "P2"],
             "[Error] Option '-lp' expects a single argument but 2 were provided.");
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_NoProfile_Watch()
     {
         var options = VerifyOptions(["--no-launch-profile", "run"]);
 
-        Assert.False(options.LaunchProfileName.HasValue);
-        Assert.Equal("run", options.Command.Name);
+        Assert.IsFalse(options.LaunchProfileName.HasValue);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["--no-launch-profile"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_NoProfile_Run()
     {
         var options = VerifyOptions(["run", "--no-launch-profile"]);
 
-        Assert.False(options.LaunchProfileName.HasValue);
-        Assert.Equal("run", options.Command.Name);
+        Assert.IsFalse(options.LaunchProfileName.HasValue);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["--no-launch-profile"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunOptions_NoProfile_Both()
     {
         var options = VerifyOptions(["--no-launch-profile", "run", "--no-launch-profile"]);
 
-        Assert.False(options.LaunchProfileName.HasValue);
-        Assert.Equal("run", options.Command.Name);
+        Assert.IsFalse(options.LaunchProfileName.HasValue);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["--no-launch-profile"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemainingOptions()
     {
         var options = VerifyOptions(["-watchArg", "--verbose", "run", "-runArg"]);
 
-        Assert.Equal(LogLevel.Debug, options.GlobalOptions.LogLevel);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual(LogLevel.Debug, options.GlobalOptions.LogLevel);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["-watchArg", "-runArg"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void UnknownOption()
     {
         var options = VerifyOptions(["--verbose", "--unknown", "x", "y", "run", "--project", "p"]);
 
-        Assert.Equal("p", options.ProjectPath);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual("p", options.ProjectPath);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["--project", "p", "--unknown", "x", "y"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemainingOptionsDashDash()
     {
         var options = VerifyOptions(["-watchArg", "--", "--verbose", "run", "-runArg"]);
 
-        Assert.Equal(LogLevel.Information, options.GlobalOptions.LogLevel);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual(LogLevel.Information, options.GlobalOptions.LogLevel);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["-watchArg", "--", "--verbose", "run", "-runArg",], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemainingOptionsDashDashRun()
     {
         var options = VerifyOptions(["--", "run"]);
 
-        Assert.Equal(LogLevel.Information, options.GlobalOptions.LogLevel);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual(LogLevel.Information, options.GlobalOptions.LogLevel);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual(["--", "run"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void NoOptionsAfterDashDash()
     {
         var options = VerifyOptions(["--"]);
-        Assert.Equal("run", options.Command.Name);
+        Assert.AreEqual("run", options.Command.Name);
         AssertEx.SequenceEqual([], options.CommandArguments);
     }
 
@@ -223,61 +229,61 @@ public class CommandLineOptionsTests
     /// Therfore, it has to also be ignored by `dotnet run`,
     /// otherwise the TFMs would be inconsistent between `dotnet watch` and `dotnet run`.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ParsedNonWatchOptionsAfterDashDash_Framework()
     {
         var options = VerifyOptions(["--", "-f", "TFM"]);
 
-        Assert.Null(options.TargetFramework);
+        Assert.IsNull(options.TargetFramework);
         AssertEx.SequenceEqual(["--", "-f", "TFM"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParsedNonWatchOptionsAfterDashDash_Project()
     {
         var options = VerifyOptions(["--", "--project", "proj"]);
 
-        Assert.Null(options.ProjectPath);
+        Assert.IsNull(options.ProjectPath);
         AssertEx.SequenceEqual(["--", "--project", "proj"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParsedNonWatchOptionsAfterDashDash_NoLaunchProfile()
     {
         var options = VerifyOptions(["--", "--no-launch-profile"]);
 
-        Assert.True(options.LaunchProfileName.HasValue);
-        Assert.Null(options.LaunchProfileName.Value);
+        Assert.IsTrue(options.LaunchProfileName.HasValue);
+        Assert.IsNull(options.LaunchProfileName.Value);
         AssertEx.SequenceEqual(["--", "--no-launch-profile"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParsedNonWatchOptionsAfterDashDash_LaunchProfile()
     {
         var options = VerifyOptions(["--", "--launch-profile", "p"]);
 
-        Assert.True(options.LaunchProfileName.HasValue);
-        Assert.Null(options.LaunchProfileName.Value);
+        Assert.IsTrue(options.LaunchProfileName.HasValue);
+        Assert.IsNull(options.LaunchProfileName.Value);
         AssertEx.SequenceEqual(["--", "--launch-profile", "p"], options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParsedNonWatchOptionsAfterDashDash_Property()
     {
         var options = VerifyOptions(["--", "--property", "x=1"]);
 
-        Assert.True(options.LaunchProfileName.HasValue);
-        Assert.Null(options.LaunchProfileName.Value);
+        Assert.IsTrue(options.LaunchProfileName.HasValue);
+        Assert.IsNull(options.LaunchProfileName.Value);
         AssertEx.SequenceEqual(["--", "--property", "x=1"], options.CommandArguments);
     }
 
-    [Theory]
-    [InlineData("-bl")]
-    [InlineData("/bl")]
-    [InlineData("/bl:X.binlog")]
-    [InlineData("-binaryLogger")]
-    [InlineData("/binaryLogger")]
-    [InlineData("--binaryLogger:LogFile=output.binlog;ProjectImports=None")]
+    [TestMethod]
+    [DataRow("-bl")]
+    [DataRow("/bl")]
+    [DataRow("/bl:X.binlog")]
+    [DataRow("-binaryLogger")]
+    [DataRow("/binaryLogger")]
+    [DataRow("--binaryLogger:LogFile=output.binlog;ProjectImports=None")]
     public void BinaryLoggerOption_AfterDashDash(string option)
     {
         var options1 = VerifyOptions(["--", option]);
@@ -295,11 +301,11 @@ public class CommandLineOptionsTests
         AssertEx.SequenceEqual(["--property:NuGetInteractive=false", option], options2.BuildArguments);
     }
 
-    [Theory]
-    [InlineData("-bl:")]
-    [InlineData("/bl:")]
-    [InlineData("-binaryLogger:")]
-    [InlineData("/binaryLogger:")]
+    [TestMethod]
+    [DataRow("-bl:")]
+    [DataRow("/bl:")]
+    [DataRow("-binaryLogger:")]
+    [DataRow("/binaryLogger:")]
     public void BinaryLoggerOption_NoValue(string option)
     {
         var options = VerifyOptions([option]);
@@ -308,8 +314,9 @@ public class CommandLineOptionsTests
         AssertEx.SequenceEqual(["--property:NuGetInteractive=false"], options.BuildArguments);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void OptionsSpecifiedBeforeOrAfterRun(bool afterRun)
     {
         var args = new[] { "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" };
@@ -317,8 +324,8 @@ public class CommandLineOptionsTests
 
         var options = VerifyOptions(args);
 
-        Assert.Equal("P", options.ProjectPath);
-        Assert.Equal("F", options.TargetFramework);
+        Assert.AreEqual("P", options.ProjectPath);
+        Assert.AreEqual("F", options.TargetFramework);
 
         // The forwarding function of --property property joins the properties with `:`
         // --framework is not forwarded as property.
@@ -336,17 +343,23 @@ public class CommandLineOptionsTests
         Both
     }
 
-    [Theory]
-    [CombinatorialData]
-    public void OptionDuplicates_Allowed_Bool(
-        ArgPosition position,
-        [CombinatorialValues(
-            "--verbose",
-            "--quiet",
-            "--list",
-            "--no-hot-reload",
-            "--non-interactive")]
-        string arg)
+    [TestMethod]
+    [DataRow(ArgPosition.Before, "--verbose")]
+    [DataRow(ArgPosition.Before, "--quiet")]
+    [DataRow(ArgPosition.Before, "--list")]
+    [DataRow(ArgPosition.Before, "--no-hot-reload")]
+    [DataRow(ArgPosition.Before, "--non-interactive")]
+    [DataRow(ArgPosition.After, "--verbose")]
+    [DataRow(ArgPosition.After, "--quiet")]
+    [DataRow(ArgPosition.After, "--list")]
+    [DataRow(ArgPosition.After, "--no-hot-reload")]
+    [DataRow(ArgPosition.After, "--non-interactive")]
+    [DataRow(ArgPosition.Both, "--verbose")]
+    [DataRow(ArgPosition.Both, "--quiet")]
+    [DataRow(ArgPosition.Both, "--list")]
+    [DataRow(ArgPosition.Both, "--no-hot-reload")]
+    [DataRow(ArgPosition.Both, "--non-interactive")]
+    public void OptionDuplicates_Allowed_Bool(ArgPosition position, string arg)
     {
         var args = new[] { arg };
 
@@ -360,7 +373,7 @@ public class CommandLineOptionsTests
 
         var options = VerifyOptions(args);
 
-        Assert.True(arg switch
+        Assert.IsTrue(arg switch
         {
             "--verbose" => options.GlobalOptions.LogLevel == LogLevel.Debug,
             "--quiet" => options.GlobalOptions.LogLevel == LogLevel.Warning,
@@ -371,7 +384,7 @@ public class CommandLineOptionsTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void OptionDuplicates_Property()
     {
         var options = VerifyOptions(["--property", "P1=V1", "run", "--property", "P2=V2"]);
@@ -381,84 +394,84 @@ public class CommandLineOptionsTests
         AssertEx.SequenceEqual(["--property", "P1=V1", "--property", "P2=V2"], options.CommandArguments);
     }
 
-    [Theory]
-    [InlineData("--file")]
-    [InlineData("--project")]
-    [InlineData("-p")]
-    [InlineData("--framework")]
+    [TestMethod]
+    [DataRow("--file")]
+    [DataRow("--project")]
+    [DataRow("-p")]
+    [DataRow("--framework")]
     public void OptionDuplicates_NotAllowed(string option)
     {
         VerifyErrors([option, "abc", "run", option, "xyz"],
             $"[Error] Option '{option}' expects a single argument but 2 were provided.");
     }
 
-    [Theory]
-    [InlineData(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" })]
-    [InlineData(new[] { "run" }, new string[] { })]
-    [InlineData(new[] { "run", "--", "runarg" }, new[] {  "--", "runarg" })]
-    [InlineData(new[] { "--verbose", "run", "runarg1", "-runarg2" }, new[] {  "runarg1", "-runarg2" })]
+    [TestMethod]
+    [DataRow(new[] { "--unrecognized-arg" }, new[] { "--unrecognized-arg" })]
+    [DataRow(new[] { "run" }, new string[] { })]
+    [DataRow(new[] { "run", "--", "runarg" }, new[] {  "--", "runarg" })]
+    [DataRow(new[] { "--verbose", "run", "runarg1", "-runarg2" }, new[] {  "runarg1", "-runarg2" })]
     // run is after -- and therefore not parsed as a command:
-    [InlineData(new[] { "--verbose", "--", "run", "--", "runarg" }, new[] {  "--", "run", "--", "runarg" })]
+    [DataRow(new[] { "--verbose", "--", "run", "--", "runarg" }, new[] {  "--", "run", "--", "runarg" })]
     // run is before -- and therefore parsed as a command:
-    [InlineData(new[] { "--verbose", "run", "--", "--", "runarg" }, new[] {  "--", "--", "runarg" })]
+    [DataRow(new[] { "--verbose", "run", "--", "--", "runarg" }, new[] {  "--", "--", "runarg" })]
     public void ParsesRemainingArgs(string[] args, string[] expected)
     {
         var options = VerifyOptions(args);
-        Assert.Equal(expected, options.CommandArguments);
+        AssertEx.SequenceEqual(expected, options.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void Project_ShortForm()
     {
         var options = VerifyOptions(["-p", "MyProject.csproj"],
             expectedMessages: [$"[Warning] {Resources.Warning_ProjectAbbreviationDeprecated}"]);
 
-        Assert.Equal("MyProject.csproj", options.ProjectPath);
+        Assert.AreEqual("MyProject.csproj", options.ProjectPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void Project_ShortAndLongForm()
     {
         VerifyErrors(["-p", "MyProject1.csproj", "--project", "MyProject2.csproj"],
             expectedErrors: [$"[Error] {string.Format(Resources.Cannot_specify_both_0_and_1_options, "--project", "-p")}"]);
     }
 
-    [Theory]
-    [InlineData("-p")]
-    [InlineData("--project")]
+    [TestMethod]
+    [DataRow("-p")]
+    [DataRow("--project")]
     public void Project_File(string projectOption)
     {
         VerifyErrors([projectOption, "MyProject1.csproj", "--file", "a.cs"],
             expectedErrors: [$"[Error] {string.Format(Resources.Cannot_specify_both_0_and_1_options, "--file", projectOption)}"]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Project_LongForm()
     {
         var options = VerifyOptions(["--project", "MyProject.csproj"]);
-        Assert.Equal("MyProject.csproj", options.ProjectPath);
+        Assert.AreEqual("MyProject.csproj", options.ProjectPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void File()
     {
         var options = VerifyOptions(["--file", "MyFile.cs"]);
-        Assert.Equal("MyFile.cs", options.FilePath);
+        Assert.AreEqual("MyFile.cs", options.FilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void LaunchProfile_LongForm()
     {
         var options = VerifyOptions(["--launch-profile", "CustomLaunchProfile"]);
-        Assert.NotNull(options);
-        Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
+        Assert.IsNotNull(options);
+        Assert.AreEqual("CustomLaunchProfile", options.LaunchProfileName);
     }
 
-    [Fact]
+    [TestMethod]
     public void LaunchProfile_ShortForm()
     {
         var options = VerifyOptions(["-lp", "CustomLaunchProfile"]);
-        Assert.Equal("CustomLaunchProfile", options.LaunchProfileName);
+        Assert.AreEqual("CustomLaunchProfile", options.LaunchProfileName);
     }
 
     private const string NugetInteractiveProperty = "--property:NuGetInteractive=false";
@@ -466,30 +479,30 @@ public class CommandLineOptionsTests
     /// <summary>
     /// Validates that options that the "run" command forwards to "build" command are forwarded by dotnet-watch.
     /// </summary>
-    [Theory]
-    [InlineData(new[] { "--configuration", "release" }, new[] { "--property:Configuration=release", NugetInteractiveProperty })]
-    [InlineData(new[] { "--framework", "net9.0" }, new[] { NugetInteractiveProperty }, new string[0])]
-    [InlineData(new[] { "--runtime", "arm64" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=arm64", "--property:_CommandLineDefinedRuntimeIdentifier=true" })]
-    [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
-    [InlineData(new[] { "--project", "x.csproj" }, new[] { NugetInteractiveProperty }, new[] { "--project", "x.csproj" })]
-    [InlineData(new[] { "--launch-profile", "x" }, new[] { NugetInteractiveProperty }, new[] { "--launch-profile", "x" })]
-    [InlineData(new[] { "--no-launch-profile" }, new[] { NugetInteractiveProperty }, new[] { "--no-launch-profile" })]
-    [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1", NugetInteractiveProperty }, new[] { "/p", "b=1" })] // it's ok to split the argument into two since `dotnet run` handles `/p b=1`
-    [InlineData(new[] { "--interactive" }, new[] { "--property:NuGetInteractive=true" })]
-    [InlineData(new[] { "--no-restore" }, new[] { NugetInteractiveProperty, "-restore:false" })]
-    [InlineData(new[] { "--sc" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
-    [InlineData(new[] { "--self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
-    [InlineData(new[] { "--no-self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=false", "--property:_CommandLineDefinedSelfContained=true" })]
-    [InlineData(new[] { "--verbose" }, new[] { NugetInteractiveProperty }, new string[0])]
-    [InlineData(new[] { "--verbosity", "q" }, new[] { NugetInteractiveProperty, "--verbosity:q" })]
-    [InlineData(new[] { "--arch", "arm", "--os", "win" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=win-arm" })]
-    [InlineData(new[] { "--disable-build-servers" }, new[] { NugetInteractiveProperty, "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
-    [InlineData(new[] { "-bl" }, new[] { NugetInteractiveProperty, "-bl" })]
-    [InlineData(new[] { "/bl" }, new[] { NugetInteractiveProperty, "/bl" })]
-    [InlineData(new[] { "/bl:X.binlog" }, new[] { NugetInteractiveProperty, "/bl:X.binlog" })]
-    [InlineData(new[] { "-binaryLogger" }, new[] { NugetInteractiveProperty, "-binaryLogger" })]
-    [InlineData(new[] { "/binaryLogger" }, new[] { NugetInteractiveProperty, "/binaryLogger" })]
-    [InlineData(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { NugetInteractiveProperty, "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
+    [TestMethod]
+    [DataRow(new[] { "--configuration", "release" }, new[] { "--property:Configuration=release", NugetInteractiveProperty })]
+    [DataRow(new[] { "--framework", "net9.0" }, new[] { NugetInteractiveProperty }, new string[0])]
+    [DataRow(new[] { "--runtime", "arm64" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=arm64", "--property:_CommandLineDefinedRuntimeIdentifier=true" })]
+    [DataRow(new[] { "--property", "b=1" }, new[] { "--property:b=1", NugetInteractiveProperty })]
+    [DataRow(new[] { "--project", "x.csproj" }, new[] { NugetInteractiveProperty }, new[] { "--project", "x.csproj" })]
+    [DataRow(new[] { "--launch-profile", "x" }, new[] { NugetInteractiveProperty }, new[] { "--launch-profile", "x" })]
+    [DataRow(new[] { "--no-launch-profile" }, new[] { NugetInteractiveProperty }, new[] { "--no-launch-profile" })]
+    [DataRow(new[] { "/p:b=1" }, new[] { "--property:b=1", NugetInteractiveProperty }, new[] { "/p", "b=1" })] // it's ok to split the argument into two since `dotnet run` handles `/p b=1`
+    [DataRow(new[] { "--interactive" }, new[] { "--property:NuGetInteractive=true" })]
+    [DataRow(new[] { "--no-restore" }, new[] { NugetInteractiveProperty, "-restore:false" })]
+    [DataRow(new[] { "--sc" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
+    [DataRow(new[] { "--self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=true", "--property:_CommandLineDefinedSelfContained=true" })]
+    [DataRow(new[] { "--no-self-contained" }, new[] { NugetInteractiveProperty, "--property:SelfContained=false", "--property:_CommandLineDefinedSelfContained=true" })]
+    [DataRow(new[] { "--verbose" }, new[] { NugetInteractiveProperty }, new string[0])]
+    [DataRow(new[] { "--verbosity", "q" }, new[] { NugetInteractiveProperty, "--verbosity:q" })]
+    [DataRow(new[] { "--arch", "arm", "--os", "win" }, new[] { NugetInteractiveProperty, "--property:RuntimeIdentifier=win-arm" })]
+    [DataRow(new[] { "--disable-build-servers" }, new[] { NugetInteractiveProperty, "--property:UseRazorBuildServer=false", "--property:UseSharedCompilation=false", "/nodeReuse:false" })]
+    [DataRow(new[] { "-bl" }, new[] { NugetInteractiveProperty, "-bl" })]
+    [DataRow(new[] { "/bl" }, new[] { NugetInteractiveProperty, "/bl" })]
+    [DataRow(new[] { "/bl:X.binlog" }, new[] { NugetInteractiveProperty, "/bl:X.binlog" })]
+    [DataRow(new[] { "-binaryLogger" }, new[] { NugetInteractiveProperty, "-binaryLogger" })]
+    [DataRow(new[] { "/binaryLogger" }, new[] { NugetInteractiveProperty, "/binaryLogger" })]
+    [DataRow(new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" }, new[] { NugetInteractiveProperty, "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
     public void ForwardedOptionsAndArguments_Run(string[] args, string[] buildArgs, string[] commandArgs = null)
     {
         var runOptions = VerifyOptions(["run", .. args]);
@@ -500,19 +513,19 @@ public class CommandLineOptionsTests
     // TODO:
     // Test MTP: https://github.com/dotnet/sdk/issues/52383
 
-    [Theory]
-    [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
-    [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
-    [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1" }, new[] { "/p", "b=1" })]
-    [InlineData(new[] { "/bl" }, new[] { "/bl" }, new[] { "/bl" })]
-    [InlineData(
+    [TestMethod]
+    [DataRow(new[] { "--property:b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
+    [DataRow(new[] { "--property", "b=1" }, new[] { "--property:b=1" }, new[] { "--property", "b=1" })]
+    [DataRow(new[] { "/p:b=1" }, new[] { "--property:b=1" }, new[] { "/p", "b=1" })]
+    [DataRow(new[] { "/bl" }, new[] { "/bl" }, new[] { "/bl" })]
+    [DataRow(
         new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
         new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
         new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
-    [InlineData(new[] { "--launch-profile", "x" }, new string[0])]
-    [InlineData(new[] { "--no-launch-profile" }, new string[0])]
-    [InlineData(new[] { "--project", "x.csproj" }, new string[0], new[] { "x.csproj" })]
-    [InlineData(new[] { "--verbose" }, new string[0])]
+    [DataRow(new[] { "--launch-profile", "x" }, new string[0])]
+    [DataRow(new[] { "--no-launch-profile" }, new string[0])]
+    [DataRow(new[] { "--project", "x.csproj" }, new string[0], new[] { "x.csproj" })]
+    [DataRow(new[] { "--verbose" }, new string[0])]
     public void ForwardedOptionsAndArguments_Test(string[] args, string[] buildArgs, string[] commandArgs = null)
     {
         var runOptions = VerifyOptions(["test", .. args]);
@@ -527,19 +540,19 @@ public class CommandLineOptionsTests
         AssertEx.SequenceEqual(commandArgs ?? [], runOptions.CommandArguments);
     }
 
-    [Theory]
-    [InlineData(new[] { "--property:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
-    [InlineData(new[] { "--property", "b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
-    [InlineData(new[] { "/p:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "/p", "b=1" })]
-    [InlineData(new[] { "/bl" }, new[] { "--property:NuGetInteractive=false", "--nologo", "/bl" }, new[] { "/bl" })]
-    [InlineData(
+    [TestMethod]
+    [DataRow(new[] { "--property:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
+    [DataRow(new[] { "--property", "b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "--property", "b=1" })]
+    [DataRow(new[] { "/p:b=1" }, new[] { "--property:b=1", "--property:NuGetInteractive=false", "--nologo" }, new[] { "/p", "b=1" })]
+    [DataRow(new[] { "/bl" }, new[] { "--property:NuGetInteractive=false", "--nologo", "/bl" }, new[] { "/bl" })]
+    [DataRow(
         new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
         new[] { "--property:NuGetInteractive=false", "--nologo", "--binaryLogger:LogFile=output.binlog;ProjectImports=None" },
         new[] { "--binaryLogger:LogFile=output.binlog;ProjectImports=None" })]
-    [InlineData(new[] { "--launch-profile", "x" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
-    [InlineData(new[] { "--no-launch-profile" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
-    [InlineData(new[] { "--project", "x.csproj" }, new[] { "--property:NuGetInteractive=false", "--nologo" }, new[] { "x.csproj" })]
-    [InlineData(new[] { "--verbose" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+    [DataRow(new[] { "--launch-profile", "x" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+    [DataRow(new[] { "--no-launch-profile" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
+    [DataRow(new[] { "--project", "x.csproj" }, new[] { "--property:NuGetInteractive=false", "--nologo" }, new[] { "x.csproj" })]
+    [DataRow(new[] { "--verbose" }, new[] { "--property:NuGetInteractive=false", "--nologo" })]
     public void ForwardedOptionsAndArguments_Build(string[] args, string[] buildArgs, string[] commandArgs = null)
     {
         var runOptions = VerifyOptions(["build", .. args]);
@@ -549,7 +562,7 @@ public class CommandLineOptionsTests
         AssertEx.SequenceEqual(commandArgs ?? [], runOptions.CommandArguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void ForwardedBuildOptions_ArtifactsPath()
     {
         var path = SdkTestContext.Current.TestAssetsDirectory;

--- a/test/dotnet-watch.Tests/CommandLine/EnvironmentOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/EnvironmentOptionsTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class BuildReporterTests
 {
-    [Fact]
+    [TestMethod]
     public void GetBinLogPath()
     {
         var root = Path.GetTempPath();

--- a/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
@@ -1,36 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 #nullable disable
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class DotNetWatcherTests : DotNetWatchTestBase
 {
     private const string AppName = "WatchKitchenSink";
 
-    public DotNetWatcherTests(ITestOutputHelper logger)
-        : base(logger)
-    {
-    }
-
-    [Fact]
+    [TestMethod]
     public async Task RunsWithDotnetWatchEnvVariable()
     {
-        Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_WATCH")), "DOTNET_WATCH cannot be set already when this test is running");
+        Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_WATCH")), "DOTNET_WATCH cannot be set already when this test is running");
 
         var testAsset = TestAssets.CopyTestAsset(AppName)
             .WithSource();
 
         App.Start(testAsset, []);
-        Assert.Equal("1", await App.AssertOutputLineStartsWith("DOTNET_WATCH = "));
+        Assert.AreEqual("1", await App.AssertOutputLineStartsWith("DOTNET_WATCH = "));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenNotExplicitlySpecified(bool hotReload)
     {
-        Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
+        Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
         var testAsset = TestAssets.CopyTestAsset(AppName, identifier: hotReload.ToString())
             .WithSource();
@@ -41,14 +40,15 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         }
 
         App.Start(testAsset, []);
-        Assert.Equal("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
+        Assert.AreEqual("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenExplicitlySpecified(bool hotReload)
     {
-        Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
+        Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
         var testAsset = TestAssets.CopyTestAsset(AppName, identifier: hotReload.ToString())
             .WithSource();
@@ -61,14 +61,15 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         App.WatchArgs.Add("--launch-profile");
         App.WatchArgs.Add("Second");
         App.Start(testAsset, []);
-        Assert.Equal("<<<Second>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
+        Assert.AreEqual("<<<Second>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenExplicitlySpecifiedButNotPresentIsEmpty(bool hotReload)
     {
-        Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
+        Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
 
         var testAsset = TestAssets.CopyTestAsset(AppName, identifier: hotReload.ToString())
             .WithSource();
@@ -79,11 +80,12 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         }
 
         App.Start(testAsset, ["--", "--launch-profile", "Third"]);
-        Assert.Equal("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
+        Assert.AreEqual("<<<First>>>", await App.AssertOutputLineStartsWith("DOTNET_LAUNCH_PROFILE = "));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RunsWithIterationEnvVariable(bool hotReload)
     {
         var testAsset = TestAssets.CopyTestAsset(AppName)
@@ -107,7 +109,7 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         await App.WaitUntilOutputContains("DOTNET_WATCH_ITERATION = 2");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
@@ -118,7 +120,7 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         await App.AssertOutputLineEquals("Environment: Development");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingProjectOption()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
@@ -135,7 +137,7 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         await App.AssertOutputLineEquals("Environment: Development");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Run_WithHotReloadEnabled_ReadsLaunchSettings_WhenUsingFileOption()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
@@ -155,7 +157,9 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         await App.AssertOutputLineEquals("Environment: Development");
     }
 
-    [CoreMSBuildOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/29047")]
+    [TestMethod]
+    [MSTestFramework::Microsoft.NET.TestFramework.CoreMSBuildOnly]
+    [Ignore("https://github.com/dotnet/sdk/issues/29047")]
     public async Task Run_WithHotReloadEnabled_DoesNotReadConsoleIn_InNonInteractiveMode()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings")
@@ -170,6 +174,6 @@ public class DotNetWatcherTests : DotNetWatchTestBase
         var inputString = "This is a test input";
 
         await standardInput.WriteLineAsync(inputString);
-        Assert.Equal(inputString, await App.AssertOutputLineStartsWith("Echo: "));
+        Assert.AreEqual(inputString, await App.AssertOutputLineStartsWith("Echo: "));
     }
 }

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.Arguments.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.Arguments.cs
@@ -5,20 +5,21 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProgramTests_Arguments(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class ProgramTests_Arguments : DotNetWatchTestBase
 {
-    [Theory]
-    [InlineData(new[] { "--no-hot-reload", "run" }, "")]
-    [InlineData(new[] { "--no-hot-reload", "run", "args" }, "args")]
-    [InlineData(new[] { "--no-hot-reload", "--", "run", "args" }, "run,args")]
-    [InlineData(new[] { "--no-hot-reload" }, "")]
-    [InlineData(new string[] { }, "")]
-    [InlineData(new[] { "run" }, "")]
-    [InlineData(new[] { "run", "args" }, "args")]
-    [InlineData(new[] { "--", "run", "args" }, "run,args")]
-    [InlineData(new[] { "--", "test", "args" }, "test,args")]
-    [InlineData(new[] { "--", "build", "args" }, "build,args")]
-    [InlineData(new[] { "abc" }, "abc")]
+    [TestMethod]
+    [DataRow(new[] { "--no-hot-reload", "run" }, "")]
+    [DataRow(new[] { "--no-hot-reload", "run", "args" }, "args")]
+    [DataRow(new[] { "--no-hot-reload", "--", "run", "args" }, "run,args")]
+    [DataRow(new[] { "--no-hot-reload" }, "")]
+    [DataRow(new string[] { }, "")]
+    [DataRow(new[] { "run" }, "")]
+    [DataRow(new[] { "run", "args" }, "args")]
+    [DataRow(new[] { "--", "run", "args" }, "run,args")]
+    [DataRow(new[] { "--", "test", "args" }, "test,args")]
+    [DataRow(new[] { "--", "build", "args" }, "build,args")]
+    [DataRow(new[] { "abc" }, "abc")]
     public async Task Arguments(string[] arguments, string expectedApplicationArgs)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: string.Join(",", arguments))
@@ -30,7 +31,8 @@ public class ProgramTests_Arguments(ITestOutputHelper output) : DotNetWatchTestB
         await App.WaitUntilOutputContains($"Arguments = {expectedApplicationArgs}");
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task RunArguments_NoHotReload()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
@@ -61,10 +63,11 @@ public class ProgramTests_Arguments(ITestOutputHelper output) : DotNetWatchTestB
         await App.WaitUntilOutputContains("Determining projects to restore...");
 
         // not expected to find verbose output of dotnet watch
-        Assert.DoesNotContain(App.Process.Output, l => l.Contains("Working directory:"));
+        Assert.DoesNotContain("Working directory:", string.Join(Environment.NewLine, App.Process.Output));
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.Linux)] // https://github.com/dotnet/sdk/issues/53061
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task RunArguments_HotReload()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppMultiTfm")
@@ -91,12 +94,12 @@ public class ProgramTests_Arguments(ITestOutputHelper output) : DotNetWatchTestB
         await App.WaitUntilOutputContains("Hot reload enabled.");
 
         // not expected to find verbose output of dotnet watch
-        Assert.DoesNotContain(App.Process.Output, l => l.Contains("Working directory:"));
+        Assert.DoesNotContain("Working directory:", string.Join(Environment.NewLine, App.Process.Output));
     }
 
-    [Theory]
-    [InlineData("P1", "argP1")]
-    [InlineData("P and Q and \"R\"", "argPQR")]
+    [TestMethod]
+    [DataRow("P1", "argP1")]
+    [DataRow("P and Q and \"R\"", "argPQR")]
     public async Task ArgumentsFromLaunchSettings_Watch(string profileName, string expectedArgs)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings", identifier: profileName)
@@ -115,9 +118,9 @@ public class ProgramTests_Arguments(ITestOutputHelper output) : DotNetWatchTestB
         await App.WaitUntilOutputContains("Hot Reload disabled by command line switch.");
     }
 
-    [Theory]
-    [InlineData("P1", "argP1")]
-    [InlineData("P and Q and \"R\"", "argPQR")]
+    [TestMethod]
+    [DataRow("P1", "argP1")]
+    [DataRow("P and Q and \"R\"", "argPQR")]
     public async Task ArgumentsFromLaunchSettings_HotReload(string profileName, string expectedArgs)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithLaunchSettings", identifier: profileName)

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.GetProjectOptions.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.GetProjectOptions.cs
@@ -1,27 +1,34 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class Program_GetProjectOptionsTests(ITestOutputHelper output)
+[TestClass]
+public class Program_GetProjectOptionsTests
 {
-    private readonly TestAssetsManager _testAssetManager = new(output);
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper? _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private TestAssetsManager? _testAssetManager;
+    private TestAssetsManager TestAssetManager => _testAssetManager ??= new(Output);
     private readonly TestLogger _testLogger = new();
 
     private string CreateTempDirectory([CallerMemberName] string? callingMethod = null, string? identifier = null)
-        => _testAssetManager.CreateTestDirectory(callingMethod, identifier).Path;
+        => TestAssetManager.CreateTestDirectory(callingMethod, identifier).Path;
 
     private CommandLineOptions ParseOptions(string[] args)
     {
         var output = new StringWriter();
         var options = CommandLineOptions.Parse(args, _testLogger, output: output, errorCode: out _);
-        Assert.NotNull(options);
+        Assert.IsNotNull(options);
         return options;
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitProjectPath()
     {
         var tempDir = CreateTempDirectory();
@@ -31,14 +38,14 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--project", projectPath]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectPath, result.Representation.PhysicalPath);
-        Assert.Null(result.Representation.EntryPointFilePath);
-        Assert.Equal(tempDir, result.WorkingDirectory);
-        Assert.True(result.IsMainProject);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(projectPath, result.Representation.PhysicalPath);
+        Assert.IsNull(result.Representation.EntryPointFilePath);
+        Assert.AreEqual(tempDir, result.WorkingDirectory);
+        Assert.IsTrue(result.IsMainProject);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProjectInWorkingDirectory()
     {
         var tempDir = CreateTempDirectory();
@@ -48,12 +55,12 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectPath, result.Representation.PhysicalPath);
-        Assert.Null(result.Representation.EntryPointFilePath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(projectPath, result.Representation.PhysicalPath);
+        Assert.IsNull(result.Representation.EntryPointFilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleProjects()
     {
         var tempDir = CreateTempDirectory();
@@ -63,13 +70,13 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
         AssertEx.SequenceEqual(
             [$"[Error] {string.Format(Resources.Error_MultipleProjectsFound, tempDir)}"],
             _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void NonExistentProject()
     {
         var tempDir = CreateTempDirectory();
@@ -77,13 +84,13 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--project", projectPath]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
         AssertEx.SequenceEqual(
             [$"[Error] {string.Format(Resources.Error_ProjectPath_NotFound, projectPath)}"],
             _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void NoProjectsInDirectoryAndNoCSharpFile()
     {
         var tempDir = CreateTempDirectory();
@@ -93,13 +100,13 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([]);
         var result = Program.GetMainProjectOptions(options, emptyDir, _testLogger);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
         AssertEx.SequenceEqual(
             [$"[Error] {string.Format(Resources.Could_not_find_msbuild_project_file_in_0, emptyDir)}"],
             _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void ProjectDirectory()
     {
         var tempDir = CreateTempDirectory();
@@ -111,15 +118,15 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--project", subDir]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectPath, result.Representation.PhysicalPath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(projectPath, result.Representation.PhysicalPath);
     }
 
-    [Theory]
-    [InlineData("csproj")]
-    [InlineData("fsproj")]
-    [InlineData("vbproj")]
-    [InlineData("proj")]
+    [TestMethod]
+    [DataRow("csproj")]
+    [DataRow("fsproj")]
+    [DataRow("vbproj")]
+    [DataRow("proj")]
     public void ProjectFile_AcceptedExtension(string projExtension)
     {
         var tempDir = CreateTempDirectory(projExtension);
@@ -129,12 +136,12 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectPath, result.Representation.PhysicalPath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(projectPath, result.Representation.PhysicalPath);
     }
 
-    [Theory]
-    [InlineData("shproj")]
+    [TestMethod]
+    [DataRow("shproj")]
     public void ProjectFile_RejectedExtension(string projExtension)
     {
         var tempDir = CreateTempDirectory(projExtension);
@@ -144,13 +151,13 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
         AssertEx.SequenceEqual(
             [$"[Error] {string.Format(Resources.Could_not_find_msbuild_project_file_in_0, tempDir)}"],
             _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void InvalidFilePath()
     {
         var tempDir = CreateTempDirectory();
@@ -170,13 +177,13 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
             message = e.Message;
         }
 
-        Assert.Null(result);
+        Assert.IsNull(result);
         AssertEx.SequenceEqual(
             [$"[Error] {string.Format(Resources.The_specified_path_0_is_invalid_1, invalidPath, message)}"],
             _testLogger.GetAndClearMessages());
     }
 
-    [Fact]
+    [TestMethod]
     public void FilePathOption()
     {
         var tempDir = CreateTempDirectory();
@@ -186,12 +193,12 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--file", csFilePath]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(csFilePath, result.Representation.EntryPointFilePath);
-        Assert.Null(result.Representation.PhysicalPath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(csFilePath, result.Representation.EntryPointFilePath);
+        Assert.IsNull(result.Representation.PhysicalPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void CSharpFileSpecifiedAsArgument()
     {
         var tempDir = CreateTempDirectory();
@@ -202,11 +209,11 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions([csFilePath]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(csFilePath, result.Representation.EntryPointFilePath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(csFilePath, result.Representation.EntryPointFilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void FileWithShebangSpecifiedAsArgument()
     {
         var tempDir = CreateTempDirectory();
@@ -217,18 +224,18 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options1 = ParseOptions([filePath]);
         var result1 = Program.GetMainProjectOptions(options1, tempDir, _testLogger);
 
-        Assert.NotNull(result1);
-        Assert.Equal(filePath, result1.Representation.EntryPointFilePath);
+        Assert.IsNotNull(result1);
+        Assert.AreEqual(filePath, result1.Representation.EntryPointFilePath);
 
         // dotnet watch -bl -e X=1 App.txt
         var options2 = ParseOptions(["-bl", "-e", "X=1", filePath]);
         var result2 = Program.GetMainProjectOptions(options2, tempDir, _testLogger);
 
-        Assert.NotNull(result2);
-        Assert.Equal(filePath, result2.Representation.EntryPointFilePath);
+        Assert.IsNotNull(result2);
+        Assert.AreEqual(filePath, result2.Representation.EntryPointFilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void RelativeProjectPath()
     {
         var tempDir = CreateTempDirectory();
@@ -240,11 +247,11 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--project", "subdir/Test.csproj"]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(projectPath, result.Representation.PhysicalPath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(projectPath, result.Representation.PhysicalPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void RelativeFilePath()
     {
         var tempDir = CreateTempDirectory();
@@ -254,11 +261,11 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--file", "Script.cs"]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(csFilePath, result.Representation.EntryPointFilePath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(csFilePath, result.Representation.EntryPointFilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void FilePathOptionTakesPrecedenceOverProjectPath()
     {
         var tempDir = CreateTempDirectory();
@@ -270,8 +277,8 @@ public class Program_GetProjectOptionsTests(ITestOutputHelper output)
         var options = ParseOptions(["--file", csFilePath]);
         var result = Program.GetMainProjectOptions(options, tempDir, _testLogger);
 
-        Assert.NotNull(result);
-        Assert.Equal(csFilePath, result.Representation.EntryPointFilePath);
-        Assert.Null(result.Representation.PhysicalPath);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(csFilePath, result.Representation.EntryPointFilePath);
+        Assert.IsNull(result.Representation.PhysicalPath);
     }
 }

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.HostArguments.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.HostArguments.cs
@@ -5,15 +5,16 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProgramTests_HostArguments(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class ProgramTests_HostArguments : DotNetWatchTestBase
 {
-    [Theory]
-    [InlineData(new[] { "--no-hot-reload", "--", "run", "args" }, "Argument Specified in Props,run,args")]
-    [InlineData(new[] { "--", "run", "args" }, "Argument Specified in Props,run,args")]
+    [TestMethod]
+    [DataRow(new[] { "--no-hot-reload", "--", "run", "args" }, "Argument Specified in Props,run,args")]
+    [DataRow(new[] { "--", "run", "args" }, "Argument Specified in Props,run,args")]
     // if arguments specified on command line the ones from launch profile are ignored
-    [InlineData(new[] { "-lp", "P1", "--", "run", "args" },"Argument Specified in Props,run,args")]
+    [DataRow(new[] { "-lp", "P1", "--", "run", "args" },"Argument Specified in Props,run,args")]
     // arguments specified in build file override arguments in launch profile
-    [InlineData(new[] { "-lp", "P1" }, "Argument Specified in Props")]
+    [DataRow(new[] { "-lp", "P1" }, "Argument Specified in Props")]
     public async Task Arguments_HostArguments(string[] arguments, string expectedApplicationArgs)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadAppCustomHost", identifier: string.Join(",", arguments))

--- a/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/ProgramTests.cs
@@ -7,9 +7,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProgramTests(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class ProgramTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task ConsoleCancelKey()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchKitchenSink")
@@ -32,22 +33,22 @@ public class ProgramTests(ITestOutputHelper output) : DotNetWatchTestBase(output
             reporter,
             out var errorCode);
 
-        Assert.Equal(0, errorCode);
-        Assert.NotNull(program);
+        Assert.AreEqual(0, errorCode);
+        Assert.IsNotNull(program);
 
         var run = program.RunAsync();
 
-        await watching.WaitAsync(TestContext.Current.CancellationToken);
+        await watching.WaitAsync(TestContext.CancellationToken);
 
         console.PressKey(new ConsoleKeyInfo('C', ConsoleKey.C, shift: false, alt: false, control: true));
 
         var exitCode = await run;
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
 
-        await shutdownRequested.WaitAsync(TestContext.Current.CancellationToken);
+        await shutdownRequested.WaitAsync(TestContext.CancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProjectGraphLoadFailure()
     {
         var testAsset = TestAssets
@@ -72,7 +73,7 @@ public class ProgramTests(ITestOutputHelper output) : DotNetWatchTestBase(output
         await App.WaitUntilOutputContains("dotnet watch ⌚ Fix the error to continue or press Ctrl+C to exit.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListsFiles()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchGlobbingApp")

--- a/test/dotnet-watch.Tests/CommandLine/SubcommandTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/SubcommandTests.cs
@@ -5,9 +5,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class SubcommandTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task TestCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("XunitCore")
@@ -32,7 +33,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         await App.WaitUntilOutputContains("    TestNamespace.VSTestXunitTests.VSTestXunitPassTest2");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TestCommand_MultiTargeting()
     {
         var testAsset = TestAssets.CopyTestAsset("XunitMulti")
@@ -44,7 +45,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         await App.AssertOutputLineEquals("    TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task BuildCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -61,7 +62,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         Assert.Contains("TestProperty", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MSBuildCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -78,7 +79,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         Assert.DoesNotContain("TestProperty", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PackCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -97,7 +98,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         Assert.Contains("-property:Configuration=Release", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PublishCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -114,7 +115,7 @@ public class SubcommandTests(ITestOutputHelper output) : DotNetWatchTestBase(out
         Assert.Contains("-property:Configuration=Release", App.Process.Output.Single(line => line.Contains("/t:GenerateWatchList")));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FormatCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")

--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -7,40 +7,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class ConsoleReporterTests
 {
     private static readonly string EOL = Environment.NewLine;
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public void WritesToStandardStreams(bool suppressEmojis)
     {
         var testConsole = new TestConsole();
         var reporter = new ConsoleReporter(testConsole, "test prefix", suppressEmojis: suppressEmojis);
 
         reporter.Report(id: default, Emoji.Watch, LogLevel.Trace, "trace {0}");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "⌚")} trace {{0}}" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "⌚")} trace {{0}}" + EOL, testConsole.GetError());
         testConsole.Clear();
 
         reporter.Report(id: default, Emoji.Watch, LogLevel.Debug, "verbose");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "⌚")} verbose" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "⌚")} verbose" + EOL, testConsole.GetError());
         testConsole.Clear();
 
         reporter.Report(id: default, Emoji.Watch, LogLevel.Information, "out");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "⌚")} out" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "⌚")} out" + EOL, testConsole.GetError());
         testConsole.Clear();
 
         reporter.Report(id: default, Emoji.Warning, LogLevel.Warning, "warn");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "⚠")} warn" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "⚠")} warn" + EOL, testConsole.GetError());
         testConsole.Clear();
 
         reporter.Report(id: default, Emoji.Error, LogLevel.Error, "error");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "❌")} error" + EOL, testConsole.GetError());
         testConsole.Clear();
 
         reporter.Report(id: default, Emoji.Error, LogLevel.Critical, "critical");
-        Assert.Equal($"test prefix {(suppressEmojis ? ":" : "❌")} critical" + EOL, testConsole.GetError());
+        Assert.AreEqual($"test prefix {(suppressEmojis ? ":" : "❌")} critical" + EOL, testConsole.GetError());
         testConsole.Clear();
     }
 

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias MSTestFramework;
 
 #nullable disable
 
@@ -9,11 +11,16 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class FileWatcherTests(ITestOutputHelper output)
+[TestClass]
+public class FileWatcherTests
 {
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
     private readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
     private readonly TimeSpan NegativeTimeout = TimeSpan.FromSeconds(5);
-    private readonly TestAssetsManager _testAssetManager = new(output);
+    private TestAssetsManager _testAssetManager;
+    private TestAssetsManager TestAssetManager => _testAssetManager ??= new(Output);
 
     private async Task TestOperation(
         string dir,
@@ -30,7 +37,7 @@ public class FileWatcherTests(ITestOutputHelper output)
             {
                 try
                 {
-                    output.WriteLine(m);
+                    Output.WriteLine(m);
                 }
                 catch (InvalidOperationException)
                 {
@@ -47,11 +54,11 @@ public class FileWatcherTests(ITestOutputHelper output)
         {
             if (filesChanged.Add(f))
             {
-                output.WriteLine($"Observed new {f.Kind}: '{f.Path}' ({filesChanged.Count} out of {expectedChanges.Length})");
+                Output.WriteLine($"Observed new {f.Kind}: '{f.Path}' ({filesChanged.Count} out of {expectedChanges.Length})");
             }
             else
             {
-                output.WriteLine($"Already seen {f.Kind}: '{f.Path}'");
+                Output.WriteLine($"Already seen {f.Kind}: '{f.Path}'");
             }
 
             if (filesChanged.Count == expectedChanges.Length)
@@ -70,7 +77,7 @@ public class FileWatcherTests(ITestOutputHelper output)
             // On Unix the file write time is in 1s increments;
             // if we don't wait, there's a chance that the polling
             // watcher will not detect the change
-            await Task.Delay(1000);
+            await Task.Delay(1000, TestContext.CancellationToken);
         }
 
         operation();
@@ -101,10 +108,10 @@ public class FileWatcherTests(ITestOutputHelper output)
     private static IEnumerable<string> Inspect(IReadOnlyDictionary<string, DirectoryWatcher> watchers)
         => watchers.OrderBy(w => w.Key).Select(w => $"{w.Key.TrimEnd('\\', '/')}: [{string.Join(',', w.Value.WatchedFileNames.Order())}]");
 
-    [Fact]
+    [TestMethod]
     public void DirectoryWatcherMerging()
     {
-        var logger = new TestLogger(output);
+        var logger = new TestLogger(Output);
         var watcher = new TestFileWatcher(logger);
         string root = SdkTestContext.Current.TestExecutionDirectory;
 
@@ -155,11 +162,12 @@ public class FileWatcherTests(ITestOutputHelper output)
         AssertEx.SequenceEqual([$"{dirA}: []"], Inspect(watcher.DirectoryWatchers));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task NewFile(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         var file = Path.Combine(dir, "file");
 
@@ -180,8 +188,11 @@ public class FileWatcherTests(ITestOutputHelper output)
             () => File.WriteAllText(file, string.Empty));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true, true)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(false, false)]
     public async Task NewFileInNewDirectory(bool usePolling, bool nested)
     {
         if (!usePolling && !(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
@@ -191,7 +202,7 @@ public class FileWatcherTests(ITestOutputHelper output)
             return;
         }
 
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         var dir1 = Path.Combine(dir, "dir1");
         var dir2 = nested ? Path.Combine(dir1, "dir2") : dir1;
@@ -224,11 +235,12 @@ public class FileWatcherTests(ITestOutputHelper output)
             });
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task ChangeFile(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         var file = Path.Combine(dir, "file");
         File.WriteAllText(file, string.Empty);
@@ -241,11 +253,12 @@ public class FileWatcherTests(ITestOutputHelper output)
             () => File.WriteAllText(file, string.Empty));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task MoveFile(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
         var srcFile = Path.Combine(dir, "file");
         var dstFile = Path.Combine(dir, "file2");
 
@@ -271,11 +284,14 @@ public class FileWatcherTests(ITestOutputHelper output)
             () => File.Move(srcFile, dstFile));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true, true)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(false, false)]
     public async Task FileInSubdirectory(bool usePolling, bool watchSubdirectories)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: $"{usePolling}{watchSubdirectories}").Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: $"{usePolling}{watchSubdirectories}").Path;
 
         var subdir = Path.Combine(dir, "subdir");
         Directory.CreateDirectory(subdir);
@@ -323,11 +339,12 @@ public class FileWatcherTests(ITestOutputHelper output)
             });
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task NoNotificationIfDisabled(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         using var watcher = DirectoryWatcher.Create(dir, watchedFileNames: [], usePolling, includeSubdirectories: true);
 
@@ -344,18 +361,19 @@ public class FileWatcherTests(ITestOutputHelper output)
             // On Unix the file write time is in 1s increments;
             // if we don't wait, there's a chance that the polling
             // watcher will not detect the change
-            await Task.Delay(1000, TestContext.Current.CancellationToken);
+            await Task.Delay(1000, TestContext.CancellationToken);
         }
         File.WriteAllText(testFileFullPath, string.Empty);
 
-        await Assert.ThrowsAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
+        await Assert.ThrowsExactlyAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task DisposedNoEvents(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
         var changedEv = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (var watcher = DirectoryWatcher.Create(dir, watchedFileNames: [], usePolling, includeSubdirectories: true))
         {
@@ -370,18 +388,19 @@ public class FileWatcherTests(ITestOutputHelper output)
             // On Unix the file write time is in 1s increments;
             // if we don't wait, there's a chance that the polling
             // watcher will not detect the change
-            await Task.Delay(1000, TestContext.Current.CancellationToken);
+            await Task.Delay(1000, TestContext.CancellationToken);
         }
         File.WriteAllText(file, string.Empty);
 
-        await Assert.ThrowsAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
+        await Assert.ThrowsExactlyAsync<TimeoutException>(() => changedEv.Task.TimeoutAfter(NegativeTimeout));
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task MultipleFiles(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         var file1 = Path.Combine(dir, "a1");
         var file2 = Path.Combine(dir, "a2");
@@ -406,11 +425,12 @@ public class FileWatcherTests(ITestOutputHelper output)
             watchedFileNames: ["a3"]);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task MultipleTriggers(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
 
         using var watcher = DirectoryWatcher.Create(dir, watchedFileNames: [], usePolling, includeSubdirectories: true);
 
@@ -430,7 +450,7 @@ public class FileWatcherTests(ITestOutputHelper output)
         var expectedPath = Path.Combine(directory, Path.GetRandomFileName());
         EventHandler<ChangedPath> handler = (_, f) =>
         {
-            output.WriteLine("File changed: " + f);
+            Output.WriteLine("File changed: " + f);
             try
             {
                 if (string.Equals(f.Path, expectedPath, StringComparison.OrdinalIgnoreCase))
@@ -455,7 +475,7 @@ public class FileWatcherTests(ITestOutputHelper output)
             // On Unix the file write time is in 1s increments;
             // if we don't wait, there's a chance that the polling
             // watcher will not detect the change
-            await Task.Delay(1000);
+            await Task.Delay(1000, TestContext.CancellationToken);
             File.AppendAllText(expectedPath, " ");
             await changedEv.Task.TimeoutAfter(DefaultTimeout);
         }
@@ -465,11 +485,12 @@ public class FileWatcherTests(ITestOutputHelper output)
         }
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task DeleteSubfolder(bool usePolling)
     {
-        var dir = _testAssetManager.CreateTestDirectory(usePolling.ToString()).Path;
+        var dir = TestAssetManager.CreateTestDirectory(usePolling.ToString()).Path;
 
         var subdir = Path.Combine(dir, "subdir");
         Directory.CreateDirectory(subdir);

--- a/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
@@ -7,9 +7,11 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class AspireHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class AspireHotReloadTests : DotNetWatchTestBase
 {
-    [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53058, https://github.com/dotnet/sdk/issues/53061, https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)] // https://github.com/dotnet/sdk/issues/53058, https://github.com/dotnet/sdk/issues/53061, https://github.com/dotnet/sdk/issues/53114
     public async Task Aspire_BuildError_ManualRestart()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAspire")
@@ -54,7 +56,7 @@ public class AspireHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         await App.WaitUntilOutputContains("Using Aspire process launcher.");
 
         // Only one browser should be launched (dashboard). The child process shouldn't launch a browser.
-        Assert.Equal(1, App.Process.Output.Count(line => line.StartsWith("dotnet watch ⌚ Launching browser: ")));
+        Assert.HasCount(1, App.Process.Output.Where(line => line.StartsWith("dotnet watch ⌚ Launching browser: ")));
         App.Process.ClearOutput();
 
         // rude edit with build error:
@@ -122,7 +124,8 @@ public class AspireHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         // It might get cancelled and not delivered on shutdown.
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows)] // https://github.com/dotnet/sdk/issues/53058, https://github.com/dotnet/sdk/issues/53061, https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)] // https://github.com/dotnet/sdk/issues/53058, https://github.com/dotnet/sdk/issues/53061, https://github.com/dotnet/sdk/issues/53114
     public async Task Aspire_NoEffect_AutoRestart()
     {
         var tfm = ToolsetInfo.CurrentTargetFramework;

--- a/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
@@ -5,10 +5,12 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class AutoRestartTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class AutoRestartTests : DotNetWatchTestBase
 {
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task AutoRestartOnRudeEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())
@@ -52,8 +54,10 @@ public class AutoRestartTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains(MessageDescriptor.ManagedCodeChangesApplied);
     }
 
-    [Theory(Skip = "https://github.com/dotnet/sdk/issues/51469")]
-    [CombinatorialData]
+    [TestMethod]
+    [Ignore("https://github.com/dotnet/sdk/issues/51469")]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task AutoRestartOnRuntimeRudeEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())
@@ -115,7 +119,7 @@ public class AutoRestartTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains("System.Byte");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AutoRestartOnRudeEditAfterRestartPrompt()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -158,8 +162,9 @@ public class AutoRestartTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains(MessageDescriptor.LaunchedProcess, projectDisplay);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task AutoRestartOnNoEffectEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())

--- a/test/dotnet-watch.Tests/HotReload/BuildParametersSelectionPromptTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildParametersSelectionPromptTests.cs
@@ -1,10 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using SpectreTestConsole = Spectre.Console.Testing.TestConsole;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class BuildParametersSelectionPromptTests
 {
     private static DeviceInfo[] CreateTestDevices() =>
@@ -14,9 +15,11 @@ public class BuildParametersSelectionPromptTests
         new("0A041FDD400327", "Pixel 7 Pro", "Device", "Online", "android-arm64"),
     ];
 
-    [Theory]
-    [CombinatorialData]
-    public async Task SelectsFrameworkByArrowKeysAndEnter([CombinatorialRange(0, count: 3)] int index)
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    public async Task SelectsFrameworkByArrowKeysAndEnter(int index)
     {
         var console = new SpectreTestConsole();
         console.Profile.Capabilities.Interactive = true;
@@ -31,13 +34,15 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var result = await prompt.SelectTargetFrameworkAsync(frameworks, CancellationToken.None);
-        Assert.Equal(frameworks[index], result);
-        Assert.Equal(frameworks[index], prompt.PreviousFrameworkSelection);
+        Assert.AreEqual(frameworks[index], result);
+        Assert.AreEqual(frameworks[index], prompt.PreviousFrameworkSelection);
     }
 
-    [Theory]
-    [CombinatorialData]
-    public async Task PreviousFrameworkSelectionIsReusedWhenUnchanged([CombinatorialRange(0, count: 3)] int index)
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    public async Task PreviousFrameworkSelectionIsReusedWhenUnchanged(int index)
     {
         var console = new SpectreTestConsole();
         console.Profile.Capabilities.Interactive = true;
@@ -52,14 +57,14 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var first = await prompt.SelectTargetFrameworkAsync(frameworks, CancellationToken.None);
-        Assert.Equal(frameworks[index], first);
+        Assert.AreEqual(frameworks[index], first);
 
         // Same frameworks (reordered, different casing) should reuse previous selection without prompting
         var second = await prompt.SelectTargetFrameworkAsync(["NET9.0", "net7.0", "net8.0"], CancellationToken.None);
-        Assert.Equal(first, second);
+        Assert.AreEqual(first, second);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PromptsAgainWhenFrameworksChange()
     {
         var console = new SpectreTestConsole();
@@ -72,13 +77,13 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var first = await prompt.SelectTargetFrameworkAsync(["net7.0", "net8.0", "net9.0"], CancellationToken.None);
-        Assert.Equal("net7.0", first);
+        Assert.AreEqual("net7.0", first);
 
         var second = await prompt.SelectTargetFrameworkAsync(["net9.0", "net10.0"], CancellationToken.None);
-        Assert.Equal("net10.0", second);
+        Assert.AreEqual("net10.0", second);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectsFrameworkBySearchText()
     {
         var console = new SpectreTestConsole();
@@ -91,10 +96,10 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var result = await prompt.SelectTargetFrameworkAsync(frameworks, CancellationToken.None);
-        Assert.Equal("net9.0", result);
+        Assert.AreEqual("net9.0", result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectsFirstDeviceByEnter()
     {
         var console = new SpectreTestConsole();
@@ -106,11 +111,11 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var result = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal(devices[0], result);
-        Assert.Equal(devices[0], prompt.PreviousDeviceSelection);
+        Assert.AreEqual(devices[0], result);
+        Assert.AreEqual(devices[0], prompt.PreviousDeviceSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectsDeviceBySearchText()
     {
         var console = new SpectreTestConsole();
@@ -123,11 +128,11 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var result = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal("0A041FDD400327", result.Id);
-        Assert.Equal("android-arm64", result.RuntimeIdentifier);
+        Assert.AreEqual("0A041FDD400327", result.Id);
+        Assert.AreEqual("android-arm64", result.RuntimeIdentifier);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PreviousDeviceSelectionIsReusedWhenUnchanged()
     {
         var console = new SpectreTestConsole();
@@ -139,14 +144,14 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var first = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal(devices[0], first);
+        Assert.AreEqual(devices[0], first);
 
         // Same devices should reuse previous selection without prompting
         var second = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal(first, second);
+        Assert.AreEqual(first, second);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PromptsAgainWhenDevicesChange()
     {
         var console = new SpectreTestConsole();
@@ -159,7 +164,7 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var first = await prompt.SelectDeviceAsync(CreateTestDevices(), CancellationToken.None);
-        Assert.Equal("emulator-5554", first.Id);
+        Assert.AreEqual("emulator-5554", first.Id);
 
         DeviceInfo[] newDevices =
         [
@@ -167,10 +172,10 @@ public class BuildParametersSelectionPromptTests
             new("sim-2", "iPhone 15 - iOS 26.0", "Simulator", "Shutdown", "iossimulator-arm64"),
         ];
         var second = await prompt.SelectDeviceAsync(newDevices, CancellationToken.None);
-        Assert.Equal("sim-2", second.Id);
+        Assert.AreEqual("sim-2", second.Id);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectsDeviceBySearchingId()
     {
         var console = new SpectreTestConsole();
@@ -183,43 +188,43 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var result = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal("emulator-5555", result.Id);
-        Assert.Equal("android-x64", result.RuntimeIdentifier);
+        Assert.AreEqual("emulator-5555", result.Id);
+        Assert.AreEqual("android-x64", result.RuntimeIdentifier);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormatDevice_WithAllMetadata()
     {
         var device = new DeviceInfo("emulator-5554", "Pixel 7 - API 35", "Emulator", "Online", "android-x64");
         var formatted = SpectreBuildParametersSelectionPrompt.FormatDevice(device);
-        Assert.Equal("emulator-5554 - Pixel 7 - API 35 (Emulator, Online)", formatted);
+        Assert.AreEqual("emulator-5554 - Pixel 7 - API 35 (Emulator, Online)", formatted);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormatDevice_WithoutType()
     {
         var device = new DeviceInfo("device-1", "My Phone", null, "Connected", null);
         var formatted = SpectreBuildParametersSelectionPrompt.FormatDevice(device);
-        Assert.Equal("device-1 - My Phone (Connected)", formatted);
+        Assert.AreEqual("device-1 - My Phone (Connected)", formatted);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormatDevice_WithoutStatus()
     {
         var device = new DeviceInfo("device-1", "My Phone", "Device", null, null);
         var formatted = SpectreBuildParametersSelectionPrompt.FormatDevice(device);
-        Assert.Equal("device-1 - My Phone (Device)", formatted);
+        Assert.AreEqual("device-1 - My Phone (Device)", formatted);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormatDevice_IdOnly()
     {
         var device = new DeviceInfo("device-1", null, null, null, null);
         var formatted = SpectreBuildParametersSelectionPrompt.FormatDevice(device);
-        Assert.Equal("device-1", formatted);
+        Assert.AreEqual("device-1", formatted);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectsFrameworkThenDevice()
     {
         var console = new SpectreTestConsole();
@@ -238,9 +243,9 @@ public class BuildParametersSelectionPromptTests
         var prompt = new SpectreBuildParametersSelectionPrompt(console);
 
         var selectedFramework = await prompt.SelectTargetFrameworkAsync(frameworks, CancellationToken.None);
-        Assert.Equal("net9.0", selectedFramework);
+        Assert.AreEqual("net9.0", selectedFramework);
 
         var selectedDevice = await prompt.SelectDeviceAsync(devices, CancellationToken.None);
-        Assert.Equal("0A041FDD400327", selectedDevice.Id);
+        Assert.AreEqual("0A041FDD400327", selectedDevice.Id);
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
@@ -1,14 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class BuildProjects(ITestOutputHelper output)
+[TestClass]
+public class BuildProjects
 {
-    private class TestContext : IDisposable
+    public Microsoft.VisualStudio.TestTools.UnitTesting.TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper? _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private class WatcherContext : IDisposable
     {
         public readonly HotReloadDotNetWatcher Watcher;
         public readonly FileWatcher FileWatcher;
@@ -18,7 +24,7 @@ public class BuildProjects(ITestOutputHelper output)
         public readonly List<string> BuildInvocations = [];
         public string? SolutionFile;
 
-        public TestContext(ITestOutputHelper output, ImmutableArray<ProjectRepresentation> rootProjects)
+        public WatcherContext(DualOutputHelper output, ImmutableArray<ProjectRepresentation> rootProjects)
         {
             var environmentOptions = TestOptions.GetEnvironmentOptions();
             var processOutputReporter = new TestProcessOutputReporter();
@@ -66,14 +72,14 @@ public class BuildProjects(ITestOutputHelper output)
 
         public void Dispose()
         {
-            Assert.False(File.Exists(SolutionFile));
+            Assert.IsFalse(File.Exists(SolutionFile));
         }
     }
 
-    private TestContext CreateContext(string[]? rootProjects = null)
-        => new(output, rootProjects?.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath).ToImmutableArray() ?? []);
+    private WatcherContext CreateContext(string[]? rootProjects = null)
+        => new(Output, rootProjects?.Select(ProjectRepresentation.FromProjectOrEntryPointFilePath).ToImmutableArray() ?? []);
 
-    [Fact]
+    [TestMethod]
     public async Task SingleProject_NotMain()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -93,12 +99,12 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual([$"build {project1} -p A=1"], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleProject_Main()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -127,7 +133,7 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual(
         [
@@ -136,7 +142,7 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleProjects()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -157,13 +163,14 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual(["build <solution> -p A=1"], context.BuildInvocations);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task FileBasedApp_NoFrameworkProperties(bool isMain)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [isMain]);
@@ -186,13 +193,14 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual([$"build {file1} -p A=1"], context.BuildInvocations);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task FileBasedApp_TargetFrameworkProperty(bool nonInteractive)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [nonInteractive]);
@@ -216,13 +224,14 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual([$"build {file1} -p A=1 --framework net9.0"], context.BuildInvocations);
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task FileBasedApp_TargetFrameworksProperty(bool nonInteractive)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [nonInteractive]);
@@ -252,17 +261,17 @@ public class BuildProjects(ITestOutputHelper output)
                 "[Error] " + MessageDescriptor.FileSpecifiesMultipleTargetFrameworks.GetMessage((file1, "net9.0', 'net10.0"))
             ], context.BuildLogger.GetAndClearMessages());
 
-            Assert.False(result.Success);
-            Assert.Empty(context.BuildInvocations);
+            Assert.IsFalse(result.Success);
+            Assert.IsEmpty(context.BuildInvocations);
         }
         else
         {
-            Assert.True(result.Success);
+            Assert.IsTrue(result.Success);
             AssertEx.SequenceEqual([$"build {file1} -p A=1 --framework net9.0"], context.BuildInvocations);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FileBasedApp_TargetFrameworkOption()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -286,12 +295,12 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual([$"build {file1} -p A=1 --framework net8.0"], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleFiles()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -312,7 +321,7 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual(
         [
@@ -321,7 +330,7 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleProject_MultipleFiles()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -344,7 +353,7 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual(
         [
@@ -354,7 +363,7 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleProjects_MultipleFiles()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -379,7 +388,7 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
 
         AssertEx.SequenceEqual(
         [
@@ -389,9 +398,9 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Theory]
-    [InlineData(ToolsetInfo.CurrentTargetFramework)]
-    [InlineData("net9.0")]
+    [TestMethod]
+    [DataRow(ToolsetInfo.CurrentTargetFramework)]
+    [DataRow("net9.0")]
     public async Task MultiTfm_FrameworkSelection(string expectedTfm)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [expectedTfm]);
@@ -422,9 +431,9 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
         
-        Assert.True(result.Success);
-        Assert.NotNull(result.ProjectGraph);
-        Assert.Equal(expectedTfm, result.MainProjectTargetFramework);
+        Assert.IsTrue(result.Success);
+        Assert.IsNotNull(result.ProjectGraph);
+        Assert.AreEqual(expectedTfm, result.MainProjectTargetFramework);
 
         AssertEx.SequenceEqual(
         [
@@ -433,7 +442,7 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultiTfm_CommandLineOption()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -464,9 +473,9 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
-        Assert.Null(result.ProjectGraph);
-        Assert.Equal("net9.0", result.MainProjectTargetFramework);
+        Assert.IsTrue(result.Success);
+        Assert.IsNull(result.ProjectGraph);
+        Assert.AreEqual("net9.0", result.MainProjectTargetFramework);
 
         AssertEx.SequenceEqual(
         [
@@ -474,7 +483,7 @@ public class BuildProjects(ITestOutputHelper output)
         ], context.BuildInvocations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultiTfm_NoMainProject()
     {
         var dir = TestAssetsManager.CreateTestDirectory();
@@ -505,9 +514,9 @@ public class BuildProjects(ITestOutputHelper output)
             deviceSelector: null,
             CancellationToken.None);
 
-        Assert.True(result.Success);
-        Assert.Null(result.ProjectGraph);
-        Assert.Null(result.MainProjectTargetFramework);
+        Assert.IsTrue(result.Success);
+        Assert.IsNull(result.ProjectGraph);
+        Assert.IsNull(result.MainProjectTargetFramework);
 
         AssertEx.SequenceEqual(
         [

--- a/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CompilationHandlerTests.cs
@@ -5,9 +5,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class CompilationHandlerTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task ReferenceOutputAssembly_False()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppMultiProc")
@@ -24,7 +25,7 @@ public class CompilationHandlerTests(ITestOutputHelper output) : DotNetWatchTest
 
         var factory = new ProjectGraphFactory([hostProjectRepr], buildProperties: [], NullLogger.Instance, cmdOptions.GlobalOptions, environmentOptions);
         var projectGraph = factory.TryLoadProjectGraph(projectGraphRequired: false, virtualProjectTargetFramework: null, CancellationToken.None);
-        Assert.NotNull(projectGraph);
+        Assert.IsNotNull(projectGraph);
 
         var processOutputReporter = new TestProcessOutputReporter();
 

--- a/test/dotnet-watch.Tests/HotReload/CtrlRTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/CtrlRTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class CtrlRTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class CtrlRTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task RestartsBuild()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -45,10 +46,10 @@ public class CtrlRTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
         // DOTNET_WATCH_ITERATION = 2
         await hasExpectedOutput.Task;
 
-        Assert.Equal(2, buildCounter);
+        Assert.AreEqual(2, buildCounter);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CancelsWaitForFileChange()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -84,6 +85,6 @@ public class CtrlRTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
 
         await hasExpectedOutput.Task;
 
-        Assert.Equal(2, buildCounter);
+        Assert.AreEqual(2, buildCounter);
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/FileBasedAppTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/FileBasedAppTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class FileBasedAppTests(ITestOutputHelper output) : DotNetWatchTestBase(output)
+[TestClass]
+public class FileBasedAppTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task IncludeDirective()
     {
         var testAsset = TestAssets.CreateTestAsset("FBA");
@@ -52,7 +53,7 @@ public class FileBasedAppTests(ITestOutputHelper output) : DotNetWatchTestBase(o
         await App.WaitUntilOutputContains("<Updated>");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TargetFrameworks_Selection()
     {
         var testAsset = TestAssets.CreateTestAsset("FBA");
@@ -81,7 +82,7 @@ public class FileBasedAppTests(ITestOutputHelper output) : DotNetWatchTestBase(o
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TargetFramework()
     {
         var testAsset = TestAssets.CreateTestAsset("FBA");

--- a/test/dotnet-watch.Tests/HotReload/FileExclusionTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/FileExclusionTests.cs
@@ -3,7 +3,8 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class FileExclusionTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class FileExclusionTests : DotNetWatchTestBase
 {
     public enum DirectoryKind
     {
@@ -13,8 +14,23 @@ public class FileExclusionTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         Obj,
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true, true, DirectoryKind.Ordinary)]
+    [DataRow(true, true, DirectoryKind.Hidden)]
+    [DataRow(true, true, DirectoryKind.Bin)]
+    [DataRow(true, true, DirectoryKind.Obj)]
+    [DataRow(true, false, DirectoryKind.Ordinary)]
+    [DataRow(true, false, DirectoryKind.Hidden)]
+    [DataRow(true, false, DirectoryKind.Bin)]
+    [DataRow(true, false, DirectoryKind.Obj)]
+    [DataRow(false, true, DirectoryKind.Ordinary)]
+    [DataRow(false, true, DirectoryKind.Hidden)]
+    [DataRow(false, true, DirectoryKind.Bin)]
+    [DataRow(false, true, DirectoryKind.Obj)]
+    [DataRow(false, false, DirectoryKind.Ordinary)]
+    [DataRow(false, false, DirectoryKind.Hidden)]
+    [DataRow(false, false, DirectoryKind.Bin)]
+    [DataRow(false, false, DirectoryKind.Obj)]
     public async Task IgnoredChange(bool isExisting, bool isIncluded, DirectoryKind directoryKind)
     {
         var testAsset = CopyTestAsset("WatchNoDepsApp", [isExisting, isIncluded, directoryKind]);

--- a/test/dotnet-watch.Tests/HotReload/HotReloadDotNetWatcherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/HotReloadDotNetWatcherTests.cs
@@ -1,39 +1,41 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class HotReloadDotNetWatcherTests
 {
-    [Theory]
-    [InlineData(new[] { ChangeKind.Update }, new[] { ChangeKind.Update })]
-    [InlineData(new[] { ChangeKind.Add }, new[] { ChangeKind.Add })]
-    [InlineData(new[] { ChangeKind.Delete }, new[] { ChangeKind.Delete })]
+    [TestMethod]
+    [DataRow(new[] { ChangeKind.Update }, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Add }, new[] { ChangeKind.Add })]
+    [DataRow(new[] { ChangeKind.Delete }, new[] { ChangeKind.Delete })]
 
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Update }, new[] { ChangeKind.Update })]
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Delete }, new[] { ChangeKind.Delete })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Add })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
-    [InlineData(new[] { ChangeKind.Delete, ChangeKind.Add}, new[] { ChangeKind.Update })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Add }, new[] { ChangeKind.Add })]
-    [InlineData(new[] { ChangeKind.Delete, ChangeKind.Delete }, new[] { ChangeKind.Delete })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Update }, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Delete }, new[] { ChangeKind.Delete })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Add })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
+    [DataRow(new[] { ChangeKind.Delete, ChangeKind.Add}, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Add }, new[] { ChangeKind.Add })]
+    [DataRow(new[] { ChangeKind.Delete, ChangeKind.Delete }, new[] { ChangeKind.Delete })]
 
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Delete, ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Delete, ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Update })]
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Delete, ChangeKind.Update, ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Update })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Delete, ChangeKind.Delete }, new ChangeKind[] { })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
-    [InlineData(new[] { ChangeKind.Add, ChangeKind.Update, ChangeKind.Delete }, new ChangeKind[] { })]
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Add, ChangeKind.Delete }, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Delete, ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Delete, ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Delete, ChangeKind.Update, ChangeKind.Add, ChangeKind.Update }, new[] { ChangeKind.Update })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Delete, ChangeKind.Delete }, new ChangeKind[] { })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Add, ChangeKind.Delete }, new ChangeKind[] { })]
+    [DataRow(new[] { ChangeKind.Add, ChangeKind.Update, ChangeKind.Delete }, new ChangeKind[] { })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Add, ChangeKind.Delete }, new[] { ChangeKind.Update })]
 
     // File.WriteAllText on macOS may produce Update + Add.
-    [InlineData(new[] { ChangeKind.Update, ChangeKind.Add }, new[] { ChangeKind.Add })]
+    [DataRow(new[] { ChangeKind.Update, ChangeKind.Add }, new[] { ChangeKind.Add })]
 
     // The following case should not occur in practice:
-    [InlineData(new[] { ChangeKind.Delete, ChangeKind.Update }, new[] { ChangeKind.Delete })]
-    internal void NormalizeFileChanges(ChangeKind[] changes, ChangeKind[] expected)
+    [DataRow(new[] { ChangeKind.Delete, ChangeKind.Update }, new[] { ChangeKind.Delete })]
+    public void NormalizeFileChanges(Array changes, Array expected)
     {
-        var normalized = HotReloadDotNetWatcher.NormalizePathChanges(changes.Select(kind => new ChangedPath("a.html", kind)));
-        AssertEx.SequenceEqual(expected, normalized.Select(c => c.Kind));
+        var normalized = HotReloadDotNetWatcher.NormalizePathChanges(changes.Cast<ChangeKind>().Select(kind => new ChangedPath("a.html", kind)));
+        AssertEx.SequenceEqual(expected.Cast<ChangeKind>(), normalized.Select(c => c.Kind));
     }
 }
+

--- a/test/dotnet-watch.Tests/HotReload/LoggingTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/LoggingTests.cs
@@ -5,9 +5,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class LoggingTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class LoggingTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task BinaryLogs()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -18,7 +19,7 @@ public class LoggingTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger
         var binLogPath = Path.Combine(logDir, "Test.binlog");
         var binLogPathBase = Path.ChangeExtension(binLogPath, "").TrimEnd('.');
 
-        Assert.False(Directory.Exists(logDir));
+        Assert.IsFalse(Directory.Exists(logDir));
 
         App.SuppressVerboseLogging();
         App.Start(testAsset, ["--verbose", $"-bl:{binLogPath}"], testFlags: TestFlags.None);

--- a/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
@@ -1,18 +1,22 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class MauiHotReloadTests : DotNetWatchTestBase
 {
     /// <summary>
     /// Currently only works on Windows.
     /// Add TestPlatforms.OSX once https://github.com/dotnet/sdk/issues/45521 is fixed.
     /// </summary>
-    [PlatformSpecificTheory(TestPlatforms.Windows, Skip = "https://github.com/dotnet/sdk/issues/54150")]
-    [CombinatorialData]
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    [Ignore("https://github.com/dotnet/sdk/issues/54150")]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task MauiBlazor(bool selectTfm)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchMauiBlazor", identifier: selectTfm.ToString())
@@ -24,7 +28,7 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         };
 
         var result = workloadInstallCommandSpec.Execute();
-        Assert.Equal(0, result.ExitCode);
+        Assert.AreEqual(0, result.ExitCode);
 
         var platform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows10.0.19041.0" : "maccatalyst";
         var tfm = $"{ToolsetInfo.CurrentTargetFramework}-{platform}";
@@ -45,8 +49,8 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
         // only the selected target framework is built:
-        Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", tfm, "win-x64", "maui-blazor.dll")));
-        Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", tfm, "maccatalyst-x64", "maui-blazor.dll")));
+        Assert.AreEqual(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", tfm, "win-x64", "maui-blazor.dll")));
+        Assert.AreEqual(RuntimeInformation.IsOSPlatform(OSPlatform.OSX), File.Exists(Path.Combine(testAsset.Path, "bin", "Debug", tfm, "maccatalyst-x64", "maui-blazor.dll")));
 
         // update code file:
         var razorPath = Path.Combine(testAsset.Path, "Components", "Pages", "Home.razor");
@@ -84,7 +88,7 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
     /// Tests device selection in dotnet-watch using the DotnetRunDevices test asset,
     /// which provides ComputeAvailableDevices and DeployToDevice MSBuild targets.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SelectsDevice()
     {
         var testAsset = TestAssets.CopyTestAsset("DotnetRunDevices")
@@ -116,7 +120,7 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
     /// KeyPressed channel is used for the first Spectre prompt, the second prompt
     /// must also receive key events from the same channel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SelectsFrameworkThenDevice()
     {
         var testAsset = TestAssets.CopyTestAsset("DotnetRunDevices")
@@ -157,7 +161,7 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
     /// dotnet-run process. This causes a stdin race: dotnet-watch's Console.ReadKey()
     /// loop steals all key presses from the child process's device prompt.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SelectsFrameworkThenDevice_WorkloadConditionalTarget()
     {
         var testAsset = TestAssets.CopyTestAsset("DotnetRunDevicesWorkload")
@@ -194,7 +198,7 @@ public class MauiHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains("Device: test-device-1");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AutoSelectsSingleDevice()
     {
         var testAsset = TestAssets.CopyTestAsset("DotnetRunDevices")

--- a/test/dotnet-watch.Tests/HotReload/MetadataUpdateHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MetadataUpdateHandlerTests.cs
@@ -5,9 +5,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class MetadataUpdateHandlerTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class MetadataUpdateHandlerTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task NoActions()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -39,8 +40,9 @@ public class MetadataUpdateHandlerTests(ITestOutputHelper logger) : DotNetWatchT
             $"dotnet watch ⚠ [WatchHotReloadApp ({ToolsetInfo.CurrentTargetFramework})] Expected to find a static method 'ClearCache', 'UpdateApplication' or 'UpdateContent' on type 'AppUpdateHandler, WatchHotReloadApp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' but neither exists.");
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task Exception(bool verbose)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: verbose.ToString())

--- a/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MobileHotReloadTests.cs
@@ -1,11 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class MobileHotReloadTests : DotNetWatchTestBase
 {
     // Matches WebSocket URLs like ws://localhost:12345 where port is non-zero
     private static readonly Regex WebSocketServerStartedPattern = new(@"WebSocket server started at: ws://localhost:([1-9]\d*)");
@@ -14,7 +15,7 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
     /// Tests that hot reload works for projects with the HotReloadWebSockets capability.
     /// Mobile workloads (Android, iOS) add this capability to indicate WebSocket transport should be used.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task HotReload_WithWebSocketCapability()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchMobileApp")
@@ -39,7 +40,7 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         await App.AssertOutputLineStartsWith("Changed!");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlC_ShutsDownCleanly()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchMobileApp")
@@ -63,7 +64,7 @@ public class MobileHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBas
         App.AssertOutputDoesNotContain("An unexpected error occurred");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlR_RestartsCleanly()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchMobileApp")

--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProjectUpdateInProcTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class ProjectUpdateInProcTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task ProjectAndSourceFileChange()
     {
         var testAsset = CopyTestAsset("WatchHotReloadApp");
@@ -52,7 +53,7 @@ public class ProjectUpdateInProcTests(ITestOutputHelper logger) : DotNetWatchTes
         await hasUpdatedOutput.Task;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProjectAndSourceFileChange_AddProjectReference()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -122,12 +123,12 @@ public class ProjectUpdateInProcTests(ITestOutputHelper logger) : DotNetWatchTes
         using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await managedCodeChangesApplied.WaitAsync(waitCts.Token);
 
-        Assert.Equal(1, projectChangeTriggeredReEvaluation.CurrentCount);
-        Assert.Equal(1, projectsRebuilt.CurrentCount);
-        Assert.Equal(1, projectDependenciesDeployed.CurrentCount);
+        Assert.AreEqual(1, projectChangeTriggeredReEvaluation.CurrentCount);
+        Assert.AreEqual(1, projectsRebuilt.CurrentCount);
+        Assert.AreEqual(1, projectDependenciesDeployed.CurrentCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProjectAndSourceFileChange_AddPackageReference()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -185,8 +186,8 @@ public class ProjectUpdateInProcTests(ITestOutputHelper logger) : DotNetWatchTes
         using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await managedCodeChangesApplied.WaitAsync(waitCts.Token);
 
-        Assert.Equal(1, projectChangeTriggeredReEvaluation.CurrentCount);
-        Assert.Equal(0, projectsRebuilt.CurrentCount);
-        Assert.Equal(1, projectDependenciesDeployed.CurrentCount);
+        Assert.AreEqual(1, projectChangeTriggeredReEvaluation.CurrentCount);
+        Assert.AreEqual(0, projectsRebuilt.CurrentCount);
+        Assert.AreEqual(1, projectDependenciesDeployed.CurrentCount);
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
@@ -7,9 +7,10 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class ProjectUpdateTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task UpdateDirectoryBuildPropsThenUpdateSource()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -48,8 +49,9 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains("Changed!");
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task Update(bool isDirectoryProps)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps", identifier: isDirectoryProps.ToString())
@@ -91,7 +93,8 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains($"{symbolName} not set");
     }
 
-    [Fact(Skip = "https://github.com/dotnet/msbuild/issues/12001")]
+    [TestMethod]
+    [Ignore("https://github.com/dotnet/msbuild/issues/12001")]
     public async Task DirectoryBuildProps_Add()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -134,7 +137,7 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains(MessageDescriptor.ProjectChangeTriggeredReEvaluation);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DirectoryBuildProps_Delete()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -174,7 +177,7 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains("BUILD_CONST_IN_PROPS not set");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DefaultItemExcludes_DefaultItemsEnabled()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -206,7 +209,7 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains($"dotnet watch ⌚ Ignoring change in excluded file '{appDataFilePath}': Add. Path matches DefaultItemExcludes glob 'AppData/**/*.*' set in '{testAsset.Path}'.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DefaultItemExcludes_DefaultItemsDisabled()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")
@@ -248,7 +251,7 @@ public class ProjectUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(
         await App.WaitUntilOutputContains($"dotnet watch ⌚ Ignoring change in output directory: Add '{objDirFilePath}'");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GlobalUsings()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp")

--- a/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
@@ -3,11 +3,13 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class RazorHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class RazorHotReloadTests : DotNetWatchTestBase
 {
-    [PlatformSpecificTheory(TestPlatforms.Windows | TestPlatforms.OSX)] // https://github.com/dotnet/sdk/issues/53114
-    [InlineData("net6.0", "6.0.36")]
-    [InlineData(ToolsetInfo.CurrentTargetFramework, null)]
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
+    [DataRow("net6.0", "6.0.36")]
+    [DataRow(ToolsetInfo.CurrentTargetFramework, null)]
     public async Task BlazorWasm(string tfm, string? wasmVersion)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasm", identifier: $"{tfm}_{wasmVersion}").WithSource(
@@ -61,7 +63,8 @@ public class RazorHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase
         await App.WaitUntilOutputContains(MessageDescriptor.ManagedCodeChangesApplied);
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)] // https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
     public async Task BlazorWasm_MSBuildWarning()
     {
         var testAsset = TestAssets
@@ -83,7 +86,8 @@ public class RazorHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)] // https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
     public async Task BlazorWasm_Restart()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasm")
@@ -106,7 +110,8 @@ public class RazorHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase
         await App.WaitUntilOutputContains(MessageDescriptor.ReloadingBrowser);
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)] // https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
     public async Task BlazorWasmHosted()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasmHosted")
@@ -120,7 +125,8 @@ public class RazorHotReloadTests(ITestOutputHelper logger) : DotNetWatchTestBase
         await App.WaitUntilOutputContains(MessageDescriptor.ApplicationKind_BlazorHosted);
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows | TestPlatforms.OSX)] // https://github.com/dotnet/sdk/issues/53114
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
     public async Task Razor_Component_ScopedCssAndStaticAssets()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -3,7 +3,8 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class RuntimeProcessLauncherTests : DotNetWatchTestBase
 {
     public enum TriggerEvent
     {
@@ -11,8 +12,9 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         WaitingForChanges,
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(TriggerEvent.RuntimeProcessLauncherCreated)]
+    [DataRow(TriggerEvent.WaitingForChanges)]
     public async Task UpdateAndRudeEdit(TriggerEvent trigger)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [trigger]);
@@ -51,12 +53,12 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             }
 
             // service should have been created after MessageDescriptor.RuntimeProcessLauncherCreatedNotification has been received:
-            Assert.NotNull(w.Service);
+            Assert.IsNotNull(w.Service);
 
-            w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token).Wait();
+            w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token).Wait(w.ShutdownSource.Token);
             launchCompletionA.TrySetResult();
 
-            w.Service.Launch(serviceProjectB, workingDirectory, w.ShutdownSource.Token).Wait();
+            w.Service.Launch(serviceProjectB, workingDirectory, w.ShutdownSource.Token).Wait(w.ShutdownSource.Token);
             launchCompletionB.TrySetResult();
         });
 
@@ -143,8 +145,8 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             Log("Waiting for updated output from project B ...");
             await hasUpdateSourceB.Task;
 
-            Assert.True(hasUpdateSourceA.Task.IsCompletedSuccessfully);
-            Assert.True(hasUpdateSourceB.Task.IsCompletedSuccessfully);
+            Assert.IsTrue(hasUpdateSourceA.Task.IsCompletedSuccessfully);
+            Assert.IsTrue(hasUpdateSourceB.Task.IsCompletedSuccessfully);
         }
 
         // make a rude edit and check that the process is restarted
@@ -167,12 +169,13 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
             Log("Waiting for updated output from project A ...");
             await hasUpdateSource.Task;
 
-            Assert.True(hasUpdateSource.Task.IsCompletedSuccessfully);
+            Assert.IsTrue(hasUpdateSource.Task.IsCompletedSuccessfully);
         }
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task UpdateAppliedToNewProcesses(bool sharedOutput)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [sharedOutput]);
@@ -227,7 +230,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
 
         // service should have been created before Hot Reload session started:
-        Assert.NotNull(w.Service);
+        Assert.IsNotNull(w.Service);
 
         await w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token);
 
@@ -271,8 +274,10 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         TopFunction,
     }
 
-    [Theory]
-    [CombinatorialData]
+    [TestMethod]
+    [DataRow(UpdateLocation.Dependency)]
+    [DataRow(UpdateLocation.TopLevel)]
+    [DataRow(UpdateLocation.TopFunction)]
     public async Task HostRestart(UpdateLocation updateLocation)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [updateLocation]);
@@ -360,7 +365,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await hasUpdate.WaitAsync(w.ShutdownSource.Token);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RudeEditInProjectWithoutRunningProcess()
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc");
@@ -387,7 +392,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
 
         // service should have been created before Hot Reload session started:
-        Assert.NotNull(w.Service);
+        Assert.IsNotNull(w.Service);
 
         var runningProject = await w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token);
         Log("Waiting for session started ...");
@@ -409,7 +414,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await applyUpdateVerbose.WaitAsync(w.ShutdownSource.Token);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RelaunchOnCrash()
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc");
@@ -449,7 +454,7 @@ public class RuntimeProcessLauncherTests(ITestOutputHelper logger) : DotNetWatch
         await waitingForChanges.WaitAsync(w.ShutdownSource.Token);
 
         // service should have been created before Hot Reload session started:
-        Assert.NotNull(w.Service);
+        Assert.IsNotNull(w.Service);
 
         await w.Service.Launch(serviceProjectA, workingDirectory, w.ShutdownSource.Token);
 

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
@@ -5,14 +5,15 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class SourceFileUpdateTests_HotReloadNotSupported : DotNetWatchTestBase
 {
-    [Theory]
-    [InlineData("PublishAot", "True")]
-    [InlineData("PublishTrimmed", "True")]
-    [InlineData("StartupHookSupport", "False")]
-    [InlineData("Optimize", "True")]
-    [InlineData("MetadataUpdaterSupport", "False")]
+    [TestMethod]
+    [DataRow("PublishAot", "True")]
+    [DataRow("PublishTrimmed", "True")]
+    [DataRow("StartupHookSupport", "False")]
+    [DataRow("Optimize", "True")]
+    [DataRow("MetadataUpdaterSupport", "False")]
     public async Task ChangeFileInAotProject(string propertyName, string propertyValue)
     {
         var tfvParsed = Version.Parse(ToolsetInfo.CurrentTargetFrameworkVersion);
@@ -57,7 +58,7 @@ public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logge
         await App.WaitForOutputLineContaining("<updated>");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ChangeFileInFSharpProject()
     {
         var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")
@@ -72,7 +73,7 @@ public class SourceFileUpdateTests_HotReloadNotSupported(ITestOutputHelper logge
         await App.WaitUntilOutputContains("<Updated>");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ChangeFileInFSharpProjectWithLoop()
     {
         var testAsset = TestAssets.CopyTestAsset("FSharpTestAppSimple")

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
@@ -1,13 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 #nullable disable
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class SourceFileUpdateTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task AddSourceFile()
     {
         Log("AddSourceFile started");
@@ -44,7 +47,7 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
         await App.WaitUntilOutputContains("Changed!");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ChangeFileInDependency()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -74,7 +77,7 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
     /// <summary>
     /// Unchanged project doesn't build. Wait for source change and rebuild.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BaselineCompilationError()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -98,7 +101,8 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
     }
 
     // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
-    [CoreMSBuildOnlyFact]
+    [TestMethod]
+    [MSTestFramework::Microsoft.NET.TestFramework.CoreMSBuildOnly]
     public async Task HandleTypeLoadFailure()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppTypeLoadFailure")
@@ -129,7 +133,8 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
     }
 
     // Test is timing out on .NET Framework: https://github.com/dotnet/sdk/issues/41669
-    [CoreMSBuildOnlyFact]
+    [TestMethod]
+    [MSTestFramework::Microsoft.NET.TestFramework.CoreMSBuildOnly]
     public async Task HandleMissingAssemblyFailure()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppMissingAssemblyFailure")
@@ -165,11 +170,16 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
         await App.WaitUntilOutputContains("Updated types: Printer");
     }
 
-    [Theory]
-    [InlineData(true, Skip = "https://github.com/dotnet/sdk/issues/43320")]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RenameSourceFile(bool useMove)
     {
+        if (useMove)
+        {
+            Assert.Inconclusive("https://github.com/dotnet/sdk/issues/43320");
+        }
+
         Log("RenameSourceFile started");
 
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps")
@@ -223,9 +233,9 @@ public class SourceFileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBa
         await App.AssertOutputLineStartsWith("> Renamed.cs");
     }
 
-    [Theory]
-    [InlineData(true, Skip = "https://github.com/dotnet/sdk/issues/43320")]
-    [InlineData(false)]
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
     public async Task RenameDirectory(bool useMove)
     {
         Log("RenameSourceFile started");

--- a/test/dotnet-watch.Tests/HotReload/TerminationTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/TerminationTests.cs
@@ -5,9 +5,11 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class TerminationTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class TerminationTests : DotNetWatchTestBase
 {
-    [PlatformSpecificFact(TestPlatforms.Windows)]
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
     public async Task GracefulTermination_Windows()
     {
         var tfm = ToolsetInfo.CurrentTargetFramework;
@@ -40,7 +42,8 @@ public class TerminationTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains("exited with exit code 0.");
     }
 
-    [PlatformSpecificFact(TestPlatforms.AnyUnix)]
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
     public async Task GracefulTermination_Unix()
     {
         var tfm = ToolsetInfo.CurrentTargetFramework;
@@ -71,7 +74,8 @@ public class TerminationTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains("exited with exit code 0.");
     }
 
-    [PlatformSpecificFact(TestPlatforms.Windows)]
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
     public async Task GracefulTermination_WinExe()
     {
         // Test that WinExe apps (WinForms, WPF, MAUI) are terminated gracefully when dotnet-watch

--- a/test/dotnet-watch.Tests/Process/LaunchSettingsProfileTest.cs
+++ b/test/dotnet-watch.Tests/Process/LaunchSettingsProfileTest.cs
@@ -1,5 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias MSTestFramework;
 
 #nullable disable
 
@@ -7,21 +9,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class LaunchSettingsProfileTest
 {
-    private readonly ILogger _logger;
-    private readonly TestAssetsManager _testAssets;
+    public TestContext TestContext { get; set; } = null!;
+    private DualOutputHelper _output;
+    private DualOutputHelper Output => _output ??= new(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+    private ILogger _logger;
+    private ILogger Logger => _logger ??= new TestLogger(Output);
+    private TestAssetsManager _testAssets;
+    private TestAssetsManager TestAssets => _testAssets ??= new TestAssetsManager(Output);
 
-    public LaunchSettingsProfileTest(ITestOutputHelper output)
-    {
-        _logger = new TestLogger(output);
-        _testAssets = new TestAssetsManager(output);
-    }
-
-    [Fact]
+    [TestMethod]
     public void LoadsLaunchProfiles()
     {
-        var project = _testAssets.CreateTestProject(new TestProject("Project1")
+        var project = TestAssets.CreateTestProject(new TestProject("Project1")
         {
             TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
         });
@@ -52,22 +54,22 @@ public class LaunchSettingsProfileTest
             projectPath: Path.Combine(project.TestRoot, "Project1", "Project1.csproj"),
             entryPointFilePath: null);
 
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: "http", _logger);
-        Assert.NotNull(expected);
-        Assert.Equal("http://localhost:5000", expected.ApplicationUrl);
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: "http", Logger);
+        Assert.IsNotNull(expected);
+        Assert.AreEqual("http://localhost:5000", expected.ApplicationUrl);
 
-        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "https", _logger);
-        Assert.NotNull(expected);
-        Assert.Equal("https://localhost:5001", expected.ApplicationUrl);
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "https", Logger);
+        Assert.IsNotNull(expected);
+        Assert.AreEqual("https://localhost:5001", expected.ApplicationUrl);
 
-        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "notfound", _logger);
-        Assert.NotNull(expected);
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "notfound", Logger);
+        Assert.IsNotNull(expected);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultLaunchProfileWithoutProjectCommand()
     {
-        var project = _testAssets.CreateTestProject(new TestProject("Project1")
+        var project = TestAssets.CreateTestProject(new TestProject("Project1")
         {
             TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
         });
@@ -87,8 +89,8 @@ public class LaunchSettingsProfileTest
             projectPath: Path.Combine(project.Path, "Project1", "Project1.csproj"),
             entryPointFilePath: null);
 
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: null, _logger);
-        Assert.Null(expected);
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: null, Logger);
+        Assert.IsNull(expected);
     }
 
     private static string WriteFile(TestAsset testAsset, string name, string contents = "")

--- a/test/dotnet-watch.Tests/Properties/AssemblyInfo.cs
+++ b/test/dotnet-watch.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-[assembly: CollectionBehavior(DisableTestParallelization = false)]

--- a/test/dotnet-watch.Tests/TestUtilities/DotNetWatchTestBase.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/DotNetWatchTestBase.cs
@@ -1,35 +1,52 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias MSTestFramework;
+
 using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 /// <summary>
 /// Base class for all tests that create dotnet watch process.
 /// </summary>
-public abstract partial class DotNetWatchTestBase : IAsyncLifetime
+public abstract partial class DotNetWatchTestBase
 {
-    internal TestAssetsManager TestAssets { get; }
-    internal WatchableApp App { get; }
+    /// <summary>Set by the MSTest runtime before each test runs.</summary>
+    public TestContext TestContext { get; set; } = null!;
 
-    public DotNetWatchTestBase(ITestOutputHelper logger)
+    private DualOutputHelper? _logger;
+    private WatchableApp? _app;
+    private TestAssetsManager? _testAssetsManager;
+
+    internal DualOutputHelper Logger
+        => _logger ??= new DualOutputHelper(new MSTestFramework::Microsoft.NET.TestFramework.TestContextOutputHelper(TestContext));
+
+    internal WatchableApp App
+        => _app ??= WatchableApp.CreateDotnetWatchApp(Logger);
+
+    internal TestAssetsManager TestAssets
+        => _testAssetsManager ??= new TestAssetsManager(Logger);
+
+    [TestInitialize]
+    public void InitializeTest()
     {
-        App = WatchableApp.CreateDotnetWatchApp(logger);
-        TestAssets = new TestAssetsManager(App.Logger);
+        // Reset lazy state so each test gets a fresh logger/app
+        _logger = null;
+        _app = null;
+        _testAssetsManager = null;
     }
 
-    public ValueTask InitializeAsync()
-        => default;
-
-    public async ValueTask DisposeAsync()
+    [TestCleanup]
+    public async Task CleanupTestAsync()
     {
-        Log("Disposing test");
-        await App.DisposeAsync();
+        Logger.Log("Disposing test");
+        if (_app != null)
+        {
+            await _app.DisposeAsync();
+        }
     }
-
-    public DebugTestOutputLogger Logger
-        => App.Logger;
 
     internal TestAsset CopyTestAsset(
         string assetName,
@@ -39,7 +56,7 @@ public abstract partial class DotNetWatchTestBase : IAsyncLifetime
         => TestAssets.CopyTestAsset(assetName, callingMethod, callerFilePath, identifier: string.Join(";", testParameters ?? [])).WithSource();
 
     public void Log(string message, [CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)
-        => App.Logger.Log(message, testPath, testLine);
+        => Logger.Log(message, testPath, testLine);
 
     public void UpdateSourceFile(string path, string text, [CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)
     {
@@ -88,8 +105,8 @@ public abstract partial class DotNetWatchTestBase : IAsyncLifetime
            reporter,
            out var errorCode);
 
-        Assert.Equal(0, errorCode);
-        Assert.NotNull(program);
+        Assert.AreEqual(0, errorCode);
+        Assert.IsNotNull(program);
 
         var serviceHolder = new StrongBox<TestRuntimeProcessLauncher?>();
         var factory = new TestRuntimeProcessLauncher.Factory(s =>

--- a/test/dotnet-watch.Tests/TestUtilities/DualOutputHelper.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/DualOutputHelper.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias MSTestFramework;
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.Watch.UnitTests;
+
+/// <summary>
+/// Bridge adapter that implements both MSTest's <see cref="Microsoft.NET.TestFramework.ITestOutputHelper"/>
+/// and xunit's <see cref="Xunit.ITestOutputHelper"/>, enabling it to be passed to utilities that
+/// still expect the xunit type (WatchableApp, DebugTestOutputLogger) while also serving the MSTest-based
+/// utilities (TestConsole, TestReporter, DotnetCommand) in the test project.
+/// </summary>
+internal sealed class DualOutputHelper(MSTestFramework::Microsoft.NET.TestFramework.ITestOutputHelper inner)
+    : MSTestFramework::Microsoft.NET.TestFramework.ITestOutputHelper, Xunit.ITestOutputHelper
+{
+    public string Output => inner.Output;
+    public void Write(string message) => inner.Write(message);
+    public void Write(string format, params object[] args) => inner.Write(format, args);
+    public void WriteLine(string message) => inner.WriteLine(message);
+    public void WriteLine(string format, params object[] args) => inner.WriteLine(format, args);
+
+    public void Log(string message, [CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)
+        => WriteLine($"[TEST {Path.GetFileName(testPath)}:{testLine}] {message}");
+}

--- a/test/dotnet-watch.Tests/TestUtilities/InProcTestWatcher.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/InProcTestWatcher.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal record class InProcTestWatcher(
-    DebugTestOutputLogger TestOutput,
+    DualOutputHelper TestOutput,
     HotReloadDotNetWatcher Watcher,
     DotNetWatchContext Context,
     TestEventObserver Observer,
@@ -20,7 +20,7 @@ internal record class InProcTestWatcher(
 
     public void Start([CallerFilePath] string? testPath = null, [CallerLineNumber] int testLine = 0)
     {
-        Assert.Null(_lazyTask);
+        Assert.IsNull(_lazyTask);
         Observer.Freeze();
 
         _lazyTask = Task.Run(async () =>
@@ -46,7 +46,7 @@ internal record class InProcTestWatcher(
 
     public async ValueTask DisposeAsync()
     {
-        Assert.NotNull(_lazyTask);
+        Assert.IsNotNull(_lazyTask);
 
         if (!ShutdownSource.IsCancellationRequested)
         {

--- a/test/dotnet-watch.Tests/TestUtilities/MSBuildFixture.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/MSBuildFixture.cs
@@ -9,8 +9,7 @@ using Microsoft.Build.Locator;
 namespace Microsoft.DotNet.Watch.UnitTests;
 
 /// <summary>
-/// Assembly fixture that registers MSBuild and sets up assembly resolution for dotnet-watch tests.
-/// A fixture is preferred over a [ModuleInitializer] because it doesn't get invoked for test discovery.
+/// Registers MSBuild and sets up assembly resolution for dotnet-watch tests when MSTest/MTP loads the test module.
 /// </summary>
 public static class MSBuildFixture
 {
@@ -21,8 +20,7 @@ public static class MSBuildFixture
         // that do not match the implementations of the core tasks.
 
         // If this throws make sure the test assembly, or any of its dependencies copied to this project's output directory,
-        // does not have any public type that has a dependency on msbuild.
-        // xUnit loads all public types and any reference to msbuild assembly will trigger its load.
+        // does not load MSBuild assemblies before MSBuildLocator.RegisterMSBuildPath is called by this module initializer.
 
         var toolset = SdkTestContext.Current.ToolsetUnderTest;
         var sdkDir = toolset.SdkFolderUnderTest;

--- a/test/dotnet-watch.Tests/TestUtilities/MSBuildFixture.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/MSBuildFixture.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using Microsoft.Build.Locator;
-
-[assembly: AssemblyFixture(typeof(Microsoft.DotNet.Watch.UnitTests.MSBuildFixture))]
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
@@ -13,9 +12,10 @@ namespace Microsoft.DotNet.Watch.UnitTests;
 /// Assembly fixture that registers MSBuild and sets up assembly resolution for dotnet-watch tests.
 /// A fixture is preferred over a [ModuleInitializer] because it doesn't get invoked for test discovery.
 /// </summary>
-public class MSBuildFixture
+public static class MSBuildFixture
 {
-    public MSBuildFixture()
+    [ModuleInitializer]
+    public static void Initialize()
     {
         // Ensure that we load the msbuild binaries from redist deployment. Otherwise, msbuild might use target files
         // that do not match the implementations of the core tasks.

--- a/test/dotnet-watch.Tests/TestUtilities/TestBuildEvaluator.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestBuildEvaluator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Watch.UnitTests;

--- a/test/dotnet-watch.Tests/TestUtilities/TestConsole.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestConsole.cs
@@ -19,7 +19,7 @@ internal class TestConsole : IConsole
 
     public readonly List<ConsoleKeyInfo> QueuedKeyPresses = [];
 
-    public TestConsole(ITestOutputHelper output)
+    public TestConsole(DualOutputHelper output)
     {
         _testWriter = new TestOutputWriter(output);
         Error = _testWriter;
@@ -47,7 +47,7 @@ internal class TestConsole : IConsole
 
     public void PressKey(ConsoleKeyInfo key)
     {
-        Assert.NotNull(_keyPressed);
+        Assert.IsNotNull(_keyPressed);
         _keyPressed.Invoke(key);
     }
 
@@ -67,11 +67,11 @@ internal class TestConsole : IConsole
 
     private class TestOutputWriter : TextWriter
     {
-        private readonly ITestOutputHelper _output;
+        private readonly DualOutputHelper _output;
         private readonly StringBuilder _sb = new();
         private readonly StringBuilder _currentOutput = new();
 
-        public TestOutputWriter(ITestOutputHelper output)
+        public TestOutputWriter(DualOutputHelper output)
         {
             _output = output;
         }

--- a/test/dotnet-watch.Tests/TestUtilities/TestLoggerFactory.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestLoggerFactory.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-internal class TestLoggerFactory(ITestOutputHelper? output = null) : ILoggerFactory
+internal class TestLoggerFactory(DualOutputHelper? output = null) : ILoggerFactory
 {
     public Func<string, ILogger>? CreateLoggerImpl;
 

--- a/test/dotnet-watch.Tests/TestUtilities/TestReporter.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestReporter.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-internal class TestReporter(ITestOutputHelper output) : IReporter, IProcessOutputReporter
+internal class TestReporter(DualOutputHelper output) : IReporter, IProcessOutputReporter
 {
     public readonly List<string> ProcessOutput = [];
     public readonly List<(LogLevel level, string text)> Messages = [];

--- a/test/dotnet-watch.Tests/TestUtilities/TestRuntimeProcessLauncher.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestRuntimeProcessLauncher.cs
@@ -49,7 +49,7 @@ internal class TestRuntimeProcessLauncher(ProjectLauncher projectLauncher) : IRu
         RestartOperation? startOp = null;
         startOp = new RestartOperation(async cancellationToken =>
         {
-            Assert.NotNull(startOp);
+            Assert.IsNotNull(startOp);
 
             runningProject = await ProjectLauncher.TryLaunchProcessAsync(
                 projectOptions,
@@ -58,14 +58,14 @@ internal class TestRuntimeProcessLauncher(ProjectLauncher projectLauncher) : IRu
                 restartOperation: startOp,
                 cancellationToken);
 
-            Assert.NotNull(runningProject);
+            Assert.IsNotNull(runningProject);
 
             await runningProject.Clients.WaitForConnectionEstablishedAsync(cancellationToken);
         });
 
         await startOp(cancellationToken);
 
-        Assert.NotNull(runningProject);
+        Assert.IsNotNull(runningProject);
         return runningProject;
     }
 }

--- a/test/dotnet-watch.Tests/Watch/BuildEvaluatorTests.cs
+++ b/test/dotnet-watch.Tests/Watch/BuildEvaluatorTests.cs
@@ -1,10 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public partial class BuildEvaluatorTests
 {
     private static readonly MSBuildFileSetFactory.EvaluationResult s_emptyEvaluationResult = new(new Dictionary<string, FileItem>(), projectGraph: null);
@@ -35,7 +36,7 @@ public partial class BuildEvaluatorTests
         };
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessAsync_EvaluatesFileSetIfProjFileChanges()
     {
         var context = CreateContext();
@@ -49,10 +50,10 @@ public partial class BuildEvaluatorTests
 
         await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Test.csproj", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
-        Assert.True(evaluator.RequiresRevaluation);
+        Assert.IsTrue(evaluator.RequiresRevaluation);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessAsync_DoesNotEvaluateFileSetIfNonProjFileChanges()
     {
         var context = CreateContext();
@@ -67,11 +68,11 @@ public partial class BuildEvaluatorTests
 
         await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
-        Assert.False(evaluator.RequiresRevaluation);
-        Assert.Equal(1, counter);
+        Assert.IsFalse(evaluator.RequiresRevaluation);
+        Assert.AreEqual(1, counter);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessAsync_EvaluateFileSetOnEveryChangeIfOptimizationIsSuppressed()
     {
         var context = CreateContext(suppressMSBuildIncrementalism: true);
@@ -87,11 +88,11 @@ public partial class BuildEvaluatorTests
 
         await evaluator.EvaluateAsync(changedFile: new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
-        Assert.True(evaluator.RequiresRevaluation);
-        Assert.Equal(2, counter);
+        Assert.IsTrue(evaluator.RequiresRevaluation);
+        Assert.AreEqual(2, counter);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessAsync_SetsEvaluationRequired_IfMSBuildFileChanges_ButIsNotChangedFile()
     {
         // There's a chance that the watcher does not correctly report edits to msbuild files on
@@ -124,6 +125,6 @@ public partial class BuildEvaluatorTests
 
         await evaluator.EvaluateAsync(new(new() { FilePath = "Controller.cs", ContainingProjectPaths = [] }, ChangeKind.Update), CancellationToken.None);
 
-        Assert.True(evaluator.RequiresRevaluation);
+        Assert.IsTrue(evaluator.RequiresRevaluation);
     }
 }

--- a/test/dotnet-watch.Tests/Watch/FileUpdateTests.cs
+++ b/test/dotnet-watch.Tests/Watch/FileUpdateTests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class FileUpdateTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task RestartProcessOnFileChange()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -21,11 +22,11 @@ public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(log
         await App.WaitUntilOutputContains("Started");
 
         var processIdentifier2 = await App.WaitUntilOutputContains("Process identifier =");
-        Assert.NotEqual(processIdentifier, processIdentifier2);
+        Assert.AreNotEqual(processIdentifier, processIdentifier2);
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RestartProcessThatTerminatesAfterFileChange()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")
@@ -45,14 +46,15 @@ public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(log
         await App.WaitUntilOutputContains("Started");
 
         var processIdentifier2 = await App.WaitUntilOutputContains("Process identifier =");
-        Assert.NotEqual(processIdentifier, processIdentifier2);
+        Assert.AreNotEqual(processIdentifier, processIdentifier2);
         await App.WaitUntilOutputContains("Exiting"); // process should exit after run
     }
 
     /// <summary>
     /// Validates `dotnet watch test` scenario: https://github.com/dotnet/sdk/issues/52528
     /// </summary>
-    [Fact(Skip = "https://github.com/dotnet/sdk/issues/54176")]
+    [TestMethod]
+    [Ignore("https://github.com/dotnet/sdk/issues/54176")]
     public async Task TestCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchXUnit")
@@ -60,14 +62,14 @@ public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(log
 
         var testFile = Path.Combine(testAsset.Path, "UnitTest1.cs");
         File.WriteAllText(testFile, """
-            using Xunit;
 
+            [TestClass]
             public class UnitTest1
             {
-                [Fact]
+                [TestMethod]
                 public void Test1()
                 {
-                    Assert.True(false);
+                    Assert.IsTrue(false);
                 }
             }
             """);
@@ -80,14 +82,14 @@ public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(log
         App.Process.ClearOutput();
 
         UpdateSourceFile(testFile, """
-            using Xunit;
             
+            [TestClass]
             public class UnitTest1
             {
-                [Fact]
+                [TestMethod]
                 public void Test1()
                 {
-                    Assert.True(true);
+                    Assert.IsTrue(true);
                 }
             }
             """);

--- a/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
+++ b/test/dotnet-watch.Tests/Watch/GlobbingAppTests.cs
@@ -5,7 +5,8 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class GlobbingAppTests : DotNetWatchTestBase
 {
     private async Task ValidateOperation(
         Action<string> operation,
@@ -28,7 +29,7 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
         await App.WaitUntilOutputContains($"Defined types = {expectedTypesAfterOperation}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ChangeCompiledFile()
     {
         await ValidateOperation(
@@ -39,7 +40,7 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
             expectedTypesAfterOperation: 2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteCompiledFile()
     {
         await ValidateOperation(
@@ -50,7 +51,7 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
             expectedTypesAfterOperation: 1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteSourceFolder()
     {
         await ValidateOperation(
@@ -61,7 +62,7 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
             expectedTypesAfterOperation: 1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenameCompiledFile()
     {
         await ValidateOperation(
@@ -74,7 +75,7 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
             expectedTypesAfterOperation: 2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ChangeExcludedFile()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchGlobbingApp")
@@ -91,11 +92,11 @@ public class GlobbingAppTests(ITestOutputHelper logger) : DotNetWatchTestBase(lo
 
         // no file change within timeout:
         var fileChanged = App.AssertOutputLineStartsWith("dotnet watch ⌚ File changed:");
-        var finished = await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken), fileChanged);
-        Assert.NotSame(fileChanged, finished);
+        var finished = await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken), fileChanged);
+        Assert.AreNotSame(fileChanged, finished);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListsFiles()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchGlobbingApp")

--- a/test/dotnet-watch.Tests/Watch/NoRestoreTests.cs
+++ b/test/dotnet-watch.Tests/Watch/NoRestoreTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class NoRestoreTests
 {
     private static DotNetWatchContext CreateContext(string[] args = null, EnvironmentOptions environmentOptions = null)
@@ -34,7 +35,7 @@ public class NoRestoreTests
         };
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedOnFirstRun()
     {
         var context = CreateContext();
@@ -43,7 +44,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run"], evaluator.GetProcessArguments(iteration: 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedIfMsBuildRevaluationIsRequired()
     {
         var context = CreateContext();
@@ -56,7 +57,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedIfOptimizationIsSuppressed()
     {
         var context = CreateContext([], TestOptions.GetEnvironmentOptions() with { SuppressMSBuildIncrementalism = true });
@@ -66,7 +67,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedIfNoRestoreAlreadyPresent()
     {
         var context = CreateContext(["--no-restore"], TestOptions.GetEnvironmentOptions() with { SuppressMSBuildIncrementalism = true });
@@ -76,7 +77,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run", "--no-restore"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedIfNoRestoreAlreadyPresent_UnlessAfterDashDash1()
     {
         var context = CreateContext(["--", "--no-restore"]);
@@ -86,7 +87,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run", "--no-restore", "--", "--no-restore"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void LeavesArgumentsUnchangedIfNoRestoreAlreadyPresent_UnlessAfterDashDash2()
     {
         var context = CreateContext(["--", "--", "--no-restore"]);
@@ -96,7 +97,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run", "--no-restore", "--", "--", "--no-restore"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void AddsNoRestoreSwitch()
     {
         var context = CreateContext();
@@ -106,7 +107,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run", "--no-restore"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void AddsNoRestoreSwitch_WithAdditionalArguments()
     {
         var context = CreateContext(["run", "-f", ToolsetInfo.CurrentTargetFramework]);
@@ -116,7 +117,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["run", "--no-restore", "--framework", ToolsetInfo.CurrentTargetFramework], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void AddsNoRestoreSwitch_ForTestCommand()
     {
         var context = CreateContext(["test", "--filter SomeFilter"]);
@@ -126,7 +127,7 @@ public class NoRestoreTests
         AssertEx.SequenceEqual(["test", "--no-restore", "--filter SomeFilter"], evaluator.GetProcessArguments(iteration: 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void DoesNotModifyArgumentsForUnknownCommands()
     {
         var context = CreateContext(["pack"]);

--- a/test/dotnet-watch.Tests/Watch/WatchOutputTests.cs
+++ b/test/dotnet-watch.Tests/Watch/WatchOutputTests.cs
@@ -1,11 +1,12 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-public class WatchOutputTests(ITestOutputHelper logger) : DotNetWatchTestBase(logger)
+[TestClass]
+public class WatchOutputTests : DotNetWatchTestBase
 {
-    [Fact]
+    [TestMethod]
     public async Task CapturesStdOutWithNoHotReload()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchNoDepsApp")

--- a/test/dotnet-watch.Tests/Web/KestrelWebSocketServerTests.cs
+++ b/test/dotnet-watch.Tests/Web/KestrelWebSocketServerTests.cs
@@ -5,17 +5,18 @@ using Microsoft.DotNet.HotReload;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class KestrelWebSocketServerTests
 {
-    [Theory]
-    [InlineData("http://contoso.com:10", "ws://contoso.com:10")]
-    [InlineData("https://contoso.com:10", "wss://contoso.com:10")]
-    [InlineData("http://127.0.0.10:10", "ws://127.0.0.10:10")]
-    [InlineData("https://127.0.0.10:10", "wss://127.0.0.10:10")]
-    [InlineData("http://127.0.0.1:10", "ws://localhost:10")]
-    [InlineData("https://127.0.0.1:10", "wss://localhost:10")]
+    [TestMethod]
+    [DataRow("http://contoso.com:10", "ws://contoso.com:10")]
+    [DataRow("https://contoso.com:10", "wss://contoso.com:10")]
+    [DataRow("http://127.0.0.10:10", "ws://127.0.0.10:10")]
+    [DataRow("https://127.0.0.10:10", "wss://127.0.0.10:10")]
+    [DataRow("http://127.0.0.1:10", "ws://localhost:10")]
+    [DataRow("https://127.0.0.1:10", "wss://localhost:10")]
     public void Urls(string httpUrl, string wsUrl)
     {
-        Assert.Equal(wsUrl, KestrelWebSocketServer.GetWebSocketUrl(httpUrl));
+        Assert.AreEqual(wsUrl, KestrelWebSocketServer.GetWebSocketUrl(httpUrl));
     }
 }

--- a/test/dotnet-watch.Tests/Web/RSATests.cs
+++ b/test/dotnet-watch.Tests/Web/RSATests.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
+[TestClass]
 public class RSATests
 {
-    [Fact]
+    [TestMethod]
     public void TestNetFrameworkImpl()
     {
 

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -37,7 +37,7 @@
          ensure xunit.v3.core (extensibility.core) and xunit.v3.assert are deployed; otherwise the test
          host crashes on load with FileNotFoundException for 'xunit.v3.core' or 'xunit.v3.assert'. -->
     <PackageReference Include="xunit.v3.extensibility.core" />
-    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
   </ItemGroup>
 
   <!-- Copies test browser files to test-browser output directory -->

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -34,9 +34,10 @@
     <!-- Microsoft.NET.TestFramework (xUnit v3 based, pulled in transitively for TestAsset/App helpers
          via Microsoft.DotNet.HotReload.Test.Utilities) needs the xUnit v3 runtime at execution time.
          The transitive reference is ExcludeAssets="Runtime", so reference the v3 runtime directly to
-         ensure xunit.v3.core is deployed; otherwise the test host crashes on load with
-         FileNotFoundException for 'xunit.v3.core'. -->
+         ensure xunit.v3.core (extensibility.core) and xunit.v3.assert are deployed; otherwise the test
+         host crashes on load with FileNotFoundException for 'xunit.v3.core' or 'xunit.v3.assert'. -->
     <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.v3.assert" />
   </ItemGroup>
 
   <!-- Copies test browser files to test-browser output directory -->

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -3,6 +3,11 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <RootNamespace>Microsoft.DotNet.Watch.UnitTests</RootNamespace>
+    <!-- These are heavy integration tests that build and run apps (dotnet watch, file watchers, ports).
+         Under xUnit they ran with class-level parallelism (classes in parallel, methods within a class
+         serialized). MSTest.Sdk defaults to MethodLevel (see test/Directory.Build.props), which
+         over-subscribes the machine and causes Helix work-item timeouts. Restore class-level scope. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Microsoft.NET.TestFramework" />

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -1,10 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <RootNamespace>Microsoft.DotNet.Watch.UnitTests</RootNamespace>
   </PropertyGroup>
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Assertions" />
+    <Using Include="Microsoft.NET.TestFramework.Commands" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
+    <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\MockBuildEngine.cs" Link="TestUtilities\MockBuildEngine.cs" />
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\MockTaskItem.cs" Link="TestUtilities\MockTaskItem.cs" />
@@ -20,10 +26,9 @@
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Test.Utilities\Microsoft.DotNet.HotReload.Test.Utilities.csproj" ExcludeAssets="Runtime" />
     <!-- Needed for AspireLauncherIntegrationTests which exec the Aspire launcher executable. -->
     <ProjectReference Include="$(RepoRoot)\src\Dotnet.Watch\Watch.Aspire\Microsoft.DotNet.HotReload.Watch.Aspire.csproj" />
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" Aliases="MSTestFramework" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Build.Locator" />
-    <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Spectre.Console.Testing" />
   </ItemGroup>
@@ -39,6 +44,7 @@
       <None Include="@(_FileItem)" Link="test-browser\%(_FileItem.Filename)%(_FileItem.Extension)" CopyToOutputDirectory="PreserveNewest" UseHardlinksIfPossible="true"/>
     </ItemGroup>
   </Target>
+
 
   <Import Project="..\..\src\Dotnet.Watch\Watch\RuntimeDependencies.props" />
 </Project>

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -31,6 +31,12 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Spectre.Console.Testing" />
+    <!-- Microsoft.NET.TestFramework (xUnit v3 based, pulled in transitively for TestAsset/App helpers
+         via Microsoft.DotNet.HotReload.Test.Utilities) needs the xUnit v3 runtime at execution time.
+         The transitive reference is ExcludeAssets="Runtime", so reference the v3 runtime directly to
+         ensure xunit.v3.core is deployed; otherwise the test host crashes on load with
+         FileNotFoundException for 'xunit.v3.core'. -->
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 
   <!-- Copies test browser files to test-browser output directory -->


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite, following the same pattern as the other open migration PRs (builds on the foundation merged in #54845).

Adds a DualOutputHelper bridge so the MSTest project interoperates with the HotReload test utilities that still use xunit's ITestOutputHelper; PlatformSpecific facts become [OSCondition] composition; DotNetWatchTestBase moves from IAsyncLifetime to TestContext + [TestInitialize]/[TestCleanup].

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact]/[Theory] -> [TestMethod], [InlineData] -> [DataRow], xUnit asserts -> MSTest (including the repo Recommended-mode idiomatic asserts), and ITestOutputHelper constructor injection removed in favour of the base SdkTest Log / TestContext.

Builds clean for the SDK target framework.
