### PR TITLE
Ignore MTP exit code 8 (zero tests ran) for Helix work items

### DIFF
--- a/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateXUnitWorkItemsWithTestExclusion.cs
@@ -287,6 +287,14 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
                     string trxArg = enableTrxReport ? "--report-trx " : "";
 
+                    // Sharding by class filter can produce work items whose tests are all skipped
+                    // (or a project may legitimately run zero tests on a given platform, e.g.
+                    // Windows-only Msi tests on Linux/macOS). MTP returns exit code 8 ("zero tests
+                    // ran") in that case, which fails the Helix work item even though nothing is
+                    // actually broken. Treat exit code 8 as success so these runs report green.
+                    // See https://github.com/dotnet/sdk/issues/54963.
+                    string ignoreZeroTestsArg = "--ignore-exit-code 8";
+
                     // .NET Framework apphosts (TargetPath is the '.exe') run directly; .NET (Core)
                     // assemblies (TargetPath is the '.dll') run via 'dotnet exec'.
                     string mtpLauncher = runtimeTargetFrameworkParsed.Framework == ".NETFramework"
@@ -294,7 +302,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                         : $"{driver} exec {assemblyName}";
 
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{mtpLauncher} " +
-                              $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg}";
+                              $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg} {ignoreZeroTestsArg}";
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

Some Helix work items fail with **exit code 8** even though the test results tab shows everything green, which is confusing and has led to PRs being merged in a falsely-failing state (see #54963, #54788).

Exit code `8` in Microsoft.Testing.Platform (MTP) means [**"the test session ran zero tests"**](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes).

## Root cause

The affected assemblies (`dotnet-aot.Tests`, `Microsoft.Win32.Msi.Tests`, …) are all `MSTest.Sdk` → MTP projects. They run through the `isMTPProject` branch in `SDKCustomCreateXUnitWorkItemsWithTestExclusion`, invoked as `dotnet exec <dll> --filter ...`.

A work item ends up running zero tests when:
- class-based sharding (`--filter`) isolates a partition containing only skipped tests, or
- a project legitimately runs no tests on a platform (e.g. Windows-only Msi tests on Linux/macOS).

MTP then returns exit code 8 and Helix treats the nonzero exit as a failure.

## Fix

Add `--ignore-exit-code 8` to the MTP work-item command so "zero tests ran" reports success instead of failing the work item. This is the mitigation called out in the issue.

- Scoped to the MTP branch only — the VSTest `dotnet test` path doesn't use MTP exit codes and is untouched.
- Real failures (exit 2, crashes, setup errors, etc.) still surface.

The stricter long-term fix (relaxing exit 8 on the test-platform side when tests exist but are all skipped) is tracked separately.

Fixes #54963