### PR TITLE
Consolidate logger utilities between run and test

### DIFF
--- a/src/Cli/dotnet/Commands/DotNetCommandFactory.cs
+++ b/src/Cli/dotnet/Commands/DotNetCommandFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
@@ -55,7 +56,7 @@ public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string? curre
         IEnumerable<Option> optionsToUseWhenParsingMSBuildFlags,
         ParseResult parseResult,
         string? msbuildPath = null,
-        Func<MSBuildArgs, MSBuildArgs>? transformer = null)
+        Func<MSBuildArgs, ImmutableArray<string>, MSBuildArgs>? transformer = null)
     {
         var args = parseResult.GetValue(catchAllUserInputArgument) ?? [];
         LoggerUtility.SeparateLoggerArguments(args, out var loggerArgs, out var nonLoggerArgs);
@@ -72,7 +73,7 @@ public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string? curre
                     CommonOptions.CreateGetTargetResultOption(),
                     CommonOptions.CreateGetResultOutputFileOption(),
                 ]);
-                msbuildArgs = transformer?.Invoke(msbuildArgs) ?? msbuildArgs;
+                msbuildArgs = transformer?.Invoke(msbuildArgs, nonLoggerArgs) ?? msbuildArgs;
                 return createVirtualCommand(msbuildArgs, Path.GetFullPath(arg));
             }
             else
@@ -110,7 +111,7 @@ public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string? curre
             }
 
             var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments([.. forwardedArgs, .. args], [.. optionsToUseWhenParsingMSBuildFlags]);
-            msbuildArgs = transformer?.Invoke(msbuildArgs) ?? msbuildArgs;
+            msbuildArgs = transformer?.Invoke(msbuildArgs, nonLoggerArgs) ?? msbuildArgs;
             return createPhysicalCommand(msbuildArgs, msbuildPath);
         }
     }

