### PR TITLE
Add retry logic to GetAssemblyVersion for transient file lock IOException

### DIFF
--- a/src/Tasks/Common/FileUtilities.MetadataReader.cs
+++ b/src/Tasks/Common/FileUtilities.MetadataReader.cs
@@ -22,7 +22,27 @@ namespace Microsoft.NET.Build.Tasks
     {
         private static readonly ConcurrentDictionary<string, (DateTime LastKnownWriteTimeUtc, Version? Version)> s_versionCache = new(StringComparer.OrdinalIgnoreCase /* Not strictly correct on *nix. Fix? */);
 
+        private const int FileAccessRetryCount = 3;
+        private const int FileAccessRetryDelayMs = 200;
+
         private static Version? GetAssemblyVersion(string sourcePath)
+        {
+            // Retry file access to handle transient IOExceptions caused by concurrent
+            // MSBuild processes locking the file during parallel builds.
+            for (int retry = 0; ; retry++)
+            {
+                try
+                {
+                    return GetAssemblyVersionCore(sourcePath);
+                }
+                catch (IOException) when (retry < FileAccessRetryCount - 1)
+                {
+                    Thread.Sleep(FileAccessRetryDelayMs);
+                }
+            }
+        }
+
+        private static Version? GetAssemblyVersionCore(string sourcePath)
         {
             DateTime lastWriteTimeUtc = File.GetLastWriteTimeUtc(sourcePath);
 


### PR DESCRIPTION
## Summary

Adds retry logic to `GetAssemblyVersion` in `FileUtilities.MetadataReader.cs` to handle transient `IOException` failures caused by file locking during parallel MSBuild builds.

## Problem

The `GetAssemblyAttributes` task intermittently fails in CI when `GetAssemblyVersion` tries to read a DLL that is temporarily locked by another concurrent MSBuild process. This manifests as:

```
System.IO.IOException: The process cannot access the file '...Microsoft.DotNet.ApiCompat.Task.dll' because it is being used by another process.
   at Microsoft.NET.Build.Tasks.FileUtilities.GetAssemblyVersion(String sourcePath)
   at Microsoft.NET.Build.Tasks.GetAssemblyAttributes.ExecuteCore()
```

This has been hitting the official CI on `main` with 7 occurrences in the last 24 hours alone (19 in the past week).

## Fix

Wraps the file access in a retry loop (3 attempts, 200ms delay between retries). The `IOException` is caught on all but the final attempt, after which it propagates normally. This matches the standard pattern for handling transient file lock contention in build infrastructure.

The original `GetAssemblyVersion` method is renamed to `GetAssemblyVersionCore` and the new `GetAssemblyVersion` method provides the retry wrapper.

Fixes #54864