### PR TITLE
Enable NativeAOT CLI command handling by default (DOTNET_CLI_ENABLEAOT)

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -178,7 +178,7 @@ extends:
       # arm64 linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is
       # required). This leg therefore BUILDS on the existing win-x64 pool with /p:CrossBuild=true and
       # produces the dotnet-aot .dll plus its mstat/dgml size-analysis artifacts (that step is gated
-      # on runAoTTests). It is build-only (runTests: false): there is no wired windows arm64 Helix
+      # on the AoT category). It is build-only (runTests: false): there is no wired windows arm64 Helix
       # queue yet, so running the *.AoT.Tests on arm64 hardware is a follow-up pending a
       # windows.11.arm64 queue. Runs for internal PRs and test builds.
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -199,10 +199,9 @@ extends:
             # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)'
             # because the ILCompiler-produced object isn't split into per-function sections, so the
             # MSVC arm64 linker cannot apply the erratum fixup. This leg has never passed. Re-enable
-            # once the ILCompiler fix lands.
+            # once the ILCompiler fix lands. Tracked by dotnet/sdk#55298.
             - categoryName: AoT
               disableJob: true
-              runAoTTests: true
               targetArchitecture: arm64
               runtimeIdentifier: win-arm64
               osProperties: /p:CrossBuild=true
@@ -316,7 +315,6 @@ extends:
             linuxJobParameterSets:
             - categoryName: AoT
               container: azureLinuxCrossArm64
-              runAoTTests: true
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
               osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -69,13 +69,14 @@ stages:
   # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC arm64
   # linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is required).
   # This leg BUILDS on the win-x64 pool with /p:CrossBuild=true and produces the dotnet-aot .dll plus
-  # its mstat/dgml size-analysis artifacts (that step is gated on runAoTTests). It is build-only
+  # its mstat/dgml size-analysis artifacts (that step is gated on the AoT category). It is build-only
   # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
   # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
   # TEMPORARILY DISABLED (disableJob: true): the win-arm64 NativeAOT cross-link fails with
   # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)' because
   # the ILCompiler-produced object isn't split into per-function sections, so the MSVC arm64 linker
   # cannot apply the erratum fixup. This leg has never passed. Re-enable once the ILCompiler fix lands.
+  # Tracked by dotnet/sdk#55298.
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
     parameters:
       pool:
@@ -86,7 +87,6 @@ stages:
       windowsJobParameterSets:
       - categoryName: AoT
         disableJob: true
-        runAoTTests: true
         targetArchitecture: arm64
         runtimeIdentifier: win-arm64
         osProperties: /p:CrossBuild=true
@@ -119,7 +119,6 @@ stages:
       linuxJobParameterSets:
       - categoryName: AoT
         container: azureLinuxCrossArm64
-        runAoTTests: true
         targetArchitecture: arm64
         runtimeIdentifier: linux-arm64
         osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -18,11 +18,14 @@ parameters:
   timeoutInMinutes: ''
   ### ENV VARS ###
   testFullMSBuild: false
+  # Enables the Blazor WebAssembly AoT tests (test/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests)
+  # on Helix via the RunAoTTests env var.
   runAoTTests: false
   # Runs the NativeAOT CLI tests (test/dotnet-aot.Tests) on the build agent after the build.
   # These publish the test assembly as a NativeAOT binary and run it on the same architecture,
-  # validating the AOT CLI entry-point code under NativeAOT compilation. This is distinct from
-  # runAoTTests, which runs the Blazor WebAssembly AoT tests on Helix.
+  # validating the AOT CLI entry-point code under NativeAOT compilation. Only enabled where the
+  # agent architecture matches the target (the produced native binary must run on the agent);
+  # cross-arch AoT legs leave it false.
   runNativeAotCliTests: false
   ### MSBUILD ###
   targetArchitecture: x64
@@ -273,10 +276,11 @@ jobs:
       continueOnError: true
       condition: always()
 
-    # Only the AoT legs publish the dotnet-aot NativeAOT library, so only they produce
-    # the size-analysis files. Gate these steps so they don't run (and upload empty
-    # artifacts) on non-AoT legs like the TestBuild/FullFramework jobs.
-    - ${{ if eq(parameters.runAoTTests, true) }}:
+    # Only the AoT legs build the dotnet-aot NativeAOT library, so only they produce the
+    # size-analysis files. Gate on the AoT category so these steps run on every AoT leg (including
+    # the build-only cross-arch legs) and never upload empty artifacts on non-AoT legs like the
+    # TestBuild/FullFramework jobs.
+    - ${{ if eq(parameters.categoryName, 'AoT') }}:
       - task: CopyFiles@2
         displayName: 🟣 Copy NativeAOT Size Analysis Files
         inputs:

