### PR TITLE
Add dotnetup local SDK setup

### DIFF
--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -162,3 +162,4 @@ This lets you change your path preference (Isolation → Terminal, etc.) or inst
 - [Install SDKs with global.json](./usecases/install-with-global-json.md) — Install the right SDK version for a project automatically
 - [Update SDK and Runtime Installations](./usecases/update-installations.md) — Keep your .NET installations current
 - [Try Daily Builds](./usecases/try-daily-builds.md) — Safely test pre-release .NET builds
+- [Project-local SDK setup design](./designs/project-local-sdk-setup.md) — API rationale and tradeoffs for repository-local SDK installs

--- a/documentation/general/dotnetup/designs/project-local-sdk-setup.md
+++ b/documentation/general/dotnetup/designs/project-local-sdk-setup.md
@@ -1,0 +1,68 @@
+# Project-local SDK setup
+
+## Scenario
+
+Some repositories want a self-contained SDK setup that can be bootstrapped from a clean checkout without asking every contributor to install a matching SDK into their user-wide dotnetup root first. The expected result is:
+
+- A .NET SDK installed under the repository, normally in `.dotnet`.
+- A `global.json` that uses .NET 10 SDK `paths` so normal `dotnet` commands resolve the repository SDK first and then fall back to the host SDK.
+- A `.gitignore` entry that prevents the SDK archive contents from being committed.
+- No PATH, profile, DOTNET_ROOT, or default-install-root mutation.
+
+This scenario still requires a .NET 10 or later host on PATH because the host is the component that understands `global.json` `sdk.paths`.
+
+## Proposed command shape
+
+```bash
+dotnetup sdk install 10.0.100 --local
+dotnetup install 10.0.100 --local
+```
+
+`--local` means "configure this repository to use an SDK installed next to its `global.json`." It is intentionally limited to SDK installs because `global.json` SDK resolution does not select runtimes.
+
+## Behavior
+
+1. Find the nearest `global.json` in the current directory or a parent directory.
+2. If no `global.json` exists, create one in the current directory.
+3. Install the resolved SDK into `.dotnet` next to that `global.json`.
+4. Merge `sdk.paths` into `global.json` as `[".dotnet", "$host$"]`.
+5. Preserve unrelated top-level `global.json` sections such as `tools` and `msbuild-sdks`.
+6. Add `.dotnet/` to the adjacent `.gitignore` idempotently.
+7. Record the install spec as global.json-sourced so update/uninstall logic can reason about it.
+
+Exact version requests write `rollForward: "disable"`. Channel requests write a roll-forward policy matching the requested channel scope and store the resolved SDK version.
+
+## API alternatives considered
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| `--local` | Short; common CLI term for "put it in this repo"; does not overload existing `--install-path`; maps directly to the end result. | "Local" can also mean user-local vs system-wide, archive vs system installer, or PATH visibility. Needs documentation to define it as project-local SDK setup. |
+| `--project-local` | More explicit than `--local`. | Longer and less discoverable; still requires explaining global.json and `.dotnet` behavior. |
+| `--install-path .dotnet --update-global-json` | Reuses existing options. | Easy to miss required `sdk.paths`, `.gitignore`, host validation, exact-version pinning, and update-tracking semantics; more chances for partially configured repos. |
+| `--install-path here` or another sentinel value | Reuses the existing install-path concept. | Makes `--install-path` perform more than path selection; special string values are harder to compose with explicit paths and require separate documentation anyway. |
+| Keep all SDKs in the dotnetup root and only update global.json | Preserves the dotnetup-managed hive model. | Does not satisfy repositories that want checkout-local SDK contents and does not provide an offline/team bootstrap artifact in the repo root. |
+
+## Why not only `--install-path`
+
+`--install-path` answers "where should the archive be extracted?" Project-local SDK setup is a higher-level workflow:
+
+- It edits `global.json`.
+- It depends on a .NET 10 host capability.
+- It chooses `.dotnet` relative to the project boundary, not necessarily the shell's current directory.
+- It updates `.gitignore`.
+- It should avoid PATH/profile/default-root mutation even though normal installs may perform onboarding steps.
+
+Keeping this as a dedicated switch makes the user's intent explicit and lets dotnetup validate the whole workflow rather than accepting a path and leaving the repository half-configured.
+
+## Install root tradeoff
+
+The existing dotnetup model generally manages SDKs in the dotnetup install root and tracks project demand through global.json-derived install specs. Project-local SDK setup intentionally creates a second, repository-owned root. That is useful when the repository wants its bootstrap command to leave the required SDK inside the checkout.
+
+This does create tradeoffs:
+
+- dotnetup update and uninstall need to retain enough manifest metadata to distinguish project-local roots from the default dotnetup root.
+- Garbage collection must not remove a repo-local SDK that is still referenced by that repo's global.json.
+- Users may have multiple copies of the same SDK across repositories.
+
+If the product direction is to avoid repository-owned SDK roots, the same global.json `paths` setup could point at a dotnetup-managed root instead. That would make this feature more of a "configure global.json for dotnetup" workflow than a "project-local SDK" workflow, and the command name should reflect that difference.
+

--- a/documentation/general/dotnetup/usecases/install-with-global-json.md
+++ b/documentation/general/dotnetup/usecases/install-with-global-json.md
@@ -23,6 +23,41 @@ Installed .NET SDK 10.0.102 to C:\Users\you\.dotnet
 
 These SDKs are installed into the 'dotnetup install root' and are available for use in your projects. `dotnetup` tracks which versions and channels are required by your projects and ensures that when you install or update new versions that none of your existing projects needs are broken.
 
+## Project-local SDK installs
+
+Use `--local` when you want the SDK installed into the repository itself instead of the default dotnetup install root:
+
+```
+$ dotnetup sdk install 10.0.100 --local
+Installing .NET SDK 10.0.100 to C:\src\myproject\.dotnet...
+Installed at C:\src\myproject\.dotnet:
+  .NET SDK 10.0.100
+Configured C:\src\myproject\global.json to use .dotnet before the host SDK fallback.
+```
+
+`--local`:
+
+- Installs the SDK into `.dotnet` next to the nearest `global.json`. If no `global.json` exists, dotnetup creates one in the current directory.
+- Writes portable SDK resolution settings:
+
+  ```json
+  {
+    "sdk": {
+      "version": "10.0.100",
+      "rollForward": "disable",
+      "paths": [".dotnet", "$host$"]
+    }
+  }
+  ```
+
+- Preserves existing top-level `global.json` sections such as `msbuild-sdks` and `tools`.
+- Adds `.dotnet/` to the adjacent `.gitignore` so the SDK is not committed.
+- Does not update PATH, DOTNET_ROOT, shell profiles, or dotnetup default-install settings.
+
+The `paths` feature is evaluated by the `dotnet` host. The machine still needs a .NET 10 or later host on PATH so normal `dotnet` commands can understand `sdk.paths` and find the project-local SDK.
+
+`--local` configures a single SDK version. Exact version requests write `rollForward: "disable"`; floating channels write a roll-forward policy matching the requested scope and store the resolved SDK version in `global.json`.
+
 ## Channel Resolution from global.json
 
 The combination of `sdk.version` and `sdk.rollForward` determines the channel that dotnetup tracks:

--- a/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using Microsoft.Dotnet.Installation;
 using Microsoft.Dotnet.Installation.Internal;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 

--- a/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using Microsoft.Dotnet.Installation;
 using Microsoft.Dotnet.Installation.Internal;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 
@@ -18,6 +19,13 @@ internal class SdkInstallCommand(ParseResult result) : InstallCommand(result)
 
     protected override void ExecuteCore()
     {
+        if (LocalInstall && _channels.Length > 1)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                "The --local option can configure one SDK version in global.json. Specify a single channel or version.");
+        }
+
         // Map each channel to a MinimalInstallSpec. If none provided, a single null-channel
         // entry lets the workflow fall back to global.json or "latest".
         var specs = _channels.Length > 0

--- a/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommandParser.cs
+++ b/src/Installer/dotnetup.Library/Commands/Sdk/Install/SdkInstallCommandParser.cs
@@ -41,6 +41,7 @@ internal static class SdkInstallCommandParser
         command.Arguments.Add(ChannelArguments);
 
         command.Options.Add(CommonOptions.InstallPathOption);
+        command.Options.Add(CommonOptions.LocalInstallOption);
         command.Options.Add(CommonOptions.SetDefaultInstallOption);
         command.Options.Add(CommonOptions.MigrateFromSystemOption);
         command.Options.Add(UpdateGlobalJsonOption);
