### PR TITLE
Remove redundant [DoNotParallelize] test attributes

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -28,9 +28,12 @@
   <!-- MSTest.Sdk defaults. Applied to projects that opt in via <Project Sdk="MSTest.Sdk">,
        which sets UsingMSTestSdk=true in its Sdk.props before this file is evaluated. -->
   <PropertyGroup Condition="'$(UsingMSTestSdk)' == 'true'">
-    <!-- Run tests in parallel at the method level by default. MSTest.TestAdapter
-         emits the corresponding [assembly: Parallelize(Scope = MethodLevel)] attribute. -->
-    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
+    <!-- Run tests in parallel at the class level by default. MSTest.TestAdapter
+         emits the corresponding [assembly: Parallelize(Scope = ClassLevel)] attribute.
+         Class-level scope runs test methods within a class sequentially while running
+         different classes in parallel, which avoids the intra-class races that method-level
+         parallelism would otherwise require [DoNotParallelize] to guard against. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- Promote info-severity MSTest analyzer rules to warnings and critical rules to errors. -->
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>

--- a/test/EndToEnd.Tests/EndToEnd.Tests.csproj
+++ b/test/EndToEnd.Tests/EndToEnd.Tests.csproj
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- These tests rely on global process state, so run serially ([assembly: DoNotParallelize]). -->
-    <MSTestParallelizeScope></MSTestParallelizeScope>
+    <!-- These tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-[assembly: DoNotParallelize]
-
 namespace EndToEnd.Tests
 {
     [TestClass]

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -7,8 +7,6 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.DotNetSdkResolver;
 using Microsoft.DotNet.MSBuildSdkResolver;
 
-[assembly: DoNotParallelize]
-
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     [TestClass]

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -7,9 +7,9 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <!-- This project's tests rely on global process state, so disable parallelization
-         (the repo default is MethodLevel). [assembly: DoNotParallelize] enforces serial execution. -->
-    <MSTestParallelizeScope></MSTestParallelizeScope>
+    <!-- This project's tests rely on global process state, so disable parallelization.
+         None makes MSTest.Sdk emit [assembly: DoNotParallelize], enforcing serial execution. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
     <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass.
          Disabling this project as references are not building in this case. -->

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -7,9 +7,6 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <!-- This project's tests rely on global process state, so disable parallelization.
-         None makes MSTest.Sdk emit [assembly: DoNotParallelize], enforcing serial execution. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
     <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass.
          Disabling this project as references are not building in this case. -->

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -8,7 +8,6 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class EndToEndToolTests : SdkTest
     {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void Dispose() => Environment.SetEnvironmentVariable(_PATH_VAR_NAME, _originalPath);
     }
 
-    [DoNotParallelize]
     [TestClass]
     public class ToolPackageDownloaderTests : SdkTest
     {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -14,7 +14,6 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class ToolPackageInstallToManagedLocationInstaller : SdkTest
     {

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageUninstallerTests.cs
@@ -15,7 +15,6 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class ToolPackageUninstallerTests : SdkTest
     {

--- a/test/Microsoft.NET.Build.Containers.UnitTests/AuthHandshakeMessageHandlerTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/AuthHandshakeMessageHandlerTests.cs
@@ -10,11 +10,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Microsoft.NET.Build.Containers.UnitTests
 {
     [TestClass]
-    // These tests mutate process-global environment variables (REGISTRY_AUTH_FILE and the
-    // registry credential vars) and rely on AuthHandshakeMessageHandler's static auth-header
-    // cache keyed by a shared registry name. Under MSTest method-level parallelism (the repo
-    // default) the methods/data rows race on that global state, so run them sequentially.
-    [DoNotParallelize]
     public class AuthHandshakeMessageHandlerTests
     {
         public TestContext TestContext { get; set; } = default!;

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -5,7 +5,6 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -22,7 +22,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// location different from the <c>TaskEnvironment.ProjectDirectory</c> so a bug that fell
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGenerateClsidMapMultiThreading
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -12,7 +12,6 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGenerateRuntimeConfigurationFiles
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -13,7 +13,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// the task reads the on-disk data from the right place even when the process
     /// current working directory differs from the project directory.
     /// </summary>
-    [DoNotParallelize]
     [TestClass]
     public class GivenAGetPackagesToPrune
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -5,7 +5,6 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAPickBestRidMultiThreading
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -18,7 +18,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// Verifies TaskEnvironment-based path resolution against ProjectDirectory (not process CWD)
     /// and that output metadata preserves the original path form.
     /// </summary>
-    [DoNotParallelize]
     [TestClass]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAResolvePackageAssetsMultiThreading
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Utilities;
 using Microsoft.NET.Build.Tasks.ConflictResolution;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
-[DoNotParallelize]
 [TestClass]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -19,7 +19,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// <see cref="TaskEnvironment"/>. Tasks default to <see cref="TaskEnvironment.Fallback"/>
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
-    [DoNotParallelize]
     [TestClass]
     public class GivenATaskEnvironmentDefault
     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -17,7 +17,6 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// These tests create files in a "project" directory, then verify task behavior by
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
-[DoNotParallelize]
 [TestClass]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
@@ -6,7 +6,6 @@
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
 {
     [TestClass]
-    [DoNotParallelize]
     public class EnvironmentHelperTests
     {
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
@@ -11,10 +11,6 @@ using Moq;
 namespace Microsoft.NET.Sdk.Razor.Tool
 {
     [TestClass]
-    // GetPidFilePath_UsesEnvironmentVariablePathIfSpecified mutates the process-wide
-    // DOTNET_BUILD_PIDFILE_DIRECTORY environment variable that GetPidFilePath_ReturnsCorrectDefaultPath
-    // reads, so the methods of this class must not run in parallel with each other.
-    [DoNotParallelize]
     public class ServerCommandTest
     {
         [TestMethod]

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
@@ -15,7 +15,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-[DoNotParallelize]
 [TestClass]
 public class ComputeStaticWebAssetsTargetPathsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/CollectStaticWebAssetsToCopyMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/CollectStaticWebAssetsToCopyMultiThreadingTest.cs
@@ -9,9 +9,6 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class CollectStaticWebAssetsToCopyMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest.cs
@@ -16,7 +16,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-[DoNotParallelize]
 [TestClass]
 
 public class ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsMultiThreadingTest.cs
@@ -15,7 +15,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-[DoNotParallelize]
 [TestClass]
 
 public class DiscoverPrecompressedAssetsMultiThreadingTest

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -9,9 +9,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetsManifestMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -10,9 +10,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
@@ -16,11 +16,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// Test parallelization is disabled assembly-wide via
-// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
-// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
-// process-CWD mutation this test performs.
-[DoNotParallelize]
 [TestClass]
 public class MergeConfigurationPropertiesMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
@@ -9,9 +9,6 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class ReadStaticWebAssetsManifestFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
@@ -15,11 +15,6 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// Test parallelization is disabled assembly-wide via
-// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
-// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
-// process-CWD mutation these tests perform.
-[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetTaskEnvironmentTests
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
@@ -10,9 +10,6 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetsGeneratePackManifestMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
@@ -15,11 +15,6 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
-// Test parallelization is disabled assembly-wide via
-// [assembly:CollectionBehavior(DisableTestParallelization = true)] in
-// LegacyStaticWebAssetsV1IntegrationTest.cs, which already isolates the
-// process-CWD mutation this test performs.
-[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/UpdatePackageStaticWebAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/UpdatePackageStaticWebAssetsMultiThreadingTest.cs
@@ -10,9 +10,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// This test mutates the process-wide current directory, so it must not run
-// concurrently with other tests under MSTest's method-level parallelization.
-[DoNotParallelize]
 [TestClass]
 public class UpdatePackageStaticWebAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -19,8 +19,8 @@ namespace Microsoft.NET.ToolPack.Tests
         private string SetupNuGetPackage(bool multiTarget, string packageType = null, [CallerMemberName] string callingMethod = "")
         {
             // Include all distinguishing parameters so each [DataRow] gets a unique test asset
-            // directory. Tests run with method-level parallelization (MSTest.Sdk default), so rows
-            // sharing a directory would race on the copied project files. Sanitize characters that
+            // directory. Tests run in parallel, so rows sharing a directory would race on the
+            // copied project files. Sanitize characters that
             // are unsafe for the directory name and the /bl: binlog argument below.
             string id = $"{callingMethod}-{multiTarget}-{packageType}-{_targetFrameworkOrFrameworks}"
                 .Replace(' ', '_').Replace(',', '_').Replace(';', '_');

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -19,8 +19,8 @@ namespace Microsoft.NET.ToolPack.Tests
         private string SetupNuGetPackage(bool multiTarget, string packageType = null, [CallerMemberName] string callingMethod = "")
         {
             // Include all distinguishing parameters so each [DataRow] gets a unique test asset
-            // directory. Tests run in parallel, so rows sharing a directory would race on the
-            // copied project files. Sanitize characters that
+            // directory. Tests run with method-level parallelization (MSTest.Sdk default), so rows
+            // sharing a directory would race on the copied project files. Sanitize characters that
             // are unsafe for the directory name and the /bl: binlog argument below.
             string id = $"{callingMethod}-{multiTarget}-{packageType}-{_targetFrameworkOrFrameworks}"
                 .Replace(' ', '_').Replace(',', '_').Replace(';', '_');

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithPackagedShim.cs
@@ -10,7 +10,6 @@ using NuGet.Packaging;
 namespace Microsoft.NET.ToolPack.Tests
 {
     [TestClass]
-    [DoNotParallelize]
     public class GivenThatWeWantToPackAToolProjectWithPackagedShim : SdkTest
     {
         private string _testRoot;

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/PostActionTests/AddJsonPropertyPostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/PostActionTests/AddJsonPropertyPostActionTests.cs
@@ -14,10 +14,6 @@ using Moq;
 namespace Microsoft.TemplateEngine.Cli.UnitTests.PostActionTests
 {
     [TestClass]
-    // These tests mutate the process-global static Microsoft.DotNet.Cli.Utils.Reporter via
-    // Reporter.SetError, so they cannot run in parallel with each other (MSTest defaults to
-    // method-level parallelism in this repo).
-    [DoNotParallelize]
     public class AddJsonPropertyPostActionTests
     {
         // MSTest has no IClassFixture equivalent; a lazily-initialized static helper

--- a/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
+++ b/test/dotnet-MsiInstallation.Tests/Framework/VMTestBase.cs
@@ -9,7 +9,6 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.MsiInstallerTests.Framework
 {
-    [DoNotParallelize]
     public class VMTestBase : SdkTest, IDisposable
     {
         private VirtualMachine _vm;

--- a/test/dotnet-aot.Tests/AssemblyInfo.cs
+++ b/test/dotnet-aot.Tests/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-// Tests in this assembly modify process-global state (environment variables,
-// Reporter.Output, Console.Out/Error, AppContext data), so they must not
-// run in parallel.
-[assembly: DoNotParallelize]

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -6,8 +6,8 @@
     <DefineConstants>$(DefineConstants);CLI_AOT</DefineConstants>
     <RootNamespace>Microsoft.DotNet.Cli.Tests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <!-- Tests modify process-global state; run serially ([assembly: DoNotParallelize]). -->
-    <MSTestParallelizeScope></MSTestParallelizeScope>
+    <!-- Tests modify process-global state; run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
 
     <!-- Strong naming deprecated on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/test/dotnet-format.UnitTests/AssemblyInfo.cs
+++ b/test/dotnet-format.UnitTests/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-[assembly: DoNotParallelize]

--- a/test/dotnet-format.UnitTests/dotnet-format.UnitTests.csproj
+++ b/test/dotnet-format.UnitTests/dotnet-format.UnitTests.csproj
@@ -8,7 +8,8 @@
     <RollForward>LatestMajor</RollForward>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);binaries\**;projects\**</DefaultExcludesInProjectFolder>
-    <MSTestParallelizeScope></MSTestParallelizeScope>
+    <!-- Tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet.Tests/CommandTests/MSBuild/DotnetMsbuildInProcTests.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/DotnetMsbuildInProcTests.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.Configurer;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class DotnetMsbuildInProcTests : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
@@ -8,7 +8,6 @@ using BuildCommand = Microsoft.DotNet.Cli.Commands.Build.BuildCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetBuildInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetCleanInvocation.cs
@@ -5,7 +5,6 @@ using CleanCommand = Microsoft.DotNet.Cli.Commands.Clean.CleanCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetCleanInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildBuildsProjects.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// There are tests which modify static TelemetryClient.CurrentSessionId. They cannot run in parallel.
-[assembly: DoNotParallelize]
-
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     [TestClass]

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetMSBuildInvocation.cs
@@ -5,7 +5,6 @@ using MSBuildCommand = Microsoft.DotNet.Cli.Commands.MSBuild.MSBuildCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetMSBuildInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPackInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPackInvocation.cs
@@ -5,7 +5,6 @@ using PackCommand = Microsoft.DotNet.Cli.Commands.Pack.PackCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetPackInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetPublishInvocation.cs
@@ -5,7 +5,6 @@ using PublishCommand = Microsoft.DotNet.Cli.Commands.Publish.PublishCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetPublishInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRestoreInvocation.cs
@@ -7,7 +7,6 @@ using RestoreCommand = Microsoft.DotNet.Cli.Commands.Restore.RestoreCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetRestoreInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
@@ -6,7 +6,6 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetRunInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetStoreInvocation.cs
@@ -5,7 +5,6 @@ using Microsoft.DotNet.Cli.Commands.Tool.Store;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetStoreInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetTestInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetTestInvocation.cs
@@ -6,7 +6,6 @@ using TestCommand = Microsoft.DotNet.Cli.Commands.Test.TestCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenDotnetTestInvocation : SdkTest
     {

--- a/test/dotnet.Tests/CommandTests/Workload/List/GivenAnMsiInstallation.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/List/GivenAnMsiInstallation.cs
@@ -11,7 +11,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.DotNet.Cli.Workload.List.Tests
 {
-    [DoNotParallelize]
     [SupportedOSPlatform("windows")]
     [TestClass]
     public class GivenAnMsiInstallation : IDisposable

--- a/test/dotnet.Tests/ConfigurerTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/test/dotnet.Tests/ConfigurerTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -10,7 +10,6 @@ using static Microsoft.DotNet.Configurer.UnitTests.GivenADotnetFirstTimeUseConfi
 
 namespace Microsoft.DotNet.Configurer.UnitTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class GivenADotnetFirstTimeUseConfigurerWithStateSetup
     {

--- a/test/dotnet.Tests/TelemetryTests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryCommandTest.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Tests.TelemetryTests;
 
-[DoNotParallelize]
 [TestClass]
 public class TelemetryCommandTests : SdkTest
 {

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -11,7 +11,8 @@
     <OutputPath>$(TestHostFolder)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <MSTestParallelizeScope></MSTestParallelizeScope>
+    <!-- Tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose

#54943 disabled in-process parallel test execution by setting `MSTestParallelizeScope=None` (and `parallelizeAssembly`/`parallelizeTestCollections=false` for xUnit). With parallelization globally disabled, the `[DoNotParallelize]` guards scattered across the test suite are now no-ops.

This PR is repurposed from "Default MSTest parallelization to class level" into a pure cleanup: it removes those now-redundant attributes. The original `MSTestParallelizeScope=ClassLevel` change is dropped — the merge keeps main's `None`.

## Changes

- Merged latest `main` (which includes #54943); resolved the `test/Directory.Build.props` conflict in favor of `MSTestParallelizeScope=None`.
- Removed all remaining `[DoNotParallelize]` attributes (class-, method-, and assembly-level), including the ones #54943 left behind:
  - Class-level guards across `Microsoft.NET.Build.Tasks.Tests`, `dotnet.Tests`, `Microsoft.DotNet.PackageInstall.Tests`, `Microsoft.NET.ToolPack.Tests`, the StaticWebAssets multithreading tests, and `DependencyProviderTests`.
  - Method-level guards in `GenerateStaticWebAssetEndpointsPropsFileTest` and `ComputeReferenceStaticWebAssetItemsTest`.
  - Deleted the `[assembly: DoNotParallelize]` `AssemblyInfo.cs` files in `dotnet-aot.Tests` and `dotnet-format.UnitTests`.

No test behavior changes: with parallelization disabled globally, these attributes have no effect. The parallelization-scope portion of the original PR is now handled by #54943.