### PR TITLE
Update canonical spec unit test example from xUnit to MSTest

### DIFF
--- a/documentation/specs/canonical.md
+++ b/documentation/specs/canonical.md
@@ -225,7 +225,7 @@ Writing tests is important, and our developer knows that. She is now writing out
 1. Create a new MSTest test project using `dotnet new`
 
 ```
-/> dotnet new mstest
+/> dotnet new mstest -o tests
 Created "tests" MSTest test project in "tests".
 
 /tests>

--- a/documentation/specs/canonical.md
+++ b/documentation/specs/canonical.md
@@ -218,15 +218,15 @@ Hello, World!
 # Running unit tests
 
 ## Narrative
-Writing tests is important, and our developer knows that. She is now writing out the shared logic in her class library and she wants to make sure that she has test coverage. Investigating the manuals, she realizes that the CLI toolset comes with support for xUnit tests including the test runner.  
+Writing tests is important, and our developer knows that. She is now writing out the shared logic in her class library and she wants to make sure that she has test coverage. Investigating the manuals, she realizes that the CLI toolset comes with support for MSTest tests including the test runner.
 
 ## Steps
 
-1. Create a new xunit test project using `dotnet new`
+1. Create a new MSTest test project using `dotnet new`
 
 ```
-/> dotnet new tests --type xunit
-Created "tests" xunit test project in "tests".
+/> dotnet new mstest
+Created "tests" MSTest test project in "tests".
 
 /tests>
 ```
@@ -246,17 +246,18 @@ Created "tests" xunit test project in "tests".
 
 3. Add a test to the test class
 ```
-using System;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace tests
 {
+    [TestClass]
     public class Tests
     {
-        [Fact]
-        public void AssertTrue() {
-            Assert.True(true);
-        }        
+        [TestMethod]
+        public void AssertTrue()
+        {
+            Assert.IsTrue(true);
+        }
     }
 }
 ```


### PR DESCRIPTION
## Summary

As part of the migration from xUnit to MSTest, this updates and cleans up the "Running unit tests" scenario in `documentation/specs/canonical.md`.

## Changes

- Narrative now references **MSTest** instead of xUnit.
- Replaced `dotnet new tests --type xunit` with `dotnet new mstest`.
- Rewrote the sample test to use MSTest APIs: `[TestClass]`/`[TestMethod]` and `Assert.IsTrue`, with the `Microsoft.VisualStudio.TestTools.UnitTesting` namespace (and dropped the now-unused `System` using).

The restore and `dotnet test` steps were already framework-agnostic and left unchanged.