### PR TITLE
Onboard MSBuild task projects to Microsoft.Build.TaskAuthoring.Analyzer (report-only)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -298,11 +298,11 @@ dotnet_diagnostic.IDE0240.severity = warning
 #
 # NOTE: src/StaticWebAssetsSdk/.editorconfig sets `root = true`, so it does not inherit these lines and
 # carries its own copy of this block. Keep the two in sync.
-dotnet_diagnostic.MSBuildTask0001.severity = silent
-dotnet_diagnostic.MSBuildTask0002.severity = silent
-dotnet_diagnostic.MSBuildTask0003.severity = silent
-dotnet_diagnostic.MSBuildTask0004.severity = silent
-dotnet_diagnostic.MSBuildTask0005.severity = silent
+dotnet_diagnostic.MSBuildTask0001.severity = suggestion
+dotnet_diagnostic.MSBuildTask0002.severity = suggestion
+dotnet_diagnostic.MSBuildTask0003.severity = suggestion
+dotnet_diagnostic.MSBuildTask0004.severity = suggestion
+dotnet_diagnostic.MSBuildTask0005.severity = suggestion
 
 # Additional rules for template engine source code
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -286,6 +286,23 @@ dotnet_diagnostic.IDE0082.severity = warning
 dotnet_diagnostic.IDE0200.severity = none
 # Remove redundant nullable directive
 dotnet_diagnostic.IDE0240.severity = warning
+# MSBuildTask0001-0005 (Microsoft.Build.TaskAuthoring.Analyzer). MSBuildTask0001 is Error severity by
+# default; the rest are warnings. All are downgraded to 'suggestion' here for report-only onboarding while
+# task migration to the multithreaded model (IMultiThreadableTask / TaskEnvironment) is pending. At
+# suggestion level they are info diagnostics, so they never fail the build (not even under Arcade's
+# MSBuild-engine warn-as-error) without needing any WarningsNotAsErrors exemptions.
+#
+# Incremental re-enablement: a follow-up PR can raise a single rule globally (edit a line below to
+# 'warning'/'error' -- a "category" at a time), or raise severity for one task class by adding an
+# .editorconfig in that task's source directory that overrides these codes.
+#
+# NOTE: src/StaticWebAssetsSdk/.editorconfig sets `root = true`, so it does not inherit these lines and
+# carries its own copy of this block. Keep the two in sync.
+dotnet_diagnostic.MSBuildTask0001.severity = silent
+dotnet_diagnostic.MSBuildTask0002.severity = silent
+dotnet_diagnostic.MSBuildTask0003.severity = silent
+dotnet_diagnostic.MSBuildTask0004.severity = silent
+dotnet_diagnostic.MSBuildTask0005.severity = silent
 
 # Additional rules for template engine source code
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,8 @@
 <Project>
 
+  <!-- Apply the MSBuild thread-safe task analyzer to projects that set IsMSBuildTaskProject=true. -->
+  <Import Project="eng\MSBuildTaskAuthoringAnalyzer.props" />
+
   <PropertyGroup>
     <!--
       Disable nullable warnings when targeting anything other than our supported .NET core version(s).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,10 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
     <!-- Roslyn analyzer that checks MSBuild task implementations for thread-unsafe API usage.
+         Produced by the msbuild repo and flowed in via eng/Version.Details.xml (dotnet/dotnet), so the
+         version stays coherent with the other Microsoft.Build packages and lifts correctly in source build.
          Applied to task-bearing projects via eng/MSBuildTaskAuthoringAnalyzer.props. -->
-    <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="18.9.0-preview-26310-106" />
+    <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="$(MicrosoftBuildTaskAuthoringAnalyzerPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
-    <!-- Roslyn analyzer that checks MSBuild task implementations for thread-unsafe API usage.
-         Produced by the msbuild repo and flowed in via eng/Version.Details.xml (dotnet/dotnet), so the
-         version stays coherent with the other Microsoft.Build packages and lifts correctly in source build.
-         Applied to task-bearing projects via eng/MSBuildTaskAuthoringAnalyzer.props. -->
     <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="$(MicrosoftBuildTaskAuthoringAnalyzerPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
