### PR TITLE
Fix potential assembly mismatches for Microsoft.TestPlatform.ObjectModel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,6 +83,10 @@
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
+    <!-- VSTestBridge requests an older TestPlatform.ObjectModel. Test projects build into the test SDK
+         layout, so that older copy would overwrite the in-box vstest assemblies from TestPlatform.CLI and
+         break 'dotnet test'. Pin it to the in-box vstest version to keep them in sync. -->
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" />


### PR DESCRIPTION
Pin Microsoft.TestPlatform.ObjectModel to the in-box vstest version.

Microsoft.Testing.Extensions.VSTestBridge (pulled in transitively by test projects using MSTest.Sdk/MTP) requests an older Microsoft.TestPlatform.ObjectModel than the in-box vstest shipped by Microsoft.TestPlatform.CLI. Because test projects build into the test SDK layout, that older ObjectModel (and the CoreUtilities / PlatformAbstractions assemblies in the same package) overwrites the newer in-box vstest assemblies, causing `dotnet test` (VSTest mode) to crash with `MissingMethodException: RunConfiguration.get_CreateNoNewWindow`.

With central package transitive pinning enabled, adding a PackageVersion entry pins the transitive ObjectModel to the in-box vstest version so the two stay in sync.

This is a standalone version of the change in #54952, branched from current `main` (which already contains the unrelated `ToolPackageInstanceTests` build-break fix), so it can land independently of that fork-based PR.