### PR TITLE
`dotnetup` should not use existing user install locations over the default

### DIFF
--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallPathResolver.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallPathResolver.cs
@@ -32,18 +32,15 @@ internal class InstallPathResolver
     /// Resolves the install path using the following precedence:
     /// 1. Explicitly provided install path
     /// 2. Path from global.json (if available)
-    /// 3. Current user installation path (if exists)
-    /// 4. Default install path
+    /// 3. Default install path
     /// </summary>
     /// <param name="explicitInstallPath">The install path explicitly provided by the user (e.g., --install-path option).</param>
     /// <param name="globalJsonInfo">Information from global.json, if available.</param>
-    /// <param name="currentDotnetInstallRoot">Current .NET installation configuration, if any.</param>
     /// <returns>The resolution result.</returns>
     /// <exception cref="DotnetInstallException">Thrown when the install path cannot be resolved.</exception>
     public InstallPathResolutionResult Resolve(
         string? explicitInstallPath,
-        GlobalJsonInfo? globalJsonInfo,
-        DotnetInstallRootConfiguration? currentDotnetInstallRoot)
+        GlobalJsonInfo? globalJsonInfo)
     {
         string? installPathFromGlobalJson = globalJsonInfo?.GlobalJsonPath is not null
             ? globalJsonInfo.SdkPath
@@ -52,8 +49,7 @@ internal class InstallPathResolver
         // Resolution precedence:
         // 1. Explicit --install-path always wins
         // 2. global.json sdk-path
-        // 3. Existing user installation
-        // 4. Default install path
+        // 3. Default install path
 
         if (explicitInstallPath is not null)
         {
@@ -62,10 +58,6 @@ internal class InstallPathResolver
         else if (installPathFromGlobalJson is not null)
         {
             return new InstallPathResolutionResult(installPathFromGlobalJson, installPathFromGlobalJson, PathSource.GlobalJson);
-        }
-        else if (currentDotnetInstallRoot is not null && currentDotnetInstallRoot.InstallType == InstallType.User)
-        {
-            return new InstallPathResolutionResult(currentDotnetInstallRoot.Path, installPathFromGlobalJson, PathSource.ExistingUserInstall);
         }
         else
         {

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -126,8 +126,7 @@ internal class InstallWorkflow
 
         var pathResolution = _installPathResolver.Resolve(
             _command.InstallPath,
-            globalJson,
-            currentInstallRoot);
+            globalJson);
 
         ValidateInstallPath(pathResolution.ResolvedInstallPath, pathResolution.PathSource, _command.ManifestPath);
 

--- a/src/Installer/dotnetup.Library/Commands/Shared/PathSource.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/PathSource.cs
@@ -14,9 +14,6 @@ internal enum PathSource
     /// <summary>The install path came from a global.json sdk-path.</summary>
     GlobalJson,
 
-    /// <summary>An existing user-level .NET installation was found and reused.</summary>
-    ExistingUserInstall,
-
     /// <summary>The user was prompted interactively and chose a path.</summary>
     InteractivePrompt,
 

--- a/test/dotnetup.Tests/InstallPathResolverTests.cs
+++ b/test/dotnetup.Tests/InstallPathResolverTests.cs
@@ -3,8 +3,6 @@
 
 using System.IO;
 using FluentAssertions;
-using Microsoft.Dotnet.Installation;
-using Microsoft.Dotnet.Installation.Internal;
 using Microsoft.DotNet.Tools.Bootstrapper;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 using Microsoft.DotNet.Tools.Dotnetup.Tests.Utilities;
@@ -36,8 +34,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
 
         var result = _resolver.Resolve(
             explicitInstallPath: ExplicitPath,
-            globalJsonInfo: globalJsonInfo,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: globalJsonInfo);
 
         output.WriteLine($"Result: {result?.ResolvedInstallPath ?? "(null)"}");
 
@@ -53,8 +50,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
 
         var result = _resolver.Resolve(
             explicitInstallPath: null,
-            globalJsonInfo: globalJsonInfo,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: globalJsonInfo);
 
         result.Should().NotBeNull();
         result!.ResolvedInstallPath.Should().Be(GlobalJsonPath);
@@ -68,8 +64,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
 
         var result = _resolver.Resolve(
             explicitInstallPath: SamePath,
-            globalJsonInfo: globalJsonInfo,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: globalJsonInfo);
 
         result!.ResolvedInstallPath.Should().Be(SamePath);
         result.PathSource.Should().Be(PathSource.Explicit);
@@ -80,8 +75,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
     {
         var result = _resolver.Resolve(
             explicitInstallPath: ExplicitPath,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: null);
 
         result.Should().NotBeNull();
         result!.ResolvedInstallPath.Should().Be(ExplicitPath);
@@ -94,8 +88,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
         var installManager = new DotnetEnvironmentManager();
         var result = _resolver.Resolve(
             explicitInstallPath: null,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: null);
 
         result.Should().NotBeNull();
         result!.ResolvedInstallPath.Should().Be(installManager.GetDefaultDotnetInstallPath());
@@ -103,18 +96,16 @@ public class InstallPathResolverTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void Resolve_UsesCurrentUserInstall_WhenNoExplicitOrGlobalJson()
+    public void Resolve_ForeignUserInstall_FallsToDefault_NotExistingInstall()
     {
-        var installRoot = new DotnetInstallRoot("/user/dotnet", InstallerUtilities.GetDefaultInstallArchitecture());
-        var currentInstall = new DotnetInstallRootConfiguration(installRoot, InstallType.User, IsFullyConfigured: true);
-
+        // Even if another tool's dotnet is on PATH, dotnetup should install to its own default path.
+        var installManager = new DotnetEnvironmentManager();
         var result = _resolver.Resolve(
             explicitInstallPath: null,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: currentInstall);
+            globalJsonInfo: null);
 
-        result!.ResolvedInstallPath.Should().Be("/user/dotnet");
-        result.PathSource.Should().Be(PathSource.ExistingUserInstall);
+        result!.ResolvedInstallPath.Should().Be(installManager.GetDefaultDotnetInstallPath());
+        result.PathSource.Should().Be(PathSource.Default);
     }
 
     /// <summary>
@@ -126,8 +117,7 @@ public class InstallPathResolverTests(ITestOutputHelper output)
     {
         var result = _resolver.Resolve(
             explicitInstallPath: ExplicitPath,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: null);
 
         result.Should().NotBeNull("explicit path must work even without global.json");
         result!.ResolvedInstallPath.Should().Be(ExplicitPath);
@@ -135,42 +125,9 @@ public class InstallPathResolverTests(ITestOutputHelper output)
         result.InstallPathFromGlobalJson.Should().BeNull();
     }
 
-    /// <summary>
-    /// Explicit path should beat an existing user install.
-    /// </summary>
-    [Fact]
-    public void Resolve_ExplicitPath_TakesPrecedenceOverExistingUserInstall()
-    {
-        var installRoot = new DotnetInstallRoot("/user/dotnet", InstallerUtilities.GetDefaultInstallArchitecture());
-        var currentInstall = new DotnetInstallRootConfiguration(installRoot, InstallType.User, IsFullyConfigured: true);
 
-        var result = _resolver.Resolve(
-            explicitInstallPath: ExplicitPath,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: currentInstall);
 
-        result!.ResolvedInstallPath.Should().Be(ExplicitPath, "explicit path should win over existing user install");
-        result.PathSource.Should().Be(PathSource.Explicit);
-    }
 
-    /// <summary>
-    /// global.json path should beat an existing user install when no explicit path is given.
-    /// </summary>
-    [Fact]
-    public void Resolve_GlobalJson_TakesPrecedenceOverExistingUserInstall()
-    {
-        var installRoot = new DotnetInstallRoot("/user/dotnet", InstallerUtilities.GetDefaultInstallArchitecture());
-        var currentInstall = new DotnetInstallRootConfiguration(installRoot, InstallType.User, IsFullyConfigured: true);
-        var globalJsonInfo = CreateGlobalJsonInfo(GlobalJsonPath);
-
-        var result = _resolver.Resolve(
-            explicitInstallPath: null,
-            globalJsonInfo: globalJsonInfo,
-            currentDotnetInstallRoot: currentInstall);
-
-        result!.ResolvedInstallPath.Should().Be(GlobalJsonPath, "global.json should win over existing user install");
-        result.PathSource.Should().Be(PathSource.GlobalJson);
-    }
 
     /// <summary>
     /// Regression: without global.json, the default fallback must not return null.
@@ -180,29 +137,10 @@ public class InstallPathResolverTests(ITestOutputHelper output)
     {
         var result = _resolver.Resolve(
             explicitInstallPath: null,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: null);
+            globalJsonInfo: null);
 
         result.Should().NotBeNull("default path fallback must always produce a result");
         result!.ResolvedInstallPath.Should().NotBeNullOrEmpty();
-        result.PathSource.Should().Be(PathSource.Default);
-    }
-
-    /// <summary>
-    /// Admin installs should not be picked up — only User installs.
-    /// </summary>
-    [Fact]
-    public void Resolve_AdminInstall_FallsToDefault_NotExistingInstall()
-    {
-        var installRoot = new DotnetInstallRoot("/admin/dotnet", InstallerUtilities.GetDefaultInstallArchitecture());
-        var currentInstall = new DotnetInstallRootConfiguration(installRoot, InstallType.System, IsFullyConfigured: true);
-
-        var result = _resolver.Resolve(
-            explicitInstallPath: null,
-            globalJsonInfo: null,
-            currentDotnetInstallRoot: currentInstall);
-
-        result!.ResolvedInstallPath.Should().NotBe("/admin/dotnet", "admin installs should not be used as fallback");
         result.PathSource.Should().Be(PathSource.Default);
     }
 

--- a/test/dotnetup.Tests/InstallPathResolverTests.cs
+++ b/test/dotnetup.Tests/InstallPathResolverTests.cs
@@ -95,19 +95,6 @@ public class InstallPathResolverTests(ITestOutputHelper output)
         result.PathSource.Should().Be(PathSource.Default);
     }
 
