### PR TITLE
Add aot-impact-analysis skill for AOT size and startup analysis

### DIFF
--- a/.github/skills/aot-impact-analysis/SKILL.md
+++ b/.github/skills/aot-impact-analysis/SKILL.md
@@ -56,6 +56,10 @@ pwsh .github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
 pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1 -Arguments '--version'
 ```
 
+Each script ships in two equivalent forms — PowerShell (`*.ps1`) and bash
+(`*.sh`); use whichever fits your shell. The bash equivalents are
+`scripts/measure-aot-size.sh`, `scripts/start-aspire-dashboard.sh`, and
+`scripts/measure-aot-startup.sh` (e.g. `scripts/measure-aot-size.sh --rid linux-x64`).
 Each subskill page documents the parameters, mechanics, and how to read the
 output. The size script writes `artifacts/aot-size-<rid>.md`; the startup script
 writes `artifacts/aot-startup.md`.

--- a/.github/skills/aot-impact-analysis/SKILL.md
+++ b/.github/skills/aot-impact-analysis/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: aot-impact-analysis
+description: >-
+  Measure and report the binary-size and startup-performance impact of a NativeAOT enablement change
+  to the dotnet CLI. Use when a PR touches src/Cli/dotnet-aot, the AOT entrypoint, or shared CLI code
+  the AOT binary compiles, and you need before/after size deltas (sizoscope on dotnet-aot.mstat),
+  startup timings through the redist dotnet.exe muxer, OpenTelemetry capture in the Aspire Dashboard,
+  or a PR-ready impact summary — "what does this AOT change cost", "size diff for the AOT binary",
+  "did startup regress", "profile the AOT entrypoint".
+license: MIT
+metadata:
+  portability: repo-local
+---
+
+# AOT impact analysis (size + startup)
+
+Produces the two artifacts an AOT enablement PR needs: a **size impact** report
+(NativeAOT binary growth, sizoscope-attributed) and a **startup performance**
+report (managed vs AOT, with an OpenTelemetry span breakdown in the Aspire
+Dashboard). All scripts are PowerShell, self-locate the repo root, and use the
+repo-local SDK (`.dotnet/dotnet.exe`); run them from anywhere in the worktree.
+
+## When to measure what
+
+- **Size** is the common ask and is fully turnkey — run it for every AOT PR. See
+  [size-analysis.md](size-analysis.md).
+- **Startup** needs a full SDK layout (`build.cmd`/`build.sh`) so the redist
+  `dotnet.exe` muxer and the AOT binary exist. Run it when the change could move
+  startup — first-run work, new dependencies in the AOT graph, host/bridge
+  changes. See [startup-and-telemetry.md](startup-and-telemetry.md).
+- **Summarize** by combining the reports into the PR description. See
+  [writing-the-summary.md](writing-the-summary.md).
+
+## The rules that always apply
+
+1. **Diff against the fork point.** Baseline at `git merge-base HEAD origin/main`
+   so the delta is exactly this change's additive cost — not unrelated drift.
+2. **Release + full ILC.** Size is meaningless from a Debug or partial-trim build;
+   the scripts default to `-c Release`. This mirrors the `aot-size-analysis` CI
+   workflow.
+3. **Measure the RIDs CI measures** — **win-x64** and **osx-arm64**. Note which
+   you actually ran locally.
+4. **Median and P95, not mean,** for the startup headline; mean is skewed by
+   GC/JIT/disk-cache outliers.
+5. **Size and startup are independent** — report both; neither implies the other.
+
+## Run it
+
+```powershell
+# 1. Size (turnkey). Re-run with -Rid osx-arm64 on a Mac.
+pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1 -Rid win-x64
+
+# 2. Startup (needs a full build). Start the dashboard in its own terminal first,
+#    then measure managed-vs-AOT through the redist muxer.
+pwsh .github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
+pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1 -Arguments '--version'
+```
+
+Each subskill page documents the parameters, mechanics, and how to read the
+output. The size script writes `artifacts/aot-size-<rid>.md`; the startup script
+writes `artifacts/aot-startup.md`.
+
+## Reference
+
+- [references/perf-and-otel.md](references/perf-and-otel.md) — OTLP env vars the
+  CLI honors, Aspire Dashboard endpoints, the `aspire otel` command surface, and
+  AOT before/after gotchas.
+
+## Related skills
+
+The repo's `incremental-test` skill rebuilds and redeploys changed SDK projects
+into the redist layout — useful for refreshing the muxer before a startup run. A
+consuming repository wires any further cross-references in its overlay.

--- a/.github/skills/aot-impact-analysis/references/perf-and-otel.md
+++ b/.github/skills/aot-impact-analysis/references/perf-and-otel.md
@@ -1,0 +1,79 @@
+# Perf & OpenTelemetry reference
+
+How the .NET CLI emits OpenTelemetry, how to capture it with the Aspire Dashboard, and how to read
+the results for an AOT before/after.
+
+## How the CLI exports telemetry
+
+`src/Cli/dotnet/Telemetry/TelemetryClient.cs` registers an OpenTelemetry tracer + meter under the
+service name **`dotnet-cli`** (`ActivitySource` name `dotnet-cli`, defined in
+`src/Cli/Microsoft.DotNet.Cli.Utils/Activities.cs`). The OTLP exporter is wired up when **either**:
+
+- `DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER=1` (SDK-specific opt-in), **or**
+- any standard OTLP env var is set (`OTEL_EXPORTER_OTLP_ENDPOINT`, `..._PROTOCOL`, `..._HEADERS`, the
+  `_TRACES_`/`_METRICS_` variants, etc.) and `OTEL_SDK_DISABLED` is not set.
+
+When enabled the exporter is added with no inline config, so it honors the standard OTLP env vars
+(endpoint, protocol, headers, timeout). Source of truth: `EnvironmentVariableNames.OtlpExporterEnvVars`.
+
+Useful knobs:
+
+| Variable | Effect |
+| --- | --- |
+| `DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER=1` | Turn the OTLP exporter on. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` | Where to send OTLP (the dashboard's gRPC receiver). |
+| `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` | Use gRPC (port 4317) vs `http/protobuf` (port 4318). |
+| `OTEL_RESOURCE_ATTRIBUTES=scenario=aot` | Tag a run so before/after are distinguishable in the dashboard. |
+| `DOTNET_CLI_ENABLEAOT=true` | Make the redist muxer dispatch to the **NativeAOT** entrypoint. |
+| `DOTNET_CLI_TELEMETRY_OPTOUT=1` | Disable telemetry entirely (used during the clean timing phase). |
+
+The CLI also propagates trace context to child processes via the `TRACEPARENT`/`TRACESTATE` env vars,
+so spans from sub-invocations (e.g. an out-of-proc command) chain under the same trace.
+
+## Aspire Dashboard endpoints
+
+`Start-AspireDashboard.ps1` runs a standalone dashboard. Default endpoints:
+
+- UI: `http://localhost:18888`
+- OTLP/gRPC: `http://localhost:4317`  -> set `OTEL_EXPORTER_OTLP_ENDPOINT` to this
+- OTLP/HTTP: `http://localhost:4318`
+
+With the `aspire` CLI, the dashboard prints a login URL like `http://localhost:18888/login?t=<token>`.
+Pass that whole URL to `aspire otel --dashboard-url` and the token is exchanged for an API key.
+With the container fallback, anonymous access is enabled so no token is needed.
+
+## Querying telemetry from the terminal (`aspire otel`)
+
+`aspire otel` reads from the dashboard's telemetry API. Subcommands: `traces`, `spans`, `logs`.
+
+```
+# Trace summaries for the AOT run
+aspire otel traces --dashboard-url http://localhost:18888 --format Table --search scenario:aot
+
+# Full span tree for one trace, as JSON (for scripting / parsing durations)
+aspire otel traces --dashboard-url http://localhost:18888 --format Json --trace-id <id>
+```
+
+`--search` supports free text and `field:value` qualifiers (`resource:`, `name:`, `trace-id:`,
+`status:`, `duration:>N`) and `@attr:value` for custom attributes such as the `scenario` tag.
+Metrics are best viewed in the dashboard UI (charts/histograms); traces+spans are the CLI's strength.
+
+## Reading an AOT before/after
+
+- **Wall-clock (primary).** `Measure-AotStartup.ps1` reports min/median/mean/p95 with the exporter
+  **off**. Prefer **median** and **P95** over mean for startup (mean is skewed by occasional GC/JIT
+  or disk-cache outliers). The AOT path should show lower startup, especially first-run.
+- **Span breakdown (secondary).** Compare the `dotnet-cli` root span and notable child spans between
+  the `scenario=managed` and `scenario=aot` traces to attribute *where* the time went (runtime
+  startup vs. parse vs. first-run work). Export-on runs add small flush overhead, so don't use them
+  for the headline numbers - only for the breakdown.
+- Run on a warm OS file cache (the script's warmup handles JIT/cache priming) and on a quiet machine.
+
+## Gotchas
+
+- Both managed and AOT runs report service name `dotnet-cli`; rely on the `scenario`/`build`
+  resource attribute (not the service name) to tell them apart.
+- The redist muxer must be fully laid out (`build.cmd`/`build.sh`) for `DOTNET_CLI_ENABLEAOT` to find
+  the AOT binary. A partial `dotnet-aot` publish alone is **not** runnable through the muxer.
+- Size and startup are independent: a size regression doesn't imply a startup regression (e.g. extra
+  cold code paths that never run at startup), and vice-versa. Report both.

--- a/.github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1
+++ b/.github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1
@@ -1,0 +1,184 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Measures the NativeAOT binary-size impact of the current branch versus a baseline ref by
+    publishing dotnet-aot on both sides and diffing the .mstat files with sizoscope-cli.
+
+.DESCRIPTION
+    Replicates the methodology of .github/workflows/aot-size-analysis.yml locally:
+      1. Publishes src/Cli/dotnet-aot (Release, full ILC) for the current worktree (the "PR" side).
+      2. Adds a detached git worktree at the baseline ref and publishes the same project there.
+      3. Runs sizoscope-cli on the two dotnet-aot.mstat files to produce a per-symbol diff.
+      4. Emits a Markdown summary (raw native dll delta + sizoscope "Total accounted size difference"
+         + the full diff) ready to paste into a PR description.
+
+    The script is idempotent and cleans up the temporary baseline worktree on exit.
+
+.PARAMETER Rid
+    Runtime identifier to publish (default: win-x64). CI publishes win-x64 and osx-arm64.
+
+.PARAMETER Configuration
+    Build configuration (default: Release - matches CI's buildConfiguration).
+
+.PARAMETER BaseRef
+    Git ref/commit to use as the baseline. Defaults to `git merge-base HEAD origin/main`
+    (the PR fork point), which yields a diff of exactly this branch's additive cost.
+
+.PARAMETER OutputPath
+    Where to write the Markdown summary (default: <repo>/artifacts/aot-size-<rid>.md).
+
+.PARAMETER SkipBaseline
+    Reuse an existing baseline publish (skips the worktree add + baseline publish) if the
+    baseline mstat is already present. Useful for re-running the diff after editing the report.
+
+.EXAMPLE
+    pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1 -Rid win-x64
+#>
+[CmdletBinding()]
+param(
+    [string]$Rid = 'win-x64',
+    [string]$Configuration = 'Release',
+    [string]$BaseRef,
+    [string]$OutputPath,
+    [switch]$SkipBaseline
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Find-RepoRoot {
+    $dir = $PSScriptRoot
+    while ($dir -and -not (Test-Path (Join-Path $dir '.git'))) {
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    if (-not $dir -or -not (Test-Path (Join-Path $dir '.git'))) {
+        throw "Could not locate the repository root from $PSScriptRoot."
+    }
+    return (Resolve-Path $dir).Path
+}
+
+function Get-DotnetExe([string]$repoRoot) {
+    $name = if ($IsWindows) { 'dotnet.exe' } else { 'dotnet' }
+    $exe = Join-Path $repoRoot (Join-Path '.dotnet' $name)
+    if (-not (Test-Path $exe)) {
+        throw "Repo-local SDK not found at $exe. Run ./restore.cmd (or ./restore.sh) first."
+    }
+    return $exe
+}
+
+function Resolve-SizoscopeCli([string]$dotnet) {
+    $toolsDir = Join-Path $HOME (Join-Path '.dotnet' 'tools')
+    if ($env:PATH -notlike "*$toolsDir*") { $env:PATH = "$toolsDir$([IO.Path]::PathSeparator)$env:PATH" }
+    if (Get-Command sizoscope-cli -ErrorAction SilentlyContinue) { return }
+    Write-Host '==> Installing sizoscope-cli (global tool)...' -ForegroundColor Cyan
+    & $dotnet tool install --global sizoscope-cli | Out-Host
+    if (-not (Get-Command sizoscope-cli -ErrorAction SilentlyContinue)) {
+        throw 'sizoscope-cli is not on PATH after install. Open a new shell or check ~/.dotnet/tools.'
+    }
+}
+
+function Publish-DotnetAot([string]$dotnet, [string]$projectRoot, [string]$rid, [string]$config, [string]$label) {
+    $proj = Join-Path $projectRoot 'src/Cli/dotnet-aot/dotnet-aot.csproj'
+    Write-Host "==> Publishing dotnet-aot ($label): $config / $rid" -ForegroundColor Cyan
+    $binlog = Join-Path $projectRoot "aot-size-$label.binlog"
+    & $dotnet publish $proj -c $config -r $rid "/bl:$binlog" | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Publish failed for $label (exit $LASTEXITCODE). Inspect $binlog with the binlog tools." }
+    Remove-Item $binlog -ErrorAction SilentlyContinue
+}
+
+function Find-Native([string]$root, [string]$config, [string]$leaf) {
+    if ($leaf -eq 'dotnet-aot.dll') {
+        $base = Join-Path $root "artifacts/bin/dotnet-aot/$config"
+    } else {
+        $base = Join-Path $root "artifacts/obj/dotnet-aot/$config"
+    }
+    $hit = Get-ChildItem -Path $base -Recurse -Filter $leaf -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match 'native' } | Select-Object -First 1
+    if (-not $hit) { throw "Could not find native/$leaf under $base." }
+    return $hit.FullName
+}
+
+$repoRoot = Find-RepoRoot
+$dotnet = Get-DotnetExe $repoRoot
+if (-not $BaseRef) {
+    $BaseRef = (& git -C $repoRoot merge-base HEAD origin/main).Trim()
+}
+$baseShort = $BaseRef.Substring(0, [Math]::Min(8, $BaseRef.Length))
+if (-not $OutputPath) { $OutputPath = Join-Path $repoRoot "artifacts/aot-size-$Rid.md" }
+$baseWorktree = Join-Path (Split-Path $repoRoot -Parent) "_aot-size-base-$Rid"
+
+Write-Host "Repo:      $repoRoot"
+Write-Host "Base ref:  $BaseRef ($baseShort)"
+Write-Host "RID:       $Rid    Config: $Configuration"
+
+Resolve-SizoscopeCli $dotnet
+
+# --- PR side (current worktree) ---
+Publish-DotnetAot $dotnet $repoRoot $Rid $Configuration 'pr'
+$prMstat = Find-Native $repoRoot $Configuration 'dotnet-aot.mstat'
+$prDll = Find-Native $repoRoot $Configuration 'dotnet-aot.dll'
+
+# --- Baseline side (temporary detached worktree) ---
+$createdWorktree = $false
+try {
+    if (-not ($SkipBaseline -and (Test-Path $baseWorktree))) {
+        if (Test-Path $baseWorktree) {
+            & git -C $repoRoot worktree remove --force $baseWorktree 2>$null
+        }
+        Write-Host "==> Adding baseline worktree at $baseShort" -ForegroundColor Cyan
+        & git -C $repoRoot worktree add --detach $baseWorktree $BaseRef | Out-Host
+        $createdWorktree = $true
+        Publish-DotnetAot $dotnet $baseWorktree $Rid $Configuration 'base'
+    }
+    $baseMstat = Find-Native $baseWorktree $Configuration 'dotnet-aot.mstat'
+    $baseDll = Find-Native $baseWorktree $Configuration 'dotnet-aot.dll'
+
+    # --- Diff ---
+    $diffFile = Join-Path $repoRoot "artifacts/aot-size-$Rid.sizoscope.txt"
+    Write-Host '==> Running sizoscope-cli diff...' -ForegroundColor Cyan
+    & sizoscope-cli "$baseMstat" "$prMstat" --output $diffFile | Out-Host
+    if (-not (Test-Path $diffFile)) { throw 'sizoscope-cli did not produce an output file.' }
+
+    $diffLines = Get-Content $diffFile
+    $totalLine = ($diffLines | Select-Object -First 1)
+    $baseLen = (Get-Item $baseDll).Length
+    $prLen = (Get-Item $prDll).Length
+    $delta = $prLen - $baseLen
+    $pct = if ($baseLen) { $delta / $baseLen * 100 } else { 0 }
+    $accounted = ($totalLine -replace '^Total accounted size difference:\s*', '')
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine("## AOT size impact ($Rid)")
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine("Published ``dotnet-aot`` ($Configuration, ``$Rid``, full ILC) on this branch vs. base (``$baseShort``); ``.mstat`` files diffed with ``sizoscope-cli``.")
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine('| Native `dotnet-aot.dll` | Size |')
+    [void]$sb.AppendLine('| --- | --- |')
+    [void]$sb.AppendLine(("| Base (``{0}``) | {1:N3} MB ({2:N0} B) |" -f $baseShort, ($baseLen / 1MB), $baseLen))
+    [void]$sb.AppendLine(("| This branch | {0:N3} MB ({1:N0} B) |" -f ($prLen / 1MB), $prLen))
+    [void]$sb.AppendLine(("| **Delta** | **{0:+0;-0} KB ({1:+0.00;-0.00}%)** |" -f ($delta / 1KB), $pct))
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine("``sizoscope-cli`` accounted difference: **$accounted**")
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine('<details><summary>sizoscope-cli diff</summary>')
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine('```')
+    foreach ($l in $diffLines) { [void]$sb.AppendLine($l) }
+    [void]$sb.AppendLine('```')
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine('</details>')
+
+    Set-Content -Path $OutputPath -Value $sb.ToString() -Encoding utf8
+    Write-Host ''
+    Write-Host "Summary written to: $OutputPath" -ForegroundColor Green
+    Write-Host ("Raw native dll delta: {0:+0;-0} KB ({1:+0.00;-0.00}%)" -f ($delta / 1KB), $pct) -ForegroundColor Green
+    Write-Host "Accounted: $totalLine" -ForegroundColor Green
+}
+finally {
+    if ($createdWorktree -and -not $SkipBaseline) {
+        Write-Host '==> Removing baseline worktree...' -ForegroundColor Cyan
+        & git -C $repoRoot worktree remove --force $baseWorktree 2>$null
+    }
+}

--- a/.github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1
+++ b/.github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1
@@ -1,0 +1,216 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Measures .NET CLI startup performance for two scenarios using the redist SDK's `dotnet.exe`
+    muxer, and (optionally) exports OpenTelemetry spans to a running Aspire Dashboard for a
+    span-level breakdown.
+
+.DESCRIPTION
+    The redist muxer dispatches to the NativeAOT entrypoint when DOTNET_CLI_ENABLEAOT=true and to
+    the managed CLI otherwise, so the default before/after compares the *same* built SDK with the
+    AOT path off vs. on. (Pass -BaselineDotnet to instead compare two different builds with
+    identical env.)
+
+    Two phases per scenario:
+      1. Timing phase - runs `dotnet <Arguments>` Iterations times with the OTLP exporter OFF and
+         records wall-clock via Stopwatch (clean numbers, no export/flush overhead). Reports
+         min / median / mean / p95.
+      2. Telemetry phase (when -OtlpEndpoint is reachable) - a few runs with the OTLP exporter ON,
+         tagged OTEL_RESOURCE_ATTRIBUTES="scenario=<label>", so the Aspire Dashboard captures the
+         CLI's `dotnet-cli` spans for drill-down. Pull them with:
+             aspire otel traces --dashboard-url <url> --format Json --search scenario:<label>
+
+    Writes a Markdown summary suitable for a PR description.
+
+.PARAMETER DotnetPath
+    Path to the redist muxer (default: <repo>/artifacts/bin/redist/<Configuration>/dotnet/dotnet.exe).
+    Requires a full build.cmd/.sh so the muxer + AOT binary are laid out.
+
+.PARAMETER BaselineDotnet
+    Optional second muxer for build-vs-build comparison. When set, both scenarios use identical
+    env and the only difference is the executable (labels: base / pr).
+
+.PARAMETER Arguments
+    The CLI invocation to benchmark (default: '--version'). Use a low-cost, deterministic command.
+
+.PARAMETER Iterations
+    Timed iterations per scenario (default: 30).
+
+.PARAMETER Warmup
+    Untimed warmup iterations per scenario (default: 5).
+
+.PARAMETER OtlpEndpoint
+    OTLP/gRPC endpoint of a running Aspire Dashboard (default: http://localhost:4317). Pass ''
+    to skip the telemetry phase entirely.
+
+.PARAMETER DashboardUrl
+    Dashboard UI URL recorded in the report for the `aspire otel` follow-up (default http://localhost:18888).
+
+.PARAMETER OutputPath
+    Markdown summary path (default: <repo>/artifacts/aot-startup.md).
+#>
+[CmdletBinding()]
+param(
+    [string]$DotnetPath,
+    [string]$BaselineDotnet,
+    [string]$Arguments = '--version',
+    [int]$Iterations = 30,
+    [int]$Warmup = 5,
+    [string]$Configuration = 'Release',
+    [string]$OtlpEndpoint = 'http://localhost:4317',
+    [string]$DashboardUrl = 'http://localhost:18888',
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Find-RepoRoot {
+    $dir = $PSScriptRoot
+    while ($dir -and -not (Test-Path (Join-Path $dir '.git'))) {
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    if (-not $dir) { throw "Could not locate the repository root from $PSScriptRoot." }
+    return (Resolve-Path $dir).Path
+}
+
+function Resolve-Muxer([string]$repoRoot, [string]$config, [string]$explicit) {
+    if ($explicit) {
+        if (-not (Test-Path $explicit)) { throw "dotnet muxer not found at $explicit." }
+        return (Resolve-Path $explicit).Path
+    }
+    $name = if ($IsWindows) { 'dotnet.exe' } else { 'dotnet' }
+    $candidate = Join-Path $repoRoot "artifacts/bin/redist/$config/dotnet/$name"
+    if (-not (Test-Path $candidate)) {
+        throw "Redist muxer not found at $candidate. Build the full SDK layout first (build.cmd /.sh), or pass -DotnetPath."
+    }
+    return (Resolve-Path $candidate).Path
+}
+
+# Percentile over a sorted double[] using linear interpolation.
+function Get-Percentile([double[]]$sorted, [double]$p) {
+    if ($sorted.Count -eq 1) { return $sorted[0] }
+    $rank = ($p / 100.0) * ($sorted.Count - 1)
+    $lo = [Math]::Floor($rank); $hi = [Math]::Ceiling($rank)
+    if ($lo -eq $hi) { return $sorted[[int]$lo] }
+    return $sorted[[int]$lo] + ($rank - $lo) * ($sorted[[int]$hi] - $sorted[[int]$lo])
+}
+
+function Invoke-Timed([string]$exe, [string]$argline, [hashtable]$env, [int]$count, [int]$warmup) {
+    $applied = @{}
+    foreach ($k in $env.Keys) { $applied[$k] = [Environment]::GetEnvironmentVariable($k); [Environment]::SetEnvironmentVariable($k, $env[$k]) }
+    try {
+        $argv = $argline.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+        for ($i = 0; $i -lt $warmup; $i++) { & $exe @argv *> $null }
+        $times = New-Object System.Collections.Generic.List[double]
+        for ($i = 0; $i -lt $count; $i++) {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            & $exe @argv *> $null
+            $sw.Stop()
+            $times.Add($sw.Elapsed.TotalMilliseconds)
+        }
+        return $times.ToArray()
+    }
+    finally {
+        foreach ($k in $applied.Keys) { [Environment]::SetEnvironmentVariable($k, $applied[$k]) }
+    }
+}
+
+$repoRoot = Find-RepoRoot
+if (-not $OutputPath) { $OutputPath = Join-Path $repoRoot 'artifacts/aot-startup.md' }
+$primary = Resolve-Muxer $repoRoot $Configuration $DotnetPath
+
+# Define scenarios.
+$scenarios = @()
+if ($BaselineDotnet) {
+    $baseMux = Resolve-Muxer $repoRoot $Configuration $BaselineDotnet
+    $scenarios += [pscustomobject]@{ Label = 'base'; Exe = $baseMux; Env = @{ DOTNET_CLI_ENABLEAOT = 'true' } }
+    $scenarios += [pscustomobject]@{ Label = 'pr'; Exe = $primary; Env = @{ DOTNET_CLI_ENABLEAOT = 'true' } }
+    $mode = 'build-vs-build (AOT path on both)'
+} else {
+    $scenarios += [pscustomobject]@{ Label = 'managed'; Exe = $primary; Env = @{ DOTNET_CLI_ENABLEAOT = 'false' } }
+    $scenarios += [pscustomobject]@{ Label = 'aot'; Exe = $primary; Env = @{ DOTNET_CLI_ENABLEAOT = 'true' } }
+    $mode = 'managed vs AOT (same SDK)'
+}
+
+Write-Host "Muxer:      $primary"
+Write-Host "Command:    dotnet $Arguments"
+Write-Host "Mode:       $mode"
+Write-Host "Iterations: $Iterations (warmup $Warmup)"
+Write-Host ''
+
+$results = @()
+foreach ($s in $scenarios) {
+    Write-Host "==> Timing scenario '$($s.Label)'..." -ForegroundColor Cyan
+    $env = @{ DOTNET_CLI_TELEMETRY_OPTOUT = '1' } + $s.Env  # disable export during timing
+    $samples = Invoke-Timed $s.Exe $Arguments $env $Iterations $Warmup
+    $sorted = ($samples | Sort-Object)
+    $results += [pscustomobject]@{
+        Label  = $s.Label
+        Min    = ($sorted | Select-Object -First 1)
+        Median = (Get-Percentile $sorted 50)
+        Mean   = ($samples | Measure-Object -Average).Average
+        P95    = (Get-Percentile $sorted 95)
+    }
+}
+
+# Telemetry phase: a handful of exporter-on runs to populate the dashboard.
+$telemetryNote = ''
+if ($OtlpEndpoint) {
+    $reachable = $false
+    try {
+        $uri = [Uri]$OtlpEndpoint
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $tcp.Connect($uri.Host, $uri.Port); $reachable = $tcp.Connected; $tcp.Close()
+    } catch { $reachable = $false }
+
+    if ($reachable) {
+        foreach ($s in $scenarios) {
+            Write-Host "==> Exporting spans for scenario '$($s.Label)' to $OtlpEndpoint..." -ForegroundColor Cyan
+            $env = @{
+                DOTNET_CLI_TELEMETRY_OPTOUT       = '0'
+                DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER = '1'
+                OTEL_EXPORTER_OTLP_ENDPOINT       = $OtlpEndpoint
+                OTEL_EXPORTER_OTLP_PROTOCOL       = 'grpc'
+                OTEL_RESOURCE_ATTRIBUTES          = "scenario=$($s.Label)"
+            } + $s.Env
+            Invoke-Timed $s.Exe $Arguments $env 5 1 | Out-Null
+        }
+        $telemetryNote = "Spans exported to the Aspire Dashboard, tagged ``scenario=<label>``. Inspect with:`n`n" +
+            "```````n" +
+            "aspire otel traces --dashboard-url $DashboardUrl --format Table --search scenario:aot`n" +
+            "aspire otel traces --dashboard-url $DashboardUrl --format Json  --search scenario:aot -n 5`n" +
+            "```````n"
+    } else {
+        $telemetryNote = "_Telemetry phase skipped: no Aspire Dashboard reachable at ``$OtlpEndpoint``. Start one with Start-AspireDashboard.ps1._"
+    }
+}
+
+# Build report.
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine('## AOT startup performance')
+[void]$sb.AppendLine('')
+[void]$sb.AppendLine("Command: ``dotnet $Arguments`` &nbsp;|&nbsp; $Iterations iterations ($Warmup warmup) &nbsp;|&nbsp; $mode.")
+[void]$sb.AppendLine('Wall-clock measured with the OTLP exporter off (clean numbers); all times in ms.')
+[void]$sb.AppendLine('')
+[void]$sb.AppendLine('| Scenario | Min | Median | Mean | P95 |')
+[void]$sb.AppendLine('| --- | ---: | ---: | ---: | ---: |')
+foreach ($r in $results) {
+    [void]$sb.AppendLine(("| {0} | {1:N1} | {2:N1} | {3:N1} | {4:N1} |" -f $r.Label, $r.Min, $r.Median, $r.Mean, $r.P95))
+}
+if ($results.Count -eq 2) {
+    $a = $results[0]; $b = $results[1]
+    $deltaMed = $b.Median - $a.Median
+    $pct = if ($a.Median) { $deltaMed / $a.Median * 100 } else { 0 }
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine(("**Median delta ({0} -> {1}): {2:+0.0;-0.0} ms ({3:+0.0;-0.0}%).**" -f $a.Label, $b.Label, $deltaMed, $pct))
+}
+[void]$sb.AppendLine('')
+if ($telemetryNote) { [void]$sb.AppendLine($telemetryNote) }
+
+Set-Content -Path $OutputPath -Value $sb.ToString() -Encoding utf8
+Write-Host ''
+Write-Host "Summary written to: $OutputPath" -ForegroundColor Green
+$results | Format-Table -AutoSize | Out-Host

--- a/.github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
+++ b/.github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
@@ -1,0 +1,67 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Starts a standalone Aspire Dashboard to receive OpenTelemetry (OTLP) data from the .NET CLI,
+    and prints the OTLP endpoint + UI login URL that Measure-AotStartup.ps1 / `aspire otel` consume.
+
+.DESCRIPTION
+    Prefers the `aspire` CLI (`aspire dashboard run`) when present; otherwise falls back to the
+    official container image (`mcr.microsoft.com/dotnet/aspire-dashboard`). Either way the dashboard
+    exposes:
+      * UI            http://localhost:18888
+      * OTLP/gRPC     http://localhost:4317   (point the CLI's OTEL_EXPORTER_OTLP_ENDPOINT here)
+      * OTLP/HTTP     http://localhost:4318
+
+    The .NET CLI starts exporting traces+metrics over OTLP when DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER=1
+    (or any standard OTEL_EXPORTER_OTLP_* var) is set - see references/perf-and-otel.md.
+
+.PARAMETER UseDocker
+    Force the container fallback even if the `aspire` CLI is installed.
+
+.PARAMETER OtlpGrpcPort
+    Host port to map to the dashboard's OTLP/gRPC receiver (default: 4317).
+
+.PARAMETER UiPort
+    Host port for the dashboard UI (default: 18888).
+
+.NOTES
+    Run this in its own terminal (it blocks) or as a background/detached process. With the `aspire`
+    CLI, copy the printed `http://localhost:18888/login?t=<token>` URL: pass it to `aspire otel`
+    via --dashboard-url and the browser token is exchanged for an API key automatically.
+#>
+[CmdletBinding()]
+param(
+    [switch]$UseDocker,
+    [int]$OtlpGrpcPort = 4317,
+    [int]$UiPort = 18888
+)
+
+$ErrorActionPreference = 'Stop'
+
+$aspire = Get-Command aspire -ErrorAction SilentlyContinue
+if ($aspire -and -not $UseDocker) {
+    Write-Host '==> Starting Aspire Dashboard via the aspire CLI...' -ForegroundColor Cyan
+    Write-Host "    UI:        http://localhost:$UiPort"
+    Write-Host "    OTLP/gRPC: http://localhost:$OtlpGrpcPort"
+    Write-Host '    Copy the printed login URL (with ?t=<token>) for `aspire otel --dashboard-url`.' -ForegroundColor Yellow
+    Write-Host ''
+    & aspire dashboard run --frontend-url "http://localhost:$UiPort"
+    return
+}
+
+$docker = Get-Command docker -ErrorAction SilentlyContinue
+if (-not $docker) {
+    throw 'Neither the `aspire` CLI nor `docker` is available. Install the Aspire CLI (`dotnet tool install -g aspire.cli` / winget) or Docker Desktop.'
+}
+
+Write-Host '==> Starting Aspire Dashboard via container image...' -ForegroundColor Cyan
+Write-Host "    UI:        http://localhost:$UiPort"
+Write-Host "    OTLP/gRPC: http://localhost:$OtlpGrpcPort"
+Write-Host '    Anonymous access is enabled for local dev (no token required).' -ForegroundColor Yellow
+Write-Host ''
+& docker run --rm -it `
+    -p "${UiPort}:18888" `
+    -p "${OtlpGrpcPort}:18889" `
+    -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true `
+    --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest

--- a/.github/skills/aot-impact-analysis/scripts/measure-aot-size.sh
+++ b/.github/skills/aot-impact-analysis/scripts/measure-aot-size.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Measures the NativeAOT binary-size impact of the current branch versus a baseline ref by
+# publishing dotnet-aot on both sides and diffing the .mstat files with sizoscope-cli.
+#
+# Replicates .github/workflows/aot-size-analysis.yml locally:
+#   1. Publishes src/Cli/dotnet-aot (Release, full ILC) for the current worktree (the "PR" side).
+#   2. Adds a detached git worktree at the baseline ref and publishes the same project there.
+#   3. Runs sizoscope-cli on the two dotnet-aot.mstat files to produce a per-symbol diff.
+#   4. Emits a Markdown summary (raw native dll delta + sizoscope accounted difference + the full
+#      diff) ready to paste into a PR description.
+#
+# The PowerShell sibling Measure-AotSize.ps1 is the canonical implementation; this is the bash
+# port for Linux/macOS shells.
+#
+# Usage:
+#   scripts/measure-aot-size.sh [--rid <rid>] [--configuration <cfg>] [--base-ref <ref>]
+#                               [--output-path <file>] [--skip-baseline]
+set -euo pipefail
+
+rid="win-x64"
+configuration="Release"
+base_ref=""
+output_path=""
+skip_baseline=0
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rid) rid="$2"; shift 2;;
+    --configuration|-c) configuration="$2"; shift 2;;
+    --base-ref) base_ref="$2"; shift 2;;
+    --output-path|-o) output_path="$2"; shift 2;;
+    --skip-baseline) skip_baseline=1; shift;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+find_repo_root() {
+  local dir="$1"
+  while [[ -n "$dir" && ! -e "$dir/.git" ]]; do
+    local parent; parent="$(dirname "$dir")"
+    [[ "$parent" == "$dir" ]] && break
+    dir="$parent"
+  done
+  if [[ ! -e "$dir/.git" ]]; then
+    echo "Could not locate the repository root from $1." >&2; exit 1
+  fi
+  ( cd "$dir" && pwd )
+}
+
+file_size() {
+  if stat -c %s "$1" >/dev/null 2>&1; then stat -c %s "$1"; else stat -f %z "$1"; fi
+}
+
+repo_root="$(find_repo_root "$script_dir")"
+
+dotnet_name="dotnet"
+[[ "${OS:-}" == "Windows_NT" ]] && dotnet_name="dotnet.exe"
+dotnet="$repo_root/.dotnet/$dotnet_name"
+if [[ ! -f "$dotnet" ]]; then
+  echo "Repo-local SDK not found at $dotnet. Run ./restore.sh (or ./restore.cmd) first." >&2
+  exit 1
+fi
+
+if [[ -z "$base_ref" ]]; then
+  base_ref="$(git -C "$repo_root" merge-base HEAD origin/main)"
+fi
+base_short="${base_ref:0:8}"
+[[ -z "$output_path" ]] && output_path="$repo_root/artifacts/aot-size-$rid.md"
+base_worktree="$(dirname "$repo_root")/_aot-size-base-$rid"
+
+echo "Repo:      $repo_root"
+echo "Base ref:  $base_ref ($base_short)"
+echo "RID:       $rid    Config: $configuration"
+
+resolve_sizoscope() {
+  local tools_dir="$HOME/.dotnet/tools"
+  case ":$PATH:" in
+    *":$tools_dir:"*) ;;
+    *) export PATH="$tools_dir:$PATH";;
+  esac
+  if command -v sizoscope-cli >/dev/null 2>&1; then return; fi
+  echo "==> Installing sizoscope-cli (global tool)..."
+  "$dotnet" tool install --global sizoscope-cli
+  if ! command -v sizoscope-cli >/dev/null 2>&1; then
+    echo "sizoscope-cli is not on PATH after install. Open a new shell or check ~/.dotnet/tools." >&2
+    exit 1
+  fi
+}
+
+publish_dotnet_aot() {
+  local project_root="$1" label="$2"
+  local proj="$project_root/src/Cli/dotnet-aot/dotnet-aot.csproj"
+  echo "==> Publishing dotnet-aot ($label): $configuration / $rid"
+  local binlog="$project_root/aot-size-$label.binlog"
+  "$dotnet" publish "$proj" -c "$configuration" -r "$rid" "/bl:$binlog"
+  rm -f "$binlog"
+}
+
+find_native() {
+  local root="$1" leaf="$2" base
+  if [[ "$leaf" == "dotnet-aot.dll" ]]; then
+    base="$root/artifacts/bin/dotnet-aot/$configuration"
+  else
+    base="$root/artifacts/obj/dotnet-aot/$configuration"
+  fi
+  local hit
+  hit="$(find "$base" -type f -name "$leaf" -path '*native*' 2>/dev/null | head -n 1)"
+  if [[ -z "$hit" ]]; then
+    echo "Could not find native/$leaf under $base." >&2; exit 1
+  fi
+  printf '%s\n' "$hit"
+}
+
+resolve_sizoscope
+
+# --- PR side (current worktree) ---
+publish_dotnet_aot "$repo_root" "pr"
+pr_mstat="$(find_native "$repo_root" "dotnet-aot.mstat")"
+pr_dll="$(find_native "$repo_root" "dotnet-aot.dll")"
+
+# --- Baseline side (temporary detached worktree) ---
+created_worktree=0
+cleanup() {
+  if [[ "$created_worktree" -eq 1 && "$skip_baseline" -eq 0 ]]; then
+    echo "==> Removing baseline worktree..."
+    git -C "$repo_root" worktree remove --force "$base_worktree" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if ! { [[ "$skip_baseline" -eq 1 ]] && [[ -d "$base_worktree" ]]; }; then
+  if [[ -d "$base_worktree" ]]; then
+    git -C "$repo_root" worktree remove --force "$base_worktree" 2>/dev/null || true
+  fi
+  echo "==> Adding baseline worktree at $base_short"
+  git -C "$repo_root" worktree add --detach "$base_worktree" "$base_ref"
+  created_worktree=1
+  publish_dotnet_aot "$base_worktree" "base"
+fi
+base_mstat="$(find_native "$base_worktree" "dotnet-aot.mstat")"
+base_dll="$(find_native "$base_worktree" "dotnet-aot.dll")"
+
+# --- Diff ---
+mkdir -p "$repo_root/artifacts"
+diff_file="$repo_root/artifacts/aot-size-$rid.sizoscope.txt"
+echo "==> Running sizoscope-cli diff..."
+sizoscope-cli "$base_mstat" "$pr_mstat" --output "$diff_file"
+[[ -f "$diff_file" ]] || { echo "sizoscope-cli did not produce an output file." >&2; exit 1; }
+
+total_line="$(head -n 1 "$diff_file")"
+base_len="$(file_size "$base_dll")"
+pr_len="$(file_size "$pr_dll")"
+delta=$(( pr_len - base_len ))
+accounted="${total_line#Total accounted size difference: }"
+
+base_mb="$(awk "BEGIN{printf \"%.3f\", $base_len/1048576}")"
+pr_mb="$(awk "BEGIN{printf \"%.3f\", $pr_len/1048576}")"
+delta_kb="$(awk "BEGIN{printf \"%+.0f\", $delta/1024}")"
+pct="$(awk "BEGIN{ if ($base_len>0) printf \"%+.2f\", $delta/$base_len*100; else printf \"%+.2f\", 0}")"
+
+{
+  echo "## AOT size impact ($rid)"
+  echo ""
+  echo "Published \`dotnet-aot\` ($configuration, \`$rid\`, full ILC) on this branch vs. base (\`$base_short\`); \`.mstat\` files diffed with \`sizoscope-cli\`."
+  echo ""
+  echo "| Native \`dotnet-aot.dll\` | Size |"
+  echo "| --- | --- |"
+  echo "| Base (\`$base_short\`) | ${base_mb} MB (${base_len} B) |"
+  echo "| This branch | ${pr_mb} MB (${pr_len} B) |"
+  echo "| **Delta** | **${delta_kb} KB (${pct}%)** |"
+  echo ""
+  echo "\`sizoscope-cli\` accounted difference: **${accounted}**"
+  echo ""
+  echo "<details><summary>sizoscope-cli diff</summary>"
+  echo ""
+  echo '```'
+  cat "$diff_file"
+  echo '```'
+  echo ""
+  echo "</details>"
+} > "$output_path"
+
+echo ""
+echo "Summary written to: $output_path"
+echo "Raw native dll delta: ${delta_kb} KB (${pct}%)"
+echo "Accounted: $total_line"

--- a/.github/skills/aot-impact-analysis/scripts/measure-aot-startup.sh
+++ b/.github/skills/aot-impact-analysis/scripts/measure-aot-startup.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Measures .NET CLI startup performance for two scenarios using the redist SDK's `dotnet` muxer, and
+# (optionally) exports OpenTelemetry spans to a running Aspire Dashboard for a span-level breakdown.
+#
+# The redist muxer dispatches to the NativeAOT entrypoint when DOTNET_CLI_ENABLEAOT=true and to the
+# managed CLI otherwise, so the default before/after compares the *same* built SDK with the AOT path
+# off vs. on. Pass --baseline-dotnet to instead compare two different builds with identical env.
+#
+# Two phases per scenario:
+#   1. Timing phase   - runs `dotnet <args>` N times with the OTLP exporter OFF and records
+#                       wall-clock (min / median / mean / p95).
+#   2. Telemetry phase - when an Aspire Dashboard is reachable, a few exporter-ON runs tagged
+#                       OTEL_RESOURCE_ATTRIBUTES="scenario=<label>" so the dashboard captures the
+#                       CLI's `dotnet-cli` spans.
+#
+# The PowerShell sibling Measure-AotStartup.ps1 is the canonical implementation; this is the bash
+# port. Sub-second timing needs bash >= 5 (EPOCHREALTIME) or GNU coreutils `gdate` on macOS.
+#
+# Usage:
+#   scripts/measure-aot-startup.sh [--dotnet-path <muxer>] [--baseline-dotnet <muxer>]
+#       [--arguments '<args>'] [--iterations N] [--warmup N] [--configuration <cfg>]
+#       [--otlp-endpoint <url>] [--dashboard-url <url>] [--output-path <file>]
+set -euo pipefail
+
+dotnet_path=""
+baseline_dotnet=""
+args="--version"
+iterations=30
+warmup=5
+configuration="Release"
+otlp_endpoint="http://localhost:4317"
+dashboard_url="http://localhost:18888"
+output_path=""
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dotnet-path) dotnet_path="$2"; shift 2;;
+    --baseline-dotnet) baseline_dotnet="$2"; shift 2;;
+    --arguments) args="$2"; shift 2;;
+    --iterations) iterations="$2"; shift 2;;
+    --warmup) warmup="$2"; shift 2;;
+    --configuration|-c) configuration="$2"; shift 2;;
+    --otlp-endpoint) otlp_endpoint="$2"; shift 2;;
+    --dashboard-url) dashboard_url="$2"; shift 2;;
+    --output-path|-o) output_path="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+find_repo_root() {
+  local dir="$1"
+  while [[ -n "$dir" && ! -e "$dir/.git" ]]; do
+    local parent; parent="$(dirname "$dir")"
+    [[ "$parent" == "$dir" ]] && break
+    dir="$parent"
+  done
+  [[ -e "$dir/.git" ]] || { echo "Could not locate the repository root from $1." >&2; exit 1; }
+  ( cd "$dir" && pwd )
+}
+
+repo_root="$(find_repo_root "$script_dir")"
+[[ -z "$output_path" ]] && output_path="$repo_root/artifacts/aot-startup.md"
+
+resolve_muxer() {
+  local explicit="$1"
+  if [[ -n "$explicit" ]]; then
+    [[ -f "$explicit" ]] || { echo "dotnet muxer not found at $explicit." >&2; exit 1; }
+    printf '%s\n' "$explicit"; return
+  fi
+  local name="dotnet"; [[ "${OS:-}" == "Windows_NT" ]] && name="dotnet.exe"
+  local candidate="$repo_root/artifacts/bin/redist/$configuration/dotnet/$name"
+  [[ -f "$candidate" ]] || { echo "Redist muxer not found at $candidate. Build the full SDK layout first (build.sh/.cmd), or pass --dotnet-path." >&2; exit 1; }
+  printf '%s\n' "$candidate"
+}
+
+_now_s() {
+  if [[ -n "${EPOCHREALTIME:-}" ]]; then printf '%s' "${EPOCHREALTIME/,/.}"; return; fi
+  if command -v gdate >/dev/null 2>&1; then gdate +%s.%N; return; fi
+  date +%s.%N 2>/dev/null | sed 's/N$//'
+}
+
+primary="$(resolve_muxer "$dotnet_path")"
+
+# Scenarios as parallel arrays (bash 3.2-compatible).
+labels=(); exes=(); aot=()
+if [[ -n "$baseline_dotnet" ]]; then
+  base_mux="$(resolve_muxer "$baseline_dotnet")"
+  labels=("base" "pr"); exes=("$base_mux" "$primary"); aot=("true" "true")
+  mode="build-vs-build (AOT path on both)"
+else
+  labels=("managed" "aot"); exes=("$primary" "$primary"); aot=("false" "true")
+  mode="managed vs AOT (same SDK)"
+fi
+
+echo "Muxer:      $primary"
+echo "Command:    dotnet $args"
+echo "Mode:       $mode"
+echo "Iterations: $iterations (warmup $warmup)"
+echo ""
+
+r_min=(); r_med=(); r_mean=(); r_p95=()
+for idx in "${!labels[@]}"; do
+  label="${labels[$idx]}"; exe="${exes[$idx]}"; aotval="${aot[$idx]}"
+  echo "==> Timing scenario '$label'..."
+  for ((i=0; i<warmup; i++)); do
+    env DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_CLI_ENABLEAOT="$aotval" "$exe" $args >/dev/null 2>&1 || true
+  done
+  samples=()
+  for ((i=0; i<iterations; i++)); do
+    start="$(_now_s)"
+    env DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_CLI_ENABLEAOT="$aotval" "$exe" $args >/dev/null 2>&1 || true
+    end="$(_now_s)"
+    samples+=("$(awk "BEGIN{printf \"%.3f\", ($end-$start)*1000}")")
+  done
+  stats="$(printf '%s\n' "${samples[@]}" | sort -n | awk '
+    { a[NR]=$1; sum+=$1 }
+    function pct(p,  rank,lo,hi){ rank=(p/100)*(n-1)+1; lo=int(rank); hi=lo+(rank>lo?1:0); if(hi>n)hi=n; return a[lo]+(rank-lo)*(a[hi]-a[lo]); }
+    END{ n=NR; printf "%.1f %.1f %.1f %.1f", a[1], pct(50), sum/n, pct(95); }')"
+  read -r mn md me p9 <<<"$stats"
+  r_min+=("$mn"); r_med+=("$md"); r_mean+=("$me"); r_p95+=("$p9")
+done
+
+# Telemetry phase.
+telemetry_state="none"
+otlp_reachable() {
+  local url="$1" hp host port
+  hp="${url#*://}"; host="${hp%%:*}"; port="${hp##*:}"; port="${port%%/*}"
+  (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+  return 1
+}
+if [[ -n "$otlp_endpoint" ]]; then
+  if otlp_reachable "$otlp_endpoint"; then
+    for idx in "${!labels[@]}"; do
+      label="${labels[$idx]}"; exe="${exes[$idx]}"; aotval="${aot[$idx]}"
+      echo "==> Exporting spans for scenario '$label' to $otlp_endpoint..."
+      for ((i=0; i<5; i++)); do
+        env DOTNET_CLI_TELEMETRY_OPTOUT=0 DOTNET_CLI_TELEMETRY_ENABLE_EXPORTER=1 \
+            OTEL_EXPORTER_OTLP_ENDPOINT="$otlp_endpoint" OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+            OTEL_RESOURCE_ATTRIBUTES="scenario=$label" DOTNET_CLI_ENABLEAOT="$aotval" \
+            "$exe" $args >/dev/null 2>&1 || true
+      done
+    done
+    telemetry_state="exported"
+  else
+    telemetry_state="skipped"
+  fi
+fi
+
+delta_med="$(awk "BEGIN{printf \"%+.1f\", ${r_med[1]} - ${r_med[0]}}")"
+pct_med="$(awk "BEGIN{ if(${r_med[0]}>0) printf \"%+.1f\", (${r_med[1]}-${r_med[0]})/${r_med[0]}*100; else printf \"%+.1f\", 0}")"
+
+mkdir -p "$(dirname "$output_path")"
+{
+  echo "## AOT startup performance"
+  echo ""
+  echo "Command: \`dotnet $args\` &nbsp;|&nbsp; $iterations iterations ($warmup warmup) &nbsp;|&nbsp; $mode."
+  echo "Wall-clock measured with the OTLP exporter off (clean numbers); all times in ms."
+  echo ""
+  echo "| Scenario | Min | Median | Mean | P95 |"
+  echo "| --- | ---: | ---: | ---: | ---: |"
+  for idx in "${!labels[@]}"; do
+    echo "| ${labels[$idx]} | ${r_min[$idx]} | ${r_med[$idx]} | ${r_mean[$idx]} | ${r_p95[$idx]} |"
+  done
+  echo ""
+  echo "**Median delta (${labels[0]} -> ${labels[1]}): ${delta_med} ms (${pct_med}%).**"
+  echo ""
+  if [[ "$telemetry_state" == "exported" ]]; then
+    echo "Spans exported to the Aspire Dashboard, tagged \`scenario=<label>\`. Inspect with:"
+    echo ""
+    echo '```'
+    echo "aspire otel traces --dashboard-url $dashboard_url --format Table --search scenario:aot"
+    echo "aspire otel traces --dashboard-url $dashboard_url --format Json  --search scenario:aot -n 5"
+    echo '```'
+  elif [[ "$telemetry_state" == "skipped" ]]; then
+    echo "_Telemetry phase skipped: no Aspire Dashboard reachable at \`$otlp_endpoint\`. Start one with start-aspire-dashboard.sh._"
+  fi
+} > "$output_path"
+
+echo ""
+echo "Summary written to: $output_path"
+for idx in "${!labels[@]}"; do
+  echo "  ${labels[$idx]}: min=${r_min[$idx]} median=${r_med[$idx]} mean=${r_mean[$idx]} p95=${r_p95[$idx]} ms"
+done

--- a/.github/skills/aot-impact-analysis/scripts/start-aspire-dashboard.sh
+++ b/.github/skills/aot-impact-analysis/scripts/start-aspire-dashboard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Starts a standalone Aspire Dashboard to receive OpenTelemetry (OTLP) data from the .NET CLI, and
+# prints the OTLP endpoint + UI login URL that measure-aot-startup.sh / `aspire otel` consume.
+#
+# Prefers the `aspire` CLI (`aspire dashboard run`); otherwise falls back to the official container
+# image (mcr.microsoft.com/dotnet/aspire-dashboard). Either way it exposes:
+#   * UI            http://localhost:18888
+#   * OTLP/gRPC     http://localhost:4317   (point the CLI's OTEL_EXPORTER_OTLP_ENDPOINT here)
+#   * OTLP/HTTP     http://localhost:4318
+#
+# Run in its own terminal (it blocks) or as a background process. With the `aspire` CLI, copy the
+# printed http://localhost:18888/login?t=<token> URL and pass it to `aspire otel --dashboard-url`.
+#
+# The PowerShell sibling Start-AspireDashboard.ps1 is the canonical implementation.
+#
+# Usage:
+#   scripts/start-aspire-dashboard.sh [--use-docker] [--otlp-grpc-port <n>] [--ui-port <n>]
+set -euo pipefail
+
+use_docker=0
+otlp_grpc_port=4317
+ui_port=18888
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "$0"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --use-docker) use_docker=1; shift;;
+    --otlp-grpc-port) otlp_grpc_port="$2"; shift 2;;
+    --ui-port) ui_port="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+if command -v aspire >/dev/null 2>&1 && [[ "$use_docker" -eq 0 ]]; then
+  echo "==> Starting Aspire Dashboard via the aspire CLI..."
+  echo "    UI:        http://localhost:${ui_port}"
+  echo "    OTLP/gRPC: http://localhost:${otlp_grpc_port}"
+  echo "    Copy the printed login URL (with ?t=<token>) for 'aspire otel --dashboard-url'."
+  echo ""
+  exec aspire dashboard run --frontend-url "http://localhost:${ui_port}"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Neither the 'aspire' CLI nor 'docker' is available. Install the Aspire CLI (dotnet tool install -g aspire.cli) or Docker." >&2
+  exit 1
+fi
+
+echo "==> Starting Aspire Dashboard via container image..."
+echo "    UI:        http://localhost:${ui_port}"
+echo "    OTLP/gRPC: http://localhost:${otlp_grpc_port}"
+echo "    Anonymous access is enabled for local dev (no token required)."
+echo ""
+exec docker run --rm -it \
+  -p "${ui_port}:18888" \
+  -p "${otlp_grpc_port}:18889" \
+  -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true \
+  --name aspire-dashboard \
+  mcr.microsoft.com/dotnet/aspire-dashboard:latest

