### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.HotReload.Client.Tests

### DIFF
--- a/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/ArrayBufferWriterTests.cs
@@ -496,8 +496,7 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public void WriteAndCopyToStream(bool clearContent)
     {
         System.Buffers.ArrayBufferWriter<byte> output = new();
@@ -544,8 +543,7 @@ public class ArrayBufferWriterTests_Byte : ArrayBufferWriterTests<byte>
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
+    [CombinatorialData]
     public async Task WriteAndCopyToStreamAsync(bool clearContent)
     {
         System.Buffers.ArrayBufferWriter<byte> output = new();

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
@@ -38,4 +38,9 @@
   <Import Project="..\..\src\Dotnet.Watch\HotReloadClient\Microsoft.DotNet.HotReload.Client.projitems" Label="Shared" />
   <Import Project="..\..\src\Dotnet.Watch\HotReloadAgent.PipeRpc\Microsoft.DotNet.HotReload.Agent.PipeRpc.projitems" Label="Shared" />
   <Import Project="..\..\src\Dotnet.Watch\HotReloadAgent.Data\Microsoft.DotNet.HotReload.Agent.Data.projitems" Label="Shared" />
+
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` (Combinatorial.MSTest) in the `Microsoft.DotNet.HotReload.Client.Tests` project.

## What changed

- **2 test methods** in `ArrayBufferWriterTests.cs` (`WriteAndCopyToStream`, `WriteAndCopyToStreamAsync`) had `[DataRow(true)]` + `[DataRow(false)]` replaced by a single `[CombinatorialData]` attribute.
- The `.csproj` gains an `<ItemGroup>` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file import needed)

## Behavior

Identical test cases are executed — `[CombinatorialData]` on a single `bool` parameter generates exactly `true` and `false` variants, matching the previous explicit `[DataRow]` list.

## Context

This is part of a per-project series converting full boolean-product `[DataRow]` patterns to `[CombinatorialData]` across the SDK test suite, reducing boilerplate and making it easier to add new parameters in the future.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>