### PR TITLE
Sign and publish `get-dotnetup.ps1` script

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -88,6 +88,17 @@
                 RelativeBlobPath="dotnetup/$(DotnetupVersion)/dotnetup-$(TargetRid)$(_DotnetupNativeExt)" />
       <Artifact Condition="'%(Filename)%(Extension)' == 'dotnetup-$(TargetRid)$(_DotnetupNativeExt).sha512'"
                 RelativeBlobPath="dotnetup/$(DotnetupVersion)/dotnetup-$(TargetRid)$(_DotnetupNativeExt).sha512" />
+      <!-- Publish get-dotnetup scripts under the same dotnetup/<version>/ prefix as the binaries.
+      This allows arcade's DotnetupAkaMSCreateLinkPatterns to properly produce aka.ms/dotnet/dotnetup/daily/get-dotnetup.{ps1,sh}.
+      -->
+      <Artifact Condition="'%(Filename)%(Extension)' == 'get-dotnetup.ps1'"
+                RelativeBlobPath="dotnetup/$(DotnetupVersion)/get-dotnetup.ps1" />
+      <Artifact Condition="'%(Filename)%(Extension)' == 'get-dotnetup.ps1.sha512'"
+                RelativeBlobPath="dotnetup/$(DotnetupVersion)/get-dotnetup.ps1.sha512" />
+      <Artifact Condition="'%(Filename)%(Extension)' == 'get-dotnetup.sh'"
+                RelativeBlobPath="dotnetup/$(DotnetupVersion)/get-dotnetup.sh" />
+      <Artifact Condition="'%(Filename)%(Extension)' == 'get-dotnetup.sh.sha512'"
+                RelativeBlobPath="dotnetup/$(DotnetupVersion)/get-dotnetup.sh.sha512" />
     </ItemGroup>
   </Target>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -123,6 +123,14 @@
     <FileSignInfo Condition="'$(TargetOS)' == 'osx' and '$(TargetRid)' != ''"
                   Include="dotnetup-$(TargetRid)"
                   CertificateName="MacDeveloperHardenWithNotarization" />
+
+    <!-- Sign the powershell script as powershell blocks running unsigned scripts -->
+    <FileSignInfo Condition="'$(OS)' == 'Windows_NT'"
+                  Include="get-dotnetup.ps1"
+                  CertificateName="MicrosoftDotNet500" />
+
+    <!-- Avoid SignTool flagging the .sh script as missing sign info. -->
+    <FileSignInfo Include="get-dotnetup.sh" CertificateName="None" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'osx'">
@@ -198,6 +206,21 @@
     <!-- The '*' wildcard is for the TargetFramework, which isn't set when evaluating this file. -->
     <_DotnetupPublishedBinary Include="$(ArtifactsBinDir)dotnetup\$(Configuration)\*\$(TargetRid)\publish\dotnetup-$(TargetRid)$(_DotnetupNativeExt)" />
     <Artifact Include="@(_DotnetupPublishedBinary)" Kind="Blob">
+      <ChecksumPath>%(FullPath).sha512</ChecksumPath>
+    </Artifact>
+  </ItemGroup>
+
+  <!--
+    Register the get-dotnetup bootstrap scripts as Blob artifacts from their staged copies
+    (see StageGetDotnetupScripts in src/Installer/dotnetup/dotnetup.csproj). The scripts are
+    RID-independent and are staged/signed/published only from the win-x64 leg to avoid
+    duplicate blob paths, so this registration is gated to that single leg. get-dotnetup.ps1
+    is Authenticode-signed via the FileSignInfo above; get-dotnetup.sh is published unsigned.
+  -->
+  <ItemGroup Condition="'$(TargetRid)' == 'win-x64'">
+    <_GetDotnetupPublishedScript Include="$(ArtifactsBinDir)dotnetup-scripts\get-dotnetup.ps1" />
+    <_GetDotnetupPublishedScript Include="$(ArtifactsBinDir)dotnetup-scripts\get-dotnetup.sh" />
+    <Artifact Include="@(_GetDotnetupPublishedScript)" Kind="Blob">
       <ChecksumPath>%(FullPath).sha512</ChecksumPath>
     </Artifact>
   </ItemGroup>

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!--
     NativeAOT entry-point Exe for dotnetup. We want to compile dotnetup into a NativeAOT
