### PR TITLE
Fix main build break: remove redundant DisplayName=nameof in dotnet.Tests (MSTEST0071)

### DIFF
--- a/test/dotnet.Tests/CommandTests/New/DotnetAddPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetAddPostActionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             }
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsOneDefaultProjFileInOutputDirectory))]
+        [TestMethod]
         public void AddRefFindsOneDefaultProjFileInOutputDirectory()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.ContainsSingle(projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsOneNameConfiguredProjFileInOutputDirectory))]
+        [TestMethod]
         public void AddRefFindsOneNameConfiguredProjFileInOutputDirectory()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.ContainsSingle(projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsOneNameConfiguredProjFileWhenMultipleExtensionsAreAllowed))]
+        [TestMethod]
         public void AddRefFindsOneNameConfiguredProjFileWhenMultipleExtensionsAreAllowed()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.ContainsSingle(projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefIgnoresOtherProjectTypesWhenMultipleTypesAreAllowed))]
+        [TestMethod]
         public void AddRefIgnoresOtherProjectTypesWhenMultipleTypesAreAllowed()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.ContainsSingle(projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsOneDefaultProjFileInAncestorOfOutputDirectory))]
+        [TestMethod]
         public void AddRefFindsOneDefaultProjFileInAncestorOfOutputDirectory()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.ContainsSingle(projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsMultipleDefaultProjFilesInOutputDirectory))]
+        [TestMethod]
         public void AddRefFindsMultipleDefaultProjFilesInOutputDirectory()
         {
             string projFilesOriginalContent = TestCsprojFile;
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.HasCount(2, projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefFindsMultipleDefaultProjFilesInAncestorOfOutputDirectory))]
+        [TestMethod]
         public void AddRefFindsMultipleDefaultProjFilesInAncestorOfOutputDirectory()
         {
             string projFilesOriginalContent = TestCsprojFile;
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.HasCount(2, projFilesFound);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefCanHandleProjectFileRenames))]
+        [TestMethod]
         public void AddRefCanHandleProjectFileRenames()
         {
             var callback = new MockAddProjectReferenceCallback();
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(referencedProjFileFullPath, callback.Reference);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefCanHandleProjectFilesWithoutRenames))]
+        [TestMethod]
         public void AddRefCanHandleProjectFilesWithoutRenames()
         {
             var callback = new MockAddProjectReferenceCallback();
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(referencedProjFileFullPath, callback.Reference);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefCanHandleExistingProjectFiles))]
+        [TestMethod]
         public void AddRefCanHandleExistingProjectFiles()
         {
             var callback = new MockAddProjectReferenceCallback();
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(referencedProjectFileFullPath, callback.Reference);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefCanTargetASingleProjectWithAJsonArray))]
+        [TestMethod]
         public void AddRefCanTargetASingleProjectWithAJsonArray()
         {
             var callback = new MockAddProjectReferenceCallback();
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual("System.Net.Json", callback.Reference);
         }
 
-        [TestMethod(DisplayName = nameof(AddRefCanTargetASingleProjectWithTheProjectName))]
+        [TestMethod]
         public void AddRefCanTargetASingleProjectWithTheProjectName()
         {
             var callback = new MockAddProjectReferenceCallback();

--- a/test/dotnet.Tests/CommandTests/New/DotnetRestorePostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetRestorePostActionTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             _engineEnvironmentSettings = new EnvironmentSettingsHelper().CreateEnvironment(hostIdentifier: GetType().Name, virtualize: true);
         }
 
-        [TestMethod(DisplayName = nameof(DotnetRestoreCanTargetASingleProjectWithAJsonArray))]
+        [TestMethod]
         public void DotnetRestoreCanTargetASingleProjectWithAJsonArray()
         {
             var callback = new MockDotnetRestoreCallback();
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(projFileFullPath, callback.Target);
         }
 
