### PR TITLE
Enable full `dotnet --info` output in the AOT CLI

### DIFF
--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -99,6 +99,53 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\CliCommandStrings.resx" Link="CliCommandStrings.resx" GenerateSource="true" Namespace="Microsoft.DotNet.Cli.Commands" />
   </ItemGroup>
 
+  <!--
+    The "MSBuild version:" line of the info command: MSBuildForwardingAppWithoutLogging.MSBuildVersion
+    (in Microsoft.DotNet.Cli.Utils) reads Microsoft.Build.Evaluation.ProjectCollection.DisplayVersion,
+    so the AOT binary needs the Microsoft.Build runtime assembly for ILC to compile that path.
+    Cli.Utils references Microsoft.Build with ExcludeAssets="runtime" / PrivateAssets="all", so it does
+    not flow transitively; reference it directly here. Microsoft.Build is only partially annotated
+    for trimming/AOT; its analysis warnings are rolled up and suppressed in dotnet-aot.csproj.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" />
+  </ItemGroup>
+
+  <!--
+    Workload reporting for the info command: WorkloadInfoHelper.GetWorkloadsVersion() and
+    ShowWorkloadsInfo(). Under CLI_AOT, WorkloadInfoHelper builds the installation-record repository
+    directly (the registry/file-based record repositories are already in the AOT source set) and does
+    not compile in the workload installer (NuGet/MSI) machinery.
+  -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\WorkloadInfoHelper.cs" Link="Commands\Workload\WorkloadInfoHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\InstallStateContents.cs" Link="Commands\Workload\InstallStateContents.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\List\InstalledWorkloadsCollection.cs" Link="Commands\Workload\List\InstalledWorkloadsCollection.cs" />
+  </ItemGroup>
+
+  <!--
+    Windows-only: 'Visual Studio installed workloads' portion of the info command's workload section.
+    VisualStudioWorkloads queries the VS Setup Configuration COM API. The AOT-safe COM interop helpers
+    (ComClassFactory, ComScope, ComSafeArrayScope, BSTR, HRESULT, IComIID, CLSID) live in
+    Microsoft.DotNet.Cli.Utils and are consumed here via InternalsVisibleTo; only the VS Setup
+    interface definitions and the query itself are compiled in. Gated on TARGET_WINDOWS to match the
+    '#if TARGET_WINDOWS' guard around the call site in WorkloadInfoHelper.AddInstalledVsWorkloads.
+  -->
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\List\VisualStudioWorkloads.cs" Link="Commands\Workload\List\VisualStudioWorkloads.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\IEnumSetupInstances.cs" Link="VisualStudio\IEnumSetupInstances.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\InstanceState.cs" Link="VisualStudio\InstanceState.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupConfiguration.cs" Link="VisualStudio\ISetupConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupConfiguration2.cs" Link="VisualStudio\ISetupConfiguration2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupErrorInfo.cs" Link="VisualStudio\ISetupErrorInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupErrorState.cs" Link="VisualStudio\ISetupErrorState.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupFailedPackageReference.cs" Link="VisualStudio\ISetupFailedPackageReference.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupInstance.cs" Link="VisualStudio\ISetupInstance.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupInstance2.cs" Link="VisualStudio\ISetupInstance2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupPackageReference.cs" Link="VisualStudio\ISetupPackageReference.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Microsoft\VisualStudio\Setup\Configuration\ISetupPropertyStore.cs" Link="VisualStudio\ISetupPropertyStore.cs" />
+  </ItemGroup>
+
   <!-- 'dotnet sdk check' command: command-specific sources and helpers. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Sdk\SdkCommandParser.cs" Link="Commands\Sdk\SdkCommandParser.cs" />

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -78,6 +78,21 @@
   </ItemGroup>
 
   <!--