--- a/src/Cli/dotnet-aot/DESIGN.md
+++ b/src/Cli/dotnet-aot/DESIGN.md
@@ -10,9 +10,27 @@ function — see
 [dotnet/runtime#126171](https://github.com/dotnet/runtime/issues/126171). The
 muxer looks for `dotnet-aot` in the resolved SDK directory and, when found,
 calls `dotnet_execute` directly. `dn.exe` follows the same contract and serves
-as a local development and testing entry point. The AOT fast path is gated
-behind `DOTNET_CLI_ENABLEAOT=true`; when the variable is unset or false, the
-bridge falls through to the managed CLI immediately.
+as a local development and testing entry point. The AOT fast path is enabled by
+default on all platforms (see [Opting out](#opting-out-dotnet_cli_enableaot));
+setting `DOTNET_CLI_ENABLEAOT=false` (or `0`/`no`/`off`) opts out, and the bridge
+falls through to the managed CLI immediately.
+
+## Opting out (`DOTNET_CLI_ENABLEAOT`)
+
+The AOT command-handling fast path is **enabled by default on all platforms**. The
+fast path is designed to be behaviorally identical to the managed CLI, transparently
+deferring to it for anything it cannot handle, so it should require no action from users.
+
+If you need to bypass the AOT path entirely — for example to diagnose a suspected parity
+issue — set the `DOTNET_CLI_ENABLEAOT` environment variable to a falsy value before
+invoking `dotnet`:
+
+- Disable: `false`, `0`, `no`, or `off`
+- Enable: `true`, `1`, `yes`, or `on`
+- Unset (default): enabled
+
+When disabled, every invocation is routed straight to the managed CLI, exactly as it
+behaved before the AOT fast path was enabled by default.
 
 ## Motivation
 
@@ -48,7 +66,7 @@ graph TD
 
     subgraph L2["Layer 2 · dotnet-aot.dll  (Native AOT Shared Library)"]
         Entry["NativeEntryPoint.Execute()"]
-        AotCheck{"DOTNET_CLI_ENABLEAOT<br/>enabled?"}
+        AotCheck{"DOTNET_CLI_ENABLEAOT<br/>not disabled?"}
         Parse["Parser.Parse(args)"]
         Fast{"Command handled<br/>by AOT path?"}
         Invoke["Parser.Invoke()"]
@@ -94,7 +112,8 @@ A NativeAOT shared library (`NativeLib=Shared`) that exports a single
 `[UnmanagedCallersOnly]` entry point: `dotnet_execute`. This layer contains
 the dual-path dispatch logic.
 
-**Fast path** — When `DOTNET_CLI_ENABLEAOT=true`, the AOT bridge builds the
+**Fast path** — Unless `DOTNET_CLI_ENABLEAOT` is explicitly disabled, the AOT
+bridge builds the
 **full** command tree (the same `DotNetCommandDefinition` used by the managed
 CLI) so that parsing and `--help` match the managed CLI exactly. Commands that
 can run entirely in AOT (`--version`, `--info`, and the AOT-capable `sln`
@@ -120,7 +139,8 @@ its full resolver set, deferral produces identical user-facing behavior. Out-of-
 process invocation only happens after a non-null spec, so a command is never
 executed twice.
 
-**Slow path** — When `DOTNET_CLI_ENABLEAOT` is not set or the AOT bridge does
+**Slow path** — When `DOTNET_CLI_ENABLEAOT` is disabled (`false`/`0`/`no`/`off`)
+or the AOT bridge does
 not handle the command, the bridge calls `ManagedHost.RunApp()`, which uses the
 hostfxr native hosting APIs (`hostfxr_initialize_for_dotnet_command_line` /
 `hostfxr_set_runtime_property_value` / `hostfxr_run_app`) to bootstrap CoreCLR
@@ -138,17 +158,23 @@ sequenceDiagram
     participant cli as dotnet.dll (Layer 3)
 
     dn->>aot: dotnet_execute(hostPath, dotnetRoot, sdkDir, hostfxrPath, argc, argv)
-    aot->>aot: Parser.Parse(args)
 
-    alt DOTNET_CLI_ENABLEAOT=true and built-in command handled by AOT
-        aot->>aot: Parser.Invoke(parseResult)
-        aot-->>dn: exit code
-    else External command that resolves in AOT (tool / PATH / app-base)
-        aot->>aot: TryInvokeExternalCommand → TryResolveCommandSpec
-        aot->>tool: Command.Execute() (out of process)
-        tool-->>aot: exit code
-        aot-->>dn: exit code
-    else Command not handled, unresolved, file-based app, or AOT disabled
+    alt DOTNET_CLI_ENABLEAOT enabled (default)
+        aot->>aot: Parser.Parse(args)
+        alt Built-in command handled by AOT
+            aot->>aot: Parser.Invoke(parseResult)
+            aot-->>dn: exit code
+        else External command that resolves in AOT (tool / PATH / app-base)
+            aot->>aot: TryInvokeExternalCommand → TryResolveCommandSpec
+            aot->>tool: Command.Execute() (out of process)
+            tool-->>aot: exit code
+            aot-->>dn: exit code
+        else Command not handled, unresolved, or file-based app
+            aot->>cli: ManagedHost.RunApp(args) → managed fallback (see below)
+            cli-->>aot: exit code
+            aot-->>dn: exit code
+        end
+    else DOTNET_CLI_ENABLEAOT disabled (opt-out)
         aot->>hfxr: hostfxr_initialize_for_dotnet_command_line(args, host_path, dotnet_root)
         aot->>hfxr: hostfxr_set_runtime_property_value(handle, "HOSTFXR_PATH", hostfxrPath)
         aot->>hfxr: hostfxr_run_app(handle)

--- a/src/Cli/dotnet-aot/NativeEntryPoint.cs
+++ b/src/Cli/dotnet-aot/NativeEntryPoint.cs
@@ -177,12 +177,6 @@ static unsafe partial class NativeEntryPoint
             // can use it instead of re-probing PATH / environment for the dotnet installation.
             DotnetRoot = string.IsNullOrEmpty(dotnetRoot) ? null : dotnetRoot;
 
-            // Try the AOT-compiled path for supported commands. This is enabled by default on all
-            // platforms. Users opt out by setting DOTNET_CLI_ENABLEAOT to a falsy value
-            // (false/0/no/off), which routes every invocation straight to the managed CLI below.
-            // (The command-line parsing crash that previously blocked macOS and Linux,
-            // https://github.com/dotnet/command-line-api/issues/2812, has been fixed upstream in
-            // https://github.com/dotnet/command-line-api/pull/2820 and flowed into the SDK.)
             if (EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_ENABLEAOT), defaultValue: true))
             {
                 ParseResult? parseResult = null;
@@ -223,8 +217,6 @@ static unsafe partial class NativeEntryPoint
                                 exitCode = CommandInvocation.ExecuteInternalCommand(parseResult);
                                 success = true;
                                 aotHandledInProcess = true;
-                                // The built-in command ran in-process (no managed fallback), so emit the same
-                                // top-level parser telemetry the managed CLI sends from Program.ProcessArgsAndExecute.
                                 SendAotParserTelemetry(parseResult, globalJsonState);
                                 return exitCode;
                             }
@@ -278,8 +270,7 @@ static unsafe partial class NativeEntryPoint
         {
             if (aotHandledInProcess && TelemetryClient is Telemetry.TelemetryClient telemetryClient)
             {
-                // Mirror the managed CLI (Program.cs finally): synchronously record the command/finish
-                // telemetry event with the exit code before the activity stops.
+                // Mirror the managed CLI behavior for compat (Program.cs finally)
                 telemetryClient.ThreadBlockingTrackEvent("command/finish", new Dictionary<string, string?> { { "exitCode", exitCode.ToString() } });
             }
 

--- a/src/Cli/dotnet-aot/NativeEntryPoint.cs
+++ b/src/Cli/dotnet-aot/NativeEntryPoint.cs
@@ -160,6 +160,10 @@ static unsafe partial class NativeEntryPoint
 
         int exitCode = 1;
         bool success = false;
+        // True once a command has been handled entirely in AOT (no managed fallback). Gates the
+        // terminal telemetry emission below: the managed fallback child writes its own disk log, so
+        // we must only write ours when we did not fall back.
+        bool aotHandledInProcess = false;
 
         try
         {
@@ -173,8 +177,13 @@ static unsafe partial class NativeEntryPoint
             // can use it instead of re-probing PATH / environment for the dotnet installation.
             DotnetRoot = string.IsNullOrEmpty(dotnetRoot) ? null : dotnetRoot;
 
-            // Try the AOT-compiled path for supported commands (if enabled)
-            if (EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_ENABLEAOT), defaultValue: false))
+            // Try the AOT-compiled path for supported commands. This is enabled by default on all
+            // platforms. Users opt out by setting DOTNET_CLI_ENABLEAOT to a falsy value
+            // (false/0/no/off), which routes every invocation straight to the managed CLI below.
+            // (The command-line parsing crash that previously blocked macOS and Linux,
+            // https://github.com/dotnet/command-line-api/issues/2812, has been fixed upstream in
+            // https://github.com/dotnet/command-line-api/pull/2820 and flowed into the SDK.)
+            if (EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_ENABLEAOT), defaultValue: true))
             {
                 ParseResult? parseResult = null;
                 using (var parse = Activities.Source.StartActivity("parse"))
@@ -205,22 +214,24 @@ static unsafe partial class NativeEntryPoint
                 {
                     if (parseResult.CanBeInvoked())
                     {
-                        try
+                        // Parse errors here usually mean the command is contributed dynamically by the managed
+                        // CLI (e.g. NuGet's `package update`/`why`) and absent from the static AOT tree, so defer.
+                        if (parseResult.Errors.Count == 0)
                         {
-                            // Invoke the built-in command in-process using the shared CommandInvocation
-                            // helper, identical to the managed CLI: same exit-code handling, including the
-                            // "new" command's 127 adjustment and Parser.ExceptionHandler. This keeps the
-                            // two entry points in parity.
-                            exitCode = CommandInvocation.ExecuteInternalCommand(parseResult);
-                            success = true;
-                            // The built-in command ran in-process (no managed fallback), so emit the same
-                            // top-level parser telemetry the managed CLI sends from Program.ProcessArgsAndExecute.
-                            SendAotParserTelemetry(parseResult, globalJsonState);
-                            return exitCode;
-                        }
-                        catch (CommandNotAvailableInAotException)
-                        {
-                            // The parsed command requires the managed CLI — fall through to the managed fallback below.
+                            try
+                            {
+                                exitCode = CommandInvocation.ExecuteInternalCommand(parseResult);
+                                success = true;
+                                aotHandledInProcess = true;
+                                // The built-in command ran in-process (no managed fallback), so emit the same
+                                // top-level parser telemetry the managed CLI sends from Program.ProcessArgsAndExecute.
+                                SendAotParserTelemetry(parseResult, globalJsonState);
+                                return exitCode;
+                            }
+                            catch (CommandNotAvailableInAotException)
+                            {
+                                // The parsed command requires the managed CLI — fall through to the managed fallback below.
+                            }
                         }
                     }
                     // An unrecognized top-level token is either an external command (`dotnet ef`, a global
@@ -229,6 +240,7 @@ static unsafe partial class NativeEntryPoint
                     // project tools, and anything that does not resolve to the managed CLI.
                     else if (parseResult is not null && TryInvokeExternalCommand(parseResult, args, sdkDirectory, mainActivity, globalJsonState, out exitCode, out success))
                     {
+                        aotHandledInProcess = true;
                         return exitCode;
                     }
                 }
@@ -236,7 +248,7 @@ static unsafe partial class NativeEntryPoint
 
             // Fall back to the fully managed dotnet CLI by hosting .NET.
             // Set a best-effort display name from args when we have not done a full parse
-            // (i.e. DOTNET_CLI_ENABLEAOT was not set or the command fell through without calling SetDisplayName).
+            // (i.e. DOTNET_CLI_ENABLEAOT was explicitly disabled or the command fell through without calling SetDisplayName).
             if (mainActivity is not null && mainActivity.DisplayName == "main")
             {
                 var fallbackName = args.Length > 0 ? $"dotnet {args[0]}" : "dotnet";
@@ -264,10 +276,24 @@ static unsafe partial class NativeEntryPoint
         }
         finally
         {
+            if (aotHandledInProcess && TelemetryClient is Telemetry.TelemetryClient telemetryClient)
+            {
+                // Mirror the managed CLI (Program.cs finally): synchronously record the command/finish
+                // telemetry event with the exit code before the activity stops.
+                telemetryClient.ThreadBlockingTrackEvent("command/finish", new Dictionary<string, string?> { { "exitCode", exitCode.ToString() } });
+            }
+
             mainActivity?.AddTag("process.exit.code", exitCode);
             mainActivity?.SetStatus(success ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
             mainActivity?.Stop();
             Telemetry.TelemetryClient.FlushProviders();
+
+            if (aotHandledInProcess)
+            {
+                // The command ran entirely in AOT, so there is no managed fallback child process to persist
+                // the telemetry disk log. Write it here, mirroring Program.cs's TelemetryClient.WriteLogIfNecessary().
+                Telemetry.TelemetryClient.WriteLogIfNecessary();
+            }
         }
     }
 

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -5,6 +5,16 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AssemblyName>dotnet-aot</AssemblyName>
+    <!--
+      Present the CLI as "dotnet" in help/usage output. As a NativeAOT native library this
+      component has no managed entry point (Assembly.GetEntryAssembly() is null), so
+      System.CommandLine.RootCommand resolves its executable name from the
+      "System.CommandLine.ExecutableName" runtimeconfig/AppContext value emitted by the
+      System.CommandLine build targets, which defaults to $(AssemblyName) ("dotnet-aot").
+      Override that escape hatch here so usage lines read "dotnet <command>" (matching the
+      managed muxer) instead of "dotnet-aot <command>".
+    -->
+    <_SystemCommandLineExecutableName>dotnet</_SystemCommandLineExecutableName>
     <OutputType>Library</OutputType>
     <NativeLib>Shared</NativeLib>
     <PublishAot>true</PublishAot>
@@ -95,31 +105,6 @@
                                     Value="true"
                                     Trim="true" />
   </ItemGroup>
-
-  <!--
-    On Apple platforms, NativeAOT unconditionally statically links libSystem.Security.Cryptography.Native.Apple.a
-    into every output, including NativeLib=Shared (dylib). This static archive contains Swift binding classes
-    (HashBox, X25519KeyBox) that register with the ObjC runtime. When the host process also has these classes
-    (from the shared framework's copy of the same library), macOS emits duplicate class warnings to stderr,
-    which breaks tests that assert stderr is empty.
-
-    The AOT CLI DOES use cryptography during first-run (ASP.NET Core developer-certificate generation), but it
-    does not need this archive statically linked: because the CLI is loaded as a shared library (NativeLib=Shared)
-    by a full .NET host, its crypto P/Invokes resolve dynamically against the host's already-loaded copy of
-    libSystem.Security.Cryptography.Native.Apple.dylib. Removing the static archive (and its DirectPInvoke) therefore
-    keeps cert generation working while avoiding the duplicate ObjC class registration and its stderr warnings.
-
-    This is a workaround for a NativeAOT issue tracked at https://github.com/dotnet/runtime/issues/128867
-    ("Two CLR-based apps cannot coexist on Apple platforms"). Once that is fixed (e.g. by guarding the
-    NetCoreAppNativeLibrary/DirectPInvoke items on '$(NativeLib)' != 'Shared', or by reusing the
-    already-loaded libSystem.*.Native libraries), this target can be removed.
-  -->
-  <Target Name="RemoveAppleCryptoFromNativeAotLink" AfterTargets="SetupOSSpecificProps">
-    <ItemGroup>
-      <NativeLibrary Remove="$(IlcFrameworkNativePath)libSystem.Security.Cryptography.Native.Apple.a" />
-      <DirectPInvoke Remove="System.Security.Cryptography.Native.Apple" />
-    </ItemGroup>
-  </Target>
 
   <Import Project="$(RepositoryEngineeringDir)common\native\LocateNativeCompiler.targets"
       Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'" />

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -123,7 +123,19 @@ public static class Parser
             }
             else if (option is HelpOption helpOption)
             {
+#if CLI_AOT
+                // On the AOT path some commands keep their static definition, but the managed CLI produces
+                // their help dynamically with content that has no static equivalent:
+                //   * `new` is replaced with a template-engine-backed command that adds the template
+                //     short-name/args usage line, the Arguments section, and per-template options.
+                //   * `test` (Microsoft.Testing.Platform mode) builds and forwards `--help` to the test
+                //     application, which contributes the "Extension Options:" section and per-extension options.
+                // Rendering the static definition's help here would omit all of that, so defer help for those
+                // subtrees to the managed CLI to keep the output in parity.
+                helpOption.Action = new AotPrintHelpAction(helpOption, DotnetHelpBuilder.Instance.Value, rootCommand.NewCommand, rootCommand.TestCommand);
+#else
                 helpOption.Action = new PrintHelpAction(helpOption, DotnetHelpBuilder.Instance.Value);
+#endif
                 helpOption.Description = CliStrings.ShowHelpDescription;
             }
         }
