### PR TITLE
Remove unnecessary data point in `dotnetup`

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstaller.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstaller.cs
@@ -17,7 +17,6 @@ internal class DotnetInstaller : IDotnetInstaller
     public void Install(DotnetInstallRoot dotnetRoot, InstallComponent component, ReleaseVersion version)
     {
         using var op = Metrics.Track("install/complete", activityName: "DotnetInstaller.Install");
-        op.Tag("install.root", dotnetRoot.Path);
         op.Tag("install.arch", dotnetRoot.Architecture.ToString());
         op.Tag("install.component", component.ToString());
         op.Tag("install.version", version.ToString());


### PR DESCRIPTION
This is categorized correctly which means it just gets dropped, this used to be not user controlled but now it is. Anyways, let's not waste the processing effort or cause any concern or confusion since this data never gets anywhere anyways.