### PR TITLE
Add add-cli-command skill for dotnet CLI command/option changes

### DIFF
--- a/.github/skills/add-cli-command/SKILL.md
+++ b/.github/skills/add-cli-command/SKILL.md
@@ -57,6 +57,12 @@ Everything above, plus:
    <Name>CommandParser.ConfigureCommand(rootCommand.<Name>Command);
    ```
 
+> **Native AOT:** a newly registered command already *runs* under Native AOT via the
+> managed fallback (the `dotnet-aot` host runs `dotnet.dll` through hostfxr), and its
+> parsing and `--help` reach the AOT CLI for free. Making the command execute
+> **in-process** in the native binary is separate, deliberate work — follow the
+> **add-dotnet-aot-command** skill when AOT support is required.
+
 ## Checklist
 
 - [ ] Option/command declared in `Definitions`, registered in its parent's constructor.
@@ -64,4 +70,5 @@ Everything above, plus:
 - [ ] Help description in `CommandDefinitionStrings.resx`; runtime message in `CliCommandStrings.resx`.
 - [ ] `.xlf` files regenerated via `/t:UpdateXlf` (not hand-edited), resx + xlf committed together.
 - [ ] No heavy dependency leaked into `Definitions`.
+- [ ] For in-process AOT execution, followed **add-dotnet-aot-command** (managed fallback applies otherwise).
 - [ ] Tests added/updated; Verify `*.verified.txt` snapshots promoted if CLI output changed.

--- a/.github/skills/add-cli-command/SKILL.md
+++ b/.github/skills/add-cli-command/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: add-cli-command
+description: >
+  Add or change a dotnet CLI command, subcommand, or option across the relevant CLI projects.
+  USE FOR: adding or changing a dotnet CLI command/subcommand, adding a new
+  Option<T> or Argument<T>, registering a subcommand in the command tree, changing
+  an option's help description or a command's runtime message, wiring a command
+  parser, or updating --help output.
+license: MIT
+---
+
+# Add or change a dotnet CLI command or option
+
+See [`references/file-map.md`](references/file-map.md) for the exact file map and the
+two-resx reference table. Read it before editing.
+
+## Add an option to an existing command
+
+1. **Declare** the option in
+   `src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/<Area>/<Name>CommandDefinition.cs`.
+   Prefer a `CommonOptions` factory (`Common/CommonOptions.cs`) when one exists:
+
+   ```csharp
+   public readonly Option<bool> NoLogoOption = CommonOptions.CreateNoLogoOption();
+   // or, declared inline:
+   public readonly Option<string> OutputOption = new Option<string>("--output", "-o")
+   {
+       Description = CommandDefinitionStrings.BuildOutputOptionDescription
+   };
+   ```
+
+   Add it to the command in the constructor: `Options.Add(OutputOption);`.
+2. **Consume** it in the managed implementation under
+   `src/Cli/dotnet/Commands/<Area>/...` via `definition.OutputOption`; runtime
+   messages come from `CliCommandStrings.<Key>`.
+3. **Strings**: add the help description to `CommandDefinitionStrings.resx` and any
+   runtime message to `CliCommandStrings.resx`, then regenerate the `.xlf` siblings.
+4. **Test**: add parser/validation tests under
+   `test/dotnet.Tests/CommandTests/<Area>/` and update any Verify help snapshots.
+
+## Add a new command
+
+Everything above, plus:
+
+1. Create `Commands/<Area>/<Name>CommandDefinition.cs` in the Definitions project.
+2. Register it in the root tree
+   (`Commands/DotNetCommandDefinition.cs` constructor):
+
+   ```csharp
+   Subcommands.Add(<Name>Command = new());
+   ```
+3. Create the managed implementation and a `<Name>CommandParser.cs` exposing
+   `ConfigureCommand(...)` under `src/Cli/dotnet/Commands/<Name>/`.
+4. Wire the parser in `src/Cli/dotnet/Parser.cs` `ConfigureManagedActions`:
+
+   ```csharp
+   <Name>CommandParser.ConfigureCommand(rootCommand.<Name>Command);
+   ```
+
+## Checklist
+
+- [ ] Option/command declared in `Definitions`, registered in its parent's constructor.
+- [ ] Managed behavior wired in `src/Cli/dotnet` and (for new commands) in `Parser.cs`.
+- [ ] Help description in `CommandDefinitionStrings.resx`; runtime message in `CliCommandStrings.resx`.
+- [ ] `.xlf` files regenerated via `/t:UpdateXlf` (not hand-edited), resx + xlf committed together.
+- [ ] No heavy dependency leaked into `Definitions`.
+- [ ] Tests added/updated; Verify `*.verified.txt` snapshots promoted if CLI output changed.

--- a/.github/skills/add-cli-command/references/file-map.md
+++ b/.github/skills/add-cli-command/references/file-map.md
@@ -25,6 +25,14 @@ repo layout.
 | Managed impl + `<Name>CommandParser.cs` (`ConfigureCommand(...)`) | `src/Cli/dotnet/Commands/<Name>/` |
 | Wire parser (`<Name>CommandParser.ConfigureCommand(rootCommand.<Name>Command);`) | `src/Cli/dotnet/Parser.cs` → `ConfigureManagedActions` |
 
+## Native AOT
+
+Parsing and `--help` reach the AOT CLI for free via `Definitions`, and a newly
+registered command runs under AOT through the managed fallback. To make a command
+execute **in-process** in the Native AOT binary — the `dotnet-aot`/`dn` source closure,
+`AotSourceFiles.props`, `#if CLI_AOT` gating, and the AOT tests — follow the
+**add-dotnet-aot-command** skill, which owns those file details.
+
 ## The two resx files
 
 | Resx | Path | Holds | Localized via |

