### PR TITLE
[StaticWebAssets] Fix endpoints manifest crash when an `All` and a more specific asset share a target path (#54779)

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
+++ b/src/StaticWebAssetsSdk/Tasks/Data/StaticWebAsset.cs
@@ -618,11 +618,16 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
     // * If we don't find a more specific (Build or Publish) asset we will return the `All` asset.
     // We assume that the manifest is correct and don't try to deal with errors at this level, if for some reason we find more
     // than one type of asset we will just return all of them.
-    // One exception to this is the `All` kind of assets, where we will just return the first two we find. The reason for it is
-    // to avoid having to allocate a buffer to collect all the `All` assets.
+    // One exception to this is the `All` kind of assets, where we will just keep track of the first two we find. The reason
+    // for it is to avoid having to allocate a buffer to collect all the `All` assets. We only surface those two `All` assets
+    // (so the caller can error out on the ambiguity) when no more specific Build or Publish asset is present in the group.
+    // It is important that we don't surface the `All` ambiguity eagerly: a more specific asset can appear *after* two `All`
+    // assets in the group (for example a project Publish manifest that shadows a package `All` asset and a project build
+    // `All` manifest that all map to the same target path). In that case the specific asset wins and there is no ambiguity.
     internal static IEnumerable<StaticWebAsset> ChooseNearestAssetKind(IEnumerable<StaticWebAsset> group, string assetKind)
     {
-        StaticWebAsset allKindAssetCandidate = null;
+        StaticWebAsset firstAllKindCandidate = null;
+        StaticWebAsset secondAllKindCandidate = null;
 
         var ignoreAllKind = false;
         foreach (var item in group)
@@ -640,20 +645,32 @@ public sealed class StaticWebAsset : IEquatable<StaticWebAsset>, IComparable<Sta
             }
             else if (!ignoreAllKind && item.IsBuildAndPublish())
             {
-                if (allKindAssetCandidate != null)
+                // Keep track of up to two `All` assets. If we never find a more specific asset, having more than
+                // one `All` asset is an error, and we'll surface both candidates below so the caller can report it.
+                if (firstAllKindCandidate == null)
                 {
-                    // At this point we have more than one `All` asset, which is an error
-                    yield return allKindAssetCandidate;
-                    yield return item;
-                    yield break;
+                    firstAllKindCandidate = item;
                 }
-                allKindAssetCandidate = item;
+                else
+                {
+                    secondAllKindCandidate ??= item;
+                }
             }
         }
 
         if (!ignoreAllKind)
         {
-            yield return allKindAssetCandidate;
+            // No more specific Build or Publish asset was found, so fall back to the `All` asset(s).
+            if (firstAllKindCandidate != null)
+            {
+                yield return firstAllKindCandidate;
+            }
+
+            if (secondAllKindCandidate != null)
+            {
+                // More than one `All` asset and no specific asset: this is a genuine ambiguity.
+                yield return secondAllKindCandidate;
+            }
         }
     }
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsManifestTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsManifestTest.cs
@@ -218,6 +218,110 @@ public class GenerateStaticWebAssetEndpointsManifestTest
     }
 
     [Fact]
