### PR TITLE
Shave 200+ms off cost to `POST` telemetry using proper connection str

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryClient.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryClient.cs
@@ -29,7 +29,7 @@ public class TelemetryClient : ITelemetryClient
     private static readonly List<Activity> s_activities = [];
 
 #if MICROSOFT_ENABLE_TELEMETRY_AZURE_MONITOR
-    private static readonly string s_connectionString = "InstrumentationKey=74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+    private static readonly string s_connectionString = "InstrumentationKey=74cc1c9e-3e6e-4d05-b3fc-dde9101d0254;IngestionEndpoint=https://southcentralus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://southcentralus.livediagnostics.monitor.azure.com/;ApplicationId=c5108c2c-b0c5-43c6-a703-424eae223a75";
     private static readonly string s_defaultStorageDirectory = Path.Combine(CliFolderPathCalculator.DotnetUserProfileFolderPath, "TelemetryStorageService");
     // Note: The TelemetryClient instance constructor takes in an environment provider. These fields don't use that currently.
     private static readonly string? s_environmentStoragePath = Env.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_STORAGE_PATH);


### PR DESCRIPTION
Shave 200+ms off cost to `POST` telemetry using proper connection string over ikey

We should not use instrumentation keys, we should use connection strings. 

If you want more motivation and context see https://github.com/dotnet/sdk/pull/55126.

Testing with SDK ('unlimited' timeout):
full connString exits ~250-300ms
ikey connString exits ~535-557ms