### PR TITLE
Flow dependencies into release/dnup by resetting only CODEOWNERS

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -43,11 +43,17 @@
             "ExtraSwitches": "-QuietComments",
             "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Version.Details.props;eng/common/*"
         },
-        // Automate opening PRs to merge sdk repos from main to release/dnup
+        // Automate opening PRs to merge sdk repos from main to release/dnup.
+        // Unlike the release-band flows above, release/dnup has NO darc/Maestro
+        // subscription, so this auto-merge is its only path to dependency and
+        // toolset updates. Resetting the dep/toolset files would freeze dnup on
+        // stale Arcade + eng/common; since dnup is the same 11.0.1xx band as main,
+        // we let those flow and reset only CODEOWNERS (kept minimal to avoid review
+        // pings on these automated PRs).
         "main":{
             "MergeToBranch": "release/dnup",
             "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*;CODEOWNERS"
+            "ResetToTargetPaths": "CODEOWNERS"
         },
         // Automate opening PRs to merge sdk repos from dnup to release/dnup
         "dnup":{


### PR DESCRIPTION

release/dnup has no darc/Maestro subscription, so the automated main -> release/dnup merge is its ONLY path to dependency + toolset updates; resetting the dep/toolset files froze dnup on stale Arcade (and eng/common) and blocked signed get-dotnetup publishing. Since dnup is the same 11.0.1xx band as main, track main's versions instead of resetting.

I chose this over enabling codeflow to avoid creating extra codeflow PRs and engineering effort / cost on the CI runners, since there is not really a reason for dotnetup's sdk source to be managed differently from the `main` version of the SDK.

We could use an older version of the SDK but we'd like to use the latest version as the SDK is often improving with things like otel/aot which impacts dotnetup.

# Context

The reset list was copied verbatim from the standard release-band template (commit 7cd20642 "Add flow from main to release/dnup"); only ";CODEOWNERS" was later appended deliberately (commit 1d0f687e "Desync CodeOwners for dnup merge flow"). The template exists to serve an invariant that does NOT hold for dnup: normal release branches (8.0.1xx -> 8.0.4xx -> ... -> main) are each independently version-managed by their own darc subscriptions, so a code-merge must reset those files to avoid (a) fighting darc and (b) cross-band contamination (e.g. flowing 9.0 versions into an 8.0 branch). release/dnup has NO subscription and is the SAME band as main, so both justifications collapse and the reset only serves to freeze dnup.

Per-file analysis:


File | Who normally owns it | Standard reason to reset | Applies to dnup? | Verdict
-- | -- | -- | -- | --
eng/Version.Details.xml | darc | Don't let a code-merge fight the target's darc subscription | No (no subscription) | Un-reset
global.json | darc/arcade | Band-specific arcade + bootstrap SDK | No (same band) | Un-reset
eng/common/* | arcade toolset | Must stay coherent with the branch's Arcade.Sdk pin | No (frozen ⇒ stale) | Un-reset
eng/Versions.props | mixed | Holds both darc package versions and repo-owned version band | Partly | Un-reset (accept main's versions)
NuGet.config | repo | Band-specific internal feeds (dotnet8 vs dotnet11) | Marginal (currently identical) | Neutral – safe to un-reset
CODEOWNERS | repo (dnup-specific) | Avoid review-ping spam on auto-merge PRs | Yes – deliberate | Keep resetting

Additional per-file detail:

- eng/Version.Details.xml -- the darc ledger (<Source Sha> + every <Dependency><Sha>). On a subscribed branch, resetting stops code-merges from fighting darc. dnup has no darc, so this auto-merge is the only thing that can advance it; resetting = permanent freeze. It was pinned at VMR 50e862b8 (Arcade 26311.113, ~June 11) -- literally why the signed get-dotnetup aka.ms link could not be created (the arcade link-pattern regex for get-dotnetup.{ps1,sh} had not arrived).

- global.json -- arcade + bootstrap SDK. Standard branches pin a band-specific arcade and bootstrap dotnet. dnup's arcade (11.0.0-beta.26311.113) is the same band as main, so no cross-band risk. Must move together with Version.Details.xml (see coherence note).

- eng/common/* -- the Arcade SDK's shipped script folder, NOT a darc dependency. When darc updates Microsoft.DotNet.Arcade.Sdk it overwrites eng/common/* from the new arcade package in the same operation, so eng/common is coupled 1:1 to the Arcade.Sdk pin. Resetting it in a code-merge (on a subscribed branch) prevents a foreign arcade's eng/common from desyncing from the branch pin. For dnup, since arcade itself was frozen, eng/common was frozen at the matching (stale) point -- the likely source of old CI plumbing (e.g. Linux images). Must be un-reset only in lockstep with global.json + Version.Details.xml.

- eng/Versions.props -- the genuinely mixed file: it holds both darc-managed <XyzPackageVersion> props AND the repo-owned version band (VersionMajor/Minor/SDKMinor, PreReleaseVersionLabel, PreReleaseVersionIteration). ResetToTargetPaths is path-level, not property-level, so you cannot flow the package versions while freezing the band. Today it is moot -- dnup and main are both 11.0.1 / preview.6 (identical). The only reason to keep resetting would be an independent dnup version band/cadence, which we do not want; if ever needed it should live in a dnup-specific override file, not rely on this reset.

- NuGet.config -- currently byte-identical between dnup and main (22 feeds, 0 diff). The template resets it because feed lists can be band-specific (a dotnet12 feed appears in main before a release branch wants it). Low-stakes for dnup; un-reset for consistency.

- CODEOWNERS -- the one deliberate entry. Prevents main's full area-ownership rules from overwriting dnup's minimal CODEOWNERS and spamming reviewers on every auto-merge PR. Rationale is dnup-specific and sound; keep resetting.

Coherence note: eng/Version.Details.xml + global.json + eng/Versions.props + eng/common/* are a single atomic unit and are un-reset together here. Un-resetting only some of them would desync the <Dependency> SHAs from the <PackageVersion> props, or run a new Arcade.Sdk against old eng/common scripts -- both worse than the status quo.