### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.ApiCompatibility.Tests

### DIFF
--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -26,4 +26,8 @@
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -114,8 +114,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void AssemblyKeyTokenMustBeCompatible(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -134,8 +133,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void LeftAssemblyKeyTokenNull(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -162,8 +160,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void RightAssemblyKeyTokenNull(bool strictMode)
         {
             string syntax = "namespace EmptyNs { }";
@@ -183,8 +180,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void RetargetableFlagSet(bool strictMode)
         {
             string syntax = @"

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotRemoveBaseTypeOrInterfaceTests.cs
@@ -88,8 +88,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void RemovedInternalInterfaceIsReportedWhenIncludeInternals(bool includeInternals)
         {
             string leftSyntax = @"
@@ -171,8 +170,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void SameOnBothSidesDoesNotFail(bool strictMode)
         {
             string leftSyntax = @"

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/CannotSealTypeTests.cs
@@ -43,8 +43,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void SealInheritableTypeInternalsVisibleReported(bool includeInternals)
         {
             string leftSyntax = @"

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.Strict.cs
@@ -145,8 +145,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
         {
             string rightSyntax = @"

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/MembersMustExistTests.cs
@@ -147,8 +147,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void IncludeInternalsIsRespectedForMembers_IndividualAssemblies(bool includeInternals)
         {
             string leftSyntax = @"

--- a/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
+++ b/test/Microsoft.DotNet.ApiCompatibility.Tests/Rules/TypeMustExistTests.cs
@@ -211,8 +211,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void InternalTypesAreIgnoredWhenSpecified(bool includeInternalSymbols)
         {
             string leftSyntax = @"
@@ -249,8 +248,7 @@ namespace CompatTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void MissingNestedTypeIsReported(bool includeInternalSymbols)
         {
             string leftSyntax = @"


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the [Combinatorial.MSTest](https://github.com/AArnott/Combinatorial.MSTest) package in the `Microsoft.DotNet.ApiCompatibility.Tests` project.

## What changed

- 11 test methods across 6 files had their explicit `[DataRow(true)]` / `[DataRow(false)]` pairs replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical — `[CombinatorialData]` on a `bool` parameter automatically generates both `true` and `false` rows.
- The `.csproj` gains an `ItemGroup` with `<PackageReference Include="Combinatorial.MSTest" />` and `<Using Include="Combinatorial.MSTest" />` (global using, so no per-file `using` directives are needed).

## Why

Explicit boolean `[DataRow]` pairs are noisy and easy to forget to add both values. `[CombinatorialData]` is the idiomatic MSTest replacement and keeps the parameter list as the single source of truth.

This is part of a per-project series so project owners can review each change independently.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>