### PR TITLE
`dotnetup`: Add support for Fish shell

### DIFF
--- a/documentation/general/dotnetup/designs/unix-environment-setup.md
+++ b/documentation/general/dotnetup/designs/unix-environment-setup.md
@@ -24,7 +24,7 @@ Choosing the shell-profile option in the walkthrough is what corresponds to maki
     eval "$('/home/user/.local/share/dotnetup/dotnetup' print-env-script --shell bash)"
   ```
 
-If the user already has a saved path preference, or if the command is non-interactive / uses an explicit `--install-path`, the walkthrough prompt is skipped and dotnetup uses the existing configuration or the explicit path directly. If shell auto-detection is wrong or unavailable, run `dotnetup init --shell bash|zsh|pwsh` (or `defaultinstall` / `print-env-script` with `--shell`) before installing.
+If the user already has a saved path preference, or if the command is non-interactive / uses an explicit `--install-path`, the walkthrough prompt is skipped and dotnetup uses the existing configuration or the explicit path directly. If shell auto-detection is wrong or unavailable, run `dotnetup init --shell bash|zsh|fish|pwsh` (or `defaultinstall` / `print-env-script` with `--shell`) before installing.
 
 ### 2. `dotnetup defaultinstall`
 
@@ -54,6 +54,7 @@ dotnetup defaultinstall system
 |-------|---------------|-----------|
 | **bash** | `~/.bashrc` (always) + the first existing of `~/.bash_profile` / `~/.profile` (creates `~/.profile` if neither exists) | `.bashrc` covers Linux terminals (non-login shells). The login profile covers macOS Terminal and SSH sessions. We never create `~/.bash_profile` to avoid shadowing an existing `~/.profile`. |
 | **zsh** | `$ZDOTDIR/.zshrc` when `ZDOTDIR` is set; otherwise `~/.zshrc` (created if needed) | Covers all interactive zsh sessions. `~/.zshenv` is avoided because on macOS, `/etc/zprofile` runs `path_helper` which resets PATH after `.zshenv` loads. |
+| **fish** | `$XDG_CONFIG_HOME/fish/conf.d/dotnetup.fish` when `XDG_CONFIG_HOME` is set; otherwise `~/.config/fish/conf.d/dotnetup.fish` (creates directory and file if needed) | fish sources every `conf.d/*.fish` snippet before `config.fish` for all interactive sessions, and a dedicated snippet file is the idiomatic way for tools to install configuration. |
 | **pwsh** (Unix) | `~/.config/powershell/profile.ps1` (creates directory and file if needed) | Standard PowerShell profile path on Unix. Targets the `CurrentUserAllHosts` slot so the entry applies to every host (terminal, VS Code, embedded). |
 | **pwsh** (Windows) | `<Documents>\WindowsPowerShell\profile.ps1` and `<Documents>\PowerShell\profile.ps1` -- both flavors are written unconditionally (creates directories and files if needed). `<Documents>` honors OneDrive Known Folder redirection via `Environment.GetFolderPath(MyDocuments)`. | Windows PowerShell 5.1 ships in-box and PowerShell 7+ (pwsh) installs separately, with disjoint profile folders. We write `profile.ps1` (`CurrentUserAllHosts`) for both flavors so the configuration is future-proof: if pwsh is installed later, dotnet is already wired up. `profile.ps1` is a standard PowerShell file; creating it for a not-yet-installed flavor is harmless. |
 
@@ -69,6 +70,15 @@ Each profile file gets a dotnetup-managed block with explicit begin/end markers:
 if [ -x '/path/to/dotnetup' ]; then
     eval "$('/path/to/dotnetup' print-env-script --shell bash)"
 fi
+# dotnetup: end
+```
+
+**Fish:**
+```fish
+# dotnetup: begin
+if test -x '/path/to/dotnetup'
+    '/path/to/dotnetup' print-env-script --shell fish | source
+end
 # dotnetup: end
 ```
 
@@ -113,7 +123,7 @@ dotnetup print-env-script [--shell <shell>] [--dotnet-install-path <path>]
 ### Options
 
 - `--shell` / `-s`: The target shell for which to generate the environment script
-  - Supported values: `bash`, `zsh`, `pwsh`
+  - Supported values: `bash`, `zsh`, `fish`, `pwsh`
   - The supported shell values are based on what `nvm` and `rustup` support today.
   - Optional: If not specified, automatically detects the current shell from the `$SHELL` environment variable
   - On Windows, defaults to PowerShell (`pwsh`)
@@ -162,6 +172,14 @@ hash -d dotnet 2>/dev/null
 hash -d dotnetup 2>/dev/null
 ```
 
+**Fish Example:**
+```fish
+# This fish script configures the environment for .NET installed at /home/user/.local/share/dotnet
+
+set -gx DOTNET_ROOT '/home/user/.local/share/dotnet'
+fish_add_path --global --move --path '/home/user/.local/share/dotnetup' '/home/user/.local/share/dotnet'
+```
+
 **PowerShell Example:**
 ```powershell
 # This PowerShell script configures the environment for .NET installed at /home/user/.local/share/dotnet
@@ -181,6 +199,7 @@ When `--shell` is not specified, the command automatically detects the current s
 
 All installation paths are properly escaped to prevent shell injection vulnerabilities:
 - **Bash/Zsh**: Uses single quotes with `'\''` escaping for embedded single quotes
+- **Fish**: Uses single quotes with `\'` for embedded single quotes
 - **PowerShell**: Uses single quotes with `''` escaping for embedded single quotes
 
 This ensures that paths containing special characters, spaces, or shell metacharacters are handled safely.
@@ -205,7 +224,7 @@ public interface IEnvShellProvider
 }
 ```
 
-**Implementations**: `BashEnvShellProvider`, `ZshEnvShellProvider`, `PowerShellEnvShellProvider`
+**Implementations**: `BashEnvShellProvider`, `ZshEnvShellProvider`, `FishEnvShellProvider`, `PowerShellEnvShellProvider`
 
 ### ShellDetection
 
@@ -222,7 +241,7 @@ public interface IEnvShellProvider
 ## Future Work
 
 1. **System-wide configuration on Unix**: Writing to system-wide locations like `/etc/profile.d/` for admin installs is not yet supported.
-2. **Additional shells**: Support for fish, tcsh, and other shells.
+2. **Additional shells**: Support for tcsh and other shells.
 3. **Environment validation**: Commands to verify that the environment is correctly configured.
 
 ## Related Issues

--- a/documentation/general/dotnetup/designs/unix-environment-setup.md
+++ b/documentation/general/dotnetup/designs/unix-environment-setup.md
@@ -217,7 +217,7 @@ public interface IEnvShellProvider
     string ArgumentName { get; }
     string Extension { get; }
     string? HelpDescription { get; }
-    string GenerateEnvScript(string dotnetInstallPath, string? dotnetupDir = null, bool includeDotnet = true);
+    string GenerateEnvScript(string dotnetInstallPath, string dotnetupDir = "", bool includeDotnet = true);
     IReadOnlyList<string> GetProfilePaths();
     string GenerateProfileEntry(string dotnetupPath, bool dotnetupOnly = false, string? dotnetInstallPath = null);
     string GenerateActivationCommand(string dotnetupPath, bool dotnetupOnly = false, string? dotnetInstallPath = null);

--- a/src/Installer/dotnetup.Library/Shell/FishEnvShellProvider.cs
+++ b/src/Installer/dotnetup.Library/Shell/FishEnvShellProvider.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tools.Bootstrapper.Shell;
+
+public class FishEnvShellProvider : IEnvShellProvider
+{
+    public string ArgumentName => "fish";
+
+    public string Extension => "fish";
+
+    public string? HelpDescription => "Fish shell";
+
+    public override string ToString() => ArgumentName;
+
+    public string GenerateEnvScript(string dotnetInstallPath, string dotnetupDir = "", bool includeDotnet = true)
+    {
+        var escapedPath = ShellProviderHelpers.EscapeFishPath(dotnetInstallPath);
+        var pathExport = ShellProviderHelpers.BuildFishPathExport(escapedPath, dotnetupDir, includeDotnet);
+
+        if (!includeDotnet)
+        {
+            return
+                $"""
+                {ShellProviderHelpers.GetDotnetupOnlyComment(ArgumentName)}
+                {pathExport}
+                """;
+        }
+
+        return
+            $"""
+            {ShellProviderHelpers.GetEnvironmentConfigurationComment(ArgumentName, dotnetInstallPath)}
+
+            set -gx DOTNET_ROOT '{escapedPath}'
+            {pathExport}
+            """;
+    }
+
+    public IReadOnlyList<string> GetProfilePaths()
+    {
+        var configurationDirectory = ShellProviderHelpers.GetFishConfigurationDirectoryOrThrow();
+        return [Path.Combine(configurationDirectory, "dotnetup.fish")];
+    }
+
+    public string GenerateProfileEntry(string dotnetupPath, bool dotnetupOnly = false, string? dotnetInstallPath = null)
+    {
+        var flags = ShellProviderHelpers.GetCommandFlags(dotnetupOnly, dotnetInstallPath, ShellProviderHelpers.EscapeFishPath);
+        return ShellProviderHelpers.BuildFishProfileEntry(dotnetupPath, ArgumentName, flags);
+    }
+
+    public string GenerateActivationCommand(string dotnetupPath, bool dotnetupOnly = false, string? dotnetInstallPath = null)
+    {
+        var flags = ShellProviderHelpers.GetCommandFlags(dotnetupOnly, dotnetInstallPath, ShellProviderHelpers.EscapeFishPath);
+        return ShellProviderHelpers.BuildFishActivationCommand(dotnetupPath, ArgumentName, flags);
+    }
+}

--- a/src/Installer/dotnetup.Library/Shell/ShellDetection.cs
+++ b/src/Installer/dotnetup.Library/Shell/ShellDetection.cs
@@ -17,6 +17,7 @@ public static class ShellDetection
     [
         new BashEnvShellProvider(),
         new ZshEnvShellProvider(),
+        new FishEnvShellProvider(),
         new PowerShellEnvShellProvider()
     ];
 

--- a/src/Installer/dotnetup.Library/Shell/ShellProviderHelpers.cs
+++ b/src/Installer/dotnetup.Library/Shell/ShellProviderHelpers.cs
@@ -24,6 +24,12 @@ internal static class ShellProviderHelpers
     internal static string EscapePowerShellPath(string path)
         => path.Replace("'", "''", StringComparison.Ordinal);
 
+    // Fish single-quoted strings treat backslash as an escape character for \' and \\,
+    // so backslashes must be escaped first and quotes use \' rather than the POSIX '\''.
+    internal static string EscapeFishPath(string path)
+        => path.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("'", "\\'", StringComparison.Ordinal);
+
     internal static string GetCommandFlags(bool dotnetupOnly, string? dotnetInstallPath, Func<string, string> escapePath)
     {
         List<string> flags = [];
@@ -59,6 +65,21 @@ internal static class ShellProviderHelpers
             if [ -x '{{escapedPath}}' ]; then
                 eval "$({{command}})"
             fi
+            """;
+    }
+
+    internal static string BuildFishActivationCommand(string dotnetupPath, string shellName, string flags)
+        => $"{BuildPosixPrintEnvCommand(dotnetupPath, shellName, flags)} | source";
+
+    internal static string BuildFishProfileEntry(string dotnetupPath, string shellName, string flags)
+    {
+        var escapedPath = EscapeFishPath(dotnetupPath);
+        var command = BuildPosixPrintEnvCommand(dotnetupPath, shellName, flags);
+
+        return $$"""
+            if test -x '{{escapedPath}}'
+                {{command}} | source
+            end
             """;
     }
 
@@ -124,6 +145,27 @@ internal static class ShellProviderHelpers
         return string.IsNullOrWhiteSpace(dotnetupDir)
             ? string.Empty
             : $"export PATH='{EscapePosixPath(dotnetupDir)}':$PATH";
+    }
+
+    internal static string BuildFishPathExport(string escapedPath, string dotnetupDir, bool includeDotnet)
+    {
+        // fish_add_path --move prepends (or moves) the entries so the shell resolves
+        // dotnet/dotnetup from the selected install immediately.
+        // --path/--global keeps the change session-scoped in $PATH instead of persisting
+        // to universal fish_user_paths.
+        if (includeDotnet && !string.IsNullOrWhiteSpace(dotnetupDir))
+        {
+            return $"fish_add_path --global --move --path '{EscapeFishPath(dotnetupDir)}' '{escapedPath}'";
+        }
+
+        if (includeDotnet)
+        {
+            return $"fish_add_path --global --move --path '{escapedPath}'";
+        }
+
+        return string.IsNullOrWhiteSpace(dotnetupDir)
+            ? string.Empty
+            : $"fish_add_path --global --move --path '{EscapeFishPath(dotnetupDir)}'";
     }
 
     internal static string BuildPowerShellPathExport(string escapedPath, string dotnetupDir, bool includeDotnet)
@@ -207,6 +249,18 @@ internal static class ShellProviderHelpers
         var fullPath = Path.GetFullPath(zdotdir);
         EnsureDirectoryWritable(fullPath, "ZDOTDIR", createIfMissing: true);
         return fullPath;
+    }
+
+    internal static string GetFishConfigurationDirectoryOrThrow()
+    {
+        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        var configHome = string.IsNullOrWhiteSpace(xdgConfigHome)
+            ? Path.Combine(GetUserHomeDirectoryOrThrow(), ".config")
+            : Path.GetFullPath(xdgConfigHome);
+
+        var confDDirectory = Path.Combine(configHome, "fish", "conf.d");
+        EnsureDirectoryWritable(confDDirectory, "fish configuration directory", createIfMissing: true);
+        return confDDirectory;
     }
 
     internal static string GetPowerShellProfileDirectoryOrThrow()

--- a/src/Installer/dotnetup.Library/Shell/ShellProviderHelpers.cs
+++ b/src/Installer/dotnetup.Library/Shell/ShellProviderHelpers.cs
@@ -69,12 +69,12 @@ internal static class ShellProviderHelpers
     }
 
     internal static string BuildFishActivationCommand(string dotnetupPath, string shellName, string flags)
-        => $"{BuildPosixPrintEnvCommand(dotnetupPath, shellName, flags)} | source";
+        => $"{BuildFishPrintEnvCommand(dotnetupPath, shellName, flags)} | source";
 
     internal static string BuildFishProfileEntry(string dotnetupPath, string shellName, string flags)
     {
         var escapedPath = EscapeFishPath(dotnetupPath);
-        var command = BuildPosixPrintEnvCommand(dotnetupPath, shellName, flags);
+        var command = BuildFishPrintEnvCommand(dotnetupPath, shellName, flags);
 
         return $$"""
             if test -x '{{escapedPath}}'
@@ -106,6 +106,12 @@ internal static class ShellProviderHelpers
     private static string BuildPosixPrintEnvCommand(string dotnetupPath, string shellName, string flags)
     {
         var escapedPath = EscapePosixPath(dotnetupPath);
+        return AppendArguments($"'{escapedPath}' print-env-script --shell {shellName}", flags);
+    }
+
+    private static string BuildFishPrintEnvCommand(string dotnetupPath, string shellName, string flags)
+    {
+        var escapedPath = EscapeFishPath(dotnetupPath);
         return AppendArguments($"'{escapedPath}' print-env-script --shell {shellName}", flags);
     }
 

--- a/test/dotnetup.Tests/EnvShellProviderTests.cs
+++ b/test/dotnetup.Tests/EnvShellProviderTests.cs
@@ -124,6 +124,86 @@ public class EnvShellProviderTests
     }
 
     [TestMethod]
+    public void FishProvider_ShouldGenerateValidScript()
+    {
+        var provider = new FishEnvShellProvider();
+        var installPath = "/test/dotnet/path";
+
+        var script = provider.GenerateEnvScript(installPath);
+
+        script.Should().NotBeNullOrEmpty();
+        script.Should().NotContain("#!/usr/bin/env");
+        script.Should().Contain("# This fish script configures the environment for .NET installed at /test/dotnet/path");
+        script.Should().Contain($"set -gx DOTNET_ROOT '{installPath}'");
+        script.Should().Contain($"fish_add_path --global --move --path '{installPath}'");
+    }
+
+    [TestMethod]
+    public void FishProvider_ShouldIncludeDotnetupDirInPath()
+    {
+        var provider = new FishEnvShellProvider();
+        var script = provider.GenerateEnvScript("/test/dotnet", "/usr/local/bin");
+
+        script.Should().Contain("fish_add_path --global --move --path '/usr/local/bin' '/test/dotnet'");
+    }
+
+    [TestMethod]
+    public void FishProvider_DotnetupOnly_ShouldNotSetDotnetRoot()
+    {
+        var provider = new FishEnvShellProvider();
+        var script = provider.GenerateEnvScript("/test/dotnet", "/usr/local/bin", includeDotnet: false);
+
+        script.Should().NotContain("DOTNET_ROOT");
+        script.Should().Contain("# This fish script adds dotnetup to your PATH");
+        script.Should().Contain("fish_add_path --global --move --path '/usr/local/bin'");
+        script.Should().NotContain("'/test/dotnet'");
+    }
+
+    [TestMethod]
+    public void FishProvider_ShouldPreferXdgConfigHomeForProfilePath()
+    {
+        var temporaryDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(temporaryDirectory);
+        try
+        {
+            var originalXdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", temporaryDirectory);
+
+                var provider = new FishEnvShellProvider();
+                var paths = provider.GetProfilePaths();
+
+                paths.Should().ContainSingle();
+                paths[0].Should().Be(Path.Combine(temporaryDirectory, "fish", "conf.d", "dotnetup.fish"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", originalXdgConfigHome);
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void FishProvider_ShouldSourcePrintEnvScriptOutput()
+    {
+        var provider = new FishEnvShellProvider();
+
+        var profileEntry = provider.GenerateProfileEntry("/test/dotnetup");
+        var activationCommand = provider.GenerateActivationCommand("/test/dotnetup");
+
+        profileEntry.Should().Contain("if test -x '/test/dotnetup'");
+        profileEntry.Should().Contain("'/test/dotnetup' print-env-script --shell fish | source");
+        profileEntry.Should().EndWith("end");
+
+        activationCommand.Should().Be("'/test/dotnetup' print-env-script --shell fish | source");
+    }
+
+    [TestMethod]
     public void PowerShellProvider_ShouldGenerateValidScript()
     {
         // Arrange
@@ -195,6 +275,7 @@ public class EnvShellProviderTests
     [TestMethod]
     [DataRow("bash")]
     [DataRow("zsh")]
+    [DataRow("fish")]
     [DataRow("pwsh")]
     public void ShellProviders_ShouldHaveCorrectArgumentName(string expectedName)
     {
@@ -209,6 +290,7 @@ public class EnvShellProviderTests
     [TestMethod]
     [DataRow("/bin/bash", "bash")]
     [DataRow("/bin/zsh", "zsh")]
+    [DataRow("/usr/local/bin/fish", "fish")]
     [DataRow(@"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh")]
     public void ShellDetection_ShouldResolveProviderFromShellPath(string shellPath, string expectedName)
     {
@@ -239,6 +321,16 @@ public class EnvShellProviderTests
         // Assert
         provider.ArgumentName.Should().Be("zsh");
         provider.Extension.Should().Be("zsh");
+        provider.HelpDescription.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void FishProvider_ShouldHaveCorrectProperties()
+    {
+        var provider = new FishEnvShellProvider();
+
+        provider.ArgumentName.Should().Be("fish");
+        provider.Extension.Should().Be("fish");
         provider.HelpDescription.Should().NotBeNullOrEmpty();
     }
 
@@ -282,6 +374,18 @@ public class EnvShellProviderTests
         // Assert
         script.Should().Contain("export DOTNET_ROOT='/test/path/with'\\''quote'");
         script.Should().Contain("export PATH='/test/path/with'\\''quote':$PATH");
+    }
+
+    [TestMethod]
+    public void FishProvider_ShouldEscapeSingleQuotesAndBackslashesInPath()
+    {
+        var provider = new FishEnvShellProvider();
+        var installPath = @"/test/path/with'quote\backslash";
+
+        var script = provider.GenerateEnvScript(installPath);
+
+        script.Should().Contain(@"set -gx DOTNET_ROOT '/test/path/with\'quote\\backslash'");
+        script.Should().Contain(@"fish_add_path --global --move --path '/test/path/with\'quote\\backslash'");
     }
 
     [TestMethod]

--- a/test/dotnetup.Tests/ParserTests.cs
+++ b/test/dotnetup.Tests/ParserTests.cs
@@ -175,6 +175,7 @@ public class ParserTests
     [TestMethod]
     [DataRow("bash")]
     [DataRow("zsh")]
+    [DataRow("fish")]
     [DataRow("pwsh")]
     public void Parser_ShouldParseEnvCommandWithValidShell(string shell)
     {

--- a/test/dotnetup.Tests/ShellProfileManagerTests.cs
+++ b/test/dotnetup.Tests/ShellProfileManagerTests.cs
@@ -737,10 +737,10 @@ public class ShellProfileManagerTests : IDisposable
         Encoding IEnvShellProvider.NewFileEncoding
             => NewFileEncodingOverride ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-        public string GenerateEnvScript(string dotnetInstallPath, string? dotnetupDir = null, bool includeDotnet = true) =>
+        public string GenerateEnvScript(string dotnetInstallPath, string dotnetupDir = "", bool includeDotnet = true) =>
             includeDotnet
                 ? $"export DOTNET_ROOT='{dotnetInstallPath}'"
-                : dotnetupDir is not null ? $"export PATH='{dotnetupDir}':$PATH" : "";
+                : !string.IsNullOrEmpty(dotnetupDir) ? $"export PATH='{dotnetupDir}':$PATH" : "";
 
         public IReadOnlyList<string> GetProfilePaths() => _profilePaths;
 


### PR DESCRIPTION
I started trying out `dotnetup` today and noticed it didn't yet have support for Fish, so I had a stab at adding it.

This PR adds automatic detection of fish, and support for explicitly specifying `--shell fish`.

It uses `fish_add_path` to manipulate the `PATH` environment variable, and writes persistent config to a new config file `dotnetup.fish` in Fish's per-user `conf.d` directory..

It works for me on Fish 4.7.1 osx-arm64 as installed by Homebrew.