### PR TITLE
Fix dotnetup bootstrap fallback on Unix

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -50,8 +50,8 @@ function InstallBootstrapSdkWithDotnetup() {
         --set-default-install false `
         --interactive false
     if ($LASTEXITCODE -ne 0) {
-        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install .NET SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' using dotnetup (exit code '$LASTEXITCODE')."
-        ExitWithExitCode $LASTEXITCODE
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install .NET SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' using dotnetup (exit code '$LASTEXITCODE'). Will fall back to standard dotnet-install script."
+        return
     }
 
     # Record the installed SDK so CleanOutStage0ToolsetsAndRuntimes does not

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -44,13 +44,15 @@ function InstallBootstrapSdkWithDotnetup() {
     $env:DOTNET_DOTNETUP_DATA_DIR = Join-Path $ArtifactsDir '.dotnetup'
 
     if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
-    & $dotnetupExe sdk install @sdkVersions `
-        --install-path $dotnetRoot `
-        --untracked `
-        --set-default-install false `
-        --interactive false
-    if ($LASTEXITCODE -ne 0) {
-        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install .NET SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' using dotnetup (exit code '$LASTEXITCODE'). Will fall back to standard dotnet-install script."
+    $installExitCode = Invoke-DotnetupNativeCommand {
+        & $dotnetupExe sdk install @sdkVersions `
+            --install-path $dotnetRoot `
+            --untracked `
+            --set-default-install false `
+            --interactive false
+    }
+    if ($installExitCode -ne 0) {
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install .NET SDK(s) '$($sdkVersions -join ', ')' to '$dotnetRoot' using dotnetup (exit code '$installExitCode'). Will fall back to standard dotnet-install script."
         return
     }
 

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -59,20 +59,12 @@ function InstallBootstrapSdkWithDotnetup {
   # Keep dotnetup's manifest under artifacts instead of the user's home dir.
   export DOTNET_DOTNETUP_DATA_DIR="$artifacts_dir/.dotnetup"
 
-  local restore_errexit=false
-  if [[ $- == *e* ]]; then
-    restore_errexit=true
-    set +e
-  fi
-  "$dotnetup_exe" sdk install "${sdk_versions[@]}" \
+  RunWithoutErrexit "$dotnetup_exe" sdk install "${sdk_versions[@]}" \
     --install-path "$dotnet_root" \
     --untracked \
     --set-default-install false \
     --interactive false
-  local lastexitcode=$?
-  if [[ "$restore_errexit" == true ]]; then
-    set -e
-  fi
+  local lastexitcode=$_RunWithoutErrexit
 
   if [[ $lastexitcode != 0 ]]; then
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install .NET SDK(s) '${sdk_versions[*]}' to '$dotnet_root' using dotnetup (exit code '$lastexitcode'). Will fall back to standard dotnet-install script."

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -51,24 +51,32 @@ function InstallBootstrapSdkWithDotnetup {
 
   if ! ShouldUseCachedDotnetup "$dotnetup_exe"; then
     if ! AcquireDotnetup "$dotnetup_dir"; then
-      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup."
-      ExitWithExitCode 1
+      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup. Will fall back to standard dotnet-install script."
+      return
     fi
   fi
 
   # Keep dotnetup's manifest under artifacts instead of the user's home dir.
   export DOTNET_DOTNETUP_DATA_DIR="$artifacts_dir/.dotnetup"
 
+  local restore_errexit=false
+  if [[ $- == *e* ]]; then
+    restore_errexit=true
+    set +e
+  fi
   "$dotnetup_exe" sdk install "${sdk_versions[@]}" \
     --install-path "$dotnet_root" \
     --untracked \
     --set-default-install false \
     --interactive false
   local lastexitcode=$?
+  if [[ "$restore_errexit" == true ]]; then
+    set -e
+  fi
 
   if [[ $lastexitcode != 0 ]]; then
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install .NET SDK(s) '${sdk_versions[*]}' to '$dotnet_root' using dotnetup (exit code '$lastexitcode')."
-    ExitWithExitCode $lastexitcode
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install .NET SDK(s) '${sdk_versions[*]}' to '$dotnet_root' using dotnetup (exit code '$lastexitcode'). Will fall back to standard dotnet-install script."
+    return
   fi
 
   # Record the installed SDK so CleanOutStage0ToolsetsAndRuntimes does not

--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -60,6 +60,34 @@ function Invoke-GetDotnetupScript([string]$ScriptPath, [string]$InstallDir, [str
     if ($LASTEXITCODE -ne 0) { throw "$ErrorLabel exited with code $LASTEXITCODE." }
 }
 
+# Invokes a native command (e.g. the dotnetup executable) and returns its process
+# exit code WITHOUT letting a non-zero exit become a terminating error that would
+# bypass the caller's graceful-fallback logic.
+#
+# Two mechanisms can otherwise turn a non-zero native exit into a throw:
+#   * $ErrorActionPreference — the build host sets this to 'Stop'
+#     (eng/common/tools.ps1), and
+#   * $PSNativeCommandUseErrorActionPreference — defaults to $true on
+#     PowerShell 7.4+ (the variable does not exist on Windows PowerShell 5.1,
+#     where assigning it is harmless and has no effect).
+# Both are neutralized locally here. If the command still throws (for example the
+# executable cannot be found), it is caught and surfaced as a non-zero exit code so
+# callers can fall back instead of crashing. Returns the process exit code.
+function Invoke-DotnetupNativeCommand([scriptblock]$Command) {
+    if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
+    $ErrorActionPreference = 'Continue'
+    $PSNativeCommandUseErrorActionPreference = $false
+    try {
+        & $Command
+        return $LASTEXITCODE
+    }
+    catch {
+        Write-Host "dotnetup command failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        if ($LASTEXITCODE -ne 0) { return $LASTEXITCODE }
+        return 1
+    }
+}
+
 # Downloads the public dotnetup installer from aka.ms
 # (https://aka.ms/dotnetup/get-dotnetup.ps1) and runs it to install dotnetup into
 # $DotnetupDir. Throws on failure so callers can choose how to react.

--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -60,19 +60,9 @@ function Invoke-GetDotnetupScript([string]$ScriptPath, [string]$InstallDir, [str
     if ($LASTEXITCODE -ne 0) { throw "$ErrorLabel exited with code $LASTEXITCODE." }
 }
 
-# Invokes a native command (e.g. the dotnetup executable) and returns its process
-# exit code WITHOUT letting a non-zero exit become a terminating error that would
-# bypass the caller's graceful-fallback logic.
-#
-# Two mechanisms can otherwise turn a non-zero native exit into a throw:
-#   * $ErrorActionPreference — the build host sets this to 'Stop'
-#     (eng/common/tools.ps1), and
-#   * $PSNativeCommandUseErrorActionPreference — defaults to $true on
-#     PowerShell 7.4+ (the variable does not exist on Windows PowerShell 5.1,
-#     where assigning it is harmless and has no effect).
-# Both are neutralized locally here. If the command still throws (for example the
-# executable cannot be found), it is caught and surfaced as a non-zero exit code so
-# callers can fall back instead of crashing. Returns the process exit code.
+# Invokes a native command (e.g. the dotnetup executable)
+# Returns that process exit code WITHOUT letting a non-zero exit become a terminating error.
+# (This covers against $ErrorActionPreference and $PSNativeCommandUseErrorActionPreference)
 function Invoke-DotnetupNativeCommand([scriptblock]$Command) {
     if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
     $ErrorActionPreference = 'Continue'

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -94,3 +94,25 @@ function AcquireDotnetup {
   rm -f "$getter_script"
   return $result
 }
+
+# Runs a command with bash 'errexit' (set -e) temporarily disabled so that a
+# non-zero exit code does not abort the calling script before it can run its own
+# exit-code handling (e.g. the graceful fallback to the dotnet-install script).
+# The command's exit code is returned via the global _RunWithoutErrexit, following
+# the _<FunctionName> return-value convention used elsewhere in these scripts (see
+# _GetDotNetInstallScript). This helper itself always returns 0 so callers can
+# invoke it as a plain command under `set -e` and then inspect $_RunWithoutErrexit.
+# It is the shell counterpart to Invoke-DotnetupNativeCommand in dotnetup-shared.ps1.
+function RunWithoutErrexit {
+  local restore_errexit=false
+  if [[ $- == *e* ]]; then
+    restore_errexit=true
+    set +e
+  fi
+  "$@"
+  _RunWithoutErrexit=$?
+  if [[ "$restore_errexit" == true ]]; then
+    set -e
+  fi
+  return 0
+}

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -2,8 +2,8 @@
 
 # Shared helpers for acquiring dotnetup, sourced by both eng/configure-toolset.sh
 # (bootstrap SDK install) and eng/restore-toolset.sh (test runtime install).
-# This file only defines functions; it has no top-level side effects so it is
-# safe to source multiple times.
+
+# This file only defines functions; it has no top-level side effects so it is safe to source multiple times.
 
 # General SDK build helpers (GetNativeMachineArchitecture, etc.).
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sdk-tools.sh"
@@ -95,14 +95,7 @@ function AcquireDotnetup {
   return $result
 }
 
-# Runs a command with bash 'errexit' (set -e) temporarily disabled so that a
-# non-zero exit code does not abort the calling script before it can run its own
-# exit-code handling (e.g. the graceful fallback to the dotnet-install script).
-# The command's exit code is returned via the global _RunWithoutErrexit, following
-# the _<FunctionName> return-value convention used elsewhere in these scripts (see
-# _GetDotNetInstallScript). This helper itself always returns 0 so callers can
-# invoke it as a plain command under `set -e` and then inspect $_RunWithoutErrexit.
-# It is the shell counterpart to Invoke-DotnetupNativeCommand in dotnetup-shared.ps1.
+# Runs a command with bash 'errexit' (set -e) temporarily disabled so that a non-zero exit code does not abort the calling script
 function RunWithoutErrexit {
   local restore_errexit=false
   if [[ $- == *e* ]]; then

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -248,10 +248,12 @@ function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$archite
     }
 
     if (-not (Test-Path Variable:LASTEXITCODE)) { $global:LASTEXITCODE = 0 }
-    & $dotnetupExe runtime install @runtimeSpecsToInstall --install-path $dotnetRoot --set-default-install false --untracked --interactive false
+    $installExitCode = Invoke-DotnetupNativeCommand {
+        & $dotnetupExe runtime install @runtimeSpecsToInstall --install-path $dotnetRoot --set-default-install false --untracked --interactive false
+    }
 
-    if ($lastExitCode -ne 0) {
-        Write-Host "Failed to install shared frameworks ($($runtimeSpecsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode'); falling back to dotnet install script." -ForegroundColor Yellow
+    if ($installExitCode -ne 0) {
+        Write-Host "Failed to install shared frameworks ($($runtimeSpecsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$installExitCode'); falling back to dotnet install script." -ForegroundColor Yellow
         InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
     }
 }

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -155,16 +155,8 @@ function InstallDotNetSharedFrameworks {
     fi
   fi
 
-  local restore_errexit=false
-  if [[ $- == *e* ]]; then
-    restore_errexit=true
-    set +e
-  fi
-  "$dotnetup_exe" runtime install "${specs_to_install[@]}" --install-path "$dotnet_root" --set-default-install false --untracked --interactive false
-  local lastexitcode=$?
-  if [[ "$restore_errexit" == true ]]; then
-    set -e
-  fi
+  RunWithoutErrexit "$dotnetup_exe" runtime install "${specs_to_install[@]}" --install-path "$dotnet_root" --set-default-install false --untracked --interactive false
+  local lastexitcode=$_RunWithoutErrexit
 
   if [[ $lastexitcode != 0 ]]; then
     Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install shared frameworks (${specs_to_install[*]}) to '$dotnet_root' using dotnetup (exit code '$lastexitcode'); falling back to dotnet install script."
@@ -200,16 +192,8 @@ function InstallDotNetSharedFrameworksWithInstallScript {
     fi
 
     # Disable errexit around the install-script call so the exit-code and filesystem checks below always run.
-    local restore_errexit=false
-    if [[ $- == *e* ]]; then
-      restore_errexit=true
-      set +e
-    fi
-    bash "$install_script" "${install_args[@]}"
-    local lastexitcode=$?
-    if [[ "$restore_errexit" == true ]]; then
-      set -e
-    fi
+    RunWithoutErrexit bash "$install_script" "${install_args[@]}"
+    local lastexitcode=$_RunWithoutErrexit
 
     # Ensure the download was actually successful to some degree.
     local framework_installed=false


### PR DESCRIPTION
Addresses the first part of dotnet/sdk#55136.

`restore-toolset` was made to not exit with a failure code so the .NET Install script fallback would work. But `restore-toolset` is only called when we begin to run tests.

The `configure-toolset` is a different script, and it exists because we need to install the SDK first so that arcade itself can download (we run `dotnet msbuild` against the arcade toolset project.)

Its call to get dotnetup and run it was not fixed with those same protections. This makes the dotnetup acquisition and run not fail or cause any side-effects if it fails. This allows the builtin call to the .NET Install scripts to work as a fallback which is how arcade normally gets set up, but arcade's logic to do that doesn't run if the sdk already exists, preventing redundant work.

