### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Restore.Tests

### DIFF
--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantAutomaticTargetingPackReferences.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantAutomaticTargetingPackReferences.cs
@@ -55,8 +55,7 @@ namespace Microsoft.NET.Restore.Tests
         }
 
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void It_restores_multitargeted_net_framework_project_successfully(bool includeExplicitReference)
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
+++ b/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
@@ -39,4 +39,8 @@
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

In `Microsoft.NET.Restore.Tests`, replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` from the `Combinatorial.MSTest` package.

### What changed

- **`GivenThatWeWantAutomaticTargetingPackReferences.cs`**: The method `It_restores_multitargeted_net_framework_project_successfully` had two `[DataRow(true)]` / `[DataRow(false)]` attributes replaced by a single `[CombinatorialData]` attribute. The executed test cases are identical — `[CombinatorialData]` automatically generates all combinations of boolean parameters.

- **`Microsoft.NET.Restore.Tests.csproj`**: Added an `ItemGroup` with:
  - `<PackageReference Include="Combinatorial.MSTest" />` — brings in the combinatorial data source
  - `<Using Include="Combinatorial.MSTest" />` — global using so no explicit `using` directive is needed in test files

### Why

Manually listing every `true`/`false` `[DataRow]` combination is verbose and error-prone. `[CombinatorialData]` expresses the intent more clearly and scales naturally if more boolean parameters are added later.

This is part of a per-project series applying the same mechanical refactor across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>