### PR TITLE
Migrate UpdateStaticWebAssetEndpoints

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/UpdateStaticWebAssetEndpoints.cs
+++ b/src/StaticWebAssetsSdk/Tasks/UpdateStaticWebAssetEndpoints.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets.Tasks;
 // This will remove the updated endpoints from the original list and add the updated ones back in. Including any endpoint that might
 // have been removed because it had the same route as one of the updated endpoints.
 
+[MSBuildMultiThreadableTask]
 public class UpdateStaticWebAssetEndpoints : Task
 {
     [Required] public ITaskItem[] EndpointsToUpdate { get; set; }


### PR DESCRIPTION
Fixes dotnet/msbuild#14168

### Context

Migrates the `UpdateStaticWebAssetEndpoints` MSBuild task to the multithreaded execution model. The task does pure in-memory work (it rewrites endpoint metadata from its `ITaskItem` inputs), so it touches no process-global state and needs only the capability attribute — not `TaskEnvironment`.

### Changes Made

- Added `[MSBuildMultiThreadableTask]` to the `UpdateStaticWebAssetEndpoints` class.
- Left `IMultiThreadableTask` unimplemented intentionally: `Execute()` and its call chain (`StaticWebAssetEndpoint.FromItemGroup`/`FromTaskItem`/`ToTaskItems`, `StaticWebAssetEndpointOperation.FromTaskItem`, and the operation helpers) perform only dictionary/list/array manipulation — no `File`/`Directory`/`Environment`/`Process`/`Console` calls and no static mutable state — so no path absolutization or `TaskEnvironment` plumbing is required.

### Testing

- Built `Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj` (net11.0 and net472) with the dotnet/msbuild `Microsoft.Build.TaskAuthoring.Analyzer` injected; `UpdateStaticWebAssetEndpoints.cs` compiles clean and the analyzer reported **0** `MSBuildTask0001–0005` diagnostics for it across both target frameworks.
- No unit test added: per the MT migration guidance, an attribute-only migration with no file/env/process/static-state interaction has nothing to assert (a decoy-CWD test would pass with or without the attribute).