### PR TITLE
Fix stale KBE action to use last summary table in issue body

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -60,8 +60,11 @@ jobs:
               // Format: |24-Hour Hit Count|7-Day Hit Count|1-Month Count|
               //         |---|---|---|
               //         |N|N|N|
-              const match = issue.body?.match(
-                /\|24-Hour Hit Count\|.*\r?\n\|[-| ]+\r?\n\|(\d+)\|(\d+)\|(\d+)\|/);
+              // Use the *last* table because infrastructure appends/updates the
+              // final occurrence when there are multiple tables in the body.
+              const matches = [...(issue.body?.matchAll(
+                /\|24-Hour Hit Count\|.*\r?\n\|[-| ]+\r?\n\|(\d+)\|(\d+)\|(\d+)\|/g) ?? [])];
+              const match = matches.length ? matches[matches.length - 1] : null;
               if (!match) {
                 console.log(`  #${issue.number}: no hit count table found`);
                 continue;


### PR DESCRIPTION
When infrastructure updates Known Build Error issues, it appends or updates the last summary table in the issue body. When multiple tables exist, the stale action was reading the first (outdated) table, potentially marking issues as stale based on stale data. This has happened multiple times (e.g. #55174 is one such case).

This switches from .match() (returns first hit) to .matchAll() taking the last match, so the action always uses the most recent hit counts.

