### PR TITLE
Update MTPHelpSnapshotTests snapshot for --progress option changes

### DIFF
--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -49,7 +49,7 @@ Waiting for options and extensions...
 Platform Options:
   --ansi                          Control whether ANSI escape characters are emitted.
                                   Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
-                                  'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --no-progress if you only want colors.
+                                  'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
                                   When both --ansi and --no-ansi are provided, --ansi wins.
   --debug                         Allows to pause execution in order to attach to the process for debug purposes.
   --diagnostic                    Enable the diagnostic logging. The default log level is 'Trace'.
@@ -66,6 +66,10 @@ Platform Options:
   --ignore-exit-code              Do not report non successful exit value for specific exit codes
                                   (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
   --info                          Display .NET test application information.
+  --progress                      Control whether progress is reported to screen.
+                                  Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
+                                  'auto' shows progress unless the terminal cannot update in place (for example with --no-ansi or in CI).
+                                  This option takes precedence over the deprecated --no-progress flag.
   --show-stderr                   Determines when to show captured error output of a test.
                                   Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an LLM/AI agent environment is detected).
   --show-stdout                   Determines when to show captured standard output of a test.
@@ -74,11 +78,7 @@ Platform Options:
                                   Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.
 
 Extension Options:
-  --ansi                 Control whether ANSI escape characters are emitted.
-                         Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
-                         'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --no-progress if you only want colors.
-                         When both --ansi and --no-ansi are provided, --ansi wins.
   --report-trx           Enable generating TRX report
   --report-trx-filename  The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
-                         Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
+                         Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
                          Example: MyReport_{tfm}.trx


### PR DESCRIPTION
## Summary

Regenerates the `MTPHelpSnapshotTests.VerifyMTPHelpOutput` Verify snapshot to match the current `dotnet test --help` output. This test is failing across **all legs** on the main CI build.

## Changes to snapshot

- `--no-progress` reference updated to `--progress off` in the `--ansi` platform option description
- New `--progress` platform option added (control whether progress is reported to screen)
- `--ansi` removed from Extension Options (it was duplicated from Platform Options)
- `{arch} (process architecture)` placeholder added to `--report-trx-filename` description

## Failing build

https://dev.azure.com/dnceng-public/public/_build/results?buildId=1477619

Fixes #54948

Regression introduced by #54765 (testfx dependency update: Microsoft.Testing.Platform 2.3.0-preview.26307.5 → 2.3.0-preview.26321.1)