### PR TITLE
Fix `sequence contains no elements` in `dotnetup`

### DIFF
--- a/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/UpdateWorkflow.cs
@@ -172,8 +172,9 @@ internal class UpdateWorkflow
         }
 
         // Check if this version is already installed (in the manifest)
-        var alreadyInstalled = root.Installations.Any(i =>
+        var existingInstallation = root.Installations.FirstOrDefault(i =>
             i.Component == spec.Component && i.Version == latestVersion.ToString());
+        var alreadyInstalled = existingInstallation is not null;
 
         // If the manifest says it's installed, validate on disk. If missing, remove the stale record.
         if (alreadyInstalled)
@@ -182,13 +183,11 @@ internal class UpdateWorkflow
             ArchiveInstallationValidator validator = new();
             if (!validator.Validate(install))
             {
-                var staleInstallation = root.Installations.First(i =>
-                    i.Component == spec.Component && i.Version == latestVersion.ToString());
                 var manifest = new DotnetupSharedManifest(manifestPath);
                 manifest.RemoveInstallation(installRoot, new Installation
                 {
-                    Component = staleInstallation.Component,
-                    Version = staleInstallation.Version
+                    Component = existingInstallation!.Component,
+                    Version = existingInstallation.Version
                 });
                 alreadyInstalled = false;
             }

--- a/src/Installer/dotnetup.Library/GarbageCollector.cs
+++ b/src/Installer/dotnetup.Library/GarbageCollector.cs
@@ -136,7 +136,7 @@ internal class GarbageCollector
             .Where(x => x.Version is not null)
             .OrderByDescending(x => x.Version)
             .Select(x => x.Installation)
-            .First();
+            .FirstOrDefault();
     }
 
     /// <summary>

--- a/src/Installer/dotnetup.Library/InstallRootManager.cs
+++ b/src/Installer/dotnetup.Library/InstallRootManager.cs
@@ -61,8 +61,12 @@ internal class InstallRootManager
         }
 
         var programFilesDotnetPaths = WindowsPathHelper.GetProgramFilesDotnetPaths();
-        bool needToModifyAdminPath = !WindowsPathHelper.SplitPath(WindowsPathHelper.ReadAdminPath(expand: true))
-            .Contains(programFilesDotnetPaths.First(), StringComparer.OrdinalIgnoreCase);
+
+        // When no dotnet is installed in Program Files, there is no admin path to reference or modify.
+        string primaryProgramFilesDotnetPath = programFilesDotnetPaths.FirstOrDefault() ?? string.Empty;
+        bool needToModifyAdminPath = !string.IsNullOrEmpty(primaryProgramFilesDotnetPath)
+            && !WindowsPathHelper.SplitPath(WindowsPathHelper.ReadAdminPath(expand: true))
+                .Contains(primaryProgramFilesDotnetPath, StringComparer.OrdinalIgnoreCase);
 
         // Get the user dotnet installation path
         string userDotnetPath = _dotnetEnvironment.GetDefaultDotnetInstallPath();
@@ -78,7 +82,7 @@ internal class InstallRootManager
         bool needToUnsetDotnetRoot = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.User));
 
         return new AdminInstallRootChanges(
-            programFilesDotnetPaths.First(),
+            primaryProgramFilesDotnetPath,
             needToModifyAdminPath,
             needToModifyUserPath,
             needToUnsetDotnetRoot,


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/54840

GetAdminInstallRootChanges() called programFilesDotnetPaths.First(), which
threw InvalidOperationException when no dotnet is installed in Program Files.
Use FirstOrDefault() and treat an empty result as 'no admin path to modify'.

I also looked into other instances where we call `.First()` or similar LINQ methods without `OrDefault` and where it could fail and tried to harden those. The other two I don't think are necessary, but this does improve readability.