-        [TestMethod(DisplayName = nameof(DotnetRestoreCanTargetASingleProjectWithTheProjectName))]
+        [TestMethod]
         public void DotnetRestoreCanTargetASingleProjectWithTheProjectName()
         {
             var callback = new MockDotnetRestoreCallback();

--- a/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             _engineEnvironmentSettings = new EnvironmentSettingsHelper().CreateEnvironment(hostIdentifier: GetType().Name, virtualize: true);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionFindSolutionFileAtOutputPath))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionFindSolutionFileAtOutputPath()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(solutionFileFullPath, solutionFiles[0]);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionPrefersSlnOverSlnx))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionPrefersSlnOverSlnx()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(slnFileFullPath, solutionFiles[0]);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionFindsOneProjectToAdd))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionFindsOneProjectToAdd()
         {
             string outputBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(creationResult.PrimaryOutputs[0].Path, foundProjectFiles?[0]);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionFindsMultipleProjectsToAdd))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionFindsMultipleProjectsToAdd()
         {
             string outputBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.DoesNotContain(creationResult.PrimaryOutputs[1].Path, foundProjectFiles.ToList());
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionDoesntFindProjectOutOfRange))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionDoesntFindProjectOutOfRange()
         {
             IPostAction postAction = new MockPostAction(default, default, default, default, default!)
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.IsEmpty(foundProjectFiles);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionFindsMultipleProjectsToAddWithOutputBasePath))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionFindsMultipleProjectsToAddWithOutputBasePath()
         {
             string outputBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.DoesNotContain(dontFindMeFullPath1, foundProjectFiles.ToList());
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionPostActionWithoutPrimaryOutputIndexesWithOutputBasePath))]
+        [TestMethod]
         public void AddProjectToSolutionPostActionWithoutPrimaryOutputIndexesWithOutputBasePath()
         {
             string outputBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.Contains(outputFileFullPath1, foundProjectFiles.ToList());
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionCanTargetASingleProjectWithAJsonArray))]
+        [TestMethod]
         public void AddProjectToSolutionCanTargetASingleProjectWithAJsonArray()
         {
             var callback = new MockAddProjectToSolutionCallback();
@@ -222,7 +222,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(slnFileFullPath, callback.Solution);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionCanTargetASingleProjectWithTheProjectName))]
+        [TestMethod]
         public void AddProjectToSolutionCanTargetASingleProjectWithTheProjectName()
         {
             var callback = new MockAddProjectToSolutionCallback();
@@ -251,7 +251,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
             Assert.AreEqual(slnFileFullPath, callback.Solution);
         }
 
-        [TestMethod(DisplayName = nameof(AddProjectToSolutionCanPlaceProjectInSolutionRoot))]
+        [TestMethod]
         public void AddProjectToSolutionCanPlaceProjectInSolutionRoot()
         {
             var callback = new MockAddProjectToSolutionCallback();


### PR DESCRIPTION
## Problem

`main` is currently failing to build (`dotnet.Tests.csproj`) with 48 `error MSTEST0071`:

```
test/dotnet.Tests/CommandTests/New/DotnetAddPostActionTests.cs(37,10): error MSTEST0071:
  The 'DisplayName' is the same as the test method name 'AddRefFindsOneDefaultProjFileInOutputDirectory' and can be removed
```

### Root cause

The testfx dependency bump (#54765) merged **after** the dotnet.Tests MSTest migration (#54905). Under `MSTestAnalysisMode=Recommended` (set in `test/Directory.Build.props`), the analyzer now promotes `MSTEST0071` to an error. The migrated New post-action tests use `[TestMethod(DisplayName = nameof(MethodName))]`, where the display name is identical to the method name — exactly what `MSTEST0071` flags as redundant.

This breaks the build for **every** PR that merges with current `main` (e.g. observed while investigating #54904).

## Fix

Drop the redundant `DisplayName = nameof(...)` from the 24 affected `[TestMethod]` attributes across:

- `test/dotnet.Tests/CommandTests/New/DotnetAddPostActionTests.cs`
- `test/dotnet.Tests/CommandTests/New/DotnetRestorePostActionTests.cs`
- `test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs`

The display name now defaults to the method name — identical observable behavior, no test renames.

### Scope notes

- Only `dotnet.Tests` (an MSTest.Sdk project) is affected. The TemplateEngine unit-test projects also use `DisplayName = nameof`, but they are still xUnit (`Microsoft.NET.Sdk`), so `MSTEST0071` does not apply and they are intentionally left untouched.
- This is split out from #54904 (which only fixes a separate `CS0104` in `dotnet-new.IntegrationTests`) per the same incremental-migration approach.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>