--- a/.github/skills/aot-impact-analysis/size-analysis.md
+++ b/.github/skills/aot-impact-analysis/size-analysis.md
@@ -20,15 +20,23 @@ diffs the same `.mstat` artifacts with `sizoscope-cli`.
 pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1 -Rid win-x64
 ```
 
+Bash equivalent (same parameters as `--kebab-case` flags):
+
+```bash
+.github/skills/aot-impact-analysis/scripts/measure-aot-size.sh --rid linux-x64
+```
+
 Useful parameters:
 
-- `-Rid` — runtime identifier to publish. CI publishes **win-x64** and
-  **osx-arm64**; re-run with `-Rid osx-arm64` on a Mac for that leg.
-- `-Configuration` — defaults to `Release` (matches CI's `buildConfiguration`).
-- `-BaseRef` — baseline ref; defaults to `git merge-base HEAD origin/main` (the
-  fork point), which yields a clean additive diff.
-- `-SkipBaseline` — reuse an already-built baseline worktree (faster re-runs).
-- `-OutputPath` — where to write the Markdown report.
+- `-Rid` / `--rid` — runtime identifier to publish. CI publishes **win-x64** and
+  **osx-arm64**; re-run with `osx-arm64` on a Mac for that leg.
+- `-Configuration` / `--configuration` — defaults to `Release` (matches CI's
+  `buildConfiguration`).
+- `-BaseRef` / `--base-ref` — baseline ref; defaults to `git merge-base HEAD
+  origin/main` (the fork point), which yields a clean additive diff.
+- `-SkipBaseline` / `--skip-baseline` — reuse an already-built baseline worktree
+  (faster re-runs).
+- `-OutputPath` / `--output-path` — where to write the Markdown report.
 
 ## How it works
 

--- a/.github/skills/aot-impact-analysis/size-analysis.md
+++ b/.github/skills/aot-impact-analysis/size-analysis.md
@@ -1,0 +1,67 @@
+# Size analysis
+
+Detail for the [aot-impact-analysis](SKILL.md) skill. Covers the before/after
+NativeAOT binary-size measurement produced by
+[scripts/Measure-AotSize.ps1](scripts/Measure-AotSize.ps1). For the env-var
+contract and dashboard mechanics used by the startup half, see
+[startup-and-telemetry.md](startup-and-telemetry.md).
+
+## What it measures
+
+The size signal for an AOT enablement is the native `dotnet-aot` shared library
+(`dotnet-aot.dll`) and the per-symbol `.mstat` the ILC compiler emits. The skill
+diffs this branch against a baseline ref so the delta is exactly the change's
+additive cost. This mirrors the repo's `aot-size-analysis` CI workflow, which
+diffs the same `.mstat` artifacts with `sizoscope-cli`.
+
+## Run it
+
+```powershell
+pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotSize.ps1 -Rid win-x64
+```
+
+Useful parameters:
+
+- `-Rid` — runtime identifier to publish. CI publishes **win-x64** and
+  **osx-arm64**; re-run with `-Rid osx-arm64` on a Mac for that leg.
+- `-Configuration` — defaults to `Release` (matches CI's `buildConfiguration`).
+- `-BaseRef` — baseline ref; defaults to `git merge-base HEAD origin/main` (the
+  fork point), which yields a clean additive diff.
+- `-SkipBaseline` — reuse an already-built baseline worktree (faster re-runs).
+- `-OutputPath` — where to write the Markdown report.
+
+## How it works
+
+1. Publishes `src/Cli/dotnet-aot` (Release, full ILC) for the current worktree.
+2. Adds a **detached git worktree** at the baseline ref beside the repo and
+   publishes the same project there, using the current worktree's repo-local SDK
+   (`.dotnet/dotnet.exe`). The baseline restore pulls the baseline package set —
+   expect a cold restore on first run.
+3. Locates `native/dotnet-aot.mstat` and `native/dotnet-aot.dll` under
+   `artifacts/obj` and `artifacts/bin` on both sides.
+4. Runs `sizoscope-cli <base.mstat> <pr.mstat> --output <diff>`; the first line is
+   `Total accounted size difference: <N> kB`.
+5. Writes the report (raw `dotnet-aot.dll` delta in KB + %, the accounted total,
+   and the full New/Grown + Removed/Shrunk diff) and removes the temp worktree.
+
+`sizoscope-cli` is installed on demand (`dotnet tool install --global
+sizoscope-cli`, from the feeds in the repo's `nuget.config`). If it is not found
+after install, open a new shell so `~/.dotnet/tools` is on `PATH`.
+
+## Reading the diff
+
+- The **raw `dotnet-aot.dll` delta** is the headline number a reviewer cares
+  about. The **accounted total** from `sizoscope-cli` attributes that delta to
+  assemblies/types.
+- Equal `+`/`-` `*.resources` rows are **localized satellite assemblies** being
+  re-attributed across the two builds; they net to ~zero. This is why the
+  accounted total is often below the raw file delta — don't read those rows as
+  real growth.
+- Map the top real contributors back to the change's features (e.g. a crypto
+  assembly to in-process cert generation, registry assemblies to workload
+  detection). A contributor that maps to nothing in the diff is worth
+  investigating — it may signal an unintended dependency pulled into the AOT
+  graph.
+
+Size and startup are independent: a size change does not imply a startup change.
+Report both — see [startup-and-telemetry.md](startup-and-telemetry.md).

--- a/.github/skills/aot-impact-analysis/startup-and-telemetry.md
+++ b/.github/skills/aot-impact-analysis/startup-and-telemetry.md
@@ -1,0 +1,74 @@
+# Startup performance and telemetry
+
+Detail for the [aot-impact-analysis](SKILL.md) skill. Covers measuring startup
+with [scripts/Measure-AotStartup.ps1](scripts/Measure-AotStartup.ps1) and
+capturing OpenTelemetry in the Aspire Dashboard with
+[scripts/Start-AspireDashboard.ps1](scripts/Start-AspireDashboard.ps1). For the
+full env-var contract and `aspire otel` query language, see
+[references/perf-and-otel.md](references/perf-and-otel.md).
+
+## Prerequisite: a full SDK layout
+
+Startup is measured through the **real redist `dotnet.exe` muxer**, which
+dispatches to the NativeAOT entrypoint when `DOTNET_CLI_ENABLEAOT=true` and to the
+managed CLI otherwise. The muxer and the AOT binary only exist after a full
+`build.cmd` / `build.sh` (a bare `dotnet-aot` publish is **not** runnable through
+the muxer). If the layout is missing, the script stops with the path it expected
+under `artifacts/bin/redist/<Config>/dotnet`.
+
+## Start the dashboard
+
+It blocks, so run it in its own terminal or a detached/background shell:
+
+```powershell
+pwsh .github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
+```
+
+Endpoints: UI `http://localhost:18888`, OTLP/gRPC `http://localhost:4317`,
+OTLP/HTTP `http://localhost:4318`. It prefers the `aspire` CLI and falls back to
+the `mcr.microsoft.com/dotnet/aspire-dashboard` container. With the CLI it prints
+a `…/login?t=<token>` URL — pass that whole URL to `aspire otel --dashboard-url`.
+
+## Measure
+
+```powershell
+pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1 -Arguments '--version'
+```
+
+- **Scenarios.** By default it compares the *same* muxer with
+  `DOTNET_CLI_ENABLEAOT=false` (managed) vs `true` (AOT). Pass
+  `-BaselineDotnet <path>` to compare two different builds instead (both AOT-on),
+  e.g. a baseline-branch redist vs this branch's.
+- **Timing phase (headline).** Runs the command `-Iterations` times (default 30,
+  `-Warmup` 5) with the exporter **off**, recording wall-clock; reports
+  min/median/mean/p95.
+- **Telemetry phase (breakdown).** If a dashboard is reachable at `-OtlpEndpoint`
+  (default `http://localhost:4317`), does a few exporter-on runs tagged
+  `OTEL_RESOURCE_ATTRIBUTES="scenario=<label>"` so the `dotnet-cli` spans land in
+  the dashboard under a distinguishable scenario.
+- Writes the report to `artifacts/aot-startup.md`.
+
+Pick a representative `-Arguments`. `--version` is the cleanest pure-startup
+probe; a real subcommand (e.g. `--help`, or the first-run path on a clean
+`DOTNET_CLI_HOME`) exercises more of the entrypoint.
+
+## Pull the span breakdown
+
+```powershell
+aspire otel traces --dashboard-url http://localhost:18888 --format Table --search scenario:aot
+aspire otel traces --dashboard-url http://localhost:18888 --format Json  --search scenario:aot -n 5
+```
+
+`--search` takes free text plus `field:value` qualifiers (`resource:`, `name:`,
+`trace-id:`, `status:`, `duration:>N`) and `@attr:value` for the `scenario` tag.
+
+## Read it
+
+- **Prefer median and P95** for the headline; mean is skewed by occasional
+  GC/JIT/disk-cache outliers. The AOT path should show lower startup, most
+  visibly on the first-run path.
+- Use the span tree only to attribute *where* time went (runtime start vs parse
+  vs first-run work) between the `scenario=managed` and `scenario=aot` traces —
+  exporter-on runs carry flush overhead, so never use them for the headline.
+- Both scenarios report service name `dotnet-cli`; tell them apart by the
+  `scenario` resource attribute, not the service name.

