### PR TITLE
[watch] Avoid updating running processes state in GetManagedCodeUpdatesAsync

### DIFF
--- a/src/Dotnet.Watch/Watch.Aspire/Server/WatchControlReader.cs
+++ b/src/Dotnet.Watch/Watch.Aspire/Server/WatchControlReader.cs
@@ -95,7 +95,10 @@ internal sealed class WatchControlReader : IAsyncDisposable
 
     private async ValueTask RestartProjectsAsync(IEnumerable<ProjectRepresentation> projects, CancellationToken cancellationToken)
     {
-        var projectsToRestart = await _compilationHandler.TerminatePeripheralProcessesAsync(projects.Select(p => p.ProjectGraphPath), cancellationToken);
+        var runningProjects = _compilationHandler.CurrentRunningProjects;
+        var projectsToRestart = projects.SelectMany(project => runningProjects.TryGetValue(project.ProjectGraphPath, out var array) ? array : []).ToArray();
+
+        await _compilationHandler.TerminatePeripheralProcessesAsync(projectsToRestart, cancellationToken);
 
         foreach (var project in projects)
         {

--- a/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
@@ -390,7 +390,8 @@ internal sealed class CompilationHandler : IDisposable
             updates.ProjectsToRestart.SelectMany(e => runningProjects.TryGetValue(GetRequiredProjectFilePath(e.Key), out var array) ? array : []));
 
         string GetRequiredProjectFilePath(ProjectId projectId)
-            => (currentSolution.GetProject(projectId) ?? throw new InvalidOperationException()).FilePath ?? throw new InvalidOperationException();
+            => (currentSolution.GetProject(projectId) ?? throw new InvalidOperationException($"Project {projectId} doesn't exist"))
+                .FilePath ?? throw new InvalidOperationException($"Project {projectId} does not have a file path.");
     }
 
     public async ValueTask ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync(
@@ -843,14 +844,8 @@ internal sealed class CompilationHandler : IDisposable
     }
 
     /// <summary>
-    /// Terminates all processes launched for peripheral projects with <paramref name="projectPaths"/>,
-    /// or all running peripheral project processes if <paramref name="projectPaths"/> is null.
-    /// 
-    /// Removes corresponding entries from <see cref="_runningProjects"/>.
-    /// 
-    /// Does not terminate the main project.
+    /// Terminates processes of given <paramref name="projectsToRestart"/> except for the main project's process.
     /// </summary>
-    /// <returns>All processes (including main) to be restarted.</returns>
     internal async ValueTask TerminatePeripheralProcessesAsync(
         IEnumerable<RunningProject> projectsToRestart, CancellationToken cancellationToken)
     {

--- a/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
@@ -86,20 +86,6 @@ internal sealed class CompilationHandler : IDisposable
         Dispose();
     }
 
-    private void DiscardPreviousUpdates(ImmutableArray<ProjectId> projectsToBeRebuilt)
-    {
-        // Remove previous updates to all modules that were affected by rude edits.
-        // All running projects that statically reference these modules have been terminated.
-        // If we missed any project that dynamically references one of these modules its rebuild will fail.
-        // At this point there is thus no process that these modules loaded and any process created in future
-        // that will load their rebuilt versions.
-
-        lock (_runningProjectsAndUpdatesGuard)
-        {
-            _previousUpdates = _previousUpdates.RemoveAll(update => projectsToBeRebuilt.Contains(update.ProjectId));
-        }
-    }
-
     public async ValueTask StartSessionAsync(ProjectGraph graph, CancellationToken cancellationToken)
     {
         var solution = await UpdateProjectGraphAsync(graph, cancellationToken);
@@ -393,8 +379,7 @@ internal sealed class CompilationHandler : IDisposable
         // Note: Releases locked project baseline readers, so we can rebuild any projects that need rebuilding.
         _hotReloadService.CommitUpdate();
 
-        DiscardPreviousUpdates(updates.ProjectsToRebuild);
-
+        builder.PreviousProjectUpdatesToDiscard.AddRange(updates.ProjectsToRebuild);
         builder.ManagedCodeUpdates.AddRange(updates.ProjectUpdates);
         builder.ProjectsToRebuild.AddRange(updates.ProjectsToRebuild.Select(GetRequiredProjectFilePath));
         builder.ProjectsToRedeploy.AddRange(updates.ProjectsToRedeploy.Select(GetRequiredProjectFilePath));
@@ -409,8 +394,7 @@ internal sealed class CompilationHandler : IDisposable
     }
 
     public async ValueTask ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync(
-        IReadOnlyList<HotReloadService.Update> managedCodeUpdates,
-        IReadOnlyDictionary<RunningProject, List<StaticWebAsset>> staticAssetUpdates,
+        HotReloadProjectUpdatesBuilder builder,
         ImmutableArray<ChangedFile> changedFiles,
         LoadedProjectGraph projectGraph,
         Stopwatch stopwatch,
@@ -422,8 +406,15 @@ internal sealed class CompilationHandler : IDisposable
         IReadOnlyList<RestartOperation> relaunchOperations;
         lock (_runningProjectsAndUpdatesGuard)
         {
+            // Remove previous updates to all modules that were affected by rude edits.
+            // All running projects that statically reference these modules have been terminated.
+            // If we missed any project that dynamically references one of these modules its rebuild will fail.
+            // At this point there is thus no process that these modules loaded and any process created in future
+            // that will load their rebuilt versions.
+            _previousUpdates = _previousUpdates.RemoveAll(update => builder.PreviousProjectUpdatesToDiscard.Contains(update.ProjectId));
+
             // Adding the updates makes sure that all new processes receive them before they are added to running processes.
-            _previousUpdates = _previousUpdates.AddRange(managedCodeUpdates);
+            _previousUpdates = _previousUpdates.AddRange(builder.ManagedCodeUpdates);
 
             // Capture the set of processes that do not have the currently calculated deltas yet.
             projectsToUpdate = _runningProjects;
@@ -459,7 +450,7 @@ internal sealed class CompilationHandler : IDisposable
             }, cancellationToken);
         }
 
