### PR TITLE
Don't let dotnet CLI disable MSBUILDUSESERVER

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -98,7 +98,12 @@ internal sealed class MSBuildForwardingAppWithoutLogging
 
         MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
-        EnvironmentVariable("MSBUILDUSESERVER", UseMSBuildServer ? "1" : "0");
+        // Only force MSBUILDUSESERVER on when DOTNET_CLI_USE_MSBUILD_SERVER opts in; otherwise leave
+        // any user-provided MSBUILDUSESERVER value untouched so it can toggle the server on its own.
+        if (UseMSBuildServer)
+        {
+            EnvironmentVariable("MSBUILDUSESERVER", "1");
+        }
 
         // If DOTNET_CLI_RUN_MSBUILD_OUTOFPROC is set, the caller requires it (e.g. the AOT CLI, which
         // cannot host MSBuild in-process), or we're asked to execute a non-default binary, call MSBuild out-of-proc.


### PR DESCRIPTION
Don't let dotnet CLI disable MSBUILDUSESERVER when DOTNET_CLI_USE_MSBUILD_SERVER is unset

Previously the CLI unconditionally wrote MSBUILDUSESERVER to "1" or "0" based solely on DOTNET_CLI_USE_MSBUILD_SERVER. When that variable was unset (the default), the host wrote MSBUILDUSESERVER=0, clobbering any value the user had set directly via MSBUILDUSESERVER and forcing the MSBuild server off.

Now the CLI only sets MSBUILDUSESERVER=1 when DOTNET_CLI_USE_MSBUILD_SERVER opts in, and otherwise leaves the variable untouched. This lets either variable toggle the MSBuild server on, so a user-provided MSBUILDUSESERVER=1 is honored.