### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Build.Tasks.Tests

### DIFF
--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
@@ -348,8 +348,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void DirectReferenceToPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources([], [], ["System.A"], dllReference);
@@ -358,8 +357,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void IndirectReferenceToPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -371,8 +369,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PackageWithNoAssetsReferencesPackageWithNoAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -384,8 +381,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PackageWithNoAssetsReferencesPackageWithAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>() {
@@ -399,8 +395,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PackageWithNoAssetsReferencesPackageReferencesByOtherPackage(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()
@@ -414,8 +409,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void PackageWithNoAssetsReferencesPackageWithAssetsWithOtherReferencer(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()
@@ -431,8 +425,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void TwoPackagesWithNoAssetsReferencePackageWithAssets(bool dllReference)
         {
             DependencyContext dependencyContext = BuildDependencyContextFromDependenciesWithResources(new Dictionary<string, List<string>>()

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageDependenciesTask.cs
@@ -142,8 +142,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItAssignsDiagnosticLevel(bool useAlias)
         {
             const string target1 = ".NETCoreApp,Version=v1.0";

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -42,4 +42,8 @@
     <None Include="..\..\src\Tasks\Common\Resources\Strings.resx" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` in the `Microsoft.NET.Build.Tasks.Tests` project.

### What changed

- **8 test methods** across two files (`GivenADependencyContextBuilder.cs`, `GivenAResolvePackageDependenciesTask.cs`) had patterns like:
  ```csharp
  [DataRow(true)]
  [DataRow(false)]
  public void SomeTest(bool flag) { ... }
  ```
  replaced with:
  ```csharp
  [CombinatorialData]
  public void SomeTest(bool flag) { ... }
  ```
- The executed test cases are **identical** — `[CombinatorialData]` automatically generates `true`/`false` for each `bool` parameter.
- `Microsoft.NET.Build.Tasks.Tests.csproj` gains a new `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using, no per-file import needed)

### Why

Full boolean `[DataRow]` enumerations are boilerplate that `Combinatorial.MSTest` handles automatically and more readably. This is part of a per-project series applying this pattern across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>