### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Sdk.WorkloadManifestReader.Tests

### DIFF
--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
@@ -21,4 +21,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/SdkDirectoryWorkloadManifestProviderTests.cs
@@ -34,8 +34,7 @@ namespace ManifestReaderTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItShouldPrioritizeInstallStateOverWorkloadSetUnlessSpecified(bool preferWorkloadSet)
         {
             Initialize(identifier: preferWorkloadSet.ToString());
@@ -68,8 +67,7 @@ namespace ManifestReaderTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void ItShouldReturnTheWorkloadVersion(bool useWorkloadSet)
         {
             Initialize(identifier: useWorkloadSet.ToString());
@@ -303,8 +301,7 @@ namespace ManifestReaderTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [CombinatorialData]
         public void ItUsesLatestWorkloadSet(bool globalJsonExists)
         {
             Initialize("8.0.200", identifier: globalJsonExists.ToString());


### PR DESCRIPTION
## Summary

In `Microsoft.NET.Sdk.WorkloadManifestReader.Tests`, three test methods had full boolean cartesian-product `[DataRow]` sets (i.e. `[DataRow(true)]` + `[DataRow(false)]`) which are exactly what `[CombinatorialData]` is designed for.

### Changes

- **`SdkDirectoryWorkloadManifestProviderTests.cs`**: Replaced `[DataRow(true)]` / `[DataRow(false)]` pairs with `[CombinatorialData]` on 3 methods:
  - `ItShouldPrioritizeInstallStateOverWorkloadSetUnlessSpecified`
  - `ItShouldReturnTheWorkloadVersion`
  - `ItUsesLatestWorkloadSet`

- **`.csproj`**: Added `Combinatorial.MSTest` package reference and global using so `[CombinatorialData]` is available without extra `using` directives in each file.

### Behavior

The executed test cases are identical — `[CombinatorialData]` on a single `bool` parameter generates the same two cases (`true` and `false`) as the explicit `[DataRow]` set. This is a pure mechanical refactor with no semantic change.

### Context

This is part of a per-project series converting full boolean-product `[DataRow]` patterns to `[CombinatorialData]` across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>