### PR TITLE
Fix ObjectDisposedException in UnixProcessReaper during Ctrl+C shutdown

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -134,14 +134,14 @@ internal class ProcessReaper : IDisposable
         // which is raised on the AppDomain.ProcessExit thread when the CLI itself is
         // shutting down (for example when a SIGTERM handler calls Environment.Exit).
         //
-        // A plain monitor lock is used here rather than a Mutex on purpose. The prior
-        // Mutex based design disposed the mutex in Dispose while a concurrent
+        // A managed System.Threading.Lock is used here rather than a Mutex on purpose.
+        // The prior Mutex based design disposed the mutex in Dispose while a concurrent
         // ProcessExit callback could still call WaitOne on it, throwing
         // "Cannot access a disposed object" during shutdown (dotnet/sdk#55096). A
-        // monitor has no disposable wait handle to race on, and the _shuttingDown flag
-        // closes the window so a ProcessExit callback that starts after Dispose has run
-        // simply becomes a no-op.
-        private readonly object _shutdownLock = new();
+        // managed lock has no disposable wait handle to race on, and the _shuttingDown
+        // flag closes the window so a ProcessExit callback that starts after Dispose has
+        // run simply becomes a no-op.
+        private readonly Lock _shutdownLock = new();
         private bool _shuttingDown;
 
         public UnixProcessReaper(Process process) : base(process)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
-#if NET
+#if !TARGET_WINDOWS && NET
 using System.ComponentModel;
 #endif
 #if TARGET_WINDOWS
@@ -127,27 +127,25 @@ internal class ProcessReaper : IDisposable
     }
 #endif
 
-#if !TARGET_WINDOWS
+    // The Unix reaper is only relevant to a Unix runtime, which is always a modern .NET
+    // (NET) target. .NET Framework (net472) runs only on Windows and must not compile this
+    // code. TARGET_WINDOWS reflects the build's TargetOS, not the runtime, and is not
+    // defined when net472 is cross-compiled on a non-Windows build - hence "&& NET" here
+    // rather than relying on TARGET_WINDOWS alone.
+#if !TARGET_WINDOWS && NET
     private sealed class UnixProcessReaper : ProcessReaper
     {
         // Coordinates Dispose (typically the main thread) with HandleProcessExit,
         // which is raised on the AppDomain.ProcessExit thread when the CLI itself is
         // shutting down (for example when a SIGTERM handler calls Environment.Exit).
         //
-        // A managed lock is used here rather than a Mutex on purpose. The prior Mutex
-        // based design disposed the mutex in Dispose while a concurrent ProcessExit
+        // A System.Threading.Lock is used here rather than a Mutex on purpose. The prior
+        // Mutex based design disposed the mutex in Dispose while a concurrent ProcessExit
         // callback could still call WaitOne on it, throwing "Cannot access a disposed
         // object" during shutdown (dotnet/sdk#55096). A managed lock has no disposable
         // wait handle to race on, and the _shuttingDown flag closes the window so a
         // ProcessExit callback that starts after Dispose has run simply becomes a no-op.
-        //
-        // System.Threading.Lock is used on modern .NET; net472 (cross-compiled on
-        // non-Windows, where TARGET_WINDOWS is not defined) falls back to a plain object.
-#if NET9_0_OR_GREATER
         private readonly Lock _shutdownLock = new();
-#else
-        private readonly object _shutdownLock = new();
-#endif
         private bool _shuttingDown;
 
         public UnixProcessReaper(Process process) : base(process)
@@ -186,7 +184,6 @@ internal class ProcessReaper : IDisposable
 
                 try
                 {
-#if NET
                     // If the target is still running, forward SIGTERM so it can shut
                     // down as well. Signal returns false if the process already exited,
                     // and throws Win32Exception if the signal could not be delivered.
@@ -194,7 +191,7 @@ internal class ProcessReaper : IDisposable
                     {
                         _process.SafeHandle.Signal(PosixSignal.SIGTERM);
                     }
-#endif
+
                     // If SIGTERM was ignored by the target, then we'll still wait.
                     _process.WaitForExit();
 
@@ -205,13 +202,11 @@ internal class ProcessReaper : IDisposable
                     // The process hasn't started yet, or no exit code is available;
                     // nothing to signal or wait for.
                 }
-#if NET
                 catch (Win32Exception)
                 {
                     // The signal could not be delivered (for example, insufficient
                     // permissions). Don't wait on a process we couldn't signal.
                 }
-#endif
             }
         }
     }
