### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Build.Tests

### DIFF
--- a/test/Microsoft.NET.Build.Tests/COMReferenceTests.cs
+++ b/test/Microsoft.NET.Build.Tests/COMReferenceTests.cs
@@ -11,8 +11,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [FullMSBuildOnly]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void COMReferenceBuildsAndRuns(bool embedInteropTypes)
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;

--- a/test/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenFrameworkReferences.cs
@@ -591,8 +591,7 @@ namespace FrameworkReferenceTest
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void TargetLatestPatchCanBeSpecifiedOnFrameworkReference(bool attributeValue)
         {
             var testProject = new TestProject();
@@ -628,8 +627,7 @@ namespace FrameworkReferenceTest
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void TargetLatestPatchCanBeSpecifiedViaProperty(bool propertyValue)
         {
             var testProject = new TestProject();
@@ -897,8 +895,7 @@ namespace FrameworkReferenceTest
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void WindowsFormsFrameworkReference(bool selfContained)
         {
             TestFrameworkReferenceProfiles(
@@ -910,8 +907,7 @@ namespace FrameworkReferenceTest
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void WPFFrameworkReference(bool selfContained)
         {
             TestFrameworkReferenceProfiles(
@@ -923,8 +919,7 @@ namespace FrameworkReferenceTest
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void WindowsFormAndWPFFrameworkReference(bool selfContained)
         {
             TestFrameworkReferenceProfiles(
@@ -936,8 +931,7 @@ namespace FrameworkReferenceTest
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void WindowsDesktopFrameworkReference(bool selfContained)
         {
             TestFrameworkReferenceProfiles(

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExe.cs
@@ -58,8 +58,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void RuntimeIdentifiersInferredCorrectly(bool useRidGraph)
         {
             Func<string, string, string> findAssembly = (a, b) => default;
@@ -906,8 +905,7 @@ class Program
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_places_package_satellites_correctly(bool crossTarget)
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopExeWtihNetStandardLib.cs
@@ -257,8 +257,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_does_not_include_netstandard_when_inbox(bool isSdk)
         {
             var testAsset = TestAssetsManager
@@ -325,8 +324,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_does_not_include_netstandard_when_library_targets_netstandard14(bool isSdk)
         {
             var testAsset = TestAssetsManager
@@ -364,8 +362,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_includes_netstandard_when_library_targets_netstandard15(bool isSdk)
         {
             var testAsset = TestAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildADesktopLibrary.cs
@@ -137,8 +137,7 @@ public class NETFramework
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PackageWithoutAssets_ShouldNotShowUpInDepsJson(bool trimLibrariesWithoutAssets)
         {
             var testProject = new TestProject()
@@ -385,8 +384,7 @@ public static class {project.Name}
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_uses_hintpath_when_replacing_simple_name_references(bool useFacades)
         {
             TestProject project = new()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildALibrary.cs
@@ -554,8 +554,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_fails_gracefully_if_targetframework_is_empty(bool useSolution)
         {
             string targetFramework = "";
@@ -564,8 +563,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_fails_gracefully_if_targetframework_is_invalid(bool useSolution)
         {
             string targetFramework = "notaframework";
@@ -574,8 +572,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_fails_gracefully_if_targetframework_should_be_targetframeworks(bool useSolution)
         {
             string targetFramework = $"{ToolsetInfo.CurrentTargetFramework};net462";

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildANetCoreApp.cs
@@ -180,8 +180,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_handles_mismatched_implicit_package_versions(bool allowMismatch)
         {
             var testProject = new TestProject()
@@ -497,8 +496,7 @@ public static class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_generates_rid_fallback_graph(bool isSelfContained)
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;
@@ -563,8 +561,7 @@ public static class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_publishes_package_satellites_correctly(bool crossTarget)
         {
             var testProject = new TestProject()
@@ -608,8 +605,7 @@ public static class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_uses_lowercase_form_of_the_target_framework_for_the_output_path(bool useStandardOutputPaths)
         {
             var testProject = new TestProject()
@@ -906,8 +902,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_builds_the_project_successfully_with_only_reference_assembly_set(bool produceOnlyReferenceAssembly)
         {
             var testProject = new TestProject()
@@ -1137,8 +1132,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_includes_local_path_for_package_dependencies(bool useCustomSubdirectory)
         {
             string targetFramework = ToolsetInfo.CurrentTargetFramework;
@@ -1308,8 +1302,7 @@ class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_includes_local_path_for_project_references(bool useCustomSubdirectory)
         {
             string targetFramework = ToolsetInfo.CurrentTargetFramework;

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAWindowsDesktopProject.cs
@@ -196,8 +196,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [OSCondition(OperatingSystems.Windows)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_succeeds_if_windows_target_platform_version_does_not_have_trailing_zeros(bool setInTargetframework)
         {
             if (!setInTargetframework)

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithGlobalJson.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildWithGlobalJson.cs
@@ -9,8 +9,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [FullMSBuildOnly]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_fails_build_on_failed_sdk_resolution(bool runningInVS)
         {
             var prevIncludeDefault = Environment.GetEnvironmentVariable("MSBUILDINCLUDEDEFAULTSDKRESOLVER");

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -748,8 +748,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_includes_repository_url(bool privateRepo)
         {
             var fakeUrl = "fakeUrl";

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToIncludeItemsOutsideTheProjectFolder.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToIncludeItemsOutsideTheProjectFolder.cs
@@ -10,10 +10,7 @@ namespace Microsoft.NET.Build.Tests
     {
 
         [TestMethod]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void Link_metadata_is_added_to_items_outside_the_project_folder(bool includeWithGlob, bool useLinkBase)
         {
             string identifier = (includeWithGlob ? "Globbed" : "Direct") + (useLinkBase ? "_LinkBase" : "");

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPreserveCompilationContextForBuild.cs
@@ -10,8 +10,7 @@ namespace Microsoft.NET.Build.Tests
     {
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_supports_copylocal_false_references(bool withoutCopyingRefs)
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -12,10 +12,7 @@ namespace Microsoft.NET.ToolPack.Tests
     {
 
         [TestMethod]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void It_builds_successfully(bool generatePackageOnBuild, bool packAsTool)
         {
             TestAsset testAsset = TestAssetsManager

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -272,8 +272,7 @@ namespace Microsoft.NET.Build.Tests
         //  Should also run on full framework, but needs the right version of NuGet, which isn't on CI yet
         [TestMethod]
         [CoreMSBuildOnly]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PlatformPackagesCanBePruned(bool prunePackages)
         {
             var referencedProject = new TestProject("ReferencedProject")

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -651,8 +651,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void Implicit_NetCoreApp_reference_can_be_overridden(bool disableImplicitFrameworkReferences)
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenTransitiveFrameworkReferencesAreDisabled.cs
@@ -12,8 +12,7 @@ namespace Microsoft.NET.Build.Tests
     {
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void TargetingPacksAreNotDownloadedIfNotDirectlyReferenced(bool referenceAspNet)
         {
             TestPackagesNotDownloaded(referenceAspNet, selfContained: false);

--- a/test/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
+++ b/test/Microsoft.NET.Build.Tests/GlobalPropertyFlowTests.cs
@@ -66,10 +66,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowToLibrary(bool passSelfContained, bool passRuntimeIdentifier)
         {
             var testAsset = Build(passSelfContained, passRuntimeIdentifier, identifier: passSelfContained.ToString() + "_" + passRuntimeIdentifier);
@@ -82,10 +79,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowToExe(bool passSelfContained, bool passRuntimeIdentifier)
         {
             _referencedProject.IsExe = true;
@@ -101,10 +95,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowToExeWithSelfContainedFalse(bool passSelfContained, bool passRuntimeIdentifier)
         {
             _referencedProject.IsExe = true;
@@ -123,10 +114,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowToLibraryWithRuntimeIdentifier(bool passSelfContained, bool passRuntimeIdentifier)
         {
             //  Set a RuntimeIdentifier in the referenced project that is different from what is passed in on the command line
@@ -144,10 +132,7 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowToMultitargetedProject(bool passSelfContained, bool passRuntimeIdentifier)
         {
             _testProject.TargetFrameworks = $"net6.0;{ToolsetInfo.CurrentTargetFramework}";
@@ -179,10 +164,7 @@ namespace Microsoft.NET.Build.Tests
         [TestMethod]
         [Ignore("https://github.com/dotnet/msbuild/issues/8154")]
         [RequiresMSBuildVersion("17.4.0.41702")]
-        [DataRow(true, true)]
-        [DataRow(true, false)]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void TestGlobalPropertyFlowInSolution(bool passSelfContained, bool passRuntimeIdentifier)
         {
             var identifier = passSelfContained.ToString() + "_" + passRuntimeIdentifier;

--- a/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj
@@ -52,4 +52,9 @@
     <!-- Use string resources from tasks in order to validate test output. -->
     <EmbeddedResource Include="..\..\src\Tasks\Common\Resources\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Build.Tasks" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
+++ b/test/Microsoft.NET.Build.Tests/ReferenceExeTests.cs
@@ -287,8 +287,7 @@ public class ReferencedExeProgram
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void ReferencedExeCanRunWhenPublished(bool selfContained)
         {
             MainSelfContained = selfContained;
@@ -302,8 +301,7 @@ public class ReferencedExeProgram
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ReferencedExeCanRunWhenPublishedWithTrimming(bool referenceExeInCode)
         {
             MainSelfContained = true;
@@ -369,8 +367,7 @@ public class ReferencedExeProgram
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void SelfContainedExecutableCannotBeReferencedByNonSelfContainedMTPTestProject(bool setIsTestingPlatformApplicationEarly)
         {
             // The setup of this test is as follows:
@@ -420,8 +417,7 @@ public class ReferencedExeProgram
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void MTPNonSelfContainedExecutableCannotBeReferencedBySelfContained(bool setIsTestingPlatformApplicationEarly)
         {
             // The setup of this test is as follows:
@@ -525,8 +521,7 @@ public class ReferencedExeProgram
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void MTPCanBeBuiltAsSelfContained(bool setIsTestingPlatformApplicationEarly)
         {
             var mtpSelfContained = new TestProject("MTPTestProject")

--- a/test/Microsoft.NET.Build.Tests/SourceLinkTests.cs
+++ b/test/Microsoft.NET.Build.Tests/SourceLinkTests.cs
@@ -218,8 +218,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void SuppressImplicitGitSourceLink_SetExplicitly(bool multitarget)
         {
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");
@@ -252,8 +251,7 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void SuppressImplicitGitSourceLink_ExplicitPackage(bool multitarget)
         {
             string targetFrameworks = ToolsetInfo.CurrentTargetFramework + (multitarget ? ";netstandard2.0" : "");


### PR DESCRIPTION
## Summary

This PR replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` in the `Microsoft.NET.Build.Tests` test project.

### What changed

- **46 test methods** across 19 files had their explicit `[DataRow(true)]` / `[DataRow(false)]` (and multi-boolean combinations) replaced with a single `[CombinatorialData]` attribute.
- The `Microsoft.NET.Build.Tests.csproj` gains a new `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file import is needed)

### Why this is safe

`[CombinatorialData]` automatically generates the full cartesian product of all `bool` parameters — identical executed test cases to the explicit `[DataRow]` set. No test logic was changed.

### Series

This is part of a per-project series migrating all boolean `[DataRow]` patterns to `[CombinatorialData]` across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>