@@ -55,9 +56,37 @@ internal static class SdkInstallCommandParser
         command.Options.Add(CommonOptions.RequireMuxerUpdateOption);
         command.Options.Add(CommonOptions.UntrackedOption);
         command.Validators.Add(CommonOptions.RejectShellOptionOnInstallCommand());
+        command.Validators.Add(RejectConflictingLocalInstallOptions());
 
         command.SetAction(parseResult => new SdkInstallCommand(parseResult).Execute());
 
         return command;
     }
+
+    private static Action<System.CommandLine.Parsing.CommandResult> RejectConflictingLocalInstallOptions()
+    {
+        return commandResult =>
+        {
+            if (!HasOption(commandResult, CommonOptions.LocalInstallOption))
+            {
+                return;
+            }
+
+            RejectIfPresent(commandResult, CommonOptions.InstallPathOption, "The --local option chooses the project-local .dotnet install path, so it can't be combined with --install-path.");
+            RejectIfPresent(commandResult, CommonOptions.SetDefaultInstallOption, "The --local option does not modify PATH or DOTNET_ROOT, so it can't be combined with --set-default-install.");
+            RejectIfPresent(commandResult, CommonOptions.MigrateFromSystemOption, "The --local option installs only the requested project SDK, so it can't be combined with --migrate-from-system.");
+            RejectIfPresent(commandResult, UpdateGlobalJsonOption, "The --local option always configures global.json, so it can't be combined with --update-global-json.");
+        };
+    }
+
+    private static void RejectIfPresent(System.CommandLine.Parsing.CommandResult commandResult, Option option, string message)
+    {
+        if (HasOption(commandResult, option))
+        {
+            commandResult.AddError(message);
+        }
+    }
+
+    private static bool HasOption(System.CommandLine.Parsing.CommandResult commandResult, Option option)
+        => commandResult.GetResult(option) is not null;
 }

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallCommand.cs
@@ -16,6 +16,7 @@ internal abstract class InstallCommand : CommandBase
 {
     public string? InstallPath { get; }
     public string? ManifestPath { get; }
+    public bool LocalInstall { get; }
     public bool Interactive { get; }
     public bool NoProgress { get; }
     public Verbosity Verbosity { get; }
@@ -34,6 +35,8 @@ internal abstract class InstallCommand : CommandBase
     {
         InstallPath = parseResult.GetValue(CommonOptions.InstallPathOption);
         ManifestPath = parseResult.GetValue(CommonOptions.ManifestPathOption);
+        LocalInstall = parseResult.GetResult(CommonOptions.LocalInstallOption) is not null
+            && parseResult.GetValue(CommonOptions.LocalInstallOption);
         Interactive = parseResult.GetValue(CommonOptions.InteractiveOption);
         NoProgress = parseResult.GetValue(CommonOptions.NoProgressOption);
         Verbosity = parseResult.GetValue(CommonOptions.VerbosityOption);

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -38,6 +38,12 @@ internal class InstallWorkflow
     /// </summary>
     public void Execute(MinimalInstallSpec[] componentSpecs)
     {
+        if (_command.LocalInstall)
+        {
+            ExecuteLocalSdkInstall(componentSpecs);
+            return;
+        }
+
         bool runOnboarding = ShouldRunFirstUseOnboarding(_command.Interactive, _command.InstallPath, _command.MigrateFromSystem);
         bool promptForStarterChannel = ShouldPromptForStarterChannel(runOnboarding, componentSpecs);
         List<ResolvedInstallRequest> requests;
@@ -122,11 +128,17 @@ internal class InstallWorkflow
         MinimalInstallSpec[] componentSpecs)
     {
         var globalJson = GlobalJsonModifier.GetGlobalJsonInfo(Environment.CurrentDirectory);
+        return GenerateInstallRequests(componentSpecs, globalJson, pathResolutionOverride: null);
+    }
+
+    private List<ResolvedInstallRequest> GenerateInstallRequests(
+        MinimalInstallSpec[] componentSpecs,
+        GlobalJsonInfo? globalJson,
+        InstallPathResolver.InstallPathResolutionResult? pathResolutionOverride)
+    {
         var currentInstallRoot = _command.DotnetEnvironment.GetCurrentPathConfiguration();
 
-        var pathResolution = _installPathResolver.Resolve(
-            _command.InstallPath,
-            globalJson);
+        var pathResolution = pathResolutionOverride ?? _installPathResolver.Resolve(_command.InstallPath, globalJson);
 
         ValidateInstallPath(pathResolution.ResolvedInstallPath, pathResolution.PathSource, _command.ManifestPath);
 
@@ -142,6 +154,41 @@ internal class InstallWorkflow
         }
 
         return requests;
+    }
+
+    private void ExecuteLocalSdkInstall(MinimalInstallSpec[] componentSpecs)
+    {
+        if (componentSpecs is not [{ Component: InstallComponent.SDK }])
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                "The --local option only supports installing one .NET SDK.");
+        }
+
+        string? requestedChannel = componentSpecs[0].VersionOrChannel;
+        var plan = LocalSdkSetupPlan.Create(Environment.CurrentDirectory, requestedChannel);
+        LocalSdkHostValidator.EnsureHostSupportsSdkPaths();
+
+        var pathResolution = new InstallPathResolver.InstallPathResolutionResult(
+            plan.LocalDotnetPath,
+            plan.LocalDotnetPath,
+            PathSource.GlobalJson);
+
+        var requests = GenerateInstallRequests(componentSpecs, plan.GlobalJsonInfo, pathResolution);
+        ExecuteInstallRequests(requests);
+
+        var resolvedRequest = requests[0];
+        var settings = LocalSdkSetupSettings.Create(
+            requestedChannel,
+            plan.GlobalJsonExisted,
+            plan.GlobalJsonInfo,
+            resolvedRequest.ResolvedVersion);
+
+        GlobalJsonModifier.ApplyLocalSdkSetup(plan.GlobalJsonPath, settings);
+        GitIgnoreUpdater.EnsureDotnetDirectoryIgnored(plan.ProjectDirectory);
+
+        SpectreAnsiConsole.MarkupLine(
+            $"Configured {DotnetupTheme.Dim(plan.GlobalJsonPath.EscapeMarkup())} to use {DotnetupTheme.Accent(".dotnet".EscapeMarkup())} before the host SDK fallback.");
     }
 
     internal static bool ShouldRunFirstUseOnboarding(bool interactive, string? installPath, bool migrateFromSystem = false)
@@ -189,6 +236,7 @@ internal class InstallWorkflow
                 + "a daily-build scope like '10.0-daily' or '10.0.1xx-daily', or a fully-qualified version like '10.0.103'.");
         }
 
+        bool useGlobalJsonSource = isFromGlobalJson || _command.LocalInstall;
         var request = new DotnetInstallRequest(
             installRoot,
             new UpdateChannel(channel),
@@ -197,8 +245,8 @@ internal class InstallWorkflow
             {
                 ManifestPath = _command.ManifestPath,
                 RequireMuxerUpdate = _command.RequireMuxerUpdate,
-                InstallSource = isFromGlobalJson ? InstallRequestSource.GlobalJson : InstallRequestSource.Explicit,
-                GlobalJsonPath = (isFromGlobalJson || _command.UpdateGlobalJson) ? globalJson?.GlobalJsonPath : null,
+                InstallSource = useGlobalJsonSource ? InstallRequestSource.GlobalJson : InstallRequestSource.Explicit,
+                GlobalJsonPath = (useGlobalJsonSource || _command.UpdateGlobalJson) ? globalJson?.GlobalJsonPath : null,
                 Untracked = _command.Untracked,
                 Verbosity = _command.Verbosity
             });

