### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Pack.Tests

### DIFF
--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -74,8 +74,7 @@ namespace Microsoft.NET.Pack.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_packs_with_release_if_PackRelease_property_set(bool optedOut)
         {
             var helloWorldAsset = TestAssetsManager

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -38,4 +38,8 @@
     <EmbeddedResource Include="..\..\src\Cli\dotnet\CliStrings.resx" LinkBase="Resources" GenerateSource="True" Namespace="Microsoft.DotNet.Cli" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Replaces full boolean cartesian-product `[DataRow(true)]` / `[DataRow(false)]` sets in `Microsoft.NET.Pack.Tests` with the `[CombinatorialData]` attribute from the `Combinatorial.MSTest` package.

### What changed

- **`GivenThatWeWantToPackAHelloWorldProject.cs`**: The method `It_packs_with_release_if_PackRelease_property_set` previously had two explicit `[DataRow]` attributes to cover both `true` and `false` for its `bool optedOut` parameter. These are replaced with a single `[CombinatorialData]` attribute, which automatically generates all boolean combinations — identical executed test cases, zero behavioral change.

- **`Microsoft.NET.Pack.Tests.csproj`**: Added an `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />` — the package providing the attribute
  - `<Using Include="Combinatorial.MSTest" />` — global using so the attribute is available without an explicit `using` directive

### Why

Full boolean `[DataRow]` expansions are mechanical boilerplate. `[CombinatorialData]` expresses the same intent more concisely and scales automatically when additional bool parameters are added.

This is part of a per-project series applying the same mechanical transformation across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>