### PR TITLE
Vendor `dotnet test` shared source instead of consuming the Internal.DotnetTest package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -497,12 +497,6 @@ dotnet_diagnostic.SA1204.severity = none
 [artifacts/**.cs]
 dotnet_diagnostic.IDE0073.severity = none
 
-# Source brought in via NuGet contentFiles (e.g. Microsoft.Testing.Platform.Internal.DotnetTest) is
-# restored under the repo-local packages folder and compiled into the consuming assembly. We do not own
-# that source, so the file-header rule must not be enforced on it.
-[.packages/**.cs]
-dotnet_diagnostic.IDE0073.severity = none
-
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/.github/scripts/check_vendored_files.py
+++ b/.github/scripts/check_vendored_files.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""
+Detect drift between locally-vendored source files and their upstream sources.
+
+Reads eng/vendored-files.json and, for each tracked file, compares the recorded
+baseline blob SHA against the current blob SHA on the tracked branch via the
+GitHub Contents API. When drift is detected, opens (or updates) a tracking
+issue containing a unified diff of the upstream changes.
+
+Modes:
+    validate    - Structural validation only. No network calls. Safe for PRs.
+    check       - Full drift detection. Requires GH_TOKEN. Creates/edits issues.
+
+The check mode is idempotent: existing issues are matched by label
+`area-vendored-sync` plus a hidden HTML marker in the body of the form
+`<!-- vendored-sync:id=<entry-id>:<source-index> -->`.
+
+See eng/vendored-files.md for the manifest schema and reconciliation workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "eng" / "vendored-files.json"
+ISSUE_LABEL = "area-vendored-sync"
+ISSUE_REPO = os.environ.get("VENDORED_SYNC_REPO", "dotnet/sdk")
+MAX_DIFF_LINES = 300
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+API_BASE = "https://api.github.com"
+RAW_BASE = "https://raw.githubusercontent.com"
+
+
+@dataclass
+class Source:
+    repo: str
+    ref: str
+    path: str
+    baseline_ref_sha: str
+    baseline_blob_sha: str
+    scope: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Source":
+        return cls(
+            repo=d["repo"],
+            ref=d["ref"],
+            path=d["path"],
+            baseline_ref_sha=d["baseline_ref_sha"],
+            baseline_blob_sha=d["baseline_blob_sha"],
+            scope=d.get("scope", ""),
+        )
+
+
+@dataclass
+class Entry:
+    id: str
+    local_path: str
+    notes: str
+    sources: list[Source]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Entry":
+        return cls(
+            id=d["id"],
+            local_path=d["local_path"],
+            notes=d.get("notes", ""),
+            sources=[Source.from_dict(s) for s in d["sources"]],
+        )
+
+
+def load_manifest() -> list[Entry]:
+    with MANIFEST_PATH.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return [Entry.from_dict(e) for e in data["entries"]]
+
+
+# ---------- validation ----------
+
+def validate(entries: list[Entry]) -> int:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for entry in entries:
+        if not entry.id:
+            errors.append("Entry missing id.")
+            continue
+        if entry.id in seen_ids:
+            errors.append(f"Duplicate entry id: {entry.id}")
+        seen_ids.add(entry.id)
+
+        local = REPO_ROOT / entry.local_path
+        if not local.is_file():
+            errors.append(f"{entry.id}: local_path does not exist: {entry.local_path}")
+
+        if not entry.sources:
+            errors.append(f"{entry.id}: must declare at least one source.")
+
+        for index, source in enumerate(entry.sources):
+            tag = f"{entry.id}#sources[{index}]"
+            if not re.match(r"^[\w.-]+/[\w.-]+$", source.repo):
+                errors.append(f"{tag}: invalid repo '{source.repo}' (expected owner/name).")
+            if not source.ref:
+                errors.append(f"{tag}: missing ref.")
+            if not source.path or source.path.startswith("/"):
+                errors.append(f"{tag}: invalid path '{source.path}'.")
+            if not SHA_RE.match(source.baseline_ref_sha):
+                errors.append(f"{tag}: baseline_ref_sha must be a 40-char hex SHA.")
+            if not SHA_RE.match(source.baseline_blob_sha):
+                errors.append(f"{tag}: baseline_blob_sha must be a 40-char hex SHA.")
+
+    if errors:
+        print("Manifest validation FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    total_sources = sum(len(entry.sources) for entry in entries)
+    print(f"Manifest OK: {len(entries)} entries, {total_sources} sources.")
+    return 0
+
+
+# ---------- HTTP helpers ----------
+
+def _request(url: str, accept: str = "application/vnd.github+json") -> tuple[int, bytes, dict[str, str]]:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    req = urllib.request.Request(url)
+    req.add_header("Accept", accept)
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "dotnet-sdk-vendored-sync")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read(), dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), dict(e.headers or {})
+
+
+def api_json(path: str) -> tuple[int, Any]:
+    url = f"{API_BASE}{path}"
+    status, body, _ = _request(url)
+    if not body:
+        return status, None
+    try:
+        return status, json.loads(body)
+    except json.JSONDecodeError:
+        return status, None
+
+
+def fetch_blob_content(repo: str, blob_sha: str) -> str | None:
+    status, data = api_json(f"/repos/{repo}/git/blobs/{blob_sha}")
+    if status != 200 or not isinstance(data, dict):
+        return None
+    if data.get("encoding") != "base64":
+        return None
+    try:
+        return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
+    except (KeyError, ValueError):
+        return None
+
+
+def fetch_raw(repo: str, ref: str, path: str) -> str | None:
+    url = f"{RAW_BASE}/{repo}/{ref}/{urllib.parse.quote(path)}"
+    status, body, _ = _request(url, accept="text/plain")
+    if status != 200:
+        return None
+    return body.decode("utf-8", errors="replace")
+
+
+# ---------- drift detection ----------
+
+@dataclass
+class DriftResult:
+    entry: Entry
+    source_index: int
+    source: Source
+    status: str            # "drift", "missing", "ref_missing", "ok", "error"
+    current_blob_sha: str | None
+    current_ref_sha: str | None
+    detail: str
+    diff_text: str
+
+
+def _resolve_ref_sha(repo: str, ref: str) -> str | None:
+    status, data = api_json(f"/repos/{repo}/commits/{urllib.parse.quote(ref, safe='/')}")
+    if status == 200 and isinstance(data, dict):
+        return data.get("sha")
+    return None
+
+
+def _get_blob_sha(repo: str, ref: str, path: str) -> tuple[int, str | None]:
+    status, data = api_json(
+        f"/repos/{repo}/contents/{urllib.parse.quote(path)}?ref={urllib.parse.quote(ref, safe='/')}"
+    )
+    if status == 200 and isinstance(data, dict) and data.get("type") == "file":
+        return status, data.get("sha")
+    return status, None
+
+
+def _truncate_diff(diff_lines: list[str], max_lines: int) -> str:
+    if len(diff_lines) <= max_lines:
+        return "".join(diff_lines)
+    head = "".join(diff_lines[:max_lines])
+    return f"{head}\n... (diff truncated; {len(diff_lines) - max_lines} more lines)"
+
+
+def check_source(entry: Entry, source_index: int, source: Source) -> DriftResult:
+    status, current_blob_sha = _get_blob_sha(source.repo, source.ref, source.path)
+
+    if status == 404:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="missing", current_blob_sha=None, current_ref_sha=None,
+            detail=(
+                f"Upstream path `{source.path}` no longer exists on "
+                f"`{source.repo}@{source.ref}`. The file may have been renamed, "
+                f"deleted, or the tracked ref was renamed."
+            ),
+            diff_text="",
+        )
+
+    if current_blob_sha is None:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="error", current_blob_sha=None, current_ref_sha=None,
+            detail=f"Unexpected response from contents API (HTTP {status}).",
+            diff_text="",
+        )
+
+    if current_blob_sha == source.baseline_blob_sha:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="ok", current_blob_sha=current_blob_sha, current_ref_sha=None,
+            detail="", diff_text="",
+        )
+
+    current_ref_sha = _resolve_ref_sha(source.repo, source.ref)
+    baseline_content = fetch_blob_content(source.repo, source.baseline_blob_sha)
+    current_content = fetch_raw(source.repo, source.ref, source.path)
+
+    if baseline_content is None or current_content is None:
+        diff_text = "(unable to fetch one or both file revisions for diff)"
+    else:
+        diff_iter = difflib.unified_diff(
+            baseline_content.splitlines(keepends=True),
+            current_content.splitlines(keepends=True),
+            fromfile=f"{source.path}@{source.baseline_blob_sha[:7]}",
+            tofile=f"{source.path}@{(current_blob_sha or 'HEAD')[:7]}",
+            lineterm="\n",
+        )
+        diff_text = _truncate_diff(list(diff_iter), MAX_DIFF_LINES)
+
+    return DriftResult(
+        entry=entry, source_index=source_index, source=source,
+        status="drift", current_blob_sha=current_blob_sha, current_ref_sha=current_ref_sha,
+        detail="Upstream blob SHA changed since the recorded baseline.",
+        diff_text=diff_text,
+    )
+
+
+# ---------- issue rendering / updating ----------
+
+def _marker(entry_id: str, source_index: int) -> str:
+    return f"<!-- vendored-sync:id={entry_id}:{source_index} -->"
+
+
+def _render_issue_body(result: DriftResult) -> str:
+    entry = result.entry
+    source = result.source
+    marker = _marker(entry.id, result.source_index)
+    cur_ref = result.current_ref_sha or source.ref
+    base_ref = source.baseline_ref_sha
+    repo = source.repo
+
+    lines = [
+        marker,
+        "",
+        f"Automated drift report for vendored file **`{entry.local_path}`**.",
+        "",
+        "## Source",
+        f"- Upstream repo: [`{repo}`](https://github.com/{repo})",
+        f"- Upstream path: [`{source.path}`](https://github.com/{repo}/blob/{cur_ref}/{source.path})",
+        f"- Tracked ref: `{source.ref}`",
+        f"- Scope: {source.scope or '_unspecified_'}",
+        "",
+        "## Drift",
+    ]
+
+    if result.status == "drift":
+        lines += [
+            f"- Baseline blob SHA: `{source.baseline_blob_sha}`",
+            f"- Current  blob SHA: `{result.current_blob_sha}`",
+            f"- Baseline ref SHA : `{base_ref}`",
+            f"- Current  ref SHA : `{result.current_ref_sha or '(unknown)'}`",
+            "",
+            "### Links",
+            f"- [File history]({_history_url(repo, source.ref, source.path)})",
+            f"- [Baseline blob]({_blob_url(repo, base_ref, source.path)})",
+            f"- [Current blob]({_blob_url(repo, cur_ref, source.path)})",
+        ]
+        if result.current_ref_sha:
+            lines.append(f"- [Upstream ref compare]({_compare_url(repo, base_ref, result.current_ref_sha)}) (whole-repo diff, may be noisy)")
+        lines += [
+            "",
+            "### Upstream-only diff",
+            "```diff",
+            result.diff_text.rstrip(),
+            "```",
+        ]
+    else:
+        lines += [
+            f"- Status: **{result.status}**",
+            f"- Detail: {result.detail}",
+        ]
+
+    if entry.notes:
+        lines += ["", "## Local adaptation notes", entry.notes]
+
+    lines += [
+        "",
+        "## How to reconcile",
+        "1. Review the upstream changes and decide whether they should be ported.",
+        f"2. Port the relevant changes to `{entry.local_path}`.",
+        f"3. Update `eng/vendored-files.json` entry `{entry.id}` (source index {result.source_index}):",
+        "   - bump `baseline_ref_sha` to the new upstream ref SHA,",
+        "   - bump `baseline_blob_sha` to the new upstream blob SHA.",
+        "4. Close this issue once the reconciliation PR is merged.",
+        "",
+        "If no port is needed (e.g. whitespace-only upstream change), still bump the baseline SHAs to silence future runs.",
+    ]
+
+    return "\n".join(lines)
+
+
+def _history_url(repo: str, ref: str, path: str) -> str:
+    return f"https://github.com/{repo}/commits/{ref}/{path}"
+
+
+def _blob_url(repo: str, ref: str, path: str) -> str:
+    return f"https://github.com/{repo}/blob/{ref}/{path}"
+
+
+def _compare_url(repo: str, old_sha: str, new_sha: str) -> str:
+    return f"https://github.com/{repo}/compare/{old_sha}...{new_sha}"
+
+
+def _gh(args: list[str], input_data: str | None = None) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["gh", *args], input=input_data, capture_output=True, text=True, check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+_issue_cache: list[dict[str, Any]] | None = None
+
+
+def _list_open_sync_issues() -> list[dict[str, Any]]:
+    """List all open issues with the sync label once and cache the result.
+
+    Issue search with HTML-comment markers is unreliable, so we fetch the full
+    label-filtered set (capped at 200, which is far more than we expect) and
+    filter in Python by exact marker match.
+    """
+    global _issue_cache
+    if _issue_cache is not None:
+        return _issue_cache
+    rc, out, err = _gh([
+        "issue", "list",
+        "--repo", ISSUE_REPO,
+        "--label", ISSUE_LABEL,
+        "--state", "open",
+        "--limit", "200",
+        "--json", "number,title,body",
+    ])
+    if rc != 0:
+        print(f"gh issue list failed: {err}", file=sys.stderr)
+        _issue_cache = []
+        return _issue_cache
+    try:
+        _issue_cache = json.loads(out)
+    except json.JSONDecodeError:
+        _issue_cache = []
+    return _issue_cache
+
+
+def find_existing_issue(marker: str) -> dict[str, Any] | None:
+    for item in _list_open_sync_issues():
+        if marker in (item.get("body") or ""):
+            return item
+    return None
+
+
+def ensure_label() -> None:
+    """Ensure the sync label exists. `gh label create --force` is idempotent."""
+    _gh([
+        "label", "create", ISSUE_LABEL,
+        "--repo", ISSUE_REPO,
+        "--description", "Drift detected between a vendored source file and its upstream copy",
+        "--color", "fbca04",
+        "--force",
+    ])
+
+
+_STATUS_TITLES = {
+    "drift": "drift detected",
+    "missing": "upstream path missing",
+    "error": "drift check error",
+}
+
+
+def upsert_issue(result: DriftResult, dry_run: bool) -> None:
+    marker = _marker(result.entry.id, result.source_index)
+    body = _render_issue_body(result)
+    status_text = _STATUS_TITLES.get(result.status, result.status)
+    title = f"[vendored-sync] {result.entry.id}: {status_text} (#{result.source_index})"
+
+    if dry_run:
+        print(f"\n--- would create/update issue ({result.entry.id}#{result.source_index}) ---")
+        print(f"title: {title}")
+        print(body[:2000])
+        print("---")
+        return
+
+    existing = find_existing_issue(marker)
+    if existing is None:
+        rc, out, err = _gh([
+            "issue", "create",
+            "--repo", ISSUE_REPO,
+            "--title", title,
+            "--label", ISSUE_LABEL,
+            "--body-file", "-",
+        ], input_data=body)
+        if rc != 0:
+            print(f"Failed to create issue for {result.entry.id}: {err}", file=sys.stderr)
+        else:
+            print(f"Created issue for {result.entry.id}#{result.source_index}: {out.strip()}")
+        return
+
+    if (existing.get("body") or "").strip() == body.strip():
+        print(f"Issue #{existing['number']} already up to date for {result.entry.id}#{result.source_index}.")
+        return
+
+    rc, _, err = _gh([
+        "issue", "edit", str(existing["number"]),
+        "--repo", ISSUE_REPO,
+        "--body-file", "-",
+    ], input_data=body)
+    if rc != 0:
+        print(f"Failed to update issue #{existing['number']}: {err}", file=sys.stderr)
+    else:
+        print(f"Updated issue #{existing['number']} for {result.entry.id}#{result.source_index}.")
+
+
+# ---------- entry points ----------
+
+def cmd_validate(_args: argparse.Namespace) -> int:
+    return validate(load_manifest())
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    if not (os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")):
+        print("GH_TOKEN or GITHUB_TOKEN must be set for `check` mode.", file=sys.stderr)
+        return 2
+
+    entries = load_manifest()
+    if validate(entries) != 0:
+        return 1
+
+    if not args.dry_run:
+        ensure_label()
+
+    drift_count = 0
+    error_count = 0
+    for entry in entries:
+        for index, source in enumerate(entry.sources):
+            result = check_source(entry, index, source)
+            short_id = f"{entry.id}#{index}"
+            if result.status == "ok":
+                print(f"[ok]      {short_id} ({source.repo}:{source.path})")
+                continue
+            if result.status == "error":
+                error_count += 1
+                print(f"[ERROR]   {short_id}: {result.detail}", file=sys.stderr)
+                continue
+            drift_count += 1
+            print(f"[{result.status:<7}] {short_id}: {result.detail}")
+            upsert_issue(result, args.dry_run)
+
+    print(f"\nSummary: {drift_count} drifted, {error_count} errors.")
+    return 1 if error_count else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_validate = sub.add_parser("validate", help="Validate manifest structure (no network).")
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_check = sub.add_parser("check", help="Run drift detection against upstream repos.")
+    p_check.add_argument("--dry-run", action="store_true", help="Skip creating/updating issues; print what would happen.")
+    p_check.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-vendored-files.yml
+++ b/.github/workflows/check-vendored-files.yml
@@ -1,0 +1,67 @@
+name: Check vendored source files
+
+# Detects drift between source files copied into this repo and their upstream
+# sources, as listed in eng/vendored-files.json. See eng/vendored-files.md.
+#
+# - Scheduled runs and manual dispatch perform full drift detection and open
+#   (or update) tracking issues labelled `area-vendored-sync`.
+# - Pull-request runs that touch the manifest, script, or workflow validate the
+#   manifest structure only (no network, no issue mutation).
+
+on:
+  schedule:
+    # Weekly, Monday 08:00 UTC.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print drift results without creating or updating issues.'
+        required: false
+        default: 'false'
+  pull_request:
+    paths:
+      - 'eng/vendored-files.json'
+      - 'eng/vendored-files.md'
+      - '.github/scripts/check_vendored_files.py'
+      - '.github/workflows/check-vendored-files.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vendored-files-check
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate vendored-files.json
+        run: python .github/scripts/check_vendored_files.py validate
+
+  check:
+    name: Check upstream drift
+    needs: validate
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check vendored files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VENDORED_SYNC_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python .github/scripts/check_vendored_files.py check --dry-run
+          else
+            python .github/scripts/check_vendored_files.py check
+          fi

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,13 +84,6 @@
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
-    <!--
-      Internal, preview, source-only package from microsoft/testfx that ships the 'dotnet test' <->
-      Microsoft.Testing.Platform wire contract and terminal reporter as compiled source (single source of
-      truth, instead of the hand-copied files under src/Cli/dotnet/Commands/Test/MTP/). Version is darc-tracked
-      via eng/Version.Details.xml -> $(MicrosoftTestingPlatformInternalDotnetTestVersion) and moves with the
-      other microsoft/testfx dependencies. -->
-    <PackageVersion Include="Microsoft.Testing.Platform.Internal.DotnetTest" Version="$(MicrosoftTestingPlatformInternalDotnetTestVersion)" />
     <!-- VSTestBridge requests an older TestPlatform.ObjectModel. Test projects build into the test SDK
          layout, so that older copy would overwrite the in-box vstest assemblies from TestPlatform.CLI and
          break 'dotnet test'. Pin it to the in-box vstest version to keep them in sync. -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -138,8 +138,8 @@ This file should be imported by eng/Versions.props
     <SystemTextJsonPackageVersion>11.0.0-preview.6.26311.113</SystemTextJsonPackageVersion>
     <SystemWindowsExtensionsPackageVersion>11.0.0-preview.6.26311.113</SystemWindowsExtensionsPackageVersion>
     <!-- microsoft-testfx dependencies -->
-    <MicrosoftTestingPlatformPackageVersion>2.3.0-preview.26330.8</MicrosoftTestingPlatformPackageVersion>
-    <MSTestPackageVersion>4.3.0-preview.26330.8</MSTestPackageVersion>
+    <MicrosoftTestingPlatformPackageVersion>2.3.0-preview.26326.13</MicrosoftTestingPlatformPackageVersion>
+    <MSTestPackageVersion>4.3.0-preview.26326.13</MSTestPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -545,17 +545,13 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>50e862b8da0c82ddbf3952cfe61a8681ab93f5bc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26330.8">
+    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26326.13">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>3090fe6407891d9303da20f718dc5aef1b890fe3</Sha>
+      <Sha>f828682ecb633d5991843029ae571903f91b17ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Platform.Internal.DotnetTest" Version="2.3.0-preview.26330.8">
+    <Dependency Name="MSTest" Version="4.3.0-preview.26326.13">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>3090fe6407891d9303da20f718dc5aef1b890fe3</Sha>
-    </Dependency>
-    <Dependency Name="MSTest" Version="4.3.0-preview.26330.8">
-      <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>3090fe6407891d9303da20f718dc5aef1b890fe3</Sha>
+      <Sha>f828682ecb633d5991843029ae571903f91b17ab</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-preview.6.26311.113">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,10 +47,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Production dependencies">
     <MicrosoftCssParserVersion>1.0.0-20230414.1</MicrosoftCssParserVersion>
-    <!-- Internal, source-only package from microsoft/testfx. Darc keeps this in sync with the matching
-         dependency in eng/Version.Details.xml and moves it together (same coherent testfx build) with the
-         Microsoft.Testing.Platform / MSTest dependencies. -->
-    <MicrosoftTestingPlatformInternalDotnetTestVersion>2.3.0-preview.26330.8</MicrosoftTestingPlatformInternalDotnetTestVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</NETStandardLibraryNETFrameworkVersion>
     <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <NewtonsoftJsonPackageVersion>13.0.4</NewtonsoftJsonPackageVersion>

--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -1,0 +1,519 @@
+{
+  "$comment": "Manifest of source files copied (vendored) from other repositories into dotnet/sdk. See eng/vendored-files.md. These files are the 'dotnet test' <-> Microsoft.Testing.Platform shared source (wire contract + terminal reporter); the source of truth is microsoft/testfx, which enumerates the same set via DotnetTestProtocolContract.props and TerminalReporterContract.props.",
+  "entries": [
+    {
+      "id": "dotnet-test-wire-contract-fieldids",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs",
+      "notes": "Named-pipe wire contract (serializer/field ids) for the 'dotnet test' <-> Microsoft.Testing.Platform protocol. MUST stay byte-aligned with testfx: ids are the on-wire identity and cannot change without a coordinated protocol break. testfx is the source of truth (its copy is packed by DotnetTestProtocolContract.props).",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "631a17e14d3222969c638302c318fb5dd3894ee3",
+          "scope": "entire file; ids must match exactly"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-wire-contract-constants",
+      "local_path": "src/Cli/dotnet/Commands/Test/CliConstants.cs",
+      "notes": "Handshake/session/state string constants for the 'dotnet test' named-pipe protocol. Upstream lives in testfx IPC/Constants.cs; the SDK inlines the same constants into CliConstants.cs (TestStates, SessionEventTypes, HandshakeMessagePropertyNames, HandshakeMessageExecutionModes, ProtocolConstants). Watch the upstream file for added/changed wire constants.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "145ed7b998f5a7dcc1d2388e650d2379227e7df3",
+          "scope": "wire constants (TestStates, SessionEventTypes, HandshakeMessage*, ProtocolConstants)"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-reporter",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs",
+      "notes": "The Microsoft.Testing.Platform terminal UI reporter, hard-forked into 'dotnet test'. testfx has since split TerminalTestReporter into partial files; the SDK keeps a single TerminalTestReporter.cs. Each upstream partial is tracked so any upstream reporter change pings the SDK to reconcile. This is a hard fork: local content intentionally diverges; the signal is 'upstream changed', not 'files differ'.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "992ddffeb9e28fe1526da63444f45dbb319e3871",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.ErroredAssemblies.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "9e805c0271f30b6ddf1c729dd286aab5956b52f4",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Formatting.ControlCharacters.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "76205cf8f8d0dc5fe48f49e060fe80c76631e910",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Formatting.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "e635002a2b75195d01327aad9508a023df0492fd",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "af07e4b686833a1b6fd09135db9fb0820bf97318",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "9e356aaa82691ef0b2143a92f13d114747fcd947",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "5807f3f16ce9304c1b0348b745e06bb7ac6c3839",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "b03abc643e27c9c5b956b3aef96c32f469b18300",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "7824a5b256401a784ccfb64b79a0512aba42f16d",
+          "scope": "reporter partial"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-ansicodes",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiCodes.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiCodes.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "634cbfae5834af1d5e181a9605c17e061aa104c1",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-ansidetector",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiDetector.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "07e0ea43228e1ac9314ecf679281e5714bef76ca",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-ansiterminal",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminal.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "9f8920d5af4a6c33fbbaf2d4d4902ecd3d0429dc",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-ansiterminaltestprogressframe",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "6a7b784d6b1eae9de031b57de801114548efc976",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-exceptionflattener",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/ExceptionFlattener.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ExceptionFlattener.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "72938eee7845c8b150e3a7925ab7eb4db9b67e5c",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-fileutilities",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/FileUtilities.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "f1084a2ff09382bd26479de00731b89824736f3a",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-humanreadabledurationformatter",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/HumanReadableDurationFormatter.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "8892f577d8d4fe399d79fedaa141108031e4550a",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-iterminal",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/ITerminal.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ITerminal.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "75c07201db35a17fe286df1175efa87342f0ecdf",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-nativemethods",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/NativeMethods.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NativeMethods.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "121d1cca743710bf2ffe5a1a8a9433526e691005",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-nonansiterminal",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/NonAnsiTerminal.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "db8dfa4f6ff2bd84e810a3a67ae50ce81d930ddb",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-simpleansiterminal",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleAnsiTerminal.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleAnsiTerminal.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "90f530c1b949b5c7f8cc5e629b37e5a8bdcc176e",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-simpleterminalbase",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleTerminalBase.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "d4d63f11a20f72f676a1378376fea41a9d1aa536",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-terminalcolor",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalColor.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalColor.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "ef36dc706786b8081dca5e088a2deba1463fcb83",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-terminaltestreporteroptions",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterOptions.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "a496e9600ded4666e298caa27bf6138914a09e87",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testdetailstate",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestDetailState.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestDetailState.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "82564a8d1ae6337d144d7b5b27fe65baa5792303",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testnoderesultsstate",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "b56f233d182ca8b09d798a0d33a25790385440b2",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testoutcome",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestOutcome.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestOutcome.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "4bdf16f8259b2b6c8725867719077f5b625146fe",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testprogressstate",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "ec860abdf7a1ae5d242101334f26c23809601e50",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testprogressstateawareterminal",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressStateAwareTerminal.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "15498557b4e8be651940f93384507c7790379c62",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-testrunartifact",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TestRunArtifact.cs",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestRunArtifact.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "62538d2cad82a449e3043e636e69c25eb64352ca",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-icolor",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/IColor.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/OutputDevice/IColor.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/IColor.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "bfd6173af166f6626846276bb90caeade2a8ac45",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-systemconsolecolor",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsoleColor.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/OutputDevice/SystemConsoleColor.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/SystemConsoleColor.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "e59363aa915e2c11b0c6936143ef8bd4198be467",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-targetframeworkparser",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TargetFrameworkParser.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "cf30ee8ed5cd18cb7fdb29fdc1d5bbc23a6b3094",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-iconsole",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/IConsole.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "93a608d60be5697e956bb40225a8914e6232757d",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-istopwatch",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/IStopwatch.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/Helpers/System/IStopwatch.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/Helpers/System/IStopwatch.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "e85a0a5bd6272a6278503d61e4fbf3a161c05aac",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-systemconsole",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsole.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "93a13204eb4b3f10879fd383a8f2679f57d4b5af",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "dotnet-test-terminal-systemstopwatch",
+      "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemStopwatch.cs",
+      "notes": "Terminal reporter platform abstraction hard-forked from testfx (src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemStopwatch.cs). In the SDK it lives under the flat Terminal/ folder; upstream it lives outside the Terminal folder.",
+      "sources": [
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemStopwatch.cs",
+          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
+          "baseline_blob_sha": "7ce0c0b08a798fdb926c45c09c38c30e4a0e1d8c",
+          "scope": "entire file"
+        }
+      ]
+    }
+  ]
+}

--- a/eng/vendored-files.md
+++ b/eng/vendored-files.md
@@ -1,0 +1,143 @@
+# Vendored source files
+
+A small set of source files in this repo are copied (vendored) from other
+repositories rather than consumed as a NuGet package. Today the tracked set is
+the **`dotnet test` ↔ [Microsoft.Testing.Platform](https://github.com/microsoft/testfx)
+shared source**: the named-pipe wire contract and the terminal reporter that the
+`dotnet test` command hard-forks from
+[`microsoft/testfx`](https://github.com/microsoft/testfx).
+
+We deliberately **copy** these files instead of referencing a source-only NuGet
+(`Microsoft.Testing.Platform.Internal.DotnetTest`) because a source-only package
+does not flow cleanly through source-build / the VMR
+([dotnet/dotnet#7529](https://github.com/dotnet/dotnet/pull/7529)). The trade-off
+is drift: when the upstream files change we need to notice and decide whether to
+port. That is what this mechanism is for.
+
+We don't want to lose track of these when upstream fixes/updates land. To make
+this manageable, the repo tracks each copied file in a manifest and a
+[scheduled GitHub Actions workflow](../.github/workflows/check-vendored-files.yml)
+opens (or updates) a tracking issue whenever the **upstream** file changes.
+
+The implementation is intentionally simple: no auto-merging, no patch
+application, and the **local** file content is never inspected. The bot compares
+the *upstream* file's current blob SHA against the recorded baseline and, on any
+change, **notifies**; a human decides what (if anything) to port. This is why a
+hard fork works fine here — the signal is "upstream moved", not "the two files
+differ".
+
+> **Source of truth.** For the shared `dotnet test` source, `microsoft/testfx`
+> is the source of truth. It enumerates the exact same set of files via
+> `src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestProtocolContract.props`
+> and
+> `src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props`,
+> so testfx contributors can see which files are consumed here.
+
+## Files involved
+
+| File | Purpose |
+| --- | --- |
+| [`vendored-files.json`](./vendored-files.json) | Manifest. Source of truth for every tracked file and its baseline. |
+| [`../.github/scripts/check_vendored_files.py`](../.github/scripts/check_vendored_files.py) | Drift detection logic (`validate` + `check` modes). |
+| [`../.github/workflows/check-vendored-files.yml`](../.github/workflows/check-vendored-files.yml) | Weekly schedule + manual dispatch + PR validation. |
+
+## Manifest schema
+
+```jsonc
+{
+  "entries": [
+    {
+      "id": "stable-kebab-case-id",
+      "local_path": "src/path/to/Local.cs",
+      "notes": "free-form description of local adaptations",
+      "sources": [
+        {
+          "repo": "owner/repo",
+          "ref": "main",
+          "path": "path/in/upstream/repo.cs",
+          "baseline_ref_sha": "<40-char SHA>",   // upstream branch HEAD at last sync
+          "baseline_blob_sha": "<40-char SHA>",  // upstream file blob SHA at last sync (primary drift signal)
+          "scope": "optional human description (e.g. 'lines 41-59 only')"
+        }
+      ]
+    }
+  ]
+}
+```
+
+A single local file may declare multiple upstream sources. For example the
+terminal reporter is one file in this repo
+(`src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs`) but many
+partial files upstream (`TerminalTestReporter.*.cs`), so its entry lists each
+upstream partial as a separate source. Each source is tracked independently.
+
+## How drift is detected
+
+For every `(entry, source)` pair the workflow:
+
+1. Calls `GET /repos/{repo}/contents/{path}?ref={ref}` to get the current blob SHA.
+2. Compares it with `baseline_blob_sha`. Equal → no drift, no issue activity.
+3. Otherwise fetches the baseline content (via the blobs API, robust to
+   force-pushes) and the current content (via `raw.githubusercontent.com`),
+   computes a unified diff, and opens/updates a tracking issue labelled
+   `area-vendored-sync` containing:
+   - links to the upstream file history, baseline blob, current blob, and the
+     whole-repo compare URL,
+   - the upstream-only diff (truncated at 300 lines),
+   - the local adaptation notes,
+   - a reconciliation checklist.
+
+Idempotency uses a hidden marker `<!-- vendored-sync:id={id}:{source-index} -->`
+in the issue body, not the title. Existing matching issues are updated in place
+when the rendered body changes; otherwise they are left alone.
+
+The workflow never auto-closes issues. A reviewer closes the issue after the
+reconciliation PR is merged.
+
+## Adding a new vendored file
+
+1. Add a comment in the local file pointing at the upstream URL (existing files
+   use `// Copied from <url>` or a "must be kept aligned with the testfx repo"
+   note).
+2. Add an entry to `eng/vendored-files.json` with a stable kebab-case `id`,
+   the local path, and at least one source. Fill in:
+   - `baseline_ref_sha`: the upstream branch SHA you copied from
+     (`gh api repos/{repo}/commits/{ref} --jq .sha`),
+   - `baseline_blob_sha`: the upstream file's blob SHA at that ref
+     (`gh api "repos/{repo}/contents/{path}?ref={ref}" --jq .sha`).
+3. Run `python .github/scripts/check_vendored_files.py validate` locally to
+   confirm the structure is correct.
+
+## Reconciling drift
+
+When a `[vendored-sync]` issue is opened:
+
+1. Read the upstream diff in the issue body and check the file history link.
+2. Port the relevant changes to the local file. If the upstream change is
+   irrelevant to the copied region (e.g. an unrelated method was modified),
+   no code change is required.
+3. Update the corresponding `baseline_ref_sha` and `baseline_blob_sha` in
+   `eng/vendored-files.json`.
+4. Open a PR with the local change (if any) and the manifest bump in a single
+   commit. After it merges, close the tracking issue.
+
+If the issue is closed without bumping the manifest, the next scheduled run
+will detect the same drift and open a new issue. That is intentional: closing
+without a manifest update is a "remind me later" action.
+
+## Excluded files
+
+Some `dotnet test` shared-source files are intentionally **not** tracked here
+because they have no single upstream file to watch:
+
+- `src/Cli/dotnet/Commands/Test/MTP/Terminal/ErrorMessage.cs`,
+  `IProgressMessage.cs`, `WarningMessage.cs` — reporter-internal helper types
+  that the SDK fork keeps but that testfx has since removed/refactored away.
+  There is no upstream file to diff against.
+- `src/Cli/dotnet/Commands/Test/MTP/IPC/Models/` and
+  `src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/` — the message models and
+  serializers are hand-copied but use a different class shape than testfx
+  (upstream still couples them to `TestMetadataProperty`). Only the
+  zero-dependency wire contract (`ObjectFieldIds.cs` + the constants in
+  `CliConstants.cs`) is tracked; the models/serializers are reconciled together
+  with any wire-contract drift the tracked files surface.

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2004,6 +2004,10 @@ Your project targets multiple frameworks. Specify which framework to run using '
   <data name="TestDefinition" xml:space="preserve">
     <value>Run unit tests using the test runner specified in a .NET project.</value>
   </data>
+  <data name="TestDiscoveryExitCode" xml:space="preserve">
+    <value>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</value>
+    <comment>0 is whole number, the value of exit code</comment>
+  </data>
   <data name="TestDiscoverySummary" xml:space="preserve">
     <value>Discovered {0} tests in {1} assemblies.</value>
     <comment>0 is number of tests, 1 is count of assemblies</comment>
@@ -2014,6 +2018,10 @@ Your project targets multiple frameworks. Specify which framework to run using '
   </data>
   <data name="TestFrameworkOptionDescription" xml:space="preserve">
     <value>The target framework to run tests for. The target framework must also be specified in the project file.</value>
+  </data>
+  <data name="TestRunExitCode" xml:space="preserve">
+    <value>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</value>
+    <comment>0 is whole number, the value of exit code</comment>
   </data>
   <data name="TestRunSummary" xml:space="preserve">
     <value>Test run summary:</value>

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -27,6 +27,65 @@ internal static class CliConstants
     public const string TestTraceLoggingEnvVar = "DOTNET_CLI_TEST_TRACEFILE";
 }
 
+internal static class TestStates
+{
+    internal const byte Discovered = 0;
+    internal const byte Passed = 1;
+    internal const byte Skipped = 2;
+    internal const byte Failed = 3;
+    internal const byte Error = 4;
+    internal const byte Timeout = 5;
+    internal const byte Cancelled = 6;
+}
+
+internal static class SessionEventTypes
+{
+    internal const byte TestSessionStart = 0;
+    internal const byte TestSessionEnd = 1;
+}
+
+internal static class HandshakeMessagePropertyNames
+{
+    internal const byte PID = 0;
+    internal const byte Architecture = 1;
+    internal const byte Framework = 2;
+    internal const byte OS = 3;
+    internal const byte SupportedProtocolVersions = 4;
+    internal const byte HostType = 5;
+    internal const byte ModulePath = 6;
+    internal const byte ExecutionId = 7;
+    internal const byte InstanceId = 8;
+    internal const byte IsIDE = 9;
+
+    // Reports which command-line execution mode the test host is running in,
+    // so the SDK can detect mismatches such as a help/list-tests option leaking
+    // from RunArguments or launchSettings.json into what the SDK thinks is a
+    // normal run. Values come from HandshakeMessageExecutionModes.
+    // Optional property — older Microsoft.Testing.Platform versions don't send
+    // it, in which case the SDK falls back to its previous (no-validation) behavior.
+    internal const byte ExecutionMode = 10;
+}
+
+internal static class HandshakeMessageExecutionModes
+{
+    // Standard test run.
+    internal const string Run = "run";
+
+    // The test host is going to print command-line help (e.g. --help, -?).
+    internal const string Help = "help";
+
+    // The test host is going to discover tests (e.g. --list-tests).
+    internal const string Discover = "discover";
+}
+
+internal static class ProtocolConstants
+{
+    /// <summary>
+    /// The protocol versions that are supported by the current SDK. Multiple versions can be present and be semicolon separated.
+    /// </summary>
+    internal const string SupportedVersions = "1.0.0;1.1.0";
+}
+
 internal static class ProjectProperties
 {
     internal const string IsTestingPlatformApplication = "IsTestingPlatformApplication";

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -1,0 +1,163 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// WARNING: Please note this file needs to be kept aligned with the one in the testfx repo.
+// It is vendored from microsoft/testfx and tracked in eng/vendored-files.json (see eng/vendored-files.md);
+// a scheduled workflow opens an issue when the upstream file changes.
+// The protocol follows the concept of optional properties.
+// The id is used to identify the property in the stream and it will be skipped if it's not recognized.
+// We can add new properties with new ids, but we CANNOT change the existing ids (to support backwards compatibility).
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC;
+
+internal static class VoidResponseFieldsId
+{
+    public const int MessagesSerializerId = 0;
+}
+
+internal static class TestHostCompletedRequestFieldsId
+{
+    public const int MessagesSerializerId = 1;
+}
+
+internal static class TestHostProcessPIDRequestFieldsId
+{
+    public const int MessagesSerializerId = 2;
+}
+
+internal static class CommandLineOptionMessagesFieldsId
+{
+    public const int MessagesSerializerId = 3;
+
+    public const ushort ModulePath = 1;
+    public const ushort CommandLineOptionMessageList = 2;
+}
+
+internal static class CommandLineOptionMessageFieldsId
+{
+    public const ushort Name = 1;
+    public const ushort Description = 2;
+    public const ushort IsHidden = 3;
+    public const ushort IsBuiltIn = 4;
+    // Reserved: field ID 5 was ObsolescenceMessage, removed as unused.
+}
+
+// Reserved: serializer ID 4 was ModuleSerializer, removed as unused.
+
+internal static class DiscoveredTestMessagesFieldsId
+{
+    public const int MessagesSerializerId = 5;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort DiscoveredTestMessageList = 3;
+}
+
+internal static class DiscoveredTestMessageFieldsId
+{
+    public const ushort Uid = 1;
+    public const ushort DisplayName = 2;
+    public const ushort FilePath = 3;
+    public const ushort LineNumber = 4;
+    public const ushort Namespace = 5;
+    public const ushort TypeName = 6;
+    public const ushort MethodName = 7;
+    public const ushort Traits = 8;
+    public const ushort ParameterTypeFullNames = 9;
+}
+
+internal static class TraitMessageFieldsId
+{
+    public const ushort Key = 1;
+    public const ushort Value = 2;
+}
+
+internal static class TestResultMessagesFieldsId
+{
+    public const int MessagesSerializerId = 6;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort SuccessfulTestMessageList = 3;
+    public const ushort FailedTestMessageList = 4;
+}
+
+internal static class SuccessfulTestResultMessageFieldsId
+{
+    public const ushort Uid = 1;
+    public const ushort DisplayName = 2;
+    public const ushort State = 3;
+    public const ushort Duration = 4;
+    public const ushort Reason = 5;
+    public const ushort StandardOutput = 6;
+    public const ushort ErrorOutput = 7;
+    public const ushort SessionUid = 8;
+}
+
+internal static class FailedTestResultMessageFieldsId
+{
+    public const ushort Uid = 1;
+    public const ushort DisplayName = 2;
+    public const ushort State = 3;
+    public const ushort Duration = 4;
+    public const ushort Reason = 5;
+    public const ushort ExceptionMessageList = 6;
+    public const ushort StandardOutput = 7;
+    public const ushort ErrorOutput = 8;
+    public const ushort SessionUid = 9;
+}
+
+internal static class ExceptionMessageFieldsId
+{
+    public const ushort ErrorMessage = 1;
+    public const ushort ErrorType = 2;
+    public const ushort StackTrace = 3;
+}
+
+internal static class FileArtifactMessagesFieldsId
+{
+    public const int MessagesSerializerId = 7;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort FileArtifactMessageList = 3;
+}
+
+internal static class FileArtifactMessageFieldsId
+{
+    public const ushort FullPath = 1;
+    public const ushort DisplayName = 2;
+    public const ushort Description = 3;
+    public const ushort TestUid = 4;
+    public const ushort TestDisplayName = 5;
+    public const ushort SessionUid = 6;
+}
+
+internal static class TestSessionEventFieldsId
+{
+    public const int MessagesSerializerId = 8;
+
+    public const ushort SessionType = 1;
+    public const ushort SessionUid = 2;
+    public const ushort ExecutionId = 3;
+}
+
+internal static class HandshakeMessageFieldsId
+{
+    public const int MessagesSerializerId = 9;
+}
+
+internal static class TestInProgressMessagesFieldsId
+{
+    public const int MessagesSerializerId = 10;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort TestInProgressMessageList = 3;
+}
+
+internal static class TestInProgressMessageFieldsId
+{
+    public const ushort Uid = 1;
+    public const ushort DisplayName = 2;
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/HandshakeMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/HandshakeMessageSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 
-using Microsoft.Testing.Platform.IPC;
-
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 
 /*

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestSessionEventSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/TestSessionEventSerializer.cs
@@ -1,10 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/VoidResponseSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/VoidResponseSerializer.cs
@@ -1,9 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-
-using Microsoft.Testing.Platform.IPC;
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -9,11 +9,10 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Run;
-using Microsoft.Testing.Platform.OutputDevice.Terminal;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -108,8 +107,8 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         var output = new TerminalTestReporter(console, new TerminalTestReporterOptions()
         {
-            ShowPassedTests = () => showPassedTests,
-            ShowProgress = () => !noProgress,
+            ShowPassedTests = showPassedTests,
+            ShowProgress = !noProgress,
             ShowActiveTests = !noProgress && ansiMode == AnsiMode.AnsiIfPossible,
             AnsiMode = ansiMode,
             ShowAssembly = true,

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiCodes.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiCodes.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// A collection of standard ANSI/VT100 control codes.
+/// </summary>
+internal static class AnsiCodes
+{
+    /// <summary>
+    ///  Escape character.
+    /// </summary>
+    public const string Esc = "\x1b";
+
+    /// <summary>
+    /// The control sequence introducer.
+    /// </summary>
+    public const string CSI = $"{Esc}[";
+
+    /// <summary>
+    /// Select graphic rendition.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/>color-code<see cref="SetColor"/> to change text color.
+    /// </remarks>
+    public const string SetColor = "m";
+
+    /// <summary>
+    /// Select graphic rendition - set bold mode.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/><see cref="SetBold"/> to change text to bold.
+    /// </remarks>
+    public const string SetBold = "1m";
+
+    /// <summary>
+    /// A shortcut to reset color back to normal.
+    /// </summary>
+    public const string SetDefaultColor = CSI + "m";
+
+    /// <summary>
+    /// Non-xterm extension to render a hyperlink.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="LinkPrefix"/>url<see cref="LinkInfix"/>text<see cref="LinkSuffix"/> to render a hyperlink.
+    /// </remarks>
+    public const string LinkPrefix = $"{Esc}]8;;";
+
+    /// <summary>
+    /// <see cref="LinkPrefix"/>.
+    /// </summary>
+    public const string LinkInfix = $"{Esc}\\";
+
+    /// <summary>
+    /// <see cref="LinkPrefix"/>.
+    /// </summary>
+    public const string LinkSuffix = $"{Esc}]8;;{Esc}\\";
+
+    /// <summary>
+    /// Moves up the specified number of lines and puts cursor at the beginning of the line.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/>N<see cref="MoveUpToLineStart"/> to move N lines up.
+    /// </remarks>
+    public const string MoveUpToLineStart = "F";
+
+    /// <summary>
+    /// Moves forward (to the right) the specified number of characters.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/>N<see cref="MoveForward"/> to move N characters forward.
+    /// </remarks>
+    public const string MoveForward = "C";
+
+    /// <summary>
+    /// Moves backward (to the left) the specified number of characters.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/>N<see cref="MoveBackward"/> to move N characters backward.
+    /// </remarks>
+    public const string MoveBackward = "D";
+
+    /// <summary>
+    /// Clears everything from cursor to end of screen.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/><see cref="EraseInDisplay"/> to clear.
+    /// </remarks>
+    public const string EraseInDisplay = "J";
+
+    /// <summary>
+    /// Clears everything from cursor to the end of the current line.
+    /// </summary>
+    /// <remarks>
+    /// Print <see cref="CSI"/><see cref="EraseInLine"/> to clear.
+    /// </remarks>
+    public const string EraseInLine = "K";
+
+    /// <summary>
+    /// Hides the cursor.
+    /// </summary>
+    public const string HideCursor = $"{Esc}[?25l";
+
+    /// <summary>
+    /// Shows/restores the cursor.
+    /// </summary>
+    public const string ShowCursor = $"{Esc}[?25h";
+
+    /// <summary>
+    /// Set progress state to a busy spinner. <br/>
+    /// Note: this code works only on ConEmu terminals, and conflicts with push a notification code on iTerm2.
+    /// </summary>
+    /// <remarks>
+    /// <see href="https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC">ConEmu specific OSC codes.</see><br/>
+    /// <see href="https://iterm2.com/documentation-escape-codes.html">iTerm2 proprietary escape codes.</see>
+    /// </remarks>
+    public const string SetBusySpinner = $"{Esc}]9;4;3;{Esc}\\";
+
+    /// <summary>
+    /// Remove progress state, restoring taskbar status to normal. <br/>
+    /// Note: this code works only on ConEmu terminals, and conflicts with push a notification code on iTerm2.
+    /// </summary>
+    /// <remarks>
+    /// <see href="https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC">ConEmu specific OSC codes.</see><br/>
+    /// <see href="https://iterm2.com/documentation-escape-codes.html">iTerm2 proprietary escape codes.</see>
+    /// </remarks>
+    public const string RemoveBusySpinner = $"{Esc}]9;4;0;{Esc}\\";
+
+    public static string Colorize(string? s, TerminalColor color)
+        => string.IsNullOrWhiteSpace(s) ? s ?? string.Empty : $"{CSI}{(int)color}{SetColor}{s}{SetDefaultColor}";
+
+    public static string MakeBold(string? s)
+        => string.IsNullOrWhiteSpace(s) ? s ?? string.Empty : $"{CSI}{SetBold}{s}{SetDefaultColor}";
+
+    public static string MoveCursorBackward(int count) => $"{CSI}{count}{MoveBackward}";
+
+    /// <summary>
+    /// Moves cursor to the specified column, or the rightmost column if <paramref name="column"/> is greater than the width of the terminal.
+    /// </summary>
+    /// <param name="column">Column index.</param>
+    /// <returns>Control codes to set the desired position.</returns>
+    public static string SetCursorHorizontal(int column) => $"{CSI}{column}G";
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiDetector.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiDetector.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Portions of the code in this file were ported from the spectre.console by Patrik Svensson, Phil Scott, Nils Andresen
+// https://github.com/spectreconsole/spectre.console/blob/main/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
+// and from the supports-ansi project by Qingrong Ke
+// https://github.com/keqingrong/supports-ansi/blob/master/index.js
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Works together with the <see cref="NativeMethods"/> to figure out if the current console is capable of using ANSI output codes.
+/// </summary>
+internal static class AnsiDetector
+{
+    private static readonly Regex[] TerminalsRegexes =
+    [
+        new("^xterm"), // xterm, PuTTY, Mintty
+        new("^rxvt"), // RXVT
+        new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
+        new("^screen"), // GNU screen, tmux
+        new("tmux"), // tmux
+        new("^vt100"), // DEC VT series
+        new("^vt102"), // DEC VT series
+        new("^vt220"), // DEC VT series
+        new("^vt320"), // DEC VT series
+        new("ansi"), // ANSI
+        new("scoansi"), // SCO ANSI
+        new("cygwin"), // Cygwin, MinGW
+        new("linux"), // Linux console
+        new("konsole"), // Konsole
+        new("bvterm"), // Bitvise SSH Client
+        new("^st-256color"), // Suckless Simple Terminal, st
+        new("alacritty"), // Alacritty
+    ];
+
+    public static bool IsAnsiSupported(string? termType)
+        => !string.IsNullOrEmpty(termType) && TerminalsRegexes.Any(regex => regex.IsMatch(termType));
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminal.cs
@@ -1,0 +1,301 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Terminal writer that is used when writing ANSI is allowed. It is capable of batching as many updates as possible and writing them at the end,
+/// because the terminal is responsible for rendering the colors and control codes.
+/// </summary>
+internal sealed class AnsiTerminal(IConsole console, string? baseDirectory) : ITerminal
+{
+    /// <summary>
+    /// File extensions that we will link to directly, all other files
+    /// are linked to their directory, to avoid opening dlls, or executables.
+    /// </summary>
+    private static readonly string[] KnownFileExtensions =
+    [
+        // code files
+        ".cs",
+        ".vb",
+        ".fs",
+        // logs
+        ".log",
+        ".txt",
+        // reports
+        ".coverage",
+        ".ctrf",
+        ".html",
+        ".junit",
+        ".nunit",
+        ".trx",
+        ".xml",
+        ".xunit",
+    ];
+
+    private readonly IConsole _console = console;
+    private readonly string? _baseDirectory = baseDirectory ?? Directory.GetCurrentDirectory();
+    // Output ansi code to get spinner on top of a terminal, to indicate in-progress task.
+    // https://github.com/dotnet/msbuild/issues/8958: iTerm2 treats ;9 code to post a notification instead, so disable progress reporting on Mac.
+    private readonly bool _useBusyIndicator = !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    private readonly StringBuilder _stringBuilder = new();
+    private bool _isBatching;
+    private AnsiTerminalTestProgressFrame _currentFrame = new(0, 0);
+
+    public int Width
+        => _console.IsOutputRedirected ? int.MaxValue : _console.BufferWidth;
+
+    public int Height
+        => _console.IsOutputRedirected ? int.MaxValue : _console.BufferHeight;
+
+    public void Append(char value)
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.Append(value);
+        }
+        else
+        {
+            _console.Write(value);
+        }
+    }
+
+    public void Append(string value)
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.Append(value);
+        }
+        else
+        {
+            _console.Write(value);
+        }
+    }
+
+    public void AppendLine()
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.AppendLine();
+        }
+        else
+        {
+            _console.WriteLine();
+        }
+    }
+
+    public void AppendLine(string value)
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.AppendLine(value);
+        }
+        else
+        {
+            _console.WriteLine(value);
+        }
+    }
+
+    public void SetColor(TerminalColor color)
+    {
+        string setColor = $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}";
+        if (_isBatching)
+        {
+            _stringBuilder.Append(setColor);
+        }
+        else
+        {
+            _console.Write(setColor);
+        }
+    }
+
+    public void ResetColor()
+    {
+        string resetColor = AnsiCodes.SetDefaultColor;
+        if (_isBatching)
+        {
+            _stringBuilder.Append(resetColor);
+        }
+        else
+        {
+            _console.Write(resetColor);
+        }
+    }
+
+    public void ShowCursor()
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.Append(AnsiCodes.ShowCursor);
+        }
+        else
+        {
+            _console.Write(AnsiCodes.ShowCursor);
+        }
+    }
+
+    public void HideCursor()
+    {
+        if (_isBatching)
+        {
+            _stringBuilder.Append(AnsiCodes.HideCursor);
+        }
+        else
+        {
+            _console.Write(AnsiCodes.HideCursor);
+        }
+    }
+
+    public void StartUpdate()
+    {
+        if (_isBatching)
+        {
+            throw new InvalidOperationException(CliCommandStrings.ConsoleIsAlreadyInBatchingMode);
+        }
+
+        _stringBuilder.Clear();
+        _isBatching = true;
+    }
+
+    public void StopUpdate()
+    {
+        _console.Write(_stringBuilder.ToString());
+        _isBatching = false;
+    }
+
+    public void AppendLink(string? path, int? lineNumber)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        // For non code files, point to the directory, so we don't end up running the
+        // exe by clicking at the link.
+        string? extension = Path.GetExtension(path);
+        bool linkToFile = !string.IsNullOrWhiteSpace(extension) && KnownFileExtensions.Contains(extension);
+
+        bool knownNonExistingFile = path.StartsWith("/_/", ignoreCase: false, CultureInfo.CurrentCulture);
+
+        string linkPath = path;
+        if (!linkToFile)
+        {
+            try
+            {
+                linkPath = Path.GetDirectoryName(linkPath) ?? linkPath;
+            }
+            catch
+            {
+                // Ignore all GetDirectoryName errors.
+            }
+        }
+
+        // If the output path is under the initial working directory, make the console output relative to that to save space.
+        if (_baseDirectory != null && path.StartsWith(_baseDirectory, FileUtilities.PathComparison))
+        {
+            if (path.Length > _baseDirectory.Length
+                && (path[_baseDirectory.Length] == Path.DirectorySeparatorChar
+                    || path[_baseDirectory.Length] == Path.AltDirectorySeparatorChar))
+            {
+                path = path[(_baseDirectory.Length + 1)..];
+            }
+        }
+
+        if (lineNumber != null)
+        {
+            path += $":{lineNumber}";
+        }
+
+        if (knownNonExistingFile)
+        {
+            Append(path);
+            return;
+        }
+
+        // Generates file:// schema url string which is better handled by various Terminal clients than raw folder name.
+        if (Uri.TryCreate(linkPath, UriKind.Absolute, out Uri? uri))
+        {
+            // url.ToString() un-escapes the URL which is needed for our case file://
+            linkPath = uri.ToString();
+        }
+
+        SetColor(TerminalColor.DarkGray);
+        Append(AnsiCodes.LinkPrefix);
+        Append(linkPath);
+        Append(AnsiCodes.LinkInfix);
+        Append(path);
+        Append(AnsiCodes.LinkSuffix);
+        ResetColor();
+    }
+
+    public void MoveCursorUp(int lineCount)
+    {
+        string moveCursor = $"{AnsiCodes.CSI}{lineCount}{AnsiCodes.MoveUpToLineStart}";
+        if (_isBatching)
+        {
+            _stringBuilder.AppendLine(moveCursor);
+        }
+        else
+        {
+            _console.WriteLine(moveCursor);
+        }
+    }
+
+    public void SetCursorHorizontal(int position)
+    {
+        string setCursor = AnsiCodes.SetCursorHorizontal(position);
+        if (_isBatching)
+        {
+            _stringBuilder.Append(setCursor);
+        }
+        else
+        {
+            _console.Write(setCursor);
+        }
+    }
+
+    /// <summary>
+    /// Erases the previously printed live node output.
+    /// </summary>
+    public void EraseProgress()
+    {
+        if (_currentFrame.RenderedLines == null || _currentFrame.RenderedLines.Count == 0)
+        {
+            return;
+        }
+
+        AppendLine($"{AnsiCodes.CSI}{_currentFrame.RenderedLines.Count + 2}{AnsiCodes.MoveUpToLineStart}");
+        Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInDisplay}");
+        _currentFrame.Clear();
+    }
+
+    public void RenderProgress(TestProgressState?[] progress)
+    {
+        AnsiTerminalTestProgressFrame newFrame = new(Width, Height);
+        newFrame.Render(_currentFrame, progress, terminal: this);
+
+        _currentFrame = newFrame;
+    }
+
+    public void StartBusyIndicator()
+    {
+        if (_useBusyIndicator)
+        {
+            Append(AnsiCodes.SetBusySpinner);
+        }
+
+        HideCursor();
+    }
+
+    public void StopBusyIndicator()
+    {
+        if (_useBusyIndicator)
+        {
+            Append(AnsiCodes.RemoveBusySpinner);
+        }
+
+        ShowCursor();
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -1,0 +1,373 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Captures <see cref="TestProgressState"/> that was rendered to screen, so we can only partially update the screen on next update.
+/// </summary>
+internal sealed class AnsiTerminalTestProgressFrame(int width, int height)
+{
+    private const int MaxColumn = 250;
+
+    public int Width { get; } = Math.Min(width, MaxColumn);
+
+    public int Height { get; } = height;
+
+    public List<RenderedProgressItem>? RenderedLines { get; set; }
+
+    public void AppendTestWorkerProgress(TestProgressState progress, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    {
+        string durationString = HumanReadableDurationFormatter.Render(progress.Stopwatch.Elapsed);
+
+        currentLine.RenderedDurationLength = durationString.Length;
+
+        int nonReservedWidth = Width - (durationString.Length + 2);
+
+        int discovered = progress.DiscoveredTests;
+        int passed = progress.PassedTests;
+        int failed = progress.FailedTests;
+        int skipped = progress.SkippedTests;
+        int retried = progress.RetriedFailedTests;
+        int charsTaken = 0;
+
+        if (!progress.IsDiscovery)
+        {
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkGreen);
+            terminal.Append('✓');
+            charsTaken++;
+            string passedText = passed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(passedText);
+            charsTaken += passedText.Length;
+            terminal.ResetColor();
+
+            terminal.Append('/');
+            charsTaken++;
+
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append('x');
+            charsTaken++;
+            string failedText = failed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(failedText);
+            charsTaken += failedText.Length;
+            terminal.ResetColor();
+
+            terminal.Append('/');
+            charsTaken++;
+
+            terminal.SetColor(TerminalColor.DarkYellow);
+            terminal.Append('↓');
+            charsTaken++;
+            string skippedText = skipped.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(skippedText);
+            charsTaken += skippedText.Length;
+            terminal.ResetColor();
+
+            if (retried > 0)
+            {
+                terminal.Append('/');
+                charsTaken++;
+                terminal.SetColor(TerminalColor.Gray);
+                terminal.Append('r');
+                charsTaken++;
+                string retriedText = retried.ToString(CultureInfo.CurrentCulture);
+                terminal.Append(retriedText);
+                charsTaken += retriedText.Length;
+                terminal.ResetColor();
+            }
+
+            terminal.Append(']');
+            charsTaken++;
+        }
+        else
+        {
+            string discoveredText = progress.DiscoveredTests.ToString(CultureInfo.CurrentCulture);
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkMagenta);
+            terminal.Append('+');
+            charsTaken++;
+            terminal.Append(discoveredText);
+            charsTaken += discoveredText.Length;
+            terminal.ResetColor();
+            terminal.Append(']');
+            charsTaken++;
+        }
+
+        terminal.Append(' ');
+        charsTaken++;
+        AppendToWidth(terminal, progress.AssemblyName, nonReservedWidth, ref charsTaken);
+
+        if (charsTaken < nonReservedWidth && (progress.TargetFramework != null || progress.Architecture != null))
+        {
+            int lengthNeeded = 0;
+
+            lengthNeeded++; // for '('
+            if (progress.TargetFramework != null)
+            {
+                lengthNeeded += progress.TargetFramework.Length;
+                if (progress.Architecture != null)
+                {
+                    lengthNeeded++; // for '|'
+                }
+            }
+
+            if (progress.Architecture != null)
+            {
+                lengthNeeded += progress.Architecture.Length;
+            }
+
+            lengthNeeded++; // for ')'
+
+            if (charsTaken + lengthNeeded < nonReservedWidth)
+            {
+                terminal.Append(" (");
+                if (progress.TargetFramework != null)
+                {
+                    terminal.Append(progress.TargetFramework);
+                    if (progress.Architecture != null)
+                    {
+                        terminal.Append('|');
+                    }
+                }
+
+                if (progress.Architecture != null)
+                {
+                    terminal.Append(progress.Architecture);
+                }
+
+                terminal.Append(')');
+            }
+        }
+
+        terminal.SetCursorHorizontal(Width - durationString.Length);
+        terminal.Append(durationString);
+    }
+
+    public void AppendTestWorkerDetail(TestDetailState detail, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    {
+        string durationString = HumanReadableDurationFormatter.Render(detail.Stopwatch?.Elapsed);
+
+        currentLine.RenderedDurationLength = durationString.Length;
+
+        int nonReservedWidth = Width - (durationString.Length + 2);
+        int charsTaken = 0;
+
+        terminal.Append("  ");
+        charsTaken += 2;
+
+        AppendToWidth(terminal, detail.Text, nonReservedWidth, ref charsTaken);
+
+        terminal.SetCursorHorizontal(Width - durationString.Length);
+        terminal.Append(durationString);
+    }
+
+    private static void AppendToWidth(AnsiTerminal terminal, string text, int width, ref int charsTaken)
+    {
+        if (charsTaken + text.Length < width)
+        {
+            terminal.Append(text);
+            charsTaken += text.Length;
+        }
+        else
+        {
+            terminal.Append("...");
+            charsTaken += 3;
+            if (charsTaken < width)
+            {
+                int charsToTake = width - charsTaken;
+                string cutText = text[^charsToTake..];
+                terminal.Append(cutText);
+                charsTaken += charsToTake;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Render VT100 string to update from current to next frame.
+    /// </summary>
+    public void Render(AnsiTerminalTestProgressFrame previousFrame, TestProgressState?[] progress, AnsiTerminal terminal)
+    {
+        // Clear everything if Terminal width or height have changed.
+        if (Width != previousFrame.Width || Height != previousFrame.Height)
+        {
+            terminal.EraseProgress();
+        }
+
+        // At the end of the terminal we're going to print the live progress.
+        // We re-render this progress by moving the cursor to the beginning of the previous progress
+        // and then overwriting the lines that have changed.
+        // The assumption we do here is that:
+        // - Each rendered line is a single line, i.e. a single detail cannot span multiple lines.
+        // - Each rendered detail can be tracked via a unique ID and version, so that we can
+        //   quickly determine if the detail has changed since the last render.
+
+        // Don't go up if we did not render any lines in previous frame or we already cleared them.
+        if (previousFrame.RenderedLines != null && previousFrame.RenderedLines.Count > 0)
+        {
+            // Move cursor back to 1st line of progress.
+            // + 2 because we output and empty line right below.
+            terminal.MoveCursorUp(previousFrame.RenderedLines.Count + 2);
+        }
+
+        // When there is nothing to render, don't write empty lines, e.g. when we start the test run, and then we kick off build
+        // in dotnet test, there is a long pause where we have no assemblies and no test results (yet).
+        //
+        // We do pre-allocate the array so it is full of nulls once we allocate it but don't have any items to render yet.
+        if (progress.Length > 0 && progress.Any(i => i != null))
+        {
+            terminal.AppendLine();
+        }
+
+        int i = 0;
+        RenderedLines = new List<RenderedProgressItem>(progress.Length * 2);
+        List<object> progresses = GenerateLinesToRender(progress);
+
+        foreach (object item in progresses)
+        {
+            if (previousFrame.RenderedLines != null && previousFrame.RenderedLines.Count > i)
+            {
+                if (item is TestProgressState progressItem)
+                {
+                    var currentLine = new RenderedProgressItem(progressItem.Id, progressItem.Version);
+                    RenderedLines.Add(currentLine);
+
+                    // We have a line that was rendered previously, compare it and decide how to render.
+                    RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
+                    if (previouslyRenderedLine.ProgressId == progressItem.Id && false)
+                    {
+                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
+                        string durationString = HumanReadableDurationFormatter.Render(progressItem.Stopwatch.Elapsed);
+
+                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
+                        {
+                            // Duration is the same length rewrite just it.
+                            terminal.SetCursorHorizontal(MaxColumn);
+                            terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");
+                            currentLine.RenderedDurationLength = durationString.Length;
+                        }
+                        else
+                        {
+                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
+                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
+                            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                            AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                        }
+                    }
+                    else
+                    {
+                        // These lines are different or the line was updated. Render the whole line.
+                        terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                        AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                    }
+                }
+
+                if (item is TestDetailState detailItem)
+                {
+                    var currentLine = new RenderedProgressItem(detailItem.Id, detailItem.Version);
+                    RenderedLines.Add(currentLine);
+
+                    // We have a line that was rendered previously, compare it and decide how to render.
+                    RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
+                    if (previouslyRenderedLine.ProgressId == detailItem.Id && previouslyRenderedLine.ProgressVersion == detailItem.Version)
+                    {
+                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
+                        string durationString = HumanReadableDurationFormatter.Render(detailItem.Stopwatch?.Elapsed);
+
+                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
+                        {
+                            // Duration is the same length rewrite just it.
+                            terminal.SetCursorHorizontal(MaxColumn);
+                            terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");
+                            currentLine.RenderedDurationLength = durationString.Length;
+                        }
+                        else
+                        {
+                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
+                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
+                            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                            AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                        }
+                    }
+                    else
+                    {
+                        // These lines are different or the line was updated. Render the whole line.
+                        terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                        AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                    }
+                }
+            }
+            else
+            {
+                // We are rendering more lines than we rendered in previous frame
+                if (item is TestProgressState progressItem)
+                {
+                    var currentLine = new RenderedProgressItem(progressItem.Id, progressItem.Version);
+                    RenderedLines.Add(currentLine);
+                    AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                }
+
+                if (item is TestDetailState detailItem)
+                {
+                    var currentLine = new RenderedProgressItem(detailItem.Id, detailItem.Version);
+                    RenderedLines.Add(currentLine);
+                    AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                }
+            }
+
+            // This makes the progress not stick to the last line on the command line, which is
+            // not what I would prefer. But also if someone writes to console, the message will
+            // start at the beginning of the new line. Not after the progress bar that is kept on screen.
+            terminal.AppendLine();
+        }
+
+        // We rendered more lines in previous frame. Clear them.
+        if (previousFrame.RenderedLines != null && i < previousFrame.RenderedLines.Count)
+        {
+            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInDisplay}");
+        }
+    }
+
+    private List<object> GenerateLinesToRender(TestProgressState?[] progress)
+    {
+        var linesToRender = new List<object>(progress.Length);
+
+        // Note: We want to render the list of active tests, but this can easily fill up the full screen.
+        // As such, we should balance the number of active tests shown per project.
+        // We do this by distributing the remaining lines for each projects.
+        TestProgressState[] progressItems = [.. progress.OfType<TestProgressState>()];
+        int linesToDistribute = (int)(Height * 0.7) - 1 - progressItems.Length;
+        var detailItems = new IEnumerable<TestDetailState>[progressItems.Length];
+        IEnumerable<int> sortedItemsIndices = Enumerable.Range(0, progressItems.Length).OrderBy(i => progressItems[i].TestNodeResultsState?.Count ?? 0);
+
+        foreach (int sortedItemIndex in sortedItemsIndices)
+        {
+            detailItems[sortedItemIndex] = progressItems[sortedItemIndex].TestNodeResultsState?.GetRunningTasks(linesToDistribute / progressItems.Length) ?? [];
+        }
+
+        for (int progressI = 0; progressI < progressItems.Length; progressI++)
+        {
+            linesToRender.Add(progressItems[progressI]);
+            linesToRender.AddRange(detailItems[progressI]);
+        }
+
+        return linesToRender;
+    }
+
+    public void Clear() => RenderedLines?.Clear();
+
+    internal sealed class RenderedProgressItem(long id, long version)
+    {
+        public long ProgressId { get; } = id;
+
+        public long ProgressVersion { get; } = version;
+
+        public int RenderedHeight { get; set; }
+
+        public int RenderedDurationLength { get; set; }
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -238,7 +238,7 @@ internal sealed class AnsiTerminalTestProgressFrame(int width, int height)
 
                     // We have a line that was rendered previously, compare it and decide how to render.
                     RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
-                    if (previouslyRenderedLine.ProgressId == progressItem.Id && false)
+                    if (previouslyRenderedLine.ProgressId == progressItem.Id && previouslyRenderedLine.ProgressVersion == progressItem.Version)
                     {
                         // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
                         string durationString = HumanReadableDurationFormatter.Render(progressItem.Stopwatch.Elapsed);
@@ -323,6 +323,8 @@ internal sealed class AnsiTerminalTestProgressFrame(int width, int height)
             // not what I would prefer. But also if someone writes to console, the message will
             // start at the beginning of the new line. Not after the progress bar that is kept on screen.
             terminal.AppendLine();
+
+            i++;
         }
 
         // We rendered more lines in previous frame. Clear them.

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ErrorMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ErrorMessage.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// An error message that was sent to output during the build.
+/// </summary>
+internal sealed record ErrorMessage(string Text) : IProgressMessage;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ExceptionFlattener.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ExceptionFlattener.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed record FlatException(string? ErrorMessage, string? ErrorType, string? StackTrace);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/FileUtilities.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/FileUtilities.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal static class FileUtilities
+{
+    internal static readonly StringComparison PathComparison = GetIsFileSystemCaseSensitive() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+    internal static readonly StringComparer PathComparer = GetIsFileSystemCaseSensitive() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// Determines whether the file system is case sensitive.
+    /// Copied from https://github.com/dotnet/runtime/blob/73ba11f3015216b39cb866d9fb7d3d25e93489f2/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs#L41-L59 .
+    /// </summary>
+    public static bool GetIsFileSystemCaseSensitive()
+    {
+        try
+        {
+            string pathWithUpperCase = Path.Combine(Path.GetTempPath(), "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+            using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+            {
+                string lowerCased = pathWithUpperCase.ToLowerInvariant();
+                return !File.Exists(lowerCased);
+            }
+        }
+        catch (Exception exc)
+        {
+            // In case something goes terribly wrong, we don't want to fail just because
+            // of a casing test, so we assume case-insensitive-but-preserving.
+            Debug.Fail("Casing test failed: " + exc);
+            return false;
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/HumanReadableDurationFormatter.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal static class HumanReadableDurationFormatter
+{
+    public static void Append(ITerminal terminal, TimeSpan duration, bool wrapInParentheses = true)
+    {
+        bool hasParentValue = false;
+
+        if (wrapInParentheses)
+        {
+            terminal.Append('(');
+        }
+
+        // Duration abbreviations (d/h/m/s/ms) are intentionally NOT localized:
+        // they use common time unit abbreviations and are kept identical across
+        // cultures to match MSBuild Terminal Logger's behavior and the typical
+        // convention for CLI tools (kubectl, cargo, etc.). This keeps timing
+        // output easy to parse and consistent regardless of the active culture.
+        if (duration.Days > 0)
+        {
+            terminal.Append($"{duration.Days}d");
+            hasParentValue = true;
+        }
+
+        if (duration.Hours > 0 || hasParentValue)
+        {
+            terminal.Append(GetFormattedPart(duration.Hours, hasParentValue, "h"));
+            hasParentValue = true;
+        }
+
+        if (duration.Minutes > 0 || hasParentValue)
+        {
+            terminal.Append(GetFormattedPart(duration.Minutes, hasParentValue, "m"));
+            hasParentValue = true;
+        }
+
+        if (duration.Seconds > 0 || hasParentValue)
+        {
+            terminal.Append(GetFormattedPart(duration.Seconds, hasParentValue, "s"));
+            hasParentValue = true;
+        }
+
+        if (duration.Milliseconds >= 0 || hasParentValue)
+        {
+            terminal.Append(GetFormattedPart(duration.Milliseconds, hasParentValue, "ms", paddingWitdh: 3));
+        }
+
+        if (wrapInParentheses)
+        {
+            terminal.Append(')');
+        }
+    }
+
+    private static string GetFormattedPart(int value, bool hasParentValue, string suffix, int paddingWitdh = 2)
+        => $"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? value.ToString(CultureInfo.InvariantCulture).PadLeft(paddingWitdh, '0') : value.ToString(CultureInfo.InvariantCulture))}{suffix}";
+
+    public static string Render(TimeSpan? duration, bool wrapInParentheses = true, bool showMilliseconds = false)
+    {
+        if (duration is null)
+        {
+            return string.Empty;
+        }
+
+        bool hasParentValue = false;
+
+        var stringBuilder = new StringBuilder();
+
+        if (wrapInParentheses)
+        {
+            stringBuilder.Append('(');
+        }
+
+        if (duration.Value.Days > 0)
+        {
+            stringBuilder.Append(CultureInfo.CurrentCulture, $"{duration.Value.Days}d");
+            hasParentValue = true;
+        }
+
+        if (duration.Value.Hours > 0 || hasParentValue)
+        {
+            stringBuilder.Append(GetFormattedPart(duration.Value.Hours, hasParentValue, "h"));
+            hasParentValue = true;
+        }
+
+        if (duration.Value.Minutes > 0 || hasParentValue)
+        {
+            stringBuilder.Append(GetFormattedPart(duration.Value.Minutes, hasParentValue, "m"));
+            hasParentValue = true;
+        }
+
+        if (duration.Value.Seconds > 0 || hasParentValue || !showMilliseconds)
+        {
+            stringBuilder.Append(GetFormattedPart(duration.Value.Seconds, hasParentValue, "s"));
+            hasParentValue = true;
+        }
+
+        if (showMilliseconds)
+        {
+            if (duration.Value.Milliseconds >= 0 || hasParentValue)
+            {
+                stringBuilder.Append(GetFormattedPart(duration.Value.Milliseconds, hasParentValue, "ms", paddingWitdh: 3));
+            }
+        }
+
+        if (wrapInParentheses)
+        {
+            stringBuilder.Append(')');
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IColor.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Represents a color.
+/// </summary>
+public interface IColor;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IConsole.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IConsole.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Wraps the static System.Console to be isolatable in tests.
+/// </summary>
+internal interface IConsole
+{
+    event ConsoleCancelEventHandler? CancelKeyPress;
+
+    public int BufferHeight { get; }
+
+    public int BufferWidth { get; }
+
+    public bool IsOutputRedirected { get; }
+
+    void SetForegroundColor(ConsoleColor color);
+
+    void SetBackgroundColor(ConsoleColor color);
+
+    ConsoleColor GetForegroundColor();
+
+    ConsoleColor GetBackgroundColor();
+
+    void WriteLine();
+
+    void WriteLine(string? value);
+
+    void WriteLine(object? value);
+
+    void WriteLine(string format, object? arg0);
+
+    void WriteLine(string format, object? arg0, object? arg1);
+
+    void WriteLine(string format, object? arg0, object? arg1, object? arg2);
+
+    void WriteLine(string format, object?[]? args);
+
+    void Write(string format, object?[]? args);
+
+    void Write(string? value);
+
+    void Write(char value);
+
+    void Clear();
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IProgressMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IProgressMessage.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Error or warning message that was sent to screen during the test run.
+/// </summary>
+internal interface IProgressMessage;

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/IStopwatch.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/IStopwatch.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal interface IStopwatch
+{
+    void Start();
+
+    void Stop();
+
+    TimeSpan Elapsed { get; }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/ITerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/ITerminal.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// An ANSI or non-ANSI terminal that is capable of rendering the messages from <see cref="TestProgressStateAwareTerminal"/>.
+/// </summary>
+internal interface ITerminal
+{
+    int Width { get; }
+
+    int Height { get; }
+
+    void Append(char value);
+
+    void Append(string value);
+
+    void AppendLine();
+
+    void AppendLine(string value);
+
+    void AppendLink(string path, int? lineNumber);
+
+    void SetColor(TerminalColor color);
+
+    void ResetColor();
+
+    void ShowCursor();
+
+    void HideCursor();
+
+    void StartUpdate();
+
+    void StopUpdate();
+
+    void EraseProgress();
+
+    void RenderProgress(TestProgressState?[] progress);
+
+    void StartBusyIndicator();
+
+    void StopBusyIndicator();
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/NativeMethods.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/NativeMethods.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal static class NativeMethods
+{
+    internal const uint FILE_TYPE_CHAR = 0x0002;
+    internal const int STD_OUTPUT_HANDLE = -11;
+    internal const int STD_ERROR_HANDLE = -12;
+    internal const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+
+    private static bool? s_isWindows;
+
+    /// <summary>
+    /// Gets a value indicating whether we are running under some version of Windows.
+    /// </summary>
+    // TODO: [SupportedOSPlatformGuard("windows")]
+    internal static bool IsWindows
+    {
+        get
+        {
+            s_isWindows ??= RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return s_isWindows.Value;
+        }
+    }
+
+    internal static (bool AcceptAnsiColorCodes, bool OutputIsScreen, uint? OriginalConsoleMode) QueryIsScreenAndTryEnableAnsiColorCodes(StreamHandleType handleType = StreamHandleType.StdOut)
+    {
+        if (Console.IsOutputRedirected)
+        {
+            // There's no ANSI terminal support if console output is redirected.
+            return (AcceptAnsiColorCodes: false, OutputIsScreen: false, OriginalConsoleMode: null);
+        }
+
+        bool acceptAnsiColorCodes = false;
+        bool outputIsScreen = false;
+        uint? originalConsoleMode = null;
+        if (IsWindows)
+        {
+            try
+            {
+                nint outputStream = GetStdHandle((int)handleType);
+                if (GetConsoleMode(outputStream, out uint consoleMode))
+                {
+                    if ((consoleMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) == ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+                    {
+                        // Console is already in required state.
+                        acceptAnsiColorCodes = true;
+                    }
+                    else
+                    {
+                        originalConsoleMode = consoleMode;
+                        consoleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+                        if (SetConsoleMode(outputStream, consoleMode) && GetConsoleMode(outputStream, out consoleMode))
+                        {
+                            // We only know if vt100 is supported if the previous call actually set the new flag, older
+                            // systems ignore the setting.
+                            acceptAnsiColorCodes = (consoleMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) == ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+                        }
+                    }
+
+                    uint fileType = GetFileType(outputStream);
+                    // The std out is a char type (LPT or Console).
+                    outputIsScreen = fileType == FILE_TYPE_CHAR;
+                    acceptAnsiColorCodes &= outputIsScreen;
+                }
+            }
+            catch
+            {
+                // In the unlikely case that the above fails we just ignore and continue.
+            }
+        }
+        else
+        {
+            // On posix OSes detect whether the terminal supports VT100 from the value of the TERM environment variable.
+#pragma warning disable RS0030 // Do not use banned APIs
+            acceptAnsiColorCodes = AnsiDetector.IsAnsiSupported(Environment.GetEnvironmentVariable("TERM"));
+#pragma warning restore RS0030 // Do not use banned APIs
+            // It wasn't redirected as tested above so we assume output is screen/console
+            outputIsScreen = true;
+        }
+
+        return (acceptAnsiColorCodes, outputIsScreen, originalConsoleMode);
+    }
+
+    internal static void RestoreConsoleMode(uint? originalConsoleMode, StreamHandleType handleType = StreamHandleType.StdOut)
+    {
+        if (IsWindows && originalConsoleMode is not null)
+        {
+            nint stdOut = GetStdHandle((int)handleType);
+            _ = SetConsoleMode(stdOut, originalConsoleMode.Value);
+        }
+    }
+
+    [DllImport("kernel32.dll")]
+    // TODO: [SupportedOSPlatform("windows")]
+    internal static extern nint GetStdHandle(int nStdHandle);
+
+    [DllImport("kernel32.dll")]
+    // TODO: [SupportedOSPlatform("windows")]
+    internal static extern uint GetFileType(nint hFile);
+
+    internal enum StreamHandleType
+    {
+        /// <summary>
+        /// StdOut.
+        /// </summary>
+        StdOut = STD_OUTPUT_HANDLE,
+
+        /// <summary>
+        /// StdError.
+        /// </summary>
+        StdErr = STD_ERROR_HANDLE,
+    }
+
+    [DllImport("kernel32.dll")]
+    internal static extern bool GetConsoleMode(nint hConsoleHandle, out uint lpMode);
+
+    [DllImport("kernel32.dll")]
+    internal static extern bool SetConsoleMode(nint hConsoleHandle, uint dwMode);
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/NonAnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/NonAnsiTerminal.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+/// <summary>
+/// Non-ANSI terminal that writes text using the standard Console.Foreground color capabilities to stay compatible with
+/// standard Windows command line, and other command lines that are not capable of ANSI, or when output is redirected.
+/// </summary>
+internal sealed class NonAnsiTerminal : SimpleTerminal
+{
+    private readonly ConsoleColor _defaultForegroundColor;
+    private bool? _colorNotSupported;
+
+    public NonAnsiTerminal(IConsole console)
+        : base(console)
+        => _defaultForegroundColor = IsForegroundColorNotSupported() ? ConsoleColor.Black : console.GetForegroundColor();
+
+    public override void SetColor(TerminalColor color)
+    {
+        if (IsForegroundColorNotSupported())
+        {
+            return;
+        }
+
+        Console.SetForegroundColor(ToConsoleColor(color));
+    }
+
+    public override void ResetColor()
+    {
+        if (IsForegroundColorNotSupported())
+        {
+            return;
+        }
+
+        Console.SetForegroundColor(_defaultForegroundColor);
+    }
+
+    private bool IsForegroundColorNotSupported()
+    {
+        _colorNotSupported ??= RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+
+        return _colorNotSupported.Value;
+    }
+
+    private ConsoleColor ToConsoleColor(TerminalColor color) => color switch
+    {
+        TerminalColor.Black => ConsoleColor.Black,
+        TerminalColor.DarkRed => ConsoleColor.DarkRed,
+        TerminalColor.DarkGreen => ConsoleColor.DarkGreen,
+        TerminalColor.DarkYellow => ConsoleColor.DarkYellow,
+        TerminalColor.DarkBlue => ConsoleColor.DarkBlue,
+        TerminalColor.DarkMagenta => ConsoleColor.DarkMagenta,
+        TerminalColor.DarkCyan => ConsoleColor.DarkCyan,
+        TerminalColor.Gray => ConsoleColor.White,
+        TerminalColor.Default => _defaultForegroundColor,
+        TerminalColor.DarkGray => ConsoleColor.Gray,
+        TerminalColor.Red => ConsoleColor.Red,
+        TerminalColor.Green => ConsoleColor.Green,
+        TerminalColor.Yellow => ConsoleColor.Yellow,
+        TerminalColor.Blue => ConsoleColor.Blue,
+        TerminalColor.Magenta => ConsoleColor.Magenta,
+        TerminalColor.Cyan => ConsoleColor.Cyan,
+        TerminalColor.White => ConsoleColor.White,
+        _ => _defaultForegroundColor,
+    };
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleAnsiTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleAnsiTerminal.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+
+/// <summary>
+/// Simple terminal that uses 4-bit ANSI for colors but does not move cursor and does not do other fancy stuff to stay compatible with CI systems like AzDO.
+/// The colors are set on start of every line to properly color multiline strings in AzDO output.
+/// </summary>
+internal sealed class SimpleAnsiTerminal : SimpleTerminal
+{
+    private string? _foregroundColor;
+    private bool _prependColor;
+
+    public SimpleAnsiTerminal(IConsole console)
+        : base(console)
+    {
+    }
+
+    public override void Append(string value)
+    {
+        // Previous write appended line, so we need to prepend color.
+        if (_prependColor)
+        {
+            Console.Write(_foregroundColor);
+            // This line is not adding new line at the end, so we don't need to prepend color on next line.
+            _prependColor = false;
+        }
+
+        Console.Write(SetColorPerLine(value));
+    }
+
+    public override void AppendLine(string value)
+    {
+        // Previous write appended line, so we need to prepend color.
+        if (_prependColor)
+        {
+            Console.Write(_foregroundColor);
+        }
+
+        Console.WriteLine(SetColorPerLine(value));
+        // This call appended new line so the next write to console needs to prepend color.
+        _prependColor = true;
+    }
+
+    public override void SetColor(TerminalColor color)
+    {
+        string setColor = $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}";
+        _foregroundColor = setColor;
+        Console.Write(setColor);
+        // This call set the color for current line, no need to prepend on next write.
+        _prependColor = false;
+    }
+
+    public override void ResetColor()
+    {
+        _foregroundColor = null;
+        _prependColor = false;
+        Console.Write(AnsiCodes.SetDefaultColor);
+    }
+
+    private string? SetColorPerLine(string value)
+        => _foregroundColor == null ? value : value.Replace("\n", $"\n{_foregroundColor}");
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
@@ -1,0 +1,241 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.DotNet.Cli.Commands;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+internal abstract class SimpleTerminal : ITerminal
+{
+    private object? _batchingLock;
+    private bool _isBatching;
+
+    public SimpleTerminal(IConsole console)
+        => Console = console;
+
+#pragma warning disable CA1416 // Validate platform compatibility
+    public int Width => Console.IsOutputRedirected ? int.MaxValue : Console.BufferWidth;
+
+    public int Height => Console.IsOutputRedirected ? int.MaxValue : Console.BufferHeight;
+
+    protected IConsole Console { get; }
+
+    public void Append(char value)
+        => Console.Write(value);
+
+    public virtual void Append(string value)
+        => Console.Write(value);
+
+    public void AppendLine()
+        => Console.WriteLine();
+
+    public virtual void AppendLine(string value)
+        => Console.WriteLine(value);
+
+    public void AppendLink(string path, int? lineNumber)
+    {
+        Append(path);
+        if (lineNumber.HasValue)
+        {
+            Append($":{lineNumber}");
+        }
+    }
+
+    public void EraseProgress()
+    {
+        // nop
+    }
+
+    public void HideCursor()
+    {
+        // nop
+    }
+
+    public void RenderProgress(TestProgressState?[] progress)
+    {
+        int count = 0;
+        foreach (TestProgressState? p in progress)
+        {
+            if (p == null)
+            {
+                continue;
+            }
+
+            count++;
+
+            string durationString = HumanReadableDurationFormatter.Render(p.Stopwatch.Elapsed);
+
+            int discovered = p.DiscoveredTests;
+            int passed = p.PassedTests;
+            int failed = p.FailedTests;
+            int skipped = p.SkippedTests;
+
+            if (!p.IsDiscovery)
+            {
+                // Use just ascii here, so we don't put too many restrictions on fonts needing to
+                // properly show unicode, or logs being saved in particular encoding.
+                Append('[');
+                SetColor(TerminalColor.DarkGreen);
+                Append('+');
+                Append(passed.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append('/');
+
+                SetColor(TerminalColor.DarkRed);
+                Append('x');
+                Append(failed.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append('/');
+
+                SetColor(TerminalColor.DarkYellow);
+                Append('?');
+                Append(skipped.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append(']');
+            }
+            else
+            {
+                // Use just ascii here, so we don't put too many restrictions on fonts needing to
+                // properly show unicode, or logs being saved in particular encoding.
+                Append('[');
+                SetColor(TerminalColor.DarkMagenta);
+                Append('+');
+                Append(discovered.ToString(CultureInfo.CurrentCulture));
+                ResetColor();
+
+                Append(']');
+            }
+
+            Append(' ');
+            Append(p.AssemblyName);
+
+            if (p.TargetFramework != null || p.Architecture != null)
+            {
+                Append(" (");
+                if (p.TargetFramework != null)
+                {
+                    Append(p.TargetFramework);
+                    Append('|');
+                }
+
+                if (p.Architecture != null)
+                {
+                    Append(p.Architecture);
+                }
+
+                Append(')');
+            }
+
+            TestDetailState? activeTest = p.TestNodeResultsState?.GetRunningTasks(1).FirstOrDefault();
+            if (!String.IsNullOrWhiteSpace(activeTest?.Text))
+            {
+                Append(" - ");
+                Append(activeTest.Text);
+                Append(' ');
+            }
+
+            Append(durationString);
+
+            AppendLine();
+        }
+
+        // Do not render empty lines when there is nothing to show.
+        if (count > 0)
+        {
+            AppendLine();
+        }
+    }
+
+    public void ShowCursor()
+    {
+        // nop
+    }
+
+    public void StartBusyIndicator()
+    {
+        // nop
+    }
+
+    // TODO: Refactor NonAnsiTerminal and AnsiTerminal such that we don't need StartUpdate/StopUpdate.
+    // It's much better if we use lock C# keyword instead of manually calling Monitor.Enter/Exit
+    // Using lock also ensures we don't accidentally have `await`s in between that could cause Exit to be on a different thread.
+    public void StartUpdate()
+    {
+        if (_isBatching)
+        {
+            throw new InvalidOperationException(CliCommandStrings.ConsoleIsAlreadyInBatchingMode);
+        }
+
+        bool lockTaken = false;
+
+        // We store Console.Out in a field to make sure we will be doing
+        // the Monitor.Exit call on the same instance.
+        _batchingLock = System.Console.Out;
+
+        // Note that we need to lock on System.Out for batching to work correctly.
+        // Consider the following scenario:
+        // 1. We call StartUpdate
+        // 2. We call a Write("A")
+        // 3. User calls Console.Write("B") from another thread.
+        // 4. We call a Write("C").
+        // 5. We call StopUpdate.
+        // The expectation is that we see either ACB, or BAC, but not ABC.
+        // Basically, when doing batching, we want to ensure that everything we write is
+        // written continuously, without anything in-between.
+        // One option (and we used to do it), is that we append to a StringBuilder while batching
+        // Then at StopUpdate, we write the whole string at once.
+        // This works to some extent, but we cannot get it to work when SetColor kicks in.
+        // Console methods will internally lock on Console.Out, so we are locking on the same thing.
+        // This locking is the easiest way to get coloring to work correctly while preventing
+        // interleaving with user's calls to Console.Write methods.
+        // One extra note:
+        // It's very important to lock on Console.Out (the current Console.Out).
+        // Consider the following scenario:
+        // 1. SystemConsole captures the original Console.Out set by runtime.
+        // 2. Framework author sets his own Console.Out which wraps the original Console.Out.
+        // 3. Two threads are writing concurrently:
+        //    - One thread is writing using Console.Write* APIs, which will use the Console.Out set by framework author.
+        //    - The other thread is writing using NonAnsiTerminal.
+        // 4. **If** we lock the original Console.Out. The following may happen (subject to race) [NOT THE CURRENT CASE - imaginary situation if we lock on the original Console.Out]:
+        //    - First thread enters the Console.Write, which will acquire the lock for the current Console.Out (set by framework author).
+        //    - Second thread executes StartUpdate, and acquires the lock for the original Console.Out.
+        //    - First thread continues in the Write implementation of the framework author, which tries to run Console.Write on the original Console.Out.
+        //    - First thread can't make any progress, because the second thread is holding the lock already.
+        //    - Second thread continues execution, and reaches into runtime code (ConsolePal.WriteFromConsoleStream - on Unix) which tries to acquire the lock for the current Console.Out (set by framework author).
+        //        - (see https://github.com/dotnet/runtime/blob/8a9d492444f06df20fcc5dfdcf7a6395af18361f/src/libraries/System.Console/src/System/ConsolePal.Unix.cs#L963)
+        //    - No thread can progress.
+        //    - Basically, what happened is that the first thread acquires the lock for current Console.Out, then for the original Console.Out.
+        //    - while the second thread acquires the lock for the original Console.Out, then for the current Console.Out.
+        //    - That's a typical deadlock where two threads are acquiring two locks in reverse order.
+        // 5. By locking the *current* Console.Out, we avoid the situation described in 4.
+        Monitor.Enter(_batchingLock, ref lockTaken);
+        if (!lockTaken)
+        {
+            // Can this happen? :/
+            throw new InvalidOperationException();
+        }
+
+        _isBatching = true;
+    }
+
+    public void StopBusyIndicator()
+    {
+        // nop
+    }
+
+    public void StopUpdate()
+    {
+        Monitor.Exit(_batchingLock!);
+        _batchingLock = null;
+        _isBatching = false;
+    }
+
+    public abstract void SetColor(TerminalColor color);
+
+    public abstract void ResetColor();
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsole.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsole.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class SystemConsole : IConsole
+{
+    private const int WriteBufferSize = 256;
+    private static readonly StreamWriter CaptureConsoleOutWriter;
+
+    /// <summary>
+    /// Gets the height of the buffer area.
+    /// </summary>
+    public int BufferHeight => Console.BufferHeight;
+
+    /// <summary>
+    /// Gets the width of the buffer area.
+    /// </summary>
+    public int BufferWidth => Console.BufferWidth;
+
+    /// <summary>
+    /// Gets a value indicating whether output has been redirected from the standard output stream.
+    /// </summary>
+    public bool IsOutputRedirected => Console.IsOutputRedirected;
+
+    static SystemConsole() =>
+        // From https://github.com/dotnet/runtime/blob/main/src/libraries/System.Console/src/System/Console.cs#L236
+        CaptureConsoleOutWriter = new StreamWriter(
+            stream: Console.OpenStandardOutput(),
+            encoding: Console.Out.Encoding,
+            bufferSize: WriteBufferSize,
+            leaveOpen: true)
+        {
+            AutoFlush = true,
+        };
+
+    // the following event does not make sense in the mobile scenarios, user cannot ctrl+c
+    // but can just kill the app in the device via a gesture
+    public event ConsoleCancelEventHandler? CancelKeyPress
+    {
+        add => Console.CancelKeyPress += value;
+        remove => Console.CancelKeyPress -= value;
+    }
+
+    public void WriteLine()
+    {
+        CaptureConsoleOutWriter.WriteLine();
+    }
+
+    public void WriteLine(string? value)
+    {
+        CaptureConsoleOutWriter.WriteLine(value);
+    }
+
+    public void WriteLine(object? value)
+    {
+        CaptureConsoleOutWriter.WriteLine(value);
+    }
+
+    public void WriteLine(string format, object? arg0)
+    {
+        CaptureConsoleOutWriter.WriteLine(format, arg0);
+    }
+
+    public void WriteLine(string format, object? arg0, object? arg1)
+    {
+        CaptureConsoleOutWriter.WriteLine(format, arg0, arg1);
+    }
+
+    public void WriteLine(string format, object? arg0, object? arg1, object? arg2)
+    {
+        CaptureConsoleOutWriter.WriteLine(format, arg0, arg1, arg2);
+    }
+
+    public void WriteLine(string format, object?[]? args)
+    {
+        CaptureConsoleOutWriter.WriteLine(format, args!);
+    }
+
+    public void Write(string format, object?[]? args)
+    {
+        CaptureConsoleOutWriter.Write(format, args!);
+    }
+
+    public void Write(string? value)
+    {
+        CaptureConsoleOutWriter.Write(value);
+    }
+
+    public void Write(char value)
+    {
+        CaptureConsoleOutWriter.Write(value);
+    }
+
+    public void SetForegroundColor(ConsoleColor color)
+        => Console.ForegroundColor = color;
+
+    public void SetBackgroundColor(ConsoleColor color)
+        => Console.BackgroundColor = color;
+
+    public ConsoleColor GetForegroundColor()
+        => Console.ForegroundColor;
+
+    public ConsoleColor GetBackgroundColor()
+        => Console.BackgroundColor;
+
+    public void Clear() => Console.Clear();
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsoleColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemConsoleColor.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Represents a system console color.
+/// </summary>
+public sealed class SystemConsoleColor : IColor
+{
+    /// <summary>
+    /// Gets or inits the console color.
+    /// </summary>
+    public ConsoleColor ConsoleColor { get; init; }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemStopwatch.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SystemStopwatch.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class SystemStopwatch : IStopwatch
+{
+    private readonly Stopwatch _stopwatch = new();
+
+    public TimeSpan Elapsed => _stopwatch.Elapsed;
+
+    public void Start() => _stopwatch.Start();
+
+    public void Stop() => _stopwatch.Stop();
+
+    public static IStopwatch StartNew()
+    {
+        SystemStopwatch wallClockStopwatch = new();
+        wallClockStopwatch.Start();
+
+        return wallClockStopwatch;
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TargetFrameworkParser.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TargetFrameworkParser.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal static class TargetFrameworkParser
+{
+    public static string? GetShortTargetFramework(string? frameworkDescription)
+    {
+        if (frameworkDescription == null)
+        {
+            return null;
+        }
+
+        // https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription
+        string netFramework = ".NET Framework";
+        if (frameworkDescription.StartsWith(netFramework, ignoreCase: false, CultureInfo.InvariantCulture))
+        {
+            // .NET Framework 4.7.2
+            if (frameworkDescription.Length < netFramework.Length + 6)
+            {
+                return frameworkDescription;
+            }
+
+            char major = frameworkDescription[netFramework.Length + 1];
+            char minor = frameworkDescription[netFramework.Length + 3];
+            char patch = frameworkDescription[netFramework.Length + 5];
+
+            if (major == '4' && minor == '6' && patch == '2')
+            {
+                return "net462";
+            }
+            else if (major == '4' && minor == '7' && patch == '1')
+            {
+                return "net471";
+            }
+            else if (major == '4' && minor == '7' && patch == '2')
+            {
+                return "net472";
+            }
+            else if (major == '4' && minor == '8' && patch == '1')
+            {
+                return "net481";
+            }
+            else
+            {
+                // Just return the first 2 numbers.
+                return $"net{major}{minor}";
+            }
+        }
+
+        string netCore = ".NET Core";
+        if (frameworkDescription.StartsWith(netCore, ignoreCase: false, CultureInfo.InvariantCulture))
+        {
+            // .NET Core 3.1
+            return frameworkDescription.Length >= netCore.Length + 4
+                ? $"netcoreapp{frameworkDescription[netCore.Length + 1]}.{frameworkDescription[netCore.Length + 3]}"
+                : frameworkDescription;
+        }
+
+        string net = ".NET";
+        if (frameworkDescription.StartsWith(net, ignoreCase: false, CultureInfo.InvariantCulture))
+        {
+            int firstDotInVersion = frameworkDescription.IndexOf('.', net.Length + 1);
+            return firstDotInVersion < 1
+                ? frameworkDescription
+                : $"net{frameworkDescription.Substring(net.Length + 1, firstDotInVersion - net.Length - 1)}.{frameworkDescription[firstDotInVersion + 1]}";
+        }
+
+        return frameworkDescription;
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalColor.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalColor.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Enumerates the text colors supported by VT100 terminal.
+/// </summary>
+internal enum TerminalColor
+{
+    /// <summary>
+    /// Black.
+    /// </summary>
+    Black = 30,
+
+    /// <summary>
+    /// DarkRed.
+    /// </summary>
+    DarkRed = 31,
+
+    /// <summary>
+    /// DarkGreen.
+    /// </summary>
+    DarkGreen = 32,
+
+    /// <summary>
+    /// DarkYellow.
+    /// </summary>
+    DarkYellow = 33,
+
+    /// <summary>
+    /// DarkBlue.
+    /// </summary>
+    DarkBlue = 34,
+
+    /// <summary>
+    /// DarkMagenta.
+    /// </summary>
+    DarkMagenta = 35,
+
+    /// <summary>
+    /// DarkCyan.
+    /// </summary>
+    DarkCyan = 36,
+
+    /// <summary>
+    /// Gray. This entry looks out of order, but in reality 37 is dark white, which is lighter than bright black = Dark Gray in Console colors.
+    /// </summary>
+    Gray = 37,
+
+    /// <summary>
+    /// Default.
+    /// </summary>
+    Default = 39,
+
+    /// <summary>
+    /// DarkGray. This entry looks out of order, but in reality 90 is bright black, which is darker than dark white = Gray in Console colors.
+    /// </summary>
+    DarkGray = 90,
+
+    /// <summary>
+    /// Red.
+    /// </summary>
+    Red = 91,
+
+    /// <summary>
+    /// Green.
+    /// </summary>
+    Green = 92,
+
+    /// <summary>
+    /// Yellow.
+    /// </summary>
+    Yellow = 93,
+
+    /// <summary>
+    /// Blue.
+    /// </summary>
+    Blue = 94,
+
+    /// <summary>
+    /// Magenta.
+    /// </summary>
+    Magenta = 95,
+
+    /// <summary>
+    /// Cyan.
+    /// </summary>
+    Cyan = 96,
+
+    /// <summary>
+    /// White.
+    /// </summary>
+    White = 97,
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -1,0 +1,1129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Help;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Terminal test reporter that outputs test progress and is capable of writing ANSI or non-ANSI output via the given terminal.
+/// </summary>
+internal sealed partial class TerminalTestReporter : IDisposable
+{
+    /// <summary>
+    /// The two directory separator characters to be passed to methods like <see cref="string.IndexOfAny(char[])"/>.
+    /// </summary>
+    private static readonly string[] NewLineStrings = ["\r\n", "\n"];
+
+    internal const string SingleIndentation = "  ";
+
+    internal const string DoubleIndentation = $"{SingleIndentation}{SingleIndentation}";
+
+    internal Func<IStopwatch> CreateStopwatch { get; set; } = SystemStopwatch.StartNew;
+
+    private readonly ConcurrentDictionary<string, TestProgressState> _assemblies = new();
+
+    private readonly List<TestRunArtifact> _artifacts = [];
+
+    private readonly TerminalTestReporterOptions _options;
+
+    private readonly TestProgressStateAwareTerminal _terminalWithProgress;
+
+    /// <summary>
+    /// Whether to track and render currently running tests. Gated on both the caller-requested
+    /// <see cref="TerminalTestReporterOptions.ShowActiveTests"/> and the effective progress
+    /// capability of the console: if progress cannot actually be rendered (e.g. redirected stdout,
+    /// non-TTY, or ANSI not supported) there is no point allocating per-test running-state.
+    /// </summary>
+    private readonly bool _showActiveTests;
+
+    private int _handshakeFailuresCount;
+
+    private readonly object _handshakeFailuresLock = new();
+    private readonly List<HandshakeFailureRecord> _handshakeFailures = new();
+
+    private readonly uint? _originalConsoleMode;
+    private bool _isDiscovery;
+    private bool _isHelp;
+    private bool _isRetry;
+    private DateTimeOffset? _testExecutionStartTime;
+
+    private DateTimeOffset? _testExecutionEndTime;
+
+    private int _buildErrorsCount;
+
+    private bool _wasCancelled;
+
+    public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
+    public int TotalTests => _assemblies.Values.Sum(a => a.TotalTests);
+
+    // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
+    // thread suspends, so the regex gets blamed incorrectly.
+    [GeneratedRegex(@$"^   at ((?<code>.+) in (?<file>.+):line (?<line>\d+)|(?<code1>.+))$", RegexOptions.ExplicitCapture)]
+    private static partial Regex GetFrameRegex();
+
+    private int _counter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TerminalTestReporter"/> class with custom terminal and manual refresh for testing.
+    /// </summary>
+    public TerminalTestReporter(IConsole console, TerminalTestReporterOptions options)
+    {
+        _options = options;
+        bool showProgress = _options.ShowProgress;
+
+        ITerminal terminal;
+        if (_options.AnsiMode == AnsiMode.SimpleAnsi)
+        {
+            // We are told externally that we are in CI, use simplified ANSI mode.
+            terminal = new SimpleAnsiTerminal(console);
+            showProgress = false;
+        }
+        else
+        {
+            // We are not in CI, or in CI non-compatible with simple ANSI, autodetect terminal capabilities
+            // Autodetect.
+            (bool consoleAcceptsAnsiCodes, bool _, uint? originalConsoleMode) = NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes();
+            _originalConsoleMode = originalConsoleMode;
+
+            bool useAnsi = _options.AnsiMode switch
+            {
+                AnsiMode.NoAnsi => false,
+                AnsiMode.AnsiIfPossible => consoleAcceptsAnsiCodes,
+                _ => throw new UnreachableException(),
+            };
+
+            showProgress = showProgress && useAnsi;
+            terminal = useAnsi ? new AnsiTerminal(console, _options.BaseDirectory) : new NonAnsiTerminal(console);
+        }
+
+        _terminalWithProgress = new TestProgressStateAwareTerminal(terminal, showProgress);
+        _showActiveTests = _options.ShowActiveTests && showProgress;
+    }
+
+    public void TestExecutionStarted(DateTimeOffset testStartTime, int workerCount, bool isDiscovery, bool isHelp, bool isRetry)
+    {
+        _isDiscovery = isDiscovery;
+        _isHelp = isHelp;
+        _isRetry = isRetry;
+        _testExecutionStartTime = testStartTime;
+        _terminalWithProgress.StartShowingProgress(workerCount);
+    }
+
+    public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId)
+    {
+        var assemblyRun = GetOrAddAssemblyRun(assembly, targetFramework, architecture, executionId);
+        assemblyRun.NotifyHandshake(instanceId);
+
+        // If we fail to parse out the parameter correctly this will enable retry on re-run of the assembly within the same execution.
+        // Not good enough for general use, because we want to show (try 1) even on the first try, but this will at
+        // least show (try 2) etc. So user is still aware there is retry going on, and counts of tests won't break.
+        _isRetry |= assemblyRun.TryCount > 1;
+
+        if (_options.ShowAssembly && _options.ShowAssemblyStartAndComplete)
+        {
+            _terminalWithProgress.WriteToTerminal(terminal =>
+            {
+                if (_isRetry)
+                {
+                    terminal.SetColor(TerminalColor.DarkGray);
+                    terminal.Append($"({string.Format(CliCommandStrings.Try, assemblyRun.TryCount)}) ");
+                    terminal.ResetColor();
+                }
+
+                terminal.Append(_isDiscovery ? CliCommandStrings.DiscoveringTestsFrom : CliCommandStrings.RunningTestsFrom);
+                terminal.Append(' ');
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly, targetFramework, architecture);
+                terminal.AppendLine();
+            });
+        }
+    }
+
+    private TestProgressState GetOrAddAssemblyRun(string assembly, string? targetFramework, string? architecture, string executionId)
+    {
+        return _assemblies.GetOrAdd(executionId, _ =>
+        {
+            IStopwatch sw = CreateStopwatch();
+            var assemblyRun = new TestProgressState(Interlocked.Increment(ref _counter), assembly, targetFramework, architecture, sw, _isDiscovery);
+            int slotIndex = _terminalWithProgress.AddWorker(assemblyRun);
+            assemblyRun.SlotIndex = slotIndex;
+
+            return assemblyRun;
+        });
+    }
+
+    public void TestExecutionCompleted(DateTimeOffset endTime, int? exitCode)
+    {
+        _testExecutionEndTime = endTime;
+        _terminalWithProgress.StopShowingProgress();
+
+        if (!_isHelp)
+        {
+            if (_isDiscovery)
+            {
+                _terminalWithProgress.WriteToTerminal(terminal => AppendTestDiscoverySummary(terminal, exitCode));
+            }
+            else
+            {
+                _terminalWithProgress.WriteToTerminal(terminal => AppendTestRunSummary(terminal, exitCode));
+            }
+        }
+
+        NativeMethods.RestoreConsoleMode(_originalConsoleMode);
+        _assemblies.Clear();
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Clear();
+        }
+        _handshakeFailuresCount = 0;
+        _buildErrorsCount = 0;
+        _testExecutionStartTime = null;
+        _testExecutionEndTime = null;
+    }
+
+    private void AppendTestRunSummary(ITerminal terminal, int? exitCode)
+    {
+        IEnumerable<IGrouping<bool, TestRunArtifact>> artifactGroups = _artifacts.GroupBy(a => a.OutOfProcess);
+
+        if (artifactGroups.Any())
+        {
+            // Add extra empty line when we will be writing any artifacts, to split it from previous output.
+            terminal.AppendLine();
+        }
+
+        foreach (IGrouping<bool, TestRunArtifact> artifactGroup in artifactGroups)
+        {
+            terminal.Append(SingleIndentation);
+            terminal.AppendLine(artifactGroup.Key ? CliCommandStrings.OutOfProcessArtifactsProduced : CliCommandStrings.InProcessArtifactsProduced);
+            foreach (TestRunArtifact artifact in artifactGroup)
+            {
+                terminal.Append(DoubleIndentation);
+                terminal.Append("- ");
+                if (!string.IsNullOrWhiteSpace(artifact.TestName))
+                {
+                    terminal.Append(CliCommandStrings.ForTest);
+                    terminal.Append(" '");
+                    terminal.Append(artifact.TestName);
+                    terminal.Append("': ");
+                }
+
+                terminal.AppendLink(artifact.Path, lineNumber: null);
+                terminal.AppendLine();
+            }
+        }
+
+        terminal.AppendLine();
+
+        int totalTests = _assemblies.Values.Sum(a => a.TotalTests);
+        int totalFailedTests = _assemblies.Values.Sum(a => a.FailedTests);
+        int totalSkippedTests = _assemblies.Values.Sum(a => a.SkippedTests);
+
+        bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
+        bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
+        bool anyTestFailed = totalFailedTests > 0;
+        bool anyAssemblyFailed = _assemblies.Values.Any(a => !a.Success) || HasHandshakeFailure;
+        bool runFailed = anyAssemblyFailed || anyTestFailed || notEnoughTests || allTestsWereSkipped || _wasCancelled;
+        terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
+
+        terminal.Append(CliCommandStrings.TestRunSummary);
+        terminal.Append(' ');
+
+        if (_wasCancelled)
+        {
+            terminal.Append(CliCommandStrings.Aborted);
+        }
+        else if (notEnoughTests)
+        {
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.MinimumExpectedTestsPolicyViolation, totalTests, _options.MinimumExpectedTests));
+        }
+        else if (anyTestFailed || HasHandshakeFailure)
+        {
+            // Handshake failures take precedence over "Zero tests ran": when an assembly failed to
+            // hand-shake we want the headline to reflect that the run failed, not that no tests ran
+            // (which would imply a benign empty run). We intentionally do NOT escalate the broader
+            // anyAssemblyFailed here, because a project that legitimately contains zero tests exits
+            // with ExitCodes.ZeroTests (non-zero) and would otherwise be misclassified as a failure.
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Failed));
+        }
+        else if (allTestsWereSkipped)
+        {
+            terminal.Append(CliCommandStrings.ZeroTestsRan);
+        }
+        else if (anyAssemblyFailed)
+        {
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Failed));
+        }
+        else
+        {
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Passed));
+        }
+
+        if (!_options.ShowAssembly && _assemblies.Count == 1)
+        {
+            TestProgressState testProgressState = _assemblies.Values.Single();
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append(" - ");
+            terminal.ResetColor();
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, testProgressState.Assembly, testProgressState.TargetFramework, testProgressState.Architecture);
+        }
+
+        terminal.AppendLine();
+
+        if (_options.ShowAssembly && _assemblies.Count > 1)
+        {
+            foreach (TestProgressState assemblyRun in _assemblies.Values)
+            {
+                terminal.Append(SingleIndentation);
+                AppendAssemblySummary(assemblyRun, terminal);
+            }
+
+            terminal.AppendLine();
+        }
+
+        int total = _assemblies.Values.Sum(t => t.TotalTests);
+        int failed = _assemblies.Values.Sum(t => t.FailedTests);
+        int passed = _assemblies.Values.Sum(t => t.PassedTests);
+        int skipped = _assemblies.Values.Sum(t => t.SkippedTests);
+        int retried = _assemblies.Values.Sum(t => t.RetriedFailedTests);
+
+        // If the process exited with non-zero exit code (t.Success is false)
+        // And also we didn't receive any failed tests, we consider these as errors.
+        // In addition, failing to handshake is also considered as an error.
+        // Note: In case of handshake failure, we shouldn't add any entries to _assemblies dictionary.
+        // So, this line cannot be double-counting handshake failures twice.
+        int error = _assemblies.Values.Count(t => !t.Success && t.FailedTests == 0) + _handshakeFailuresCount;
+        TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
+
+        bool colorizeFailed = failed > 0;
+        bool colorizeError = error > 0;
+        bool colorizePassed = passed > 0 && _buildErrorsCount == 0 && failed == 0 && error == 0;
+        bool colorizeSkipped = skipped > 0 && skipped == total && _buildErrorsCount == 0 && failed == 0 && error == 0;
+
+        string errorText = $"{SingleIndentation}{CliCommandStrings.ErrorColon} {error}";
+        string totalText = $"{SingleIndentation}{CliCommandStrings.TotalColon} {total}";
+        string retriedText = $" (+{retried} {CliCommandStrings.Retried})";
+        string failedText = $"{SingleIndentation}{CliCommandStrings.FailedColon} {failed}";
+        string passedText = $"{SingleIndentation}{CliCommandStrings.SucceededColon} {passed}";
+        string skippedText = $"{SingleIndentation}{CliCommandStrings.SkippedColon} {skipped}";
+        string durationText = $"{SingleIndentation}{CliCommandStrings.DurationColon} ";
+
+        if (error > 0)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.AppendLine(errorText);
+            terminal.ResetColor();
+            terminal.AppendLine();
+        }
+
+        terminal.ResetColor();
+        terminal.Append(totalText);
+        if (retried > 0)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append(retriedText);
+            terminal.ResetColor();
+        }
+        terminal.AppendLine();
+
+        if (colorizeFailed)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+        }
+
+        terminal.AppendLine(failedText);
+
+        if (colorizeFailed)
+        {
+            terminal.ResetColor();
+        }
+
+        if (colorizePassed)
+        {
+            terminal.SetColor(TerminalColor.DarkGreen);
+        }
+
+        terminal.AppendLine(passedText);
+
+        if (colorizePassed)
+        {
+            terminal.ResetColor();
+        }
+
+        if (colorizeSkipped)
+        {
+            terminal.SetColor(TerminalColor.DarkYellow);
+        }
+
+        terminal.AppendLine(skippedText);
+
+        if (colorizeSkipped)
+        {
+            terminal.ResetColor();
+        }
+
+        terminal.Append(durationText);
+        AppendLongDuration(terminal, runDuration, wrapInParentheses: false, colorize: false);
+        terminal.AppendLine();
+
+        AppendExitCodeAndUrl(terminal, exitCode, isRun: true);
+
+        AppendHandshakeFailureRecap(terminal);
+    }
+
+    private void AppendHandshakeFailureRecap(ITerminal terminal)
+    {
+        // Re-print handshake failures captured during the run so that — even when there is a lot of
+        // diagnostic output before the summary — the user sees the actionable failure context
+        // (assembly, exit code, stdout, stderr) at the end of the run rather than having to scroll
+        // back. See https://github.com/dotnet/sdk/issues/51608.
+        HandshakeFailureRecord[] failures;
+        lock (_handshakeFailuresLock)
+        {
+            if (_handshakeFailures.Count == 0)
+            {
+                return;
+            }
+
+            failures = _handshakeFailures.ToArray();
+        }
+
+        terminal.AppendLine();
+        terminal.SetColor(TerminalColor.DarkRed);
+        terminal.AppendLine(CliCommandStrings.HandshakeFailuresHeader);
+        terminal.ResetColor();
+
+        foreach (HandshakeFailureRecord failure in failures)
+        {
+            terminal.Append(SingleIndentation);
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, failure.AssemblyPath, failure.TargetFramework, architecture: null);
+            terminal.AppendLine();
+            AppendExecutableSummary(terminal, failure.ExitCode, failure.OutputData, failure.ErrorData);
+        }
+    }
+
+    private static void AppendExitCodeAndUrl(ITerminal terminal, int? exitCode, bool isRun)
+    {
+        // When we crash with exception we don't have any predetermined exit code, and won't write our helper message to point users to exit code overview.
+        // When we succeed we also don't point users to exit code overview.
+        if (exitCode == null || exitCode == 0)
+        {
+            return;
+        }
+
+        terminal.AppendLine(string.Format(isRun ? CliCommandStrings.TestRunExitCode : CliCommandStrings.TestDiscoveryExitCode, exitCode));
+    }
+
+    /// <summary>
+    /// Print a build result summary to the output.
+    /// </summary>
+    private static void AppendAssemblyResult(ITerminal terminal, TestProgressState state)
+    {
+        if (!state.Success)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            // If the build failed, we print one of three red strings.
+            string text = (state.FailedTests > 0, state.TotalTests == 0) switch
+            {
+                (true, _) => string.Format(CultureInfo.CurrentCulture, CliCommandStrings.FailedWithErrors, state.FailedTests),
+                (false, true) => CliCommandStrings.ZeroTestsRan,
+                (false, false) => CliCommandStrings.FailedLowercase,
+            };
+            terminal.Append(text);
+            terminal.ResetColor();
+        }
+        else
+        {
+            terminal.SetColor(TerminalColor.DarkGreen);
+            terminal.Append(CliCommandStrings.PassedLowercase);
+            terminal.ResetColor();
+        }
+    }
+
+    internal void TestCompleted(
+        string assembly,
+        string? targetFramework,
+        string? architecture,
+        string executionId,
+        string instanceId,
+        string testNodeUid,
+        string displayName,
+        string? informativeMessage,
+        TestOutcome outcome,
+        TimeSpan? duration,
+        FlatException[]? exceptions,
+        string? expected,
+        string? actual,
+        string? standardOutput,
+        string? errorOutput)
+    {
+        TestProgressState asm = _assemblies[executionId];
+        var attempt = asm.TryCount;
+
+        if (_showActiveTests)
+        {
+            asm.TestNodeResultsState?.RemoveRunningTestNode(instanceId, testNodeUid);
+        }
+
+        switch (outcome)
+        {
+            case TestOutcome.Error:
+            case TestOutcome.Timeout:
+            case TestOutcome.Canceled:
+            case TestOutcome.Fail:
+                asm.ReportFailedTest(testNodeUid, instanceId);
+                break;
+            case TestOutcome.Passed:
+                asm.ReportPassingTest(testNodeUid, instanceId);
+                break;
+            case TestOutcome.Skipped:
+                asm.ReportSkippedTest(testNodeUid, instanceId);
+                break;
+        }
+
+        _terminalWithProgress.UpdateWorker(asm.SlotIndex);
+        if (outcome != TestOutcome.Passed || _options.ShowPassedTests)
+        {
+            _terminalWithProgress.WriteToTerminal(terminal => RenderTestCompleted(
+                terminal,
+                assembly,
+                attempt,
+                targetFramework,
+                architecture,
+                displayName,
+                informativeMessage,
+                outcome,
+                duration,
+                exceptions,
+                expected,
+                actual,
+                standardOutput,
+                errorOutput));
+        }
+    }
+
+    internal /* for testing */ void RenderTestCompleted(
+        ITerminal terminal,
+        string assembly,
+        int attempt,
+        string? targetFramework,
+        string? architecture,
+        string displayName,
+        string? informativeMessage,
+        TestOutcome outcome,
+        TimeSpan? duration,
+        FlatException[]? flatExceptions,
+        string? expected,
+        string? actual,
+        string? standardOutput,
+        string? errorOutput)
+    {
+        if (outcome == TestOutcome.Passed && !_options.ShowPassedTests)
+        {
+            return;
+        }
+
+        TerminalColor color = outcome switch
+        {
+            TestOutcome.Error or TestOutcome.Fail or TestOutcome.Canceled or TestOutcome.Timeout => TerminalColor.DarkRed,
+            TestOutcome.Skipped => TerminalColor.DarkYellow,
+            TestOutcome.Passed => TerminalColor.DarkGreen,
+            _ => throw new NotSupportedException(),
+        };
+        string outcomeText = outcome switch
+        {
+            TestOutcome.Fail or TestOutcome.Error => CliCommandStrings.FailedLowercase,
+            TestOutcome.Skipped => CliCommandStrings.SkippedLowercase,
+            TestOutcome.Canceled or TestOutcome.Timeout => $"{CliCommandStrings.FailedLowercase} ({CliCommandStrings.CancelledLowercase})",
+            TestOutcome.Passed => CliCommandStrings.PassedLowercase,
+            _ => throw new NotSupportedException(),
+        };
+
+        terminal.SetColor(color);
+        terminal.Append(outcomeText);
+        if (_isRetry)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append($" ({string.Format(CliCommandStrings.Try, attempt)})");
+        }
+        terminal.ResetColor();
+        terminal.Append(' ');
+        terminal.Append(displayName);
+
+        if (duration.HasValue)
+        {
+            terminal.Append(' ');
+            AppendLongDuration(terminal, duration.Value);
+        }
+
+        if (!string.IsNullOrEmpty(informativeMessage))
+        {
+            terminal.AppendLine();
+            terminal.Append(SingleIndentation);
+            terminal.Append(informativeMessage);
+        }
+
+        if (_options.ShowAssembly)
+        {
+            terminal.AppendLine();
+            terminal.Append(SingleIndentation);
+            terminal.Append(CliCommandStrings.FromFile);
+            terminal.Append(' ');
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly, targetFramework, architecture);
+        }
+
+        terminal.AppendLine();
+
+        FormatErrorMessage(terminal, flatExceptions, outcome, 0);
+        FormatExpectedAndActual(terminal, expected, actual);
+        FormatStackTrace(terminal, flatExceptions, 0);
+        FormatInnerExceptions(terminal, flatExceptions);
+        FormatStandardAndErrorOutput(terminal, standardOutput, errorOutput);
+    }
+
+    private static void FormatInnerExceptions(ITerminal terminal, FlatException[]? exceptions)
+    {
+        if (exceptions is null || exceptions.Length == 0)
+        {
+            return;
+        }
+
+        for (int i = 1; i < exceptions.Length; i++)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append(SingleIndentation);
+            terminal.Append("--->");
+            FormatErrorMessage(terminal, exceptions, TestOutcome.Error, i);
+            FormatStackTrace(terminal, exceptions, i);
+        }
+    }
+
+    private static void FormatErrorMessage(ITerminal terminal, FlatException[]? exceptions, TestOutcome outcome, int index)
+    {
+        string? firstErrorMessage = GetStringFromIndexOrDefault(exceptions, e => e.ErrorMessage, index);
+        string? firstErrorType = GetStringFromIndexOrDefault(exceptions, e => e.ErrorType, index);
+        string? firstStackTrace = GetStringFromIndexOrDefault(exceptions, e => e.StackTrace, index);
+        if (string.IsNullOrWhiteSpace(firstErrorMessage) && string.IsNullOrWhiteSpace(firstErrorType) && string.IsNullOrWhiteSpace(firstStackTrace))
+        {
+            return;
+        }
+
+        terminal.SetColor(TerminalColor.DarkRed);
+
+        if (firstStackTrace is null)
+        {
+            AppendIndentedLine(terminal, firstErrorMessage, SingleIndentation);
+        }
+        else if (outcome == TestOutcome.Fail)
+        {
+            // For failed tests, we don't prefix the message with the exception type because it is most likely an assertion specific exception like AssertionFailedException, and we prefer to show that without the exception type to avoid additional noise.
+            AppendIndentedLine(terminal, firstErrorMessage, SingleIndentation);
+        }
+        else
+        {
+            AppendIndentedLine(terminal, $"{firstErrorType}: {firstErrorMessage}", SingleIndentation);
+        }
+
+        terminal.ResetColor();
+    }
+
+    private static string? GetStringFromIndexOrDefault(FlatException[]? exceptions, Func<FlatException, string?> property, int index) =>
+        exceptions != null && exceptions.Length >= index + 1 ? property(exceptions[index]) : null;
+
+    private static void FormatExpectedAndActual(ITerminal terminal, string? expected, string? actual)
+    {
+        if (string.IsNullOrWhiteSpace(expected) && string.IsNullOrWhiteSpace(actual))
+        {
+            return;
+        }
+
+        terminal.SetColor(TerminalColor.DarkRed);
+        terminal.Append(SingleIndentation);
+        terminal.AppendLine(CliCommandStrings.Expected);
+        AppendIndentedLine(terminal, expected, DoubleIndentation);
+        terminal.Append(SingleIndentation);
+        terminal.AppendLine(CliCommandStrings.Actual);
+        AppendIndentedLine(terminal, actual, DoubleIndentation);
+        terminal.ResetColor();
+    }
+
+    private static void FormatStackTrace(ITerminal terminal, FlatException[]? exceptions, int index)
+    {
+        string? stackTrace = GetStringFromIndexOrDefault(exceptions, e => e.StackTrace, index);
+        if (string.IsNullOrWhiteSpace(stackTrace))
+        {
+            return;
+        }
+
+        terminal.SetColor(TerminalColor.DarkGray);
+
+        string[] lines = stackTrace.Split(NewLineStrings, StringSplitOptions.None);
+        foreach (string line in lines)
+        {
+            AppendStackFrame(terminal, line);
+        }
+
+        terminal.ResetColor();
+    }
+
+    private static void FormatStandardAndErrorOutput(ITerminal terminal, string? standardOutput, string? standardError)
+    {
+        if (string.IsNullOrWhiteSpace(standardOutput) && string.IsNullOrWhiteSpace(standardError))
+        {
+            return;
+        }
+
+        terminal.SetColor(TerminalColor.DarkGray);
+        terminal.Append(SingleIndentation);
+        terminal.AppendLine(CliCommandStrings.StandardOutput);
+        string? standardOutputWithoutSpecialChars = NormalizeSpecialCharacters(standardOutput);
+        AppendIndentedLine(terminal, standardOutputWithoutSpecialChars, DoubleIndentation);
+        terminal.Append(SingleIndentation);
+        terminal.AppendLine(CliCommandStrings.StandardError);
+        string? standardErrorWithoutSpecialChars = NormalizeSpecialCharacters(standardError);
+        AppendIndentedLine(terminal, standardErrorWithoutSpecialChars, DoubleIndentation);
+        terminal.ResetColor();
+    }
+
+    private static void AppendAssemblyLinkTargetFrameworkAndArchitecture(ITerminal terminal, string assembly, string? targetFramework, string? architecture)
+    {
+        terminal.AppendLink(assembly, lineNumber: null);
+        if (targetFramework != null || architecture != null)
+        {
+            terminal.Append(" (");
+            if (targetFramework != null)
+            {
+                terminal.Append(targetFramework);
+                if (architecture != null)
+                {
+                    terminal.Append('|');
+                }
+            }
+
+            if (architecture != null)
+            {
+                terminal.Append(architecture);
+            }
+
+            terminal.Append(')');
+        }
+    }
+
+    internal /* for testing */ static void AppendStackFrame(ITerminal terminal, string stackTraceLine)
+    {
+        terminal.Append(DoubleIndentation);
+        Match match = GetFrameRegex().Match(stackTraceLine);
+        if (match.Success)
+        {
+            bool weHaveFilePathAndCodeLine = !string.IsNullOrWhiteSpace(match.Groups["code"].Value);
+            terminal.Append(CliCommandStrings.StackFrameAt);
+            terminal.Append(' ');
+
+            if (weHaveFilePathAndCodeLine)
+            {
+                terminal.Append(match.Groups["code"].Value);
+            }
+            else
+            {
+                terminal.Append(match.Groups["code1"].Value);
+            }
+
+            if (weHaveFilePathAndCodeLine)
+            {
+                terminal.Append(' ');
+                terminal.Append(CliCommandStrings.StackFrameIn);
+                terminal.Append(' ');
+                if (!string.IsNullOrWhiteSpace(match.Groups["file"].Value))
+                {
+                    int line = int.TryParse(match.Groups["line"].Value, out int value) ? value : 0;
+                    terminal.AppendLink(match.Groups["file"].Value, line);
+
+                    // AppendLink finishes by resetting color
+                    terminal.SetColor(TerminalColor.DarkGray);
+                }
+            }
+
+            terminal.AppendLine();
+        }
+        else
+        {
+            terminal.AppendLine(stackTraceLine);
+        }
+    }
+
+    private static void AppendIndentedLine(ITerminal terminal, string? message, string indent)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        if (!message.Contains('\n'))
+        {
+            terminal.Append(indent);
+            terminal.AppendLine(message);
+            return;
+        }
+
+        string[] lines = message.Split(NewLineStrings, StringSplitOptions.None);
+        foreach (string line in lines)
+        {
+            // Here we could check if the messages are longer than then line, and reflow them so a long line is split into multiple
+            // and prepended by the respective indentation.
+            // But this does not play nicely with ANSI escape codes. And if you
+            // run in narrow terminal and then widen it the text does not reflow correctly. And you also have harder time copying
+            // values when the assertion message is longer.
+            terminal.Append(indent);
+            terminal.Append(line);
+            terminal.AppendLine();
+        }
+    }
+
+    internal void AssemblyRunCompleted(string executionId,
+        // These parameters are useful only for "remote" runs in dotnet test, where we are reporting on multiple processes.
+        // In single process run, like with testing platform .exe we report these via messages, and run exit.
+        int exitCode, string? outputData, string? errorData)
+    {
+        // Defense in depth: under the current TestApplicationHandler routing this branch is
+        // unreachable in normal operation. OnTestProcessExited only calls AssemblyRunCompleted
+        // when the TestHost handshake was received (which in turn caused AssemblyRunStarted to
+        // register the executionId via GetOrAddAssemblyRun); controller-only handshakes go to
+        // HandshakeFailure directly. The fallback below exists only to keep stray completions
+        // (e.g. one that arrives after TestExecutionCompleted's _assemblies.Clear()) or a future
+        // routing regression from surfacing as a KeyNotFoundException that would bury the real
+        // exit cause.
+        if (!_assemblies.TryGetValue(executionId, out TestProgressState? assemblyRun))
+        {
+            HandshakeFailure(assemblyPath: string.Empty, targetFramework: null, exitCode, outputData ?? string.Empty, errorData ?? string.Empty);
+            return;
+        }
+
+        assemblyRun.Success = exitCode == 0 && assemblyRun.FailedTests == 0;
+        assemblyRun.Stopwatch.Stop();
+
+        _terminalWithProgress.RemoveWorker(assemblyRun.SlotIndex);
+
+        if (!_isHelp && !_isDiscovery && _options.ShowAssembly && _options.ShowAssemblyStartAndComplete)
+        {
+            _terminalWithProgress.WriteToTerminal(terminal => AppendAssemblySummary(assemblyRun, terminal));
+        }
+
+        if (exitCode == 0)
+        {
+            // Report nothing, we don't want to report on success, because then we will also report on test-discovery etc.
+            return;
+        }
+
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            AppendExecutableSummary(terminal, exitCode, outputData, errorData);
+        });
+    }
+
+    internal void HandshakeFailure(string assemblyPath, string? targetFramework, int exitCode, string outputData, string errorData, bool reportEvenWhenHelp = false)
+    {
+        if (_isHelp && !reportEvenWhenHelp)
+        {
+            // Backward-compat workaround: older Microsoft.Testing.Platform versions don't perform
+            // a handshake on the --help path (the host just prints help and exits). In that case
+            // OnTestProcessExited routes here with the "process exited without a usable handshake"
+            // payload, which is expected and should not be reported as a failure.
+            //
+            // Newer MTP versions (microsoft/testfx#8794) always handshake — including on --help —
+            // so this workaround is only needed while older MTP versions are still in use. Explicit
+            // protocol-level rejections (e.g. ExecutionMode mismatch) pass reportEvenWhenHelp=true
+            // and are still surfaced.
+            return;
+        }
+
+        Interlocked.Increment(ref _handshakeFailuresCount);
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Add(new HandshakeFailureRecord(assemblyPath, targetFramework, exitCode, outputData, errorData));
+        }
+
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.ResetColor();
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyPath, targetFramework, architecture: null);
+            terminal.Append(' ');
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append(CliCommandStrings.ZeroTestsRan);
+            terminal.ResetColor();
+            terminal.AppendLine();
+            AppendExecutableSummary(terminal, exitCode, outputData, errorData);
+        });
+    }
+
+    private static void AppendExecutableSummary(ITerminal terminal, int? exitCode, string? outputData, string? errorData)
+    {
+        terminal.Append(CliCommandStrings.ExitCode);
+        terminal.Append(": ");
+        terminal.AppendLine(exitCode?.ToString(CultureInfo.CurrentCulture) ?? "<null>");
+        AppendOutputWhenPresent(CliCommandStrings.StandardOutput, outputData);
+        AppendOutputWhenPresent(CliCommandStrings.StandardError, errorData);
+
+        void AppendOutputWhenPresent(string description, string? output)
+        {
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                AppendIndentedLine(terminal, $"{description}: {output}", SingleIndentation);
+            }
+        }
+    }
+
+    private static string? NormalizeSpecialCharacters(string? text)
+        => text?.Replace('\0', '\x2400')
+            // escape char
+            .Replace('\x001b', '\x241b');
+
+    private static void AppendAssemblySummary(TestProgressState assemblyRun, ITerminal terminal)
+    {
+        terminal.ResetColor();
+
+        AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyRun.Assembly, assemblyRun.TargetFramework, assemblyRun.Architecture);
+        terminal.Append(' ');
+        AppendAssemblyResult(terminal, assemblyRun);
+        terminal.Append(' ');
+        AppendAssemblyTestCounts(terminal, assemblyRun);
+        terminal.Append(' ');
+        AppendLongDuration(terminal, assemblyRun.Stopwatch.Elapsed);
+        terminal.AppendLine();
+    }
+
+    /// <summary>
+    /// Renders a compact, per-assembly counts block that mirrors the in-progress indicator.
+    /// Full-ANSI terminals get "[✓P/xF/↓S]" (with optional "/rR"); simple terminals
+    /// (NoAnsi / SimpleAnsi / CI) get the ASCII "[+P/xF/?S]" form so logs stay font- and
+    /// encoding-friendly. Glyphs and colors are intentionally kept in sync with the rendering in
+    /// <see cref="AnsiTerminalTestProgressFrame"/> and <see cref="SimpleTerminal.RenderProgress"/>.
+    /// </summary>
+    private static void AppendAssemblyTestCounts(ITerminal terminal, TestProgressState assemblyRun)
+    {
+        int failed = assemblyRun.FailedTests;
+        int passed = assemblyRun.PassedTests;
+        int skipped = assemblyRun.SkippedTests;
+        int retried = assemblyRun.RetriedFailedTests;
+
+        bool unicode = terminal is AnsiTerminal;
+        char passedGlyph = unicode ? '✓' : '+';
+        char skippedGlyph = unicode ? '↓' : '?';
+
+        terminal.Append('[');
+
+        AppendGlyphCount(terminal, passedGlyph, passed, TerminalColor.DarkGreen);
+        terminal.Append('/');
+        AppendGlyphCount(terminal, 'x', failed, TerminalColor.DarkRed);
+        terminal.Append('/');
+        AppendGlyphCount(terminal, skippedGlyph, skipped, TerminalColor.DarkYellow);
+
+        if (retried > 0)
+        {
+            terminal.Append('/');
+            AppendGlyphCount(terminal, 'r', retried, TerminalColor.Gray);
+        }
+
+        terminal.Append(']');
+    }
+
+    private static void AppendGlyphCount(ITerminal terminal, char glyph, int count, TerminalColor color)
+    {
+        terminal.SetColor(color);
+        terminal.Append(glyph);
+        terminal.Append(count.ToString(CultureInfo.CurrentCulture));
+        terminal.ResetColor();
+    }
+
+    /// <summary>
+    /// Appends a long duration in human readable format such as 1h 23m 500ms.
+    /// </summary>
+    private static void AppendLongDuration(ITerminal terminal, TimeSpan duration, bool wrapInParentheses = true, bool colorize = true)
+    {
+        if (colorize)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+        }
+
+        HumanReadableDurationFormatter.Append(terminal, duration, wrapInParentheses);
+
+        if (colorize)
+        {
+            terminal.ResetColor();
+        }
+    }
+
+    public void Dispose() => _terminalWithProgress.Dispose();
+
+    public void ArtifactAdded(bool outOfProcess, string? assembly, string? targetFramework, string? architecture, string? executionId, string? testName, string path)
+        => _artifacts.Add(new TestRunArtifact(outOfProcess, assembly, targetFramework, architecture, executionId, testName, path));
+
+    internal void WriteMessage(string text) =>
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.Append(text);
+        });
+
+    /// <summary>
+    /// Let the user know that cancellation was triggered.
+    /// </summary>
+    public void StartCancelling()
+    {
+        if (_wasCancelled)
+        {
+            return;
+        }
+
+        _wasCancelled = true;
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.AppendLine();
+            terminal.AppendLine(CliCommandStrings.CancellingTestSession);
+            terminal.AppendLine(CliCommandStrings.PressCtrlCAgainToForceExit);
+            terminal.AppendLine();
+        });
+    }
+
+    internal void TestDiscovered(
+        string executionId,
+        string? displayName,
+        string? uid,
+        string? filePath,
+        int? lineNumber)
+    {
+        if (!_isDiscovery)
+        {
+            // Don't count discovered tests if we are not in discovery mode.
+            // NOTE: DiscoverTest call increments PassedTests, so it must not be called when we get discovery message in run mode.
+            // Also, don't bother adding discovered tests to the DiscoveredTests list when the list is only used in discovery mode.
+            return;
+        }
+
+        TestProgressState asm = _assemblies[executionId];
+
+        // TODO: add mode for discovered tests to the progress bar - jajares
+        asm.DiscoverTest(displayName, uid, filePath, lineNumber);
+        _terminalWithProgress.UpdateWorker(asm.SlotIndex);
+    }
+
+    public void AppendTestDiscoverySummary(ITerminal terminal, int? exitCode)
+    {
+        terminal.AppendLine();
+
+        var assemblies = _assemblies.Select(asm => asm.Value).OrderBy(a => a.Assembly).Where(a => a is not null).ToList();
+
+        int totalTests = _assemblies.Values.Sum(a => a.TotalTests);
+        bool runFailed = _wasCancelled || totalTests < 1;
+
+        foreach (TestProgressState assembly in assemblies)
+        {
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.DiscoveredTestsInAssembly, assembly.DiscoveredTestNames.Count));
+            terminal.Append(" - ");
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly.Assembly, assembly.TargetFramework, assembly.Architecture);
+            terminal.AppendLine();
+            foreach ((string? displayName, string? uid, string? filePath, int? lineNumber) in assembly.DiscoveredTestNames)
+            {
+                if (displayName is not null)
+                {
+                    terminal.Append(SingleIndentation);
+                    terminal.Append(displayName);
+                    if (!string.IsNullOrEmpty(filePath))
+                    {
+                        terminal.Append(" [");
+                        terminal.Append(filePath);
+                        if (lineNumber is > 0)
+                        {
+                            terminal.Append(':');
+                            terminal.Append(lineNumber.Value.ToString(CultureInfo.InvariantCulture));
+                        }
+
+                        terminal.Append(']');
+                    }
+
+                    terminal.AppendLine();
+                }
+            }
+
+            terminal.AppendLine();
+        }
+
+        terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
+        if (assemblies.Count <= 1)
+        {
+            terminal.AppendLine(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.TestDiscoverySummarySingular, totalTests));
+        }
+        else
+        {
+            terminal.AppendLine(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.TestDiscoverySummary, totalTests, assemblies.Count));
+        }
+
+        terminal.ResetColor();
+        terminal.AppendLine();
+
+        if (_wasCancelled)
+        {
+            terminal.Append(CliCommandStrings.Aborted);
+            terminal.AppendLine();
+        }
+
+        AppendExitCodeAndUrl(terminal, exitCode, isRun: false);
+    }
+
+    public void AssemblyDiscoveryCompleted(int testCount) =>
+        _terminalWithProgress.WriteToTerminal(terminal => terminal.Append($"Found {testCount} tests"));
+
+    private static TerminalColor ToTerminalColor(ConsoleColor consoleColor)
+        => consoleColor switch
+        {
+            ConsoleColor.Black => TerminalColor.Black,
+            ConsoleColor.DarkBlue => TerminalColor.DarkBlue,
+            ConsoleColor.DarkGreen => TerminalColor.DarkGreen,
+            ConsoleColor.DarkCyan => TerminalColor.DarkCyan,
+            ConsoleColor.DarkRed => TerminalColor.DarkRed,
+            ConsoleColor.DarkMagenta => TerminalColor.DarkMagenta,
+            ConsoleColor.DarkYellow => TerminalColor.DarkYellow,
+            ConsoleColor.DarkGray => TerminalColor.DarkGray,
+            ConsoleColor.Gray => TerminalColor.Gray,
+            ConsoleColor.Blue => TerminalColor.Blue,
+            ConsoleColor.Green => TerminalColor.Green,
+            ConsoleColor.Cyan => TerminalColor.Cyan,
+            ConsoleColor.Red => TerminalColor.Red,
+            ConsoleColor.Magenta => TerminalColor.Magenta,
+            ConsoleColor.Yellow => TerminalColor.Yellow,
+            ConsoleColor.White => TerminalColor.White,
+            _ => TerminalColor.Default,
+        };
+
+    public void TestInProgress(
+        string assembly,
+        string? targetFramework,
+        string? architecture,
+        string executionId,
+        string instanceId,
+        string testNodeUid,
+        string displayName)
+    {
+        TestProgressState asm = _assemblies[executionId];
+
+        if (_showActiveTests)
+        {
+            asm.TestNodeResultsState ??= new(Interlocked.Increment(ref _counter));
+            asm.TestNodeResultsState.AddRunningTestNode(
+                Interlocked.Increment(ref _counter), instanceId, testNodeUid, displayName, CreateStopwatch());
+        }
+
+        _terminalWithProgress.UpdateWorker(asm.SlotIndex);
+    }
+
+    private readonly record struct HandshakeFailureRecord(
+        string AssemblyPath,
+        string? TargetFramework,
+        int ExitCode,
+        string OutputData,
+        string ErrorData);
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class TerminalTestReporterOptions
+{
+    /// <summary>
+    /// Gets path to which all other paths in output should be relative.
+    /// </summary>
+    public string? BaseDirectory { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether we should show passed tests.
+    /// </summary>
+    public bool ShowPassedTests { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether we should show information about which assembly is the source of the data on screen. Turn this off when running directly from an exe to reduce noise, because the path will always be the same.
+    /// </summary>
+    public bool ShowAssembly { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether we should show information about which assembly started or completed. Turn this off when running directly from an exe to reduce noise, because the path will always be the same.
+    /// </summary>
+    public bool ShowAssemblyStartAndComplete { get; init; }
+
+    /// <summary>
+    /// Gets minimum amount of tests to run.
+    /// </summary>
+    public int MinimumExpectedTests { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether we should write the progress periodically to screen. When ANSI is allowed we update the progress as often as we can.
+    /// When ANSI is not allowed we never have progress.
+    /// </summary>
+    public bool ShowProgress { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the active tests should be visible when the progress is shown.
+    /// </summary>
+    public bool ShowActiveTests { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating the ANSI mode.
+    /// </summary>
+    public AnsiMode AnsiMode { get; init; }
+}
+
+internal enum AnsiMode
+{
+    /// <summary>
+    /// Disable ANSI escape codes.
+    /// </summary>
+    NoAnsi,
+
+    /// <summary>
+    /// Use simplified ANSI renderer, which colors output, but does not move cursor.
+    /// This is used in compatible CI environments.
+    /// </summary>
+    SimpleAnsi,
+
+    /// <summary>
+    /// Enable ANSI escape codes, including cursor movement, when the capabilities of the console allow it.
+    /// </summary>
+    AnsiIfPossible,
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestDetailState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestDetailState.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class TestDetailState(long id, IStopwatch? stopwatch, string text)
+{
+    private string _text = text;
+
+    public long Id { get; } = id;
+
+    public long Version { get; set; }
+
+    public IStopwatch? Stopwatch { get; } = stopwatch;
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (!_text.Equals(value, StringComparison.Ordinal))
+            {
+                Version++;
+                _text = value;
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestNodeResultsState.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class TestNodeResultsState(long id)
+{
+    public long Id { get; } = id;
+
+    private readonly TestDetailState _summaryDetail = new(id, stopwatch: null, text: string.Empty);
+    private readonly ConcurrentDictionary<string, TestDetailState> _testNodeProgressStates = new();
+    private readonly ConcurrentDictionary<string, byte> _completed = new();
+
+    public int Count => _testNodeProgressStates.Count;
+
+    public void AddRunningTestNode(int id, string instanceId, string uid, string name, IStopwatch stopwatch)
+    {
+        string key = MakeKey(instanceId, uid);
+
+        // Guard against stale "in-progress" notifications that arrive after the
+        // test already completed. Without this we could surface a "running"
+        // entry that will never be removed.
+        if (_completed.ContainsKey(key))
+        {
+            return;
+        }
+
+        _testNodeProgressStates[key] = new TestDetailState(id, stopwatch, name);
+    }
+
+    public void RemoveRunningTestNode(string instanceId, string uid)
+    {
+        string key = MakeKey(instanceId, uid);
+        _completed[key] = 0;
+        _testNodeProgressStates.TryRemove(key, out _);
+    }
+
+    private static string MakeKey(string instanceId, string uid) => $"{instanceId}\u0000{uid}";
+
+    public IEnumerable<TestDetailState> GetRunningTasks(int maxCount)
+    {
+        var sortedDetails = _testNodeProgressStates
+            .Select(d => d.Value)
+            .OrderByDescending(d => d.Stopwatch?.Elapsed ?? TimeSpan.Zero)
+            .ToList();
+
+        bool tooManyItems = sortedDetails.Count > maxCount;
+
+        if (tooManyItems)
+        {
+            // Note: If there's too many items to display, the summary will take up one line.
+            // As such, we can only take maxCount - 1 items.
+            int itemsToTake = maxCount - 1;
+            _summaryDetail.Text =
+                itemsToTake == 0
+                    // Note: If itemsToTake is 0, then we only show two lines, the project summary and the number of running tests.
+                    ? string.Format(CultureInfo.CurrentCulture, CliCommandStrings.ActiveTestsRunning_FullTestsCount, sortedDetails.Count)
+                    // If itemsToTake is larger, then we show the project summary, active tests, and the number of active tests that are not shown.
+                    : $"... {string.Format(CultureInfo.CurrentCulture, CliCommandStrings.ActiveTestsRunning_MoreTestsCount, sortedDetails.Count - itemsToTake)}";
+            sortedDetails = [.. sortedDetails.Take(itemsToTake)];
+        }
+
+        foreach (TestDetailState? detail in sortedDetails)
+        {
+            yield return detail;
+        }
+
+        if (tooManyItems)
+        {
+            yield return _summaryDetail;
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestOutcome.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestOutcome.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Outcome of a test.
+/// </summary>
+internal enum TestOutcome
+{
+    /// <summary>
+    /// Error.
+    /// </summary>
+    Error,
+
+    /// <summary>
+    /// Fail.
+    /// </summary>
+    Fail,
+
+    /// <summary>
+    /// Passed.
+    /// </summary>
+    Passed,
+
+    /// <summary>
+    /// Skipped.
+    /// </summary>
+    Skipped,
+
+    /// <summary>
+    ///  Timeout.
+    /// </summary>
+    Timeout,
+
+    /// <summary>
+    /// Canceled.
+    /// </summary>
+    Canceled,
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using TestNodeInfoEntry = (int Passed, int Skipped, int Failed, int LastAttemptNumber);
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+internal sealed class TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch, bool isDiscovery)
+{
+    private readonly Dictionary<string, TestNodeInfoEntry> _testUidToResults = new();
+
+    // In most cases, retries don't happen. So we start with a capacity of 1.
+    // Resizes will be rare and will be okay with such small sizes.
+    private readonly List<string> _orderedInstanceIds = new(capacity: 1);
+
+    public string Assembly { get; } = assembly;
+
+    public string AssemblyName { get; } = Path.GetFileName(assembly)!;
+
+    public string? TargetFramework { get; } = targetFramework;
+
+    public string? Architecture { get; } = architecture;
+
+    public IStopwatch Stopwatch { get; } = stopwatch;
+
+    public int DiscoveredTests { get; private set; }
+
+    public int FailedTests { get; private set; }
+
+    public int PassedTests { get; private set; }
+
+    public int SkippedTests { get; private set; }
+
+    public int TotalTests => IsDiscovery ? DiscoveredTests : PassedTests + SkippedTests + FailedTests;
+
+    public int RetriedFailedTests { get; private set; }
+
+    public TestNodeResultsState? TestNodeResultsState { get; internal set; }
+
+    public int SlotIndex { get; internal set; }
+
+    public long Id { get; internal set; } = id;
+
+    public long Version { get; internal set; }
+
+    public List<(string? DisplayName, string? UID, string? FilePath, int? LineNumber)> DiscoveredTestNames { get; internal set; } = [];
+
+    public bool Success { get; internal set; }
+
+    public bool IsDiscovery = isDiscovery;
+
+    public int TryCount { get; private set; }
+
+    private void ReportGenericTestResult(
+        string testNodeUid,
+        string instanceId,
+        Func<TestNodeInfoEntry, TestNodeInfoEntry> incrementTestNodeInfoEntry,
+        Action<TestProgressState> incrementCountAction)
+    {
+        var currentAttemptNumber = GetAttemptNumberFromInstanceId(instanceId);
+
+        if (_testUidToResults.TryGetValue(testNodeUid, out var value))
+        {
+            // We received a result for this test node uid before.
+            if (value.LastAttemptNumber == currentAttemptNumber)
+            {
+                // We are getting a test result for the same attempt.
+                // This means that the test framework is reporting multiple results for the same test node uid.
+                // We will just increment the count of the result.
+                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
+            }
+            else if (currentAttemptNumber > value.LastAttemptNumber)
+            {
+                // This is a retry!
+                // We are getting a test result for a different instance id.
+                // This means that the test was retried.
+                // We discard the results from the previous instance id
+                RetriedFailedTests += value.Failed;
+                PassedTests -= value.Passed;
+                SkippedTests -= value.Skipped;
+                FailedTests -= value.Failed;
+                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+            }
+            else
+            {
+                // This is an unexpected case where we received a result for an instance id that is older than the last one we saw.
+                throw new UnreachableException($"Unexpected test result for attempt '{currentAttemptNumber}' while the last attempt is '{value.LastAttemptNumber}'");
+            }
+        }
+        else
+        {
+            // This is the first time we see this test node.
+            _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
+        }
+
+        incrementCountAction(this);
+    }
+
+    public void ReportPassingTest(string testNodeUid, string instanceId)
+    {
+        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        {
+            entry.Passed++;
+            return entry;
+        }, static @this => @this.PassedTests++);
+    }
+
+    public void ReportSkippedTest(string testNodeUid, string instanceId)
+    {
+        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        {
+            entry.Skipped++;
+            return entry;
+        }, static @this => @this.SkippedTests++);
+    }
+
+    public void ReportFailedTest(string testNodeUid, string instanceId)
+    {
+        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        {
+            entry.Failed++;
+            return entry;
+        }, static @this => @this.FailedTests++);
+    }
+
+    public void DiscoverTest(string? displayName, string? uid, string? filePath, int? lineNumber)
+    {
+        DiscoveredTests++;
+        DiscoveredTestNames.Add(new(displayName, uid, filePath, lineNumber));
+    }
+
+    internal void NotifyHandshake(string instanceId)
+    {
+        var index = _orderedInstanceIds.IndexOf(instanceId);
+        if (index < 0)
+        {
+            // New instanceId for a retry. We add it to _orderedInstanceIds.
+            _orderedInstanceIds.Add(instanceId);
+            TryCount++;
+        }
+        else if (index != _orderedInstanceIds.Count - 1)
+        {
+            // This is an unexpected case where we received a handshake for an instance id that is not the last one we saw.
+            // This means that the test framework is trying to report results for an instance id that is not the last one.
+            throw new UnreachableException($"Unexpected handshake for instance id '{instanceId}' at index '{index}' while the last index is '{_orderedInstanceIds.Count - 1}'");
+        }
+    }
+
+    private int GetAttemptNumberFromInstanceId(string instanceId)
+    {
+        var index = _orderedInstanceIds.IndexOf(instanceId);
+        if (index < 0)
+        {
+            throw new UnreachableException($"The instanceId '{instanceId}' not found.");
+        }
+
+        // Attempt numbers are 1-based, so we add 1 to the index.
+        return index + 1;
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressStateAwareTerminal.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// Terminal that updates the progress in place when progress reporting is enabled.
+/// </summary>
+internal sealed partial class TestProgressStateAwareTerminal(ITerminal terminal, bool showProgress) : IDisposable
+{
+    /// <summary>
+    /// A cancellation token to signal the rendering thread that it should exit.
+    /// </summary>
+    private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Protects access to state shared between the logger callbacks and the rendering thread.
+    /// </summary>
+    private readonly object _lock = Console.Out;
+
+    private readonly ITerminal _terminal = terminal;
+    private readonly bool _showProgress = showProgress;
+    private TestProgressState?[] _progressItems = [];
+
+    /// <summary>
+    /// The thread that performs periodic refresh of the console output.
+    /// </summary>
+    private Thread? _refresher;
+    private long _counter;
+
+    /// <summary>
+    /// The <see cref="_refresher"/> thread proc.
+    /// </summary>
+    private void ThreadProc()
+    {
+        try
+        {
+            // When writing to ANSI, we update the progress in place and it should look responsive so we
+            // update every half second, because we only show seconds on the screen, so it is good enough.
+            // When writing to non-ANSI, we never show progress as the output can get long and messy.
+            const int AnsiUpdateCadenceInMs = 500;
+            while (!_cts.Token.WaitHandle.WaitOne(AnsiUpdateCadenceInMs))
+            {
+                lock (_lock)
+                {
+                    _terminal.StartUpdate();
+                    try
+                    {
+                        _terminal.RenderProgress(_progressItems);
+                    }
+                    finally
+                    {
+                        _terminal.StopUpdate();
+                    }
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // When we dispose _cts too early this will throw.
+        }
+
+        _terminal.EraseProgress();
+    }
+
+    public int AddWorker(TestProgressState testWorker)
+    {
+        if (_showProgress)
+        {
+            for (int i = 0; i < _progressItems.Length; i++)
+            {
+                if (_progressItems[i] == null)
+                {
+                    _progressItems[i] = testWorker;
+                    return i;
+                }
+            }
+
+            throw new InvalidOperationException("No empty slot found");
+        }
+
+        return 0;
+    }
+
+    public void StartShowingProgress(int workerCount)
+    {
+        if (_showProgress)
+        {
+            _progressItems = new TestProgressState[workerCount];
+            _terminal.StartBusyIndicator();
+            // If we crash unexpectedly without completing this thread we don't want it to keep the process running.
+            _refresher = new Thread(ThreadProc) { IsBackground = true };
+            _refresher.Start();
+        }
+    }
+
+    internal void StopShowingProgress()
+    {
+        if (_showProgress)
+        {
+            _cts.Cancel();
+            _refresher?.Join();
+
+            _terminal.EraseProgress();
+            _terminal.StopBusyIndicator();
+        }
+    }
+
+    public void Dispose() =>
+        ((IDisposable)_cts).Dispose();
+
+    internal void WriteToTerminal(Action<ITerminal> write)
+    {
+        if (_showProgress)
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    _terminal.StartUpdate();
+                    _terminal.EraseProgress();
+                    write(_terminal);
+                    _terminal.RenderProgress(_progressItems);
+                }
+                finally
+                {
+                    _terminal.StopUpdate();
+                }
+            }
+        }
+        else
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    _terminal.StartUpdate();
+                    write(_terminal);
+                }
+                finally
+                {
+                    _terminal.StopUpdate();
+                }
+            }
+        }
+    }
+
+    internal void RemoveWorker(int slotIndex)
+    {
+        if (_showProgress)
+        {
+            _progressItems[slotIndex] = null;
+        }
+    }
+
+    internal void UpdateWorker(int slotIndex)
+    {
+        if (_showProgress)
+        {
+            // We increase the counter to say that this version of data is newer than what we had before and
+            // it should be completely re-rendered. Another approach would be to use timestamps, or to replace the
+            // instance and compare that, but that means more objects floating around.
+            _counter++;
+
+            TestProgressState? progress = _progressItems[slotIndex];
+            if (progress != null)
+            {
+                progress.Version = _counter;
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestRunArtifact.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestRunArtifact.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// An artifact / attachment that was reported during run.
+/// </summary>
+internal sealed record TestRunArtifact(bool OutOfProcess, string? Assembly, string? TargetFramework, string? Architecture, string? ExecutionId, string? TestName, string Path);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/WarningMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/WarningMessage.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+/// <summary>
+/// A warning message that was sent during run.
+/// </summary>
+internal sealed record WarningMessage(string Text) : IProgressMessage;

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -9,8 +9,7 @@ using System.Threading;
 using Microsoft.DotNet.Cli.Commands.Test.IPC;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
-using Microsoft.Testing.Platform.IPC;
-using Microsoft.Testing.Platform.OutputDevice.Terminal;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectTools;
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -3,7 +3,7 @@
 
 using System.Threading.Channels;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-using Microsoft.Testing.Platform.OutputDevice.Terminal;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
-using Microsoft.Testing.Platform.IPC;
-using Microsoft.Testing.Platform.OutputDevice;
-using Microsoft.Testing.Platform.OutputDevice.Terminal;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -290,7 +288,7 @@ internal sealed class TestApplicationHandler
                 testResult.Reason,
                 ToOutcome(testResult.State),
                 testResult.Duration.HasValue ? TimeSpan.FromTicks(testResult.Duration.Value) : null,
-                exceptions: [.. (testResult.Exceptions ?? []).Select(fe => new FlatException(fe.ErrorMessage, fe.ErrorType, fe.StackTrace))],
+                exceptions: [.. (testResult.Exceptions ?? []).Select(fe => new Terminal.FlatException(fe.ErrorMessage, fe.ErrorType, fe.StackTrace))],
                 expected: null,
                 actual: null,
                 standardOutput: testResult.StandardOutput,

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -3187,6 +3187,11 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <target state="translated">Spustí testy jednotek v nástroji Test Runner zadaném v projektu .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Testovací zjišťování bylo dokončeno s neúspěšným ukončovacím kódem: {0} (viz: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">Počet zjištěných testů v(e) {1} sestaveních: {0}</target>
@@ -3201,6 +3206,11 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Cílová architektura pro spuštění testů. Cílová architektura musí být určená také v souboru projektu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Testovací běh byl dokončen s neúspěšným ukončovacím kódem: {0} (viz: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -3187,6 +3187,11 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <target state="translated">Hiermit werden mithilfe des im .NET-Projekt angegebenen Test Runners Komponententests ausgeführt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Die Testermittlung wurde mit einem nicht erfolgreichen Exitcode abgeschlossen: {0} (siehe: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">Ermittelte {0} Tests in {1} Assemblys.</target>
@@ -3201,6 +3206,11 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Das Zielframework für den Testlauf. Das Zielframework muss auch in der Projektdatei angegeben werden.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Der Testlauf wurde mit einem nicht erfolgreichen Exitcode abgeschlossen: {0} (siehe: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -3187,6 +3187,11 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <target state="translated">Ejecuta pruebas unitarias usando el ejecutor de pruebas especificado en un proyecto de .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Detección de pruebas completada con código de salida no correcto: {0} (vea: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{0} pruebas detectadas en {1} ensamblados.</target>
@@ -3201,6 +3206,11 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">La plataforma de destino para la que se ejecutan pruebas. La plataforma de destino se debe especificar en el archivo de proyecto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Serie de pruebas completada con código de salida incorrecto: {0} (consulte: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -3187,6 +3187,11 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <target state="translated">Exécutez des tests unitaires à l'aide du programme Test Runner spécifié dans un projet .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">La découverte de tests s’est terminée avec un code de sortie non réussi : {0} (voir : https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{0} tests découverts dans {1} assemblys.</target>
@@ -3201,6 +3206,11 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Framework cible pour lequel les tests sont exécutés. Le framework cible doit également être spécifié dans le fichier projet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">L’exécution de tests s’est terminée avec un code de sortie non réussi : {0} (voir : https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -3187,6 +3187,11 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <target state="translated">Esegue gli unit test con l'istanza di Test Runner specificata in un progetto .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Individuazione dei test completata con codice di uscita non riuscito: {0} (vedi: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{0} individuati in {1} assembly.</target>
@@ -3201,6 +3206,11 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Framework di destinazione per cui eseguire i test. Il framework di destinazione deve essere specificato anche nel file di progetto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Esecuzione del test completata con codice di uscita non riuscito: {0} (vedi: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -3187,6 +3187,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">.NET プロジェクトに指定されているテスト ランナーを使用して、単体テストを実行します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">テスト検出が異常終了コードで完了しました: {0} (参照: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{1} アセンブリで {0} つのテストを検出しました。</target>
@@ -3201,6 +3206,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">テストを実行する対象のターゲット フレームワーク。ターゲット フレームワークはプロジェクト ファイルでも指定する必要があります。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">テスト実行が非成功終了コードで完了しました: {0} (参照: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -3187,6 +3187,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">.NET 프로젝트에 지정된 Test Runner를 사용하여 단위 테스트를 실행합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">성공하지 않은 종료 코드로 테스트 검색이 완료되었습니다. {0}(참조: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{1}개의 어셈블리에서 {0}개의 테스트가 검색됨</target>
@@ -3201,6 +3206,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">테스트를 실행할 대상 프레임워크입니다. 대상 프레임워크는 프로젝트 파일에도 지정되어야 합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">성공하지 않은 종료 코드로 테스트 실행이 완료되었습니다. {0}(참조: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -3187,6 +3187,11 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <target state="translated">Uruchom testy jednostkowe przy użyciu modułu uruchamiającego testy określonego w projekcie platformy .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Odnajdywanie testów zostało ukończone z kodem zakończenia bez powodzenia: {0} (zobacz: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">Odnaleziono testy ({0}) w zestawach {1}.</target>
@@ -3201,6 +3206,11 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Platforma docelowa, dla której mają być uruchamiane testy. Platforma docelowa musi być również określona w pliku projektu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Przebieg testu został ukończony z kodem zakończenia bez powodzenia: {0} (zobacz: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -3187,6 +3187,11 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <target state="translated">Executar testes de unidade usando o executor de testes especificado em um projeto do .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Descoberta de testes concluída com código de saída sem sucesso: {0} (veja: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">Testes {0} descobertos nos assemblies {1}.</target>
@@ -3201,6 +3206,11 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">A estrutura de destino para a qual a execução de testes ocorrerá. A estrutura de destino também precisa ser especificada no arquivo de projeto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Execução de testes concluída com código de saída sem sucesso: {0} (veja: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -3187,6 +3187,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">Запуск модульных тестов с помощью средства, указанного в проекте .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Обнаружение тестов завершено с кодом выхода неудачного состояния: {0} (сведения: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">Обнаружены тесты ({0}) в сборках ({1})</target>
@@ -3201,6 +3206,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Целевая платформа для выполнения тестов. Целевая платформа также должна быть указана в файле проекта.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Выполнение теста завершено с кодом выхода неудачного состояния: {0} (сведения: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -3187,6 +3187,11 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <target state="translated">.NET projesinde belirtilen test çalıştırıcısını kullanarak birim testleri çalıştırır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Test bulma, {0} başarısız çıkış koduyla tamamlandı ( https://aka.ms/testingplatform/exitcodes adresine bakın)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">{1} derlemelerde {0} test bulundu.</target>
@@ -3201,6 +3206,11 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">Testlerin çalıştırılacağı hedef çerçeve. Hedef çerçevenin proje dosyasında da belirtilmesi gerekir.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">Test çalıştırması, {0} başarısız çıkış koduyla tamamlandı ( https://aka.ms/testingplatform/exitcodes adresine bakın)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -3187,6 +3187,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">使用 .NET 项目中指定的测试运行程序运行单元测试。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">已完成测试发现，但显示非成功退出代码: {0} (请参阅: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">在 {1} 个程序集中发现了 {0} 个测试。</target>
@@ -3201,6 +3206,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">运行测试的目标框架。必须在项目文件中指定目标框架。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">已完成测试运行，但显示非成功退出代码: {0} (请参阅: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -3187,6 +3187,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <target state="translated">使用 .NET 專案中指定的測試執行器，執行單元測試。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">測試探索已完成，未成功的結束代碼為: {0} (請參閱: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummary">
         <source>Discovered {0} tests in {1} assemblies.</source>
         <target state="translated">在 {1} 組件中找到 {0} 個測試。</target>
@@ -3201,6 +3206,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>The target framework to run tests for. The target framework must also be specified in the project file.</source>
         <target state="translated">要為其執行測試的目標架構。該目標架構必須在專案檔中指定。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0} (see: https://aka.ms/testingplatform/exitcodes)</source>
+        <target state="translated">測試執行已完成，未成功的結束代碼為: {0} (請參閱: https://aka.ms/testingplatform/exitcodes)</target>
+        <note>0 is whole number, the value of exit code</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -23,15 +23,6 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
 
     <!--
-      DRAFT: consuming the source-only Microsoft.Testing.Platform.Internal.DotnetTest package compiles the shared
-      terminal-reporter source into THIS assembly. A few of its platform abstractions (IConsole/IStopwatch/IColor/
-      SystemConsole/SystemConsoleColor/SystemStopwatch) are NOT [Microsoft.CodeAnalysis.Embedded], so a consumer that
-      also transitively sees Microsoft.Testing.Platform gets benign CS0436 'type conflicts with imported type'
-      warnings (the locally-compiled copy wins). TreatWarningsAsErrors=true in this repo turns those into errors, so
-      they must be suppressed. See the package PACKAGE.md. -->
-    <NoWarn>$(NoWarn);CS0436</NoWarn>
-
-    <!--
       Mark as Native AOT compatible. This will enable relevant analyzers.
       https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
     -->
@@ -88,15 +79,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
-    <!--
-      DRAFT: source-only package that supplies the 'dotnet test' <-> Microsoft.Testing.Platform wire contract
-      (IPC/ObjectFieldIds.cs + Constants.cs) and the terminal reporter as compiled source, replacing the files
-      hand-copied under Commands/Test/MTP/. The package's source lives in the Microsoft.Testing.Platform.IPC and
-      Microsoft.Testing.Platform.OutputDevice.Terminal namespaces, so consuming code under
-      Microsoft.DotNet.Cli.Commands.Test.* must be re-pointed to those namespaces (see PR description for the full
-      reconciliation list). It ships on the Microsoft.Testing.Platform preview train and must flow via darc once
-      testfx publishes it (see Directory.Packages.props). -->
-    <PackageReference Include="Microsoft.Testing.Platform.Internal.DotnetTest" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="NuGet.CommandLine.XPlat" />
     <PackageReference Include="Microsoft.Build" />

--- a/test/dotnet.Tests/CommandTests/Test/CapturingConsole.cs
+++ b/test/dotnet.Tests/CommandTests/Test/CapturingConsole.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+internal sealed class CapturingConsole : IConsole
+{
+    private readonly StringBuilder _output = new();
+    private ConsoleColor _foreground = ConsoleColor.Gray;
+    private ConsoleColor _background = ConsoleColor.Black;
+
+#pragma warning disable CS0067 // Event is never used; required by IConsole contract.
+    public event ConsoleCancelEventHandler? CancelKeyPress;
+#pragma warning restore CS0067
+
+    public int BufferHeight => 30;
+
+    public int BufferWidth => 120;
+
+    public bool IsOutputRedirected => true;
+
+    public string GetOutput() => _output.ToString();
+
+    public void SetForegroundColor(ConsoleColor color) => _foreground = color;
+
+    public void SetBackgroundColor(ConsoleColor color) => _background = color;
+
+    public ConsoleColor GetForegroundColor() => _foreground;
+
+    public ConsoleColor GetBackgroundColor() => _background;
+
+    public void WriteLine() => _output.AppendLine();
+
+    public void WriteLine(string? value) => _output.AppendLine(value);
+
+    public void WriteLine(object? value) => _output.AppendLine(value?.ToString());
+
+    public void WriteLine(string format, object? arg0) => _output.AppendLine(string.Format(format, arg0));
+
+    public void WriteLine(string format, object? arg0, object? arg1) => _output.AppendLine(string.Format(format, arg0, arg1));
+
+    public void WriteLine(string format, object? arg0, object? arg1, object? arg2) => _output.AppendLine(string.Format(format, arg0, arg1, arg2));
+
+    public void WriteLine(string format, object?[]? args) => _output.AppendLine(string.Format(format, args ?? Array.Empty<object?>()));
+
+    public void Write(string format, object?[]? args) => _output.Append(string.Format(format, args ?? Array.Empty<object?>()));
+
+    public void Write(string? value) => _output.Append(value);
+
+    public void Write(char value) => _output.Append(value);
+
+    public void Clear() => _output.Clear();
+}

--- a/test/dotnet.Tests/CommandTests/Test/DiscoveredTestMessagesSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/DiscoveredTestMessagesSerializerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using Microsoft.DotNet.Cli.Commands.Test.IPC;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 
@@ -10,12 +11,6 @@ namespace dotnet.Tests.CommandTests.Test;
 [TestClass]
 public class DiscoveredTestMessagesSerializerTests
 {
-    // Mirror the wire field ids from Microsoft.Testing.Platform.IPC (ObjectFieldIds.cs) in the
-    // Microsoft.Testing.Platform.Internal.DotnetTest package. Those types are [Embedded] and therefore not
-    // referenceable from this (separate) test assembly, so the values are inlined here.
-    private const ushort DiscoveredTestMessageListFieldId = 3; // DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList
-    private const ushort LineNumberFieldId = 4;                // DiscoveredTestMessageFieldsId.LineNumber
-
     [TestMethod]
     public void RoundTrip_AllFieldsPopulated_PreservesValues()
     {
@@ -130,7 +125,7 @@ public class DiscoveredTestMessagesSerializerTests
         outerFieldCount.Should().Be(1, "only the DiscoveredTestMessageList field is populated");
 
         ushort outerFieldId = reader.ReadUInt16();
-        outerFieldId.Should().Be(DiscoveredTestMessageListFieldId);
+        outerFieldId.Should().Be(DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList);
         _ = reader.ReadInt32(); // payload size of the list
         int listLength = reader.ReadInt32();
         listLength.Should().Be(1);
@@ -139,7 +134,7 @@ public class DiscoveredTestMessagesSerializerTests
         innerFieldCount.Should().Be(1, "only the LineNumber field is populated on the inner test");
 
         ushort innerFieldId = reader.ReadUInt16();
-        innerFieldId.Should().Be(LineNumberFieldId);
+        innerFieldId.Should().Be(DiscoveredTestMessageFieldsId.LineNumber);
 
         int lineNumberFieldSize = reader.ReadInt32();
         lineNumberFieldSize.Should().Be(sizeof(int), "LineNumber must be serialized as 4 bytes");

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -557,8 +557,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("failed: 0")
                     .And.Contain("skipped: 0");
 
-                // The test app process exits with code 0 before sending the session-end event, so the
-                // package reporter prints no per-assembly "Exit code" line for this crash scenario.
+                result.StdOut.Should().Contain("Test run completed with non-success exit code: 1 (see: https://aka.ms/testingplatform/exitcodes)");
             }
         }
 
@@ -587,7 +586,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("failed: 0")
                     .And.Contain("skipped: 0");
 
-                result.StdOut.Should().Contain("Exit code: 47");
+                result.StdOut.Should().Contain("Test run completed with non-success exit code: 47 (see: https://aka.ms/testingplatform/exitcodes)");
             }
         }
 

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -1,0 +1,234 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+using Moq;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TerminalTestReporterTests
+{
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/51608: if a test host process exits
+    /// before the test session was ever started (so the execution id is never registered with the
+    /// reporter), AssemblyRunCompleted must not throw KeyNotFoundException — it must surface the
+    /// exit as a handshake failure instead.
+    ///
+    /// This is a defensive unit test: under the current TestApplicationHandler routing this branch
+    /// is unreachable, so it cannot be exercised end-to-end. End-to-end coverage of the recap
+    /// behavior triggered when handshake failures are reported lives in
+    /// <c>GivenDotnetTestRunsConsoleAppWithoutHandshake</c>.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyRunCompleted_WhenExecutionIdUnknown_DoesNotThrowAndReportsHandshakeFailure()
+    {
+        var console = new Mock<IConsole>(MockBehavior.Loose);
+        console.SetupGet(c => c.IsOutputRedirected).Returns(true);
+        console.SetupGet(c => c.BufferWidth).Returns(120);
+        console.SetupGet(c => c.BufferHeight).Returns(30);
+        console.Setup(c => c.GetForegroundColor()).Returns(ConsoleColor.Gray);
+        console.Setup(c => c.GetBackgroundColor()).Returns(ConsoleColor.Black);
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        };
+
+        using var reporter = new TerminalTestReporter(console.Object, options);
+
+        Action act = () => reporter.AssemblyRunCompleted(
+            executionId: "never-registered",
+            exitCode: 1,
+            outputData: "stdout",
+            errorData: "stderr");
+
+        act.Should().NotThrow();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/52128: the mid-stream per-assembly
+    /// summary printed when an assembly completes (ShowAssembly + ShowAssemblyStartAndComplete)
+    /// must include the per-assembly counts in the same compact bracketed form used by the
+    /// in-progress indicator. Tests use <see cref="AnsiMode.SimpleAnsi"/> which routes through
+    /// <c>SimpleTerminal</c>, so the expected glyphs are the ASCII variants
+    /// <c>[+P/xF/?S]</c> (mirroring <c>SimpleTerminal.RenderProgress</c>). The full-ANSI path
+    /// uses <c>[✓P/xF/↓S]</c> and is exercised end-to-end by acceptance tests.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyRunCompleted_WithShowAssemblyStartAndComplete_PrintsPerAssemblyCounts()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = true,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assembly = "/repo/bin/Debug/net9.0/MyTests.dll";
+        const string executionId = "exec-1";
+
+        reporter.AssemblyRunStarted(assembly, targetFramework: "net9.0", architecture: "x64", executionId, instanceId: "inst-1");
+
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "t-pass-1", TestOutcome.Passed);
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "t-pass-2", TestOutcome.Passed);
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "t-pass-3", TestOutcome.Passed);
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "t-skip-1", TestOutcome.Skipped);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+
+        string assemblyLine = GetAssemblySummaryLine(capturingConsole.GetOutput(), assembly);
+        assemblyLine.Should().Contain("[+3/x0/?1]");
+    }
+
+    /// <summary>
+    /// In the final test-run summary, when more than one assembly ran, each assembly entry
+    /// must include its own per-assembly counts in the compact bracketed form
+    /// (https://github.com/dotnet/sdk/issues/52128). See the note on
+    /// <see cref="AssemblyRunCompleted_WithShowAssemblyStartAndComplete_PrintsPerAssemblyCounts"/>
+    /// for why the SimpleAnsi (ASCII) variant is asserted here.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WithMultipleAssemblies_PrintsPerAssemblyCountsInSummary()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            // Suppress mid-stream per-assembly lines so we can assert against the final summary only.
+            ShowAssemblyStartAndComplete = false,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 2, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assemblyA = "/repo/bin/Debug/net9.0/A.Tests.dll";
+        const string assemblyB = "/repo/bin/Debug/net9.0/B.Tests.dll";
+
+        reporter.AssemblyRunStarted(assemblyA, "net9.0", "x64", executionId: "exec-A", instanceId: "inst-A");
+        reporter.AssemblyRunStarted(assemblyB, "net9.0", "x64", executionId: "exec-B", instanceId: "inst-B");
+
+        // Assembly A: 2 passed, 1 failed, 0 skipped.
+        ReportTest(reporter, assemblyA, executionId: "exec-A", instanceId: "inst-A", testUid: "a-1", TestOutcome.Passed);
+        ReportTest(reporter, assemblyA, executionId: "exec-A", instanceId: "inst-A", testUid: "a-2", TestOutcome.Passed);
+        ReportTest(reporter, assemblyA, executionId: "exec-A", instanceId: "inst-A", testUid: "a-3", TestOutcome.Fail);
+
+        // Assembly B: 5 passed, 0 failed, 2 skipped.
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-1", TestOutcome.Passed);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-2", TestOutcome.Passed);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-3", TestOutcome.Passed);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-4", TestOutcome.Passed);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-5", TestOutcome.Passed);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-6", TestOutcome.Skipped);
+        ReportTest(reporter, assemblyB, executionId: "exec-B", instanceId: "inst-B", testUid: "b-7", TestOutcome.Skipped);
+
+        reporter.AssemblyRunCompleted(executionId: "exec-A", exitCode: 1, outputData: null, errorData: null);
+        reporter.AssemblyRunCompleted(executionId: "exec-B", exitCode: 0, outputData: null, errorData: null);
+
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 1);
+
+        string output = capturingConsole.GetOutput();
+
+        GetAssemblySummaryLine(output, assemblyA).Should().Contain("[+2/x1/?0]");
+        GetAssemblySummaryLine(output, assemblyB).Should().Contain("[+5/x0/?2]");
+    }
+
+    /// <summary>
+    /// When an assembly's tests were retried, the per-assembly summary should append a
+    /// "/r{N}" segment to the compact counts block so users can tell the final counts came from retries.
+    /// </summary>
+    [TestMethod]
+    public void AssemblyRunCompleted_WhenTestsWereRetried_ShowsRetriedCount()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = true,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Flaky.Tests.dll";
+        const string executionId = "exec-flaky";
+
+        // Attempt 1: register the first instance and report a failure.
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
+
+        // Attempt 2: a new instance id triggers a retry; the failing test now passes.
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+
+        string assemblyLine = GetAssemblySummaryLine(capturingConsole.GetOutput(), assembly);
+        assemblyLine.Should().Contain("[+1/x0/?0/r1]");
+    }
+
+    private static void ReportTest(TerminalTestReporter reporter, string assembly, string executionId, string instanceId, string testUid, TestOutcome outcome)
+    {
+        reporter.TestCompleted(
+            assembly: assembly,
+            targetFramework: "net9.0",
+            architecture: "x64",
+            executionId: executionId,
+            instanceId: instanceId,
+            testNodeUid: testUid,
+            displayName: testUid,
+            informativeMessage: null,
+            outcome: outcome,
+            duration: TimeSpan.FromMilliseconds(1),
+            exceptions: null,
+            expected: null,
+            actual: null,
+            standardOutput: null,
+            errorOutput: null);
+    }
+
+    /// <summary>
+    /// Finds the per-assembly summary line for the given assembly. Multiple lines may mention the
+    /// assembly (e.g. the "Running tests from ..." banner and the summary line). The summary line
+    /// is the one that contains the compact counts block written by <c>AppendAssemblyTestCounts</c>.
+    /// ANSI color escape sequences are stripped so callers can use plain-text assertions like
+    /// <c>Contain("[+3/x0/?1]")</c> (SimpleAnsi/SimpleTerminal mode uses the ASCII glyph set).
+    /// </summary>
+    private static string GetAssemblySummaryLine(string output, string assemblyPath)
+    {
+        foreach (string line in output.Split('\n'))
+        {
+            string stripped = StripAnsi(line);
+            if (stripped.Contains(assemblyPath, StringComparison.Ordinal)
+                && stripped.Contains("[+", StringComparison.Ordinal))
+            {
+                return stripped;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Expected output to contain a per-assembly summary line for '{assemblyPath}', but it did not. Full output:{Environment.NewLine}{output}");
+    }
+
+    private static string StripAnsi(string value) => s_ansiEscapeRegex.Replace(value, string.Empty);
+
+    private static readonly Regex s_ansiEscapeRegex = new("\x1b\\[[0-9;]*[a-zA-Z]", RegexOptions.Compiled);
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -12,7 +12,7 @@ namespace dotnet.Tests.CommandTests.Test;
 public class TestApplicationHandlerTests : IDisposable
 {
     // TerminalTestReporter is IDisposable and starts progress tracking via TestExecutionStarted
-    // inside CreateHandler. xUnit instantiates the test class per test, so disposing this list in
+    // inside CreateHandler. MSTest instantiates the test class per test, so disposing this list in
     // Dispose() releases every reporter built for the current test.
     private readonly List<IDisposable> _disposables = new();
 

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -1,0 +1,358 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestApplicationHandlerTests : IDisposable
+{
+    // TerminalTestReporter is IDisposable and starts progress tracking via TestExecutionStarted
+    // inside CreateHandler. xUnit instantiates the test class per test, so disposing this list in
+    // Dispose() releases every reporter built for the current test.
+    private readonly List<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Regression test for the handler-level routing fix in https://github.com/dotnet/sdk/pull/52308
+    /// (linked to https://github.com/dotnet/sdk/issues/51608). When the test host process exits
+    /// after only a controller (non-"TestHost") handshake — i.e. <c>_receivedTestHostHandshake</c>
+    /// is false — <see cref="TestApplicationHandler.OnTestProcessExited"/> must route to
+    /// <c>HandshakeFailure</c> with the module's TargetPath and TargetFramework preserved, rather
+    /// than to <c>AssemblyRunCompleted</c> (which would hit the defensive empty-path fallback in
+    /// <c>TerminalTestReporter</c> and drop the assembly identifier from the output).
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenOnlyControllerHandshakeReceived_RoutesToHandshakeFailureWithModuleContext()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+
+        const string targetPath = "/repo/bin/Debug/net9.0/MyTest.dll";
+        const string projectPath = "/repo/MyTest.csproj";
+        const string targetFramework = "net9.0";
+
+        var module = new TestModule(
+            RunProperties: new RunProperties("dotnet", targetPath, "/repo"),
+            ProjectFullPath: projectPath,
+            TargetFramework: targetFramework,
+            IsTestingPlatformApplication: true,
+            LaunchSettings: null,
+            TargetPath: targetPath,
+            DotnetRootArchVariableName: null);
+
+        var testOptions = new TestOptions(IsHelp: false, IsDiscovery: false, EnvironmentVariables: new Dictionary<string, string>());
+
+        var handler = new TestApplicationHandler(reporter, module, testOptions);
+
+        // Controller-only handshake — hostType is not "TestHost", so _receivedTestHostHandshake stays false
+        // and AssemblyRunStarted is never called (so the executionId is never registered in _assemblies).
+        var handshake = new HandshakeMessage(new Dictionary<byte, string>
+        {
+            [HandshakeMessagePropertyNames.PID] = "1234",
+            [HandshakeMessagePropertyNames.Architecture] = "x64",
+            [HandshakeMessagePropertyNames.Framework] = ".NETCoreApp,Version=v9.0",
+            [HandshakeMessagePropertyNames.OS] = "Windows",
+            [HandshakeMessagePropertyNames.SupportedProtocolVersions] = ProtocolConstants.SupportedVersions,
+            [HandshakeMessagePropertyNames.HostType] = "TestHostController",
+            [HandshakeMessagePropertyNames.ModulePath] = targetPath,
+            [HandshakeMessagePropertyNames.ExecutionId] = "exec-1",
+            [HandshakeMessagePropertyNames.InstanceId] = "inst-1",
+        });
+
+        Action handshakeAct = () => handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+        handshakeAct.Should().NotThrow();
+
+        Action exitAct = () => handler.OnTestProcessExited(exitCode: 1, outputData: "stdout-line", errorData: "stderr-line");
+        exitAct.Should().NotThrow();
+
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        // The handler must preserve module context (TargetPath + TargetFramework) when routing to
+        // HandshakeFailure. If a future regression of #52308 routes through AssemblyRunCompleted's
+        // defensive fallback instead, the assembly identifier would be empty and this assertion would fail.
+        string rendered = capturingConsole.GetOutput();
+        rendered.Should().Contain(targetPath);
+        rendered.Should().Contain(targetFramework);
+        rendered.Should().Contain("stdout-line");
+        rendered.Should().Contain("stderr-line");
+    }
+
+    /// <summary>
+    /// Backward-compat regression test. Older Microsoft.Testing.Platform versions don't include the
+    /// optional <see cref="HandshakeMessagePropertyNames.ExecutionMode"/> property at all (added in
+    /// https://github.com/microsoft/testfx/pull/8794). When the property is absent the SDK must keep
+    /// today's behavior and not perform any execution-mode validation.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    public void OnHandshakeReceived_WhenExecutionModePropertyIsAbsent_AcceptsHandshakeAndDoesNotReportFailure(bool isHelp, bool isDiscovery)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(executionMode: null);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+        console.GetOutput().Should().NotContain("MismatchingHandshakeExecutionMode");
+    }
+
+    [TestMethod]
+    [DataRow(false, false, HandshakeMessageExecutionModes.Run)]
+    [DataRow(true, false, HandshakeMessageExecutionModes.Help)]
+    [DataRow(false, true, HandshakeMessageExecutionModes.Discover)]
+    public void OnHandshakeReceived_WhenExecutionModeMatchesSdkExpectation_AcceptsHandshake(bool isHelp, bool isDiscovery, string executionMode)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(executionMode);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Drives the new validation added in this change: if the host reports an execution mode that
+    /// doesn't match what <c>dotnet test</c> intended (e.g. <c>RunArguments</c> or
+    /// <c>launchSettings.json</c> injected a <c>--help</c> or <c>--list-tests</c> option), the SDK
+    /// must reject the handshake at the protocol level and report the mismatch.
+    /// </summary>
+    [TestMethod]
+    [DataRow(false, false, HandshakeMessageExecutionModes.Help, HandshakeMessageExecutionModes.Run)]
+    [DataRow(false, false, HandshakeMessageExecutionModes.Discover, HandshakeMessageExecutionModes.Run)]
+    [DataRow(true, false, HandshakeMessageExecutionModes.Run, HandshakeMessageExecutionModes.Help)]
+    [DataRow(false, true, HandshakeMessageExecutionModes.Run, HandshakeMessageExecutionModes.Discover)]
+    public void OnHandshakeReceived_WhenExecutionModeMismatch_RejectsHandshakeAndReportsFailure(
+        bool isHelp, bool isDiscovery, string reportedMode, string expectedMode)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: isHelp, isDiscovery: isDiscovery);
+
+        var handshake = BuildHandshake(reportedMode);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        string rendered = console.GetOutput();
+        rendered.Should().Contain(reportedMode);
+        rendered.Should().Contain(expectedMode);
+    }
+
+    /// <summary>
+    /// Even when the SDK itself was invoked in help mode, an explicit ExecutionMode mismatch reported
+    /// by the test host is a protocol-level rejection and must still be surfaced. This pins down the
+    /// <c>reportEvenWhenHelp: true</c> opt-out around the legacy "swallow handshake failures in help
+    /// mode" workaround in <see cref="TerminalTestReporter.HandshakeFailure"/>.
+    /// </summary>
+    [TestMethod]
+    public void OnHandshakeReceived_WhenSdkInHelpModeAndExecutionModeMismatch_StillReportsFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        var handshake = BuildHandshake(HandshakeMessageExecutionModes.Run);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Every protocol-level rejection inside <c>OnHandshakeReceived</c> (not just ExecutionMode
+    /// mismatch) opts out of the legacy "swallow handshake failures when SDK is in help mode"
+    /// workaround. Missing-required-property is one such rejection — covered here. The workaround
+    /// is intentionally scoped to <c>OnTestProcessExited</c> calling <c>HandshakeFailure</c>
+    /// without ever having received a real handshake (older MTP behavior on <c>--help</c>).
+    /// </summary>
+    [TestMethod]
+    public void OnHandshakeReceived_WhenSdkInHelpModeAndRequiredPropertyMissing_StillReportsFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        // Build a handshake that's missing the required ExecutionId property.
+        var handshake = BuildHandshake(executionMode: null);
+        var properties = handshake.Properties.Where(kvp => kvp.Key != HandshakeMessagePropertyNames.ExecutionId).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var incompleteHandshake = new HandshakeMessage(properties);
+
+        bool accepted = handler.OnHandshakeReceived(incompleteHandshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// When the protocol version itself is unsupported, that failure is reported and we exit early
+    /// — we don't also report an ExecutionMode mismatch on the same handshake, since the version
+    /// rejection makes any subsequent property validation moot (and it would be confusing to
+    /// surface two distinct failures for one handshake).
+    /// </summary>
+    [TestMethod]
+    public void OnHandshakeReceived_WhenUnsupportedProtocolVersion_DoesNotAlsoReportExecutionModeMismatch()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        // ExecutionMode is "help" which would mismatch (SDK expects "run") if we got that far.
+        var handshake = BuildHandshake(HandshakeMessageExecutionModes.Help);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: false);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        // The version-related failure IS reported and the ExecutionMode-related one is NOT —
+        // both sides of the assertion matter: it should catch a regression that produces no
+        // failure at all (no version error) as well as one that produces both.
+        string rendered = console.GetOutput();
+        rendered.Should().Contain("protocol version", "the unsupported-protocol-version failure is expected to be reported");
+        rendered.Should().NotContain("execution mode", "the ExecutionMode validation should be skipped when the protocol version itself was rejected");
+    }
+
+    /// <summary>
+    /// Forward-compat/protocol guard: a future testing-platform release that ships a new ExecutionMode
+    /// value without bumping the protocol version, or a host that sends an empty value, is not silently
+    /// accepted; we reject so we don't try to interpret a message stream we don't understand.
+    /// </summary>
+    [TestMethod]
+    [DataRow("future-mode")]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void OnHandshakeReceived_WhenExecutionModeIsUnknownOrEmpty_RejectsHandshake(string executionMode)
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        var handshake = BuildHandshake(executionMode: executionMode);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A controller-host handshake (no <c>AssemblyRunStarted</c> bookkeeping) with a mismatched
+    /// ExecutionMode must still be rejected — the validation lives in <c>OnHandshakeReceived</c>,
+    /// not in a code path gated on <c>HostType == "TestHost"</c>.
+    /// </summary>
+    [TestMethod]
+    public void OnHandshakeReceived_WhenControllerHostReportsMismatchedExecutionMode_RejectsHandshake()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        var handshake = BuildHandshake(
+            executionMode: HandshakeMessageExecutionModes.Help,
+            hostType: "TestHostController",
+            includeInstanceId: false);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeFalse();
+        reporter.HasHandshakeFailure.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Old-MTP help path: the test host exits without performing a handshake at all because older
+    /// Microsoft.Testing.Platform versions don't handshake on <c>--help</c>. The SDK's existing
+    /// workaround in <see cref="TerminalTestReporter.HandshakeFailure"/> must keep swallowing that
+    /// case so we don't print a spurious failure for the legacy host. The new
+    /// <c>reportEvenWhenHelp</c> opt-out must not break this — only the explicit protocol-level
+    /// mismatch path opts in.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenSdkInHelpModeAndNoHandshakeReceived_DoesNotReportFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler(isHelp: true, isDiscovery: false);
+
+        Action act = () => handler.OnTestProcessExited(exitCode: 0, outputData: "help text", errorData: string.Empty);
+        act.Should().NotThrow();
+
+        reporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
+    private const string TargetPath = "/repo/bin/Debug/net9.0/MyTest.dll";
+    private const string ProjectPath = "/repo/MyTest.csproj";
+    private const string TargetFramework = "net9.0";
+
+    private (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery)
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var reporterOptions = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        };
+
+        var reporter = new TerminalTestReporter(capturingConsole, reporterOptions);
+        _disposables.Add(reporter);
+
+        // Mirror the test options on the reporter — TerminalTestReporter._isHelp / _isDiscovery are set
+        // here, not in the constructor. The reporter's _isHelp flag drives the legacy "swallow handshake
+        // failures when in help mode" path that the new reportEvenWhenHelp opt-out is meant to bypass.
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: isDiscovery, isHelp: isHelp, isRetry: false);
+
+        var module = new TestModule(
+            RunProperties: new RunProperties("dotnet", TargetPath, "/repo"),
+            ProjectFullPath: ProjectPath,
+            TargetFramework: TargetFramework,
+            IsTestingPlatformApplication: true,
+            LaunchSettings: null,
+            TargetPath: TargetPath,
+            DotnetRootArchVariableName: null);
+
+        var testOptions = new TestOptions(IsHelp: isHelp, IsDiscovery: isDiscovery, EnvironmentVariables: new Dictionary<string, string>());
+
+        return (new TestApplicationHandler(reporter, module, testOptions), reporter, capturingConsole);
+    }
+
+    private static HandshakeMessage BuildHandshake(string? executionMode, string hostType = "TestHost", bool includeInstanceId = true)
+    {
+        var properties = new Dictionary<byte, string>
+        {
+            [HandshakeMessagePropertyNames.PID] = "1234",
+            [HandshakeMessagePropertyNames.Architecture] = "x64",
+            [HandshakeMessagePropertyNames.Framework] = ".NETCoreApp,Version=v9.0",
+            [HandshakeMessagePropertyNames.OS] = "Windows",
+            [HandshakeMessagePropertyNames.SupportedProtocolVersions] = ProtocolConstants.SupportedVersions,
+            [HandshakeMessagePropertyNames.HostType] = hostType,
+            [HandshakeMessagePropertyNames.ModulePath] = TargetPath,
+            [HandshakeMessagePropertyNames.ExecutionId] = "exec-1",
+        };
+
+        if (includeInstanceId)
+        {
+            properties[HandshakeMessagePropertyNames.InstanceId] = "inst-1";
+        }
+
+        if (executionMode is not null)
+        {
+            properties[HandshakeMessagePropertyNames.ExecutionMode] = executionMode;
+        }
+
+        return new HandshakeMessage(properties);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationProtocolVersionTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationProtocolVersionTests.cs
@@ -9,11 +9,6 @@ namespace dotnet.Tests.CommandTests.Test;
 [TestClass]
 public class TestApplicationProtocolVersionTests
 {
-    // Mirrors Microsoft.Testing.Platform.IPC.HandshakeMessagePropertyNames.SupportedProtocolVersions from the
-    // Microsoft.Testing.Platform.Internal.DotnetTest package. That type is [Embedded] and therefore not referenceable
-    // from this (separate) test assembly, so the wire value is inlined here.
-    private const byte SupportedProtocolVersionsProperty = 4;
-
     [TestMethod]
     [DataRow("1.0.0;1.1.0", "1.1.0")]
     [DataRow("1.0.0", "1.0.0")]
@@ -27,7 +22,7 @@ public class TestApplicationProtocolVersionTests
         var properties = new Dictionary<byte, string>();
         if (advertisedVersions is not null)
         {
-            properties[SupportedProtocolVersionsProperty] = advertisedVersions;
+            properties[HandshakeMessagePropertyNames.SupportedProtocolVersions] = advertisedVersions;
         }
 
         var handshake = new HandshakeMessage(properties);

--- a/test/dotnet.Tests/CommandTests/Test/TestNodeResultsStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestNodeResultsStateTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestNodeResultsStateTests
+{
+    [TestMethod]
+    public void AddRunningTestNode_AfterRemove_IsSuppressed()
+    {
+        // Simulates the stale-add race: the producer may emit an in-progress
+        // notification for a test that already completed. The state must not
+        // resurrect the test in the "running" list.
+        var state = new TestNodeResultsState(id: 1);
+        const string instanceId = "instance-A";
+        const string uid = "Foo";
+
+        state.AddRunningTestNode(id: 100, instanceId, uid, "Foo", new FakeStopwatch());
+        Assert.AreEqual(1, state.Count);
+
+        state.RemoveRunningTestNode(instanceId, uid);
+        Assert.AreEqual(0, state.Count);
+
+        // Stale in-progress arriving after completion must be ignored.
+        state.AddRunningTestNode(id: 101, instanceId, uid, "Foo", new FakeStopwatch());
+        Assert.AreEqual(0, state.Count);
+    }
+
+    [TestMethod]
+    public void AddRunningTestNode_DifferentInstance_SameUid_NotSuppressed()
+    {
+        // Retries use a new instanceId. A previous instance completing must
+        // not prevent the new instance from showing as running.
+        var state = new TestNodeResultsState(id: 1);
+        const string uid = "Foo";
+
+        state.AddRunningTestNode(id: 100, "instance-A", uid, "Foo", new FakeStopwatch());
+        state.RemoveRunningTestNode("instance-A", uid);
+        Assert.AreEqual(0, state.Count);
+
+        state.AddRunningTestNode(id: 200, "instance-B", uid, "Foo", new FakeStopwatch());
+        Assert.AreEqual(1, state.Count);
+    }
+
+    [TestMethod]
+    public void AddRunningTestNode_DistinctTests_AllTracked()
+    {
+        var state = new TestNodeResultsState(id: 1);
+
+        state.AddRunningTestNode(id: 100, "instance-A", "Test1", "Test1", new FakeStopwatch());
+        state.AddRunningTestNode(id: 101, "instance-A", "Test2", "Test2", new FakeStopwatch());
+        state.AddRunningTestNode(id: 102, "instance-B", "Test1", "Test1", new FakeStopwatch());
+
+        Assert.AreEqual(3, state.Count);
+    }
+
+    private sealed class FakeStopwatch : IStopwatch
+    {
+        public TimeSpan Elapsed => TimeSpan.Zero;
+
+        public void Start() { }
+
+        public void Stop() { }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -45,7 +45,7 @@ public class TestProgressStateTests
     /// Tests that reporting a skipped test with a previously seen instance after retry throws.
     /// </summary>
     [TestMethod]
-    public void ReportSkippedTest_RepeatedInstanceAfterRetry_ThrowsInvalidOperationException()
+    public void ReportSkippedTest_RepeatedInstanceAfterRetry_ThrowsUnreachableException()
     {
         var stopwatchMock = new Mock<IStopwatch>();
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
@@ -108,10 +108,10 @@ public class TestProgressStateTests
     }
 
     /// <summary>
-    /// Tests that reusing an old instance ID after a retry throws an InvalidOperationException.
+    /// Tests that reusing an old instance ID after a retry throws an UnreachableException.
     /// </summary>
     [TestMethod]
-    public void ReportFailedTest_ReusingOldInstanceId_ThrowsInvalidOperationException()
+    public void ReportFailedTest_ReusingOldInstanceId_ThrowsUnreachableException()
     {
         var stopwatchMock = new Mock<IStopwatch>();
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -1,0 +1,312 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+using Moq;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestProgressStateTests
+{
+    [TestMethod]
+    public void ReportSkippedTest_MultipleCalls_DifferentInstanceId()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        string testUid = "test1";
+        string instanceA = "instanceA";
+        string instanceB = "instanceB";
+        state.NotifyHandshake(instanceA);
+        state.NotifyHandshake(instanceB);
+
+        state.ReportSkippedTest(testUid, instanceA);
+        state.SkippedTests.Should().Be(1);
+        state.RetriedFailedTests.Should().Be(0);
+        state.TotalTests.Should().Be(1);
+
+        state.ReportSkippedTest(testUid, instanceA);
+        state.SkippedTests.Should().Be(2);
+        state.RetriedFailedTests.Should().Be(0);
+        state.TotalTests.Should().Be(2);
+
+        state.ReportSkippedTest(testUid, instanceB);
+        state.SkippedTests.Should().Be(1);
+        state.RetriedFailedTests.Should().Be(0);
+        state.TotalTests.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Tests that reporting a skipped test with a previously seen instance after retry throws.
+    /// </summary>
+    [TestMethod]
+    public void ReportSkippedTest_RepeatedInstanceAfterRetry_ThrowsInvalidOperationException()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        string testUid = "test1";
+        string instanceA = "instanceA";
+        string instanceB = "instanceB";
+        state.NotifyHandshake("instanceA");
+        state.ReportSkippedTest(testUid, instanceA);
+        state.ReportSkippedTest(testUid, instanceA);
+        state.NotifyHandshake("instanceB");
+        state.ReportSkippedTest(testUid, instanceB);
+
+        Action act = () => state.ReportSkippedTest(testUid, instanceA);
+        act.Should().Throw<UnreachableException>()
+           .WithMessage("Unexpected test result for attempt '1' while the last attempt is '2'");
+    }
+
+    /// <summary>
+    /// Tests that repeated calls to ReportFailedTest with the same UID and instance ID
+    /// increment FailedTests and TotalTests without affecting RetriedFailedTests.
+    /// </summary>
+    /// <param name="callCount">The number of times ReportFailedTest is invoked.</param>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void ReportFailedTest_RepeatedCalls_IncrementsFailedTests(int callCount)
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        state.NotifyHandshake("instance1");
+        for (int i = 0; i < callCount; i++)
+        {
+            state.ReportFailedTest("testUid", "instance1");
+        }
+
+        state.FailedTests.Should().Be(callCount);
+        state.TotalTests.Should().Be(callCount);
+        state.RetriedFailedTests.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Tests that ReportFailedTest with a new instance ID after failures
+    /// resets the failure count, increments RetriedFailedTests, and reports one failure.
+    /// </summary>
+    [TestMethod]
+    public void ReportFailedTest_DifferentInstanceId_RetriesFailureAndResetsCount()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        state.NotifyHandshake("id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.NotifyHandshake("id2");
+        state.ReportFailedTest("testUid", "id2");
+
+        state.RetriedFailedTests.Should().Be(2);
+        state.FailedTests.Should().Be(1);
+        state.TotalTests.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Tests that reusing an old instance ID after a retry throws an InvalidOperationException.
+    /// </summary>
+    [TestMethod]
+    public void ReportFailedTest_ReusingOldInstanceId_ThrowsInvalidOperationException()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        state.NotifyHandshake("id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.NotifyHandshake("id2");
+        state.ReportFailedTest("testUid", "id2");
+
+        Action act = () => state.ReportFailedTest("testUid", "id1");
+
+        act.Should()
+           .Throw<UnreachableException>()
+           .WithMessage("Unexpected test result for attempt '1' while the last attempt is '2'");
+    }
+
+    /// <summary>
+    /// Tests that reporting with a new instance id clears old reports.
+    /// </summary>
+    [TestMethod]
+    public void ReportTest_WithNewInstanceId_ClearsOldReports()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+        state.NotifyHandshake("id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "id1");
+        state.ReportSkippedTest("testUid", "id1");
+        state.ReportSkippedTest("testUid", "id1");
+
+        state.NotifyHandshake("id2");
+        state.ReportFailedTest("testUid", "id2");
+        state.ReportPassingTest("testUid", "id2");
+        state.ReportPassingTest("testUid", "id2");
+        state.ReportPassingTest("testUid", "id2");
+        state.ReportSkippedTest("testUid", "id2");
+
+        state.PassedTests.Should().Be(3);
+        state.FailedTests.Should().Be(1);
+        state.SkippedTests.Should().Be(1);
+        state.RetriedFailedTests.Should().Be(3);
+    }
+
+    /// <summary>
+    /// Tests that DiscoverTest increments PassedTests and adds the displayName and uid to DiscoveredTests.
+    /// </summary>
+    /// <param name="displayName">The display name of the test, can be null, empty, or whitespace.</param>
+    /// <param name="uid">The unique identifier of the test, can be null, empty, or whitespace.</param>
+    /// <remarks>After invocation, PassedTests should be 1 and DiscoveredTests should contain a single entry matching the inputs.</remarks>
+    [TestMethod]
+    [DataRow("testName", "uid123")]
+    [DataRow("", "")]
+    [DataRow(" ", " ")]
+    [DataRow(null, null)]
+    public void DiscoverTest_DisplayNameAndUid_AddsEntryAndIncrementsPassedTests(string? displayName, string? uid)
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(
+            id: 1,
+            assembly: "assembly.dll",
+            targetFramework: null,
+            architecture: null,
+            stopwatch: stopwatchMock.Object,
+            isDiscovery: true);
+
+        state.DiscoverTest(displayName, uid, filePath: null, lineNumber: null);
+
+        state.DiscoveredTests.Should().Be(1);
+        state.DiscoveredTestNames.Count.Should().Be(1);
+        state.DiscoveredTestNames[0].DisplayName.Should().Be(displayName);
+        state.DiscoveredTestNames[0].UID.Should().Be(uid);
+        state.DiscoveredTestNames[0].FilePath.Should().BeNull();
+        state.DiscoveredTestNames[0].LineNumber.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void DiscoverTest_WithFilePathAndLineNumber_StoresLocation()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(
+            id: 1,
+            assembly: "assembly.dll",
+            targetFramework: null,
+            architecture: null,
+            stopwatch: stopwatchMock.Object,
+            isDiscovery: true);
+
+        state.DiscoverTest("MyTest", "uid-1", filePath: "C:/repo/MyTests.cs", lineNumber: 42);
+
+        state.DiscoveredTestNames.Count.Should().Be(1);
+        state.DiscoveredTestNames[0].FilePath.Should().Be("C:/repo/MyTests.cs");
+        state.DiscoveredTestNames[0].LineNumber.Should().Be(42);
+    }
+
+    [TestMethod]
+    public void FailedTestRetryShouldShouldShowTheSameTotalCountsInEachRetry()
+    {
+        // Tests are retried, total test count stays 3 to give use comparable counts, no matter how many times we retry.
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        // First run
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("failed-test", "run1");
+        state.ReportPassingTest("passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "run1");
+        
+        state.RetriedFailedTests.Should().Be(0);
+        state.FailedTests.Should().Be(1);
+        state.PassedTests.Should().Be(1);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(3);
+
+        // Second run (first retry)
+        state.NotifyHandshake("run2");
+        state.ReportFailedTest("failed-test", "run2");
+
+        state.RetriedFailedTests.Should().Be(1);
+        state.FailedTests.Should().Be(1);
+        state.PassedTests.Should().Be(1);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(3);
+
+        // Third run (second retry) - failing test passes
+        state.NotifyHandshake("run3");
+        state.ReportPassingTest("failed-test", "run3");
+        state.RetriedFailedTests.Should().Be(2);
+        state.FailedTests.Should().Be(0);
+        state.PassedTests.Should().Be(2);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void FailedTestRetryShouldNotFailTheRunWhenSecondRunProducesLessDynamicTests()
+    {
+        // This is special test for dynamic tests where we don't know how many tests will be produced in the second run.
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        // First run
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("failed-test1", "run1"); // 2 test cases
+        state.ReportFailedTest("failed-test1", "run1");
+
+        state.ReportPassingTest("passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "run1");
+
+        state.RetriedFailedTests.Should().Be(0);
+        state.FailedTests.Should().Be(2);
+        state.PassedTests.Should().Be(1);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(4);
+
+        // Second run (first retry)
+        state.NotifyHandshake("run2");
+        state.ReportPassingTest("failed-test1", "run2"); // 1 test case, now passes
+
+        state.RetriedFailedTests.Should().Be(2);
+        state.FailedTests.Should().Be(0);
+        state.PassedTests.Should().Be(2);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void FailedTestRetryShouldAccountPassedTestsInRetry()
+    {
+        // This is special test for dynamic tests where we cannot avoid re-running even non-failing tests from dynamic tests.
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        // First run
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("failed-test1", "run1"); // 2 test cases, one passes, one fails
+        state.ReportPassingTest("failed-test1", "run1");
+
+        state.ReportPassingTest("passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "run1");
+
+        state.RetriedFailedTests.Should().Be(0);
+        state.FailedTests.Should().Be(1);
+        state.PassedTests.Should().Be(2);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(4);
+
+        // Second run (first retry)
+        state.NotifyHandshake("run2");
+        state.ReportFailedTest("failed-test1", "run2"); // 1 test case still fails, but we also re-run the passing one
+        state.ReportPassingTest("failed-test1", "run2");
+
+        state.RetriedFailedTests.Should().Be(1);
+        state.FailedTests.Should().Be(1);
+        state.PassedTests.Should().Be(2);
+        state.SkippedTests.Should().Be(1);
+        state.TotalTests.Should().Be(4);
+    }
+}


### PR DESCRIPTION
## Why

PR #54959 made `dotnet/sdk` consume the source-only NuGet `Microsoft.Testing.Platform.Internal.DotnetTest` for the shared `dotnet test` ↔ Microsoft.Testing.Platform source. That breaks source-build / the VMR ([dotnet/dotnet#7529](https://github.com/dotnet/dotnet/pull/7529)): source-only packages don't flow cleanly through source-build, and the dev workflow (updating the checked-in source + the SDK dependency together) is awkward.

Instead, this PR keeps the shared source **vendored** (hand-copied) and adds a drift-tracking mechanism — the same one `microsoft/testfx` already uses — so we get notified when the upstream testfx files change and a human decides whether to port.

## What

**1. Revert the package consumption (#54959)** — clean `git revert -m 1`, no conflicts:
- Restores the vendored `Terminal/*` reporter, `IPC/ObjectFieldIds.cs`, and the wire constants in `CliConstants.cs` (plus their namespaces).
- Drops the `Microsoft.Testing.Platform.Internal.DotnetTest` `PackageReference`, the CPM version, the darc wiring in `eng/Version.Details.*` / `eng/Versions.props`, the `NoWarn;CS0436`, and the `.editorconfig` `[.packages/**.cs]` addition.

**2. Add the vendored-files drift-tracking mechanism** (ported from testfx):
- `eng/vendored-files.json` — manifest of the 30 testfx-sourced files (38 upstream sources), pinned to testfx `main@4a09ad6`.
- `eng/vendored-files.md` — docs: schema, drift model, reconciliation flow.
- `.github/scripts/check_vendored_files.py` — `validate` (PR-safe, no network) + `check` (opens/updates tracking issues labelled `area-vendored-sync`).
- `.github/workflows/check-vendored-files.yml` — weekly schedule + manual dispatch + PR validation.
- Enhanced the existing "keep aligned with the testfx repo" note in `ObjectFieldIds.cs` to point at the manifest.

The detector compares the **upstream** file's current blob SHA against the recorded baseline — it never inspects the local content — so the hard-forked reporter (testfx split it into partials; the SDK keeps a monolith) is tracked correctly: any upstream change opens an issue to reconcile.

## Validation

- `python .github/scripts/check_vendored_files.py validate` → *Manifest OK: 30 entries, 38 sources*.
- Live `check --dry-run` against `microsoft/testfx` → **0 drifted, 0 errors** (all 38 `ok`).
- Full `build.cmd` → **Build succeeded, 0 warnings, 0 errors**.

## Companion change (testfx)

A companion PR in `microsoft/testfx` stops producing the `Microsoft.Testing.Platform.Internal.DotnetTest` package and updates the `DotnetTestProtocolContract.props` / `TerminalReporterContract.props` comments to mark those files as vendored by `dotnet/sdk` (keeping the item lists + standalone contract tests). Will cross-link once it's up.

Closes the source-build regression from #54959.