--- a/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkHostValidator.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkHostValidator.cs
@@ -44,7 +44,24 @@ internal static class LocalSdkHostValidator
         }
         finally
         {
-            Directory.Delete(workingDirectory);
+            DeleteWorkingDirectory(workingDirectory);
+        }
+    }
+
+    private static void DeleteWorkingDirectory(string workingDirectory)
+    {
+        try
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 

--- a/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkHostValidator.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkHostValidator.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Dotnet.Installation;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+
+/// <summary>
+/// Validates that the dotnet host on PATH can understand global.json sdk.paths.
+/// The sdk.paths feature is consumed by the host, so installing a local SDK is not enough when the host is older than .NET 10.
+/// </summary>
+internal static class LocalSdkHostValidator
+{
+    public static void EnsureHostSupportsSdkPaths()
+    {
+        string version = GetDotnetHostVersion();
+        if (!TryGetMajorVersion(version, out int major) || major < 10)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                $".NET SDK resolution through global.json sdk.paths requires a .NET 10 or later host on PATH. The current 'dotnet --info' Host.Version is '{version}'.");
+        }
+    }
+
+    internal static bool TryGetMajorVersion(string version, out int major)
+    {
+        major = 0;
+        int dotIndex = version.IndexOf('.', StringComparison.Ordinal);
+        string majorPart = dotIndex >= 0 ? version.Substring(0, dotIndex) : version;
+        return int.TryParse(majorPart, NumberStyles.None, CultureInfo.InvariantCulture, out major);
+    }
+
+    private static string GetDotnetHostVersion()
+    {
+        string workingDirectory = Path.Combine(Path.GetTempPath(), "dotnetup-host-check-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workingDirectory);
+
+        try
+        {
+            return GetDotnetHostVersion(workingDirectory);
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory);
+        }
+    }
+
+    private static string GetDotnetHostVersion(string workingDirectory)
+    {
+        try
+        {
+            string output = RunDotnetInfo(workingDirectory);
+            if (TryGetHostVersionFromInfo(output, out string hostVersion))
+            {
+                return hostVersion;
+            }
+
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                "Unable to verify that the dotnet host on PATH supports global.json sdk.paths because 'dotnet --info' did not report a Host.Version value.");
+        }
+        catch (Win32Exception ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                "Unable to verify global.json sdk.paths support because the dotnet host was not found on PATH. Install .NET 10 or later first.",
+                ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                "Unable to verify global.json sdk.paths support because dotnet could not be started.",
+                ex);
+        }
+    }
+
+    private static string RunDotnetInfo(string workingDirectory)
+    {
+        using var process = new Process();
+        process.StartInfo.FileName = "dotnet";
+        process.StartInfo.Arguments = "--info";
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.CreateNoWindow = true;
+        process.StartInfo.WorkingDirectory = workingDirectory;
+
+        if (!process.Start())
+        {
+            throw CreateDotnetNotFoundException();
+        }
+
+        string output = process.StandardOutput.ReadToEnd().Trim();
+        string error = process.StandardError.ReadToEnd().Trim();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+        {
+            string details = string.IsNullOrWhiteSpace(error) ? "no version output was produced" : error;
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                $"Unable to verify that the dotnet host on PATH supports global.json sdk.paths because 'dotnet --info' failed: {details}");
+        }
+
+        return output;
+    }
+
+    private static DotnetInstallException CreateDotnetNotFoundException()
+        => new(
+            DotnetInstallErrorCode.ContextResolutionFailed,
+            "Unable to verify global.json sdk.paths support because the dotnet host was not found on PATH. Install .NET 10 or later first.");
+
+    internal static bool TryGetHostVersionFromInfo(string dotnetInfo, out string hostVersion)
+    {
+        hostVersion = string.Empty;
+        bool inHostSection = false;
+
+        foreach (string line in dotnetInfo.Split(["\r\n", "\n"], StringSplitOptions.None))
+        {
+            string trimmed = line.Trim();
+            if (string.Equals(trimmed, "Host:", StringComparison.Ordinal))
+            {
+                inHostSection = true;
+                continue;
+            }
+
+            if (!inHostSection)
+            {
+                continue;
+            }
+
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (!trimmed.StartsWith("Version:", StringComparison.Ordinal))
+            {
+                if (!char.IsWhiteSpace(line[0]))
+                {
+                    inHostSection = false;
+                }
+
+                continue;
+            }
+
+            hostVersion = trimmed["Version:".Length..].Trim();
+            return !string.IsNullOrWhiteSpace(hostVersion);
+        }
+
+        return false;
+    }
+}

--- a/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkSetupPlan.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkSetupPlan.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.Dotnet.Installation;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+
+/// <summary>
+/// Determines which project global.json file and sibling .dotnet directory a local SDK install should use.
+/// Assumes the nearest global.json found by walking up from the starting directory owns that project scope.
+/// </summary>
+internal sealed record LocalSdkSetupPlan(
+    string ProjectDirectory,
+    string GlobalJsonPath,
+    string LocalDotnetPath,
+    bool GlobalJsonExisted,
+    GlobalJsonInfo GlobalJsonInfo)
+{
+    public static LocalSdkSetupPlan Create(string startDirectory, string? requestedChannel)
+    {
+        string fullStartDirectory = Path.GetFullPath(startDirectory);
+        GlobalJsonInfo globalJsonInfo;
+        try
+        {
+            globalJsonInfo = GlobalJsonModifier.GetGlobalJsonInfo(fullStartDirectory);
+        }
+        catch (JsonException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.UserConfigurationCorrupted,
+                $"The global.json file found while resolving local SDK setup is not valid JSON: {ex.Message}",
+                ex);
+        }
+
+        bool globalJsonExisted = globalJsonInfo.GlobalJsonPath is not null;
+        string projectDirectory = globalJsonExisted
+            ? Path.GetDirectoryName(globalJsonInfo.GlobalJsonPath!)!
+            : fullStartDirectory;
+        string globalJsonPath = globalJsonInfo.GlobalJsonPath ?? Path.Combine(projectDirectory, "global.json");
+
+        if (globalJsonExisted
+            && string.IsNullOrWhiteSpace(globalJsonInfo.SdkVersion)
+            && string.IsNullOrWhiteSpace(requestedChannel))
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                $"The global.json file at '{globalJsonPath}' does not specify sdk.version. Specify the SDK channel or version to install locally.");
+        }
+
+        string localDotnetPath = Path.GetFullPath(Path.Combine(projectDirectory, ".dotnet"));
+        RejectReparsePoint(localDotnetPath);
+
+        globalJsonInfo.GlobalJsonPath = globalJsonPath;
+        return new LocalSdkSetupPlan(
+            projectDirectory,
+            globalJsonPath,
+            localDotnetPath,
+            globalJsonExisted,
+            globalJsonInfo);
+    }
+
+    private static void RejectReparsePoint(string localDotnetPath)
+    {
+        if (!Directory.Exists(localDotnetPath))
+        {
+            return;
+        }
+
+        if ((File.GetAttributes(localDotnetPath) & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.ContextResolutionFailed,
+                $"The local SDK directory '{localDotnetPath}' is a symlink or reparse point. Remove it or replace it with a regular directory before using --local.");
+        }
+    }
+}

--- a/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkSetupSettings.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/LocalSdkSetupSettings.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Dotnet.Installation.Internal;
+
+namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+
+/// <summary>
+/// Describes the sdk properties dotnetup should write for project-local SDK resolution.
+/// Keeps roll-forward decisions separate from file mutation so they can be tested independently.
+/// </summary>
+internal sealed record LocalSdkSetupSettings(
+    string SdkVersion,
+    string? RollForward,
+    bool UpdateRollForward,
+    bool? AllowPrerelease,
+    bool UpdateAllowPrerelease)
+{
+    public static LocalSdkSetupSettings Create(
+        string? requestedChannel,
+        bool globalJsonExisted,
+        GlobalJsonInfo globalJsonInfo,
+        ReleaseVersion resolvedVersion)
+    {
+        bool commandSelectedVersion = !string.IsNullOrWhiteSpace(requestedChannel) || !globalJsonExisted;
+        string? rollForward = commandSelectedVersion
+            ? GetRollForwardForRequestedChannel(requestedChannel ?? ChannelVersionResolver.LatestChannel)
+            : globalJsonInfo.RollForward;
+
+        bool isPrerelease = !string.IsNullOrEmpty(resolvedVersion.Prerelease);
+        bool? allowPrerelease = commandSelectedVersion
+            ? isPrerelease ? true : null
+            : isPrerelease ? true : globalJsonInfo.AllowPrerelease;
+
+        return new LocalSdkSetupSettings(
+            resolvedVersion.ToString(),
+            rollForward,
+            UpdateRollForward: commandSelectedVersion || rollForward is not null,
+            allowPrerelease,
+            UpdateAllowPrerelease: commandSelectedVersion || isPrerelease || globalJsonInfo.AllowPrerelease is not null);
+    }
+
+    internal static string GetRollForwardForRequestedChannel(string requestedChannel)
+    {
+        var channel = new UpdateChannel(requestedChannel);
+        if (channel.IsFullySpecifiedVersion())
+        {
+            return "disable";
+        }
+
+        string channelName = UpdateChannel.StripDailySuffix(requestedChannel);
+        if (ChannelVersionResolver.KnownChannelKeywords.Any(keyword =>
+            string.Equals(keyword, channelName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return "latestPatch";
+        }
+
+        var parts = channelName.Split('.');
+        if (parts.Length == 1 && int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            return "latestMinor";
+        }
+
+        if (parts.Length == 2
+            && int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out _)
+            && int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            return "latestFeature";
+        }
+
+        return "latestPatch";
+    }
+}

--- a/src/Installer/dotnetup.Library/CommonOptions.cs
+++ b/src/Installer/dotnetup.Library/CommonOptions.cs
@@ -59,6 +59,12 @@ internal class CommonOptions
         Description = "The path to install .NET to",
     };
 
