### PR TITLE
Enable MTP crash/hang dump extensions and wire them into Helix

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -41,7 +41,7 @@
          progress, so intermittent hangs/crashes on CI (especially on Helix) are diagnosable.
          MSTest.Sdk pulls in the Microsoft.Testing.Extensions.CrashDump / .HangDump packages
          automatically when these are set, so no explicit PackageReference or version pin is
-         required. The Helix dispatcher passes --crashdump / --hangdump to activate them. -->
+         required. The Helix dispatcher passes the crashdump / hangdump switches to activate them. -->
     <EnableMicrosoftTestingExtensionsCrashDump>true</EnableMicrosoftTestingExtensionsCrashDump>
     <EnableMicrosoftTestingExtensionsHangDump>true</EnableMicrosoftTestingExtensionsHangDump>
   </PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -36,6 +36,14 @@
 
     <!-- Promote info-severity MSTest analyzer rules to warnings and critical rules to errors. -->
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
+
+    <!-- Collect a crash dump if the test host crashes, and a hang dump when a run stops making
+         progress, so intermittent hangs/crashes on CI (especially on Helix) are diagnosable.
+         MSTest.Sdk pulls in the Microsoft.Testing.Extensions.CrashDump / .HangDump packages
+         automatically when these are set, so no explicit PackageReference or version pin is
+         required. The Helix dispatcher passes --crashdump / --hangdump to activate them. -->
+    <EnableMicrosoftTestingExtensionsCrashDump>true</EnableMicrosoftTestingExtensionsCrashDump>
+    <EnableMicrosoftTestingExtensionsHangDump>true</EnableMicrosoftTestingExtensionsHangDump>
   </PropertyGroup>
 
 </Project>

--- a/test/HelixTasks/SDKCustomCreateTestWorkItemsWithTestExclusion.cs
+++ b/test/HelixTasks/SDKCustomCreateTestWorkItemsWithTestExclusion.cs
@@ -177,9 +177,9 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             bool isMTPProject = string.Equals(isMTPProjectMetadata, "true", StringComparison.OrdinalIgnoreCase);
 
             // True when the Microsoft.Testing.Extensions.TrxReport extension is loaded on the
-            // project. MSTest.Sdk enables it by default; xUnit v3 MTP projects do not bundle
-            // it unless added explicitly. Passing '--report-trx' to an MTP host without the
-            // extension fails with an 'unknown argument' error, so only emit it when known safe.
+            // project. MSTest.Sdk enables it by default. Passing '--report-trx' to an MTP host
+            // without the extension fails with an 'unknown argument' error, so only emit it when
+            // known safe.
             testProject.TryGetMetadata("EnableTrxReport", out string enableTrxReportMetadata);
             bool enableTrxReport = string.Equals(enableTrxReportMetadata, "true", StringComparison.OrdinalIgnoreCase);
 
@@ -232,13 +232,18 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
 
                 var testFilter = string.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
 
-                // xUnit v3 tests run out-of-process: the VSTest adapter launches the AppHost executable.
-                // On POSIX, the execute bit is lost when the Helix SDK packages the payload as a zip archive,
-                // so we need to restore it before running.
+                // Test executables run out-of-process (MTP hosts are launched directly; the legacy
+                // VSTest path launches the AppHost executable). On POSIX, the execute bit is lost
+                // when the Helix SDK packages the payload as a zip archive, so restore it before running.
                 string exeName = Path.GetFileNameWithoutExtension(assemblyName);
                 string chmodPrefix = IsPosixShell ? $"chmod +x {exeName} && " : "";
                 // On macOS, ad-hoc sign the test exe with get-task-allow entitlement so createdump can attach via task_for_pid for crash dumps.
                 string codesignPrefix = IsPosixShell && TargetRid.StartsWith("osx") ? $"codesign -s - -f --entitlements $HELIX_CORRELATION_PAYLOAD/t/helix-debug-entitlements.plist {exeName} && " : "";
+
+                // blame-hang-timeout / hangdump-timeout is set to a % of the Helix work item timeout so
+                // that a hang dump can be captured and the results written before Helix hard-kills the
+                // process. Shared by both the MTP (--hangdump) and legacy VSTest (--blame-hang) branches.
+                var blameHangTimeout = TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.8);
 
                 string command;
                 if (isMTPProject)
