### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in dotnet-watch.Tests

### DIFF
--- a/test/dotnet-watch.Tests/ConsoleReporterTests.cs
+++ b/test/dotnet-watch.Tests/ConsoleReporterTests.cs
@@ -13,8 +13,7 @@ public class ConsoleReporterTests
     private static readonly string EOL = Environment.NewLine;
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void WritesToStandardStreams(bool suppressEmojis)
     {
         var testConsole = new TestConsole();

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs
@@ -171,8 +171,7 @@ public class SourceFileUpdateTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public async Task RenameSourceFile(bool useMove)
     {
         if (useMove)
@@ -234,8 +233,7 @@ public class SourceFileUpdateTests : DotNetWatchTestBase
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public async Task RenameDirectory(bool useMove)
     {
         Log("RenameSourceFile started");


### PR DESCRIPTION
## Summary

In `dotnet-watch.Tests`, replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from `Combinatorial.MSTest`.

### Changes

- `ConsoleReporterTests.WritesToStandardStreams`: replaced `[DataRow(true)]` + `[DataRow(false)]` with `[CombinatorialData]`
- `SourceFileUpdateTests.RenameSourceFile`: same replacement
- `SourceFileUpdateTests.RenameDirectory`: same replacement

The executed test cases are identical — `[CombinatorialData]` on a single `bool` parameter generates `true` and `false` automatically. No behavior change.

No `.csproj` change is needed as the project already references `Combinatorial.MSTest`.

This is part of a per-project series replacing verbose boolean `[DataRow]` patterns with the more concise `[CombinatorialData]` attribute.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>