### PR TITLE
Restore [CombinatorialData] in dotnet-watch.Tests using Combinatorial.MSTest

### DIFF
--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -17,20 +17,8 @@ public class BrowserRefreshServerTests
     }
 
     [TestMethod]
-    [DataRow(LogLevel.Trace, true)]
-    [DataRow(LogLevel.Trace, false)]
-    [DataRow(LogLevel.Debug, true)]
-    [DataRow(LogLevel.Debug, false)]
-    [DataRow(LogLevel.Information, true)]
-    [DataRow(LogLevel.Information, false)]
-    [DataRow(LogLevel.Warning, true)]
-    [DataRow(LogLevel.Warning, false)]
-    [DataRow(LogLevel.Error, true)]
-    [DataRow(LogLevel.Error, false)]
-    [DataRow(LogLevel.Critical, true)]
-    [DataRow(LogLevel.Critical, false)]
-    [DataRow(LogLevel.None, true)]
-    [DataRow(LogLevel.None, false)]
+
+    [CombinatorialData]
     public async Task ConfigureLaunchEnvironmentAsync(LogLevel logLevel, bool enableHotReload) 
     {
         var middlewarePath = Path.GetTempPath();

--- a/test/dotnet-watch.Tests/Build/EvaluationTests.cs
+++ b/test/dotnet-watch.Tests/Build/EvaluationTests.cs
@@ -126,13 +126,9 @@ public class EvaluationTests
     }
 
     [TestMethod]
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(true, null)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
-    [DataRow(false, null)]
-    public async Task StaticAssets(bool isWeb, bool? enableStaticWebAssets)
+
+    [CombinatorialData]
+    public async Task StaticAssets(bool isWeb, [CombinatorialValues(true, false, null)] bool? enableStaticWebAssets)
     {
         var project = new TestProject("Project1")
         {
@@ -316,8 +312,8 @@ public class EvaluationTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task SingleTargetRoot_MultiTargetedDependency(bool specifyTargetFramework)
     {
         var project2 = new TestProject("Project2")

--- a/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/CommandLineOptionsTests.cs
@@ -97,15 +97,11 @@ public class CommandLineOptionsTests
     }
 
     [TestMethod]
-    [DataRow("--quiet", true)]
-    [DataRow("--quiet", false)]
-    [DataRow("--verbose", true)]
-    [DataRow("--verbose", false)]
-    [DataRow("--no-hot-reload", true)]
-    [DataRow("--no-hot-reload", false)]
-    [DataRow("--non-interactive", true)]
-    [DataRow("--non-interactive", false)]
-    public void WatchOptions_NotPassedThrough(string option, bool beforeCommand)
+
+    [CombinatorialData]
+    public void WatchOptions_NotPassedThrough(
+        [CombinatorialValues("--quiet", "--verbose", "--no-hot-reload", "--non-interactive")] string option,
+        bool beforeCommand)
     {
         var options = VerifyOptions(beforeCommand ? [option, "test"] : ["test", option]);
         Assert.AreEqual("test", options.Command.Name);
@@ -315,8 +311,8 @@ public class CommandLineOptionsTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public void OptionsSpecifiedBeforeOrAfterRun(bool afterRun)
     {
         var args = new[] { "--project", "P", "--framework", "F", "--property", "P1=V1", "--property", "P2=V2" };
@@ -344,22 +340,17 @@ public class CommandLineOptionsTests
     }
 
     [TestMethod]
-    [DataRow(ArgPosition.Before, "--verbose")]
-    [DataRow(ArgPosition.Before, "--quiet")]
-    [DataRow(ArgPosition.Before, "--list")]
-    [DataRow(ArgPosition.Before, "--no-hot-reload")]
-    [DataRow(ArgPosition.Before, "--non-interactive")]
-    [DataRow(ArgPosition.After, "--verbose")]
-    [DataRow(ArgPosition.After, "--quiet")]
-    [DataRow(ArgPosition.After, "--list")]
-    [DataRow(ArgPosition.After, "--no-hot-reload")]
-    [DataRow(ArgPosition.After, "--non-interactive")]
-    [DataRow(ArgPosition.Both, "--verbose")]
-    [DataRow(ArgPosition.Both, "--quiet")]
-    [DataRow(ArgPosition.Both, "--list")]
-    [DataRow(ArgPosition.Both, "--no-hot-reload")]
-    [DataRow(ArgPosition.Both, "--non-interactive")]
-    public void OptionDuplicates_Allowed_Bool(ArgPosition position, string arg)
+
+    [CombinatorialData]
+    public void OptionDuplicates_Allowed_Bool(
+        ArgPosition position,
+        [CombinatorialValues(
+            "--verbose",
+            "--quiet",
+            "--list",
+            "--no-hot-reload",
+            "--non-interactive")]
+        string arg)
     {
         var args = new[] { arg };
 

--- a/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
+++ b/test/dotnet-watch.Tests/CommandLine/LaunchSettingsTests.cs
@@ -25,8 +25,8 @@ public class DotNetWatcherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenNotExplicitlySpecified(bool hotReload)
     {
         Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
@@ -44,8 +44,8 @@ public class DotNetWatcherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenExplicitlySpecified(bool hotReload)
     {
         Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
@@ -65,8 +65,8 @@ public class DotNetWatcherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task RunsWithDotnetLaunchProfileEnvVariableWhenExplicitlySpecifiedButNotPresentIsEmpty(bool hotReload)
     {
         Assert.IsTrue(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")), "DOTNET_LAUNCH_PROFILE cannot be set already when this test is running");
@@ -84,8 +84,8 @@ public class DotNetWatcherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task RunsWithIterationEnvVariable(bool hotReload)
     {
         var testAsset = TestAssets.CopyTestAsset(AppName)

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -163,8 +163,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task NewFile(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -189,10 +189,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
+
+    [CombinatorialData]
     public async Task NewFileInNewDirectory(bool usePolling, bool nested)
     {
         if (!usePolling && !(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
@@ -236,8 +234,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task ChangeFile(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -254,8 +252,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task MoveFile(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -285,10 +283,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true, true)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(false, false)]
+
+    [CombinatorialData]
     public async Task FileInSubdirectory(bool usePolling, bool watchSubdirectories)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: $"{usePolling}{watchSubdirectories}").Path;
@@ -340,8 +336,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task NoNotificationIfDisabled(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -369,8 +365,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task DisposedNoEvents(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -396,8 +392,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task MultipleFiles(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -426,8 +422,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task MultipleTriggers(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(identifier: usePolling.ToString()).Path;
@@ -486,8 +482,8 @@ public class FileWatcherTests
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task DeleteSubfolder(bool usePolling)
     {
         var dir = TestAssetManager.CreateTestDirectory(usePolling.ToString()).Path;

--- a/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AutoRestartTests.cs
@@ -9,8 +9,7 @@ namespace Microsoft.DotNet.Watch.UnitTests;
 public class AutoRestartTests : DotNetWatchTestBase
 {
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public async Task AutoRestartOnRudeEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())
@@ -55,9 +54,9 @@ public class AutoRestartTests : DotNetWatchTestBase
     }
 
     [TestMethod]
+
+    [CombinatorialData]
     [Ignore("https://github.com/dotnet/sdk/issues/51469")]
-    [DataRow(true)]
-    [DataRow(false)]
     public async Task AutoRestartOnRuntimeRudeEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())
@@ -163,8 +162,8 @@ public class AutoRestartTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task AutoRestartOnNoEffectEdit(bool nonInteractive)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: nonInteractive.ToString())

--- a/test/dotnet-watch.Tests/HotReload/BuildParametersSelectionPromptTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildParametersSelectionPromptTests.cs
@@ -16,10 +16,9 @@ public class BuildParametersSelectionPromptTests
     ];
 
     [TestMethod]
-    [DataRow(0)]
-    [DataRow(1)]
-    [DataRow(2)]
-    public async Task SelectsFrameworkByArrowKeysAndEnter(int index)
+
+    [CombinatorialData]
+    public async Task SelectsFrameworkByArrowKeysAndEnter([CombinatorialRange(0, count: 3)] int index)
     {
         var console = new SpectreTestConsole();
         console.Profile.Capabilities.Interactive = true;
@@ -39,10 +38,9 @@ public class BuildParametersSelectionPromptTests
     }
 
     [TestMethod]
-    [DataRow(0)]
-    [DataRow(1)]
-    [DataRow(2)]
-    public async Task PreviousFrameworkSelectionIsReusedWhenUnchanged(int index)
+
+    [CombinatorialData]
+    public async Task PreviousFrameworkSelectionIsReusedWhenUnchanged([CombinatorialRange(0, count: 3)] int index)
     {
         var console = new SpectreTestConsole();
         console.Profile.Capabilities.Interactive = true;

--- a/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/BuildProjectsTests.cs
@@ -169,8 +169,8 @@ public class BuildProjects
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task FileBasedApp_NoFrameworkProperties(bool isMain)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [isMain]);
@@ -199,8 +199,8 @@ public class BuildProjects
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task FileBasedApp_TargetFrameworkProperty(bool nonInteractive)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [nonInteractive]);
@@ -230,8 +230,8 @@ public class BuildProjects
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task FileBasedApp_TargetFrameworksProperty(bool nonInteractive)
     {
         var dir = TestAssetsManager.CreateTestDirectory(identifiers: [nonInteractive]);

--- a/test/dotnet-watch.Tests/HotReload/FileExclusionTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/FileExclusionTests.cs
@@ -15,22 +15,8 @@ public class FileExclusionTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true, true, DirectoryKind.Ordinary)]
-    [DataRow(true, true, DirectoryKind.Hidden)]
-    [DataRow(true, true, DirectoryKind.Bin)]
-    [DataRow(true, true, DirectoryKind.Obj)]
-    [DataRow(true, false, DirectoryKind.Ordinary)]
-    [DataRow(true, false, DirectoryKind.Hidden)]
-    [DataRow(true, false, DirectoryKind.Bin)]
-    [DataRow(true, false, DirectoryKind.Obj)]
-    [DataRow(false, true, DirectoryKind.Ordinary)]
-    [DataRow(false, true, DirectoryKind.Hidden)]
-    [DataRow(false, true, DirectoryKind.Bin)]
-    [DataRow(false, true, DirectoryKind.Obj)]
-    [DataRow(false, false, DirectoryKind.Ordinary)]
-    [DataRow(false, false, DirectoryKind.Hidden)]
-    [DataRow(false, false, DirectoryKind.Bin)]
-    [DataRow(false, false, DirectoryKind.Obj)]
+
+    [CombinatorialData]
     public async Task IgnoredChange(bool isExisting, bool isIncluded, DirectoryKind directoryKind)
     {
         var testAsset = CopyTestAsset("WatchNoDepsApp", [isExisting, isIncluded, directoryKind]);

--- a/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MauiHotReloadTests.cs
@@ -13,10 +13,9 @@ public class MauiHotReloadTests : DotNetWatchTestBase
     /// Add TestPlatforms.OSX once https://github.com/dotnet/sdk/issues/45521 is fixed.
     /// </summary>
     [TestMethod]
+    [CombinatorialData]
     [OSCondition(OperatingSystems.Windows)]
     [Ignore("https://github.com/dotnet/sdk/issues/54150")]
-    [DataRow(true)]
-    [DataRow(false)]
     public async Task MauiBlazor(bool selectTfm)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchMauiBlazor", identifier: selectTfm.ToString())

--- a/test/dotnet-watch.Tests/HotReload/MetadataUpdateHandlerTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/MetadataUpdateHandlerTests.cs
@@ -41,8 +41,8 @@ public class MetadataUpdateHandlerTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task Exception(bool verbose)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchHotReloadApp", identifier: verbose.ToString())

--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateTests.cs
@@ -50,8 +50,8 @@ public class ProjectUpdateTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task Update(bool isDirectoryProps)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchAppWithProjectDeps", identifier: isDirectoryProps.ToString())

--- a/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RuntimeProcessLauncherTests.cs
@@ -13,8 +13,8 @@ public class RuntimeProcessLauncherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(TriggerEvent.RuntimeProcessLauncherCreated)]
-    [DataRow(TriggerEvent.WaitingForChanges)]
+
+    [CombinatorialData]
     public async Task UpdateAndRudeEdit(TriggerEvent trigger)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [trigger]);
@@ -174,8 +174,8 @@ public class RuntimeProcessLauncherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+
+    [CombinatorialData]
     public async Task UpdateAppliedToNewProcesses(bool sharedOutput)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [sharedOutput]);
@@ -275,9 +275,8 @@ public class RuntimeProcessLauncherTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(UpdateLocation.Dependency)]
-    [DataRow(UpdateLocation.TopLevel)]
-    [DataRow(UpdateLocation.TopFunction)]
+
+    [CombinatorialData]
     public async Task HostRestart(UpdateLocation updateLocation)
     {
         var testAsset = CopyTestAsset("WatchAppMultiProc", [updateLocation]);

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -15,6 +15,7 @@
     <Using Include="Microsoft.NET.TestFramework.Commands" />
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
     <Using Include="Microsoft.NET.TestFramework.ProjectConstruction" />
+    <Using Include="Combinatorial.MSTest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\MockBuildEngine.cs" Link="TestUtilities\MockBuildEngine.cs" />
@@ -36,6 +37,7 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Spectre.Console.Testing" />
+    <PackageReference Include="Combinatorial.MSTest" />
     <!-- Microsoft.NET.TestFramework (xUnit v3 based, pulled in transitively for TestAsset/App helpers
          via Microsoft.DotNet.HotReload.Test.Utilities) needs the xUnit v3 runtime at execution time.
          The transitive reference is ExcludeAssets="Runtime", so reference the v3 runtime directly to


### PR DESCRIPTION
Follow-up to #54903.

That PR migrated `dotnet-watch.Tests` from xUnit to MSTest.Sdk (MTP). As an unwanted side effect, it removed the use of combinatorial test data — every `[CombinatorialData]` method was replaced with hand-expanded `[DataRow(...)]` lists, which are verbose and easy to get out of sync with the parameter space.

This PR restores the combinatorial style using **[`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest)** — the MSTest-native port whose attribute surface (`[CombinatorialData]`, `[CombinatorialValues]`, `[CombinatorialRange]`) matches `Xunit.Combinatorial`. This is the same package already consumed by `test/dotnet.Tests`, and its version flows through central package management (`eng/dependabot/Packages.props`). The xUnit `Xunit.Combinatorial` package is left untouched (still used by other projects).

### Changes
- **`dotnet-watch.Tests.csproj`**: add `Combinatorial.MSTest` `PackageReference` and the `Combinatorial.MSTest` global `Using`.
- **13 test files**: convert the affected methods back from `[TestMethod]` + explicit `[DataRow(...)]` lists to `[TestMethod, CombinatorialData]`, restoring `[CombinatorialValues(...)]` / `[CombinatorialRange(...)]` parameter attributes where needed and preserving `[Ignore]` / `[OSCondition]`:
  - BrowserRefreshServerTests, EvaluationTests, CommandLineOptionsTests, LaunchSettingsTests, FileWatcherTests, AutoRestartTests, BuildParametersSelectionPromptTests, BuildProjectsTests, FileExclusionTests, MauiHotReloadTests, MetadataUpdateHandlerTests, ProjectUpdateTests, RuntimeProcessLauncherTests

All other MSTest migration changes from #54903 (the `[TestMethod]` attribute, MSTest assertions, lifecycle, etc.) are kept intact. Methods that originally used `[InlineData]` (now legitimately `[DataRow]`) are left unchanged.

### Validation
`dotnet build test/dotnet-watch.Tests/dotnet-watch.Tests.csproj` — **Build succeeded, 0 warnings, 0 errors.**