### PR TITLE
Escaping more quotation marks in PowerShell help descriptions.

### DIFF
--- a/src/System.CommandLine.StaticCompletions/shells/PowershellShellProvider.cs
+++ b/src/System.CommandLine.StaticCompletions/shells/PowershellShellProvider.cs
@@ -81,7 +81,7 @@ Register-ArgumentCompleter -Native -CommandName '{{{binaryName}}}' -ScriptBlock 
 
     private static string ParameterValueResult(string name, string value, string? helpText) => CompletionResult(name, value, "ParameterValue", helpText);
 
-    private static string? SanitizeHelpDescription(Symbol s) => s.Description?.ReplaceLineEndings(" ").Replace("`", "``").Replace("'", "`'").Replace("\"", "`\"").Replace("$", "`$");
+    private static string? SanitizeHelpDescription(Symbol s) => s.Description?.ReplaceLineEndings(" ").Replace("`", "``").Replace("\"", "`\"").Replace("“", "`“").Replace("”", "`”").Replace("„", "`„").Replace("$", "`$");
 
     /// <summary>
     /// Generations completion-list items for the names of the given option. Typically used by commands/subcommands for static lookup lists.

--- a/test/System.CommandLine.StaticCompletions.Tests/PowershellProviderTests.cs
+++ b/test/System.CommandLine.StaticCompletions.Tests/PowershellProviderTests.cs
@@ -44,4 +44,17 @@ public class PowershellProviderTests : VerifyMSTest.VerifyBase
             }
         }, TestContext);
     }
+
+    [TestMethod]
+    public async Task SanitizesSpecialCharactersInHelpText()
+    {
+        await provider.Verify(new("mycommand") {
+            new Option<string>("--curly") { Description = "Text with “curly” and „low“ quotes" },
+            new Option<string>("--dollar") { Description = "Text with $dollar sign" },
+            new Option<string>("--backtick") { Description = "Text with `backtick` char" },
+            new Option<string>("--double") { Description = "Text with \"double\" quote" },
+            new Option<string>("--single") { Description = "Text with 'single' quotes" },
+            new Command("subcmd", "Subcmd: “curly” „low“ $dollar `backtick` \"double\" and 'single'"),
+        }, TestContext);
+    }
 }

--- a/test/System.CommandLine.StaticCompletions.Tests/snapshots/pwsh/PowershellProviderTests.SanitizesSpecialCharactersInHelpText.verified.ps1
+++ b/test/System.CommandLine.StaticCompletions.Tests/snapshots/pwsh/PowershellProviderTests.SanitizesSpecialCharactersInHelpText.verified.ps1
@@ -1,0 +1,43 @@
+﻿using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'mycommand' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'mycommand'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
+                break
+            }
+            $element.Value
+        }) -join ';'
+
+    $completions = @()
+    switch ($command) {
+        'mycommand' {
+            $staticCompletions = @(
+                [CompletionResult]::new('--curly', '--curly', [CompletionResultType]::ParameterName, "Text with `“curly`” and `„low`“ quotes")
+                [CompletionResult]::new('--dollar', '--dollar', [CompletionResultType]::ParameterName, "Text with `$dollar sign")
+                [CompletionResult]::new('--backtick', '--backtick', [CompletionResultType]::ParameterName, "Text with ``backtick`` char")
+                [CompletionResult]::new('--double', '--double', [CompletionResultType]::ParameterName, "Text with `"double`" quote")
+                [CompletionResult]::new('--single', '--single', [CompletionResultType]::ParameterName, "Text with 'single' quotes")
+                [CompletionResult]::new('subcmd', 'subcmd', [CompletionResultType]::ParameterValue, "Subcmd: `“curly`” `„low`“ `$dollar ``backtick`` `"double`" and 'single'")
+            )
+            $completions += $staticCompletions
+            break
+        }
+        'mycommand;subcmd' {
+            $staticCompletions = @(
+            )
+            $completions += $staticCompletions
+            break
+        }
+    }
+    $completions | Where-Object -FilterScript { $_.CompletionText -like "$wordToComplete*" } | Sort-Object -Property ListItemText
+}


### PR DESCRIPTION
Currently, the `SanitizeHelpDescription` function does not escape curly quotes `“` and `”`. However, PowerShell utilizes "smart quotes", which causes it to mistakenly interpret curly quotes within Simplified Chinese command descriptions as string delimiters, breaking the PowerShell completions script.

This PR adds escaping for `“` and `”` to resolve the PowerShell string delimiting issue. Additionally, it escapes `„`, which should help prevent similar issues with PowerShell completion in languages like German.

Since we surround command descriptions with double quotes (`"`), escaping single quotes (`'`) should be unnecessary.

Fix: #51260 