@@ -221,9 +216,16 @@ internal class ProcessReaper : IDisposable
     public static ProcessReaper Create(Process process)
     {
 #if TARGET_WINDOWS
-            return new WindowsProcessReaper(process);
+        return new WindowsProcessReaper(process);
+#elif NET
+        return new UnixProcessReaper(process);
 #else
-            return new UnixProcessReaper(process);
+        // .NET Framework only runs on Windows, so the Unix reaper is never relevant and
+        // the CsWin32 based Windows reaper is only compiled for Windows TargetOS builds.
+        // This branch is reached only when the net472 target is cross-compiled on a
+        // non-Windows build (not a shipping configuration); fall back to the base reaper,
+        // which still suppresses Ctrl+C so the target process can handle it.
+        return new ProcessReaper(process);
 #endif
     }
 

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -134,14 +134,20 @@ internal class ProcessReaper : IDisposable
         // which is raised on the AppDomain.ProcessExit thread when the CLI itself is
         // shutting down (for example when a SIGTERM handler calls Environment.Exit).
         //
-        // A managed System.Threading.Lock is used here rather than a Mutex on purpose.
-        // The prior Mutex based design disposed the mutex in Dispose while a concurrent
-        // ProcessExit callback could still call WaitOne on it, throwing
-        // "Cannot access a disposed object" during shutdown (dotnet/sdk#55096). A
-        // managed lock has no disposable wait handle to race on, and the _shuttingDown
-        // flag closes the window so a ProcessExit callback that starts after Dispose has
-        // run simply becomes a no-op.
+        // A managed lock is used here rather than a Mutex on purpose. The prior Mutex
+        // based design disposed the mutex in Dispose while a concurrent ProcessExit
+        // callback could still call WaitOne on it, throwing "Cannot access a disposed
+        // object" during shutdown (dotnet/sdk#55096). A managed lock has no disposable
+        // wait handle to race on, and the _shuttingDown flag closes the window so a
+        // ProcessExit callback that starts after Dispose has run simply becomes a no-op.
+        //
+        // System.Threading.Lock is used on modern .NET; net472 (cross-compiled on
+        // non-Windows, where TARGET_WINDOWS is not defined) falls back to a plain object.
+#if NET9_0_OR_GREATER
         private readonly Lock _shutdownLock = new();
+#else
+        private readonly object _shutdownLock = new();
+#endif
         private bool _shuttingDown;
 
         public UnixProcessReaper(Process process) : base(process)

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
+#if NET
+using System.ComponentModel;
+#endif
 #if TARGET_WINDOWS
 using Windows.Win32.System.JobObjects;
 #endif