@@ -245,6 +257,39 @@ public static class Parser
             }
 
             return 0;
+        }
+    }
+
+    /// <summary>
+    ///  Help action for the AOT CLI. It renders help entirely from the shared command tree (like the
+    ///  managed CLI) except for commands whose managed help is produced dynamically and therefore has
+    ///  no static equivalent in the AOT definition. For those it throws
+    ///  <see cref="CommandNotAvailableInAotException"/> so <c>NativeEntryPoint</c> defers to the managed
+    ///  CLI, whose help output the snapshot tests expect. Such commands include <c>new</c> (the managed
+    ///  CLI replaces it with a template-engine-backed command that adds the template short-name/args usage
+    ///  line, the Arguments section, and per-template options) and <c>test</c> (Microsoft.Testing.Platform
+    ///  mode builds and forwards <c>--help</c> to the test application, which contributes the
+    ///  "Extension Options:" section and per-extension options).
+    /// </summary>
+    private sealed class AotPrintHelpAction(Option option, HelpBuilder builder, params Command[] managedHelpCommands)
+        : PrintHelpAction(option, builder)
+    {
+        private readonly Command[] _managedHelpCommands = managedHelpCommands;
+
+        public override int Invoke(ParseResult parseResult)
+        {
+            // Walk from the innermost parsed command up to the root; if any command whose help the
+            // managed CLI generates dynamically is anywhere in that chain, defer to the managed CLI.
+            for (System.CommandLine.Parsing.SymbolResult? result = parseResult.CommandResult; result is not null; result = result.Parent)
+            {
+                if (result is System.CommandLine.Parsing.CommandResult commandResult
+                    && Array.Exists(_managedHelpCommands, c => ReferenceEquals(c, commandResult.Command)))
+                {
+                    throw new CommandNotAvailableInAotException();
+                }
+            }
+
+            return base.Invoke(parseResult);
         }
     }
 #endif

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// </summary>
 [TestCategory("AOT")]
 [TestClass]
