### PR TITLE
Fix dotnet-watch test flakiness

### DIFF
--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
@@ -10,9 +10,17 @@ namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal sealed class AwaitableProcess : IAsyncDisposable
     {
-        // cancel just before we hit timeout used on CI (XUnitWorkItemTimeout value in sdk\test\UnitTests.proj)
+        // Per-operation timeout for waiting on individual output lines.
+        // Capped at 10 minutes to prevent a single hanging wait from consuming the entire
+        // Helix work item timeout (typically 1 hour). This ensures other tests in the shard
+        // still run even if one test's process never produces expected output.
+        // The 90-second buffer before the work item timeout allows test cleanup (process kill,
+        // tree teardown) to complete before Helix hard-kills the work item.
         private static readonly TimeSpan s_timeout = Environment.GetEnvironmentVariable("HELIX_WORK_ITEM_TIMEOUT") is { } value
-            ? TimeSpan.Parse(value).Subtract(TimeSpan.FromSeconds(10)) : TimeSpan.FromMinutes(10);
+            ? Min(TimeSpan.Parse(value).Subtract(TimeSpan.FromSeconds(90)), TimeSpan.FromMinutes(10))
+            : TimeSpan.FromMinutes(10);
+
+        private static TimeSpan Min(TimeSpan a, TimeSpan b) => a < b ? a : b;
 
         private readonly List<string> _lines = [];
 
@@ -156,7 +164,7 @@ namespace Microsoft.DotNet.Watch.UnitTests
             {
                 if (timeoutCancellation.Token.IsCancellationRequested)
                 {
-                    Assert.Fail($"Output not found within {s_timeout}");
+                    Assert.Fail($"Output not found within {s_timeout}. Process {Id} output so far ({_lines.Count} lines):{Environment.NewLine}{string.Join(Environment.NewLine, _lines.TakeLast(20))}");
                 }
 
                 if (disposalCompletionSource.Token.IsCancellationRequested)
@@ -240,8 +248,12 @@ namespace Microsoft.DotNet.Watch.UnitTests
             {
             }
 
-            // ensure process has exited
-            await _processExitAwaiter;
+            // ensure process has exited (with a timeout to prevent cleanup hangs)
+            var exitTask = _processExitAwaiter;
+            if (await Task.WhenAny(exitTask, Task.Delay(TimeSpan.FromSeconds(30))) != exitTask)
+            {
+                Logger.Log($"Process {Id} did not exit within 30s after kill");
+            }
 
             Process.Dispose();
 


### PR DESCRIPTION
## Summary

Fixes the intermittent `dotnet-watch.Tests.dll.1` Helix work item failures tracked by Known Build Error #40006.

## Problem

The dotnet-watch test suite intermittently fails in Helix when the entire work item times out. This happens because:

1. **Per-operation timeout was nearly the full work item timeout** — `AwaitableProcess.s_timeout` was set to `HELIX_WORK_ITEM_TIMEOUT - 10 seconds` (≈59m50s with a 1-hour timeout). A single test whose process never produces expected output (due to a rare race condition) would burn nearly the entire shard's time, starving other tests.

2. **Insufficient cleanup buffer** — The 10-second buffer before the work item hard-kills was not enough time for `DisposeAsync` to kill the process tree and await exit.

3. **DisposeAsync could hang indefinitely** — After calling `Process.Kill(entireProcessTree: true)`, the code awaited `_processExitAwaiter` with no timeout. On rare occasions (zombie processes, Linux process group issues), this could hang.

## Fix

- **Cap per-operation timeout at 10 minutes** — matches the local-dev fallback value and prevents one hanging test from consuming the entire 1-hour work item. Most tests complete in seconds; 10 minutes is generous for slow-machine builds.
- **Increase work item buffer from 10s to 90s** — gives adequate time for process tree teardown.
- **Add 30-second timeout on process exit wait in DisposeAsync** — prevents cleanup hangs.
- **Include last 20 output lines in timeout error message** — aids diagnosis of future failures.

## Impact

These changes apply to `AwaitableProcess` in `Microsoft.DotNet.HotReload.Test.Utilities`, which is used by all dotnet-watch integration tests. The 10-minute cap is the same value already used when `HELIX_WORK_ITEM_TIMEOUT` is not set (local development), so this should not affect legitimate test behavior.

Fixes #40006