### PR TITLE
Make Microsoft.NET.Build.Tasks AOT/trim compatible

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -3,11 +3,11 @@
 
 #nullable disable
 
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
@@ -281,13 +281,11 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
-            JObject runtimeOptionsFromProject;
-            using (JsonTextReader reader = new(File.OpenText(userConfigPath)))
-            {
-                runtimeOptionsFromProject = JObject.Load(reader);
-            }
+            JsonObject runtimeOptionsFromProject = (JsonObject)JsonNode.Parse(
+                File.ReadAllText(userConfigPath),
+                documentOptions: new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true });
 
-            foreach (var runtimeOption in runtimeOptionsFromProject)
+            foreach (KeyValuePair<string, JsonNode> runtimeOption in runtimeOptionsFromProject)
             {
                 runtimeOptions.RawOptions.Add(runtimeOption.Key, runtimeOption.Value);
             }
@@ -300,7 +298,7 @@ namespace Microsoft.NET.Build.Tasks
                 return;
             }
 
-            JObject configProperties = GetConfigProperties(runtimeOptions);
+            JsonObject configProperties = GetConfigProperties(runtimeOptions);
 
             foreach (var hostConfigurationOption in HostConfigurationOptions)
             {
@@ -308,37 +306,33 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private static JObject GetConfigProperties(RuntimeOptions runtimeOptions)
+        private static JsonObject GetConfigProperties(RuntimeOptions runtimeOptions)
         {
-            JToken configProperties;
-            if (!runtimeOptions.RawOptions.TryGetValue("configProperties", out configProperties)
-                || configProperties == null
-                || configProperties.Type != JTokenType.Object)
+            if (!runtimeOptions.RawOptions.TryGetValue("configProperties", out JsonNode configProperties)
+                || configProperties is not JsonObject)
             {
-                configProperties = new JObject();
+                configProperties = new JsonObject();
                 runtimeOptions.RawOptions["configProperties"] = configProperties;
             }
 
-            return (JObject)configProperties;
+            return (JsonObject)configProperties;
         }
 
-        private static JToken GetConfigPropertyValue(ITaskItem hostConfigurationOption)
+        private static JsonNode GetConfigPropertyValue(ITaskItem hostConfigurationOption)
         {
             string valueString = hostConfigurationOption.GetMetadata("Value");
 
-            bool boolValue;
-            if (bool.TryParse(valueString, out boolValue))
+            if (bool.TryParse(valueString, out bool boolValue))
             {
-                return new JValue(boolValue);
+                return JsonValue.Create(boolValue);
             }
 
-            int intValue;
-            if (int.TryParse(valueString, out intValue))
+            if (int.TryParse(valueString, out int intValue))
             {
-                return new JValue(intValue);
+                return JsonValue.Create(intValue);
             }
 
-            return new JValue(valueString);
+            return JsonValue.Create(valueString);
         }
 
         private void WriteDevRuntimeConfig(IList<LockFileItem> packageFolders)
@@ -391,19 +385,115 @@ namespace Microsoft.NET.Build.Tasks
             return path;
         }
 
-        private static void WriteToJsonFile(string fileName, object value)
+        private static void WriteToJsonFile(string fileName, RuntimeConfig value)
         {
-            JsonSerializer serializer = new()
+            // Build the document explicitly with the System.Text.Json node API instead of a
+            // reflection-based serializer, which is not trim/AOT safe (IL2026/IL3050). The writer
+            // is configured to reproduce the previous output exactly: 2-space indentation,
+            // environment newlines, and relaxed escaping (so characters such as '+' in paths are
+            // written verbatim rather than as \uXXXX escapes).
+            JsonObject json = new()
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Formatting = Formatting.Indented,
-                DefaultValueHandling = DefaultValueHandling.Ignore
+                ["runtimeOptions"] = SerializeRuntimeOptions(value.RuntimeOptions)
             };
 
