### PR TITLE
Minimize RuntimeFramework cache key

### DIFF
--- a/src/Tasks/Common/MetadataKeys.cs
+++ b/src/Tasks/Common/MetadataKeys.cs
@@ -27,6 +27,7 @@ namespace Microsoft.NET.Build.Tasks
         public const string FrameworkVersion = "FrameworkVersion";
         public const string IsTrimmable = "IsTrimmable";
         public const string RuntimeFrameworkName = "RuntimeFrameworkName";
+        public const string Profile = "Profile";
 
         // SDK Metadata
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -427,6 +427,8 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     TaskItem runtimeFramework = new(knownFrameworkReference.RuntimeFrameworkName);
 
+                    // NOTE: Any metadata added here must be part of the cache key in
+                    // ResolveTargetingPackAssets.
                     runtimeFramework.SetMetadata(MetadataKeys.Version, runtimeFrameworkVersion);
                     runtimeFramework.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
                     runtimeFramework.SetMetadata("Profile", knownFrameworkReference.Profile);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -298,7 +298,7 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (!string.IsNullOrEmpty(knownFrameworkReference.Profile))
                 {
-                    targetingPack.SetMetadata("Profile", knownFrameworkReference.Profile);
+                    targetingPack.SetMetadata(MetadataKeys.Profile, knownFrameworkReference.Profile);
                 }
 
                 //  Get the path of the targeting pack in the targeting pack root (e.g. dotnet/packs)
@@ -431,7 +431,7 @@ namespace Microsoft.NET.Build.Tasks
                     // ResolveTargetingPackAssets.
                     runtimeFramework.SetMetadata(MetadataKeys.Version, runtimeFrameworkVersion);
                     runtimeFramework.SetMetadata(MetadataKeys.FrameworkName, knownFrameworkReference.Name);
-                    runtimeFramework.SetMetadata("Profile", knownFrameworkReference.Profile);
+                    runtimeFramework.SetMetadata(MetadataKeys.Profile, knownFrameworkReference.Profile);
 
                     runtimeFrameworks.Add(runtimeFramework);
                     Log.LogMessage(MessageImportance.Low, $"Added runtime framework '{runtimeFramework.ItemSpec}@{runtimeFrameworkVersion}'");
@@ -1312,7 +1312,7 @@ namespace Microsoft.NET.Build.Tasks
             public bool RuntimePackAlwaysCopyLocal =>
                 _item.HasMetadataValue(MetadataKeys.RuntimePackAlwaysCopyLocal, "true");
 
-            public string Profile => _item.GetMetadata("Profile");
+            public string Profile => _item.GetMetadata(MetadataKeys.Profile);
 
             public NuGetFramework TargetFramework { get; }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveFrameworkReferences.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NET.Build.Tasks
                 resolvedFrameworkReference.SetMetadata("TargetingPackPath", targetingPack.GetMetadata(MetadataKeys.Path));
                 resolvedFrameworkReference.SetMetadata("TargetingPackName", targetingPack.GetMetadata(MetadataKeys.NuGetPackageId));
                 resolvedFrameworkReference.SetMetadata("TargetingPackVersion", targetingPack.GetMetadata(MetadataKeys.NuGetPackageVersion));
-                resolvedFrameworkReference.SetMetadata("Profile", targetingPack.GetMetadata("Profile"));
+                resolvedFrameworkReference.SetMetadata(MetadataKeys.Profile, targetingPack.GetMetadata(MetadataKeys.Profile));
 
                 ITaskItem runtimePack;
                 if (resolvedRuntimePacks.TryGetValue(frameworkReference.ItemSpec, out runtimePack))

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveRuntimePackAssets.cs
@@ -79,8 +79,8 @@ namespace Microsoft.NET.Build.Tasks
                 // For example, A WinForms app that uses useWindowsForms (and useWPF will be set to false) has the following values that will result in a match of the below RuntimeFramework
                 // matchingRTReference.GetMetadata("Profile") will be "WindowsForms". 'Profile' will be an empty string if no matching RuntimeFramework is found
                 HashSet<string> profiles = matchingRuntimeFrameworks?
-                    .Where(matchingRTReference => runtimePack.GetMetadata("FrameworkName").Equals(matchingRTReference.ItemSpec))
-                    .Select(matchingRTReference => matchingRTReference.GetMetadata("Profile")).ToHashSet() ?? [];
+                    .Where(matchingRTReference => runtimePack.GetMetadata(MetadataKeys.FrameworkName).Equals(matchingRTReference.ItemSpec))
+                    .Select(matchingRTReference => matchingRTReference.GetMetadata(MetadataKeys.Profile)).ToHashSet() ?? [];
 
                 // Special case the Windows SDK projections. Normally the Profile information flows through the RuntimeFramework items,
                 // but those aren't created for RuntimePackAlwaysCopyLocal references. This logic could be revisited later to be generalized in some way.

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -655,24 +655,9 @@ namespace Microsoft.NET.Build.Tasks
 
             public string CacheKey()
             {
-                StringBuilder builder = new();
-                builder.AppendLine(nameof(RuntimeFramework));
-                builder.AppendLine(Name);
-                builder.AppendLine(FrameworkName);
-
-                if (Item is not null)
-                {
-                    builder.AppendLine(Item.ItemSpec);
-
-                    foreach (string metadataName in Item.MetadataNames.Cast<string>().OrderBy(name => name, StringComparer.OrdinalIgnoreCase))
-                    {
-                        builder.Append(metadataName);
-                        builder.Append('=');
-                        builder.AppendLine(Item.GetMetadata(metadataName));
-                    }
-                }
-
-                return builder.ToString();
+                // NOTE: The cache key should include any metadata added to runtimeFramework items
+                // in ProcessFrameworkReferences.
+                return $"{nameof(RuntimeFramework)}: {Name} ({FrameworkName} {Item?.GetMetadata(MetadataKeys.Version)} {Item?.GetMetadata(MetadataKeys.Profile)})";
             }
         }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveTargetingPackAssets.cs
@@ -124,8 +124,8 @@ namespace Microsoft.NET.Build.Tasks
                     item.ItemSpec,
                     path,
                     item.GetMetadata("TargetingPackFormat"),
-                    item.GetMetadata("TargetFramework"),
-                    item.GetMetadata("Profile"),
+                    item.GetMetadata(MetadataKeys.TargetFramework),
+                    item.GetMetadata(MetadataKeys.Profile),
                     item.GetMetadata(MetadataKeys.NuGetPackageId),
                     item.GetMetadata(MetadataKeys.NuGetPackageVersion),
                     item.GetMetadata(MetadataKeys.PackageConflictPreferredPackages));


### PR DESCRIPTION
Copilot analysis of an allocation regression when inserting .NET SDK 11
into Visual Studio and building OrchardCore pointed to a 43× increase
in `Slot[TaskItem][]` allocations in `ResolveTargetingPackAssets`.

The cache key introduced in #53944 added _all_ metadata to the cache
identity. That includes the computed metadatum `DefiningProjectFullPath`
that's distinct for every project, which caused spurious cache
invalidation.

Just reverting it didn't look quite right as another possibly-relevant
metadatum was added in #39402. Added that and put comments in both
places to hopefully avoid future drift.
