### PR TITLE
[release/10.0.4xx] Pack RID-specific tool pointer packages with DotnetToolSettings.xml under tools/any/any

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -186,7 +186,6 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     Condition=" '$(PackAsTool)' == 'true' "
     Returns="@(TfmSpecificPackageFile)">
     <ItemGroup>
-      <_GeneratedFiles Include="$(_ToolsSettingsFilePath)"/>
       <!-- Note here that we're _not_ computing relative directories inside the package anymore. In our packages, we essentially want to
           recreate the publish layout, but under a TFM- or RID-specific root path. Because we're globbing from the PublishDir,
           the MSBuild Items will have the RecursiveDir metadata - this is used by the PackLogic to combine with the PackagePath
@@ -205,8 +204,15 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <PropertyGroup>
       <_ToolRidPath Condition="'$(RuntimeIdentifier)' == ''">any</_ToolRidPath>
       <_ToolRidPath Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_ToolRidPath>
+      <_ToolSettingsTargetFrameworkPath>$(_ToolPackShortTargetFrameworkName)</_ToolSettingsTargetFrameworkPath>
+      <!-- RID-specific top-level packages are pointers only, so their settings file should be TFM-agnostic too. -->
+      <_ToolSettingsTargetFrameworkPath Condition="'$(_ToolPackageShouldIncludeImplementation)' != 'true' and '$(_UserSpecifiedToolPackageRids)' != ''">any</_ToolSettingsTargetFrameworkPath>
     </PropertyGroup>
     <ItemGroup>
+      <TfmSpecificPackageFile Include="$(_ToolsSettingsFilePath)">
+        <PackagePath>tools/$(_ToolSettingsTargetFrameworkPath)/$(_ToolRidPath)/</PackagePath>
+      </TfmSpecificPackageFile>
+
       <TfmSpecificPackageFile Include="@(_GeneratedFiles)">
         <PackagePath>tools/$(_ToolPackShortTargetFrameworkName)/$(_ToolRidPath)/%(_GeneratedFiles.RecursiveDir)</PackagePath>
       </TfmSpecificPackageFile>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -167,6 +167,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
 
             // top-level package should declare all of the rids
             var topLevelPackage = packages.First(p => p.EndsWith($"{packageIdentifier}.{toolSettings.ToolPackageVersion}.nupkg"));
+            EnsureToolSettingsFileUsesAnyTfmAndRid(topLevelPackage);
             var foundRids = GetRidsInSettingsFile(topLevelPackage);
             foundRids.Should().BeEquivalentTo(expectedRids, "The top-level package should declare all of the RIDs for the tools it contains");
         }
@@ -263,6 +264,7 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             // top-level package should declare all of the rids
             var topLevelPackage = packages.FirstOrDefault(p => p.EndsWith($"{packageIdentifier}.{toolSettings.ToolPackageVersion}.nupkg"));
             topLevelPackage.Should().NotBeNull($"Package {packageIdentifier}.{toolSettings.ToolPackageVersion}.nupkg should be present in the tool packages directory")
+                .And.Satisfy<string>(EnsureToolSettingsFileUsesAnyTfmAndRid)
                 .And.Satisfy<string>(SupportAllOfTheseRuntimes([.. expectedRids, "any"]));
         }
 
@@ -553,14 +555,27 @@ namespace Microsoft.DotNet.PackageInstall.Tests
             return nodes;
         }
 
+        static void EnsureToolSettingsFileUsesAnyTfmAndRid(string packagePath)
+        {
+            using var zipArchive = ZipFile.OpenRead(packagePath);
+            GetToolSettingsFileEntry(zipArchive).FullName.Should().Be("tools/any/any/DotnetToolSettings.xml");
+        }
+
         static XElement GetToolSettingsFile(string packagePath)
         {
             using var zipArchive = ZipFile.OpenRead(packagePath);
-            var nuspecEntry = zipArchive.Entries.First(e => e.Name == "DotnetToolSettings.xml")!;
-            var stream = nuspecEntry.Open();
+            var toolSettingsEntry = GetToolSettingsFileEntry(zipArchive);
+            var stream = toolSettingsEntry.Open();
             var xml = XDocument.Load(stream, LoadOptions.None);
             return xml.Root!;
 
+        }
+
+        static ZipArchiveEntry GetToolSettingsFileEntry(ZipArchive zipArchive)
+        {
+            var settingsEntries = zipArchive.Entries.Where(e => e.Name == "DotnetToolSettings.xml").ToArray();
+            settingsEntries.Should().ContainSingle("tool packages should contain exactly one DotnetToolSettings.xml file");
+            return settingsEntries[0];
         }
 
         /// <summary>


### PR DESCRIPTION
Backport of #55107 to `release/10.0.4xx`.

## Why this is needed

When packing a RID-specific .NET tool, the SDK produces a top-level "pointer" package plus one implementation package per RID. The pointer package is metadata-only: it declares the available RIDs and points consumers at the correct RID-specific implementation package to download. It contains no tool binaries.

Previously the SDK wrote the pointer package's `DotnetToolSettings.xml` under a concrete TFM/RID path (e.g. `tools/net11.0/<rid>/`). That coupled the TFM-agnostic pointer to a specific target framework path, which is inconsistent with the pointer's role and can lead to the settings file not being discovered as expected for the pointer package. The pointer should be TFM- and RID-agnostic, since it exists only to route consumers to the real payload packages.

## What changed

- **Packaging layout** (`Microsoft.NET.PackTool.targets`)
  - The top-level RID-specific pointer package now writes `DotnetToolSettings.xml` to `tools/any/any/`, keeping the pointer TFM- and RID-agnostic.
  - Implementation packages are unchanged; they keep their existing TFM/RID-specific layout (e.g. `tools/net11.0/linux-x64/...`).

- **Pointer package behavior**
  - The `any/any` path is applied only when packing the RID-specific top-level package that contains metadata but no implementation files.
  - The existing settings generation and RID declarations inside the XML are preserved.

- **Coverage** (`EndToEndToolTests.cs`)
  - End-to-end assertions verify the pointer package contains exactly one `DotnetToolSettings.xml` and that its path is `tools/any/any/DotnetToolSettings.xml`.
  - Covers both standard RID-specific packages and the variant that also includes an `any` RID payload.

```
<!-- top-level pointer package -->
tools/any/any/DotnetToolSettings.xml

<!-- RID-specific implementation package -->
tools/net11.0/linux-x64/...
```

## Backport notes

Cherry-picked from squash merge commit `f64ec67374cd10769878f458fb1825e4b36999a1`. The `EndToEndToolTests.cs` change had a conflict because the `Net99Tool`-related tests do not exist on `release/10.0.4xx`; only the relevant additions from the original PR were carried over (the `GetToolSettingsFileEntry` and `EnsureToolSettingsFileUsesAnyTfmAndRid` helpers, their call sites, and the `GetToolSettingsFile` refactor). The `Microsoft.NET.PackTool.targets` change applied cleanly.