### PR TITLE
Fix intermittent SDK resolution failure in tests

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/TransientSdkResolutionErrorDetectorTests.cs
@@ -59,5 +59,31 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 "found. [/work/InstantiatePr.csproj]";
             TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
         }
+
+        [TestMethod]
+        public void DefaultResolverDirectoryFlakeIsDetected()
+        {
+            // MSB4276 is raised when the default SDK resolver fails to find the Sdks directory under
+            // heavy parallel I/O – the directory is present on disk but the probe races with other processes.
+            string input =
+                "project.csproj : error : Could not resolve SDK \"Microsoft.NET.Sdk\". Exactly one of the probing " +
+                "messages below indicates why we could not resolve the SDK.\r\n" +
+                "project.csproj : error :   MSB4276: The default SDK resolver failed to resolve SDK " +
+                "\"Microsoft.NET.Sdk\" because directory " +
+                "\"C:\\Program Files\\dotnet\\sdk\\11.0.100\\Sdks\\Microsoft.NET.Sdk\\Sdk\" did not exist.\r\n" +
+                "project.csproj : error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found. [/work/project.csproj]";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void CustomSdkDirectoryNotExistIsNotTransient()
+        {
+            // MSB4276 for a non-Microsoft.NET.Sdk should not be treated as transient.
+            string input =
+                "project.csproj : error :   MSB4276: The default SDK resolver failed to resolve SDK " +
+                "\"Contoso.Custom.Sdk\" because directory " +
+                "\"/usr/share/dotnet/sdk/11.0.100/Sdks/Contoso.Custom.Sdk/Sdk\" did not exist.";
+            TransientSdkResolutionErrorDetector.IsTransientError(input).Should().BeFalse();
+        }
     }
 }

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -174,8 +174,14 @@ namespace Microsoft.NET.TestFramework.Commands
                 return false;
             }
 
-            return !NuGetTransientErrorDetector.IsTransientError(result.StdOut)
-                && !TransientSdkResolutionErrorDetector.IsTransientError(result.StdOut);
+            // Check both stdout and stderr – MSBuild may emit error diagnostics to either stream
+            // depending on the logger configuration and hosting context.
+            string? combinedOutput = result.StdOut is not null || result.StdErr is not null
+                ? (result.StdOut ?? string.Empty) + (result.StdErr ?? string.Empty)
+                : null;
+
+            return !NuGetTransientErrorDetector.IsTransientError(combinedOutput)
+                && !TransientSdkResolutionErrorDetector.IsTransientError(combinedOutput);
         }
 
         public virtual CommandResult Execute(IEnumerable<string> args)

--- a/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
+++ b/test/Microsoft.NET.TestFramework/TransientSdkResolutionErrorDetector.cs
@@ -24,6 +24,16 @@ namespace Microsoft.NET.TestFramework
                 return false;
             }
 
+            return IsWorkloadResolverDeferralFlake(errorMessage)
+                || IsDefaultResolverDirectoryFlake(errorMessage);
+        }
+
+        /// <summary>
+        /// Pattern 1: The workload resolver defers (returns null) under parallel I/O and then the
+        /// default resolver also fails to find the SDK directory, producing MSB4236.
+        /// </summary>
+        private static bool IsWorkloadResolverDeferralFlake(string errorMessage)
+        {
             // The combination below is specific to the transient in-box SDK resolution flake:
             //   - MSB4236 is raised for an SDK that "could not be found",
             //   - for an in-box SDK in the Microsoft.NET.Sdk family, and
@@ -36,6 +46,18 @@ namespace Microsoft.NET.TestFramework
                 && errorMessage.Contains("Microsoft.NET.Sdk")
                 && errorMessage.Contains("Microsoft.DotNet.MSBuildWorkloadSdkResolver")
                 && errorMessage.Contains("returned null");
+        }
+
+        /// <summary>
+        /// Pattern 2: The default SDK resolver fails to probe the Sdks directory under heavy parallel
+        /// I/O, reporting MSB4276 with "did not exist" even though the directory is present on disk.
+        /// This is a race condition in filesystem enumeration under load.
+        /// </summary>
+        private static bool IsDefaultResolverDirectoryFlake(string errorMessage)
+        {
+            return errorMessage.Contains("MSB4276")
+                && errorMessage.Contains("Microsoft.NET.Sdk")
+                && errorMessage.Contains("did not exist");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes intermittent "Could not resolve SDK" test failures that occur under heavy parallel I/O in CI.

Fixes #51530

## Changes

### 1. Check both stdout and stderr for transient errors (`TestCommand.cs`)

The `ShouldStopRetry` method previously only checked `result.StdOut` for transient SDK resolution errors. However, MSBuild may emit error diagnostics to stderr depending on the logger configuration and hosting context. This meant transient errors written to stderr were not detected, causing the test to fail without retrying.

### 2. Detect MSB4276 default resolver directory probe failures (`TransientSdkResolutionErrorDetector.cs`)

Added a second detection pattern for MSB4276 errors where the default SDK resolver fails to find the `Sdks/<name>/Sdk` directory under heavy parallel I/O. This is a race condition where the directory exists on disk but the filesystem probe fails transiently under load. The detection is constrained to `Microsoft.NET.Sdk` family SDKs to avoid retrying genuinely missing custom SDKs.

### 3. Test coverage (`TransientSdkResolutionErrorDetectorTests.cs`)

Added tests for the new MSB4276 pattern, including a negative test ensuring custom (non-Microsoft.NET.Sdk) SDKs are not retried.

## Context

See also: https://github.com/dotnet/sdk/issues/51525 (related testfx issue where SDK resolution fails due to PATH/environment issues after image updates — a different root cause but similar symptom).