### PR TITLE
Fix intermittent file-lock race in dotnet-watch tests

### DIFF
--- a/test/dotnet-watch.Tests/TestUtilities/DotNetWatchTestBase.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/DotNetWatchTestBase.cs
@@ -69,11 +69,13 @@ public abstract partial class DotNetWatchTestBase
         => UpdateSourceFile(path, contentTransform(File.ReadAllText(path, Encoding.UTF8)), testPath, testLine);
 
     /// <summary>
-    /// Replacement for <see cref="File.WriteAllText"/>, which fails to write to hidden file
+    /// Replacement for <see cref="File.WriteAllText"/>, which fails to write to hidden file.
+    /// Uses FileShare.Read so that dotnet-watch (via Roslyn workspace) can still read the file
+    /// while it's being written, avoiding IOException file-lock races.
     /// </summary>
     public static void WriteAllText(string path, string text)
     {
-        using var stream = File.Open(path, FileMode.OpenOrCreate);
+        using var stream = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
 
         using (var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true))
         {


### PR DESCRIPTION
## Summary

Fixes the intermittent `IOException: The process cannot access the file ... because it is being used by another process` failure in `MetadataUpdateHandlerTests.NoActions` (and the same race family affecting `RuntimeProcessLauncherTests.RelaunchOnCrash`).

## Problem

`DotNetWatchTestBase.WriteAllText` uses `File.Open(path, FileMode.OpenOrCreate)` which defaults to `FileShare.None`, exclusively locking the file. When dotnet-watch's file watcher detects the change and Roslyn's `HotReloadMSBuildWorkspace.GetSourceTextAsync` tries to read the file concurrently, it throws an `IOException` if the test still holds the lock.

## Fix

Specify `FileShare.Read` so that dotnet-watch can read the file while the test is writing it:

```csharp
File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)
```

Fixes #55164