### PR TITLE
Cut over dotnetup bootstrap to versioned signed daily aka.ms link

### DIFF
--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -61,7 +61,7 @@ function Invoke-GetDotnetupScript([string]$ScriptPath, [string]$InstallDir, [str
 }
 
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnetup/get-dotnetup.ps1) and runs it to install dotnetup into
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1) and runs it to install dotnetup into
 # $DotnetupDir. Throws on failure so callers can choose how to react.
 #
 # If a local get-dotnetup.ps1 script exists in the repo (scripts/get-dotnetup.ps1),
@@ -79,7 +79,7 @@ function Install-DotnetupFromAkaMs([string]$DotnetupDir) {
         return
     }
 
-    $getterUrl = 'https://aka.ms/dotnetup/get-dotnetup.ps1'
+    $getterUrl = 'https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1'
     $getterScript = Join-Path ([System.IO.Path]::GetTempPath()) ("get-dotnetup-{0}.ps1" -f [System.IO.Path]::GetRandomFileName())
 
     # Download the installer with retry/backoff. Invoke-WebRequest's built-in

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -48,7 +48,7 @@ function ShouldUseCachedDotnetup {
 }
 
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnetup/get-dotnetup.sh) and runs it to install dotnetup into
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh) and runs it to install dotnetup into
 # the directory given by $1. Returns non-zero on failure. Callers run under
 # `set -e`, so invoke via `if ! AcquireDotnetup ...; then` to handle failure.
 #
@@ -71,7 +71,7 @@ function AcquireDotnetup {
     return $?
   fi
 
-  local getter_url="https://aka.ms/dotnetup/get-dotnetup.sh"
+  local getter_url="https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh"
   local getter_script
   # Use an explicit template: bare `mktemp` is not portable because BSD/macOS
   # mktemp requires a template (or -t prefix) and errors without one.


### PR DESCRIPTION
Part 3 of migrating dotnetup bootstrap scripts to versioned, signed daily aka.ms links. Tracks dotnet/sdk#54990.

The get-dotnetup.{ps1,sh} scripts are now published as signed Arcade blob artifacts and served via the version-stable link `https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.{ps1,sh}`. This repoints `eng/dotnetup-shared.{ps1,sh}` off the legacy raw-GitHub vanity link (`aka.ms/dotnetup/get-dotnetup.*`) to the signed daily link.

### Verified the daily link is live before cutover
- `aka.ms/dotnet/dotnetup/daily/get-dotnetup.{ps1,sh}` (and `.sha512`) resolve to the published blob (`ci.dot.net/public/dotnetup/0.1.4-preview.6.26356.1/...`), not raw GitHub.
- `get-dotnetup.ps1` Authenticode signature reports **Valid** (`CN=.NET, O=Microsoft Corporation`).
- Served `.sha512` matches the served script bytes.

### Notes
- On `main` there is no local `scripts/get-dotnetup.*`, so the aka.ms URL path is actually exercised here.
- The `documentation/general/dotnetup/README.md` snippets and the legacy vanity-link retirement live on `release/dnup` and are handled separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
