### PR TITLE
Remove xUnit dependencies from shipping TemplateVerifier package

### DIFF
--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using Microsoft.TemplateEngine.Authoring.CLI.Commands;
 using Microsoft.TemplateEngine.Authoring.CLI.Commands.Verify;
+using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 
 namespace Microsoft.TemplateEngine.Authoring.CLI
 {
@@ -11,6 +12,13 @@ namespace Microsoft.TemplateEngine.Authoring.CLI
     {
         internal static Task<int> Main(string[] args)
         {
+            // TemplateVerifier no longer ships with a built-in verifier, so the hosting application must
+            // supply one. Route snapshot directory verification through the xUnit (v3) Verify integration,
+            // which is the verifier this tool has always used.
+            VerificationEngine.DirectoryVerifier ??=
+                (path, include, pattern, options, settings, info, fileScrubber, sourceFile)
+                    => VerifyXunit.Verifier.VerifyDirectory(path, include, pattern, options, settings, info, fileScrubber, sourceFile);
+
             RootCommand rootCommand = new("dotnet-template-authoring");
             rootCommand.Subcommands.Add(new LocalizeCommand());
             rootCommand.Subcommands.Add(new VerifyCommand());

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ITestOutputHelper.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ITestOutputHelper.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.TemplateEngine.CommandUtils
+{
+    /// <summary>
+    /// Runner-agnostic test output abstraction used by the shared
+    /// <c>Microsoft.TemplateEngine.CommandUtils</c> sources that are compiled into this package.
+    /// </summary>
+    /// <remarks>
+    /// The shared command sources reference the unqualified name <c>ITestOutputHelper</c>. In test
+    /// projects that name binds to the framework-specific type (for example
+    /// <c>Microsoft.NET.TestFramework.ITestOutputHelper</c> or xUnit v3's <c>ITestOutputHelper</c>)
+    /// via a global using alias. This shipping package intentionally does not depend on any test
+    /// framework, so it provides its own minimal binding here. The shape mirrors xUnit v3's
+    /// <c>ITestOutputHelper</c> so the shared sources compile unchanged.
+    /// </remarks>
+    internal interface ITestOutputHelper
+    {
+        /// <summary>
+        /// Gets everything written to this output helper so far.
+        /// </summary>
+        string Output { get; }
+
+        /// <summary>
+        /// Writes a message to the test output.
+        /// </summary>
+        void Write(string message);
+
+        /// <summary>
+        /// Writes a formatted message to the test output.
+        /// </summary>
+        void Write(string format, params object[] args);
+
+        /// <summary>
+        /// Writes a message followed by a line break to the test output.
+        /// </summary>
+        void WriteLine(string message);
+
+        /// <summary>
+        /// Writes a formatted message followed by a line break to the test output.
+        /// </summary>
+        void WriteLine(string format, params object[] args);
+    }
+}

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/LocalizableStrings.resx
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/LocalizableStrings.resx
@@ -120,6 +120,9 @@
   <data name="VerificationEngine_Error_InstallUnexpectedFail" xml:space="preserve">
     <value>Template installation expected to pass but it had exit code '{0}'.</value>
   </data>
+  <data name="VerificationEngine_Error_NoDirectoryVerifier" xml:space="preserve">
+    <value>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</value>
+  </data>
   <data name="VerificationEngine_Error_ScrubberExtension" xml:space="preserve">
     <value>File extension passed to scrubber should not start with dot.</value>
   </data>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
@@ -12,6 +12,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Verify.DiffPlex" />
+    <!-- Verify core is used directly (VerifySettings, SettingsTask, FileScrubber). Pin it to the same
+         version the Authoring.CLI tool resolves (via Verify.XunitV3) so the two projects don't contribute
+         different EmptyFiles versions to the CLI's publish output, which would fail with NETSDK1152. -->
+    <PackageReference Include="Verify" VersionOverride="28.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
@@ -6,8 +6,6 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Unset IsTestProject which gets set by xunit.props which gets imported by the xunit PackageReference below. -->
-    <IsTestProject />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
@@ -3,12 +3,6 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props" />
 
   <ItemGroup>
-    <PackageReference Include="Verify.XunitV3" />
-    <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
-    <PackageReference Include="xunit.v3.extensibility.core" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Update="LocalizableStrings.resx"
                       GenerateSource="true" />
   </ItemGroup>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
@@ -49,13 +49,19 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
             string sourceFile);
 
         /// <summary>
-        /// Optional override for the test-framework-specific Verify directory verifier used by the
-        /// built-in (non-custom) verification path. When unset, the built-in xUnit (v3) verifier is used.
-        /// Consumers running under a different test framework (for example MSTest) can set this to that
-        /// framework's <c>Verifier.VerifyDirectory</c> so snapshot verification resolves the ambient test
-        /// context of the active framework rather than xUnit's (which would otherwise be unavailable and
-        /// fail with <c>TestContext.TestMethod is null</c>).
+        /// The test-framework-specific Verify directory verifier used by the built-in (non-custom)
+        /// verification path. This must be set by the consuming test project to its framework's
+        /// <c>Verifier.VerifyDirectory</c> (for example <c>VerifyXunit.Verifier.VerifyDirectory</c> or
+        /// <c>VerifyMSTest.Verifier.VerifyDirectory</c>) so snapshot verification resolves the ambient
+        /// test context of the active framework. When left unset, snapshot verification throws an
+        /// <see cref="InvalidOperationException"/>.
         /// </summary>
+        /// <remarks>
+        /// This package intentionally does not depend on any test framework, so it cannot supply a
+        /// default verifier. Consumers that verify against snapshot files must assign this property
+        /// (typically from a <c>[ModuleInitializer]</c>) or provide a per-call verifier via
+        /// <see cref="TemplateVerifierOptions.CustomDirectoryVerifier"/>.
+        /// </remarks>
         public static VerifyDirectoryDelegate? DirectoryVerifier { get; set; }
 
         public VerificationEngine(ILogger logger)
@@ -266,7 +272,8 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
                 return includeGlobs.Any(g => g.IsMatch(relativePath)) && !excludeGlobs.Any(g => g.IsMatch(relativePath));
             };
 
-            VerifyDirectoryDelegate verifyDirectory = DirectoryVerifier ?? DefaultVerifyDirectory;
+            VerifyDirectoryDelegate verifyDirectory = DirectoryVerifier
+                ?? throw new InvalidOperationException(LocalizableStrings.VerificationEngine_Error_NoDirectoryVerifier);
 
             return verifyDirectory(
                 callerInfo.ContentDirectory,
@@ -282,21 +289,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
                 fileScrubber: ExtractFileScrubber(options, callerInfo.ContentDirectory, fileSystem),
                 sourceFile: callerInfo.CallerSourceFile);
         }
