### PR TITLE
Disable in-process parallel test execution

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -28,9 +28,8 @@
   <!-- MSTest.Sdk defaults. Applied to projects that opt in via <Project Sdk="MSTest.Sdk">,
        which sets UsingMSTestSdk=true in its Sdk.props before this file is evaluated. -->
   <PropertyGroup Condition="'$(UsingMSTestSdk)' == 'true'">
-    <!-- Run tests in parallel at the method level by default. MSTest.TestAdapter
-         emits the corresponding [assembly: Parallelize(Scope = MethodLevel)] attribute. -->
-    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
+    <!-- Parallelization disabled due to widespread concurrency-related intermittent test failures. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
 
     <!-- Promote info-severity MSTest analyzer rules to warnings and critical rules to errors. -->
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/xunit.runner.json
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/xunit.runner.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
     "diagnosticMessages": true,
-    "longRunningTestSeconds": 120
+    "longRunningTestSeconds": 120,
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false
 }

--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -3,5 +3,7 @@
   "diagnosticMessages": false,
   "longRunningTestSeconds": 20,
   "showLiveOutput": false,
-  "shadowCopy": false
+  "shadowCopy": false,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
## Purpose

Disable in-process parallel test execution to address widespread concurrency-related intermittent test failures.

## Changes

- `test/xunit.runner.json`: Set `parallelizeAssembly: false` and `parallelizeTestCollections: false`
- `test/TemplateEngine/.../xunit.runner.json`: Same
- `test/Directory.Build.props`: Set `MSTestParallelizeScope=None`

## Context

See #54967 for the full analysis and data supporting this change.

Closes #54967