### PR TITLE
Run multi-TFM tests sequentially to fix XunitMultiTFM/MStestMultiTFM flakiness

### DIFF
--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -35,7 +35,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Execute()
                 .Should().Pass();
 
-            var result = new DotnetTestCommand(Log, disableNewOutput: true, "-r", runtime)
+            // Run the two target frameworks' tests sequentially so their VSTest console output can't
+            // interleave mid-line and break the contiguous substring assertions below. See dotnet/sdk#55194.
+            var result = new DotnetTestCommand(Log, disableNewOutput: true, "-r", runtime, "--property:TestTfmsInParallel=false")
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute(ConsoleLoggerOutputNormal);
 
@@ -72,8 +74,9 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .Should()
                 .Pass();
 
-            // Call test
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true)
+            // Call test. Run the two target frameworks' tests sequentially so their VSTest console output
+            // can't interleave mid-line and break the contiguous substring assertions below. See dotnet/sdk#55194.
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: true, "--property:TestTfmsInParallel=false")
                                        .WithWorkingDirectory(testProjectDirectory)
                                        .Execute(ConsoleLoggerOutputNormal);
 


### PR DESCRIPTION
`XunitMultiTFM` and `MStestMultiTFM` run `dotnet test` on a `net48;net11.0` project through the legacy VSTest console logger and assert on contiguous substrings like `Passed TestNamespace...VSTestXunitPassTestDesktop`. `DispatchToInnerBuildsWithVSTestTarget` fans the TFMs out with `BuildInParallel`, so both console loggers write to the same redirected stdout and occasionally interleave mid-line — `Passed` lands on one line, `Stack Trace:` from the other TFM flushes in between, and the substring assertion fails. Purely timing-dependent, which is why it's rare and won't reproduce on demand.

Pass `--property:TestTfmsInParallel=false` (the documented knob) so the TFMs run sequentially. Both still run; their output just can't interleave.

Fixes #55194.