### PR TITLE
Append attempt number to build log artifact names

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -223,7 +223,7 @@ jobs:
         PathtoPublish: $(Build.ArtifactStagingDirectory)
         # This is the job name, but because of "legacy reasons", both Agent.JobName and System.JobName are not the actual job name.
         # See: https://developercommunity.visualstudio.com/t/systemjobname-seems-to-be-incorrectly-assigned-and/1209736#TPIN-N1211828
-        ArtifactName: $(System.PhaseName)_Logs
+        ArtifactName: $(System.PhaseName)_Logs_Attempt$(System.JobAttempt)
         publishLocation: Container
       continueOnError: true
       condition: always()


### PR DESCRIPTION
## Problem

When a build job is retried, the `Publish Logs` step in `eng/pipelines/templates/jobs/sdk-build.yml` publishes artifacts using the static name `$(System.PhaseName)_Logs`. Because the name does not change between attempts, a retry overwrites the binlogs from the previous (failed) attempt, making it impossible to diagnose what went wrong on the original run.

## Fix

Append `_Attempt$(System.JobAttempt)` to the log artifact name so each attempt produces a uniquely named artifact -- for example, `Build_windows_x64_Logs_Attempt1` and `Build_windows_x64_Logs_Attempt2`.

This mirrors the pattern already used in `eng/common/core-templates/steps/publish-logs.yml` for `PostBuildLogs` artifacts, which correctly includes `_Attempt$(System.JobAttempt)` in its artifact name.

Non-log artifacts (`_Assets`, `_AotSizeAnalysis`) are intentionally left unchanged -- overwriting those on retry is acceptable since later successful builds supersede earlier ones.

## Change

```diff
- ArtifactName: $(System.PhaseName)_Logs
+ ArtifactName: $(System.PhaseName)_Logs_Attempt$(System.JobAttempt)
```

## Note

This is especially valuable when investigating known flaky or broken builds where jobs are being retried -- whether manually or via auto-retry (e.g., `build-configuration.json`). Previously, the only binlogs available after a retry were from the final attempt, making it impossible to compare failure signatures across attempts or confirm whether a transient issue reproduced consistently. With this change, logs from every attempt are preserved and independently accessible in the pipeline artifacts.
