### PR TITLE
Fix case-sensitive path comparison in GlobalSettingsTemplatePackageProvider.EnsureInstallPrerequisites

### DIFF
--- a/src/TemplateEngine/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
@@ -260,7 +261,7 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             var packages = await GetAllTemplatePackagesAsync(cancellationToken).ConfigureAwait(false);
 
             //check if the package with same identifier is already installed
-            if (packages.OfType<IManagedTemplatePackage>().FirstOrDefault(s => s.Identifier == identifier && s.Installer == installer) is IManagedTemplatePackage packageToBeUpdated)
+            if (packages.OfType<IManagedTemplatePackage>().FirstOrDefault(s => string.Equals(s.Identifier, identifier, StringComparison.OrdinalIgnoreCase) && s.Installer == installer) is IManagedTemplatePackage packageToBeUpdated)
             {
                 //if same version is already installed - return
                 if (!forceUpdate && packageToBeUpdated.Version == version)

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;


### PR DESCRIPTION
﻿### Description

The `EnsureInstallPrerequisites` method in `GlobalSettingsTemplatePackageProvider` uses ordinal (case-sensitive) comparison (`s.Identifier == identifier`) to detect if a managed template package is already installed. On Windows, file paths can have different drive letter casing (e.g., `c:\path` vs `C:\path`), causing the check to miss existing packages.

### Repro

```sh
# First install with one casing
dotnet new install "c:\templates\my-template"

# Re-install with different casing + --force
dotnet new install "C:\templates\my-template" --force
```

The second command succeeds but doesn't remove the old entry (because `"c:\..." != "C:\..."` with ordinal comparison). Both packages survive, and the template cache reports overlapping identity conflicts:

> `The following templates use the same identity '...'`

### Fix

Changed `s.Identifier == identifier` to use `string.Equals(s.Identifier, identifier, StringComparison.OrdinalIgnoreCase)`.

This matches the behavior of `TemplatePackageCoordinator.ValidateInstallationRequestsAsync` and `TemplatePackageCoordinator.DetermineSourcesToUninstallAsync` which already use case-insensitive comparison.