+    Select the System.Text.Json source-generated deserialization path in the NuGet client
+    libraries (NuGet.Packaging, NuGet.ProjectModel, NuGet.Configuration, etc.) instead of the
+    reflection-based Newtonsoft.Json path, which is not trim- or AOT-safe.
+
+    NuGet defines this as a [FeatureSwitchDefinition], so Trim="true" tells the trimmer/ILC the
+    value is a compile-time constant. That lets it dead-code-eliminate the Newtonsoft.Json branch
+    and avoid IL2026/IL2104/IL3050/IL3053 warnings when publishing this AOT binary.
+  -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
+                                    Value="true"
+                                    Trim="true" />
+  </ItemGroup>
+
+  <!--
     On Apple platforms, NativeAOT unconditionally statically links libSystem.Security.Cryptography.Native.Apple.a
     into every output, including NativeLib=Shared (dylib). This static archive contains Swift binding classes
     (HashBox, X25519KeyBox) that register with the ObjC runtime. When the host process also has these classes

--- a/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
+++ b/src/Cli/dotnet/Commands/Workload/List/VisualStudioWorkloads.cs
@@ -4,7 +4,9 @@
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using Microsoft.Deployment.DotNet.Releases;
+#if !CLI_AOT
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
+#endif
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using Microsoft.VisualStudio.Setup.Configuration;
@@ -254,6 +256,7 @@ internal static class VisualStudioWorkloads
     /// ...  but these workloads don't have their corresponding packs installed as VS doesn't update its workloads as the CLI does.
     /// </summary>
     /// <returns>Updated list of workloads including any that may have had new install records written</returns>
+#if !CLI_AOT
     internal static IEnumerable<WorkloadId> WriteSDKInstallRecordsForVSWorkloads(IInstaller workloadInstaller, IWorkloadResolver workloadResolver,
         IEnumerable<WorkloadId> workloadsWithExistingInstallRecords, IReporter reporter)
     {
@@ -282,4 +285,5 @@ internal static class VisualStudioWorkloads
 
         return workloadsWithExistingInstallRecords;
     }
+#endif
 }

--- a/src/Cli/dotnet/Commands/Workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadInfoHelper.cs
@@ -6,7 +6,9 @@ using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Commands.Workload.Install;
 using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
 using Microsoft.DotNet.Cli.Commands.Workload.List;
+#if !CLI_AOT
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+#endif
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
@@ -14,7 +16,14 @@ using Product = Microsoft.DotNet.Cli.Utils.Product;
 
 namespace Microsoft.DotNet.Cli.Commands.Workload;
 
+#if CLI_AOT
+// Under NativeAOT the workload installer (and its NuGet/MSI machinery) is not compiled in; this type
+// only provides the read-only info-reporting surface (workload version + installed workloads), so it
+// does not implement IWorkloadInfoHelper (which exposes the installer) in the AOT build.
+internal class WorkloadInfoHelper
+#else
 internal class WorkloadInfoHelper : IWorkloadInfoHelper
+#endif
 {
     public readonly SdkFeatureBand _currentSdkFeatureBand;
     private readonly string? _targetSdkVersion;
@@ -49,6 +58,14 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
             ManifestProvider, DotnetPath,
             currentSdkReleaseVersion.ToString(), userProfileDir);
 
