### PR TITLE
Fix flaky Nuget_reference_compat test: make TestContextOutputHelper thread-safe

### DIFF
--- a/test/Microsoft.NET.TestFramework.MSTest/TestContextOutputHelper.cs
+++ b/test/Microsoft.NET.TestFramework.MSTest/TestContextOutputHelper.cs
@@ -15,20 +15,24 @@ public sealed class TestContextOutputHelper : ITestOutputHelper
 {
     private readonly TestContext? _testContext;
     private readonly StringBuilder _output = new();
+    private readonly object _lock = new();
 
     public TestContextOutputHelper(TestContext? testContext)
     {
         _testContext = testContext;
     }
 
-    public string Output => _output.ToString();
+    public string Output => ToString();
 
     public void Write(string message)
     {
-        _output.Append(message);
-        // TestContext.Write appends without a trailing line break, matching this partial-write
-        // semantic (don't switch to WriteLine here: that would add an unintended newline).
-        _testContext?.Write(message);
+        lock (_lock)
+        {
+            _output.Append(message);
+            // TestContext.Write appends without a trailing line break, matching this partial-write
+            // semantic (don't switch to WriteLine here: that would add an unintended newline).
+            _testContext?.Write(message);
+        }
     }
 
     public void Write(string format, params object[] args)
@@ -36,12 +40,18 @@ public sealed class TestContextOutputHelper : ITestOutputHelper
 
     public void WriteLine(string message)
     {
-        _output.AppendLine(message);
-        _testContext?.WriteLine("{0}", message);
+        lock (_lock)
+        {
+            _output.AppendLine(message);
+            _testContext?.WriteLine("{0}", message);
+        }
     }
 
     public void WriteLine(string format, params object[] args)
         => WriteLine(string.Format(format, args));
 
-    public override string ToString() => _output.ToString();
+    public override string ToString()
+    {
+        lock (_lock) { return _output.ToString(); }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #54960

`TestContextOutputHelper` (introduced in #54769) is not thread-safe, but it is used concurrently from [`Parallel.ForEach` in `Nuget_reference_compat`](https://github.com/dotnet/sdk/blob/54b99958954c7143ddd856ce7c4061a393d41469/test/Microsoft.NET.Build.Tests/GivenThatWeWantToVerifyNuGetReferenceCompat.cs#L60-L97) where multiple threads share the same `Log` instance and call `Execute()` → `TestContextOutputHelper.WriteLine()` simultaneously.

Neither `StringBuilder` nor `TestContext.WriteLine` are thread-safe, so the concurrent writes intermittently race on the internal buffer, producing:

```
System.AggregateException: One or more errors occurred.
  (Destination is too short. (Parameter 'destination'))
  ---> System.ArgumentException: Destination is too short. (Parameter 'destination')
    at System.Text.StringBuilder.AppendWithExpansion(...)
    at Microsoft.NET.TestFramework.TestContextOutputHelper.WriteLine(...)
```

## Fix

Added a `lock` around all `StringBuilder` and `TestContext` operations in `TestContextOutputHelper`. Also consolidated the duplicate `Output` property to delegate to `ToString()`.

## Impact

Test infrastructure only — no product code changes.