-        if (managedCodeUpdates is not [])
+        if (builder.ManagedCodeUpdates is not [])
         {
             // Apply changes to all running projects, even if they do not have a static project dependency on any project that changed.
             // The process may load any of the binaries using MEF or some other runtime dependency loader.
@@ -472,7 +463,7 @@ internal sealed class CompilationHandler : IDisposable
 
                     // Only cancel applying updates when the process exits. Canceling disables further updates since the state of the runtime becomes unknown.
                     var applyTask = await runningProject.Clients.ApplyManagedCodeUpdatesAsync(
-                        ToManagedCodeUpdates(managedCodeUpdates),
+                        ToManagedCodeUpdates(builder.ManagedCodeUpdates),
                         applyOperationCancellationToken: runningProject.Process.ExitedCancellationToken,
                         cancellationToken);
 
@@ -484,7 +475,7 @@ internal sealed class CompilationHandler : IDisposable
         // Creating apply tasks involves reading static assets from disk. Parallelize this IO.
         var staticAssetApplyTaskProducers = new List<Task<Task>>();
 
-        foreach (var (runningProject, assets) in staticAssetUpdates)
+        foreach (var (runningProject, assets) in builder.StaticAssetUpdates)
         {
             // Only cancel applying updates when the process exits. Canceling in-progress static asset update might be ok,
             // but for consistency with managed code updates we only cancel when the process exits.
@@ -507,19 +498,19 @@ internal sealed class CompilationHandler : IDisposable
 
                 var elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
 
-                if (managedCodeUpdates.Count > 0)
+                if (builder.ManagedCodeUpdates.Count > 0)
                 {
                     _context.Logger.Log(MessageDescriptor.ManagedCodeChangesApplied, elapsedMilliseconds);
                 }
 
-                if (staticAssetUpdates.Count > 0)
+                if (builder.StaticAssetUpdates.Count > 0)
                 {
                     _context.Logger.Log(MessageDescriptor.StaticAssetsChangesApplied, elapsedMilliseconds);
                 }
 
                 _context.Logger.Log(MessageDescriptor.ChangesAppliedToProjectsNotification,
                     projectsToUpdate.Select(e => e.Value.First().Options.Representation).Concat(
-                        staticAssetUpdates.Select(e => e.Key.Options.Representation)));
+                        builder.StaticAssetUpdates.Select(e => e.Key.Options.Representation)));
             }
             catch (OperationCanceledException)
             {
@@ -832,9 +823,9 @@ internal sealed class CompilationHandler : IDisposable
 
             foreach (var runningProject in GetCorrespondingRunningProjects(runningProjects, applicationProjectInstance))
             {
-                if (!builder.StaticAssetsToUpdate.TryGetValue(runningProject, out var updatesPerRunningProject))
+                if (!builder.StaticAssetUpdates.TryGetValue(runningProject, out var updatesPerRunningProject))
                 {
-                    builder.StaticAssetsToUpdate.Add(runningProject, updatesPerRunningProject = []);
+                    builder.StaticAssetUpdates.Add(runningProject, updatesPerRunningProject = []);
                 }
 
                 if (!runningProject.Clients.UseRefreshServerToApplyStaticAssets && !runningProject.Clients.IsManagedAgentSupported)

--- a/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
@@ -75,10 +75,14 @@ internal sealed class CompilationHandler : IDisposable
     public ILogger Logger
         => _context.Logger;
 
+    public ImmutableDictionary<string, ImmutableArray<RunningProject>> CurrentRunningProjects
+        => _runningProjects;
+
     public async ValueTask TerminatePeripheralProcessesAndDispose(CancellationToken cancellationToken)
     {
         Logger.LogDebug("Terminating remaining child processes.");
-        await TerminatePeripheralProcessesAsync(projectPaths: null, cancellationToken);
+
+        await TerminatePeripheralProcessesAsync([.. _runningProjects.SelectMany(entry => entry.Value)], cancellationToken);
         Dispose();
     }
 
@@ -359,7 +363,7 @@ internal sealed class CompilationHandler : IDisposable
 
         var updates = await _hotReloadService.GetUpdatesAsync(currentSolution, runningProjectInfos, cancellationToken);
 
-        await DisplayResultsAsync(updates, currentSolution, runningProjectInfos, cancellationToken);
+        await DisplayResultsAsync(updates, currentSolution, runningProjects, runningProjectInfos, cancellationToken);
 
         if (updates.Status is HotReloadService.Status.NoChangesToApply or HotReloadService.Status.Blocked)
         {
@@ -392,15 +396,16 @@ internal sealed class CompilationHandler : IDisposable
         DiscardPreviousUpdates(updates.ProjectsToRebuild);
 
         builder.ManagedCodeUpdates.AddRange(updates.ProjectUpdates);
-        builder.ProjectsToRebuild.AddRange(updates.ProjectsToRebuild.Select(id => currentSolution.GetProject(id)!.FilePath!));
-        builder.ProjectsToRedeploy.AddRange(updates.ProjectsToRedeploy.Select(id => currentSolution.GetProject(id)!.FilePath!));
+        builder.ProjectsToRebuild.AddRange(updates.ProjectsToRebuild.Select(GetRequiredProjectFilePath));
+        builder.ProjectsToRedeploy.AddRange(updates.ProjectsToRedeploy.Select(GetRequiredProjectFilePath));
 
         // Terminate all tracked processes that need to be restarted,
         // except for the root process, which will terminate later on.
-        if (!updates.ProjectsToRestart.IsEmpty)
-        {
-            builder.ProjectsToRestart.AddRange(await TerminatePeripheralProcessesAsync(updates.ProjectsToRestart.Select(e => currentSolution.GetProject(e.Key)!.FilePath!), cancellationToken));
-        }
+        builder.ProjectsToRestart.AddRange(
+            updates.ProjectsToRestart.SelectMany(e => runningProjects.TryGetValue(GetRequiredProjectFilePath(e.Key), out var array) ? array : []));
+
+        string GetRequiredProjectFilePath(ProjectId projectId)
+            => (currentSolution.GetProject(projectId) ?? throw new InvalidOperationException()).FilePath ?? throw new InvalidOperationException();
     }
 
     public async ValueTask ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync(
@@ -528,7 +533,12 @@ internal sealed class CompilationHandler : IDisposable
         }
     }
 
-    private async ValueTask DisplayResultsAsync(HotReloadService.Updates updates, Solution solution, ImmutableDictionary<ProjectId, HotReloadService.RunningProjectInfo> runningProjectInfos, CancellationToken cancellationToken)
+    private async ValueTask DisplayResultsAsync(
+        HotReloadService.Updates updates,
+        Solution solution,
+        ImmutableDictionary<string, ImmutableArray<RunningProject>> runningProjects,
+        ImmutableDictionary<ProjectId, HotReloadService.RunningProjectInfo> runningProjectInfos,
+        CancellationToken cancellationToken)
     {
         switch (updates.Status)
         {
@@ -560,7 +570,7 @@ internal sealed class CompilationHandler : IDisposable
         ReportRudeEdits();
 
         // report or clear diagnostics in the browser UI
-        await _runningProjects.ForEachValueAsync(
+        await runningProjects.ForEachValueAsync(
             (project, cancellationToken) => project.Clients.ReportCompilationErrorsInApplicationAsync([.. errorsToDisplayInApp], cancellationToken).AsTask() ?? Task.CompletedTask,
             cancellationToken);
 
@@ -850,24 +860,13 @@ internal sealed class CompilationHandler : IDisposable
     /// Does not terminate the main project.
     /// </summary>
     /// <returns>All processes (including main) to be restarted.</returns>
-    internal async ValueTask<ImmutableArray<RunningProject>> TerminatePeripheralProcessesAsync(
-        IEnumerable<string>? projectPaths, CancellationToken cancellationToken)
+    internal async ValueTask TerminatePeripheralProcessesAsync(
+        IEnumerable<RunningProject> projectsToRestart, CancellationToken cancellationToken)
     {
-        ImmutableArray<RunningProject> projectsToRestart = [];
-
-        lock (_runningProjectsAndUpdatesGuard)
-        {
-            projectsToRestart = projectPaths == null
-                ? [.. _runningProjects.SelectMany(entry => entry.Value)]
-                : [.. projectPaths.SelectMany(path => _runningProjects.TryGetValue(path, out var array) ? array : [])];
-        }
-
         // Do not terminate root process at this time - it would signal the cancellation token we are currently using.
         // The process will be restarted later on.
         // Wait for all processes to exit to release their resources, so we can rebuild.
         await Task.WhenAll(projectsToRestart.Where(p => !p.Options.IsMainProject).Select(p => p.TerminateForRestartAsync())).WaitAsync(cancellationToken);
-
-        return projectsToRestart;
     }
 
     /// <summary>

--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
@@ -320,7 +320,7 @@ internal sealed class HotReloadDotNetWatcher
 
                     // Apply updates only after dependencies have been deployed,
                     // so that updated code doesn't attempt to access the dependency before it has been deployed.
-                    await compilationHandler.ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync(updates.ManagedCodeUpdates, updates.StaticAssetsToUpdate, changedFiles, evaluationResult.ProjectGraph, stopwatch, iterationCancellationToken);
+                    await compilationHandler.ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync(updates, changedFiles, evaluationResult.ProjectGraph, stopwatch, iterationCancellationToken);
                     if (updates.ProjectsToRestart is not [])
                     {
                         await compilationHandler.RestartPeripheralProjectsAsync(updates.ProjectsToRestart, shutdownCancellationToken);

--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
@@ -266,6 +266,11 @@ internal sealed class HotReloadDotNetWatcher
                         autoRestart: _context.Options.NonInteractive || _rudeEditRestartPrompt?.AutoRestartPreference is true,
                         iterationCancellationToken);
 
+                    if (updates.ProjectsToRestart is not [])
+                    {
+                        await compilationHandler.TerminatePeripheralProcessesAsync(updates.ProjectsToRestart, iterationCancellationToken);
+                    }
+
                     // Terminate root process if it had rude edits or is non-reloadable.
                     if (updates.ProjectsToRestart.Any(static project => project.Options.IsMainProject))
                     {

--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadProjectUpdatesBuilder.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadProjectUpdatesBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.HotReload.Api;
 using Microsoft.DotNet.HotReload;
 
@@ -8,8 +9,9 @@ namespace Microsoft.DotNet.Watch;
 
 internal sealed class HotReloadProjectUpdatesBuilder
 {
+    public List<ProjectId> PreviousProjectUpdatesToDiscard { get; } = [];
     public List<HotReloadService.Update> ManagedCodeUpdates { get; } = [];
-    public Dictionary<RunningProject, List<StaticWebAsset>> StaticAssetsToUpdate { get; } = [];
+    public Dictionary<RunningProject, List<StaticWebAsset>> StaticAssetUpdates { get; } = [];
     public List<string> ProjectsToRebuild { get; } = [];
     public List<string> ProjectsToRedeploy { get; } = [];
     public List<RunningProject> ProjectsToRestart { get; } = [];


### PR DESCRIPTION
Refactor `GetManagedCodeUpdatesAsync` to only populate `HotReloadProjectUpdatesBuilder` but not terminate processes or discard updates.

Avoid capturing snapshot of running processes multiple times.
Move capturing of the snapshot from `TerminatePeripheralProcessesAsync`to the callers.
Move previous update discarding from `GetManagedCodeUpdatesAsync` to `ApplyManagedCodeAndStaticAssetUpdatesAndRelaunchAsync`