### PR TITLE
Add gh CLI and Copilot CLI extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,9 @@
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {
         "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+        "version": "latest"
     }
   },
   // Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,9 +15,8 @@
     "ghcr.io/devcontainers/features/sshd:1": {
         "version": "latest"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-        "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1": {}
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/post-creation.sh",

--- a/.devcontainer/scripts/post-creation.sh
+++ b/.devcontainer/scripts/post-creation.sh
@@ -10,5 +10,3 @@
 # this script is run from repo root so shellcheck warning about relative-path lookups can be ignored
 # shellcheck disable=SC1091
 . ./artifacts/sdk-build-env.sh
-# install GitHub Copilot CLI extension
-gh extension install github/gh-copilot

--- a/.devcontainer/scripts/post-creation.sh
+++ b/.devcontainer/scripts/post-creation.sh
@@ -10,3 +10,5 @@
 # this script is run from repo root so shellcheck warning about relative-path lookups can be ignored
 # shellcheck disable=SC1091
 . ./artifacts/sdk-build-env.sh
+# install GitHub Copilot CLI extension
+gh extension install github/gh-copilot


### PR DESCRIPTION
## Summary

Adds the GitHub CLI and GitHub Copilot CLI to the Codespace/devcontainer setup so contributors have them available out of the box, following the same approach used in [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/.devcontainer/devcontainer.json).

### Changes
- **`.devcontainer/devcontainer.json`**: Adds `ghcr.io/devcontainers/features/github-cli:1` and `ghcr.io/devcontainers/features/copilot-cli:1` features.