@@ -254,12 +259,13 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     //   --results-directory     same as VSTest
                     //   --report-trx            replaces '--logger trx' -- only emitted when the
                     //                           Microsoft.Testing.Extensions.TrxReport extension is
-                    //                           loaded (always true for MSTest.Sdk default profile;
-                    //                           not bundled with xUnit v3 MTP)
+                    //                           loaded (always true for MSTest.Sdk default profile)
                     //   --diagnostic            replaces VSTest '-d <log>'
-                    // Note: --logger "console;verbosity=detailed" and --blame-hang* have no direct MTP
-                    // equivalent in the MSTest.Sdk default extension set; the Helix work-item timeout
-                    // (TestWorkItemTimeout / HELIX_WORK_ITEM_TIMEOUT) still terminates runaway runs.
+                    //   --crashdump             captures a dump if the test host crashes
+                    //   --hangdump              captures a dump if the run stops making progress
+                    // Note: --logger "console;verbosity=detailed" has no direct MTP equivalent in the
+                    // MSTest.Sdk default extension set; the Helix work-item timeout (TestWorkItemTimeout
+                    // / HELIX_WORK_ITEM_TIMEOUT) still terminates runaway runs.
                     // Carry over the same execution-directory / MSBuild SDK resolver environment
                     // variables that the 'dotnet test' path sets via '-e'. They are required for
                     // macOS workitem-directory execution (DOTNET_SDK_TEST_EXECUTION_DIRECTORY) and
@@ -295,6 +301,15 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                     // See https://github.com/dotnet/sdk/issues/54963.
                     string ignoreZeroTestsArg = "--ignore-exit-code 8";
 
+                    // Capture a crash dump on test-host crash and a hang dump when the run stops making
+                    // progress. --hangdump-timeout is a % of the work item timeout (see blameHangTimeout
+                    // above) so the dump is written before Helix hard-kills the work item. The dump files
+                    // land in the results directory and are copied to HELIX_WORKITEM_UPLOAD_ROOT by the
+                    // HelixPostCommands *.dmp glob in UnitTests.proj. Enabled repo-wide via
+                    // EnableMicrosoftTestingExtensions{Crash,Hang}Dump in test/Directory.Build.props.
+                    // --crashdump is recognized (and silently no-ops) on the .NET Framework MTP hosts.
+                    string dumpArgs = $"--crashdump --hangdump --hangdump-timeout {blameHangTimeout.TotalMinutes:0}m";
+
                     // .NET Framework apphosts (TargetPath is the '.exe') run directly; .NET (Core)
                     // assemblies (TargetPath is the '.dll') run via 'dotnet exec'.
                     string mtpLauncher = runtimeTargetFrameworkParsed.Framework == ".NETFramework"
@@ -302,13 +317,10 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                         : $"{driver} exec {assemblyName}";
 
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{envPrefix}{mtpLauncher} " +
-                              $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg} {ignoreZeroTestsArg}";
+                              $"--results-directory .{Path.DirectorySeparatorChar} {trxArg}{testFilter} {diagArg} {dumpArgs} {ignoreZeroTestsArg}";
                 }
                 else
                 {
-                    // blame-hang-timeout is set to a % of the Helix work item timeout so that blame can
-                    // collect hang dumps and write the TRX file before Helix hard-kills the process.
-                    var blameHangTimeout = TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.8);
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
                               $"{(TestArguments != null ? " " + TestArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout {blameHangTimeout.TotalMinutes:0}m {testFilter} {enableDiagLogging} {arguments}";
                 }

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -227,8 +227,11 @@
       <HelixPreCommands Condition="'$(RunAoTTests)' == 'true' and !$(IsPosixShell)">$(HelixPreCommands);%DOTNET_ROOT%\dotnet workload install wasm-tools --skip-manifest-update --configfile %TestExecutionDirectory%\NuGet.config</HelixPreCommands>
       <HelixPreCommands Condition="'$(RunAoTTests)' == 'true' and $(IsPosixShell)">$(HelixPreCommands);$DOTNET_ROOT/dotnet workload install wasm-tools --skip-manifest-update --configfile $TestExecutionDirectory/NuGet.config</HelixPreCommands>
       <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "dotnet nuget locals all -l | ForEach-Object { $_.Split(' ')[1]} | Where-Object{$_ -like '*cache'} | Get-ChildItem -Recurse -File -Filter '*.dat' | Measure";$(HelixPostCommands)</HelixPostCommands>
