### PR TITLE
Pass --targetos to crossgen2

### DIFF
--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -186,40 +186,36 @@
     <Crossgen
         SourceAssembly="%(RoslynTargets.FullPath)"
         DestinationPath="%(RoslynTargets.FullPath)"
-        Architecture="$(TargetArchitecture)"
+        TargetArchitecture="$(TargetArchitecture)"
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
-        ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
         PlatformAssemblyPaths="@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
         SourceAssembly="%(FSharpTargets.FullPath)"
         DestinationPath="%(FSharpTargets.FullPath)"
-        Architecture="$(TargetArchitecture)"
+        TargetArchitecture="$(TargetArchitecture)"
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
-        ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
         PlatformAssemblyPaths="@(FSharpFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
         SourceAssembly="%(RemainingTargets.FullPath)"
         DestinationPath="%(RemainingTargets.FullPath)"
-        Architecture="$(TargetArchitecture)"
+        TargetArchitecture="$(TargetArchitecture)"
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
-        ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
         PlatformAssemblyPaths="@(RemainingFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
         SourceAssembly="%(RazorToolTargets.FullPath)"
         DestinationPath="%(RazorToolTargets.FullPath)"
-        Architecture="$(TargetArchitecture)"
+        TargetArchitecture="$(TargetArchitecture)"
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
-        ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
         PlatformAssemblyPaths="@(RazorToolFolders);@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
 

--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -26,8 +26,7 @@
       <!-- The target OS to pass to crossgen2. Without it, crossgen2 defaults to the OS it is running
            on, which produces images for the wrong OS when cross-compiling the SDK toolset (e.g.
            building an OpenBSD SDK on a Linux host). crossgen2 only recognizes the base OS name, so