+    public void GeneratesPublishManifest_WhenAllAndPublishAssetsShareTargetPath_PrefersPublishAsset()
+    {
+        // Regression test for https://github.com/dotnet/sdk/issues/54779
+        // A MAUI Blazor Hybrid app that references a Razor class library AND the BlazorWebView package
+        // produces three assets that map to the same target path "_framework/blazor.modules.json":
+        //   * An "All" asset coming from the Microsoft.AspNetCore.Components.WebView package.
+        //   * An "All" project build JS modules manifest.
+        //   * A "Publish" project publish JS modules manifest.
+        // ChooseNearestAssetKind used to surface the "two All assets" ambiguity (yielding both and breaking)
+        // before it ever reached the more specific Publish asset, so SingleOrDefault threw
+        // "Sequence contains more than one element". The Publish asset should win and produce a single endpoint.
+        var relativePath = "_framework/blazor#[.{fingerprint}]?.modules.json";
+
+        // Order matters: the two "All" assets appear before the "Publish" asset, reproducing the original failure.
+        var assets = new[]
+        {
+            CreateAsset(
+                "blazor.modules.json",
+                sourceId: "Microsoft.AspNetCore.Components.WebView",
+                sourceType: "Package",
+                relativePath: "blazor#[.{fingerprint}]?.modules.json",
+                basePath: "_framework",
+                assetKind: "All",
+                assetMode: "All",
+                assetTraitName: "JSModule",
+                assetTraitValue: "JSModuleManifest",
+                integrity: "package-integrity",
+                fingerprint: "packagefp"),
+            CreateAsset(
+                "jsmodules.build.manifest.json",
+                sourceId: "MyApp",
+                sourceType: "Computed",
+                relativePath: relativePath,
+                basePath: "/",
+                assetKind: "All",
+                assetMode: "All",
+                assetTraitName: "JSModule",
+                assetTraitValue: "JSModuleManifest",
+                integrity: "build-integrity",
+                fingerprint: "buildfp"),
+            CreateAsset(
+                "jsmodules.publish.manifest.json",
+                sourceId: "MyApp",
+                sourceType: "Computed",
+                relativePath: relativePath,
+                basePath: "/",
+                assetKind: "Publish",
+                assetMode: "CurrentProject",
+                assetTraitName: "JSModule",
+                assetTraitValue: "JSModuleManifest",
+                integrity: "publish-integrity",
+                fingerprint: "publishfp"),
+        };
+
+        var endpoints = CreateEndpoints(assets);
+        var path = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N") + "endpoints.json");
+
+        var errors = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(e => errors.Add(e.Message));
+
+        var task = new GenerateStaticWebAssetEndpointsManifest
+        {
+            Assets = assets.Select(a => a.ToTaskItem()).ToArray(),
+            Endpoints = endpoints.Select(e => e.ToTaskItem()).ToArray(),
+            ManifestType = "Publish",
+            Source = "MyApp",
+            ManifestPath = path,
+            BuildEngine = buildEngine.Object
+        };
+
+        try
+        {
+            // Act - this used to throw "Sequence contains more than one element".
+            var result = task.Execute();
+
+            // Assert
+            errors.Should().BeEmpty();
+            result.Should().BeTrue();
+            new FileInfo(path).Should().Exist();
+            var manifest = File.ReadAllText(path);
+            var json = JsonSerializer.Deserialize<StaticWebAssetEndpointsManifest>(manifest);
+            json.Should().NotBeNull();
+            json.Endpoints.Should().NotBeEmpty();
+
+            // The Publish asset must win over the two "All" assets, so every endpoint for the shared
+            // target path must come from the publish manifest (identified by its unique integrity).
+            json.Endpoints.Should().OnlyContain(e =>
+                e.ResponseHeaders.Any(h => h.Name == "ETag" && h.Value.Contains("publish-integrity")));
+            json.Endpoints.Should().NotContain(e =>
+                e.ResponseHeaders.Any(h => h.Name == "ETag"
+                    && (h.Value.Contains("package-integrity") || h.Value.Contains("build-integrity"))));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void ExcludesEndpoints_BasedOnExclusionPatterns()
     {
         // Arrange
@@ -458,7 +562,9 @@ public class GenerateStaticWebAssetEndpointsManifestTest
         string assetTraitName = "",
         string assetTraitValue = "",
         string copyToOutputDirectory = "Never",
-        string copytToPublishDirectory = "PreserveNewest")
+        string copytToPublishDirectory = "PreserveNewest",
+        string integrity = "integrity",
+        string fingerprint = "fingerprint")
     {
         var result = new StaticWebAsset()
         {
@@ -480,8 +586,8 @@ public class GenerateStaticWebAssetEndpointsManifestTest
             CopyToPublishDirectory = copytToPublishDirectory,
             OriginalItemSpec = itemSpec,
             // Add these to avoid accessing the disk to compute them
-            Integrity = "integrity",
-            Fingerprint = "fingerprint",
+            Integrity = integrity,
+            Fingerprint = fingerprint,
             FileLength = 10,
             LastWriteTime = new DateTime(2000, 1, 1, 0, 0, 1)
         };


### PR DESCRIPTION
Fixes #54779

### Regression (Preview 6)

A MAUI Blazor Hybrid app that references a Razor class library **and** the `Microsoft.AspNetCore.Components.WebView` (BlazorWebView) package fails to build with:

```
GenerateStaticWebAssetEndpointsManifest ... Sequence contains more than one element
```

### Root cause

Three static web assets map to the same target path `_framework/blazor#[.{fingerprint}]?.modules.json`:

* an `All` asset coming from the BlazorWebView package,
* an `All` project *build* JS-modules manifest, and
* **new in Preview 6**, a `Publish` project *publish* JS-modules manifest.

`StaticWebAsset.ChooseNearestAssetKind` surfaced the "two `All` assets" ambiguity eagerly (it `yield`ed both and `break`ed) **before** it ever reached the more specific `Publish` asset, so the consumer's `SingleOrDefault()` threw. `GenerateStaticWebAssetEndpointsManifest` itself is unchanged — the new publish manifest changed the *input* to it.

### Fix

Defer the multi-`All` decision: track up to two `All` candidates and only surface them (so the caller can still error on a genuine ambiguity) **when no more specific Build/Publish asset is present in the group**. A more specific asset that appears after the `All` assets now correctly wins. This also fixes the identical latent path in `GenerateStaticWebAssetsDevelopmentManifest` — the only other caller of `ChooseNearestAssetKind`.

### Testing

* Added `GeneratesPublishManifest_WhenAllAndPublishAssetsShareTargetPath_PrefersPublishAsset`, which reconstructs the exact 3-asset group. It throws `Sequence contains more than one element` before the fix and passes after, producing a single endpoint sourced from the publish manifest.
* Existing `GenerateStaticWebAssetEndpointsManifestTest` (5), `GenerateStaticWebAssetsDevelopmentManifestTest` (23), and `GenerateStaticWebAssetsManifestTest` (19) all still pass.
