### PR TITLE
[release/dnup] Cut over dotnetup bootstrap to versioned signed daily aka.ms link

### DIFF
--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -13,14 +13,14 @@
 The easiest way to download `dotnetup` is to use the installation script:
 
 ```bash
-curl -fsSL https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh | bash
+curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash
 ```
 
-On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 is signed by the .NET signing certificate):
+On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from https://aka.ms/dotnetup/get-dotnetup.ps1 is signed by the .NET signing certificate):
 
 ```pwsh
 $s = Join-Path $env:TEMP 'get-dotnetup.ps1'
-iwr https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 -OutFile $s
+iwr https://aka.ms/dotnetup/get-dotnetup.ps1 -OutFile $s
 # Get-AuthenticodeSignature $s   # optional: inspect the signature
 & $s
 ```
@@ -28,7 +28,7 @@ iwr https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 -OutFile $s
 If you prefer a one-liner and don't need signature verification, you can pipe the script straight into PowerShell (this bypasses execution-policy signature checks):
 
 ```pwsh
-iwr https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 | iex
+iwr https://aka.ms/dotnetup/get-dotnetup.ps1 | iex
 ```
 
 These scripts will download the latest version of `dotnetup` and install it in your user directory, then print instructions to update your $PATH so that `dotnetup` is available in your terminal.

--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -13,11 +13,22 @@
 The easiest way to download `dotnetup` is to use the installation script:
 
 ```bash
-curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash
+curl -fsSL https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh | bash
 ```
 
+On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from the link above is signed by the .NET signing certificate):
+
 ```pwsh
-iwr https://aka.ms/dotnetup/get-dotnetup.ps1 | iex
+$s = Join-Path $env:TEMP 'get-dotnetup.ps1'
+iwr https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 -OutFile $s
+# Get-AuthenticodeSignature $s   # optional: inspect the signature
+& $s
+```
+
+If you prefer a one-liner and don't need signature verification, you can pipe the script straight into PowerShell (this bypasses execution-policy signature checks):
+
+```pwsh
+iwr https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 | iex
 ```
 
 These scripts will download the latest version of `dotnetup` and install it in your user directory, then print instructions to update your $PATH so that `dotnetup` is available in your terminal.

--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -16,7 +16,7 @@ The easiest way to download `dotnetup` is to use the installation script:
 curl -fsSL https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh | bash
 ```
 
-On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from the link above is signed by the .NET signing certificate):
+On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 is signed by the .NET signing certificate):
 
 ```pwsh
 $s = Join-Path $env:TEMP 'get-dotnetup.ps1'

--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -61,7 +61,7 @@ function Invoke-GetDotnetupScript([string]$ScriptPath, [string]$InstallDir, [str
 }
 
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnetup/get-dotnetup.ps1) and runs it to install dotnetup into
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1) and runs it to install dotnetup into
 # $DotnetupDir. Throws on failure so callers can choose how to react.
 #
 # If a local get-dotnetup.ps1 script exists in the repo (scripts/get-dotnetup.ps1),
@@ -79,7 +79,7 @@ function Install-DotnetupFromAkaMs([string]$DotnetupDir) {
         return
     }
 
-    $getterUrl = 'https://aka.ms/dotnetup/get-dotnetup.ps1'
+    $getterUrl = 'https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1'
     $getterScript = Join-Path ([System.IO.Path]::GetTempPath()) ("get-dotnetup-{0}.ps1" -f [System.IO.Path]::GetRandomFileName())
 
     # Download the installer with retry/backoff. Invoke-WebRequest's built-in

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -48,7 +48,7 @@ function ShouldUseCachedDotnetup {
 }
 
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnetup/get-dotnetup.sh) and runs it to install dotnetup into
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh) and runs it to install dotnetup into
 # the directory given by $1. Returns non-zero on failure. Callers run under
 # `set -e`, so invoke via `if ! AcquireDotnetup ...; then` to handle failure.
 #
@@ -71,7 +71,7 @@ function AcquireDotnetup {
     return $?
   fi
 
-  local getter_url="https://aka.ms/dotnetup/get-dotnetup.sh"
+  local getter_url="https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh"
   local getter_script
   # Use an explicit template: bare `mktemp` is not portable because BSD/macOS
   # mktemp requires a template (or -t prefix) and errors without one.


### PR DESCRIPTION
Part 3 of migrating dotnetup bootstrap scripts to versioned, signed daily aka.ms links, targeting `release/dnup`. Tracks dotnet/sdk#54990. Companion to the `main` PR dotnet/sdk#55153.

Codeflow can handle the aka.ms link part but not the readme.md update so I opened this PR as well.


### README: make the signature actually verifiable
`iwr | iex` runs the script as an in-memory expression and **bypasses execution-policy signature checks entirely**. The README now documents a save-then-run PowerShell pattern so the Authenticode signature is honored, keeping the one-liner as a convenience alternative.

### Not included
- Retiring/repointing the legacy vanity link `aka.ms/dotnetup/get-dotnetup.*` is an aka.ms infra change, not a repo change.