+    public static readonly Option<bool> LocalInstallOption = new("--local")
+    {
+        Description = "Install the SDK into a project-local .dotnet directory and configure global.json sdk.paths.",
+        Arity = ArgumentArity.Zero
+    };
+
     public static readonly Option<IEnvShellProvider?> ShellOption = new("--shell", "-s")
     {
         Description = $"The shell to use for profile-based environment configuration (supported: {string.Join(", ", ShellDetection.s_supportedShells.Select(s => s.ArgumentName))}). If not specified, the current shell will be detected.",

--- a/src/Installer/dotnetup.Library/GitIgnoreUpdater.cs
+++ b/src/Installer/dotnetup.Library/GitIgnoreUpdater.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Bootstrapper;
+
+/// <summary>
+/// Maintains the project .gitignore entry needed for repo-local .NET SDK installs.
+/// Assumes the .gitignore file lives next to the local .dotnet directory configured in global.json.
+/// </summary>
+internal static class GitIgnoreUpdater
+{
+    private const string DotnetIgnoreEntry = ".dotnet/";
+
+    public static void EnsureDotnetDirectoryIgnored(string projectDirectory)
+    {
+        string gitIgnorePath = Path.Combine(projectDirectory, ".gitignore");
+        if (!File.Exists(gitIgnorePath))
+        {
+            File.WriteAllText(gitIgnorePath, DotnetIgnoreEntry + Environment.NewLine);
+            return;
+        }
+
+        string content = File.ReadAllText(gitIgnorePath);
+        if (ContainsDotnetIgnoreEntry(content))
+        {
+            return;
+        }
+
+        string newline = content.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        string prefix = content.Length == 0 || content.EndsWith('\n') || content.EndsWith('\r')
+            ? string.Empty
+            : newline;
+
+        File.AppendAllText(gitIgnorePath, prefix + DotnetIgnoreEntry + newline);
+    }
+
+    private static bool ContainsDotnetIgnoreEntry(string content)
+    {
+        var lines = content.Split(["\r\n", "\n", "\r"], StringSplitOptions.None);
+        return lines.Any(line =>
+        {
+            string trimmed = line.Trim();
+            return string.Equals(trimmed, DotnetIgnoreEntry, StringComparison.Ordinal)
+                || string.Equals(trimmed, ".dotnet", StringComparison.Ordinal)
+                || string.Equals(trimmed, "/" + DotnetIgnoreEntry, StringComparison.Ordinal);
+        });
+    }
+}

--- a/src/Installer/dotnetup.Library/GlobalJsonContents.cs
+++ b/src/Installer/dotnetup.Library/GlobalJsonContents.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;
@@ -20,7 +21,11 @@ public class GlobalJsonContents
     public SdkSection? Sdk { get; set; }
 }
 
-[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    AllowTrailingCommas = true,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
 [JsonSerializable(typeof(GlobalJsonContents))]
 public partial class GlobalJsonContentsJsonContext : JsonSerializerContext
 {

--- a/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
+++ b/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
@@ -124,7 +124,12 @@ public static class GlobalJsonModifier
         sdkObject["paths"] = new JsonArray(".dotnet", "$host$");
 
         string updatedJson = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
-        Directory.CreateDirectory(Path.GetDirectoryName(globalJsonPath)!);
+        string? directory = Path.GetDirectoryName(globalJsonPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
         File.WriteAllText(globalJsonPath, updatedJson, encoding);
     }
 

--- a/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
+++ b/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Deployment.DotNet.Releases;
+using Microsoft.Dotnet.Installation;
+using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;
 
@@ -104,6 +107,28 @@ public static class GlobalJsonModifier
     }
 
     /// <summary>
+    /// Merges the SDK properties required for project-local SDK resolution into global.json.
+    /// Unknown root sections are preserved; comments are accepted while reading but are not preserved on write.
+    /// </summary>
+    internal static void ApplyLocalSdkSetup(string globalJsonPath, LocalSdkSetupSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(globalJsonPath);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var (root, encoding) = ReadOrCreateGlobalJsonObject(globalJsonPath);
+        var sdkObject = GetOrCreateSdkObject(root, globalJsonPath);
+
+        sdkObject["version"] = settings.SdkVersion;
+        SetOrRemove(sdkObject, "rollForward", settings.RollForward, settings.UpdateRollForward);
+        SetOrRemove(sdkObject, "allowPrerelease", settings.AllowPrerelease, settings.UpdateAllowPrerelease);
+        sdkObject["paths"] = new JsonArray(".dotnet", "$host$");
+
+        string updatedJson = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
+        Directory.CreateDirectory(Path.GetDirectoryName(globalJsonPath)!);
+        File.WriteAllText(globalJsonPath, updatedJson, encoding);
+    }
+
+    /// <summary>
     /// Replaces the "version" value inside the "sdk" section of a global.json string,
     /// preserving all existing formatting. Uses <see cref="Utf8JsonReader"/> to find
     /// exact token positions.
@@ -155,6 +180,94 @@ public static class GlobalJsonModifier
         }
 
         return null;
+    }
+
+    private static (JsonObject Root, System.Text.Encoding Encoding) ReadOrCreateGlobalJsonObject(string globalJsonPath)
+    {
+        if (!File.Exists(globalJsonPath))
+        {
+            return ([], System.Text.Encoding.UTF8);
+        }
+
+        var (fileText, encoding) = GlobalJsonFileHelper.ReadFileWithEncodingDetection(globalJsonPath);
+        try
+        {
+            JsonNode? rootNode = JsonNode.Parse(
+                fileText,
+                nodeOptions: null,
+                documentOptions: new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true,
+                    CommentHandling = JsonCommentHandling.Skip
+                });
+
+            if (rootNode is JsonObject rootObject)
+            {
+                return (rootObject, encoding);
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw new DotnetInstallException(
+                DotnetInstallErrorCode.UserConfigurationCorrupted,
+                $"The global.json file at '{globalJsonPath}' is not valid JSON: {ex.Message}",
+                ex);
+        }
+
+        throw new DotnetInstallException(
+            DotnetInstallErrorCode.UserConfigurationCorrupted,
+            $"The global.json file at '{globalJsonPath}' must contain a JSON object.");
+    }
+
+    private static JsonObject GetOrCreateSdkObject(JsonObject root, string globalJsonPath)
+    {
+        if (root["sdk"] is null)
+        {
+            var newSdkObject = new JsonObject();
+            root["sdk"] = newSdkObject;
+            return newSdkObject;
+        }
+
+        if (root["sdk"] is JsonObject sdkObject)
+        {
+            return sdkObject;
+        }
+
+        throw new DotnetInstallException(
+            DotnetInstallErrorCode.UserConfigurationCorrupted,
+            $"The sdk section in global.json at '{globalJsonPath}' must be a JSON object.");
+    }
+
+    private static void SetOrRemove(JsonObject sdkObject, string propertyName, string? value, bool update)
+    {
+        if (!update)
+        {
+            return;
+        }
+
+        if (value is null)
+        {
+            sdkObject.Remove(propertyName);
+            return;
+        }
+
+        sdkObject[propertyName] = value;
+    }
+
+    private static void SetOrRemove(JsonObject sdkObject, string propertyName, bool? value, bool update)
+    {
+        if (!update)
+        {
+            return;
+        }
+
+        if (value is null)
+        {
+            sdkObject.Remove(propertyName);
+            return;
+        }
+
+        sdkObject[propertyName] = value;
     }
 
     private static string SpliceUtf8Token(byte[] bytes, int tokenStart, int bytesConsumed, string newVersion)

--- a/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
+++ b/src/Installer/dotnetup.Library/GlobalJsonModifier.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Deployment.DotNet.Releases;
-using Microsoft.Dotnet.Installation;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper;

