### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.GenAPI.Tests

### DIFF
--- a/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/CSharpFileBuilderTests.cs
@@ -3137,8 +3137,7 @@ namespace A.C.D {{ public partial struct Bar {{}} }}
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void TestAttributeWithInternalTypeArgumentOmitted(bool includeInternalSymbols)
         {
             string expected = includeInternalSymbols ? """

--- a/test/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
+++ b/test/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="$(RepoRoot)src\Compatibility\Microsoft.DotNet.ApiSymbolExtensions\Microsoft.DotNet.ApiSymbolExtensions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` (from the `Combinatorial.MSTest` package) in the `Microsoft.DotNet.GenAPI.Tests` project.

## What changed

- **`CSharpFileBuilderTests.cs`**: The method `TestAttributeWithInternalTypeArgumentOmitted` had `[DataRow(true)]` + `[DataRow(false)]` replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical — MSTest's combinatorial runner generates the same `true`/`false` parameter values.
- **`Microsoft.DotNet.GenAPI.Tests.csproj`**: Added an `<ItemGroup>` with:
  - `<PackageReference Include="Combinatorial.MSTest" />` — pulls in the package
  - `<Using Include="Combinatorial.MSTest" />` — makes the `[CombinatorialData]` attribute available globally without a `using` directive in each file

## Why

Using `[CombinatorialData]` instead of manually listing every `true`/`false` combination reduces boilerplate and makes it easier to add new boolean parameters in the future without an exponential growth of `[DataRow]` attributes.

This is part of a per-project series applying this mechanical refactor across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>