--- a/.github/skills/add-cli-command/references/file-map.md
+++ b/.github/skills/add-cli-command/references/file-map.md
@@ -1,0 +1,33 @@
+# File map: CLI command/option changes
+
+Reference tables for the `add-cli-command` skill. All paths are verified against the
+repo layout.
+
+## Add an option — files to touch
+
+| Step | File |
+|------|------|
+| Declare `Option<T>` + `Options.Add(...)` in ctor | `src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/<Area>/<Name>CommandDefinition.cs` |
+| Shared option factory (preferred) | `src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs` |
+| Help description string | `src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx` |
+| Consume option in handler | `src/Cli/dotnet/Commands/<Area>/...` |
+| Runtime message string | `src/Cli/dotnet/Commands/CliCommandStrings.resx` |
+| Regenerate localization | `.xlf` siblings of both resx (via `/t:UpdateXlf`) |
+| Parser/validation tests | `test/dotnet.Tests/CommandTests/<Area>/` |
+| Help snapshot (if `--help` output changes) | `*.verified.txt` next to the snapshot test |
+
+## Add a command — additional files
+
+| Step | File |
+|------|------|
+| New command definition class | `src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/<Area>/<Name>CommandDefinition.cs` |
+| Register in the root tree (`Subcommands.Add(<Name>Command = new());`) | `src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/DotNetCommandDefinition.cs` |
+| Managed impl + `<Name>CommandParser.cs` (`ConfigureCommand(...)`) | `src/Cli/dotnet/Commands/<Name>/` |
+| Wire parser (`<Name>CommandParser.ConfigureCommand(rootCommand.<Name>Command);`) | `src/Cli/dotnet/Parser.cs` → `ConfigureManagedActions` |
+
+## The two resx files
+
+| Resx | Path | Holds | Localized via |
+|------|------|-------|---------------|
+| `CommandDefinitionStrings` | `src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx` | **Help descriptions** for commands, options, and arguments (parsed by both managed and AOT hosts). | `xlf/CommandDefinitionStrings.<locale>.xlf` |
+| `CliCommandStrings` | `src/Cli/dotnet/Commands/CliCommandStrings.resx` | **Runtime messages** emitted by managed handlers (errors, status, validation). | `Commands/xlf/CliCommandStrings.<locale>.xlf` |


### PR DESCRIPTION
Skill guiding agents through adding or changing a dotnet CLI command or option across the Definitions/managed/AOT projects.