### PR TITLE
Add retry logic for file locking in GetAssemblyAttributes

### DIFF
--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -22,6 +22,9 @@ namespace Microsoft.NET.Build.Tasks
     {
         private static readonly ConcurrentDictionary<string, (DateTime LastKnownWriteTimeUtc, Version? Version)> s_versionCache = new(StringComparer.OrdinalIgnoreCase /* Not strictly correct on *nix. Fix? */);
 
+        // Retry delays for sharing violation IOExceptions (100ms, 500ms, 1000ms).
+        private static readonly int[] s_retryDelaysMs = [100, 500, 1000];
+
         private static Version? GetAssemblyVersion(string sourcePath)
         {
             DateTime lastWriteTimeUtc = File.GetLastWriteTimeUtc(sourcePath);
@@ -46,6 +49,21 @@ namespace Microsoft.NET.Build.Tasks
             return version;
 
             static Version? GetAssemblyVersionFromFile(string sourcePath)
+            {
+                for (int attempt = 0; ; attempt++)
+                {
+                    try
+                    {
+                        return ReadVersionFromFile(sourcePath);
+                    }
+                    catch (IOException ex) when (attempt < s_retryDelaysMs.Length && IsSharingViolation(ex))
+                    {
+                        Thread.Sleep(s_retryDelaysMs[attempt]);
+                    }
+                }
+            }
+
+            static Version? ReadVersionFromFile(string sourcePath)
             {
                 using (var assemblyStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
                 {
@@ -72,6 +90,15 @@ namespace Microsoft.NET.Build.Tasks
                     return result;
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns true if the IOException represents a sharing violation (ERROR_SHARING_VIOLATION / HRESULT 0x80070020).
+        /// </summary>
+        internal static bool IsSharingViolation(IOException ex)
+        {
+            const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
+            return ex.HResult == ERROR_SHARING_VIOLATION;
         }
     }
 }

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenFileUtilitiesRetryLogic.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenFileUtilitiesRetryLogic.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+
+namespace Microsoft.NET.Build.Tasks.UnitTests
+{
+    [TestClass]
+    public class GivenFileUtilitiesRetryLogic
+    {
+        [TestMethod]
+        public void IsSharingViolation_ReturnsTrueForSharingViolationHResult()
+        {
+            const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
+            var ex = new IOException("The process cannot access the file because it is being used by another process.", ERROR_SHARING_VIOLATION);
+
+            FileUtilities.IsSharingViolation(ex).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsSharingViolation_ReturnsFalseForOtherIOException()
+        {
+            var ex = new IOException("File not found.");
+
+            FileUtilities.IsSharingViolation(ex).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void TryGetAssemblyVersion_RetriesOnSharingViolationAndSucceeds()
+        {
+            // Use the test assembly itself as a valid PE file
+            var sourceAssembly = typeof(GivenFileUtilitiesRetryLogic).Assembly.Location;
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var targetPath = Path.Combine(tempDir, "test.dll");
+
+            try
+            {
+                File.Copy(sourceAssembly, targetPath);
+
+                // TryGetAssemblyVersion should succeed on a normal file
+                var version = FileUtilities.TryGetAssemblyVersion(targetPath);
+                version.Should().NotBeNull();
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When `GetAssemblyVersion` opens an assembly file to read its version metadata, it can fail with an `IOException` (ERROR_SHARING_VIOLATION / HRESULT `0x80070020`) if another concurrent MSBuild process has the file locked. This is an intermittent CI failure on AoT macOS (arm64) builds that has been hitting ~4 times per day on `main`.

## Changes

- **`src/Tasks/Common/FileUtilities.MetadataReader.cs`**: Added retry logic (3 attempts with 100ms, 500ms, 1000ms exponential backoff delays) specifically for sharing violation `IOException`s in `GetAssemblyVersionFromFile`. Added an `IsSharingViolation` helper that checks the HRESULT to ensure we only retry on the specific `ERROR_SHARING_VIOLATION` (0x80070020) error code.

- **`test/Microsoft.NET.Build.Tasks.Tests/GivenFileUtilitiesRetryLogic.cs`**: Added unit tests for the `IsSharingViolation` helper and basic validation that `TryGetAssemblyVersion` works correctly on normal files.

## Error being fixed

```
error MSB4018: System.IO.IOException: The process cannot access the file
'.../artifacts/obj/Microsoft.DotNet.ApiCompat.Task/Release/net10.0/Microsoft.DotNet.ApiCompat.Task.dll'
because it is being used by another process.
   at Microsoft.NET.Build.Tasks.FileUtilities.GetAssemblyVersion(String sourcePath)
   at Microsoft.NET.Build.Tasks.GetAssemblyAttributes.ExecuteCore()
```

Fixes #54864