--- a/src/Installer/dotnetup.Library/IDotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/IDotnetEnvironmentManager.cs
@@ -59,8 +59,18 @@ public class GlobalJsonInfo
     {
         get
         {
-            return (GlobalJsonContents?.Sdk?.Paths is not null && GlobalJsonContents.Sdk.Paths.Length > 0) ?
-                Path.GetFullPath(GlobalJsonContents.Sdk.Paths[0], Path.GetDirectoryName(GlobalJsonPath)!) : null;
+            if (GlobalJsonContents?.Sdk?.Paths is null || GlobalJsonContents.Sdk.Paths.Length == 0)
+            {
+                return null;
+            }
+
+            string? configuredPath = GlobalJsonContents.Sdk.Paths.FirstOrDefault(path =>
+                !string.IsNullOrWhiteSpace(path) &&
+                !string.Equals(path, "$host$", StringComparison.OrdinalIgnoreCase));
+
+            return configuredPath is not null
+                ? Path.GetFullPath(configuredPath, Path.GetDirectoryName(GlobalJsonPath)!)
+                : null;
         }
     }
 }

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -167,12 +167,11 @@ public class InstallEndToEndTests
     /// <param name="tempRoot">Temporary directory for test scripts</param>
     private static void VerifyEnvScriptWorks(string shell, string installPath, string? expectedVersion, string tempRoot)
     {
-        string dotnetupPath = DotnetupTestUtilities.GetDotnetupExecutablePath();
-
         // Determine shell-specific settings
         string shellExecutable;
         string scriptPath;
         string scriptContent;
+        string? managedDotnetupRuntimeDirectory = DotnetupTestUtilities.GetManagedDotnetupRuntimeDirectory();
 
         if (shell == "bash" || shell == "zsh")
         {
@@ -186,6 +185,28 @@ public class InstallEndToEndTests
             }
 
             static string Escape(string s) => s.Replace("'", "'\\''");
+            string dotnetupInvocation = DotnetupTestUtilities.GetDotnetupScriptInvocation(
+                shell,
+                ["print-env-script", "--shell", shell, "--dotnet-install-path", installPath]);
+            string managedDotnetupPathCleanup = managedDotnetupRuntimeDirectory is null
+                ? string.Empty
+                : $"""
+                # Remove the test-only managed dotnetup runtime path. A NativeAOT dotnetup binary does not add this.
+                _clean_path=""
+                _old_ifs=$IFS
+                IFS=:
+                for _entry in $PATH; do
+                    if [ "$_entry" != '{Escape(managedDotnetupRuntimeDirectory)}' ]; then
+                        if [ -z "$_clean_path" ]; then
+                            _clean_path=$_entry
+                        else
+                            _clean_path=$_clean_path:$_entry
+                        fi
+                    fi
+                done
+                IFS=$_old_ifs
+                export PATH=$_clean_path
+                """;
 
             // Use a temp file to capture dotnetup output instead of process substitution.
             // Process substitution failures are silently ignored by `source`, making
@@ -196,11 +217,12 @@ public class InstallEndToEndTests
             scriptContent = $@"#!/bin/{shell}
 set -e
 # Generate env script to a file (errors will be caught by set -e)
-'{Escape(dotnetupPath)}' print-env-script --shell {shell} --dotnet-install-path '{Escape(installPath)}' > '{Escape(envScriptOutput)}'
+            {dotnetupInvocation} > '{Escape(envScriptOutput)}'
 # Source the generated env script
 source '{Escape(envScriptOutput)}'
-# Clear cached dotnet path to ensure we use the newly configured PATH
-hash -d dotnet 2>/dev/null || true
+            {managedDotnetupPathCleanup}
+            # Clear cached dotnet path to ensure we use the newly configured PATH
+            hash -d dotnet 2>/dev/null || true
 # Capture versions into variables first to avoid nested quoting issues on macOS bash 3.2
 _path_ver=$(dotnet --version)
 _root_ver=""$DOTNET_ROOT/dotnet""
@@ -215,8 +237,6 @@ echo ""DOTNET_ROOT=$DOTNET_ROOT""
         }
         else // pwsh / powershell
         {
-            static string Escape(string s) => s.Replace("'", "''");
-
             // Prefer pwsh (PowerShell Core, cross-platform) over powershell.exe (Windows PowerShell 5.1).
             // The generated env script uses standard PowerShell syntax compatible with both.
             shellExecutable = ResolvePowerShellExecutable()!;
@@ -226,10 +246,22 @@ echo ""DOTNET_ROOT=$DOTNET_ROOT""
                 return;
             }
 
+            string dotnetupInvocation = DotnetupTestUtilities.GetDotnetupScriptInvocation(
+                "pwsh",
+                ["print-env-script", "--shell", "pwsh", "--dotnet-install-path", installPath]);
+            string managedDotnetupPathCleanup = managedDotnetupRuntimeDirectory is null
+                ? string.Empty
+                : $$"""
+                # Remove the test-only managed dotnetup runtime path. A NativeAOT dotnetup binary does not add this.
+                $env:PATH = (($env:PATH -split [IO.Path]::PathSeparator) |
+                    Where-Object { $_ -ne '{{managedDotnetupRuntimeDirectory.Replace("'", "''")}}' }) -join [IO.Path]::PathSeparator
+                """;
+
             scriptPath = Path.Combine(tempRoot, "test-env.ps1");
             scriptContent = $@"
 $ErrorActionPreference = 'Stop'
-iex (& '{Escape(dotnetupPath)}' print-env-script --shell pwsh --dotnet-install-path '{Escape(installPath)}' | Out-String)
+iex ({dotnetupInvocation} | Out-String)
+{managedDotnetupPathCleanup}
 # Verify both dotnet and DOTNET_ROOT/dotnet return the same version
 Write-Output ""DOTNET_VERSION=$(dotnet --version)""
 Write-Output ""DOTNET_ROOT_VERSION=$(& ""$env:DOTNET_ROOT/dotnet"" --version)""
@@ -971,6 +1003,81 @@ public class LifecycleEndToEndTests
             "SDK install spec should record the global.json path");
         sdkSpec.GlobalJsonPath.Should().Be(globalJsonPath,
             "SDK install spec should record the correct global.json path");
+    }
+
+    [Fact]
+    public void SdkInstallLocal_CreatesGlobalJsonAndInstallsToProjectDotnetDirectory()
+    {
+        using var testEnv = DotnetupTestUtilities.CreateTestEnvironment();
+
+        string projectDir = Path.Combine(testEnv.TempRoot, "local-project");
+        Directory.CreateDirectory(projectDir);
+        string expectedInstallPath = Path.Combine(projectDir, ".dotnet");
+        string globalJsonPath = Path.Combine(projectDir, "global.json");
+
+        var sdkArgs = new List<string>(["sdk", "install", "9.0.103",
+            "--local",
+            "--interactive", "false",
+            "--no-progress"]);
+        if (!string.IsNullOrEmpty(testEnv.ManifestPath))
+        {
+            sdkArgs.AddRange(["--manifest-path", testEnv.ManifestPath]);
+        }
+
+        (int exitCode, string output) = DotnetupTestUtilities.RunDotnetupProcess(
+            [.. sdkArgs], captureOutput: true, workingDirectory: projectDir);
+        exitCode.Should().Be(0, $"SDK local install failed. Output:\n{output}");
+
+        Directory.Exists(Path.Combine(expectedInstallPath, "sdk", "9.0.103")).Should().BeTrue(
+            "local SDK install should land under the project .dotnet directory");
+
+        string globalJson = File.ReadAllText(globalJsonPath);
+        globalJson.Should().Contain("\"version\": \"9.0.103\"");
+        globalJson.Should().Contain("\"rollForward\": \"disable\"");
+        globalJson.Should().Contain("\"paths\"");
+        globalJson.Should().Contain("\".dotnet\"");
+        globalJson.Should().Contain("\"$host$\"");
+
+        File.ReadAllText(Path.Combine(projectDir, ".gitignore"))
+            .Should().Contain(".dotnet/");
+
+        File.WriteAllText(globalJsonPath, """
+            {
+              "sdk": {
+                "version": "9.0.103",
+                "rollForward": "latestFeature"
+              },
+              "msbuild-sdks": {
+                "Example.Sdk": "1.2.3"
+              },
+              "tools": {
+                "example": "preserve-me"
+              }
+            }
+            """);
+
+        (exitCode, output) = DotnetupTestUtilities.RunDotnetupProcess(
+            [.. sdkArgs], captureOutput: true, workingDirectory: projectDir);
+        exitCode.Should().Be(0, $"SDK local install should repair an existing global.json without paths. Output:\n{output}");
+
+        globalJson = File.ReadAllText(globalJsonPath);
+        globalJson.Should().Contain("\"rollForward\": \"disable\"");
+        globalJson.Should().Contain("\"paths\"");
+        globalJson.Should().Contain("\"Example.Sdk\": \"1.2.3\"");
+        globalJson.Should().Contain("\"example\": \"preserve-me\"");
+
+        using var mutex = new ScopedMutex(Constants.MutexNames.ModifyInstallationStates);
+        var manifest = new DotnetupSharedManifest(testEnv.ManifestPath);
+        var manifestData = manifest.ReadManifest();
+        var installSpecs = manifestData.DotnetRoots
+            .Where(r => DotnetupUtilities.PathsEqual(r.Path, expectedInstallPath))
+            .SelectMany(r => r.InstallSpecs)
+            .ToList();
+
+        installSpecs.Should().ContainSingle(s => s.Component == InstallComponent.SDK);
+        var sdkSpec = installSpecs.First(s => s.Component == InstallComponent.SDK);
+        sdkSpec.InstallSource.Should().Be(InstallSource.GlobalJson);
+        sdkSpec.GlobalJsonPath.Should().Be(globalJsonPath);
     }
 
     [Fact]