-           Linux flavors ('linux-musl', 'linux-bionic') must be normalized to 'linux' to match the
-           same convention used by the runtime repo (see runtime's eng/RuntimeIdentifier.props). -->
+           Linux flavors ('linux-musl', 'linux-bionic') must be normalized to 'linux'. -->
       <_CrossgenTargetOS>$(TargetOS)</_CrossgenTargetOS>
       <_CrossgenTargetOS Condition="$(TargetOS.StartsWith('linux'))">linux</_CrossgenTargetOS>
     </PropertyGroup>

--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -22,6 +22,14 @@
       <!-- When ingesting stable pgo instrumented binaries, the shared framework will be a non-stable version,
            as will the archive file names themselves. -->
       <SharedFrameworkNameVersionPath>$(RedistInstallerLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
+
+      <!-- The target OS to pass to crossgen2. Without it, crossgen2 defaults to the OS it is running
+           on, which produces images for the wrong OS when cross-compiling the SDK toolset (e.g.
+           building an OpenBSD SDK on a Linux host). crossgen2 only recognizes the base OS name, so
+           Linux flavors ('linux-musl', 'linux-bionic') must be normalized to 'linux' to match the
+           same convention used by the runtime repo (see runtime's eng/RuntimeIdentifier.props). -->
+      <_CrossgenTargetOS>$(TargetOS)</_CrossgenTargetOS>
+      <_CrossgenTargetOS Condition="$(TargetOS.StartsWith('linux'))">linux</_CrossgenTargetOS>
     </PropertyGroup>
 
     <!-- This PropertyGroup contains the paths to the various SDK tooling that should be
@@ -179,6 +187,7 @@
         SourceAssembly="%(RoslynTargets.FullPath)"
         DestinationPath="%(RoslynTargets.FullPath)"
         Architecture="$(TargetArchitecture)"
+        TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -188,6 +197,7 @@
         SourceAssembly="%(FSharpTargets.FullPath)"
         DestinationPath="%(FSharpTargets.FullPath)"
         Architecture="$(TargetArchitecture)"
+        TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -197,6 +207,7 @@
         SourceAssembly="%(RemainingTargets.FullPath)"
         DestinationPath="%(RemainingTargets.FullPath)"
         Architecture="$(TargetArchitecture)"
+        TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -206,6 +217,7 @@
         SourceAssembly="%(RazorToolTargets.FullPath)"
         DestinationPath="%(RazorToolTargets.FullPath)"
         Architecture="$(TargetArchitecture)"
+        TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"

--- a/src/Tasks/sdk-tasks/Crossgen.cs
+++ b/src/Tasks/sdk-tasks/Crossgen.cs
@@ -7,13 +7,6 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     public sealed class Crossgen : ToolTask
     {
-        public Crossgen()
-        {
-            // Disable partial NGEN to avoid excess JIT-compilation.
-            // The intention is to pre-compile as much as possible.
-            EnvironmentVariables = new string[] { "COMPlus_PartialNGen=0" };
-        }
-
         [Required]
         public string SourceAssembly { get;set; }
 
@@ -21,15 +14,13 @@ namespace Microsoft.DotNet.Build.Tasks
         public string DestinationPath { get; set; }
 
         [Required]
-        public string Architecture { get; set; }
+        public string TargetArchitecture { get; set; }
 
         public string TargetOS { get; set; }
 
         public string CrossgenPath { get; set; }
 
         public bool CreateSymbols { get; set; }
-
-        public bool ReadyToRun { get; set; }
 
         public ITaskItem[] PlatformAssemblyPaths { get; set; }
 
@@ -115,7 +106,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         protected override string GenerateCommandLineCommands() => $"{GetInPath()} {GetOutPath()} {GetTargetOS()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
 
-        private string GetArchitecture() => $"--targetarch {Architecture}";
+        private string GetArchitecture() => $"--targetarch {TargetArchitecture}";
 
         // Explicitly specify the target OS. When omitted, crossgen2 defaults to the OS it is
         // running on, which produces images for the wrong OS when cross-compiling (e.g. building

--- a/src/Tasks/sdk-tasks/Crossgen.cs
+++ b/src/Tasks/sdk-tasks/Crossgen.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string Architecture { get; set; }
 
+        public string TargetOS { get; set; }
+
         public string CrossgenPath { get; set; }
 
         public bool CreateSymbols { get; set; }
@@ -111,9 +113,14 @@ namespace Microsoft.DotNet.Build.Tasks
 
         protected override string GenerateFullPathToTool() => CrossgenPath ?? "crossgen2";
 
-        protected override string GenerateCommandLineCommands() => $"{GetInPath()} {GetOutPath()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
+        protected override string GenerateCommandLineCommands() => $"{GetInPath()} {GetOutPath()} {GetTargetOS()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
 
         private string GetArchitecture() => $"--targetarch {Architecture}";
+
+        // Explicitly specify the target OS. When omitted, crossgen2 defaults to the OS it is
+        // running on, which produces images for the wrong OS when cross-compiling (e.g. building
+        // an OpenBSD SDK on a Linux host). An empty value preserves the host-default behavior.
+        private string GetTargetOS() => string.IsNullOrEmpty(TargetOS) ? string.Empty : $"--targetos {TargetOS}";
 
         private string GetCreateSymbols() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap";
 

--- a/src/Tasks/sdk-tasks/Crossgen.cs
+++ b/src/Tasks/sdk-tasks/Crossgen.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string TargetArchitecture { get; set; }
 
+        [Required]
         public string TargetOS { get; set; }
 
         public string CrossgenPath { get; set; }
@@ -108,10 +109,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private string GetArchitecture() => $"--targetarch {TargetArchitecture}";
 
-        // Explicitly specify the target OS. When omitted, crossgen2 defaults to the OS it is
-        // running on, which produces images for the wrong OS when cross-compiling (e.g. building
-        // an OpenBSD SDK on a Linux host). An empty value preserves the host-default behavior.
-        private string GetTargetOS() => string.IsNullOrEmpty(TargetOS) ? string.Empty : $"--targetos {TargetOS}";
+        private string GetTargetOS() => $"--targetos {TargetOS}";
 
         private string GetCreateSymbols() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap";
 


### PR DESCRIPTION
OpenBSD x64 SDK is throwing
```sh
$ dotnet --version
Unhandled exception. System.BadImageFormatException: An attempt was made to load a program with an incorrect format.
 (0x8007000B)
Abort trap                 (core dumped) dotnet --version
```