### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in dotnet-MsiInstallation.Tests

### DIFF
--- a/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
+++ b/test/dotnet-MsiInstallation.Tests/WorkloadSetTests2.cs
@@ -160,8 +160,7 @@ namespace Microsoft.DotNet.MsiInstallerTests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void UpdateDoesNotTryToInstallOlderWorkloadSet(bool usePreview)
         {
             if (NeedsIncludePreviews && usePreview)

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -52,4 +52,8 @@
     <Using Remove="@(Using)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

In `dotnet-MsiInstallation.Tests`, replaces full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the `Combinatorial.MSTest` package.

### Changes

- **`WorkloadSetTests2.cs`**: `UpdateDoesNotTryToInstallOlderWorkloadSet` — two `[DataRow(true)]` / `[DataRow(false)]` attributes replaced with a single `[CombinatorialData]` attribute. The executed test cases are identical.
- **`dotnet-MsiInstallation.Tests.csproj`**: Added an `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />`
  - `<Using Include="Combinatorial.MSTest" />` (global using so the attribute is available without explicit namespace import)

### Motivation

`[CombinatorialData]` is the idiomatic MSTest way to generate all combinations of parameter values. For `bool` parameters it covers `true` and `false` automatically, eliminating the need to list each value explicitly as a `[DataRow]`. This makes the intent clearer and reduces boilerplate.

This is part of a per-project series applying the same mechanical refactor across the repo.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>