-            using (JsonTextWriter writer = new(new StreamWriter(File.Create(fileName))))
+            JsonWriterOptions options = new()
             {
-                serializer.Serialize(writer, value);
+                Indented = true,
+                NewLine = Environment.NewLine,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+
+            using (FileStream stream = File.Create(fileName))
+            using (Utf8JsonWriter writer = new(stream, options))
+            {
+                json.WriteTo(writer);
             }
+        }
+
+        private static JsonObject SerializeRuntimeOptions(RuntimeOptions runtimeOptions)
+        {
+            // Declared properties are emitted in declaration order. Null values are omitted.
+            JsonObject json = new();
+
+            if (runtimeOptions.Tfm != null)
+            {
+                json["tfm"] = runtimeOptions.Tfm;
+            }
+
+            if (runtimeOptions.RollForward != null)
+            {
+                json["rollForward"] = runtimeOptions.RollForward;
+            }
+
+            if (runtimeOptions.Framework != null)
+            {
+                json["framework"] = SerializeFramework(runtimeOptions.Framework);
+            }
+
+            if (runtimeOptions.Frameworks != null)
+            {
+                json["frameworks"] = SerializeFrameworks(runtimeOptions.Frameworks);
+            }
+
+            if (runtimeOptions.IncludedFrameworks != null)
+            {
+                json["includedFrameworks"] = SerializeFrameworks(runtimeOptions.IncludedFrameworks);
+            }
+
+            if (runtimeOptions.AdditionalProbingPaths != null)
+            {
+                JsonArray probingPaths = new();
+                foreach (string probingPath in runtimeOptions.AdditionalProbingPaths)
+                {
+                    // Cast to JsonNode so the non-generic Add overload is used; the generic
+                    // JsonArray.Add<T> is annotated as trim/AOT unsafe (IL2026/IL3050).
+                    probingPaths.Add((JsonNode)probingPath);
+                }
+
+                json["additionalProbingPaths"] = probingPaths;
+            }
+
+            // RawOptions is the extension-data bag; its entries are written as direct children of
+            // runtimeOptions, after the declared properties. Clone each value so it can be
+            // re-parented into this document regardless of where it originated.
+            foreach (KeyValuePair<string, JsonNode> rawOption in runtimeOptions.RawOptions)
+            {
+                json[rawOption.Key] = rawOption.Value?.DeepClone();
+            }
+
+            return json;
+        }
+
+        private static JsonArray SerializeFrameworks(List<RuntimeConfigFramework> frameworks)
+        {
+            JsonArray array = new();
+
+            foreach (RuntimeConfigFramework framework in frameworks)
+            {
+                // Cast to JsonNode to use the non-generic Add overload (the generic
+                // JsonArray.Add<T> is annotated as trim/AOT unsafe).
+                array.Add((JsonNode)SerializeFramework(framework));
+            }
+
+            return array;
+        }
+
+        private static JsonObject SerializeFramework(RuntimeConfigFramework framework)
+        {
+            JsonObject json = new();
+
+            if (framework.Name != null)
+            {
+                json["name"] = framework.Name;
+            }
+
+            if (framework.Version != null)
+            {
+                json["version"] = framework.Version;
+            }
+
+            return json;
         }
     }
 }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj
@@ -13,6 +13,7 @@
     <Description>The MSBuild targets and properties for building .NET Core projects.</Description>
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(SdkTargetFramework);net472</TargetFrameworks>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RuntimeOptions.cs
@@ -3,8 +3,7 @@
 
 #nullable disable
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -12,7 +11,6 @@ namespace Microsoft.NET.Build.Tasks
     {
         public string Tfm { get; set; }
 
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string RollForward { get; set; }
 
         public RuntimeConfigFramework Framework { get; set; }
@@ -23,8 +21,7 @@ namespace Microsoft.NET.Build.Tasks
 
         public List<string> AdditionalProbingPaths { get; set; }
 
-        [JsonExtensionData]
-        public IDictionary<string, JToken> RawOptions { get; } = new Dictionary<string, JToken>();
+        public IDictionary<string, JsonNode> RawOptions { get; } = new Dictionary<string, JsonNode>();
 
         public RuntimeOptions()
         {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigurationFiles.cs
@@ -214,6 +214,171 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 }}");
         }
 