-    [Fact]
-    public void Resolve_ForeignUserInstall_FallsToDefault_NotExistingInstall()
-    {
-        // Even if another tool's dotnet is on PATH, dotnetup should install to its own default path.
-        var installManager = new DotnetEnvironmentManager();
-        var result = _resolver.Resolve(
-            explicitInstallPath: null,
-            globalJsonInfo: null);
-
-        result!.ResolvedInstallPath.Should().Be(installManager.GetDefaultDotnetInstallPath());
-        result.PathSource.Should().Be(PathSource.Default);
-    }
-
     /// <summary>
     /// Regression: before the refactor, passing an explicit path without a global.json
     /// caused the method to return null because all logic was gated behind the global.json check.


### PR DESCRIPTION
 
@333fred was trying out `dotnetup` and mentioned that he hit this error:

```
➜ dotnetup
Error: The install path '/home/FOO/.local/share/dnvm/dn' already contains a .NET installation that is not tracked by
dotnetup. To avoid conflicts, use a different install path, remove the existing installation first, or use the --untracked
option to install without tracking.
```

He had to remove `/home/FOO/.local/share/dnvm` from the path and it was confusing behavior in his perspective that we starting trying to use the `dnvm` path to install to.

I think the behavior is well intended but perhaps we should change it to not do this. Most of the time the user existing location will have untracked installs in it, which we might change and make this work, but I don't think this is what users will expect.

I'm open to opinions and no problem if we just toss this PR and decide to keep the behavior as-is.