### PR TITLE
Mark TemplateEngine packages as shipping

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,8 +63,10 @@
 # Area-Templates
 /src/Cli/dotnet/Commands/New @dotnet/templating-engine-maintainers
 /src/Cli/Microsoft.TemplateEngine.Cli @dotnet/templating-engine-maintainers
+/src/TemplateEngine @dotnet/templating-engine-maintainers
 /test/dotnet-new.IntegrationTests @dotnet/templating-engine-maintainers
 /test/Microsoft.TemplateEngine.* @dotnet/templating-engine-maintainers
+/test/TemplateEngine @dotnet/templating-engine-maintainers
 /template_feed @dotnet/templating-engine-maintainers
 
 # ILLink and ReadyToRun targets and tasks owned by runtime team

--- a/src/TemplateEngine/Directory.Build.props
+++ b/src/TemplateEngine/Directory.Build.props
@@ -19,6 +19,9 @@
     <!-- Enable reproducible build per binskim -->
     <Deterministic>true</Deterministic>
 
+    <!-- Override the SDK default of non-shipping packages -->
+    <IsShippingPackage>true</IsShippingPackage>
+
     <!-- Disable analyzers in sourcebuild -->
     <EnableAnalyzers>true</EnableAnalyzers>
     <EnableAnalyzers Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</EnableAnalyzers>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <IsShippingPackage>false</IsShippingPackage>
     <PackAsTool>true</PackAsTool>
     <RollForward>Major</RollForward>
   </PropertyGroup>


### PR DESCRIPTION
After the dotnet/templating merge into dotnet/sdk, the TemplateEngine packages inherited `IsShippingPackage=false` from the SDK repo root `Directory.Build.props`. In the standalone templating repo, the Arcade default (`IsShippingPackage=true`) applied, so packages were classified as shipping and published to NuGet.

This PR overrides `IsShippingPackage` to `true` in `src/TemplateEngine/Directory.Build.props` so these packages are classified as shipping again. `Microsoft.TemplateSearch.TemplateDiscovery` gets an explicit `IsShippingPackage=false` since the parent props would otherwise override its existing `IsShipping=false`.

Also updates CODEOWNERS to include `src/TemplateEngine` and `test/TemplateEngine` under the Area-Templates section owned by `@dotnet/templating-engine-maintainers`.

**Affected packages:**
- Microsoft.TemplateEngine.Abstractions
- Microsoft.TemplateEngine.Authoring.CLI
- Microsoft.TemplateEngine.Authoring.Tasks
- Microsoft.TemplateEngine.Authoring.TemplateVerifier
- Microsoft.TemplateEngine.Core
- Microsoft.TemplateEngine.Core.Contracts
- Microsoft.TemplateEngine.Edge
- Microsoft.TemplateEngine.IDE
- Microsoft.TemplateEngine.Orchestrator.RunnableProjects
- Microsoft.TemplateEngine.TemplateLocalizer.Core
- Microsoft.TemplateEngine.Utils
- Microsoft.TemplateSearch.Common