### PR TITLE
Migrate dotnet-aot.Tests to MSTest.Sdk on MTP

### DIFF
--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Xunit;
 
 namespace Microsoft.DotNet.Cli.Tests;
 
@@ -11,15 +10,14 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  These tests require the AOT binary to be present in the SDK layout.
 ///  They are traited with "Category=AOT" so they can be filtered in CI.
 /// </summary>
-[Trait("Category", "AOT")]
+[TestCategory("AOT")]
+[TestClass]
 public class AotIntegrationTests
 {
-    private readonly ITestOutputHelper _log;
+    public TestContext TestContext { get; set; } = null!;
 
-    public AotIntegrationTests(ITestOutputHelper log)
-    {
-        _log = log;
-    }
+    private ITestOutputHelper? _logBacking;
+    private ITestOutputHelper _log => _logBacking ??= new TestContextOutputHelper(TestContext);
 
     private static string? FindDnPath()
     {
@@ -82,8 +80,8 @@ public class AotIntegrationTests
 
         // Read streams asynchronously before WaitForExit to avoid deadlocks
         // when the child process fills the OS pipe buffer.
-        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.CancellationToken);
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync(TestContext.CancellationToken);
 
         if (!process.WaitForExit(timeoutMs))
         {
@@ -105,46 +103,46 @@ public class AotIntegrationTests
     {
         if (FindDnPath() is null)
         {
-            Assert.Skip("AOT binary (dn) not found in SDK layout. Build with NativeAOT to enable these tests.");
+            Assert.Inconclusive("AOT binary (dn) not found in SDK layout. Build with NativeAOT to enable these tests.");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void AotVersion_WithEnableAot_OutputsVersionAndExitsZero()
     {
         SkipIfDnUnavailable();
 
         var (exitCode, stdout, _) = RunDn(["--version"], enableAot: true);
 
-        Assert.Equal(0, exitCode);
-        Assert.False(string.IsNullOrWhiteSpace(stdout), "Expected version output");
+        Assert.AreEqual(0, exitCode);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(stdout), "Expected version output");
     }
 
-    [Fact]
+    [TestMethod]
     public void AotInfo_WithEnableAot_OutputsInfoAndExitsZero()
     {
         SkipIfDnUnavailable();
 
         var (exitCode, stdout, _) = RunDn(["--info"], enableAot: true);
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains(".NET SDK:", stdout);
-        Assert.Contains("Version:", stdout);
-        Assert.Contains("Runtime Environment:", stdout);
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().Contain(".NET SDK:");
+        stdout.Should().Contain("Version:");
+        stdout.Should().Contain("Runtime Environment:");
     }
 
-    [Fact]
+    [TestMethod]
     public void AotNoArgs_WithEnableAot_ShowsUsage()
     {
         SkipIfDnUnavailable();
 
         var (exitCode, stdout, _) = RunDn([], enableAot: true);
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Usage:", stdout);
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().Contain("Usage:");
     }
 
-    [Fact]
+    [TestMethod]
     public void AotBuild_WithEnableAot_FallsBackToManaged()
     {
         SkipIfDnUnavailable();
@@ -156,11 +154,11 @@ public class AotIntegrationTests
         // If managed fallback works, it should show build help (exit 0)
         // If managed fallback is missing, it returns 1
         // Either way, it shouldn't crash or timeout
-        Assert.True(exitCode == 0 || exitCode == 1,
+        Assert.IsTrue(exitCode == 0 || exitCode == 1,
             $"Expected exit code 0 or 1, got {exitCode}. Stderr: {stderr}");
     }
 
-    [Fact]
+    [TestMethod]
     public void Version_WithoutEnableAot_StillWorks()
     {
         SkipIfDnUnavailable();
@@ -173,14 +171,14 @@ public class AotIntegrationTests
         // the fallback correctly fails because dotnet.dll is missing.
         if (exitCode != 0 && stderr.Contains("dotnet.dll"))
         {
-            Assert.Skip("Managed fallback not available (dotnet.dll not in layout)");
+            Assert.Inconclusive("Managed fallback not available (dotnet.dll not in layout)");
         }
 
-        Assert.Equal(0, exitCode);
-        Assert.False(string.IsNullOrWhiteSpace(stdout));
+        Assert.AreEqual(0, exitCode);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(stdout));
     }
 
-    [Fact]
+    [TestMethod]
     public void Info_WithoutEnableAot_ShowsFullInfo()
     {
         SkipIfDnUnavailable();
@@ -189,11 +187,11 @@ public class AotIntegrationTests
 
         if (exitCode != 0 && stderr.Contains("dotnet.dll"))
         {
-            Assert.Skip("Managed fallback not available (dotnet.dll not in layout)");
+            Assert.Inconclusive("Managed fallback not available (dotnet.dll not in layout)");
         }
 
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
         // Managed fallback should include workload and MSBuild info
-        Assert.Contains("Version:", stdout);
+        stdout.Should().Contain("Version:");
     }
 }

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -8,7 +8,8 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// <summary>
 ///  Integration tests that run the actual AOT binary (dn.exe / dn) end-to-end.
 ///  These tests require the AOT binary to be present in the SDK layout.
-///  They are traited with "Category=AOT" so they can be filtered in CI.
+///  They are categorized with <c>[TestCategory("AOT")]</c> so they can be filtered in CI
+///  (e.g. by the <c>AOT</c> test category).
 /// </summary>
 [TestCategory("AOT")]
 [TestClass]

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -6,7 +6,6 @@ using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework.Utilities;
-using Xunit;
 
 namespace Microsoft.DotNet.Cli.Tests;
 
@@ -17,39 +16,53 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  and that commands which require the managed CLI report this via
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
 /// </summary>
+[TestClass]
 public class AotParserTests
 {
-    [Fact]
+    private static Exception? RecordException(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception e)
+        {
+            return e;
+        }
+    }
+
+    [TestMethod]
     public void ParseVersion_HasNoErrors()
     {
         var result = Parser.Parse(["--version"]);
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInfo_HasNoErrors()
     {
         var result = Parser.Parse(["--info"]);
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseNoArgs_HasNoErrors()
     {
         var result = Parser.Parse([]);
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseKnownCommand_HasNoErrors()
     {
         // The AOT parser now builds the full command tree, so real commands like `build`
         // parse cleanly (they no longer surface as unknown). Execution still falls back.
         var result = Parser.Parse(["build"]);
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void DetectFileBasedApp_WhenFirstArgIsCSharpFile()
     {
         // `dotnet app.cs` is an implicit file-based app invocation. The AOT parser only sees the
@@ -60,8 +73,8 @@ public class AotParserTests
         try
         {
             var result = Parser.Parse([csFile]);
-            Assert.Empty(result.Errors);
-            Assert.NotNull(result.GetFileBasedAppEntryPointToken());
+            Assert.IsEmpty(result.Errors);
+            Assert.IsNotNull(result.GetFileBasedAppEntryPointToken());
         }
         finally
         {
@@ -69,124 +82,124 @@ public class AotParserTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void DoesNotDetectFileBasedApp_ForBuiltInCommand()
     {
         var result = Parser.Parse(["build"]);
-        Assert.Null(result.GetFileBasedAppEntryPointToken());
+        Assert.IsNull(result.GetFileBasedAppEntryPointToken());
     }
 
-    [Fact]
+    [TestMethod]
     public void DoesNotDetectFileBasedApp_ForNonExistentFile()
     {
         // IsValidEntryPointPath requires the file to exist, so a bogus *.cs argument is not
         // treated as a file-based app (it would resolve as an external `dotnet-<name>` command).
         var result = Parser.Parse([$"does-not-exist-{Guid.NewGuid():N}.cs"]);
-        Assert.Null(result.GetFileBasedAppEntryPointToken());
+        Assert.IsNull(result.GetFileBasedAppEntryPointToken());
     }
 
-    [Theory]
-    [InlineData("ef")]                                  // external command: dotnet-ef
-    [InlineData("does-not-exist-command")]              // unknown external command
+    [TestMethod]
+    [DataRow("ef")]                                  // external command: dotnet-ef
+    [DataRow("does-not-exist-command")]              // unknown external command
     public void DetectExternalCommand_RequiresManagedResolution(string command)
     {
         // `dotnet <external>` doesn't match a built-in command, so it lands on the root's hidden
         // subcommand argument and must be deferred to the managed CLI's external command resolution
         // rather than executed by the AOT root usage action.
         var result = Parser.Parse([command]);
-        Assert.Empty(result.Errors);
-        Assert.True(result.RequiresManagedCommandResolution());
+        Assert.IsEmpty(result.Errors);
+        Assert.IsTrue(result.RequiresManagedCommandResolution());
     }
 
-    [Theory]
-    [InlineData("")]                                    // `dotnet` (usage)
-    [InlineData("--version")]
-    [InlineData("--info")]
+    [TestMethod]
+    [DataRow("")]                                    // `dotnet` (usage)
+    [DataRow("--version")]
+    [DataRow("--info")]
     public void RootInvocations_DoNotRequireManagedResolution(string arg)
     {
         // Bare `dotnet`, `--version`, `--info`, etc. are handled entirely in AOT.
         string[] args = arg.Length == 0 ? [] : [arg];
         var result = Parser.Parse(args);
-        Assert.False(result.RequiresManagedCommandResolution());
+        Assert.IsFalse(result.RequiresManagedCommandResolution());
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseHostHandledOption_HasNoErrors()
     {
         // --list-sdks / --list-runtimes are host-handled options defined on the root command
         // so they appear in help and parse without error. The host resolves them before AOT.
-        Assert.Empty(Parser.Parse(["--list-sdks"]).Errors);
-        Assert.Empty(Parser.Parse(["--list-runtimes"]).Errors);
+        Assert.IsEmpty(Parser.Parse(["--list-sdks"]).Errors);
+        Assert.IsEmpty(Parser.Parse(["--list-runtimes"]).Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseUnknownToken_IsToleratedForExternalCommandForwarding()
     {
         // The dotnet root command is intentionally tolerant of unknown tokens so that
         // `dotnet foo` can be forwarded to an external `dotnet-foo` command. Unknown tokens
         // therefore do not produce parse errors; they are resolved by the managed CLI on fallback.
         var result = Parser.Parse(["--this-option-does-not-exist"]);
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeKnownCommand_FallsBackToManaged()
     {
         // Commands that cannot run in AOT must signal a managed fallback rather than execute.
         var result = Parser.Parse(["build"]);
-        Assert.Empty(result.Errors);
-        Assert.Throws<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
+        Assert.IsEmpty(result.Errors);
+        Assert.ThrowsExactly<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeRootHelp_RendersUsageFromAot()
     {
         var (exitCode, stdout, _) = InvokeWithCapture(["--help"]);
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("dotnet", stdout);
-        Assert.Contains("build", stdout);
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().Contain("dotnet");
+        stdout.Should().Contain("build");
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeCommandHelp_RendersFromAotWithoutFallback()
     {
         // Help for a definition-backed command (one that does not shell out to an external
         // tool) renders entirely from AOT and must not request a managed fallback.
         var result = Parser.Parse(["build", "--help"]);
-        var exception = Record.Exception(() => Parser.Invoke(result));
+        var exception = RecordException(() => Parser.Invoke(result));
 
-        Assert.Null(exception);
+        Assert.IsNull(exception);
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeExternalToolHelp_RendersFromAotWithoutFallback()
     {
         // Help for the external-tool commands (msbuild/nuget/vstest/format/fsi) now shells out to the
         // underlying tool from AOT instead of falling back to the managed CLI. The forwarded process
         // may fail in the test environment, but help must never request a managed fallback.
         var result = Parser.Parse(["msbuild", "--help"]);
-        var exception = Record.Exception(() => Parser.Invoke(result));
+        var exception = RecordException(() => Parser.Invoke(result));
 
-        Assert.IsNotType<CommandNotAvailableInAotException>(exception);
+        Assert.IsFalse(exception is CommandNotAvailableInAotException);
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeCliSchema_RendersSchemaJsonFromAot()
     {
         // --cli-schema serializes the command tree via a source-generated JsonSerializerContext,
         // so it runs entirely in AOT (no managed fallback) and emits the command surface as JSON.
         var (exitCode, stdout, _) = InvokeWithCapture(["--cli-schema"]);
 
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
         // The root command name reflects the host executable, so assert on stable content instead:
         // the SDK version, the subcommands collection, and a representative built-in subcommand.
-        Assert.Contains($"\"version\": \"{Product.Version}\"", stdout);
-        Assert.Contains("\"subcommands\"", stdout);
-        Assert.Contains("\"build\"", stdout);
+        stdout.Should().Contain($"\"version\": \"{Product.Version}\"");
+        stdout.Should().Contain("\"subcommands\"");
+        stdout.Should().Contain("\"build\"");
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseVersionWithExtraArgs_IsHandledGracefully()
     {
         // System.CommandLine may or may not error on extra tokens after --version.
@@ -196,38 +209,38 @@ public class AotParserTests
         if (result.Errors.Count == 0)
         {
             // --version is still recognized and returns 0
-            Assert.Equal(0, Parser.Invoke(result));
+            Assert.AreEqual(0, Parser.Invoke(result));
         }
         else
         {
             // Extra args produce a parse error, which is also acceptable
-            Assert.NotEmpty(result.Errors);
+            Assert.IsNotEmpty(result.Errors);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeVersion_ReturnsZeroAndOutputsVersion()
     {
         var (exitCode, stdout, _) = InvokeWithCapture(["--version"]);
 
-        Assert.Equal(0, exitCode);
-        Assert.False(string.IsNullOrWhiteSpace(stdout), "Expected version output on stdout");
-        Assert.Equal(Product.Version, stdout.Trim());
+        Assert.AreEqual(0, exitCode);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(stdout), "Expected version output on stdout");
+        Assert.AreEqual(Product.Version, stdout.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeInfo_ReturnsZeroAndContainsExpectedSections()
     {
         var (exitCode, stdout, _) = InvokeWithCapture(["--info"]);
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains(".NET SDK:", stdout);
-        Assert.Contains("Version:", stdout);
-        Assert.Contains("Commit:", stdout);
-        Assert.Contains("Runtime Environment:", stdout);
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().Contain(".NET SDK:");
+        stdout.Should().Contain("Version:");
+        stdout.Should().Contain("Commit:");
+        stdout.Should().Contain("Runtime Environment:");
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeInfo_DoesNotContainManagedOnlySections()
     {
         var (_, stdout, _) = InvokeWithCapture(["--info"]);
@@ -237,32 +250,32 @@ public class AotParserTests
         Assert.DoesNotContain("MSBuild version:", stdout);
     }
 
-    [Fact]
+    [TestMethod]
     public void InvokeNoArgs_ReturnsZeroAndShowsUsage()
     {
         var (exitCode, stdout, _) = InvokeWithCapture([]);
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Usage:", stdout);
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().Contain("Usage:");
     }
 
-    [Theory]
-    [InlineData("tool list")]
-    [InlineData("tool list --local")]
-    [InlineData("tool run mytool")]
-    [InlineData("tool uninstall mypackage")]
-    [InlineData("tool search mysearchterm")]
+    [TestMethod]
+    [DataRow("tool list")]
+    [DataRow("tool list --local")]
+    [DataRow("tool run mytool")]
+    [DataRow("tool uninstall mypackage")]
+    [DataRow("tool search mysearchterm")]
     public void ParseAotToolCommand_HasNoErrors(string commandLine)
     {
         // The AOT-capable `tool` subcommands (local list/uninstall, run, search) parse cleanly
         // because their real implementations are linked into the AOT CLI.
         var result = Parser.Parse(commandLine.Split(' '));
-        Assert.Empty(result.Errors);
+        Assert.IsEmpty(result.Errors);
     }
 
-    [Theory]
-    [InlineData("tool list")]
-    [InlineData("tool list --local")]
+    [TestMethod]
+    [DataRow("tool list")]
+    [DataRow("tool list --local")]
     public void InvokeAotToolListCommand_ExecutesWithoutManagedFallback(string commandLine)
     {
         // `tool list` is AOT-capable: the real ToolListLocalCommand is linked in. It succeeds even
@@ -271,25 +284,25 @@ public class AotParserTests
         // tests would miss.
         var (exitCode, _, _) = InvokeWithCapture(commandLine.Split(' '));
 
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Theory]
-    [InlineData("tool list --global")]                  // global list dispatches to managed CLI
-    [InlineData("tool list --tool-path somepath")]      // tool-path list dispatches to managed CLI
-    [InlineData("tool uninstall mypackage --global")]   // global uninstall dispatches to managed CLI
-    [InlineData("tool install mypackage")]              // install is not AOT-capable
-    [InlineData("tool update mypackage")]               // update is not AOT-capable
-    [InlineData("tool restore")]                        // restore is not AOT-capable
-    [InlineData("tool execute dotnetsay")]              // execute is not AOT-capable
+    [TestMethod]
+    [DataRow("tool list --global")]                  // global list dispatches to managed CLI
+    [DataRow("tool list --tool-path somepath")]      // tool-path list dispatches to managed CLI
+    [DataRow("tool uninstall mypackage --global")]   // global uninstall dispatches to managed CLI
+    [DataRow("tool install mypackage")]              // install is not AOT-capable
+    [DataRow("tool update mypackage")]               // update is not AOT-capable
+    [DataRow("tool restore")]                        // restore is not AOT-capable
+    [DataRow("tool execute dotnetsay")]              // execute is not AOT-capable
     public void InvokeManagedOnlyToolCommand_FallsBackToManaged(string commandLine)
     {
         // The global/tool-path variants and install/update/restore depend on NuGet package
         // install/restore infrastructure that isn't AOT-ready, so they must signal a managed
         // fallback via CommandNotAvailableInAotException rather than execute.
         var result = Parser.Parse(commandLine.Split(' '));
-        Assert.Empty(result.Errors);
-        Assert.Throws<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
+        Assert.IsEmpty(result.Errors);
+        Assert.ThrowsExactly<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
     }
 
     /// <summary>

--- a/test/dotnet-aot.Tests/AssemblyInfo.cs
+++ b/test/dotnet-aot.Tests/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // Tests in this assembly modify process-global state (environment variables,
 // Reporter.Output, Console.Out/Error, AppContext data), so they must not
 // run in parallel.
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: DoNotParallelize]

--- a/test/dotnet-aot.Tests/DotnetRootResolverTests.cs
+++ b/test/dotnet-aot.Tests/DotnetRootResolverTests.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli;
-using Xunit;
 
 namespace Microsoft.DotNet.Cli.Tests;
 
@@ -13,6 +12,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  process path walk-up, and hostfxr discovery.
 ///  Path construction uses Path.Combine for cross-platform compatibility.
 /// </summary>
+[TestClass]
 public class DotnetRootResolverTests
 {
     // Helper to build platform-appropriate paths for test inputs/outputs.
@@ -23,7 +23,7 @@ public class DotnetRootResolverTests
         return segments.Length == 0 ? root : Path.Combine(root, Path.Combine(segments));
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_WithDotnetRootEnvVar_ReturnsThatPath()
     {
         string dotnetDir = BuildPath(true, "dotnet");
@@ -38,10 +38,10 @@ public class DotnetRootResolverTests
             fileExists: _ => false,
             baseDirectory: fallback);
 
-        Assert.Equal(dotnetDir, result);
+        Assert.AreEqual(dotnetDir, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_WithArchSpecificEnvVar_OnWindows_ReturnsThatPath()
     {
         string dotnetX64 = BuildPath(true, "dotnet-x64");
@@ -56,10 +56,10 @@ public class DotnetRootResolverTests
             fileExists: _ => false,
             baseDirectory: fallback);
 
-        Assert.Equal(dotnetX64, result);
+        Assert.AreEqual(dotnetX64, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_ArchSpecificEnvVar_IgnoredOnNonWindows()
     {
         string baseDir = BuildPath(false, "usr", "lib", "dotnet") + Path.DirectorySeparatorChar;
@@ -76,10 +76,10 @@ public class DotnetRootResolverTests
             baseDirectory: baseDir);
 
         // On non-Windows, arch-specific env vars are ignored; falls to baseDirectory parent
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_WithDotnetRootNotExisting_SkipsIt()
     {
         string nonexistent = BuildPath(true, "nonexistent");
@@ -96,10 +96,10 @@ public class DotnetRootResolverTests
             baseDirectory: baseDir);
 
         // Non-existent DOTNET_ROOT is skipped; falls to baseDirectory parent
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_WalksUpFromProcessPath()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -116,10 +116,10 @@ public class DotnetRootResolverTests
             fileExists: path => path == dotnetExe,
             baseDirectory: fallback);
 
-        Assert.Equal(dotnetRoot, result);
+        Assert.AreEqual(dotnetRoot, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveDotnetRoot_NoDotnetAncestor_FallsBackToBaseDirectory()
     {
         string processPath = BuildPath(true, "app", "bin", "myapp.exe");
@@ -136,10 +136,10 @@ public class DotnetRootResolverTests
             baseDirectory: baseDir);
 
         // Last resort: parent of baseDirectory
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_WithValidFxrDir_ReturnsPath()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -155,10 +155,10 @@ public class DotnetRootResolverTests
             getDirectories: _ => new[] { fxrVersion },
             fileExists: path => path == expectedPath);
 
-        Assert.Equal(expectedPath, result);
+        Assert.AreEqual(expectedPath, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_PicksHighestVersion()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -176,10 +176,10 @@ public class DotnetRootResolverTests
             getDirectories: _ => new[] { v800, v901, v900 },
             fileExists: _ => true);
 
-        Assert.Equal(expectedPath, result);
+        Assert.AreEqual(expectedPath, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_SkipsPrereleaseDirectories()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -198,10 +198,10 @@ public class DotnetRootResolverTests
             fileExists: _ => true);
 
         // Should pick 9.0.0 since the preview dir is skipped
-        Assert.Equal(expectedPath, result);
+        Assert.AreEqual(expectedPath, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_MissingFxrDirectory_ReturnsEmpty()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -214,10 +214,10 @@ public class DotnetRootResolverTests
             getDirectories: _ => Array.Empty<string>(),
             fileExists: _ => false);
 
-        Assert.Equal(string.Empty, result);
+        Assert.AreEqual(string.Empty, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_FxrDirExistsButNoHostfxrFile_ReturnsEmpty()
     {
         string dotnetRoot = BuildPath(true, "dotnet");
@@ -232,10 +232,10 @@ public class DotnetRootResolverTests
             getDirectories: _ => new[] { fxrVersion },
             fileExists: _ => false);
 
-        Assert.Equal(string.Empty, result);
+        Assert.AreEqual(string.Empty, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_OnMacOS_LooksForDylib()
     {
         string dotnetRoot = Path.Combine("/", "usr", "local", "share", "dotnet");
@@ -251,10 +251,10 @@ public class DotnetRootResolverTests
             getDirectories: _ => new[] { fxrVersion },
             fileExists: path => path == expectedPath);
 
-        Assert.Equal(expectedPath, result);
+        Assert.AreEqual(expectedPath, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveHostfxrPath_OnLinux_LooksForSo()
     {
         string dotnetRoot = Path.Combine("/", "usr", "share", "dotnet");
@@ -270,6 +270,6 @@ public class DotnetRootResolverTests
             getDirectories: _ => new[] { fxrVersion },
             fileExists: path => path == expectedPath);
 
-        Assert.Equal(expectedPath, result);
+        Assert.AreEqual(expectedPath, result);
     }
 }

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
-using Xunit;
 
 namespace Microsoft.DotNet.Cli.Tests;
 
@@ -15,6 +14,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  Note: Tests that hit the managed fallback path (ManagedHost.RunApp) will get the
 ///  "managed fallback not found" error because test env doesn't have dotnet.dll in sdkDir.
 /// </summary>
+[TestClass]
 public class NativeEntryPointTests
 {
     /// <summary>
@@ -73,7 +73,7 @@ public class NativeEntryPointTests
         return sink;
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_VersionCommand_ReturnsZero()
     {
         WithEnvRestore(() =>
@@ -87,11 +87,11 @@ public class NativeEntryPointTests
                 hostfxrPath: "",
                 args: ["--version"]);
 
-            Assert.Equal(0, exitCode);
+            Assert.AreEqual(0, exitCode);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_InfoCommand_ReturnsZero()
     {
         WithEnvRestore(() =>
@@ -105,11 +105,11 @@ public class NativeEntryPointTests
                 hostfxrPath: "",
                 args: ["--info"]);
 
-            Assert.Equal(0, exitCode);
+            Assert.AreEqual(0, exitCode);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_UnrecognizedCommand_FallsBack()
     {
         WithEnvRestore(() =>
@@ -125,11 +125,11 @@ public class NativeEntryPointTests
                 hostfxrPath: "",
                 args: ["build"]);
 
-            Assert.Equal(1, exitCode);
+            Assert.AreEqual(1, exitCode);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotDisabled_VersionCommand_FallsBack()
     {
         WithEnvRestore(() =>
@@ -145,11 +145,11 @@ public class NativeEntryPointTests
                 args: ["--version"]);
 
             // Returns 1 because managed fallback files don't exist
-            Assert.Equal(1, exitCode);
+            Assert.AreEqual(1, exitCode);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotNotSet_VersionCommand_FallsBack()
     {
         WithEnvRestore(() =>
@@ -164,17 +164,17 @@ public class NativeEntryPointTests
                 args: ["--version"]);
 
             // Default is false → managed fallback → files missing → returns 1
-            Assert.Equal(1, exitCode);
+            Assert.AreEqual(1, exitCode);
         });
     }
 
-    [Theory]
-    [InlineData("true")]
-    [InlineData("True")]
-    [InlineData("TRUE")]
-    [InlineData("1")]
-    [InlineData("yes")]
-    [InlineData("on")]
+    [TestMethod]
+    [DataRow("true")]
+    [DataRow("True")]
+    [DataRow("TRUE")]
+    [DataRow("1")]
+    [DataRow("yes")]
+    [DataRow("on")]
     public void ExecuteCore_AotEnabledVariousFormats_TakesAotPath(string enableValue)
     {
         WithEnvRestore(() =>
@@ -189,11 +189,11 @@ public class NativeEntryPointTests
                 args: ["--version"]);
 
             // All these formats should enable AOT → --version handled → exit 0
-            Assert.Equal(0, exitCode);
+            Assert.AreEqual(0, exitCode);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_MissingFallbackFiles_ReturnsOneAndWritesError()
     {
         WithEnvRestore(() =>
@@ -213,10 +213,10 @@ public class NativeEntryPointTests
                     hostfxrPath: "",
                     args: ["--version"]);
 
-                Assert.Equal(1, exitCode);
+                Assert.AreEqual(1, exitCode);
                 string stderr = stderrWriter.ToString();
                 // Verify the error mentions the expected fallback files
-                Assert.Contains("dotnet.dll", stderr);
+                stderr.Should().Contain("dotnet.dll");
             }
             finally
             {
@@ -225,7 +225,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_UnsupportedCommand_NoAotErrorLeaked()
     {
         WithEnvRestore(() =>
@@ -248,7 +248,7 @@ public class NativeEntryPointTests
                 string stderr = stderrWriter.ToString();
                 // The only error should be about managed fallback, not AOT parser errors
                 Assert.DoesNotContain("Unrecognized", stderr);
-                Assert.Contains("dotnet.dll", stderr);
+                stderr.Should().Contain("dotnet.dll");
             }
             finally
             {
@@ -257,7 +257,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_FileBasedApp_FallsBackToManaged()
     {
         WithEnvRestore(() =>
@@ -283,8 +283,8 @@ public class NativeEntryPointTests
                     hostfxrPath: "",
                     args: [csFile]);
 
-                Assert.Equal(1, exitCode);
-                Assert.Contains("dotnet.dll", stderrWriter.ToString());
+                Assert.AreEqual(1, exitCode);
+                stderrWriter.ToString().Should().Contain("dotnet.dll");
             }
             finally
             {
@@ -294,7 +294,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_UnresolvedExternalCommand_FallsBackToManaged()
     {
         WithEnvRestore(() =>
@@ -319,8 +319,8 @@ public class NativeEntryPointTests
                     hostfxrPath: "",
                     args: ["some-command-that-does-not-resolve-anywhere-xyz", "arg1"]);
 
-                Assert.Equal(1, exitCode);
-                Assert.Contains("dotnet.dll", stderrWriter.ToString());
+                Assert.AreEqual(1, exitCode);
+                stderrWriter.ToString().Should().Contain("dotnet.dll");
             }
             finally
             {
@@ -329,7 +329,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_ResolvableExternalCommandOnPath_InvokesOutOfProcess()
     {
         WithEnvRestore(() =>
@@ -371,7 +371,7 @@ public class NativeEntryPointTests
                     hostfxrPath: "",
                     args: ["aotpathtool"]);
 
-                Assert.Equal(expectedExitCode, exitCode);
+                Assert.AreEqual(expectedExitCode, exitCode);
             }
             finally
             {
@@ -381,7 +381,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotEnabled_ResolvableExternalCommand_EmitsParserAndResolutionTelemetry()
     {
         WithEnvRestore(() =>
@@ -423,8 +423,8 @@ public class NativeEntryPointTests
                         hostfxrPath: "",
                         args: ["aotteltool"]));
 
-                Assert.Contains("toplevelparser/command", events);
-                Assert.Contains("commandresolution/commandresolved", events);
+                events.Should().Contain("toplevelparser/command");
+                events.Should().Contain("commandresolution/commandresolved");
             }
             finally
             {
@@ -434,7 +434,7 @@ public class NativeEntryPointTests
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotDisabled_DefersToManagedHost_DoesNotEmitParserTelemetry()
     {
         WithEnvRestore(() =>
@@ -458,7 +458,7 @@ public class NativeEntryPointTests
     }
 
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_SetsHostfxrPathInAppContext()
     {
         WithEnvRestore(() =>
@@ -473,11 +473,11 @@ public class NativeEntryPointTests
                 hostfxrPath: testPath,
                 args: ["--version"]);
 
-            Assert.Equal(testPath, AppContext.GetData("HOSTFXR_PATH") as string);
+            Assert.AreEqual(testPath, AppContext.GetData("HOSTFXR_PATH") as string);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_EmptyHostfxrPath_DoesNotSetAppContext()
     {
         WithEnvRestore(() =>
@@ -493,11 +493,11 @@ public class NativeEntryPointTests
                 hostfxrPath: "",
                 args: ["--version"]);
 
-            Assert.Null(AppContext.GetData("HOSTFXR_PATH"));
+            Assert.IsNull(AppContext.GetData("HOSTFXR_PATH"));
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_AotFastPath_CreatesMainActivity()
     {
         WithEnvRestore(() =>
@@ -522,14 +522,14 @@ public class NativeEntryPointTests
                 args: ["--version"]);
 
             var mainActivity = collectedActivities.FirstOrDefault(a => a.OperationName == "main");
-            Assert.NotNull(mainActivity);
-            Assert.Equal(0, mainActivity.GetTagItem("process.exit.code"));
-            Assert.Equal(ActivityStatusCode.Ok, mainActivity.Status);
+            Assert.IsNotNull(mainActivity);
+            Assert.AreEqual(0, mainActivity.GetTagItem("process.exit.code"));
+            Assert.AreEqual(ActivityStatusCode.Ok, mainActivity.Status);
         });
     }
 
 
-    [Fact]
+    [TestMethod]
     public void ExecuteCore_TelemetryOptedOut_NoActivities()
     {
         WithEnvRestore(() =>

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -116,7 +116,7 @@ public class NativeEntryPointTests
         {
             Environment.SetEnvironmentVariable("DOTNET_CLI_ENABLEAOT", "true");
 
-            // "build" produces parse errors → AOT path skipped → falls to managed fallback
+            // "build" parses cleanly, so the AOT path is taken but cannot execute it and falls back during invocation.
             // Since sdkDir doesn't contain dotnet.dll, this returns 1 (no managed fallback)
             int exitCode = NativeEntryPoint.ExecuteCore(
                 hostPath: "test-host",

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
@@ -6,6 +6,8 @@
     <DefineConstants>$(DefineConstants);CLI_AOT</DefineConstants>
     <RootNamespace>Microsoft.DotNet.Cli.Tests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <!-- Tests modify process-global state; run serially ([assembly: DoNotParallelize]). -->
+    <MSTestParallelizeScope></MSTestParallelizeScope>
 
     <!-- Strong naming deprecated on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
@@ -14,17 +16,12 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
-  <!-- AOT publish support: dotnet publish -p:PublishAotTests=true -->
+  <!-- AOT publish support: dotnet publish -p:PublishAotTests=true. MSTest.Sdk runs on
+       Microsoft.Testing.Platform and uses the MSTest source generator for test discovery,
+       which is NativeAOT-compatible (no reflection-based discovery). -->
   <PropertyGroup Condition="'$(PublishAotTests)' == 'true'">
     <PublishAot>true</PublishAot>
-    <!-- Tell eng/XUnitV3/XUnitV3.targets to use the AOT xUnit packages. -->
-    <UseXUnitAotPackages>true</UseXUnitAotPackages>
-    <!-- The xunit.v3.core.aot.mtp-v2 package includes MTP v2 support. Force MTP mode
-         to prevent xunit.runner.visualstudio (which transitively brings in the
-         reflection-mode xunit.v3.core) from being added. -->
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <!-- xUnit v3 AOT packages are swapped in via eng/XUnitV3/XUnitV3.targets.
-         Project references (TestFramework, Cli.Utils, NativeWrapper) may produce
+    <!-- Project references (TestFramework.MSTest, Cli.Utils, NativeWrapper) may produce
          trim/AOT warnings since they are not annotated for AOT. -->
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
@@ -46,12 +43,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.TestFramework\Microsoft.NET.TestFramework.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.TestFramework.MSTest\Microsoft.NET.TestFramework.MSTest.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj" />
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Cli.Definitions\Microsoft.DotNet.Cli.Definitions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.NET.TestFramework" />
+    <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,16 +66,6 @@
   <!-- Azure Monitor dependencies aren't part of source build yet - see file://../../../Directory.Build.props#L85 for details -->
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
-  </ItemGroup>
-
-  <!-- When publishing AOT, exclude the reflection-mode xUnit packages
-       that flow transitively from Microsoft.NET.TestFramework. They ship
-       DLLs (xunit.v3.core.dll, xunit.v3.assert.dll) that conflict with the
-       AOT variants (xunit.v3.core.aot.dll, xunit.v3.assert.aot.dll). -->
-  <ItemGroup Condition="'$(UseXUnitAotPackages)' == 'true'">
-    <PackageReference Include="xunit.v3.extensibility.core" ExcludeAssets="all" PrivateAssets="all" />
-    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" ExcludeAssets="all" PrivateAssets="all" />
-    <PackageReference Include="xunit.v3.common" VersionOverride="$(XUnitV3Version)" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Part of the ongoing xUnit -> MSTest.Sdk (MTP) test migration of the .NET SDK test suite. Migrates the last remaining xUnit test project, dotnet-aot.Tests, to MSTest.Sdk on Microsoft.Testing.Platform.

This project has a NativeAOT publish mode (dotnet publish -p:PublishAotTests=true) that previously relied on the xUnit v3 AOT packages (xunit.v3.core.aot.mtp-v2) and the eng/XUnitV3/XUnitV3.targets machinery. That is replaced by MSTest.Sdk on MTP, whose source generator performs reflection-free test discovery and is NativeAOT-compatible, so the UseXUnitAotPackages property, the UseMicrosoftTestingPlatformRunner override, and the transitive xUnit AOT package exclusions are all removed.

Standard transformations: Microsoft.NET.Sdk -> MSTest.Sdk, the TestFramework project reference -> Microsoft.NET.TestFramework.MSTest, [Fact] -> [TestMethod], xUnit asserts -> MSTest (Empty -> IsEmpty, Equal -> AreEqual, Contains -> FluentAssertions Should().Contain, Skip -> Inconclusive, IsNotType -> an is-type check, Record.Exception -> a local try/catch helper), the AOT [Trait] category -> [TestCategory], CollectionBehavior(DisableTestParallelization = true) -> [assembly: DoNotParallelize] plus an empty MSTestParallelizeScope, and ITestOutputHelper constructor injection replaced with a TestContext-backed output helper.

Verified: the regular build is clean, and dotnet publish -r win-x64 -p:PublishAotTests=true produces a native dotnet-aot.Tests.exe that discovers and lists all tests (the MSTest source generator works under NativeAOT).
