### PR TITLE
Force-build WasmSdk before layout glob to fix dropped WebAssembly SDK

### DIFF
--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -196,10 +196,10 @@
 
   <Target Name="PublishNetSdks" DependsOnTargets="PublishNETAnalyzers;PublishDotnetFormat;PublishBlazorWasmTools;PublishStaticWebAssetsTools;PublishRazorSdkTools">
     <ItemGroup>
-      <WebSdkProjectFile Include="$(RepoRoot)src\WebSdk\**\*.csproj" />
+      <_SdkProjectFile Include="$(RepoRoot)src\WebSdk\**\*.csproj;$(RepoRoot)src\WasmSdk\**\*.csproj" />
     </ItemGroup>
 
-    <MSBuild Projects="@(WebSdkProjectFile)" />
+    <MSBuild Projects="@(_SdkProjectFile)" />
 
     <PropertyGroup>
       <NETSdkSourceRoot>$(ArtifactsBinDir)$(Configuration)\Sdks\Microsoft.NET.Sdk</NETSdkSourceRoot>


### PR DESCRIPTION
PublishNetSdks in GenerateLayout.targets collects the per-SDK layout content via wildcard globs that are evaluated when the target runs. The Microsoft.NET.Sdk.WebAssembly folder is populated by CopyAdditionalFilesToLayout (AfterTargets="Build") on src/WasmSdk/Tasks/Microsoft.NET.Sdk.WebAssembly.Tasks.csproj. If that project has not finished building when the glob runs, the glob resolves to an empty folder and the entire Microsoft.NET.Sdk.WebAssembly SDK is silently dropped from the layout.

This is the same class of ordering race that dotnet/sdk#15651 worked around for src/WebSdk by force-building those projects up front, but that workaround never covered the sibling src/WasmSdk directory (added later). Extend the force-build to include src/WasmSdk/**/*.csproj so the WebAssembly layout source folder is guaranteed to be populated before the glob runs.

Diagnosed from the reproducibility pipeline (build-twice-and-diff): one build contained the 9 WebAssembly SDK files and the other did not; the binlogs showed PublishNetSdks copied 0 WebAssembly files in the failing build while CopyAdditionalFilesToLayout still ran completely, confirming an ordering race rather than an incremental/timestamp skip.