### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.ToolPack.Tests

### DIFF
--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -49,8 +49,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_packs_successfully(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -63,8 +62,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_finds_the_entry_point_dll_and_command_name_and_put_in_setting_file(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -129,8 +127,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_removes_all_package_dependencies(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -143,8 +140,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_contains_runtimeconfig_for_each_tfm(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -162,8 +158,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_does_not_contain_apphost_exe(bool multiTarget)
         {
             var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
@@ -202,8 +197,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_contains_DotnetToolSettingsXml_for_each_tfm(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -221,8 +215,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_does_not_contain_lib(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -233,8 +226,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_contains_folder_structure_tfm_any(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -249,8 +241,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_contains_packagetype_dotnettool(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);
@@ -291,8 +282,7 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_contains_dependencies_dll(bool multiTarget)
         {
             var nugetPackage = SetupNuGetPackage(multiTarget);

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithComplexNugetDependency.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithComplexNugetDependency.cs
@@ -11,8 +11,7 @@ namespace Microsoft.NET.ToolPack.Tests
     public class GivenThatWeWantToPackAToolProjectWithComplexNugetDependency : SdkTest
     {
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_has_native_and_transitive_dependencies_dll(bool multiTarget)
         {
             TestAsset helloWorldAsset = TestAssetsManager

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProjectWithGeneratePackageOnBuild.cs
@@ -72,10 +72,7 @@ namespace Microsoft.NET.ToolPack.Tests
 
         [TestMethod]
         [Ignore("https://github.com/dotnet/sdk/issues/10335")]
-        [DataRow(false, false)]
-        [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void It_packs_successfully(bool generatePackageOnBuild, bool packAsTool)
         {
             Console.WriteLine(generatePackageOnBuild.ToString() + packAsTool.ToString());

--- a/test/Microsoft.NET.ToolPack.Tests/Microsoft.NET.ToolPack.Tests.csproj
+++ b/test/Microsoft.NET.ToolPack.Tests/Microsoft.NET.ToolPack.Tests.csproj
@@ -34,4 +34,8 @@
     <EmbeddedResource Include="..\..\src\Tasks\Common\Resources\Strings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.NET.Build.Tasks" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

This is part of a per-project series replacing full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the `Combinatorial.MSTest` package.

### What changed

- **12 test methods** across 3 files in `Microsoft.NET.ToolPack.Tests` had their explicit boolean `[DataRow(true)]`/`[DataRow(false)]` (or multi-bool combinations) replaced with a single `[CombinatorialData]` attribute.
- The `Microsoft.NET.ToolPack.Tests.csproj` gains a new `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file import is needed)

### No behavior change

`[CombinatorialData]` generates the same test cases as the removed `[DataRow]` combinations — it enumerates all combinations of the `bool` parameters automatically, producing identical executed test cases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>