### PR TITLE
Use Combinatorial.MSTest for boolean DataRow tests in Microsoft.NET.Sdk.StaticWebAssets.Tests

### DIFF
--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/GroupedFrameworkAssetsIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/GroupedFrameworkAssetsIntegrationTest.cs
@@ -29,8 +29,7 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
         //  * The materialized framework asset is a current-project asset of the library, so the app (which
         //    does not enable the group) does not include it at the root.
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        [CombinatorialData]
         public void Build_PackageToLibraryToApp_GroupedFrameworkAsset_IsConditionalAndMaterializedIntoLibrary(bool includeGroupedFrameworkAssets)
         {
             ProjectDirectory = CreateAspNetSdkTestAsset("GroupedFrameworkAssetsSample", identifier: includeGroupedFrameworkAssets.ToString())

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
@@ -77,4 +77,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
+    <Using Include="Combinatorial.MSTest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace full boolean cartesian-product `[DataRow]` sets with `[CombinatorialData]` (Combinatorial.MSTest) in the `Microsoft.NET.Sdk.StaticWebAssets.Tests` project.

## Changes

- **`GroupedFrameworkAssetsIntegrationTest.cs`**: Replaced two `[DataRow(true)]` / `[DataRow(false)]` attributes with a single `[CombinatorialData]` attribute on `Build_PackageToLibraryToApp_GroupedFrameworkAsset_IsConditionalAndMaterializedIntoLibrary`. The executed test cases are identical — the framework now generates the same `true`/`false` combinations automatically.

- **`Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj`**: Added `Combinatorial.MSTest` package reference and a global `<Using>` so the attribute is available without an explicit `using` directive in each file.

This is part of a per-project series to reduce boilerplate in boolean-only `[DataRow]` patterns across the SDK test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>