-public class AotIntegrationTests
+public partial class AotIntegrationTests
 {
     public TestContext TestContext { get; set; } = null!;
 
@@ -72,7 +72,9 @@ public class AotIntegrationTests
         }
         else
         {
-            psi.Environment.Remove("DOTNET_CLI_ENABLEAOT");
+            // The AOT fast path is enabled by default, so explicitly disable it (rather than just
+            // removing the variable) to exercise the managed-fallback behavior.
+            psi.Environment["DOTNET_CLI_ENABLEAOT"] = "false";
         }
 
         if (extraEnv is not null)
@@ -237,11 +239,11 @@ public class AotIntegrationTests
     }
 
     [TestMethod]
-    public void Version_WithoutEnableAot_StillWorks()
+    public void Version_WithAotDisabled_StillWorks()
     {
         SkipIfDnUnavailable();
 
-        // Without DOTNET_CLI_ENABLEAOT, everything goes through managed fallback
+        // With DOTNET_CLI_ENABLEAOT disabled, everything goes through managed fallback
         var (exitCode, stdout, stderr) = RunDn(["--version"], enableAot: false);
 
         // Managed fallback requires dotnet.dll + all dependencies in the layout.
@@ -257,7 +259,7 @@ public class AotIntegrationTests
     }
 
     [TestMethod]
