### PR TITLE
Cache GetFileVersion to avoid redundant per-project version reads in GenerateDepsFile

### DIFF
--- a/src/Tasks/Common/FileUtilities.cs
+++ b/src/Tasks/Common/FileUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 
@@ -8,16 +9,35 @@ namespace Microsoft.NET.Build.Tasks
 {
     static partial class FileUtilities
     {
+        // Cache file versions across the build keyed by path + last-write time. The same
+        // framework/package assemblies are referenced by many projects, so without this each
+        // project's GenerateDepsFile re-opens and re-parses the Win32 version resource of the
+        // same files. Mirrors the existing s_versionCache used for assembly versions and is
+        // safe under multithreaded (-mt) builds (ConcurrentDictionary, immutable cache entries).
+        private static readonly ConcurrentDictionary<string, (DateTime LastKnownWriteTimeUtc, Version? Version)> s_fileVersionCache
+            = new(StringComparer.OrdinalIgnoreCase);
+
         public static Version? GetFileVersion(string? sourcePath)
         {
             if (sourcePath != null)
             {
-                var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+                DateTime lastWriteTimeUtc = File.GetLastWriteTimeUtc(sourcePath);
 
+                if (s_fileVersionCache.TryGetValue(sourcePath, out var cacheEntry)
+                    && lastWriteTimeUtc == cacheEntry.LastKnownWriteTimeUtc)
+                {
+                    return cacheEntry.Version;
+                }
+
+                Version? version = null;
+                var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
                 if (fvi != null)
                 {
-                    return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+                    version = new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
                 }
+
+                s_fileVersionCache[sourcePath] = (lastWriteTimeUtc, version);
+                return version;
             }
 
             return null;

--- a/src/Tasks/Common/FileUtilities.cs
+++ b/src/Tasks/Common/FileUtilities.cs
@@ -9,11 +9,6 @@ namespace Microsoft.NET.Build.Tasks
 {
     static partial class FileUtilities
     {
-        // Cache file versions across the build keyed by path + last-write time. The same
-        // framework/package assemblies are referenced by many projects, so without this each
-        // project's GenerateDepsFile re-opens and re-parses the Win32 version resource of the
-        // same files. Mirrors the existing s_versionCache used for assembly versions and is
-        // safe under multithreaded (-mt) builds (ConcurrentDictionary, immutable cache entries).
         private static readonly ConcurrentDictionary<string, (DateTime LastKnownWriteTimeUtc, Version? Version)> s_fileVersionCache
             = new(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary

`FileUtilities.GetFileVersion` re-opens and re-parses the Win32 version resource of the same
runtime files for **every project** that references them. The same framework/package assemblies
are referenced by many projects, so this is highly redundant I/O and allocation during
`GenerateDepsFile` (which calls it per resolved runtime file when `IncludeRuntimeFileVersions`
is set).

This adds a `path + last-write-time` cache, mirroring the existing cache already used for
**assembly** versions (`GetAssemblyVersion`). It is a `ConcurrentDictionary`, so it is safe
under multithreaded (`-mt`) builds, and the cached entries are immutable.

## Why it helps `-mt` in particular

The cache is static, so in `-mt` (single process) it is shared across **all** projects in the
build, eliminating far more redundant reads than in multi-process `-m`, where each worker
process keeps its own cache.

## Measurements (OrchardCore `Cms.Web` Rebuild, 192 `GenerateDepsFile` calls)

- `GenerateDepsFile` task time: **`-mt` ≈ −65%** (59 → 20 ms avg), `-m` ≈ −14% (74 → 64 ms avg).
- Deps-attributed allocation: **≈ −33%** (174 → 116 MB); `GetFileVersion` drops out of the hot path.
- The produced `deps.json` is **byte-identical** (verified by hash) — pure speedup, no behavior change.


## Follow-ups (draft)

- [ ] Add a unit test (cache hit on unchanged write time; re-read when the file's write time changes).