+#if CLI_AOT
+        // The NativeAOT build does not compile in the workload installer (NuGet/MSI machinery). The info
+        // path only needs the installation-record repository, so build it directly here - mirroring the
+        // read-only construction in WorkloadInstallDetector.
+        WorkloadRecordRepo = workloadRecordRepo ?? CreateInstallationRecordRepository(DotnetPath, _currentSdkFeatureBand, userProfileDir);
+
+        UserLocalPath = dotnetDir ?? (IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
+#else
         var restoreConfig = new RestoreActionConfig(Interactive: isInteractive);
 
         // When verifyMsiSignature is not specified by the caller, we delegate to
@@ -68,9 +85,31 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
         WorkloadRecordRepo = workloadRecordRepo ?? Installer.GetWorkloadInstallationRecordRepository();
 
         UserLocalPath = dotnetDir ?? (WorkloadFileBasedInstall.IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
+#endif
     }
 
+#if CLI_AOT
+    // Build the installation-record repository without the workload installer (not compiled into the
+    // AOT build). Mirrors WorkloadInstallDetector: registry-backed for MSI installs on Windows,
+    // file-based otherwise.
+    private static IWorkloadInstallationRecordRepository CreateInstallationRecordRepository(string dotnetDir, SdkFeatureBand sdkFeatureBand, string userProfileDir)
+        => WorkloadInstallType.GetWorkloadInstallType(sdkFeatureBand, dotnetDir) switch
+        {
+            InstallType.Msi => new RegistryWorkloadInstallationRecordRepository(),
+            _ => new FileBasedInstallationRecordRepository(Path.Combine(
+                     IsUserLocal(dotnetDir, sdkFeatureBand.ToString()) ? userProfileDir : dotnetDir,
+                     "metadata", "workloads")),
+        };
+
+    // Inlined equivalent of WorkloadFileBasedInstall.IsUserLocal, avoiding that type's workload-history
+    // (System.Text.Json) helpers compiled under '#if DotnetCsproj'.
+    private static bool IsUserLocal(string dotnetDir, string sdkFeatureBand)
+        => File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand, "userlocal"));
+#endif
+
+#if !CLI_AOT
     public IInstaller Installer { get; private init; }
+#endif
     public SdkDirectoryWorkloadManifestProvider ManifestProvider { get; }
     public IWorkloadInstallationRecordRepository WorkloadRecordRepo { get; private init; }
     public IWorkloadResolver WorkloadResolver { get; private init; }
@@ -89,6 +128,7 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
         return installedWorkloads;
     }
 
+#if !CLI_AOT
     public void CheckTargetSdkVersionIsValid()
     {
         if (!string.IsNullOrWhiteSpace(_targetSdkVersion))
@@ -112,6 +152,7 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
                 installed.AsEnumerable().Select(t => new WorkloadId(t.Key)));
         }
     }
+#endif
 
     internal static string GetWorkloadsVersion(WorkloadInfoHelper? workloadInfoHelper = null)
     {

--- a/src/Cli/dotnet/ParserOptionActions.cs
+++ b/src/Cli/dotnet/ParserOptionActions.cs
@@ -6,8 +6,8 @@ using System.CommandLine.Invocation;
 using System.Runtime.InteropServices;
 #if !CLI_AOT
 using Microsoft.DotNet.Cli.CommandLine;
-using Microsoft.DotNet.Cli.Commands.Workload;
 #endif
+using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Help;
 using Microsoft.DotNet.Cli.Utils;
@@ -149,12 +149,8 @@ internal class PrintInfoAction(Option<bool> option) : InvocableOptionAction(opti
         Reporter.Output.WriteLine($"{LocalizableStrings.DotNetSdkInfoLabel}");
         Reporter.Output.WriteLine($" Version:           {Product.Version}");
         Reporter.Output.WriteLine($" Commit:            {commitSha}");
-#if !CLI_AOT
-        // Workload and MSBuild version reporting are not AOT-compatible yet (they pull in the
-        // workload manager and MSBuild forwarding machinery), so they are omitted from the AOT build.
         Reporter.Output.WriteLine($" Workload version:  {WorkloadInfoHelper.GetWorkloadsVersion()}");
         Reporter.Output.WriteLine($" MSBuild version:   {MSBuildForwardingAppWithoutLogging.MSBuildVersion}");
-#endif
         Reporter.Output.WriteLine();
         Reporter.Output.WriteLine($"{LocalizableStrings.DotNetRuntimeInfoLabel}");
         Reporter.Output.WriteLine($" OS Name:     {RuntimeEnvironment.OperatingSystem}");
@@ -167,11 +163,9 @@ internal class PrintInfoAction(Option<bool> option) : InvocableOptionAction(opti
         Reporter.Output.WriteLine($" RID:         {RuntimeInformation.RuntimeIdentifier}");
 #endif
         Reporter.Output.WriteLine($" Base Path:   {AppContext.BaseDirectory}");
-#if !CLI_AOT
         Reporter.Output.WriteLine();
         Reporter.Output.WriteLine($"{LocalizableStrings.DotnetWorkloadInfoLabel}");
         new WorkloadInfoHelper(isInteractive: false).ShowWorkloadsInfo(showVersion: false);
-#endif
 
         return 0;
     }

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -129,6 +129,8 @@ public class AotIntegrationTests
         Assert.AreEqual(0, exitCode);
         stdout.Should().Contain(".NET SDK:");
         stdout.Should().Contain("Version:");
+        stdout.Should().Contain("Workload version:");
+        stdout.Should().Contain("MSBuild version:");
         stdout.Should().Contain("Runtime Environment:");
     }
 

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -280,17 +280,22 @@ public class AotParserTests
         stdout.Should().Contain(".NET SDK:");
         stdout.Should().Contain("Version:");
         stdout.Should().Contain("Commit:");
+        stdout.Should().Contain("Workload version:");
+        stdout.Should().Contain("MSBuild version:");
         stdout.Should().Contain("Runtime Environment:");
     }
 
     [TestMethod]
