### PR TITLE
Follow-up to #55095: address review comments from joeloff

### DIFF
--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
@@ -12,9 +12,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Verify.DiffPlex" />
-    <!-- Verify core is used directly (VerifySettings, SettingsTask, FileScrubber). Pin it to the same
-         version the Authoring.CLI tool resolves (via Verify.XunitV3) so the two projects don't contribute
-         different EmptyFiles versions to the CLI's publish output, which would fail with NETSDK1152. -->
+    <!-- Verify core is used directly (VerifySettings, SettingsTask, FileScrubber). It is intentionally NOT
+         centrally managed: the repo needs two different Verify versions side by side - 28.12.0 (pulled in via
+         Verify.XunitV3 by the Authoring.CLI/TemplateSearch toolchain) and 31.19.0 (pulled in via Verify.MSTest
+         by the test projects). A single CPM version can't satisfy both (it produces NU1109 downgrade errors),
+         so VersionOverride is used here to pin just this shipping project to 28.12.0. That matches the version
+         Authoring.CLI resolves transitively, so the two projects don't contribute different EmptyFiles versions
+         to the CLI's publish output, which would otherwise fail with NETSDK1152. -->
     <PackageReference Include="Verify" VersionOverride="28.12.0" />
   </ItemGroup>
 

--- a/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
+++ b/src/TemplateEngine/Tools/Shared/Microsoft.TemplateEngine.CommandUtils/CommandResultAssertions.cs
@@ -19,39 +19,39 @@ namespace Microsoft.TemplateEngine.CommandUtils
 
         internal CommandResultAssertions ExitWith(int expectedExitCode)
         {
-            AssertTrue(expectedExitCode == _commandResult.ExitCode, AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode} but it did not."));
+            AssertTrue(expectedExitCode == _commandResult.ExitCode, AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode}, but it did not."));
             return this;
         }
 
         internal CommandResultAssertions Pass()
         {
-            AssertTrue(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to pass but it did not."));
+            AssertTrue(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to pass, but it did not."));
             return this;
         }
 
         internal CommandResultAssertions Fail()
         {
-            AssertFalse(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to fail but it passed."));
+            AssertFalse(_commandResult.ExitCode == 0, AppendDiagnosticsTo("Expected command to fail, but it passed."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOut()
         {
-            AssertFalse(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to have standard output but it did not."));
+            AssertFalse(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to have standard output, but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOut(string expectedOutput)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(expectedOutput == _commandResult.StdOut, AppendDiagnosticsTo($"Expected standard output to be '{expectedOutput}' but it was not."));
+            AssertTrue(expectedOutput == _commandResult.StdOut, AppendDiagnosticsTo($"Expected standard output to be '{expectedOutput}', but it was not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContaining(string pattern)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}', but it did not."));
             return this;
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.TemplateEngine.CommandUtils
         internal CommandResultAssertions NotHaveStdOutContaining(string pattern)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(!_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to not contain '{pattern}' but it did."));
+            AssertTrue(!_commandResult.StdOut.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to not contain '{pattern}', but it did."));
             return this;
         }
 
@@ -73,91 +73,91 @@ namespace Microsoft.TemplateEngine.CommandUtils
         {
             AssertNotNull(_commandResult.StdOut);
             string commandResultNoSpaces = _commandResult.StdOut.Replace(" ", string.Empty);
-            AssertTrue(commandResultNoSpaces.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertTrue(commandResultNoSpaces.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutContainingIgnoreCase(string pattern)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}' but it did not."));
+            AssertTrue(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase), AppendDiagnosticsTo($"Expected standard output to contain '{pattern}', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to match pattern '{pattern}' but it did not."));
+            AssertTrue(Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to match pattern '{pattern}', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(!Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to not match pattern '{pattern}' but it did."));
+            AssertTrue(!Regex.Match(_commandResult.StdOut, pattern, options).Success, AppendDiagnosticsTo($"Expected standard output to not match pattern '{pattern}', but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErr()
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertFalse(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to have standard error but it did not."));
+            AssertFalse(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to have standard error, but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErr(string expectedOutput)
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(expectedOutput == _commandResult.StdErr, AppendDiagnosticsTo($"Expected standard error to be '{expectedOutput}' but it was not."));
+            AssertTrue(expectedOutput == _commandResult.StdErr, AppendDiagnosticsTo($"Expected standard error to be '{expectedOutput}', but it was not."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErrContaining(string pattern)
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}' but it did not."));
+            AssertTrue(_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to contain '{pattern}', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdErrContaining(string pattern)
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to not contain '{pattern}' but it did."));
+            AssertTrue(!_commandResult.StdErr.Contains(pattern, StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard error to not contain '{pattern}', but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(Regex.Match(_commandResult.StdErr, pattern, options).Success, AppendDiagnosticsTo($"Expected standard error to match pattern '{pattern}' but it did not."));
+            AssertTrue(Regex.Match(_commandResult.StdErr, pattern, options).Success, AppendDiagnosticsTo($"Expected standard error to match pattern '{pattern}', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdOut()
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to not have standard output but it did."));
+            AssertTrue(string.IsNullOrEmpty(_commandResult.StdOut), AppendDiagnosticsTo("Expected command to not have standard output, but it did."));
             return this;
         }
 
         internal CommandResultAssertions NotHaveStdErr()
         {
             AssertNotNull(_commandResult.StdErr);
-            AssertTrue(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to not have standard error but it did."));
+            AssertTrue(string.IsNullOrEmpty(_commandResult.StdErr), AppendDiagnosticsTo("Expected command to not have standard error, but it did."));
             return this;
         }
 
         internal CommandResultAssertions HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(_commandResult.StdOut.Contains($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.' but it did not."));
+            AssertTrue(_commandResult.StdOut.Contains($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.', but it did not."));
             return this;
         }
 
         internal CommandResultAssertions HaveCompiledProject(string compiledProject, string frameworkFullName)
         {
             AssertNotNull(_commandResult.StdOut);
-            AssertTrue(_commandResult.StdOut.Contains($"Project {compiledProject} ({frameworkFullName}) will be compiled", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {compiledProject} ({frameworkFullName}) will be compiled' but it did not."));
+            AssertTrue(_commandResult.StdOut.Contains($"Project {compiledProject} ({frameworkFullName}) will be compiled", StringComparison.Ordinal), AppendDiagnosticsTo($"Expected standard output to contain 'Project {compiledProject} ({frameworkFullName}) will be compiled', but it did not."));
             return this;
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.TemplateEngine.CommandUtils
         {
             if (value is null)
             {
-                throw new CommandResultAssertionException("Expected value to not be null but it was.");
+                throw new CommandResultAssertionException("Expected value to not be null, but it was.");
             }
         }
     }


### PR DESCRIPTION
Follow-up to #55095 addressing the two open review threads from @joeloff.

## 1. Grammar in assertion messages (`CommandResultAssertions.cs`)
joeloff suggested a comma before "but" in the null-check message, and noted "a few other messages have the same issue." Added a comma before "but" consistently across all assertion messages (e.g. `Expected command to pass, but it did not.`).

## 2. `Verify` `VersionOverride` vs CPM (`TemplateVerifier.Shared.props`)
joeloff questioned whether `VersionOverride` is the opposite of pinning under Central Package Management.

I investigated moving `Verify` into CPM, but it doesn't work: the repo genuinely needs **two** `Verify` versions side by side — `28.12.0` (pulled in via `Verify.XunitV3` by the Authoring.CLI/TemplateSearch toolchain) and `31.19.0` (pulled in via `Verify.MSTest` by the test projects). Centrally pinning `Verify` to `28.12.0` produces `NU1109` package-downgrade errors in the MSTest-based test projects; pinning to `31.19.0` would break the CLI publish output (`NETSDK1152`, mismatched `EmptyFiles` versions).

`VersionOverride` is therefore the correct, targeted tool here — it aligns only the shipping `TemplateVerifier` project with the CLI's transitive `28.12.0`, without disturbing the test projects. Rather than change the mechanism, this PR expands the comment to explain exactly why CPM can't be used, directly answering the review question.

## Validation
- `restore.cmd` across the full solution: 0 warnings, 0 errors.
- `TemplateVerifier` project build: 0 warnings, 0 errors.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>