@@ -6,7 +6,7 @@
     dotnetup.Library project, which is what tests reference.  This project is published
     as a NativeAOT executable and simply has an entry point that forwards to the one in
     the library.
-    
+
     We set _IsPublishing=true and have a PublishOnBuild target so that the AOT publish
     runs as part of the normal build.
 
@@ -66,8 +66,8 @@
   </ItemGroup>
 
     <!-- We want to always create a NativeAOT executable when this project is built or published.
-    
-        So we set _IsPublishing=true and add a target to run Publish after Build.  But in order to 
+
+        So we set _IsPublishing=true and add a target to run Publish after Build.  But in order to
         avoid a target cycle error when publish is invoked directly, we first check whether
         _IsPublishing was already set, and if so let the normal publish flow run instead. -->
   <PropertyGroup>
@@ -108,6 +108,24 @@
           Outputs="$(PublishDir)dotnetup-$(RuntimeIdentifier)$(_DotnetupNativeBinaryExt)">
     <Copy SourceFiles="$(PublishDir)$(TargetName)$(_DotnetupNativeBinaryExt)"
           DestinationFiles="$(PublishDir)dotnetup-$(RuntimeIdentifier)$(_DotnetupNativeBinaryExt)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!--
+    Stage the get-dotnetup scripts for signing and publishing, only on one target CI machine and scripts are rid-agnostic.
+    The matching aka.ms link patterns live in dotnet/arcade's DotnetupAkaMSCreateLinkPatterns.
+  -->
+  <ItemGroup>
+    <_GetDotnetupScript Include="$(RepoRoot)scripts\get-dotnetup.ps1" />
+    <_GetDotnetupScript Include="$(RepoRoot)scripts\get-dotnetup.sh" />
+  </ItemGroup>
+  <Target Name="StageGetDotnetupScripts"
+          AfterTargets="Build"
+          Condition="'$(RuntimeIdentifier)' == 'win-x64'"
+          Inputs="@(_GetDotnetupScript)"
+          Outputs="@(_GetDotnetupScript->'$(ArtifactsBinDir)dotnetup-scripts\%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(_GetDotnetupScript)"
+          DestinationFolder="$(ArtifactsBinDir)dotnetup-scripts"
           SkipUnchangedFiles="true" />
   </Target>
 

--- a/src/Installer/dotnetup/dotnetup.csproj
+++ b/src/Installer/dotnetup/dotnetup.csproj
@@ -121,7 +121,7 @@
   </ItemGroup>
   <Target Name="StageGetDotnetupScripts"
           AfterTargets="Build"
-          Condition="'$(RuntimeIdentifier)' == 'win-x64'"
+          Condition="'$(TargetRid)' == 'win-x64'"
           Inputs="@(_GetDotnetupScript)"
           Outputs="@(_GetDotnetupScript->'$(ArtifactsBinDir)dotnetup-scripts\%(Filename)%(Extension)')">
     <Copy SourceFiles="@(_GetDotnetupScript)"


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/54777

- Signs the `get-dotnetup.ps1` script but not the `.sh` script

- Prepares to publish the get-dotnetup script so it can be consumed via a `/daily/` url, as right now the url is generic, unversioned, and pointing at the raw github file which prevents signing.

- An arcade change is needed to pickup that artifact and publish it as well. This has been merged: 
https://github.com/dotnet/arcade/pull/17053

- A build can be viewed here [but ](https://dev.azure.com/dnceng/internal/_build/results?buildId=3011835&view=results) we need an actual automated CI run to get the URL: `https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1` to work.

The script gets rejected by powershell if it's unsigned hence the motivation to do this.

Before:
<img width="1124" height="149" alt="image" src="https://github.com/user-attachments/assets/3fff733d-bacc-4873-9a63-5d3716a785b2" />

Now: (on sandbox)
<img width="1163" height="80" alt="image" src="https://github.com/user-attachments/assets/22df1242-7601-4ca5-b6ae-f0606fa93a79" />

