### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in TemplateEngine unit tests

### DIFF
--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
@@ -154,14 +154,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         }
 
         [TestMethod]
-        [DataRow(false, false, false)]
-        [DataRow(false, false, true)]
-        [DataRow(false, true, false)]
-        [DataRow(false, true, true)]
-        [DataRow(true, false, false)]
-        [DataRow(true, false, true)]
-        [DataRow(true, true, false)]
-        [DataRow(true, true, true)]
+        [CombinatorialData]
         public void VerifyWhitespaceHandlerConsumeWholeLine(bool trim, bool trimForward, bool trimBackward)
         {
             MockOperation o = new MockOperation(
@@ -187,10 +180,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         }
 
         [TestMethod]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void VerifyWhitespaceHandlerTrim(bool trimForward, bool trimBackward)
         {
             MockOperation o = new MockOperation(

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="$(TemplateEngTestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
@@ -14,4 +14,8 @@
     <Compile Include="..\Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringUpdaterTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringUpdaterTests.cs
@@ -147,8 +147,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public async Task UnchangedFileShouldntBeOverwritten(bool fileStartsWithBom)
         {
             CancellationTokenSource cts = new CancellationTokenSource(10000);
@@ -255,8 +254,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public async Task BomPreambleIsPreserved(bool fileStartsWithBom)
         {
             CancellationTokenSource cts = new CancellationTokenSource(10000);


### PR DESCRIPTION
## Summary

Replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` (from the `Combinatorial.MSTest` package) in the TemplateEngine test subprojects.

### What changed

- **`Microsoft.TemplateEngine.Core.UnitTests`** – 2 methods converted:
  - `VerifyWhitespaceHandlerConsumeWholeLine` (8 DataRows → CombinatorialData)
  - `VerifyWhitespaceHandlerTrim` (4 DataRows → CombinatorialData)
- **`Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests`** – 2 methods converted:
  - `UnchangedFileShouldntBeOverwritten` (2 DataRows → CombinatorialData)
  - `BomPreambleIsPreserved` (2 DataRows → CombinatorialData)

Both `.csproj` files receive a new `ItemGroup` with:
```xml
<PackageReference Include="Combinatorial.MSTest" />
<Using Include="Combinatorial.MSTest" />
```

### Behaviour

Identical test cases are executed — `[CombinatorialData]` generates the same full boolean product as the explicit `[DataRow]` list, just without the boilerplate.

### Series

This is part of a per-project series replacing redundant boolean `[DataRow]` combinations with `[CombinatorialData]` across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>