### PR TITLE
Fix main build break: convert ToolPackageInstanceTests to MSTest (#54822)

### DIFF
--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstanceTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstanceTests.cs
@@ -6,9 +6,10 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    [TestClass]
     public class ToolPackageInstanceTests
     {
-        [Fact]
+        [TestMethod]
         public void MissingToolSettingsFileMessageIncludesPackageAndVersion()
         {
             var message = ToolPackageInstance.GetMissingToolSettingsFileMessage(


### PR DESCRIPTION
## Summary

Fixes the current `main` build break in `Microsoft.DotNet.PackageInstall.Tests`.

`ToolPackageInstanceTests.cs` (added by #54822) uses the xUnit `[Fact]` attribute, but the project was migrated to **MSTest.Sdk** (`Migrate Microsoft.DotNet.PackageInstall.Tests to MSTest.Sdk on MTP`) and no longer references xUnit, so `[Fact]` fails to compile:

```
ToolPackageInstanceTests.cs(11,10): error CS0246: The type or namespace name 'Fact' could not be found
```

This converts the test to `[TestClass]`/`[TestMethod]` to match the rest of the (MSTest) test project.

## Root cause

A stale-base merge race: #54822 was validated on a pre-migration (xUnit) base, the MSTest migration merged in between, and #54822 was squash-merged later without re-running CI against current `main`. The change doesn't textually conflict, so no merge conflict surfaced and the incompatibility wasn't caught.