### PR TITLE
Update FindSolutionFilesAtOrAbovePath to prioritize *.slnx over *.sln found in parent directories

### DIFF
--- a/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
+++ b/src/Cli/dotnet/Commands/New/PostActions/DotnetSlnPostActionProcessor.cs
@@ -6,7 +6,6 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
-using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.New.PostActions;
 
@@ -20,8 +19,31 @@ internal class DotnetSlnPostActionProcessor(Func<string, IReadOnlyList<string>, 
 
     internal static IReadOnlyList<string> FindSolutionFilesAtOrAbovePath(IPhysicalFileSystem fileSystem, string outputBasePath)
     {
-        var slnFiles = FileFindHelpers.FindFilesAtOrAbovePath(fileSystem, outputBasePath, "*.sln");
-        return slnFiles.Count > 0 ? slnFiles : FileFindHelpers.FindFilesAtOrAbovePath(fileSystem, outputBasePath, "*.slnx");
+        // Search for .sln and .slnx at each directory level before walking up.
+        // This prevents finding an unrelated .sln in a distant parent directory when
+        // the intended .slnx exists in the output directory (or a closer ancestor).
+        string? directory = fileSystem.DirectoryExists(outputBasePath) ? outputBasePath : Path.GetDirectoryName(outputBasePath);
+        while (directory != null)
+        {
+            List<string> slnFiles = fileSystem.EnumerateFileSystemEntries(directory, "*.sln", SearchOption.TopDirectoryOnly)
+                .Where(f => f.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (slnFiles.Count > 0)
+            {
+                return slnFiles;
+            }
+
+            List<string> slnxFiles = fileSystem.EnumerateFileSystemEntries(directory, "*.slnx", SearchOption.TopDirectoryOnly)
+                .Where(f => f.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (slnxFiles.Count > 0)
+            {
+                return slnxFiles;
+            }
+
+            directory = Path.GetPathRoot(directory) != directory ? Directory.GetParent(directory)?.FullName : null;
+        }
+        return [];
     }
 
     // The project files to add are a subset of the primary outputs, specifically the primary outputs indicated by the primaryOutputIndexes post action argument (semicolon separated)

--- a/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
@@ -65,6 +65,30 @@ namespace Microsoft.DotNet.Cli.New.Tests
         }
 
         [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/49923
+        public void AddProjectToSolutionPostActionPrefersNearbySlnxOverDistantSln()
+        {
+            string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
+            _engineEnvironmentSettings.Host.VirtualizeDirectory(targetBasePath);
+            EnsureParentDirectoriesExist(targetBasePath);
+
+            // Place a .sln in targetBasePath (acts as "parent" directory)
+            string parentSlnPath = Path.Combine(targetBasePath, "Parent.sln");
+            _engineEnvironmentSettings.Host.FileSystem.WriteAllText(parentSlnPath, string.Empty);
+
+            // Create a subdirectory and place .slnx there (the "output" directory)
+            string outputDir = Path.Combine(targetBasePath, "output");
+            _engineEnvironmentSettings.Host.FileSystem.CreateDirectory(outputDir);
+            string slnxFileFullPath = Path.Combine(outputDir, "MySln.slnx");
+            _engineEnvironmentSettings.Host.FileSystem.WriteAllText(slnxFileFullPath, string.Empty);
+
+            // Should find the .slnx in the output directory, not the .sln in the parent
+            IReadOnlyList<string> solutionFiles = DotnetSlnPostActionProcessor.FindSolutionFilesAtOrAbovePath(_engineEnvironmentSettings.Host.FileSystem, outputDir);
+            Assert.ContainsSingle(solutionFiles);
+            Assert.AreEqual(slnxFileFullPath, solutionFiles[0]);
+        }
+
+        [TestMethod]
         public void AddProjectToSolutionPostActionFindsOneProjectToAdd()
         {
             string outputBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();


### PR DESCRIPTION
## Root Cause

The `FindSolutionFilesAtOrAbovePath` method in `DotnetSlnPostActionProcessor` used a two-pass strategy:
1. First, search the **entire** parent directory chain for `*.sln` files
2. Only if no `.sln` file is found anywhere up to the root, search for `*.slnx`

Since `dotnet new sln` now creates `.slnx` files by default, the `*.sln` search would walk all the way up from the output directory to the filesystem root. If a stale or unrelated `.sln` file existed in any ancestor directory (from parallel tests, other repos, the CI workspace, etc.), it would be returned instead of the `.slnx` in the output directory. When that transient file was subsequently deleted by another process between the search and the `File.Exists` validation in `PathUtility.EnsureAllPathsExist`, the error "Failed to add project(s) to the solution: File `<path>.sln` not found." occurred.

Additionally, on Windows, `Directory.EnumerateFileSystemEntries(dir, "*.sln")` can match `.slnx` files through the legacy FindFirstFile 8.3 short-name matching behavior. While .NET's managed filter usually rejects these, the behavior can vary across configurations.

## Fix

Changed `FindSolutionFilesAtOrAbovePath` to search for **both** `.sln` and `.slnx` at each directory level before walking up to the parent. This ensures:
- A `.slnx` in the output directory is found immediately without searching ancestors
- `.sln` is still preferred over `.slnx` when both exist at the same level
- Explicit `EndsWith` filtering guards against Windows legacy glob matching

## Testing

- All existing `DotnetSlnPostActionTests` pass (14 tests)
- Added new test `AddProjectToSolutionPostActionPrefersNearbySlnxOverDistantSln` that specifically verifies the fix: a `.slnx` in the output directory is found even when a `.sln` exists in a parent directory

Related to #54942