### PR TITLE
Format GitHub Copilot Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,9 @@
-Use the instructions from the main branch if available: @dotnet/sdk/files/.github/copilot-instructions.md
+# Agent Instructions
 
-If the instructions from main are not available, use the following as a fallback:
+Instructions for GitHub Copilot and other AI coding agents working with the .NET SDK repository.
 
-Coding Style and Changes:
+## Coding Style
+
 - Code should match the style of the file it's in.
 - Changes should be minimal to resolve a problem in a clean way.
 - User-visible changes to behavior should be considered carefully before committing. They should always be flagged.
@@ -11,7 +12,8 @@ Coding Style and Changes:
 - Do not allow unused `using` directives to be committed.
 - Use `#if NET` blocks for .NET Core specific code, and `#if NETFRAMEWORK` for .NET Framework specific code.
 
-Testing:
+## Testing
+
 - Large changes should always include test changes.
 - When creating new test projects in test/TestAssets/TestProjects, always use `$(CurrentTargetFramework)` for the `<TargetFramework>` property instead of hard-coding a specific version like `net8.0`.
 - The Skip parameter of the Fact attribute to point to the specific issue link.
@@ -29,22 +31,23 @@ Testing:
   - Test commands in the dogfood shell (e.g., `dnx --help`, `dotnet tool install --help`)
   - The dogfood script sets up PATH and environment to use the newly built SDK
 
-Investigating PR validation failures:
+## Investigating PR validation failures
+
 1. Read the PR and its comments/reviews. Check for references to other PRs or issues where the problem might have already been solved.
 2. Use the `ci-analysis` skill (if available) to diagnose build failures.
 
-Output Considerations:
-- When considering how output should look, solicit advice from baronfel.
+## Localization
 
-Localization:
 - Avoid modifying .xlf files and instead prompt the user to update them using the `/t:UpdateXlf` target on MSBuild. Correctly automatically modified .xlf files have elements with state `needs-review-translation` or `new`.
 - Consider localizing strings in .resx files when possible.
 - When adding a new NETSDK error message in `src/Tasks/Common/Resources/Strings.resx`, assign the next available NETSDK code, append the entry at the end of the file, and update the trailing "latest message added" guard comment.
 
-Documentation:
+## Documentation
+
 - Do not manually edit files under documentation/manpages/sdk as these are generated based on documentation and should not be manually modified.
 
-External Dependencies:
+## External Dependencies
+
 - Changes that require modifications to the dotnet/templating repository (Microsoft.TemplateEngine packages) should be made directly in that repository, not worked around in this repo.
 - The dotnet/templating repository owns the TemplateEngine.Edge, TemplateEngine.Abstractions, and related packages.
 - If a change requires updates to template engine behavior or formatting (e.g., DisplayName properties), file an issue in dotnet/templating and make the changes there rather than adding workarounds in this SDK repository.


### PR DESCRIPTION
This PR formats the GitHub Copilot instructions. They previously were not structured.