### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Publish.Tests

### DIFF
--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAHelloWorldProject.cs
@@ -422,8 +422,7 @@ public static class Program
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_publishes_on_release_if_PublishRelease_property_set(bool optedOut)
         {
             var helloWorldAsset = TestAssetsManager

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -295,8 +295,7 @@ namespace Microsoft.NET.Publish.Tests
 
         [TestMethod]
         [RequiresMSBuildVersion("17.0.0.32901")]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_supports_composite_r2r(bool extractAll)
         {
             var projName = "SingleFileTest";
@@ -890,8 +889,7 @@ class C
 
         [TestMethod]
         [RequiresMSBuildVersion("16.8.0")]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void It_errors_when_including_symbols_targeting_net5(bool selfContained)
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool.cs
@@ -11,10 +11,7 @@ namespace Microsoft.NET.ToolPack.Tests
     public class GivenThatWeWantToPublishWithGeneratePackageOnBuildAndPackAsTool : SdkTest
     {
         [TestMethod]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void It_publishes_successfully(bool generatePackageOnBuild, bool packAsTool)
         {
             Console.WriteLine(generatePackageOnBuild.ToString() + packAsTool.ToString());
@@ -39,10 +36,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void It_builds_with_GeneratePackageOnBuild_successfully(bool generatePackageOnBuild, bool packAsTool)
         {
             TestAsset testAsset = TestAssetsManager

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithoutConflicts.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishWithoutConflicts.cs
@@ -46,8 +46,7 @@ namespace Microsoft.NET.Publish.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_has_consistent_behavior_when_publishing_single_file(bool shouldPublishSingleFile)
         {
             var targetFramework = ToolsetInfo.CurrentTargetFramework;

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToStoreAProjectWithDependencies.cs
@@ -265,8 +265,7 @@ namespace Microsoft.NET.Publish.Tests
         //  https://github.com/dotnet/sdk/issues/49665
         [TestMethod]
         [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_stores_when_targeting_netcoreapp3(bool isExe)
         {
             const string TFM = "netcoreapp3.0";

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -44,4 +44,8 @@
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.NET.Publish.Tests/PublishNoRestoreTests.cs
+++ b/test/Microsoft.NET.Publish.Tests/PublishNoRestoreTests.cs
@@ -11,24 +11,21 @@ namespace Microsoft.NET.Publish.Tests;
 public class PublishNoRestoreTests : SdkTest
 {
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void PublishTrimmed(bool specifyRuntimeIdentifier)
     {
         TestNoRestore("PublishTrimmed", specifyRuntimeIdentifier);
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void PublishSingleFile(bool specifyRuntimeIdentifier)
     {
         TestNoRestore("PublishSingleFile", specifyRuntimeIdentifier);
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void PublishAot(bool specifyRuntimeIdentifier)
     {
         TestNoRestore("PublishAot", specifyRuntimeIdentifier);


### PR DESCRIPTION
## Summary

In `Microsoft.NET.Publish.Tests`, replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the **Combinatorial.MSTest** package.

### What changed

- **10 test methods** across 6 files had their explicit `[DataRow(true)]` / `[DataRow(false)]` (or multi-bool combinations like `[DataRow(false, false)]` … `[DataRow(true, true)]`) replaced by a single `[CombinatorialData]` attribute.
- The executed test cases are **identical** — `[CombinatorialData]` automatically generates all combinations of the boolean parameters.
- `Microsoft.NET.Publish.Tests.csproj` gains an `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />` (version controlled centrally via `Directory.Packages.props`)
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file `using` directives needed)

### Why

Explicit full boolean cartesian products are noise: they're tedious to write, easy to miss a combination, and harder to read. `[CombinatorialData]` expresses the intent directly and scales automatically when new parameters are added.

This is part of a per-project series applying the same mechanical refactor across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>