### PR TITLE
Remove redundant [DoNotParallelize] from serialized test projects

### DIFF
--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -12,7 +12,6 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public class CreateImageIndexTests : SdkTest
 {
     [TestMethod]

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -10,7 +10,6 @@ using Microsoft.NET.Build.Containers.IntegrationTests;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public class CreateNewImageTests : SdkTest
 {
     [TestMethod]

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -5,7 +5,6 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 [TestClass]
-[DoNotParallelize]
 public class DockerRegistryTests : SdkTest
 {
     private TestLoggerFactory? _loggerFactory;

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -14,7 +14,6 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public class EndToEndTests : SdkTest, IDisposable
 {
     private TestLoggerFactory? _loggerFactory;

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public sealed class LayerEndToEndTests : SdkTest, IDisposable
 {
     public LayerEndToEndTests()

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -8,7 +8,6 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public class ParseContainerPropertiesTests
 {
     [TestMethod]

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -8,7 +8,6 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 namespace Microsoft.NET.Build.Containers.Targets.IntegrationTests;
 
 [TestClass]
-[DoNotParallelize]
 public class TargetsTests
 {
     [TestMethod]

--- a/test/Microsoft.NET.Sdk.Razor.Tests/FindAssembliesWithReferencesToMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/FindAssembliesWithReferencesToMultiThreadingTest.cs
@@ -10,7 +10,6 @@ using TaskItem = Microsoft.Build.Utilities.TaskItem;
 
 namespace Microsoft.NET.Sdk.Razor.Test
 {
-    [DoNotParallelize]
     [TestClass]
     public class FindAssembliesWithReferencesToMultiThreadingTest
     {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -14,7 +14,6 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
 {
-    [DoNotParallelize]
     [TestClass]
     public class ComputeReferenceStaticWebAssetItemsTest
     {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -10,7 +10,6 @@ using Moq;
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
 [TestClass]
-[DoNotParallelize]
 public class GenerateStaticWebAssetsManifestMultiThreadingTest
 {
     [TestMethod]

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -11,7 +11,6 @@ using Moq;
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
 [TestClass]
-[DoNotParallelize]
 public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 {
     [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/ExampleTemplateTest.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/ExampleTemplateTest.cs
@@ -10,7 +10,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {
     [TestClass]
     [UsesVerify]
-    [DoNotParallelize]
     public partial class ExampleTemplateTest : TestBase
     {
         private ILogger Log => new TestContextLogger(TestContext);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -11,7 +11,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {
     [TestClass]
     [UsesVerify]
-    [DoNotParallelize]
     public partial class TemplateEngineSamplesTest : TestBase
     {
         private ILogger Log => new TestContextLogger(TestContext);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/VerificationEngineTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/VerificationEngineTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {
     [TestClass]
     [UsesVerify]
-    [DoNotParallelize]
     public partial class VerificationEngineTests
     {
         private ILogger Log => new TestContextLogger(TestContext);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
@@ -13,7 +13,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests
 {
     [TestClass]
     [UsesVerify]
-    [DoNotParallelize]
     public partial class VerificationEngineTests
     {
         private ILogger Log => new TestContextLogger(TestContext);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/FolderInstallerTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/FolderInstallerTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Edge.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FolderInstallerTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
@@ -13,7 +13,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Edge.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class TemplateCreatorTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/TemplatePackageManagerTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/TemplatePackageManagerTests.cs
@@ -16,7 +16,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Edge.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class TemplatePackageManagerTests : TestBase
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -10,7 +10,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class BasicTests : BootstrapperTestBase
     {
         private TestContext _testContext = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/ConfigurationTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/ConfigurationTests.cs
@@ -10,7 +10,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class ConfigurationTests : BootstrapperTestBase
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
@@ -11,7 +11,6 @@ using WellKnownSearchFilters = Microsoft.TemplateEngine.Utils.WellKnownSearchFil
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class End2EndTests : BootstrapperTestBase
     {
         private TestContext _testContext = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/LocalizationTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/LocalizationTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
     }
 
     [TestClass]
-    [DoNotParallelize]
     public class LocalizationTests : BootstrapperTestBase
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/SnapshotTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/SnapshotTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Tests;
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class SnapshotTests : TestBase
     {
         private TestContext _testContext = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
@@ -16,7 +16,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class BindSymbolTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroProcessorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroProcessorTests.cs
@@ -15,7 +15,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class MacroProcessorTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CaseChangeMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CaseChangeMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class CaseChangeMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CoalesceMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CoalesceMacroTests.cs
@@ -12,7 +12,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class CoalesceMacroTests
     {
         private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/ConstantMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/ConstantMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class ConstantMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/EvaluateMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/EvaluateMacroTests.cs
@@ -10,7 +10,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class EvaluateMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/FakeMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/FakeMacroTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FakeMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GeneratePortMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GeneratePortMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class GeneratePortMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
@@ -10,7 +10,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class GuidMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/JoinMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/JoinMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class JoinMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/NowMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/NowMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class NowMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RandomMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RandomMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class RandomMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class RegexMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMatchMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMatchMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class RegexMatchMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/SwtichMacroTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/SwtichMacroTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class SwtichMacroTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
@@ -18,7 +18,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class RunnableProjectConfigTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
@@ -15,7 +15,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class RunnableProjectGeneratorTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class ScanTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
@@ -12,7 +12,6 @@ using Microsoft.TemplateEngine.Tests;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class SnapshotTests : TestBase
     {
         private TestContext _testContext = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/FileRenameTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/FileRenameTests.cs
@@ -14,7 +14,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FileRenameTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
@@ -13,7 +13,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class LocalizationTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/PostActionTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/PostActionTests.cs
@@ -12,7 +12,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class PostActionTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SourceConfigTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SourceConfigTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class SourceConfigTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SplitConfigurationTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SplitConfigurationTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class SplitConfigurationTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateRootTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateRootTests.cs
@@ -11,7 +11,6 @@ using Microsoft.TemplateEngine.Utils;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class TemplateRootTests
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValidationTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValidationTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.Tests;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class ValidationTests : TestBase
     {
         public TestContext TestContext { get; set; } = null!;

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FirstLowerCaseInvariantValueFormTests
     {
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FirstLowerCaseValueFormTests
     {
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FirstUpperCaseInvariantValueFormTests
     {
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class FirstUpperCaseValueFormTests
     {
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TemplateJsonDefinedFormsTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TemplateJsonDefinedFormsTests.cs
@@ -12,7 +12,6 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
     [TestClass]
-    [DoNotParallelize]
     public class TemplateJsonDefinedFormsTests
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;

--- a/test/dotnet-new.IntegrationTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewLocaleTests.cs
@@ -8,7 +8,6 @@ using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class DotnetNewLocaleTests : BaseIntegrationTest
     {

--- a/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
-    [DoNotParallelize]
     [TestClass]
     public class TemplateEngineSamplesTest : BaseIntegrationTest
     {


### PR DESCRIPTION
## What

Remove **redundant** class-level `[DoNotParallelize]` attributes from 56 test files.

## Why they are no-ops today

Every affected project inherits the repo-wide default in `test/Directory.Build.props`:

```xml
<MSTestParallelizeScope>None</MSTestParallelizeScope>
```

`None` makes MSTest.Sdk emit `[assembly: DoNotParallelize]`, which already fully serializes the entire assembly. A class-level `[DoNotParallelize]` on top of that changes nothing, so these attributes are dead configuration.

Removing them reduces noise and prevents the false impression that a specific class has a concurrency hazard being guarded. If a project ever opts in to parallelization (as done for the true unit-test projects in #55090), the guard should be re-added deliberately, next to a comment explaining the shared state it protects.

## Kept intentionally

Three classes that document a real concurrency hazard keep their `[DoNotParallelize]` and are **not** touched:

- `GenerateStaticWebAssetsDevelopmentManifestMultiThreadingTest` (mutates process CWD; documented)
- `AuthHandshakeMessageHandlerTests`, `DockerDaemonTests` (env-var mutation; added in #55090)

## Scope

Affects Containers integration tests, dotnet-new integration tests, Razor, StaticWebAssets, and the TemplateEngine test suites. Pure attribute deletions — no behavior change (assemblies remain serialized via the `None` default). A representative TemplateEngine unit-test project builds clean (0 warnings) after the change.