### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.DotNet.PackageValidation.Tests

### DIFF
--- a/test/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
@@ -30,4 +30,8 @@
     <Using Include="Microsoft.NET.TestFramework.Utilities" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
+++ b/test/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
@@ -74,10 +74,7 @@ namespace Microsoft.DotNet.PackageValidation.Tests
         }
 
         [TestMethod]
-        [DataRow(false, true)]
-        [DataRow(false, false)]
-        [DataRow(true, false)]
-        [DataRow(true, true)]
+        [CombinatorialData]
         public void ValidateOnlyErrorWhenAReferenceIsRequired(bool createDependencyToDummy, bool useReferences)
         {
             string testDependencyCode = createDependencyToDummy ?
@@ -156,8 +153,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences(bool useReferences)
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}");


### PR DESCRIPTION
## Summary

This is a mechanical refactor in `Microsoft.DotNet.PackageValidation.Tests` that replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the `Combinatorial.MSTest` package.

### What changed

**`ValidatePackageInProcessTests.cs`** — 2 test methods updated:

- `ValidateOnlyErrorWhenAReferenceIsRequired`: replaced 4 `[DataRow]` lines (all combinations of two booleans) with a single `[CombinatorialData]` attribute.
- `ValidateMissingReferencesIsOnlyLoggedWhenRunningWithReferences`: replaced 2 `[DataRow]` lines (`true`/`false`) with a single `[CombinatorialData]` attribute.

**`Microsoft.DotNet.PackageValidation.Tests.csproj`** — added:

```xml
<ItemGroup>
  <PackageReference Include="Combinatorial.MSTest" />
  <Using Include="Combinatorial.MSTest" />
</ItemGroup>
```

### Behavior

The executed test cases are **identical** — `[CombinatorialData]` generates all combinations of the boolean parameters, which is exactly what the explicit `[DataRow]` entries enumerated. This is a zero-behavior-change refactor.

### Context

This is part of a per-project series replacing manually written boolean cartesian-product `[DataRow]` data with `[CombinatorialData]`, making tests easier to maintain and extend.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>