### PR TITLE
Stabilize flaky dotnet-watch tests (DeleteSubfolder, ServerAndResources)

### DIFF
--- a/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
@@ -185,9 +185,10 @@ public class AspireLauncherIntegrationTests : MSTestFramework::Microsoft.NET.Tes
         // so there is no race between cancellation and status delivery.
         var statusEvents = await statusReaderTask;
 
-        // validate that we received the expected status events from the server, ignoring the order:
+        // validate that we received the expected status events from the server, ignoring the order
+        // (both sequences are sorted so the comparison does not depend on event arrival order):
         AssertEx.SequenceEqual(
-            expectedStatusEvents,
+            expectedStatusEvents.Order(),
             statusEvents.Select(e => $"type={e.Type}, projects=[{string.Join(";", e.Projects.Order())}]").Order());
     }
 }

--- a/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
+++ b/test/dotnet-watch.Tests/Aspire/AspireLauncherIntegrationTests.cs
@@ -111,8 +111,21 @@ public class AspireLauncherIntegrationTests : MSTestFramework::Microsoft.NET.Tes
         serviceA.Start(testAsset, ["--entrypoint", serviceProjectA]);
         serviceB.Start(testAsset, ["--entrypoint", serviceProjectB]);
 
-        using var statusCancellationSource = new CancellationTokenSource();
-        var statusReaderTask = PipeUtilities.ReadStatusEventsAsync(statusPipeName, statusCancellationSource.Token);
+        // The expected status events delivered by the server over the status pipe (listed in causal order;
+        // the assertion below compares them order-independently). The reader stops once it has received this
+        // many events, so we don't need to cancel based on the server's output, which races with delivery.
+        string[] expectedStatusEvents =
+        [
+            $"type=build_complete, projects=[{serviceProjectA};{serviceProjectB}]",
+            $"type=building, projects=[{serviceProjectA};{serviceProjectB}]",
+            $"type=hot_reload_applied, projects=[{serviceProjectA};{serviceProjectB}]",
+            $"type=process_started, projects=[{serviceProjectA}]",
+            $"type=process_started, projects=[{serviceProjectA}]",
+            $"type=process_started, projects=[{serviceProjectB}]",
+            $"type=restarting, projects=[{serviceProjectA}]",
+        ];
+
+        var statusReaderTask = PipeUtilities.ReadStatusEventsAsync(statusPipeName, expectedStatusEvents.Length, TestContext.CancellationToken);
 
         server.Start(testAsset,
         [
@@ -168,19 +181,13 @@ public class AspireLauncherIntegrationTests : MSTestFramework::Microsoft.NET.Tes
         // initial updates are applied when the process restarts:
         await server.WaitUntilOutputContains(MessageDescriptor.SendingUpdateBatch.GetMessage(0), $"A ({tfm})");
 
-        statusCancellationSource.Cancel();
+        // The reader completes once all expected status events have been received (or the test times out),
+        // so there is no race between cancellation and status delivery.
         var statusEvents = await statusReaderTask;
 
         // validate that we received the expected status events from the server, ignoring the order:
         AssertEx.SequenceEqual(
-        [
-            $"type=build_complete, projects=[{serviceProjectA};{serviceProjectB}]",
-            $"type=building, projects=[{serviceProjectA};{serviceProjectB}]",
-            $"type=hot_reload_applied, projects=[{serviceProjectA};{serviceProjectB}]",
-            $"type=process_started, projects=[{serviceProjectA}]",
-            $"type=process_started, projects=[{serviceProjectA}]",
-            $"type=process_started, projects=[{serviceProjectB}]",
-            $"type=restarting, projects=[{serviceProjectA}]",
-        ], statusEvents.Select(e => $"type={e.Type}, projects=[{string.Join(";", e.Projects.Order())}]").Order());
+            expectedStatusEvents,
+            statusEvents.Select(e => $"type={e.Type}, projects=[{string.Join(";", e.Projects.Order())}]").Order());
     }
 }

--- a/test/dotnet-watch.Tests/Aspire/PipeUtilities.cs
+++ b/test/dotnet-watch.Tests/Aspire/PipeUtilities.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Watch.UnitTests;
 
 internal static class PipeUtilities
 {
-    public static async Task<IReadOnlyList<WatchStatusEvent>> ReadStatusEventsAsync(string pipeName, CancellationToken cancellationToken)
+    public static async Task<IReadOnlyList<WatchStatusEvent>> ReadStatusEventsAsync(string pipeName, int expectedEventCount, CancellationToken cancellationToken)
     {
         var lines = new List<WatchStatusEvent>();
 
@@ -20,7 +20,10 @@ internal static class PipeUtilities
 
         try
         {
-            while (!cancellationToken.IsCancellationRequested)
+            // Read until we have observed the expected number of events. The status events are delivered
+            // over a separate pipe from the server's output, so stopping based on output (instead of the
+            // event count) races with delivery and can drop trailing events.
+            while (lines.Count < expectedEventCount && !cancellationToken.IsCancellationRequested)
             {
                 var line = await reader.ReadLineAsync(cancellationToken);
                 if (line == null)

--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -525,6 +525,10 @@ public class FileWatcherTests
             ],
             usePolling,
             watchSubdirectories: true,
-            () => Directory.Delete(subdir, recursive: true));
+            () => Directory.Delete(subdir, recursive: true),
+            // Restrict to the watched files so the macOS event replay (which intermittently includes a
+            // directory-level "subdir" Add event) doesn't displace one of the expected file events and
+            // make the test flaky.
+            watchedFileNames: ["foo1", "foo2", "foo3"]);
     }
 }


### PR DESCRIPTION
## Summary

Attempt to fix two flaky `dotnet-watch` tests.  This is based on copilot's analysis of failures seen in https://github.com/dotnet/sdk/pull/54945.  One of them also failed on an unrelated PR.  Pipelines:

- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1478226
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1478247

Copilot's descriptions below:

### `FileWatcherTests.DeleteSubfolder`
On macOS the file-system event replay intermittently includes a directory-level `subdir` `Add` event. Because the test stops collecting once it has seen the expected number of events, that spurious event displaces one of the expected file events and the assertion fails. Restrict the watcher to the watched file names (`foo1`/`foo2`/`foo3`) so the directory event is filtered out by the watcher's existing name filter. Harmless on other platforms.

### `AspireLauncherIntegrationTests.ServerAndResources`
Status events are delivered over a separate pipe from the server's output. The test cancelled the status reader based on the server output, which races with status delivery and occasionally dropped the restart's `process_started` event. `ReadStatusEventsAsync` now reads until the expected number of status events has been received instead of relying on output-based cancellation.

Related: #53061 (the existing macOS tracking issue for this test; the `[OSCondition(Exclude)]` is left in place for the watch team to re-evaluate).

## Notes

These touch nondeterministic file-watcher / launcher tests, so they're proposed for watch-team review.

fixes https://github.com/dotnet/sdk/issues/54921