### PR TITLE
Make DependencyProvider test cleanup tolerant of missing registry subkey

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/DependencyProviderTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         private void DeleteProviderKey(DependencyProvider dep)
         {
             using RegistryKey providerKey = dep.BaseKey.OpenSubKey(DependencyProvider.DependenciesKeyRelativePath, writable: true);
-            providerKey?.DeleteSubKeyTree(dep.ProviderKeyName);
+            providerKey?.DeleteSubKeyTree(dep.ProviderKeyName, throwOnMissingSubKey: false);
         }
     }
 #pragma warning restore CA1416


### PR DESCRIPTION
## Problem

`DependencyProviderTests.ItCanAddDependents` (and the other registry-backed tests) could fail with:

```
System.ArgumentException: Cannot delete a subkey tree because the subkey does not exist.
   at Microsoft.Win32.RegistryKey.DeleteSubKeyTree(String subkey, Boolean throwOnMissingSubKey)
   at DependencyProviderTests.DeleteProviderKey(DependencyProvider dep)
   at DependencyProviderTests.ItCanAddDependents()
```

The `DeleteProviderKey` cleanup helper runs in a `finally` block. When an assertion inside the `try` fails before the provider key is created (or the key was already removed), `DeleteSubKeyTree` throws `ArgumentException`, which masks the real test failure.

## Fix

Use the `DeleteSubKeyTree(string subkey, bool throwOnMissingSubKey)` overload with `throwOnMissingSubKey: false` so the cleanup is idempotent and never throws when the subkey is absent.

Fixes #54927

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>