--- a/test/dotnetup.Tests/DnupE2Etest.cs
+++ b/test/dotnetup.Tests/DnupE2Etest.cs
@@ -1014,6 +1014,12 @@ public class LifecycleEndToEndTests
         Directory.CreateDirectory(projectDir);
         string expectedInstallPath = Path.Combine(projectDir, ".dotnet");
         string globalJsonPath = Path.Combine(projectDir, "global.json");
+        Dictionary<string, string> localInstallEnvironment = new()
+        {
+            ["PATH"] = DotnetupTestUtilities.GetRepoDotnetDirectory()
+                + Path.PathSeparator
+                + (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+        };
 
         var sdkArgs = new List<string>(["sdk", "install", "9.0.103",
             "--local",
@@ -1025,7 +1031,10 @@ public class LifecycleEndToEndTests
         }
 
         (int exitCode, string output) = DotnetupTestUtilities.RunDotnetupProcess(
-            [.. sdkArgs], captureOutput: true, workingDirectory: projectDir);
+            [.. sdkArgs],
+            captureOutput: true,
+            workingDirectory: projectDir,
+            environmentVariables: localInstallEnvironment);
         exitCode.Should().Be(0, $"SDK local install failed. Output:\n{output}");
 
         Directory.Exists(Path.Combine(expectedInstallPath, "sdk", "9.0.103")).Should().BeTrue(
@@ -1057,7 +1066,10 @@ public class LifecycleEndToEndTests
             """);
 
         (exitCode, output) = DotnetupTestUtilities.RunDotnetupProcess(
-            [.. sdkArgs], captureOutput: true, workingDirectory: projectDir);
+            [.. sdkArgs],
+            captureOutput: true,
+            workingDirectory: projectDir,
+            environmentVariables: localInstallEnvironment);
         exitCode.Should().Be(0, $"SDK local install should repair an existing global.json without paths. Output:\n{output}");
 
         globalJson = File.ReadAllText(globalJsonPath);

--- a/test/dotnetup.Tests/DotnetCommandStdinForwardingTests.cs
+++ b/test/dotnetup.Tests/DotnetCommandStdinForwardingTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Dotnetup.Tests.Utilities;
 
 namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
@@ -37,11 +36,13 @@ public class DotnetCommandStdinForwardingTests
         {
             DotnetCommandTests.CreateStdinEchoFakeDotnet(tempDir.FullName);
 
-            string dotnetupPath = DotnetupTestUtilities.GetDotnetupExecutablePath();
             string testInput = "HelloInteractive_" + Guid.NewGuid().ToString("N")[..8];
 
             using var process = new Process();
-            process.StartInfo.FileName = dotnetupPath;
+            string[] args = OperatingSystem.IsWindows()
+                ? ["dotnet", "/c", "findstr /r ."]
+                : ["dotnet"];
+            DotnetupTestUtilities.ConfigureDotnetupProcess(process.StartInfo, args);
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardInput = true;
@@ -53,19 +54,6 @@ public class DotnetCommandStdinForwardingTests
             process.StartInfo.Environment["PATH"] = tempDir.FullName + Path.PathSeparator + currentPath;
             process.StartInfo.Environment["DOTNET_NOLOGO"] = "1";
             process.StartInfo.Environment["NO_COLOR"] = "1";
-
-            if (OperatingSystem.IsWindows())
-            {
-                // Fake dotnet.exe is cmd.exe; forward /c "findstr /r ." to echo stdin.
-                // findstr reads from stdin and echoes lines matching regex "." (non-empty).
-                process.StartInfo.Arguments = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(
-                    ["dotnet", "/c", "findstr /r ."]);
-            }
-            else
-            {
-                // Fake dotnet is a shell script that cats stdin to stdout.
-                process.StartInfo.Arguments = "dotnet";
-            }
 
             process.Start();
 

--- a/test/dotnetup.Tests/GlobalJsonUpdateTests.cs
+++ b/test/dotnetup.Tests/GlobalJsonUpdateTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.Dotnet.Installation;
 using Microsoft.DotNet.Tools.Bootstrapper;
+using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Sdk.Install;
 
 namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
@@ -213,6 +215,92 @@ public class GlobalJsonUpdateTests : IDisposable
     }
 
     [Fact]
+    public void ApplyLocalSdkSetup_CreatesGlobalJsonWithLocalPaths()
+    {
+        var path = Path.Combine(_testDir, "global.json");
+        var settings = new LocalSdkSetupSettings(
+            SdkVersion: "10.0.100",
+            RollForward: "disable",
+            UpdateRollForward: true,
+            AllowPrerelease: null,
+            UpdateAllowPrerelease: true);
+
+        GlobalJsonModifier.ApplyLocalSdkSetup(path, settings);
+
+        var updated = File.ReadAllText(path);
+        updated.Should().Contain("\"version\": \"10.0.100\"");
+        updated.Should().Contain("\"rollForward\": \"disable\"");
+        updated.Should().Contain("\"paths\"");
+        updated.Should().Contain("\".dotnet\"");
+        updated.Should().Contain("\"$host$\"");
+        updated.Should().NotContain("allowPrerelease");
+    }
+
+    [Fact]
+    public void ApplyLocalSdkSetup_PreservesExistingSectionsAndMergesSdk()
+    {
+        var path = Path.Combine(_testDir, "global.json");
+        File.WriteAllText(path, """
+            {
+              "sdk": {
+                "version": "9.0.100",
+                "rollForward": "latestFeature"
+              },
+              "msbuild-sdks": {
+                "Example.Sdk": "1.2.3"
+              },
+              "tools": {
+                "dotnet-example": "4.5.6"
+              }
+            }
+            """);
+        var settings = new LocalSdkSetupSettings(
+            SdkVersion: "10.0.100-preview.1",
+            RollForward: "latestPatch",
+            UpdateRollForward: true,
+            AllowPrerelease: true,
+            UpdateAllowPrerelease: true);
+
+        GlobalJsonModifier.ApplyLocalSdkSetup(path, settings);
+
+        var updated = File.ReadAllText(path);
+        updated.Should().Contain("\"version\": \"10.0.100-preview.1\"");
+        updated.Should().Contain("\"allowPrerelease\": true");
+        updated.Should().Contain("\"rollForward\": \"latestPatch\"");
+        updated.Should().Contain("\"paths\"");
+        updated.Should().Contain("\"msbuild-sdks\"");
+        updated.Should().Contain("\"Example.Sdk\": \"1.2.3\"");
+        updated.Should().Contain("\"tools\"");
+        updated.Should().Contain("\"dotnet-example\": \"4.5.6\"");
+    }
+
+    [Theory]
+    [InlineData("10.0.100", "disable")]
+    [InlineData("10.0.1xx", "latestPatch")]
+    [InlineData("10.0", "latestFeature")]
+    [InlineData("10", "latestMinor")]
+    [InlineData("latest", "latestPatch")]
+    [InlineData("preview", "latestPatch")]
+    public void LocalSdkSetupSettings_ChoosesRollForwardForRequestedChannel(string requestedChannel, string expectedRollForward)
+    {
+        LocalSdkSetupSettings.GetRollForwardForRequestedChannel(requestedChannel)
+            .Should().Be(expectedRollForward);
+    }
+
+    [Fact]
+    public void LocalSdkSetupSettings_SetsAllowPrereleaseForPrereleaseResolvedVersion()
+    {
+        var settings = LocalSdkSetupSettings.Create(
+            requestedChannel: "preview",
+            globalJsonExisted: false,
+            new GlobalJsonInfo(),
+            new ReleaseVersion("10.0.100-preview.1"));
+
+        settings.AllowPrerelease.Should().BeTrue();
+        settings.UpdateAllowPrerelease.Should().BeTrue();
+    }
+
+    [Fact]
     public void UpdateGlobalJson_DoesNotWriteFile_WhenNoSdkVersionToReplace()
     {
         var path = Path.Combine(_testDir, "global.json");
@@ -227,6 +315,118 @@ public class GlobalJsonUpdateTests : IDisposable
 
         File.ReadAllText(path).Should().Be(original);
         File.GetLastWriteTimeUtc(path).Should().Be(lastWrite);
+    }
+
+    [Fact]
+    public void LocalSdkSetupPlan_UsesNearestGlobalJsonDirectoryForNestedStart()
+    {
+        var projectDir = Path.Combine(_testDir, "project");
+        var nestedDir = Path.Combine(projectDir, "src", "app");
+        Directory.CreateDirectory(nestedDir);
+        File.WriteAllText(Path.Combine(projectDir, "global.json"), """{ "sdk": { "version": "10.0.100" } }""");
+
+        var plan = LocalSdkSetupPlan.Create(nestedDir, requestedChannel: null);
+
+        plan.ProjectDirectory.Should().Be(projectDir);
+        plan.GlobalJsonPath.Should().Be(Path.Combine(projectDir, "global.json"));
+        plan.LocalDotnetPath.Should().Be(Path.Combine(projectDir, ".dotnet"));
+    }
+
+    [Fact]
+    public void LocalSdkSetupPlan_AcceptsGlobalJsonCommentsAndTrailingCommas()
+    {
+        File.WriteAllText(Path.Combine(_testDir, "global.json"), """
+            {
+              // global.json accepts comments and trailing commas.
+              "sdk": {
+                "version": "10.0.100",
+              },
+            }
+            """);
+
+        var plan = LocalSdkSetupPlan.Create(_testDir, requestedChannel: null);
+
+        plan.GlobalJsonInfo.SdkVersion.Should().Be("10.0.100");
+    }
+
+    [Fact]
+    public void LocalSdkSetupPlan_ThrowsWhenExistingGlobalJsonHasNoSdkVersionAndNoChannel()
+    {
+        File.WriteAllText(Path.Combine(_testDir, "global.json"), """{ "sdk": { "rollForward": "latestFeature" } }""");
+
+        var act = () => LocalSdkSetupPlan.Create(_testDir, requestedChannel: null);
+
+        act.Should().Throw<DotnetInstallException>()
+            .Where(ex => ex.ErrorCode == DotnetInstallErrorCode.ContextResolutionFailed)
+            .WithMessage("*does not specify sdk.version*");
+    }
+
+    [Theory]
+    [InlineData("10.0.100", true)]
+    [InlineData("10.0.100-preview.1.12345", true)]
+    [InlineData("9.0.306", true)]
+    [InlineData("not-a-version", false)]
+    public void LocalSdkHostValidator_TryGetMajorVersion(string version, bool expected)
+    {
+        LocalSdkHostValidator.TryGetMajorVersion(version, out int major).Should().Be(expected);
+        if (expected)
+        {
+            major.Should().Be(int.Parse(version.Split('.')[0], System.Globalization.CultureInfo.InvariantCulture));
+        }
+    }
+
+    [Fact]
+    public void LocalSdkHostValidator_ParsesHostVersionFromDotnetInfo()
+    {
+        var dotnetInfo = """
+            .NET SDK:
+             Version:           9.0.306
+
+            Host:
+              Version:      10.0.0
+              Architecture: arm64
+
+            .NET SDKs installed:
+              9.0.306 [C:\Program Files\dotnet\sdk]
+            """;
+
+        LocalSdkHostValidator.TryGetHostVersionFromInfo(dotnetInfo, out string? hostVersion)
+            .Should().BeTrue();
+        hostVersion.Should().Be("10.0.0");
+    }
+
+    [Fact]
+    public void GitIgnoreUpdater_CreatesGitIgnoreWhenMissing()
+    {
+        GitIgnoreUpdater.EnsureDotnetDirectoryIgnored(_testDir);
+
+        File.ReadAllText(Path.Combine(_testDir, ".gitignore"))
+            .Should().Be(".dotnet/" + Environment.NewLine);
+    }
+
+    [Fact]
+    public void GitIgnoreUpdater_AppendsNewlineSafely()
+    {
+        var path = Path.Combine(_testDir, ".gitignore");
+        File.WriteAllText(path, "bin/");
+
+        GitIgnoreUpdater.EnsureDotnetDirectoryIgnored(_testDir);
+
+        File.ReadAllText(path).Should().Be("bin/\n.dotnet/\n");
+    }
+
+    [Theory]
+    [InlineData(".dotnet/")]
+    [InlineData(".dotnet")]
+    [InlineData("/.dotnet/")]
+    public void GitIgnoreUpdater_DoesNotDuplicateExistingDotnetEntry(string existingEntry)
+    {
+        var path = Path.Combine(_testDir, ".gitignore");
+        File.WriteAllText(path, existingEntry + Environment.NewLine);
+
+        GitIgnoreUpdater.EnsureDotnetDirectoryIgnored(_testDir);
+
+        File.ReadAllLines(path).Should().ContainSingle(line => line == existingEntry);
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/test/dotnetup.Tests/LibraryTests.cs
+++ b/test/dotnetup.Tests/LibraryTests.cs
@@ -288,4 +288,23 @@ public class LibraryTests
 
         globalJsonInfo.SdkPath.Should().BeNull();
     }
+
+    [Fact]
+    public void GlobalJsonInfo_SdkPath_SkipsHostFallbackEntry()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), "test-repo");
+        var globalJsonInfo = new GlobalJsonInfo
+        {
+            GlobalJsonPath = Path.Combine(repoDir, "global.json"),
+            GlobalJsonContents = new GlobalJsonContents
+            {
+                Sdk = new GlobalJsonContents.SdkSection
+                {
+                    Paths = ["$host$", ".dotnet"]
+                }
+            }
+        };
+
+        globalJsonInfo.SdkPath.Should().Be(Path.Combine(repoDir, ".dotnet"));
+    }
 }

--- a/test/dotnetup.Tests/ParserTests.cs
+++ b/test/dotnetup.Tests/ParserTests.cs
@@ -20,6 +20,20 @@ public class ParserTests
         [new[] { "runtime", "install", "aspnetcore@9.0", "--migrate-from-system" }]
     ];
 
+    public static IEnumerable<object[]> LocalInstallCommandArgs =>
+    [
+        [new[] { "sdk", "install", "10.0.100", "--local" }],
+        [new[] { "install", "10.0.100", "--local" }]
+    ];
+
+    public static IEnumerable<object[]> LocalInstallConflictingCommandArgs =>
+    [
+        [new[] { "sdk", "install", "10.0.100", "--local", "--install-path", @"C:\dotnet" }, "--install-path"],
+        [new[] { "sdk", "install", "10.0.100", "--local", "--set-default-install" }, "--set-default-install"],
+        [new[] { "sdk", "install", "10.0.100", "--local", "--migrate-from-system" }, "--migrate-from-system"],
+        [new[] { "sdk", "install", "10.0.100", "--local", "--update-global-json" }, "--update-global-json"]
+    ];
+
     [Fact]
     public void Parser_ShouldParseValidCommands()
     {
@@ -32,6 +46,29 @@ public class ParserTests
         // Assert
         parseResult.Should().NotBeNull();
         parseResult.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(LocalInstallCommandArgs))]
+    public void Parser_ShouldParseSdkLocalInstallCommands(string[] args)
+    {
+        var parseResult = Parser.Parse(args);
+
+        parseResult.Should().NotBeNull();
+        parseResult.Errors.Should().BeEmpty();
+        parseResult.GetValue(CommonOptions.LocalInstallOption).Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(LocalInstallConflictingCommandArgs))]
+    public void Parser_ShouldRejectLocalInstallConflictingOptions(string[] args, string optionName)
+    {
+        var parseResult = Parser.Parse(args);
+
+        parseResult.Should().NotBeNull();
+        parseResult.Errors.Should().NotBeEmpty();
+        parseResult.Errors.Select(error => error.Message)
+            .Should().Contain(message => message.Contains(optionName, StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
+++ b/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
@@ -308,6 +308,27 @@ internal static class DotnetupTestUtilities
                     Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to managed build output at '{managedPath}'.");
                     return Path.GetFullPath(managedPath);
                 }
+
+                string[] ridManagedPaths = Directory.GetFiles(tfmDir, executableName, SearchOption.AllDirectories);
+                if (ridManagedPaths.Length > 0)
+                {
+                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed build output at '{ridManagedPaths[0]}'.");
+                    return Path.GetFullPath(ridManagedPaths[0]);
+                }
+
+                string managedDllPath = Path.Combine(tfmDir, "dotnetup.dll");
+                if (File.Exists(managedDllPath))
+                {
+                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to managed DLL output at '{managedDllPath}'.");
+                    return Path.GetFullPath(managedDllPath);
+                }
+
+                string[] ridManagedDllPaths = Directory.GetFiles(tfmDir, "dotnetup.dll", SearchOption.AllDirectories);
+                if (ridManagedDllPaths.Length > 0)
+                {
+                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed DLL output at '{ridManagedDllPaths[0]}'.");
+                    return Path.GetFullPath(ridManagedDllPaths[0]);
+                }
             }
         }
 
@@ -332,11 +353,8 @@ internal static class DotnetupTestUtilities
         string? workingDirectory = null,
         Dictionary<string, string>? environmentVariables = null)
     {
-        string dotnetupPath = GetDotnetupExecutablePath();
-
         using var process = new Process();
-        process.StartInfo.FileName = dotnetupPath;
-        process.StartInfo.Arguments = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
+        ConfigureDotnetupProcess(process.StartInfo, args);
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         process.StartInfo.RedirectStandardOutput = captureOutput;
@@ -389,6 +407,82 @@ internal static class DotnetupTestUtilities
         process.WaitForExit();
         return (process.ExitCode, outputBuilder.ToString());
     }
+
+    public static void ConfigureDotnetupProcess(ProcessStartInfo startInfo, string[] args)
+    {
+        string dotnetupPath = GetDotnetupExecutablePath();
+        if (Path.GetExtension(dotnetupPath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.FileName = GetRepoDotnetPath();
+            startInfo.Arguments = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart([dotnetupPath, .. args]);
+        }
+        else
+        {
+            startInfo.FileName = dotnetupPath;
+            startInfo.Arguments = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
+        }
+    }
+
+    public static string GetDotnetupScriptInvocation(string shell, string[] args)
+    {
+        string dotnetupPath = GetDotnetupExecutablePath();
+        if (Path.GetExtension(dotnetupPath).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            dotnetupPath = CreateManagedDotnetupShim(dotnetupPath);
+        }
+
+        return shell switch
+        {
+            "bash" or "zsh" =>
+                $"'{EscapeSingleQuotedShellArgument(dotnetupPath)}' {string.Join(" ", args.Select(arg => $"'{EscapeSingleQuotedShellArgument(arg)}'"))}",
+            "pwsh" =>
+                $"& '{EscapeSingleQuotedPowerShellArgument(dotnetupPath)}' {string.Join(" ", args.Select(arg => $"'{EscapeSingleQuotedPowerShellArgument(arg)}'"))}",
+            _ => throw new ArgumentException($"Unsupported shell '{shell}'.", nameof(shell)),
+        };
+    }
+
+    public static string? GetManagedDotnetupRuntimeDirectory()
+    {
+        string dotnetupPath = GetDotnetupExecutablePath();
+        return Path.GetExtension(dotnetupPath).Equals(".dll", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetDirectoryName(GetRepoDotnetPath())
+            : null;
+    }
+
+    private static string CreateManagedDotnetupShim(string dotnetupPath)
+    {
+        string shimPath = Path.Combine(
+            Path.GetTempPath(),
+            "dotnetup-test-shim-" + Guid.NewGuid().ToString("N") + (OperatingSystem.IsWindows() ? ".cmd" : ".sh"));
+
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(
+                shimPath,
+                $"@echo off{Environment.NewLine}\"{GetRepoDotnetPath()}\" \"{dotnetupPath}\" %*{Environment.NewLine}");
+        }
+        else
+        {
+            File.WriteAllText(
+                shimPath,
+                $"#!/bin/sh{Environment.NewLine}exec '{EscapeSingleQuotedShellArgument(GetRepoDotnetPath())}' '{EscapeSingleQuotedShellArgument(dotnetupPath)}' \"$@\"{Environment.NewLine}");
+            File.SetUnixFileMode(shimPath, File.GetUnixFileMode(shimPath) | UnixFileMode.UserExecute);
+        }
+
+        return shimPath;
+    }
+
+    private static string GetRepoDotnetPath()
+    {
+        string repoDotnet = Path.Combine(GetRepositoryRoot(), ".dotnet", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+        return File.Exists(repoDotnet) ? repoDotnet : "dotnet";
+    }
+
+    private static string EscapeSingleQuotedShellArgument(string value)
+        => value.Replace("'", "'\\''");
+
+    private static string EscapeSingleQuotedPowerShellArgument(string value)
+        => value.Replace("'", "''");
 
     private static string GetRepositoryRoot()
     {

--- a/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
+++ b/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
@@ -309,11 +309,11 @@ internal static class DotnetupTestUtilities
                     return Path.GetFullPath(managedPath);
                 }
 
-                string[] ridManagedPaths = Directory.GetFiles(tfmDir, executableName, SearchOption.AllDirectories);
-                if (ridManagedPaths.Length > 0)
+                string? ridManagedPath = FindRidSpecificOutput(tfmDir, rid, executableName);
+                if (ridManagedPath is not null)
                 {
-                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed build output at '{ridManagedPaths[0]}'.");
-                    return Path.GetFullPath(ridManagedPaths[0]);
+                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed build output at '{ridManagedPath}'.");
+                    return Path.GetFullPath(ridManagedPath);
                 }
 
                 string managedDllPath = Path.Combine(tfmDir, "dotnetup.dll");
@@ -323,11 +323,11 @@ internal static class DotnetupTestUtilities
                     return Path.GetFullPath(managedDllPath);
                 }
 
-                string[] ridManagedDllPaths = Directory.GetFiles(tfmDir, "dotnetup.dll", SearchOption.AllDirectories);
-                if (ridManagedDllPaths.Length > 0)
+                string? ridManagedDllPath = FindRidSpecificOutput(tfmDir, rid, "dotnetup.dll");
+                if (ridManagedDllPath is not null)
                 {
-                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed DLL output at '{ridManagedDllPaths[0]}'.");
-                    return Path.GetFullPath(ridManagedDllPaths[0]);
+                    Console.WriteLine($"Warning: AOT-published native binary not found. Falling back to RID-specific managed DLL output at '{ridManagedDllPath}'.");
+                    return Path.GetFullPath(ridManagedDllPath);
                 }
             }
         }
@@ -475,7 +475,27 @@ internal static class DotnetupTestUtilities
     private static string GetRepoDotnetPath()
     {
         string repoDotnet = Path.Combine(GetRepositoryRoot(), ".dotnet", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
-        return File.Exists(repoDotnet) ? repoDotnet : "dotnet";
+        if (!File.Exists(repoDotnet))
+        {
+            throw new FileNotFoundException(
+                $"The repo-local dotnet executable was not found at '{repoDotnet}'. Run build.cmd or build.cmd -restore from the repository root before running dotnetup process tests.",
+                repoDotnet);
+        }
+
+        return repoDotnet;
+    }
+
+    private static string? FindRidSpecificOutput(string tfmDir, string rid, string fileName)
+    {
+        string currentRidPath = Path.Combine(tfmDir, rid, fileName);
+        if (File.Exists(currentRidPath))
+        {
+            return currentRidPath;
+        }
+
+        return Directory.GetFiles(tfmDir, fileName, SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
     }
 
     private static string EscapeSingleQuotedShellArgument(string value)

--- a/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
+++ b/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
@@ -445,9 +445,12 @@ internal static class DotnetupTestUtilities
     {
         string dotnetupPath = GetDotnetupExecutablePath();
         return Path.GetExtension(dotnetupPath).Equals(".dll", StringComparison.OrdinalIgnoreCase)
-            ? Path.GetDirectoryName(GetRepoDotnetPath())
+            ? GetRepoDotnetDirectory()
             : null;
     }
+
+    public static string GetRepoDotnetDirectory()
+        => Path.GetDirectoryName(GetRepoDotnetPath())!;
 
     private static string CreateManagedDotnetupShim(string dotnetupPath)
     {


### PR DESCRIPTION
## Summary
- Adds `dotnetup sdk install --local` / root install `--local` for project-local SDK setup.
- Installs into the nearest project `.dotnet` directory and configures `global.json` with `sdk.paths: [".dotnet", "$host$"]`.
- Preserves existing `global.json` sections, supports exact/channel/prerelease settings, updates `.gitignore` idempotently, and avoids PATH/profile/default install mutations.
- Adds unit, parser, and end-to-end coverage plus docs for the new local install flow.

## Validation
- Built `src\Installer\dotnetup\dotnetup.csproj` with `/p:_DotnetupSkipPublishOnBuild=true`.
- Built `test\dotnetup.Tests\dotnetup.Tests.csproj` with isolated `ArtifactsDir`.
- Ran focused tests: `GlobalJsonUpdateTests`, `ParserTests`, `LibraryTests`, local install E2E, env script E2E, and stdin forwarding E2E.
- Ran manual throwaway-project E2E for exact local install, existing `global.json` preservation, nested global.json discovery, invalid/missing version errors, `.gitignore` newline/idempotence, and preview local install.
- Ran full `dotnetup.Tests`; local result has one pre-existing environment-specific failure in `WindowsPathHelperTests.GetProgramFilesDotnetPaths_ReturnsValidPaths` because this machine returns `C:\Program Files\dotnet\x64`.