-
-        // Kept in a separate, non-inlined method so that the reference to VerifyXunit.Verifier (and therefore
-        // the load of Verify.XunitV3) only happens when no framework-specific override has been supplied.
-        // When DirectoryVerifier is set (for example to the MSTest verifier) this method is never invoked.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static SettingsTask DefaultVerifyDirectory(
-            string path,
-            Func<string, bool>? include,
-            string? pattern,
-            EnumerationOptions? options,
-            VerifySettings? settings,
-            object? info,
-            FileScrubber? fileScrubber,
-            string sourceFile)
-            => VerifyXunit.Verifier.VerifyDirectory(path, include, pattern, options, settings, info, fileScrubber, sourceFile);
 
         private static FileScrubber? ExtractFileScrubber(TemplateVerifierOptions options, string contentDir, IPhysicalFileSystemEx fileSystem)
         {

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.cs.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Očekávalo se, že instalace šablony bude úspěšné, ale měla ukončovací kód{0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">Přípona souboru předaná scrubberu by neměla začínat tečkou.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.de.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Es wurde erwartet, dass die Vorlageninstallation erfolgreich ist, aber sie wies den Exitcode „{0}“ auf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">Die an die Bereinigung übergebene Dateierweiterung darf nicht mit einem Punkt beginnen.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.es.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Se esperaba que se pasara la instalación de la plantilla, pero tenía el código de salida "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">La extensión de archivo pasada a la limpieza no debe comenzar con un punto.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.fr.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">L’installation du modèle devait réussir, mais le code de sortie était '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">L’extension de fichier passée au programme de nettoyage ne doit pas commencer par un point.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.it.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">È previsto il passaggio dell'installazione del modello, ma il codice di uscita '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">L'estensione di file passata alla pulitura non deve iniziare con il punto.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ja.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">テンプレートのインストールは成功する必要がありますが、終了コードが '{0}' ありました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">スクラブに渡されるファイル拡張子はドットで始まってはいけません。</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ko.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">템플릿 설치는 통과해야 하지만 종료 코드 '{0}'이(가) 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">스크러버에 전달된 파일 확장자는 점으로 시작하지 않아야 합니다.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.pl.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Instalacja szablonu powinna zakończyć się powodzeniem, ale zawiera kod zakończenia „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">Rozszerzenie pliku przekazane do szybkiej kontroli nie powinno rozpoczynać się od kropki.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Esperava-se que a instalação do modelo fosse aprovada, mas tinha o código de saída '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">A extensão de arquivo passada para o programa de limpeza não deve começar com ponto.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ru.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Ожидалась, что установка шаблона будет выполнена, однако операция закончилась кодом завершения "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">Расширение файла, переданное в средство очистки, не должно начинаться с точки.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.tr.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Şablon yüklemenin başarılı olması bekleniyordu ancak '{0}' çıkış kodu oluştu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">Temizleyiciye geçirilen dosya uzantısı noktayla başlamamalıdır.</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">模板安装应通过，但它具有退出代码 "{0}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">传递给清理程序的文件扩展名不应以点开头。</target>

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">範本安裝預期會通過，但有結束代碼 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerificationEngine_Error_NoDirectoryVerifier">
+        <source>No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</source>
+        <target state="new">No directory verifier was configured. Set VerificationEngine.DirectoryVerifier to your test framework's Verifier.VerifyDirectory (for example VerifyXunit.Verifier.VerifyDirectory or VerifyMSTest.Verifier.VerifyDirectory), or supply a custom verifier via TemplateVerifierOptions.WithCustomDirectoryVerifier.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerificationEngine_Error_ScrubberExtension">
         <source>File extension passed to scrubber should not start with dot.</source>
         <target state="translated">傳遞至清除程式的副檔名不可以點開頭。</target>

--- a/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
+++ b/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.TemplateEngine.CommandUtils
         internal CommandResultAssertions NotHaveStdErrContaining(string pattern)
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
+            AssertTrue(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to not contain '{pattern}' but it did."));
             return this;
         }
 

--- a/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
+++ b/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.TemplateEngine.CommandUtils
@@ -18,145 +19,145 @@ namespace Microsoft.TemplateEngine.CommandUtils
 
         internal CommandResultAssertions ExitWith(int expectedExitCode)
         {
-            Assert.True(expectedExitCode == _commandResult.ExitCode, AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode} but it did not."));
+            AssertTrue(expectedExitCode == _commandResult.ExitCode, AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode} but it did not."));
             return this;
         }
 
         internal CommandResultAssertions Pass()
         {
-            Assert.True(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to pass but it did not."));
+            AssertTrue(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to pass but it did not."));
             return this;
         }
 
         internal CommandResultAssertions Fail()
         {
-            Assert.False(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to fail but it passed."));
+            AssertFalse(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to fail but it passed."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOut()
         {
-            Assert.False(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to have standard output but it did not."));
+            AssertFalse(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to have standard output but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOut(string expectedOutput)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(expectedOutput == _commandResult.StdOut, AppendDiagnosticsTo($"Expected standard output to be '{expectedOutput}' but it was not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(expectedOutput == _commandResult.StdOut, AppendDiagnosticsTo($"Expected standard output to be '{expectedOutput}' but it was not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContaining(string pattern)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContaining(Func<string, bool> predicate, string description = "")
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(predicate(_commandResult.StdOut), $"The command output did not contain expected result: {description} {Environment.NewLine}");
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(predicate(_commandResult.StdOut), $"The command output did not contain expected result: {description} {Environment.NewLine}");
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdOutContaining(string pattern)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(!_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to not contain '{pattern}' but it did."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(!_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to not contain '{pattern}' but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContainingIgnoreSpaces(string pattern)
         {
-            Assert.NotNull(_commandResult.StdOut);
+            AssertNotNull(_commandResult.StdOut);
             string commandResultNoSpaces = _commandResult.StdOut.Replace(" ", string.Empty);
-            Assert.True(commandResultNoSpaces.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertTrue(commandResultNoSpaces.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContainingIgnoreCase(string pattern)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to match pattern '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to match pattern '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(!Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to not match pattern '{pattern}' but it did."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(!Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to not match pattern '{pattern}' but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErr()
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.False(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to have standard error but it did not."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertFalse(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to have standard error but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErr(string expectedOutput)
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.True(expectedOutput == _commandResult.StdErr, AppendDiagnosticsTo($"Expected standard error to be '{expectedOutput}' but it was not."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertTrue(expectedOutput == _commandResult.StdErr, AppendDiagnosticsTo($"Expected standard error to be '{expectedOutput}' but it was not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErrContaining(string pattern)
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.True(_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertTrue(_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdErrContaining(string pattern)
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.True(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertTrue(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.True(Regex.Match(_commandResult.StdErr, pattern, options).Success, AppendDiagnosticsTo($"Expected standard error to match pattern '{pattern}' but it did not."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertTrue(Regex.Match(_commandResult.StdErr, pattern, options).Success, AppendDiagnosticsTo($"Expected standard error to match pattern '{pattern}' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdOut()
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to not have standard output but it did."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to not have standard output but it did."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdErr()
         {
-            Assert.NotNull(_commandResult.StdErr);
-            Assert.True(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to not have standard error but it did."));
+            AssertNotNull(_commandResult.StdErr);
+            AssertTrue(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to not have standard error but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(_commandResult.StdOut.Contains($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.' but it did not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(_commandResult.StdOut.Contains($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.' but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveCompiledProject(string compiledProject, string frameworkFullName)
         {
-            Assert.NotNull(_commandResult.StdOut);
-            Assert.True(_commandResult.StdOut.Contains($"Project {compiledProject} ({frameworkFullName}) will be compiled", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {compiledProject} ({frameworkFullName}) will be compiled' but it did not."));
+            AssertNotNull(_commandResult.StdOut);
+            AssertTrue(_commandResult.StdOut.Contains($"Project {compiledProject} ({frameworkFullName}) will be compiled", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {compiledProject} ({frameworkFullName}) will be compiled' but it did not."));
             return this;
         }
 
@@ -170,6 +171,38 @@ namespace Microsoft.TemplateEngine.CommandUtils
                        $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}")
                        //escape curly braces for String.Format
                        .Replace("{", "{{").Replace("}", "}}");
+        }
+
+        private static void AssertTrue([DoesNotReturnIf(false)] bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new CommandResultAssertionException(message);
+            }
+        }
+
+        private static void AssertFalse([DoesNotReturnIf(true)] bool condition, string message)
+        {
+            if (condition)
+            {
+                throw new CommandResultAssertionException(message);
+            }
+        }
+
+        private static void AssertNotNull([NotNull] object? value)
+        {
+            if (value is null)
+            {
+                throw new CommandResultAssertionException("Expected value to not be null but it was.");
+            }
+        }
+    }
+
+    internal sealed class CommandResultAssertionException : Exception
+    {
+        public CommandResultAssertionException(string message)
+            : base(message)
+        {
         }
     }
 }


### PR DESCRIPTION
## Summary

`Microsoft.TemplateEngine.Authoring.TemplateVerifier` is now a shipping package, but it still pulled in three xUnit v3 packages. This removes them and replaces their usages with framework-agnostic equivalents so the shipping package no longer depends on any test framework.

Removed `PackageReference`s:
- `Verify.XunitV3`
- `xunit.v3.assert`
- `xunit.v3.extensibility.core`

## What each dependency was used for, and the replacement

1. **`Verify.XunitV3`** → the `DefaultVerifyDirectory` fallback (`VerifyXunit.Verifier.VerifyDirectory`). Removed. `VerificationEngine.DirectoryVerifier` is now **required** — when unset, snapshot verification throws a clear localized `InvalidOperationException` pointing the consumer at `DirectoryVerifier` / `WithCustomDirectoryVerifier`. Every in-repo consumer already injects `VerifyMSTest.Verifier.VerifyDirectory`.

2. **`xunit.v3.assert`** → `Assert.True/False/NotNull` in the shared `CommandResultAssertions.cs`. Replaced with local `AssertTrue/AssertFalse/AssertNotNull` helpers (nullable-annotated with `[DoesNotReturnIf]`/`[NotNull]`) that throw a new internal `CommandResultAssertionException`.

3. **`xunit.v3.extensibility.core`** → provided `Xunit.ITestOutputHelper`, referenced by the shared command runner's `ITestOutputHelper` overloads (the package itself only uses the `ILogger` overloads). Added a package-owned internal `ITestOutputHelper` in the `Microsoft.TemplateEngine.CommandUtils` namespace, mirroring the repo's runner-agnostic `Microsoft.NET.TestFramework.ITestOutputHelper` shape, so the short name resolves without any test framework.

Also dropped the now-obsolete `<IsTestProject />` hack in the shared props (it only existed to counter `xunit.props`).

## Localization

Added `VerificationEngine_Error_NoDirectoryVerifier` to `LocalizableStrings.resx`; the `.xlf` files were regenerated via the build's `UpdateXlf` target (entries are `state="new"`), not hand-edited.

## Validation

- `TemplateVerifier` package: builds with **0 warnings, 0 errors**, no xUnit deps.
- Shipping consumers `Authoring.CLI` and `TemplateApiVerifier`: build clean.
- `CLI.IntegrationTests` (MSTest; exercises the internal `BasicCommand` via `InternalsVisibleTo`, plus `Verify.MSTest`): builds clean — confirms the IVT surface and `ILogger` overloads are intact.

## Behavior / breaking-change note

Removing the built-in xUnit default verifier is a breaking change for any **external** consumer that relied on it without injecting a `DirectoryVerifier` — they will now get the explanatory error and must set one (or provide a custom verifier). All internal consumers already inject a verifier.