### PR TITLE
[release/9.0.1xx] Use full Application Insights connection string instead of instrumentation key

### DIFF
--- a/src/Cli/dotnet/Telemetry/Telemetry.cs
+++ b/src/Cli/dotnet/Telemetry/Telemetry.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private Dictionary<string, double> _commonMeasurements = null;
         private Task _trackEventTask = null;
 
-        private const string ConnectionString = "InstrumentationKey=74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+        private const string ConnectionString = "InstrumentationKey=74cc1c9e-3e6e-4d05-b3fc-dde9101d0254;IngestionEndpoint=https://southcentralus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://southcentralus.livediagnostics.monitor.azure.com/;ApplicationId=c5108c2c-b0c5-43c6-a703-424eae223a75";
 
         public bool Enabled { get; }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/55127 to `release/9.0.1xx`.

The SDK telemetry client was configured with an Application Insights *connection string* that only contained the bare `InstrumentationKey`. When only an instrumentation key is supplied, the Azure Monitor client must resolve the ingestion/live endpoints at runtime, which adds an extra network round-trip on every `POST` of telemetry. Supplying the full connection string (with `IngestionEndpoint`, `LiveEndpoint`, and `ApplicationId`) removes that round-trip.

Instrumentation-key-only configuration is also the legacy approach; Azure Monitor has moved to connection strings. See the Microsoft Learn documentation: https://learn.microsoft.com/azure/azure-monitor/app/connection-strings

Motivation and measurements are in https://github.com/dotnet/sdk/pull/55127 (and https://github.com/dotnet/sdk/pull/55126). The telemetry code was substantially refactored in `main`, so this could not be cherry-picked cleanly; the equivalent one-line change is applied to `src/Cli/dotnet/Telemetry/Telemetry.cs` on this branch.

---

## Tactics

### Summary

Switches the SDK telemetry client from an instrumentation-key-only Application Insights connection string to the full connection string (including `IngestionEndpoint`, `LiveEndpoint`, and `ApplicationId`). Connection strings are the current Azure Monitor standard and are ~200ms faster to `POST` because the ingestion endpoints no longer have to be resolved from a bare instrumentation key at runtime. We have moved on from instrumentation keys to connection strings (https://learn.microsoft.com/azure/azure-monitor/app/connection-strings). This is a one-line change to `src/Cli/dotnet/Telemetry/Telemetry.cs`, backporting https://github.com/dotnet/sdk/pull/55127.

### Customer Impact

Improves the time to `POST` telemetry (~200ms faster per post) and improves data consistency, since telemetry is sent directly to the correct ingestion/live endpoints rather than relying on endpoint resolution from a bare instrumentation key. There is no customer-facing behavior change other than reduced telemetry overhead.

### Regression?

No. This is not a regression; it is a performance and correctness improvement to how telemetry is posted.

### Testing

Tested by posting telemetry using `curl` and by running existing SDK versions that carry the same fix, confirming telemetry is ingested correctly with the full connection string and that the `POST` cost is reduced (~250-300ms with the full connection string vs. ~535-557ms with the instrumentation-key-only string, as measured in https://github.com/dotnet/sdk/pull/55127).

### Risk

Low. The change is a single-line update to the telemetry connection string constant. The connection string points to the same Application Insights resource (same instrumentation key), only adding the explicit endpoint/application metadata. See https://github.com/dotnet/sdk/pull/54613 for an example of the tactics template.
