### PR TITLE
Update templating docs: dotnet/templating absorbed into dotnet/sdk

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,9 +45,3 @@ Instructions for GitHub Copilot and other AI coding agents working with the .NET
 ## Documentation
 
 - Do not manually edit files under documentation/manpages/sdk as these are generated based on documentation and should not be manually modified.
-
-## External Dependencies
-
-- Changes that require modifications to the dotnet/templating repository (Microsoft.TemplateEngine packages) should be made directly in that repository, not worked around in this repo.
-- The dotnet/templating repository owns the TemplateEngine.Edge, TemplateEngine.Abstractions, and related packages.
-- If a change requires updates to template engine behavior or formatting (e.g., DisplayName properties), file an issue in dotnet/templating and make the changes there rather than adding workarounds in this SDK repository.

--- a/documentation/TemplateEngine/api/Inside-the-Template-Engine.md
+++ b/documentation/TemplateEngine/api/Inside-the-Template-Engine.md
@@ -36,8 +36,7 @@ managing file system and logging. Host may also provide default parameter
 values for templates via `TryGetHostParamDefault` method.
 
 Applications using template engine are often called “hosts”.
-dotnet/templating repo is managing one of such hosts: dotnet new CLI, which is
-part of .NET SDK.
+The .NET SDK includes one such host: the dotnet new CLI.
 
 Main host properties:
 

--- a/documentation/TemplateEngine/authoring-tools/Localization.md
+++ b/documentation/TemplateEngine/authoring-tools/Localization.md
@@ -72,7 +72,7 @@ In addition to that, localization handover process should be changed as followin
 After the translation is done, the repo should receive the PR replacing original English values in generated JSON files with localized ones. It is important to ensure that files are handed over to original location (`.template.config\localize` folder).
 
 It is recommended to setup a way to update `Microsoft.TemplateEngine.Authoring.Tasks` package version, however it is not recommended to update it on each daily build. 
-The package is released with each build of dotnet/templating repo, even if there are no changes. Therefore, updating the version on each build might be superfluous. It is recommended to update the version when the next preview or stable version is released.
+The package is released with each build of the dotnet/sdk repo, even if there are no changes. Therefore, updating the version on each build might be superfluous. It is recommended to update the version when the next preview or stable version is released.
 
 ## 3rd party templates localization
 

--- a/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
+++ b/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
@@ -7,4 +7,4 @@ The package contains the templates useful for the template authoring:
 |`template.json` configuration file|`template.json`|A template for template.json configuration file for .NET template.|
 
 The package is available for download from nuget.org.
-Please feel to contribute or provide the feedback in discussions or via opening the issue in dotnet/templating repo.
+Please feel to contribute or provide the feedback in discussions or via opening the issue in the dotnet/sdk repo.

--- a/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
+++ b/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
@@ -7,4 +7,4 @@ The package contains the templates useful for the template authoring:
 |`template.json` configuration file|`template.json`|A template for template.json configuration file for .NET template.|
 
 The package is available for download from nuget.org.
-Please feel to contribute or provide the feedback in discussions or via opening the issue in the dotnet/sdk repo.
+Please feel free to contribute or provide feedback in discussions or by opening an issue in the dotnet/sdk repo.


### PR DESCRIPTION
## Why

The dotnet/templating repository has been absorbed into dotnet/sdk: the template engine library (`Microsoft.TemplateEngine.*`) lives in this repo. Several docs still instructed contributors to route templating changes and issues to the now-defunct external repo, which is misleading.

## What changed

- **`.github/copilot-instructions.md`**: Removed the `## External Dependencies` section that told agents to make templating changes in the external dotnet/templating repo and file issues there.
- **`template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md`**: Feedback/issue link now points to the dotnet/sdk repo.
- **`documentation/TemplateEngine/api/Inside-the-Template-Engine.md`**: Reworded the host description to "The .NET SDK includes one such host: the dotnet new CLI."
- **`documentation/TemplateEngine/authoring-tools/Localization.md`**: "each build of dotnet/templating repo" now reads "each build of the dotnet/sdk repo."

## Notes

Docs-only change. `documentation/TemplateEngine/README.md` already describes the merge correctly and was left untouched. Historical issue-tracker links of the form `https://github.com/dotnet/templating/issues/NNNN` were intentionally left as-is since they point to real archived issues.