-      <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "Get-ChildItem -Recurse -File -Filter '*hangdump.dmp' | Copy-Item -Destination $env:HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
-      <HelixPostCommands Condition="$(IsPosixShell)">find "$HELIX_WORKITEM_UPLOAD_ROOT/../../.." -name '*hangdump.dmp' -print0 | xargs -0 -I@ cp @ "$HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
+      <!-- Upload any crash/hang dumps to the work item so they are retained. Matches both the MTP
+           crash/hang dump extensions (*_crash.dmp / *_hang.dmp) and the legacy VSTest blame-hang
+           dumps (*hangdump.dmp). -->
+      <HelixPostCommands Condition="!$(IsPosixShell)">PowerShell -ExecutionPolicy ByPass "Get-ChildItem -Recurse -File -Filter '*.dmp' | Copy-Item -Destination $env:HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
+      <HelixPostCommands Condition="$(IsPosixShell)">find "$HELIX_WORKITEM_UPLOAD_ROOT/../../.." -name '*.dmp' -print0 | xargs -0 -I@ cp @ "$HELIX_WORKITEM_UPLOAD_ROOT";$(HelixPostCommands)</HelixPostCommands>
       <TestDotnetVersion>$(Version)</TestDotnetVersion>
       <MSBuildSdkResolverDir>$(RepoRoot)artifacts\bin\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverDir>
       <HelixStage0Targz>$(RepoRoot)artifacts\tmp\HelixStage0.tar.gz</HelixStage0Targz>

--- a/test/test-runner/TestPublish.targets
+++ b/test/test-runner/TestPublish.targets
@@ -4,15 +4,14 @@
   <!-- Returns 'true' if the project is a Microsoft.Testing.Platform (MTP) project that
        must be invoked via 'dotnet exec' rather than 'dotnet test'. In this repo,
        MSTest.Sdk-based projects ship as MTP self-contained executables and set
-       UsingMSTestSdk=true; non-MSTest projects (e.g. xUnit v3) keep using the VSTest path. -->
+       UsingMSTestSdk=true; any remaining non-MSTest projects keep using the VSTest path. -->
   <Target Name="GetIsMTPProject" Returns="$(UsingMSTestSdk)" />
 
   <!-- Returns 'true' when the Microsoft.Testing.Extensions.TrxReport extension is
        enabled on the project. MSTest.Sdk defaults this to 'true' for the Default and
-       AllMicrosoft extension profiles (see microsoft/testfx Runner/Common.targets);
-       other MTP project types (e.g. xUnit v3 MTP) do not bundle the extension unless
-       added explicitly. The Helix dispatcher uses this to decide whether emitting the
-       report-trx switch on the test command is safe; passing it to an MTP host without
-       the extension fails with an 'unknown argument' error. -->
+       AllMicrosoft extension profiles (see microsoft/testfx Runner/Common.targets).
+       The Helix dispatcher uses this to decide whether emitting the report-trx switch on
+       the test command is safe; passing it to an MTP host without the extension fails with
+       an 'unknown argument' error. -->
   <Target Name="GetTrxReportEnabled" Returns="$(EnableMicrosoftTestingExtensionsTrxReport)" />
 </Project>

--- a/test/test-runner/TestRunner.targets
+++ b/test/test-runner/TestRunner.targets
@@ -10,7 +10,7 @@
 
     <SDKCustomTestArguments Condition="'$(SDKCustomTestArguments)' == ''">-nocolor</SDKCustomTestArguments>
 