-    public void Info_WithoutEnableAot_ShowsFullInfo()
+    public void Info_WithAotDisabled_ShowsFullInfo()
     {
         SkipIfDnUnavailable();
 

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
 /// </summary>
 [TestClass]
-public class AotParserTests
+public partial class AotParserTests
 {
     // File-based app detection (GetFileBasedAppEntryPointToken -> VirtualProjectBuilder.IsValidEntryPointPath)
     // pulls in the Microsoft.Build assembly, which cannot be loaded into a NativeAOT image, so the call
@@ -231,6 +231,35 @@ public class AotParserTests
         var exception = RecordException(() => Parser.Invoke(result));
 
         Assert.IsNull(exception);
+    }
+
+    [TestMethod]
+    [DataRow("new")]
+    [DataRow("new --help")]
+    [DataRow("new console --help")]
+    [DataRow("new list --help")]
+    [DataRow("new install --help")]
+    public void InvokeNewHelp_FallsBackToManaged(string commandLine)
+    {
+        // The managed CLI replaces `new` with a template-engine-backed command whose help is
+        // generated dynamically (template short-name/args usage line, Arguments section, per-template
+        // options). The AOT definition has no static equivalent, so help for the `new` subtree must
+        // defer to the managed CLI rather than render the incomplete static help.
+        var result = Parser.Parse(commandLine.Split(' '));
+        Assert.ThrowsExactly<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
+    }
+
+    [TestMethod]
+    [DataRow("test")]
+    [DataRow("test --help")]
+    public void InvokeTestHelp_FallsBackToManaged(string commandLine)
+    {
+        // In Microsoft.Testing.Platform mode the managed CLI builds the test project and forwards
+        // `--help` to the test application, which contributes the "Extension Options:" section and
+        // per-extension options. The AOT definition cannot reproduce that, so help for the `test`
+        // subtree must defer to the managed CLI. (Bare `test` also requires MSBuild and falls back.)
+        var result = Parser.Parse(commandLine.Split(' '));
+        Assert.ThrowsExactly<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
     }
 
     [TestMethod]

--- a/test/dotnet-aot.Tests/DotnetRootResolverTests.cs
+++ b/test/dotnet-aot.Tests/DotnetRootResolverTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  Path construction uses Path.Combine for cross-platform compatibility.
 /// </summary>
 [TestClass]
-public class DotnetRootResolverTests
+public partial class DotnetRootResolverTests
 {
     // Helper to build platform-appropriate paths for test inputs/outputs.
     // When isWindows=true, uses a Windows-style root; otherwise Unix-style.

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  "managed fallback not found" error because test env doesn't have dotnet.dll in sdkDir.
 /// </summary>
 [TestClass]
-public class NativeEntryPointTests
+public partial class NativeEntryPointTests
 {
     /// <summary>
     /// Runs a test action with relevant environment variables restored afterward.
@@ -243,7 +243,7 @@ public class NativeEntryPointTests
     }
 
     [TestMethod]
-    public void ExecuteCore_AotNotSet_VersionCommand_FallsBack()
+    public void ExecuteCore_AotNotSet_VersionCommand_UsesAotByDefault()
     {
         WithEnvRestore(() =>
         {
@@ -256,8 +256,9 @@ public class NativeEntryPointTests
                 hostfxrPath: "",
                 args: ["--version"]);
 
-            // Default is false → managed fallback → files missing → returns 1
-            Assert.AreEqual(1, exitCode);
+            // Default is enabled on all platforms → AOT path handles --version in-process → exit 0
+            // (without falling back to the missing managed dotnet.dll).
+            Assert.AreEqual(0, exitCode);
         });
     }
 
@@ -287,11 +288,38 @@ public class NativeEntryPointTests
     }
 
     [TestMethod]
