### PR TITLE
Do not bundle the ILCompiler (NativeAOT) on ppc64le

### DIFF
--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -74,10 +74,12 @@
       )">true</SkipBuildingInstallers>
   </PropertyGroup>
 
+  <Import Project="$(RepositoryEngineeringDir)common\native\NativeAotSupported.props" />
+
   <PropertyGroup>
     <GenerateSdkBundleOnly Condition="'$(DotNetBuildPass)' == '3' and '$(OS)' == 'Windows_NT'">true</GenerateSdkBundleOnly>
     <BundleRuntimePacks Condition="'$(BundleRuntimePacks)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</BundleRuntimePacks>
-    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">true</BundleNativeAotCompiler>
+    <BundleNativeAotCompiler Condition="'$(BundleNativeAotCompiler)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$(NativeAotSupported)' == 'true'">true</BundleNativeAotCompiler>
 
     <!-- Crossgen2 is not bundled by default on platforms where Microsoft provides a package on nuget.org,
          because it is large (100MB+). -->


### PR DESCRIPTION
PowerPC has no NativeAOT/ILCompiler code-generation backend, so the freebsd-ppc64le ILCompiler/NativeAOT packs don't exist. Disable BundleNativeAotCompiler for ppc64le in `src/Layout/Directory.Build.props` so the source build doesn't try to restore them (RestoreLayout.targets keys the ILCompiler/NativeAOT/ILLink packs on this property). Part of a FreeBSD/powerpc64le (ppc64le) port. Sibling PRs: dotnet/runtime (PAL/platform), dotnet/arcade (eng/common detection), dotnet/fsharp.

I have signed (or will sign on the dnfadmin bot's prompt) the .NET Foundation CLA.