--- a/src/Cli/dotnet/Commands/Pack/PackCommand.cs
+++ b/src/Cli/dotnet/Commands/Pack/PackCommand.cs
@@ -32,9 +32,6 @@ public class PackCommand(
     public static CommandBase FromParseResult(ParseResult parseResult, string? msbuildPath = null)
     {
         var definition = (PackCommandDefinition)parseResult.CommandResult.Command;
-        var args = parseResult.GetValue(definition.SlnOrProjectOrFileArgument) ?? [];
-
-        LoggerUtility.SeparateLoggerArguments(args, out var loggerArgs, out var nonLoggerArgs);
 
         bool noBuild = parseResult.HasOption(definition.NoBuildOption);
 
@@ -65,7 +62,7 @@ public class PackCommand(
             ],
             parseResult,
             msbuildPath,
-            transformer: (msbuildArgs) =>
+            transformer: (msbuildArgs, nonLoggerArgs) =>
             {
                 ReleasePropertyProjectLocator projectLocator = new(msbuildArgs.GlobalProperties, MSBuildPropertyNames.PACK_RELEASE,
                     new ReleasePropertyProjectLocator.DependentCommandOptions(

--- a/src/Cli/dotnet/Commands/Pack/PackCommand.cs
+++ b/src/Cli/dotnet/Commands/Pack/PackCommand.cs
@@ -34,7 +34,7 @@ public class PackCommand(
         var definition = (PackCommandDefinition)parseResult.CommandResult.Command;
         var args = parseResult.GetValue(definition.SlnOrProjectOrFileArgument) ?? [];
 
-        LoggerUtility.SeparateBinLogArguments(args, out var binLogArgs, out var nonBinLogArgs);
+        LoggerUtility.SeparateLoggerArguments(args, out var loggerArgs, out var nonLoggerArgs);
 
         bool noBuild = parseResult.HasOption(definition.NoBuildOption);
 
@@ -69,7 +69,7 @@ public class PackCommand(
             {
                 ReleasePropertyProjectLocator projectLocator = new(msbuildArgs.GlobalProperties, MSBuildPropertyNames.PACK_RELEASE,
                     new ReleasePropertyProjectLocator.DependentCommandOptions(
-                            nonBinLogArgs,
+                            nonLoggerArgs,
                             parseResult.HasOption(definition.ConfigurationOption) ? parseResult.GetValue(definition.ConfigurationOption) : null
                         )
                 );

--- a/src/Cli/dotnet/Commands/Publish/PublishCommand.cs
+++ b/src/Cli/dotnet/Commands/Publish/PublishCommand.cs
@@ -35,10 +35,6 @@ public class PublishCommand : RestoringCommand
         parseResult.HandleDebugSwitch();
         parseResult.ShowHelpOrErrorIfAppropriate();
 
-        string[] args = parseResult.GetValue(definition.SlnOrProjectOrFileArgument) ?? [];
-
-        LoggerUtility.SeparateLoggerArguments(args, out var loggerArgs, out var nonLoggerArgs);
-
         CommonOptions.ValidateSelfContainedOptions(parseResult.HasOption(definition.SelfContainedOption),
             parseResult.HasOption(definition.NoSelfContainedOption));
 
@@ -72,7 +68,7 @@ public class PublishCommand : RestoringCommand
             ],
             parseResult,
             msbuildPath,
-            transformer: (msbuildArgs) =>
+            transformer: (msbuildArgs, nonLoggerArgs) =>
             {
                 var options = new ReleasePropertyProjectLocator.DependentCommandOptions(
                         nonLoggerArgs,

--- a/src/Cli/dotnet/Commands/Publish/PublishCommand.cs
+++ b/src/Cli/dotnet/Commands/Publish/PublishCommand.cs
@@ -37,7 +37,7 @@ public class PublishCommand : RestoringCommand
 
         string[] args = parseResult.GetValue(definition.SlnOrProjectOrFileArgument) ?? [];
 
-        LoggerUtility.SeparateBinLogArguments(args, out var binLogArgs, out var nonBinLogArgs);
+        LoggerUtility.SeparateLoggerArguments(args, out var loggerArgs, out var nonLoggerArgs);
 
         CommonOptions.ValidateSelfContainedOptions(parseResult.HasOption(definition.SelfContainedOption),
             parseResult.HasOption(definition.NoSelfContainedOption));
@@ -75,7 +75,7 @@ public class PublishCommand : RestoringCommand
             transformer: (msbuildArgs) =>
             {
                 var options = new ReleasePropertyProjectLocator.DependentCommandOptions(
-                        nonBinLogArgs,
+                        nonLoggerArgs,
                         parseResult.HasOption(definition.ConfigurationOption) ? parseResult.GetValue(definition.ConfigurationOption) : null,
                         parseResult.HasOption(definition.FrameworkOption) ? parseResult.GetValue(definition.FrameworkOption) : null
                     );

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -210,7 +210,7 @@ internal static class MSBuildUtility
 
         LoggerUtility.SeparateLoggerArguments(parseResult.UnmatchedTokens, out var loggerArgs, out var otherArgs);
 
-        var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(otherArgs);
+        var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(ref otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(definition)
             .Concat(loggerArgs);
@@ -262,7 +262,7 @@ internal static class MSBuildUtility
             Device: parseResult.GetValue(definition.DeviceOption));
     }
 
-    private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(ImmutableArray<string> otherArgs)
+    private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(ref ImmutableArray<string> otherArgs)
     {
         string? positionalProjectOrSolution = null;
         string? positionalTestModules = null;
@@ -282,7 +282,7 @@ internal static class MSBuildUtility
                 if (i == 0)
                 {
                     positionalProjectOrSolution = token;
-                    otherArgs.RemoveAt(0);
+                    otherArgs = otherArgs.RemoveAt(0);
                     break;
                 }
                 else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
@@ -297,7 +297,7 @@ internal static class MSBuildUtility
                 if (i == 0)
                 {
                     positionalProjectOrSolution = token;
-                    otherArgs.RemoveAt(0);
+                    otherArgs = otherArgs.RemoveAt(0);
                     break;
                 }
                 else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
@@ -312,7 +312,7 @@ internal static class MSBuildUtility
                 if (i == 0)
                 {
                     positionalTestModules = token;
-                    otherArgs.RemoveAt(0);
+                    otherArgs = otherArgs.RemoveAt(0);
                     break;
                 }
                 else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)
@@ -325,7 +325,7 @@ internal static class MSBuildUtility
                 if (i == 0)
                 {
                     positionalProjectOrSolution = token;
-                    otherArgs.RemoveAt(0);
+                    otherArgs = otherArgs.RemoveAt(0);
                     break;
                 }
                 else if (throwOnUnexpectedFilePassedAsNonFirstPositionalArgument)

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -15,6 +15,7 @@ using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.VisualStudio.SolutionPersistence.Model;
 using System.Diagnostics.CodeAnalysis;
+using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -207,27 +208,12 @@ internal static class MSBuildUtility
     {
         var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
 
-        LoggerUtility.SeparateBinLogArguments(parseResult.UnmatchedTokens, out var binLogArgs, out var otherArgs);
-
-        // Terminal logger arguments (e.g. --tl:off, -terminalLogger:auto, -tlp:default=true)
-        // should be forwarded to MSBuild during the build phase rather than being passed to
-        // the test application as it doesn't recognize them. See https://github.com/dotnet/sdk/issues/52229.
-        var terminalLoggerArgs = new List<string>();
-        for (int i = otherArgs.Count - 1; i >= 0; i--)
-        {
-            if (LoggerUtility.IsTerminalLoggerArgument(otherArgs[i]))
-            {
-                terminalLoggerArgs.Add(otherArgs[i]);
-                otherArgs.RemoveAt(i);
-            }
-        }
-        terminalLoggerArgs.Reverse();
+        LoggerUtility.SeparateLoggerArguments(parseResult.UnmatchedTokens, out var loggerArgs, out var otherArgs);
 
         var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(definition)
-            .Concat(binLogArgs)
-            .Concat(terminalLoggerArgs);
+            .Concat(loggerArgs);
 
         string? resultsDirectory = parseResult.GetValue(definition.ResultsDirectoryOption);
         if (resultsDirectory is not null)
@@ -276,7 +262,7 @@ internal static class MSBuildUtility
             Device: parseResult.GetValue(definition.DeviceOption));
     }
 
-    private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(List<string> otherArgs)
+    private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(ImmutableArray<string> otherArgs)
     {
         string? positionalProjectOrSolution = null;
         string? positionalTestModules = null;
@@ -286,7 +272,7 @@ internal static class MSBuildUtility
         // So, disabling validation is okay if the user scenario is valid.
         bool throwOnUnexpectedFilePassedAsNonFirstPositionalArgument = Environment.GetEnvironmentVariable("DOTNET_TEST_DISABLE_SWITCH_VALIDATION") is not ("true" or "1");
 
-        for (int i = 0; i < otherArgs.Count; i++)
+        for (int i = 0; i < otherArgs.Length; i++)
         {
             var token = otherArgs[i];
             if ((token.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal record TestOptions(bool IsHelp, bool IsDiscovery, IReadOnlyDictionary<string, string> EnvironmentVariables);
@@ -14,6 +16,6 @@ internal record BuildOptions(
     Utils.VerbosityOptions? Verbosity,
     bool NoLaunchProfile,
     bool NoLaunchProfileArguments,
-    List<string> TestApplicationArguments,
+    ImmutableArray<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs,
     string? Device);

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -63,23 +63,6 @@ internal static class LoggerUtility
         return new FacadeLogger(dispatcher);
     }
 
-    internal static void SeparateBinLogArguments(IEnumerable<string>? args, out List<string> binLogArgs, out List<string> nonBinLogArgs)
-    {
-        binLogArgs = new List<string>();
-        nonBinLogArgs = new List<string>();
-        foreach (var arg in args ?? [])
-        {
-            if (IsBinLogArgument(arg))
-            {
-                binLogArgs.Add(arg);
-            }
-            else
-            {
-                nonBinLogArgs.Add(arg);
-            }
-        }
-    }
-
     internal static void SeparateLoggerArguments(IEnumerable<string>? args, out ImmutableArray<string> loggerArgs, out ImmutableArray<string> nonLoggerArgs)
     {
         var loggerArgsBuilder = ImmutableArray.CreateBuilder<string>();
@@ -112,7 +95,7 @@ internal static class LoggerUtility
     internal static bool HasNoConsoleLoggerArgument(IEnumerable<string>? args) =>
         args?.Any(IsNoConsoleLoggerArgument) == true;
 
-    internal static bool IsNoConsoleLoggerArgument(string arg)
+    private static bool IsNoConsoleLoggerArgument(string arg)
     {
         return TryParseSwitch(arg, out string? prefix, out string? switchName, out string? switchValue, out bool hasValue) &&
             prefix is "-" or "/" &&

--- a/src/Cli/dotnet/LoggerUtility.cs
+++ b/src/Cli/dotnet/LoggerUtility.cs
@@ -135,7 +135,8 @@ internal static class LoggerUtility
         }
 
         const StringComparison comp = StringComparison.OrdinalIgnoreCase;
-        if (switchName.Equals("tl", comp) || switchName.Equals("terminalLogger", comp))
+        if (switchName.Equals("tl", comp) || switchName.Equals("terminalLogger", comp) ||
+            switchName.Equals("ll", comp) || switchName.Equals("livelogger", comp))
         {
             if (!hasValue)
             {
@@ -199,49 +200,6 @@ internal static class LoggerUtility
         switchValue = hasValue ? value[(separatorIndex + 1)..] : null;
 
         return switchName.Length > 0;
-    }
-
-    private static readonly string[] s_terminalLoggerArgumentNames =
-    [
-        "tl",
-        "terminallogger",
-        "ll",
-        "livelogger",
-        "tlp",
-        "terminalloggerparameters",
-    ];
-
-    private static readonly string[] s_argumentPrefixes = ["--", "-", "/"];
-
-    /// <summary>
-    /// Determines whether the given argument is an MSBuild terminal logger argument
-    /// (e.g. <c>-tl[:value]</c>, <c>--terminalLogger[:value]</c>, <c>-ll[:value]</c>,
-    /// <c>--livelogger[:value]</c>, <c>-tlp:...</c>, or <c>--terminalLoggerParameters:...</c>).
-    /// </summary>
-    internal static bool IsTerminalLoggerArgument(string arg)
-    {
-        const StringComparison comp = StringComparison.OrdinalIgnoreCase;
-        foreach (var prefix in s_argumentPrefixes)
-        {
-            if (!arg.StartsWith(prefix, comp))
-            {
-                continue;
-            }
-
-            var nameAndValue = arg.AsSpan(prefix.Length);
-            int colonIndex = nameAndValue.IndexOf(':');
-            var name = colonIndex < 0 ? nameAndValue : nameAndValue[..colonIndex];
-
-            foreach (var knownName in s_terminalLoggerArgumentNames)
-            {
-                if (name.Equals(knownName.AsSpan(), comp))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 }
 

--- a/test/dotnet.Tests/LoggerUtilityTests.cs
+++ b/test/dotnet.Tests/LoggerUtilityTests.cs
@@ -11,14 +11,31 @@ namespace dotnet.Tests
     {
         [TestMethod]
         [DataRow("-tl", "-tl:auto")]
+        [DataRow("--tl", "--tl:auto")]
         [DataRow("/tl", "/tl:auto")]
-        [DataRow("--terminalLogger", "--terminalLogger:auto")]
         [DataRow("-tl:off", "-tl:off")]
         [DataRow("-TL:off", "-TL:off")]
+        [DataRow("-TL:Off", "-TL:Off")]
+        [DataRow("--tl:off", "--tl:off")]
+        [DataRow("/tl:on", "/tl:on")]
         [DataRow("/tl:off", "/tl:off")]
+        [DataRow("-terminallogger", "-terminallogger:auto")]
+        [DataRow("--terminalLogger", "--terminalLogger:auto")]
+        [DataRow("/terminallogger", "/terminallogger:auto")]
+        [DataRow("-terminallogger:auto", "-terminallogger:auto")]
+        [DataRow("--TerminalLogger:on", "--TerminalLogger:on")]
         [DataRow("--terminalLogger:off", "--terminalLogger:off")]
+        [DataRow("-ll", "-ll:auto")]
+        [DataRow("--ll:off", "--ll:off")]
+        [DataRow("/ll", "/ll:auto")]
+        [DataRow("-livelogger", "-livelogger:auto")]
+        [DataRow("--livelogger:off", "--livelogger:off")]
+        [DataRow("-tlp:default=true", "-tlp:default=true")]
+        [DataRow("--tlp:default=auto", "--tlp:default=auto")]
         [DataRow("-tlp:verbosity=quiet", "-tlp:verbosity=quiet")]
         [DataRow("/tlp:DISABLENODEDISPLAY", "/tlp:DISABLENODEDISPLAY")]
+        [DataRow("-terminalloggerparameters:default=true", "-terminalloggerparameters:default=true")]
+        [DataRow("--terminalLoggerParameters:default=true", "--terminalLoggerParameters:default=true")]
         [DataRow("--terminalLoggerParameters:verbosity=quiet", "--terminalLoggerParameters:verbosity=quiet")]
         [DataRow("-clp:NoSummary", "-clp:NoSummary")]
         [DataRow("--consoleLoggerParameters:NoSummary", "--consoleLoggerParameters:NoSummary")]
@@ -40,56 +57,19 @@ namespace dotnet.Tests
         [DataRow("-noconsolelogger:false")]
         [DataRow("--noconsolelogger")]
         [DataRow("--unknownLogger:off")]
-        public void LoggerArgument_InvalidFormsAreNotRecognized(string arg)
-        {
-            LoggerUtility.SeparateLoggerArguments([arg], out var loggerArgs, out var nonLoggerArgs);
-
-            loggerArgs.Should().BeEmpty();
-            nonLoggerArgs.Should().Equal(arg);
-        }
-
-        [TestMethod]
-        [DataRow("-tl")]
-        [DataRow("--tl")]
-        [DataRow("/tl")]
-        [DataRow("-tl:off")]
-        [DataRow("--tl:off")]
-        [DataRow("/tl:on")]
-        [DataRow("-TL:Off")]
-        [DataRow("-terminallogger")]
-        [DataRow("--terminalLogger")]
-        [DataRow("/terminallogger")]
-        [DataRow("-terminallogger:auto")]
-        [DataRow("--TerminalLogger:on")]
-        [DataRow("-ll")]
-        [DataRow("--ll:off")]
-        [DataRow("/ll")]
-        [DataRow("-livelogger")]
-        [DataRow("--livelogger:off")]
-        [DataRow("-tlp:default=true")]
-        [DataRow("--tlp:default=auto")]
-        [DataRow("/tlp:DISABLENODEDISPLAY")]
-        [DataRow("-terminalloggerparameters:default=true")]
-        [DataRow("--terminalLoggerParameters:default=true")]
-        public void IsTerminalLoggerArgument_RecognizesTerminalLoggerArguments(string arg)
-        {
-            LoggerUtility.IsTerminalLoggerArgument(arg).Should().BeTrue();
-        }
-
-        [TestMethod]
         [DataRow("--no-build")]
-        [DataRow("-bl")]
-        [DataRow("--binaryLogger")]
-        [DataRow("-bl:foo.binlog")]
         [DataRow("-tlapropertythatstartslikethis")]
         [DataRow("--tlpwithnocolon")]
         [DataRow("--terminallogger-something")]
         [DataRow("-llextra")]
         [DataRow("foo.csproj")]
         [DataRow("")]
-        public void IsTerminalLoggerArgument_RejectsNonTerminalLoggerArguments(string arg)
+        public void LoggerArgument_InvalidFormsAreNotRecognized(string arg)
         {
-            LoggerUtility.IsTerminalLoggerArgument(arg).Should().BeFalse();
+            LoggerUtility.SeparateLoggerArguments([arg], out var loggerArgs, out var nonLoggerArgs);
+
+            loggerArgs.Should().BeEmpty();
+            nonLoggerArgs.Should().Equal(arg);
         }
 
         [TestMethod]


### PR DESCRIPTION
Follow up on https://github.com/dotnet/sdk/pull/54637 merged into 10.0.4xx - since it flew into main (via https://github.com/dotnet/sdk/pull/55003), some utilities can be consolidated.