### PR TITLE
Avoid redundant deduplication in ResolveTargetingPackAssets

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -267,8 +267,8 @@ namespace Microsoft.NET.Build.Tasks
 
             ResolvedAssetsCacheEntry newCacheEntry = new()
             {
-                ReferencesToAdd = deduplicatedReferences.Distinct().ToArray(),
-                AnalyzersToAdd = deduplicatedAnalyzers.Distinct().ToArray(),
+                ReferencesToAdd = deduplicatedReferences.ToArray(),
+                AnalyzersToAdd = deduplicatedAnalyzers.ToArray(),
                 PlatformManifests = platformManifests.ToArray(),
                 PackageConflictOverrides = packageConflictOverrides.ToArray(),
                 PackageConflictPreferredPackages = string.Join(";", preferredPackages),


### PR DESCRIPTION
Copilot analysis of an SDK insertion to VS found this--the variable is already the output of `DeduplicateItems` so we shouldn't need to make it `Distinct()`.