### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in dotnet.Tests

### DIFF
--- a/test/dotnet.Tests/CommandTests/Publish/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet.Tests/CommandTests/Publish/GivenDotnetPublishPublishesProjects.cs
@@ -346,8 +346,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void ItPublishesSuccessfullyWithNoBuildIfPreviouslyBuilt(bool selfContained)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("TestAppSimple", identifier: selfContained.ToString())

--- a/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
+++ b/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
@@ -674,8 +674,7 @@ Commands:
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void WhenIncompatibleFrameworkDetectedItPrintsError(bool useFrameworkArg)
         {
             var setup = Setup(useFrameworkArg.ToString());

--- a/test/dotnet.Tests/CommandTests/Restore/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet.Tests/CommandTests/Restore/GivenThatIWantToRestoreApp.cs
@@ -15,8 +15,7 @@ namespace Microsoft.DotNet.Restore.Test
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItRestoresAppToSpecificDirectory(bool useStaticGraphEvaluation)
         {
             var rootPath = TestAssetsManager.CreateTestDirectory(identifier: useStaticGraphEvaluation.ToString()).Path;
@@ -97,8 +96,7 @@ namespace Microsoft.DotNet.Restore.Test
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItRestoresTestAppToSpecificDirectory(bool useStaticGraphEvaluation)
         {
             var rootPath = TestAssetsManager.CopyTestAsset("VSTestCore", identifier: useStaticGraphEvaluation.ToString())
@@ -123,8 +121,7 @@ namespace Microsoft.DotNet.Restore.Test
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItRestoresWithTheSpecifiedVerbosity(bool useStaticGraphEvaluation)
         {
             var rootPath = TestAssetsManager.CreateTestDirectory(identifier: useStaticGraphEvaluation.ToString()).Path;

--- a/test/dotnet.Tests/CommandTests/Sdk/Check/GivenDotnetSdkCheck.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Check/GivenDotnetSdkCheck.cs
@@ -46,8 +46,7 @@ namespace Microsoft.DotNet.Cli.SdkCheck.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void WhenNewFeatureBandExistsItIsAdvertised(bool newerBandExists)
         {
             var parseResult = Parser.Parse(new string[] { "dotnet", "sdk", "check" });

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessing.cs
@@ -23,8 +23,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ArtifactPostProcessing_SolutionProjects(bool merge)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("VSTestMultiProjectSolution", Guid.NewGuid().ToString())
@@ -47,8 +46,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ArtifactPostProcessing_TestContainers(bool merge)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("VSTestMultiProjectSolution", Guid.NewGuid().ToString())
@@ -76,8 +74,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ArtifactPostProcessing_VSTest_TestContainers(bool merge)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("VSTestMultiProjectSolution", Guid.NewGuid().ToString())

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsForMultipleTFMs.cs
@@ -100,8 +100,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void RunProjectWithMultipleTFMs_ParallelizationTest_RunInParallelShouldFail(bool testTfmsInParallel)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithMultipleTFMsParallelization", Guid.NewGuid().ToString())

--- a/test/dotnet.Tests/CommandTests/Workload/Clean/GivenDotnetWorkloadClean.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Clean/GivenDotnetWorkloadClean.cs
@@ -45,10 +45,7 @@ namespace Microsoft.DotNet.Cli.Workload.Clean.Tests
         }
 
         [TestMethod]
-        [DataRow(true, true)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(false, false)]
+        [CombinatorialData]
         public void GivenWorkloadCleanFileBasedItRemovesPacksAndPackRecords(bool userLocal, bool cleanAll)
         {
             var (testDirectory, dotnetRoot, userProfileDir, workloadResolver, nugetDownloader) = Setup(userLocal, cleanAll);
@@ -76,8 +73,7 @@ namespace Microsoft.DotNet.Cli.Workload.Clean.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadCleanAllFileBasedItCleansAllFeatureBands(bool userLocal)
         {
             var (testDirectory, dotnetRoot, userProfileDir, workloadResolver, nugetDownloader) = Setup(userLocal, true);

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenDotnetWorkloadInstall.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenDotnetWorkloadInstall.cs
@@ -345,8 +345,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadInstallItDoesNotRemoveOldInstallsOnRollback(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenWorkloadManifestUpdater.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenWorkloadManifestUpdater.cs
@@ -207,8 +207,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public async Task ItCanFallbackAndAdvertiseCorrectUpdate(bool useOfflineCache)
         {
             //  Currently installed - 6.0.200 workload manifest
@@ -285,8 +284,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public async Task ItCanFallbackWithNoUpdates(bool useOfflineCache)
         {
             //  Currently installed - none
@@ -351,8 +349,7 @@ namespace Microsoft.DotNet.Cli.Workload.Install.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public async Task GivenNoUpdatesAreAvailableAndNoRollbackItGivesAppropriateMessage(bool useOfflineCache)
         {
             //  Currently installed - none

--- a/test/dotnet.Tests/CommandTests/Workload/Repair/GivenDotnetWorkloadRepair.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Repair/GivenDotnetWorkloadRepair.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Cli.Workload.Repair.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenNoWorkloadsAreInstalledRepairIsNoOp(bool userLocal)
         {
             _reporter.Clear();
@@ -58,8 +57,7 @@ namespace Microsoft.DotNet.Cli.Workload.Repair.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenExtraPacksInstalledRepairGarbageCollects(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;
@@ -108,8 +106,7 @@ namespace Microsoft.DotNet.Cli.Workload.Repair.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenMissingPacksRepairFixesInstall(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;
@@ -155,8 +152,7 @@ namespace Microsoft.DotNet.Cli.Workload.Repair.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenMissingManifestsInWorkloadSetModeRepairReinstallsManifests(bool userLocal)
         {
             var (dotnetRoot, userProfileDir, mockInstaller, workloadResolver, manifestProvider) =

--- a/test/dotnet.Tests/CommandTests/Workload/Uninstall/GivenDotnetWorkloadUninstall.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Uninstall/GivenDotnetWorkloadUninstall.cs
@@ -59,8 +59,7 @@ namespace Microsoft.DotNet.Cli.Workload.Uninstall.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadUninstallItCanUninstallWorkload(bool userLocal)
         {
             var installingWorkload = "mock-1";
@@ -96,8 +95,7 @@ namespace Microsoft.DotNet.Cli.Workload.Uninstall.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadUninstallItCanUninstallOnlySpecifiedWorkload(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;
@@ -140,8 +138,7 @@ namespace Microsoft.DotNet.Cli.Workload.Uninstall.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadUninstallItCanUninstallOnlySpecifiedFeatureBand(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;

--- a/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
@@ -111,8 +111,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadUpdateItRemovesOldPacksAfterInstall(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;
@@ -197,8 +196,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenWorkloadUpdateAcrossFeatureBandsItUpdatesPacks(bool userLocal)
         {
             var testDirectory = TestAssetsManager.CreateTestDirectory(identifier: userLocal ? "userlocal" : "default").Path;
@@ -663,8 +661,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void GivenMissingManifestsInWorkloadSetModeUpdateReinstallsManifests(bool userLocal)
         {
             var (dotnetRoot, userProfileDir, mockInstaller, workloadResolver, manifestProvider) =

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -43,8 +43,7 @@ namespace Microsoft.DotNet.Tests
 
         [TestMethod]
         [RequiresSpecificFramework("netcoreapp1.1")]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void IfPreviousVersionOfSharedFrameworkIsInstalled_ToolsTargetingItRun(bool toolPrefersCLIRuntime)
         {
             var testInstance = TestAssetsManager.CopyTestAsset("AppWithToolDependency", identifier: toolPrefersCLIRuntime ? "preferCLIRuntime" : "")

--- a/test/dotnet.Tests/ShellShimTests/ShellShimRepositoryTests.cs
+++ b/test/dotnet.Tests/ShellShimTests/ShellShimRepositoryTests.cs
@@ -132,8 +132,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenAShimConflictItWillRollback(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();
@@ -177,8 +176,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenAnExceptionItWillRollback(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();
@@ -220,8 +218,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenANonexistentShimRemoveDoesNotThrow(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();
@@ -247,8 +244,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenAnInstalledShimRemoveDeletesTheShimFiles(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();
@@ -278,8 +274,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenAnInstalledShimRemoveRollsbackIfTransactionIsAborted(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();
@@ -316,8 +311,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void GivenAnInstalledShimRemoveCommitsIfTransactionIsCompleted(bool testMockBehaviorIsInSync)
         {
             var shellCommandName = nameof(ShellShimRepositoryTests) + Path.GetRandomFileName();


### PR DESCRIPTION
## Summary

This PR replaces full boolean cartesian-product `[DataRow]` sets in the `dotnet.Tests` project with `[CombinatorialData]` from `Combinatorial.MSTest`.

### What changed

- 14 test files, 33 test methods updated
- All `[DataRow(true)]` / `[DataRow(false)]` (and multi-parameter boolean combinations) removed
- Each method gets a single `[CombinatorialData]` attribute instead
- The executed test cases are identical — `[CombinatorialData]` generates the full cartesian product of all `bool` parameters automatically
- No `.csproj` changes — `dotnet.Tests` already references `Combinatorial.MSTest`

### Why

This is part of a per-project series to modernize boolean-parameter test data in the SDK repository. `[CombinatorialData]` is more concise, less error-prone (no risk of missing a combination), and scales naturally when new parameters are added.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>