### PR TITLE
Make apple mobile targets R2R size optimized by default

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -41,6 +41,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripInliningInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-inlining-info</PublishReadyToRunCrossgen2ExtraArgs>
     <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(PublishReadyToRunStripDebugInfo)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--strip-debug-info</PublishReadyToRunCrossgen2ExtraArgs>
+
+    <!-- iOS-like platforms always optimize R2R codegen for size. -->
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(_IsIOSLikeRid)' == 'true'">$(PublishReadyToRunCrossgen2ExtraArgs);--Os</PublishReadyToRunCrossgen2ExtraArgs>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Pass --Os which should instruct the compiler to generate compact code. Reduces code size by about 1.5%.

Runtime equivalent https://github.com/dotnet/runtime/pull/130128