### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.ApiSymbolExtensions.Tests

### DIFF
--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/AssemblySymbolLoaderTests.cs
@@ -163,8 +163,7 @@ namespace MyNamespace
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void LoadMatchingAssemblies_DifferentIdentity(bool validateIdentities)
         {
             var assetInfo = GetSimpleTestAsset();
@@ -260,8 +259,7 @@ namespace MyNamespace
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void LoadAssemblyResolveReferences_WarnsWhenEnabled(bool resolveReferences)
         {
             var assetInfo = GetSimpleTestAsset();

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFilterFactoryTests.cs
@@ -13,32 +13,28 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests;
 public class SymbolFilterFactoryTests
 {
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void Test_FilterFromFiles(bool includeCustomType)
     {
         Test_FilterFromFiles_Internal(includeCustomType, accessibilitySymbolFilter: null);
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void Test_FilterFromFiles_CustomAccessibilityFilter(bool includeCustomType)
     {
         Test_FilterFromFiles_Internal(includeCustomType, new AccessibilitySymbolFilter(includeInternalSymbols: true));
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void Test_FilterFromList(bool includeCustomType)
     {
         Test_FilterFromList_Internal(includeCustomType, accessibilitySymbolFilter: null);
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void Test_FilterFromList_WithCustomAccessibilityFilter(bool includeCustomType)
     {
         Test_FilterFromList_Internal(includeCustomType, new AccessibilitySymbolFilter(includeInternalSymbols: true));


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` (from the `Combinatorial.MSTest` package) in the `Microsoft.DotNet.ApiSymbolExtensions.Tests` project.

## What changed

- **6 test methods** across `AssemblySymbolLoaderTests.cs` and `SymbolFilterFactoryTests.cs` had pairs of `[DataRow(true)]` / `[DataRow(false)]` replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical.
- `Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj` gains a new `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file import needed)

## Why

`[CombinatorialData]` is the idiomatic MSTest way to cover all combinations of boolean parameters. It removes boilerplate `[DataRow]` lines and scales naturally when additional parameters are added later.

This is part of a per-project series applying the same mechanical refactor across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>