@@ -127,11 +130,22 @@ internal class ProcessReaper : IDisposable
 #if !TARGET_WINDOWS
     private sealed class UnixProcessReaper : ProcessReaper
     {
-        private readonly Mutex _shutdownMutex;
+        // Coordinates Dispose (typically the main thread) with HandleProcessExit,
+        // which is raised on the AppDomain.ProcessExit thread when the CLI itself is
+        // shutting down (for example when a SIGTERM handler calls Environment.Exit).
+        //
+        // A plain monitor lock is used here rather than a Mutex on purpose. The prior
+        // Mutex based design disposed the mutex in Dispose while a concurrent
+        // ProcessExit callback could still call WaitOne on it, throwing
+        // "Cannot access a disposed object" during shutdown (dotnet/sdk#55096). A
+        // monitor has no disposable wait handle to race on, and the _shuttingDown flag
+        // closes the window so a ProcessExit callback that starts after Dispose has run
+        // simply becomes a no-op.
+        private readonly object _shutdownLock = new();
+        private bool _shuttingDown;
 
         public UnixProcessReaper(Process process) : base(process)
         {
-            _shutdownMutex = new Mutex();
             AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
         }
 
@@ -139,45 +153,60 @@ internal class ProcessReaper : IDisposable
         {
             AppDomain.CurrentDomain.ProcessExit -= HandleProcessExit;
 
-            // If there's been a shutdown via the process exit handler,
-            // this will block the current thread so we don't race with the CLR shutdown
-            // from the signal handler.
-            _shutdownMutex.WaitOne();
-            _shutdownMutex.ReleaseMutex();
-            _shutdownMutex.Dispose();
+            // If a ProcessExit driven shutdown is already running on another thread,
+            // block here until it finishes so we don't race with the CLR shutdown from
+            // the signal handler. Setting _shuttingDown also makes any ProcessExit
+            // callback that starts after this point a no-op.
+            lock (_shutdownLock)
+            {
+                _shuttingDown = true;
+            }
 
             base.Dispose();
         }
 
         private void HandleProcessExit(object? sender, EventArgs args)
         {
-            int processId;
-            try
+            lock (_shutdownLock)
             {
-                processId = _process.Id;
-            }
-            catch (InvalidOperationException)
-            {
-                // The process hasn't started yet; nothing to signal
-                return;
-            }
+                if (_shuttingDown)
+                {
+                    // Dispose has already run (or is running on another thread); there
+                    // is nothing to do and the process state may already be torn down.
+                    return;
+                }
 
-            // Take ownership of the shutdown mutex; this will ensure that the other
-            // thread also waiting on the process to exit won't complete CLR shutdown before
-            // this one does.
-            _shutdownMutex?.WaitOne();
+                _shuttingDown = true;
 
+                try
+                {
 #if NET
-            if (!_process.WaitForExit(0) && _process.SafeHandle.Signal(PosixSignal.SIGTERM))
-            {
-                // Couldn't send the signal, don't wait
-                return;
-            }
+                    // If the target is still running, forward SIGTERM so it can shut
+                    // down as well. Signal returns false if the process already exited,
+                    // and throws Win32Exception if the signal could not be delivered.
+                    if (!_process.WaitForExit(0))
+                    {
+                        _process.SafeHandle.Signal(PosixSignal.SIGTERM);
+                    }
 #endif
-            // If SIGTERM was ignored by the target, then we'll still wait
-            _process.WaitForExit();
+                    // If SIGTERM was ignored by the target, then we'll still wait.
+                    _process.WaitForExit();
 
-            Environment.ExitCode = _process.ExitCode;
+                    Environment.ExitCode = _process.ExitCode;
+                }
+                catch (InvalidOperationException)
+                {
+                    // The process hasn't started yet, or no exit code is available;
+                    // nothing to signal or wait for.
+                }
+#if NET
+                catch (Win32Exception)
+                {
+                    // The signal could not be delivered (for example, insufficient
+                    // permissions). Don't wait on a process we couldn't signal.
+                }
+#endif
+            }
         }
     }
 #endif

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/ProcessReaperTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/ProcessReaperTests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    [TestClass]
+    public class ProcessReaperTests : SdkTest
+    {
+        // Regression test for https://github.com/dotnet/sdk/issues/55096.
+        //
+        // On Unix the reaper handles AppDomain.ProcessExit (raised when the CLI itself
+        // receives SIGTERM and calls Environment.Exit) to forward the signal to the child.
+        // That callback used to WaitOne on a Mutex that Dispose could dispose concurrently,
+        // throwing "Cannot access a disposed object" during shutdown. This verifies that a
+        // ProcessExit callback which runs after Dispose is a harmless no-op.
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+        public void ProcessExitCallbackAfterDisposeDoesNotThrow()
+        {
+            int savedExitCode = Environment.ExitCode;
+            try
+            {
+                using var process = CreateShortLivedProcess();
+
+                var reaper = ProcessReaper.Create(process);
+                process.Start();
+                reaper.NotifyProcessStarted();
+                process.WaitForExit();
+
+                var handleProcessExit = GetProcessExitCallback(reaper);
+
+                // Dispose first (this disposed the shutdown handle in the buggy version),
+                // then run the ProcessExit callback that raced with it.
+                reaper.Dispose();
+
+                // In the buggy version this threw ObjectDisposedException on the disposed
+                // Mutex's SafeWaitHandle. It must now be a no-op.
+                handleProcessExit(sender: null, e: EventArgs.Empty);
+            }
+            finally
+            {
+                Environment.ExitCode = savedExitCode;
+            }
+        }
+
+        // Stress the actual race: Dispose on one thread and the ProcessExit callback on
+        // another. After the fix this is race-free and must never throw.
+        [TestMethod]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+        public void ProcessExitCallbackRacingDisposeDoesNotThrow()
+        {
+            int savedExitCode = Environment.ExitCode;
+            try
+            {
+                for (int i = 0; i < 50; i++)
+                {
+                    using var process = CreateShortLivedProcess();
+
+                    var reaper = ProcessReaper.Create(process);
+                    process.Start();
+                    reaper.NotifyProcessStarted();
+                    process.WaitForExit();
+
+                    var handleProcessExit = GetProcessExitCallback(reaper);
+
+                    Exception callbackException = null;
+                    var callbackThread = new Thread(() =>
+                    {
+                        try
+                        {
+                            handleProcessExit(sender: null, e: EventArgs.Empty);
+                        }
+                        catch (Exception e)
+                        {
+                            callbackException = e;
+                        }
+                    });
+
+                    callbackThread.Start();
+                    reaper.Dispose();
+                    callbackThread.Join();
+
+                    callbackException.Should().BeNull(
+                        $"the ProcessExit callback must not throw when racing Dispose (iteration {i})");
+                }
+            }
+            finally
+            {
+                Environment.ExitCode = savedExitCode;
+            }
+        }
+
+        private static Process CreateShortLivedProcess()
+        {
+            // Unix-only test (Windows is excluded), so /bin/sh is available. Exit
+            // immediately so WaitForExit inside the callback returns promptly.
+            var startInfo = new ProcessStartInfo("/bin/sh")
+            {
+                UseShellExecute = false,
+            };
+
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add("exit 0");
+
+            return new Process { StartInfo = startInfo };
+        }
+
+        private static EventHandler GetProcessExitCallback(ProcessReaper reaper)
+        {
+            // HandleProcessExit is a private instance method on the internal
+            // UnixProcessReaper. It matches the EventHandler signature, so bind it as a
+            // delegate to invoke it directly (exceptions surface without wrapping).
+            MethodInfo method = reaper.GetType().GetMethod(
+                "HandleProcessExit",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            method.Should().NotBeNull("UnixProcessReaper.HandleProcessExit should exist on Unix");
+
+            return (EventHandler)Delegate.CreateDelegate(typeof(EventHandler), reaper, method);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #55096.

## Problem

On Linux/macOS, pressing Ctrl+C under `dotnet watch` intermittently crashed the child `dotnet run` process with an unhandled exception (exit 134):

```text
Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.Win32.SafeHandles.SafeWaitHandle'.
   at System.Threading.WaitHandle.WaitOneNoCheck(...)
   at Microsoft.DotNet.Cli.Utils.ProcessReaper.UnixProcessReaper.HandleProcessExit(...)
   at System.AppContext.OnProcessExit(...)
```

This is a regression in Preview 6 (works in Preview 5), introduced by the `UnixProcessReaper` rewrite in commit `f8c229052f` ("Modernize Util Windows interop, enable Native AOT, refactor code").

## Root cause

`dotnet watch` sends SIGTERM to `dotnet run` on Ctrl+C. The CLI's SIGTERM handler calls `Environment.Exit`, which raises `AppDomain.ProcessExit` -> `HandleProcessExit` on one thread, while the main thread disposes the `ProcessReaper` as the child exits. Two bugs resulted:

1. **The crash:** `HandleProcessExit` called `Mutex.WaitOne()` on a `Mutex` that `Dispose()` could dispose concurrently. The mutex-ownership design has an inherent TOCTOU hole with no guard flag, so `WaitOne()` hit a disposed `SafeWaitHandle` and threw — unhandled, inside the ProcessExit callback, which aborts the process.

2. **Inverted signal logic:** `kill(pid, SIGTERM) != 0` (nonzero = *failure*) was replaced with `SafeProcessHandle.Signal(SIGTERM)` (true = *success*). The "couldn't send the signal, don't wait" early-return then fired on **success**, so the reaper stopped waiting for the child and stopped propagating its exit code.

## Fix

- Replace the thread-affine `Mutex` with a monitor `lock` plus a `_shuttingDown` guard flag. A monitor has no disposable wait handle to race on, and the flag makes a ProcessExit callback that starts after `Dispose()` a no-op — closing the race while preserving the original intent (Dispose waits for an in-flight ProcessExit to finish propagating the exit code).
- Make `HandleProcessExit` never throw out of the ProcessExit callback: forward SIGTERM only while the child is running, handle `Win32Exception`/`InvalidOperationException`, then wait and propagate the exit code — restoring Preview 5 behavior.

## Tests

Added `ProcessReaperTests` (Unix-only, since `UnixProcessReaper` is compiled only when `!TARGET_WINDOWS`):

- `ProcessExitCallbackAfterDisposeDoesNotThrow` — deterministically reproduces the crash ordering (Dispose, then the ProcessExit callback). Throws `ObjectDisposedException` against the buggy code; a no-op after the fix.
- `ProcessExitCallbackRacingDisposeDoesNotThrow` — stresses the Dispose vs ProcessExit race across many iterations.

## Validation

- Unix path cross-compiled clean (`TargetOS=linux`, `net11.0`); Windows build clean (`net11.0` + `net472`); tests build and are discovered. The Unix-only tests were validated by cross-compilation and reasoning (the dev box is Windows); they run on CI.

## Behavior change

On Unix Ctrl+C/SIGTERM, `dotnet run` again forwards SIGTERM to the child, waits for it, and propagates its exit code — restoring Preview 5 behavior that the inverted logic had removed.
