### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Build.Extensions.Tasks.Tests

### DIFF
--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -37,8 +37,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void DependsOnNETStandard_IsConsistent_RegardlessOfCwd(bool useDifferentCwd)
         {
             // Use the test assembly itself as input — it references System.Runtime.

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
@@ -31,4 +31,8 @@
     <Using Include="Microsoft.NET.TestFramework" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

In `Microsoft.NET.Build.Extensions.Tasks.Tests`, replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the `Combinatorial.MSTest` package.

### What changed

- **1 test method** (`DependsOnNETStandard_IsConsistent_RegardlessOfCwd`) had its `[DataRow(true)]` / `[DataRow(false)]` pair replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical — MSTest will still run both `true` and `false` variants.
- The `.csproj` gains a new `<ItemGroup>` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so no per-file import needed)

### Why

`[CombinatorialData]` is more concise and scales automatically as more `bool` parameters are added — it generates the full cartesian product without requiring manual `[DataRow]` enumeration. This is part of a per-project series applying this pattern across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>