+    <!-- Roslyn analyzer that checks MSBuild task implementations for thread-unsafe API usage.
+         Applied to task-bearing projects via eng/MSBuildTaskAuthoringAnalyzer.props. -->
+    <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="18.9.0-preview-26310-106" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribPackageVersion)" />

--- a/eng/MSBuildTaskAuthoringAnalyzer.props
+++ b/eng/MSBuildTaskAuthoringAnalyzer.props
@@ -1,0 +1,29 @@
+<!--
+  Applies the Microsoft.Build.TaskAuthoring.Analyzer (MSBuild thread-safe task analyzer) to projects
+  that contain MSBuild task implementations. A project opts in by setting:
+
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
+
+  This file is imported from the repo-root Directory.Build.targets so the opt-in property set in the
+  project body is visible.
+
+  Report-only onboarding: the analyzer emits MSBuildTask0001 at Error severity and MSBuildTask0002-0005 at
+  Warning severity by default. All five are downgraded to 'suggestion' in the root .editorconfig, which
+  keeps the build green (info-level diagnostics are never promoted by warn-as-error) without any
+  WarningsNotAsErrors exemptions here. Severity is re-raised incrementally per rule or per task directory
+  via .editorconfig as the multithreaded-task migration (IMultiThreadableTask / TaskEnvironment) proceeds.
+
+  The analyzer package comes from the dotnet-eng feed and is not available in source-only builds, so it
+  is excluded when DotNetBuildSourceOnly is set.
+-->
+<Project>
+
+  <PropertyGroup>
+    <_UseMSBuildTaskAuthoringAnalyzer Condition="'$(IsMSBuildTaskProject)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">true</_UseMSBuildTaskAuthoringAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">
+    <PackageReference Include="Microsoft.Build.TaskAuthoring.Analyzer" PrivateAssets="all" IncludeAssets="analyzers" />
+  </ItemGroup>
+
+</Project>

--- a/eng/MSBuildTaskAuthoringAnalyzer.props
+++ b/eng/MSBuildTaskAuthoringAnalyzer.props
@@ -13,13 +13,13 @@
   WarningsNotAsErrors exemptions here. Severity is re-raised incrementally per rule or per task directory
   via .editorconfig as the multithreaded-task migration (IMultiThreadableTask / TaskEnvironment) proceeds.
 
-  The analyzer package comes from the dotnet-eng feed and is not available in source-only builds, so it
-  is excluded when DotNetBuildSourceOnly is set.
+  The analyzer package is produced by the msbuild repo and flows to this repo via eng/Version.Details.xml
+  (dotnet/dotnet), so it is available in source build as well and does not need to be excluded there.
 -->
 <Project>
 
   <PropertyGroup>
-    <_UseMSBuildTaskAuthoringAnalyzer Condition="'$(IsMSBuildTaskProject)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">true</_UseMSBuildTaskAuthoringAnalyzer>
+    <_UseMSBuildTaskAuthoringAnalyzer Condition="'$(IsMSBuildTaskProject)' == 'true'">true</_UseMSBuildTaskAuthoringAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -35,6 +35,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftBclAsyncInterfacesPackageVersion>11.0.0-preview.6.26311.113</MicrosoftBclAsyncInterfacesPackageVersion>
     <MicrosoftBuildPackageVersion>18.9.0-preview-26311-113</MicrosoftBuildPackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>18.9.0-preview-26311-113</MicrosoftBuildLocalizationPackageVersion>