+    [DataRow("false")]
+    [DataRow("False")]
+    [DataRow("FALSE")]
+    [DataRow("0")]
+    [DataRow("no")]
+    [DataRow("off")]
+    public void ExecuteCore_AotDisabledVariousFormats_FallsBack(string disableValue)
+    {
+        WithEnvRestore(() =>
+        {
+            Environment.SetEnvironmentVariable("DOTNET_CLI_ENABLEAOT", disableValue);
+
+            int exitCode = NativeEntryPoint.ExecuteCore(
+                hostPath: "test-host",
+                dotnetRoot: "test-root",
+                sdkDir: "nonexistent-sdk-dir",
+                hostfxrPath: "",
+                args: ["--version"]);
+
+            // All these formats opt out of AOT → managed fallback → files missing → returns 1
+            Assert.AreEqual(1, exitCode);
+        });
+    }
+
+    [TestMethod]
     public void ExecuteCore_MissingFallbackFiles_ReturnsOneAndWritesError()
     {
         WithEnvRestore(() =>
         {
-            Environment.SetEnvironmentVariable("DOTNET_CLI_ENABLEAOT", null);
+            // Disable the AOT fast path so the invocation is routed to the managed fallback,
+            // which is missing in the test layout and should surface the fallback error.
+            Environment.SetEnvironmentVariable("DOTNET_CLI_ENABLEAOT", "false");
 
             var originalErr = Console.Error;
             var stderrWriter = new StringWriter();

--- a/test/dotnet-aot.Tests/WorkloadInstallDetectorTests.cs
+++ b/test/dotnet-aot.Tests/WorkloadInstallDetectorTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  detection runs without NuGet, MSBuild, or installer-IPC dependencies.
 /// </summary>
 [TestClass]
-public class WorkloadInstallDetectorTests
+public partial class WorkloadInstallDetectorTests
 {
     private static string CurrentFeatureBand => new SdkFeatureBand(Product.Version).ToString();
 


### PR DESCRIPTION
Fixes #55078.

## What

Flips the default of `DOTNET_CLI_ENABLEAOT` in the NativeAOT entry point from `false` to `true`, so the AOT command-handling fast path runs by default **on all platforms**. Users opt out by setting `DOTNET_CLI_ENABLEAOT` to a falsy value (`false`/`0`/`no`/`off`), which routes every invocation to the managed CLI exactly as before.

Now that the native path has reached parity with the managed CLI, enabling it by default gives broad real-world testing and improves CLI startup for common commands.

## History: macOS + Linux were temporarily gated

Earlier revisions of this PR restricted the default to Windows only, because the AOT path was blocked on macOS and Linux by a command-line parsing crash: [dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812). When the AOT CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returned an empty array on those platforms, so `System.CommandLine`'s `RootCommand` constructor threw an `IndexOutOfRangeException`. (Although the upstream issue was titled for macOS, it was empirically confirmed to reproduce identically on Linux with a focused NativeAOT shared-library repro.)

That crash is now **fixed upstream** in [dotnet/command-line-api#2820](https://github.com/dotnet/command-line-api/pull/2820) — `RootCommand.ExecutablePath` guards the empty-args case and `ExecutableName` falls back to the build-injected `System.CommandLine.ExecutableName` from `AppContext` for the native-library scenario. The fix has flowed into the SDK via `System.CommandLine` `3.0.0-preview.7.26359.117`, so the platform gate has been removed and the default is now unconditional (`ParseBool(..., defaultValue: true)`). Explicit `DOTNET_CLI_ENABLEAOT` values still override on every platform.

## Changes

The branch is organized into five focused commits:

1. **Keep `MSTest.Sdk` in sync with the MSTest framework** (from @dsplaisted, [#55302](https://github.com/dotnet/sdk/pull/55302)) — `global.json` + `eng/Version.Details.xml`. The reflection-free MSTest source generator (required for NativeAOT test discovery) emits zero tests when `MSTest.Sdk` (in `msbuild-sdks`) drifts from the darc-flowed MSTest framework version — which is why the "Run NativeAOT CLI Tests" step reported "Zero tests ran". Bumps `MSTest.Sdk` to match and tracks it as a darc dependency so the two stay in lockstep on every testfx flow. This is the root-cause fix that replaces the earlier CI workarounds.
2. **Disable the win-arm64 NativeAOT cross-build AoT leg** — `disableJob: true` in `.vsts-pr.yml` / `.vsts-ci.yml`. The win-x64 → win-arm64 ILC cross-link fails persistently; tracked by #55298 for the dotnet/illink (ILCompiler) team. Re-enable once fixed.
3. **Decouple the NativeAOT size-analysis publish onto the AoT category** — gate the size-analysis Copy/Publish steps on `categoryName == 'AoT'` instead of `runAoTTests` (`sdk-build.yml`), and drop the now-dead `runAoTTests: true` from the build-only cross-arch legs (they have `runTests: false`, so the Helix block never consumed it). `runAoTTests` remains the Blazor WebAssembly AoT test switch.
4. **Enable NativeAOT command handling by default on all platforms**:
   - `src/Cli/dotnet-aot/NativeEntryPoint.cs`: unconditional default — `ParseBool(..., defaultValue: true)`.
   - `src/Cli/dotnet/Parser.cs`: new `AotPrintHelpAction` (under `CLI_AOT`) renders help from the shared command tree but defers the `new` and `test` subtrees to the managed CLI, whose help for those is generated dynamically (template-engine short-name/args + per-template options; Microsoft.Testing.Platform "Extension Options:" + per-extension options) and has no static equivalent.
   - `src/Cli/dotnet-aot/dotnet-aot.csproj`: present the CLI as `dotnet` in usage output via the `System.CommandLine` executable-name escape hatch (`_SystemCommandLineExecutableName`) rather than the default `dotnet-aot`; and remove the now-unneeded Apple-crypto NativeAOT link workaround (the fixed runtime has flowed to the SDK).
   - `src/Cli/dotnet-aot/DESIGN.md`: on-by-default gating text/diagrams and the **Opting out (`DOTNET_CLI_ENABLEAOT`)** section.
5. **Get the dotnet-aot test suite green** — `test/dotnet-aot.Tests/*`: make the test classes `partial` (required by the MSTest source generator under NativeAOT), cover the help fall-back-to-managed action, and use a single space-delimited string for the `DataRow` cases (`params string[]` cannot be stored into the `DataRow` `object[]` under NativeAOT).

## Verification

Built `dotnet-aot.Tests` and exercised the managed test classes locally (`NativeEntryPointTests`, `AotParserTests`); integration tests skip without the native `dn` binary in the layout, as expected. The #2812 fix was verified present in `System.CommandLine` `3.0.0-preview.7.26359.117` on `main` before removing the gate. Full NativeAOT test discovery/run is validated by the "Run NativeAOT CLI Tests" step on the AoT CI legs.

## Breaking change

This is a behavioral breaking change (label `breaking-change`). Related documentation work in dotnet/docs:

- Breaking-change documentation issue: dotnet/docs#54650
- Environment variable reference issue: dotnet/docs#54648
- Environment variable reference PR (Windows-only, merged): dotnet/docs#54649
- All-platforms follow-up PR: dotnet/docs#54735

The opt-out is documented at:
https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_cli_enableaot