-    <!-- xUnit v3 runs tests out-of-process via a native AppHost.  When cross-compiling
+    <!-- Tests run out-of-process via a native AppHost.  When cross-compiling
          (e.g. building on arm64 for x64 Helix queues), set RuntimeIdentifier so the
          AppHost matches the target architecture.  SelfContained=false keeps the publish
          framework-dependent.  ErrorOnDuplicatePublishOutputFiles=false suppresses
@@ -86,8 +86,8 @@
     </MSBuild>
 
     <!-- Detect whether the project has the Microsoft.Testing.Extensions.TrxReport extension
-         loaded. MSTest.Sdk enables it by default; other MTP runners (e.g. xUnit v3 MTP) do
-         not, so passing the report-trx switch to those hosts would fail with 'unknown argument'. -->
+         loaded. MSTest.Sdk enables it by default; MTP hosts without the extension reject the
+         report-trx switch with an 'unknown argument' error. -->
     <MSBuild Projects="$(_CurrentSDKCustomTestProject)" Targets="GetTrxReportEnabled" Properties="CustomAfterMicrosoftCommonTargets=$(_SDKCustomTestPublishTargetsPath);TargetFramework=$(_CurrentPublishTargetFramework);$(_CurrentAdditionalProperties)">
       <Output TaskParameter="TargetOutputs" PropertyName="_EnableTrxReport" />
     </MSBuild>


### PR DESCRIPTION
## Summary

Almost all `test/` projects use `MSTest.Sdk` and run on Microsoft.Testing.Platform (MTP). On Helix they are dispatched via the `isMTPProject` branch of `SDKCustomCreateTestWorkItemsWithTestExclusion`, which — unlike the legacy VSTest branch — had **no crash/hang dump support**. This made intermittent CI hangs and crashes hard to diagnose. This PR enables the MTP crash-dump and hang-dump extensions, wires them into the Helix command, ensures the dumps are uploaded, and cleans up stale xUnit-mentioning comments.

## Changes

**1. Enable the dump extensions (`test/Directory.Build.props`)**
- Set `EnableMicrosoftTestingExtensionsCrashDump=true` and `EnableMicrosoftTestingExtensionsHangDump=true` in the existing `UsingMSTestSdk=='true'` block. MSTest.Sdk pulls in the `Microsoft.Testing.Extensions.CrashDump` / `.HangDump` packages automatically and manages their versions, so **no explicit `PackageReference` or version pin is required**.

**2. Wire dumps into the Helix MTP command (`SDKCustomCreateTestWorkItemsWithTestExclusion.cs`)**
- Hoisted the existing `blameHangTimeout` (80% of the Helix work-item timeout) above the branch so both the MTP and legacy VSTest paths share the same calculation.
- The MTP branch now appends `--crashdump --hangdump --hangdump-timeout <T>m`, where `T` is the shared 80%-of-timeout value, so a hang dump is captured before Helix hard-kills the work item.
- `--crashdump` is recognized (and silently no-ops) on the .NET Framework MTP hosts, so this is safe for the net472 rows.

**3. Upload both hang and crash dumps (`test/UnitTests.proj`)**
- The MTP extensions write default filenames ending in `_hang.dmp` / `_crash.dmp`, which the old `*hangdump.dmp` glob missed. Broadened both `HelixPostCommands` copy globs (Windows PowerShell + POSIX `find`) to `*.dmp`, which also still matches the legacy VSTest `*hangdump.dmp`. macOS crash dumps continue to work via the pre-existing ad-hoc codesign step.

**4. Comment cleanup (non-behavioral)**
- Refreshed stale `xUnit v3` / VSTest references in the dispatcher, `TestRunner.targets`, and `TestPublish.targets`. Comments that still accurately document the retained legacy VSTest branch were left intact.

## Validation
- Verified the MSTest.Sdk property names, the MTP CLI switches, and the default dump filenames against the `microsoft/testfx` source and the official docs.
- Confirmed the C# dispatcher change compiles cleanly (isolated Roslyn compile of the HelixTasks sources succeeded with 0 errors).

## Notes
- No behavioral change beyond enabling the dumps; the legacy VSTest branch is untouched.
- Does not touch `Microsoft.Win32.Msi.Manual.Tests` or remove the VSTest branch (tracked separately in #55132).
- No `.xlf` edits and no new strings.