--- a/.github/skills/aot-impact-analysis/startup-and-telemetry.md
+++ b/.github/skills/aot-impact-analysis/startup-and-telemetry.md
@@ -24,6 +24,9 @@ It blocks, so run it in its own terminal or a detached/background shell:
 pwsh .github/skills/aot-impact-analysis/scripts/Start-AspireDashboard.ps1
 ```
 
+Bash equivalent: `scripts/start-aspire-dashboard.sh` (flags `--use-docker`,
+`--otlp-grpc-port`, `--ui-port`).
+
 Endpoints: UI `http://localhost:18888`, OTLP/gRPC `http://localhost:4317`,
 OTLP/HTTP `http://localhost:4318`. It prefers the `aspire` CLI and falls back to
 the `mcr.microsoft.com/dotnet/aspire-dashboard` container. With the CLI it prints
@@ -34,6 +37,11 @@ a `…/login?t=<token>` URL — pass that whole URL to `aspire otel --dashboard-
 ```powershell
 pwsh .github/skills/aot-impact-analysis/scripts/Measure-AotStartup.ps1 -Arguments '--version'
 ```
+
+Bash equivalent: `scripts/measure-aot-startup.sh --arguments '--version'` (same
+options as `--kebab-case` flags: `--baseline-dotnet`, `--iterations`, `--warmup`,
+`--otlp-endpoint`, …). Sub-second timing needs bash ≥ 5 (`EPOCHREALTIME`) or GNU
+coreutils `gdate` on macOS.
 
 - **Scenarios.** By default it compares the *same* muxer with
   `DOTNET_CLI_ENABLEAOT=false` (managed) vs `true` (AOT). Pass

--- a/.github/skills/aot-impact-analysis/writing-the-summary.md
+++ b/.github/skills/aot-impact-analysis/writing-the-summary.md
@@ -1,0 +1,41 @@
+# Writing the impact summary
+
+Detail for the [aot-impact-analysis](SKILL.md) skill. How to turn the two report
+files into the PR-ready summary a reviewer can act on.
+
+## Combine the reports
+
+```powershell
+Get-Content artifacts/aot-size-win-x64.md, artifacts/aot-startup.md |
+    Set-Content artifacts/aot-impact.md
+```
+
+Size table first, then startup. If only size was run (the common case — startup
+needs a full SDK layout), the size report alone is the summary.
+
+## What a good summary says, in order
+
+1. **Headline native-binary delta** — the raw `dotnet-aot.dll` change in KB and
+   %. This is the number reviewers anchor on.
+2. **Accounted total** — the `sizoscope-cli` `Total accounted size difference`,
+   which attributes that delta to assemblies/types.
+3. **Top contributors and *why*** — the largest grown assemblies, each mapped to
+   a feature of the PR (e.g. a crypto assembly ← in-process dev-cert generation;
+   registry/ACL assemblies ← workload detection). A contributor that maps to
+   nothing is a flag, not a footnote — call it out as a possible unintended
+   dependency.
+4. **Startup delta** — median and P95 managed-vs-AOT (or build-vs-build), only if
+   the startup phase ran. State the scenario/arguments measured.
+5. **Caveats** — anything not validated locally (e.g. a platform whose path
+   couldn't be exercised on this machine), and the baseline ref used.
+
+## Discipline
+
+- Keep every claim tied to a number a script produced; don't editorialize past
+  the data.
+- Ignore the equal `+`/`-` `*.resources` rows when narrating growth — they are
+  satellite re-attribution, not real cost (see
+  [size-analysis.md](size-analysis.md)).
+- Report size and startup as **independent** signals: neither implies the other.
+- Note the RIDs measured. CI covers **win-x64** and **osx-arm64**; if you only
+  ran one locally, say so.


### PR DESCRIPTION
## What

Adds a reusable agent skill, `aot-impact-analysis`, that automates the binary-size and startup-performance analysis we run when enabling NativeAOT functionality in the dotnet CLI (e.g. #54970).

## Structure

Follows a thin-core + subskill-pages layout (modeled on the [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) conventions): a small `SKILL.md` that loads on every trigger, plus sibling pages loaded on demand.

| File | Role |
| --- | --- |
| `SKILL.md` | Thin orchestrator: when to measure size vs startup, the always-apply rules |
| `size-analysis.md` | Before/after `dotnet-aot.mstat` diff via `sizoscope-cli` |
| `startup-and-telemetry.md` | Redist-muxer startup timing + Aspire Dashboard OpenTelemetry capture |
| `writing-the-summary.md` | Assembling the PR-ready impact summary |
| `references/perf-and-otel.md` | OTLP env-var contract the CLI honors + `aspire otel` command surface |
| `scripts/` | `Measure-AotSize.ps1`, `Measure-AotStartup.ps1`, `Start-AspireDashboard.ps1` |

## Notes

- Size methodology mirrors the existing `aot-size-analysis` CI workflow (sizoscope on the per-platform `dotnet-aot.mstat`, baselined at the fork point).
- Startup is measured through the **real redist `dotnet.exe` muxer** (`DOTNET_CLI_ENABLEAOT`), not a standalone host, so it exercises the same dispatch users hit.
- Scripts are PowerShell and use the repo-local SDK (`.dotnet/dotnet.exe`); `SKILL.md` validates against `.github/skills/ValidateSkill.cs`.