### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.MSBuildSdkResolver.Tests

### DIFF
--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -173,8 +173,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItReturnsHighestSdkAvailableThatIsCompatibleWithMSBuild(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviews.ToString())
@@ -254,8 +253,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItDoesNotReturnHighestSdkAvailableThatIsCompatibleWithMSBuildWhenVersionInGlobalJsonCannotBeFoundOutsideOfVisualStudio(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, callingMethod: "ItDoesNotReturnHighest___", identifier: disallowPreviews.ToString())
@@ -291,8 +289,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItReturnsHighestSdkAvailableThatIsCompatibleWithMSBuildWhenVersionInGlobalJsonCannotBeFoundAndRunningInVisualStudio(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, callingMethod: "ItReturnsHighest___", identifier: disallowPreviews.ToString())
@@ -431,8 +428,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItDisallowsPreviewsBasedOnDefault(bool disallowPreviewsByDefault)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviewsByDefault.ToString());
@@ -458,8 +454,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItDisallowsPreviewsBasedOnFile(bool disallowPreviews)
         {
             var environment = new TestEnvironment(TestAssetsManager, identifier: disallowPreviews.ToString());

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -48,4 +48,8 @@
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` in the `Microsoft.DotNet.MSBuildSdkResolver.Tests` project.

## What changed

- **5 test methods** in `GivenAnMSBuildSdkResolver.cs` had pairs of `[DataRow(true)]` / `[DataRow(false)]` replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical — MSTest's combinatorial engine expands each `bool` parameter to `true` and `false` automatically.
- `Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj` gains a new `<ItemGroup>` with:
  - `<PackageReference Include="Combinatorial.MSTest" />` — picks up the version from the repo's central package management.
  - `<Using Include="Combinatorial.MSTest" />` — makes `[CombinatorialData]` available globally in the project without an explicit `using` directive in each file.

## Why

Enumerating every boolean combination by hand is noisy and error-prone. `[CombinatorialData]` expresses the same intent in one line and scales automatically if additional bool parameters are added later.

This is part of a per-project series applying the same mechanical refactor across the repo.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>