+        [TestMethod]
+        public void GivenHostConfigurationOptionsItWritesConfigProperties()
+        {
+            var task = new TestableGenerateRuntimeConfigurationFiles
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                TargetFrameworkMoniker = $".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}",
+                RuntimeConfigPath = _runtimeConfigPath,
+                RuntimeConfigDevPath = _runtimeConfigDevPath,
+                RuntimeFrameworks = new[]
+                {
+                    new MockTaskItem(
+                        "Microsoft.NETCore.App",
+                        new Dictionary<string, string>
+                        {
+                            {"FrameworkName", "Microsoft.NETCore.App"}, {"Version", $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0"}
+                        }
+                    )
+                },
+                RollForward = "LatestMinor",
+                HostConfigurationOptions = new[]
+                {
+                    new MockTaskItem("System.GC.Server", new Dictionary<string, string> { {"Value", "true"} }),
+                    new MockTaskItem("MaxThreads", new Dictionary<string, string> { {"Value", "42"} }),
+                    new MockTaskItem("SomeText", new Dictionary<string, string> { {"Value", "hello"} })
+                }
+            };
+
+            Action a = () => task.PublicExecuteCore();
+            a.Should().NotThrow();
+
+            // configProperties is the [JsonExtensionData] bag, written after the declared
+            // properties. Bool/int/string host option values keep their JSON types
+            // (true, 42, "hello"), matching the previous reflection-based serializer.
+            File.ReadAllText(_runtimeConfigPath).Should()
+                .Be(
+                    $@"{{
+  ""runtimeOptions"": {{
+    ""tfm"": ""{ToolsetInfo.CurrentTargetFramework}"",
+    ""rollForward"": ""LatestMinor"",
+    ""framework"": {{
+      ""name"": ""Microsoft.NETCore.App"",
+      ""version"": ""{ToolsetInfo.CurrentTargetFrameworkVersion}.0""
+    }},
+    ""configProperties"": {{
+      ""System.GC.Server"": true,
+      ""MaxThreads"": 42,
+      ""SomeText"": ""hello""
+    }}
+  }}
+}}");
+        }
+
+        [TestMethod]
+        public void GivenAdditionalProbingPathsItWritesThemToMainConfig()
+        {
+            var task = new TestableGenerateRuntimeConfigurationFiles
+            {
+                BuildEngine = new MockNeverCacheBuildEngine4(),
+                TargetFrameworkMoniker = $".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}",
+                RuntimeConfigPath = _runtimeConfigPath,
+                RuntimeConfigDevPath = _runtimeConfigDevPath,
+                RuntimeFrameworks = new[]
+                {
+                    new MockTaskItem(
+                        "Microsoft.NETCore.App",
+                        new Dictionary<string, string>
+                        {
+                            {"FrameworkName", "Microsoft.NETCore.App"}, {"Version", $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0"}
+                        }
+                    )
+                },
+                RollForward = "LatestMinor",
+                WriteAdditionalProbingPathsToMainConfig = true,
+                AdditionalProbingPaths = new[]
+                {
+                    new MockTaskItem("/probing/path1", new Dictionary<string, string>()),
+                    new MockTaskItem("/probing/path2", new Dictionary<string, string>())
+                }
+            };
+
+            Action a = () => task.PublicExecuteCore();
+            a.Should().NotThrow();
+
+            File.ReadAllText(_runtimeConfigPath).Should()
+                .Be(
+                    $@"{{
+  ""runtimeOptions"": {{
+    ""tfm"": ""{ToolsetInfo.CurrentTargetFramework}"",
+    ""rollForward"": ""LatestMinor"",
+    ""framework"": {{
+      ""name"": ""Microsoft.NETCore.App"",
+      ""version"": ""{ToolsetInfo.CurrentTargetFrameworkVersion}.0""
+    }},
+    ""additionalProbingPaths"": [
+      ""/probing/path1"",
+      ""/probing/path2""
+    ]
+  }}
+}}");
+        }
+
+        [TestMethod]
+        public void GivenUserRuntimeConfigItMergesExtensionData()
+        {
+            var userConfigPath = Path.Combine(
+                Path.GetTempPath(), "dotnetSdkTests", nameof(GivenUserRuntimeConfigItMergesExtensionData) + ".template.json");
+            File.WriteAllText(
+                userConfigPath,
+                "{\"configProperties\":{\"TestProperty\":true},\"customSection\":{\"value\":42}}");
+            try
+            {
+                var task = new TestableGenerateRuntimeConfigurationFiles
+                {
+                    BuildEngine = new MockNeverCacheBuildEngine4(),
+                    TargetFrameworkMoniker = $".NETCoreApp,Version=v{ToolsetInfo.CurrentTargetFrameworkVersion}",
+                    RuntimeConfigPath = _runtimeConfigPath,
+                    RuntimeConfigDevPath = _runtimeConfigDevPath,
+                    RuntimeFrameworks = new[]
+                    {
+                        new MockTaskItem(
+                            "Microsoft.NETCore.App",
+                            new Dictionary<string, string>
+                            {
+                                {"FrameworkName", "Microsoft.NETCore.App"}, {"Version", $"{ToolsetInfo.CurrentTargetFrameworkVersion}.0"}
+                            }
+                        )
+                    },
+                    RollForward = "LatestMinor",
+                    UserRuntimeConfig = userConfigPath
+                };
+
+                Action a = () => task.PublicExecuteCore();
+                a.Should().NotThrow();
+
+                // The user template's properties flow through [JsonExtensionData] and are written
+                // after the declared properties, preserving nested objects and value types exactly.
+                File.ReadAllText(_runtimeConfigPath).Should()
+                    .Be(
+                        $@"{{
+  ""runtimeOptions"": {{
+    ""tfm"": ""{ToolsetInfo.CurrentTargetFramework}"",
+    ""rollForward"": ""LatestMinor"",
+    ""framework"": {{
+      ""name"": ""Microsoft.NETCore.App"",
+      ""version"": ""{ToolsetInfo.CurrentTargetFrameworkVersion}.0""
+    }},
+    ""configProperties"": {{
+      ""TestProperty"": true
+    }},
+    ""customSection"": {{
+      ""value"": 42
+    }}
+  }}
+}}");
+            }
+            finally
+            {
+                if (File.Exists(userConfigPath))
+                {
+                    File.Delete(userConfigPath);
+                }
+            }
+        }
+
         private class TestableGenerateRuntimeConfigurationFiles : GenerateRuntimeConfigurationFiles
         {
             public TestableGenerateRuntimeConfigurationFiles()


### PR DESCRIPTION
## Summary

Enables `IsAotCompatible` for the `Microsoft.NET.Build.Tasks` project and resolves the resulting IL trim/AOT analyzer warnings.

The only warnings (IL2026/IL3050) came from the reflection-based **Newtonsoft.Json** serializer used by `GenerateRuntimeConfigurationFiles` to write `.runtimeconfig.json` / `.runtimeconfig.dev.json`. This replaces that usage with the **System.Text.Json** node API (`JsonObject` / `JsonArray` / `JsonNode` + `Utf8JsonWriter`), configured to reproduce the previous output exactly.

## Changes

- Add `<IsAotCompatible>` (conditioned on net8.0+, so net472 is unaffected and no `NETSDK1210` is emitted).
- Migrate `GenerateRuntimeConfigurationFiles` serialization from Newtonsoft.Json LINQ-to-JSON to System.Text.Json nodes. The writer uses `Indented = true`, `NewLine = Environment.NewLine`, and `Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping` so indentation, line endings, and escaping match the previous output.
- Change `RuntimeOptions.RawOptions` (the extension-data bag) from `IDictionary<string, JToken>` to `IDictionary<string, JsonNode>`, and drop the now-unneeded `[JsonProperty]` / `[JsonExtensionData]` attributes.
- Add exact-output regression tests for config properties, additional probing paths, and user runtime config template merging.

## Validation

- **0 IL warnings**; both `net11.0` and `net472` build clean.
- All `GenerateRuntimeConfig` task tests pass (existing + new exact-output tests).
- An old-vs-new characterization confirmed byte-identical output across every branch and escaping case (backslashes, `+`, `<>&`, non-ASCII Unicode, quotes, control characters, null extension data, nested structures).

## Notes

- One intentional nuance: numbers written in **scientific notation** inside a user `runtimeconfig.template.json` round-trip slightly differently (Newtonsoft normalized `1e10` to `10000000000.0`; System.Text.Json preserves the literal `1e10`). Plain integers, decimals, negatives, and zero are unchanged. This is semantically identical to the host, effectively never occurs in practice, and STJ's behavior is more faithful to the user's input.
- `Newtonsoft.Json` remains a transitive dependency (via `NuGet.Packaging`) and is still used by a few other files in this project. This change only removes its use from runtime config generation to clear the AOT analyzer warnings.