-    public void InvokeInfo_DoesNotContainManagedOnlySections()
+    public void InvokeInfo_ReportsMSBuildAndWorkloadVersions()
     {
-        var (_, stdout, _) = InvokeWithCapture(["--info"]);
+        var (exitCode, stdout, _) = InvokeWithCapture(["--info"]);
 
-        // Under CLI_AOT, workload and MSBuild info are excluded
-        Assert.DoesNotContain("Workload version:", stdout);
-        Assert.DoesNotContain("MSBuild version:", stdout);
+        // Workload and MSBuild reporting used to be excluded from the AOT build; the AOT --info now
+        // matches the managed CLI. Assert the MSBuild line renders a real (non-empty) version so a
+        // future trim/substitution regression that blanks it out would be caught.
+        Assert.AreEqual(0, exitCode);
+        stdout.Should().MatchRegex(@"MSBuild version:\s+\S");
+        stdout.Should().Contain("Workload version:");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

The AOT `dotnet` CLI (`dotnet-aot`) previously omitted the **Workload version**, **MSBuild version**, and the **`.NET workloads installed`** section from `dotnet --info` (they were gated behind `#if !CLI_AOT`). This enables all of them so the AOT `--info` output matches the managed CLI **line-for-line**.

## Changes

- **MSBuild version** — reference `Microsoft.Build` in the AOT closure so ILC compiles `ProjectCollection.DisplayVersion`. This path is AOT-clean (zero trim/AOT warnings).
- **Workload version + section** — gate the eager workload installer (NuGet/MSI) out of `WorkloadInfoHelper` under `#if CLI_AOT` and build the installation-record repository directly, mirroring `WorkloadInstallDetector`. The full installer subsystem is therefore not compiled into the AOT binary; only the read-only reporting surface is.
- **Visual Studio workload detection (COM)** — compiled into the AOT build, consuming the AOT-safe COM interop helpers (`ComClassFactory`, `ComScope`, `BSTR`, `HRESULT`, `CLSID`) from `Microsoft.DotNet.Cli.Utils` via `InternalsVisibleTo`. Gated on `TARGET_WINDOWS`.
- **NuGet System.Text.Json** — select the STJ deserialization path in the AOT binary via the `NuGet.UseSystemTextJsonDeserialization` runtime host configuration option (`Trim="true"`) so the reflection-based `Newtonsoft.Json` branch is trimmed.
- **Tests** — updated the AOT `--info` tests to assert the now-included workload and MSBuild sections (including a non-empty value check on the MSBuild version line).

The shared files (`ParserOptionActions.cs`, `WorkloadInfoHelper.cs`, `VisualStudioWorkloads.cs`) use `#if CLI_AOT` so the managed CLI behavior is unchanged.

## Validation

- `dotnet-aot` NativeAOT publish (`win-x64`): **0 trim/AOT warnings**.
- AOT and managed `--info` output verified **identical line-for-line** (`Compare-Object`).
- `--info` tests pass **in-process** and as a **native AOT binary**; full `AotParserTests` (42) pass; the managed `dotnet.csproj` builds clean.

Sample output (identical for AOT and managed):

```
.NET SDK:
 Version:           11.0.100-dev
 Commit:            N/A
 Workload version:  11.0.100-manifests.e3b0c442
 MSBuild version:   18.9.0-preview-26311-113+50e862b8d

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.26200
 OS Platform: Windows
 RID:         win-x64
 Base Path:   ...

.NET workloads installed:
There are no installed workloads to display.
Configured to use workload sets when installing new manifests.
No workload sets are installed. Run "dotnet workload restore" to install a workload set.
```

## AOT size & startup impact

Measured with the [`aot-impact-analysis` skill](https://github.com/dotnet/sdk/pull/55085) (win-x64). Size is isolated to this PR: PR side is the merged squash commit `3279708b`, baseline is its parent `110f3d0c`.

### Size — native `dotnet-aot.dll`

| | Size |
| --- | --- |
| Base (`110f3d0c`) | 17.668 MB |
| This PR (`3279708b`) | 18.226 MB |
| **Delta** | **+571 KB (+3.15%)** |

Top real contributors all map to features this PR enables — nothing large maps to "nothing", so no sign of an unintended dependency in the AOT graph:

| Grown | Δ | Maps to |
| --- | ---: | --- |
| `System.Private.CoreLib` | +181.8 kB | reflection/formatting for workload + MSBuild reporting |
| `System.Linq` | +86.4 kB | enumeration in `WorkloadInfoHelper` / workload set reporting |
| `Microsoft.NET.Sdk.WorkloadManifestReader` | +67.2 kB | workload version + `.NET workloads installed` section |
| `System.Text.Json` | +40.9 kB | NuGet STJ deserialization path (trims Newtonsoft branch) |
| `Microsoft.Build.Framework` | +4.5 kB | MSBuild version line |
| `Microsoft.DotNet.Cli.Utils` | +1.4 kB | AOT-safe COM interop for VS workload detection |

### Startup — managed vs AOT (same SDK build)

`DOTNET_CLI_ENABLEAOT` off = managed `dotnet.dll` (bridged in-process), on = native `NativeEntryPoint`. 15 iterations / 3 warmup, median wall-clock:

| Command | managed | AOT | Delta |
| --- | ---: | ---: | --- |
| `dotnet --version` | 219.4 ms | **21.0 ms** | **-90.4% (~10x)** |
| `dotnet --info` | 371.5 ms | **73.2 ms** | **-80.3% (~5x)** |

The expanded `--info` from this PR is compiled natively into the AOT binary and still comes in ~5x faster than the managed equivalent. `cli.runtime=aot` + `telemetry-setup`/`parse`/`invocation` spans confirmed the AOT path was actually exercised (the info-gathering this PR added lives in the `invocation` span).

> ⚠️ Methodology note: perf runs must launch from **outside the repo tree**. The repo `global.json` `sdk.paths: [".dotnet", "$host$"]` makes the native muxer resolve the bootstrap `.dotnet` SDK (no `dotnet-aot.dll`) before the built redist, so from inside the repo the AOT path never fires and both legs run the same managed CLI. Setting `DOTNET_ROOT`/`PATH` alone does not override this.

_win-x64 only; osx-arm64 (also in CI) not measured here._