+    <MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>18.9.0-preview-26311-113</MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>
     <MicrosoftBuildNuGetSdkResolverPackageVersion>7.9.0-rc.31213</MicrosoftBuildNuGetSdkResolverPackageVersion>
     <MicrosoftBuildTasksGitPackageVersion>11.0.100-preview.6.26311.113</MicrosoftBuildTasksGitPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>5.9.0-1.26311.113</MicrosoftCodeAnalysisPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -44,6 +44,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>50e862b8da0c82ddbf3952cfe61a8681ab93f5bc</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build.TaskAuthoring.Analyzer" Version="18.9.0-preview-26311-113">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>50e862b8da0c82ddbf3952cfe61a8681ab93f5bc</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="15.2.101-preview6.26311.113">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>50e862b8da0c82ddbf3952cfe61a8681ab93f5bc</Sha>

--- a/src/BlazorWasmSdk/Tasks/Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj
+++ b/src/BlazorWasmSdk/Tasks/Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <BlazorWasmSdkRoot>$(RepoRoot)\src\BlazorWasmSdk\</BlazorWasmSdkRoot>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <PackageId>Microsoft.NET.Sdk.BlazorWebAssembly</PackageId>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\tools</OutDirName>
   </PropertyGroup>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Task/Microsoft.DotNet.ApiCompat.Task.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetMinimum)</TargetFramework>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <!-- Disable transitive pinning, we shouldn't upgrade dependencies that are excluded for runtime and provided externally. -->
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <IsPackable>true</IsPackable>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Task/Microsoft.DotNet.GenAPI.Task.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetMinimum)</TargetFramework>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/src/Containers/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
 
     <TargetsForTfmSpecificBuildOutput>
       $(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage

--- a/src/Dotnet.Watch/DotNetWatchTasks/DotNetWatchTasks.csproj
+++ b/src/Dotnet.Watch/DotNetWatchTasks/DotNetWatchTasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
+++ b/src/RazorSdk/Tasks/Microsoft.NET.Sdk.Razor.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RazorSdkRoot>$(RepoRoot)\src\RazorSdk\</RazorSdkRoot>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <PackageId>Microsoft.NET.Sdk.Razor</PackageId>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\tasks</OutDirName>
 

--- a/src/StaticWebAssetsSdk/.editorconfig
+++ b/src/StaticWebAssetsSdk/.editorconfig
@@ -94,6 +94,17 @@ charset = utf-8-bom
 
 [*.{cs,vb}]
 
+# MSBuildTask0001-0005 (Microsoft.Build.TaskAuthoring.Analyzer) downgraded to 'suggestion' for report-only
+# onboarding while task migration to the multithreaded model (IMultiThreadableTask / TaskEnvironment) is
+# pending. This must be duplicated from the repo-root .editorconfig because this file sets `root = true`,
+# which severs inheritance from the root. Raise these to 'warning'/'error' (here or in a more specific
+# nested .editorconfig) as task classes are migrated.
+dotnet_diagnostic.MSBuildTask0001.severity = suggestion
+dotnet_diagnostic.MSBuildTask0002.severity = suggestion
+dotnet_diagnostic.MSBuildTask0003.severity = suggestion
+dotnet_diagnostic.MSBuildTask0004.severity = suggestion
+dotnet_diagnostic.MSBuildTask0005.severity = suggestion
+
 # SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 dotnet_diagnostic.SYSLIB1054.severity = warning
 

--- a/src/StaticWebAssetsSdk/Tasks/Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj
+++ b/src/StaticWebAssetsSdk/Tasks/Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <StaticWebAssetsSdkRoot>$(RepoRoot)\src\StaticWebAssetsSdk\</StaticWebAssetsSdkRoot>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <PackageId>Microsoft.NET.Sdk.StaticWebAssets</PackageId>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\tasks</OutDirName>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Extensions.Tasks/Microsoft.NET.Build.Extensions.Tasks.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.NET.Build.Extensions</PackageId>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\tools</OutDirName>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <PackageId>Microsoft.NET.Sdk</PackageId>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\tools</OutDirName>
   </PropertyGroup>

--- a/src/Tasks/sdk-tasks/sdk-tasks.csproj
+++ b/src/Tasks/sdk-tasks/sdk-tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(BundledNETCoreAppTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <Description>MSBuild tasks for template authoring.</Description>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 

--- a/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
+++ b/src/WebSdk/Publish/Tasks/Microsoft.NET.Sdk.Publish.Tasks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PublishRoot Condition="'$(PublishRoot)' == ''">$(RepoRoot)\src\WebSdk\Publish\</PublishRoot>
+    <IsMSBuildTaskProject>true</IsMSBuildTaskProject>
     <PackageId>Microsoft.NET.Sdk.Publish</PackageId>
     <OutDirName>$(Configuration)\Sdks\$(PackageId)\tools</OutDirName>
 


### PR DESCRIPTION
## What

Onboards the repo to the **`Microsoft.Build.TaskAuthoring.Analyzer`** (the MSBuild thread-safe task analyzer) and applies it to the **12 projects that contain MSBuild task implementations**, in **report-only** mode. The repo builds **green** (0 errors, 0 warnings); every analyzer finding surfaces as an info-level *suggestion*.

This is the first step toward getting SDK's MSBuild Tasks 'green' from an analyzer perspective. Follow-up PRs can then tackle one task class — or one diagnostic category — at a time by raising severity in `.editorconfig`.

## Mechanism (centralized + opt-in)

- **`Directory.Packages.props`** — pins the analyzer (`18.9.0-preview-26310-106`, dotnet-eng feed).
- **`eng/MSBuildTaskAuthoringAnalyzer.props`** (new) — adds the analyzer as an analyzers-only `PackageReference` (`PrivateAssets="all" IncludeAssets="analyzers"`) for any project that opts in with `IsMSBuildTaskProject=true` (excluded in source-only builds). Imported from `Directory.Build.targets`.
- **12 task `.csproj` files** — each opts in via `<IsMSBuildTaskProject>true</IsMSBuildTaskProject>`.
- **`.editorconfig`** — downgrades `MSBuildTask0001`–`0005` to `suggestion`. At info severity the diagnostics are never promoted to warnings/errors — not even by the MSBuild engine's warn-as-error (`MSBuildTreatWarningsAsErrors`) that Arcade enables — so **no** `WarningsNotAsErrors` exemption lists are needed.
- **`src/StaticWebAssetsSdk/.editorconfig`** — carries its own copy of the `suggestion` block because it sets `root = true` and so does not inherit the repo-root `.editorconfig`. It's the only one of the 12 task projects with a `root = true` editorconfig.

## Diagnostics

The analyzer raises **373 unique findings** across **11** projects (`Microsoft.DotNet.GenAPI.Task` is clean):

| Rule | Count | Meaning |
| --- | --- | --- |
| `MSBuildTask0002` | 49 | API needs a `TaskEnvironment` alternative (env vars, CWD, `Path.GetFullPath`, `Process.Start`) |
| `MSBuildTask0003` | 268 | File-system API needs an absolutized path |
| `MSBuildTask0005` | 56 | Transitive unsafe usage in a task call chain |

Top projects: StaticWebAssets.Tasks (144), sdk-tasks (86), Publish.Tasks (51), Build.Tasks (43).

A full report (per-rule / per-project / per-file breakdown) is attached to the tracking work.

## Re-enablement path (follow-up PRs)

- **Per category:** raise a single `dotnet_diagnostic.MSBuildTask000X.severity` to `warning`/`error` in the root `.editorconfig` (and the StaticWebAssets copy) once that rule is repo-wide clean.
- **Per task class:** add/edit an `.editorconfig` in that task's source directory raising severity, then migrate that class to `IMultiThreadableTask` / `TaskEnvironment`.

## Validation

`build.cmd` → **Build succeeded, 0 errors, 0 warnings.** No `.xlf` changes; no new NETSDK error codes.