### PR TITLE
Verify SHA-512 of the downloaded get-dotnetup script in eng

### DIFF
--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -78,9 +78,88 @@ function Invoke-DotnetupNativeCommand([scriptblock]$Command) {
     }
 }
 
+# Downloads a URL to a file, retrying with exponential backoff. Invoke-WebRequest's
+# built-in -MaximumRetryCount is unavailable on Windows PowerShell 5.1, so retry manually.
+function Invoke-DotnetupDownload([string]$Uri, [string]$OutFile, [string]$Description) {
+    $maxAttempts = 3
+    for ($attempt = 1; $true; $attempt++) {
+        try {
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
+            return
+        }
+        catch {
+            if ($attempt -ge $maxAttempts) {
+                throw "$Description failed after $maxAttempts attempts ($Uri): $($_.Exception.Message)"
+            }
+            $delaySeconds = [Math]::Pow(2, $attempt)
+            Write-Host "$Description failed (attempt $attempt of $maxAttempts): $($_.Exception.Message). Retrying in $delaySeconds seconds..." -ForegroundColor Yellow
+            Start-Sleep -Seconds $delaySeconds
+        }
+    }
+}
+
+# Follows redirects for a mutable 'daily' shortlink and returns the concrete,
+# versioned URL it currently points at (or $null if it cannot be resolved). The
+# daily aka.ms link is a moving pointer, so downloading the script and its
+# .sha512 as two separate requests can straddle a new build publish and yield a
+# script from one build with a checksum from another. Resolving the shortlink to
+# a single concrete URL first lets us derive both the script and checksum URLs
+# from the same build so they always match. This mirrors the standalone
+# get-dotnetup script's own binary check, but is kept as a deliberately separate
+# copy here because that script does not exist in this branch and must stand alone.
+function Resolve-DotnetupFinalUrl([string]$Url) {
+    # Require an actual curl executable; on Windows PowerShell 5.1 'curl' is an alias for Invoke-WebRequest, so -CommandType Application excludes it.
+    $curl = Get-Command curl.exe -CommandType Application -ErrorAction SilentlyContinue
+    if (-not $curl) { $curl = Get-Command curl -CommandType Application -ErrorAction SilentlyContinue }
+    if ($curl) {
+        $sink = [System.IO.Path]::GetTempFileName()
+        try {
+            # --head resolves redirects without downloading the body.
+            $final = & $curl.Source --silent --show-error --location --head `
+                --output $sink --write-out '%{url_effective}' $Url 2>$null
+            if ($LASTEXITCODE -eq 0 -and $final) { return "$final".Trim() }
+        }
+        catch { }
+        finally { Remove-Item $sink -Force -ErrorAction SilentlyContinue }
+    }
+
+    # Fallback for hosts without a curl executable (e.g. Windows PowerShell 5.1):
+    try {
+        $req = [System.Net.WebRequest]::Create($Url)
+        $req.Method = "HEAD"
+        $req.AllowAutoRedirect = $true
+        $resp = $req.GetResponse()
+        try { return $resp.ResponseUri.AbsoluteUri }
+        finally { $resp.Dispose() }
+    }
+    catch {
+        return $null
+    }
+}
+
+# Computes the lowercase SHA-512 hex digest of a file. Uses .NET directly rather
+# than Get-FileHash, which is not always resolvable in stripped-down PowerShell hosts.
+function Get-DotnetupSha512([string]$Path) {
+    $sha512 = [System.Security.Cryptography.SHA512]::Create()
+    try {
+        $stream = [System.IO.File]::OpenRead($Path)
+        try {
+            $hashBytes = $sha512.ComputeHash($stream)
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $sha512.Dispose()
+    }
+    return ([System.BitConverter]::ToString($hashBytes) -replace '-', '').ToLowerInvariant()
+}
+
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1) and runs it to install dotnetup into
-# $DotnetupDir. Throws on failure so callers can choose how to react.
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1), verifies its SHA-512
+# checksum, and runs it to install dotnetup into $DotnetupDir. Throws on failure
+# so callers can choose how to react.
 #
 # If a local get-dotnetup.ps1 script exists in the repo (scripts/get-dotnetup.ps1),
 # it is used directly instead of downloading from aka.ms. This supports branches
@@ -98,30 +177,40 @@ function Install-DotnetupFromAkaMs([string]$DotnetupDir) {
     }
 
     $getterUrl = 'https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1'
-    $getterScript = Join-Path ([System.IO.Path]::GetTempPath()) ("get-dotnetup-{0}.ps1" -f [System.IO.Path]::GetRandomFileName())
+    $checksumUrl = "$getterUrl.sha512"
 
-    # Download the installer with retry/backoff. Invoke-WebRequest's built-in
-    # -MaximumRetryCount is unavailable on Windows PowerShell 5.1, so retry manually.
-    $maxAttempts = 3
-    for ($attempt = 1; $true; $attempt++) {
-        try {
-            Invoke-WebRequest -Uri $getterUrl -OutFile $getterScript -UseBasicParsing
-            break
-        }
-        catch {
-            if ($attempt -ge $maxAttempts) {
-                throw "Failed to download dotnetup installer from $getterUrl after $maxAttempts attempts: $($_.Exception.Message)"
-            }
-            $delaySeconds = [Math]::Pow(2, $attempt)
-            Write-Host "Download of dotnetup installer failed (attempt $attempt of $maxAttempts): $($_.Exception.Message). Retrying in $delaySeconds seconds..." -ForegroundColor Yellow
-            Start-Sleep -Seconds $delaySeconds
-        }
+    # Pin the mutable 'daily' shortlink to the concrete build it currently resolves
+    # to, then derive both the script and checksum URLs from that single build so a
+    # publish happening mid-download cannot cause a spurious checksum mismatch.
+    $resolvedUrl = Resolve-DotnetupFinalUrl $getterUrl
+    if ($resolvedUrl -and $resolvedUrl -like "*/public/*") {
+        Write-Host "Resolved get-dotnetup.ps1 to concrete build: $resolvedUrl" -ForegroundColor DarkGray
+        $getterUrl = $resolvedUrl
+        # Checksums live under the sibling 'public-checksums' path with a .sha512 suffix.
+        $checksumUrl = ($resolvedUrl -replace '/public/', '/public-checksums/') + ".sha512"
+    }
+    else {
+        Write-Host "Could not resolve get-dotnetup.ps1 shortlink to a concrete build; using shortlink URLs directly." -ForegroundColor DarkGray
     }
 
+    $getterScript = Join-Path ([System.IO.Path]::GetTempPath()) ("get-dotnetup-{0}.ps1" -f [System.IO.Path]::GetRandomFileName())
+    $checksumFile = "$getterScript.sha512"
+
     try {
+        Invoke-DotnetupDownload -Uri $getterUrl -OutFile $getterScript -Description "Download of dotnetup installer"
+        Invoke-DotnetupDownload -Uri $checksumUrl -OutFile $checksumFile -Description "Download of dotnetup installer checksum"
+
+        $expected = ((Get-Content $checksumFile -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+        $actual = Get-DotnetupSha512 $getterScript
+        if ($expected -ne $actual) {
+            throw "get-dotnetup.ps1 checksum mismatch.`n  Expected: $expected`n  Actual:   $actual"
+        }
+        Write-Host "get-dotnetup.ps1 checksum verified." -ForegroundColor DarkGray
+
         Invoke-GetDotnetupScript -ScriptPath $getterScript -InstallDir $DotnetupDir -ErrorLabel "get-dotnetup.ps1"
     }
     finally {
         Remove-Item $getterScript -Force -ErrorAction SilentlyContinue
+        Remove-Item $checksumFile -Force -ErrorAction SilentlyContinue
     }
 }

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -47,10 +47,34 @@ function ShouldUseCachedDotnetup {
   return 0
 }
 
+# Follows redirects for a mutable 'daily' shortlink and prints the concrete,
+# versioned URL it currently points at (empty if it cannot be resolved). The daily
+# aka.ms link is a moving pointer, so downloading the script and its .sha512 as two
+# separate requests can straddle a new build publish and yield a script from one
+# build with a checksum from another. Resolving the shortlink to a single concrete
+# URL first lets us derive both the script and checksum URLs from the same build so
+# they always match. This mirrors the standalone get-dotnetup script's own binary
+# check, but is kept as a deliberately separate copy here because that script does
+# not exist in this branch and must stand alone.
+function ResolveDotnetupFinalUrl {
+  local url="$1"
+  if command -v curl > /dev/null 2>&1; then
+    # --head resolves redirects without downloading the body.
+    curl --silent --show-error --location --head --output /dev/null \
+      --write-out '%{url_effective}' "$url" 2>/dev/null
+  elif command -v wget > /dev/null 2>&1; then
+    # wget lacks --write-out; --spider -S prints the redirect headers, whose final 'Location:' is the concrete build URL. tolower() keeps awk portable.
+    wget --spider -S "$url" 2>&1 \
+      | awk 'tolower($1) == "location:" { u = $2 } END { if (u != "") print u }'
+  fi
+  # An empty result falls back to the shortlink URLs used by the caller.
+}
+
 # Downloads the public dotnetup installer from aka.ms
-# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh) and runs it to install dotnetup into
-# the directory given by $1. Returns non-zero on failure. Callers run under
-# `set -e`, so invoke via `if ! AcquireDotnetup ...; then` to handle failure.
+# (https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh), verifies its SHA-512
+# checksum, and runs it to install dotnetup into the directory given by $1. Returns
+# non-zero on failure. Callers run under `set -e`, so invoke via
+# `if ! AcquireDotnetup ...; then` to handle failure.
 #
 # If a local get-dotnetup.sh script exists in the repo (scripts/get-dotnetup.sh),
 # it is used directly instead of downloading from aka.ms. This supports branches
@@ -72,26 +96,84 @@ function AcquireDotnetup {
   fi
 
   local getter_url="https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh"
-  local getter_script
+  local checksum_url="${getter_url}.sha512"
+
+  # Pin the mutable 'daily' shortlink to the concrete build it currently resolves
+  # to, then derive both the script and checksum URLs from that single build so a
+  # publish happening mid-download cannot cause a spurious checksum mismatch.
+  local resolved_url
+  resolved_url="$(ResolveDotnetupFinalUrl "$getter_url" || true)"
+  if [[ -n "$resolved_url" && "$resolved_url" == *"/public/"* ]]; then
+    echo "Resolved get-dotnetup.sh to concrete build: $resolved_url"
+    getter_url="$resolved_url"
+    # Checksums live under the sibling 'public-checksums' path. Use sed, not bash
+    # ${var/p/r}, since bash 3.2 (macOS) keeps the escaped backslashes literally.
+    checksum_url="$(printf '%s' "$resolved_url" | sed 's#/public/#/public-checksums/#').sha512"
+  else
+    echo "Could not resolve get-dotnetup.sh shortlink to a concrete build; using shortlink URLs directly."
+  fi
+
+  local getter_script checksum_file
   # Use an explicit template: bare `mktemp` is not portable because BSD/macOS
   # mktemp requires a template (or -t prefix) and errors without one.
   getter_script="$(mktemp "${TMPDIR:-/tmp}/get-dotnetup.XXXXXX")"
+  checksum_file="${getter_script}.sha512"
 
-  local downloaded=false
+  local downloader=""
   if command -v curl > /dev/null 2>&1; then
-    if curl -fsSL --retry 3 "$getter_url" -o "$getter_script"; then downloaded=true; fi
+    downloader="curl"
   elif command -v wget > /dev/null 2>&1; then
-    if wget -q --tries=3 -O "$getter_script" "$getter_url"; then downloaded=true; fi
+    downloader="wget"
   else
     echo "Cannot download dotnetup: neither 'curl' nor 'wget' is available on PATH. Install one of them to acquire dotnetup." >&2
+    rm -f "$getter_script" "$checksum_file"
+    return 1
   fi
+
+  DownloadDotnetupFile() {
+    local url="$1" out="$2"
+    if [[ "$downloader" == "curl" ]]; then
+      curl -fsSL --retry 3 "$url" -o "$out"
+    else
+      wget -q --tries=3 -O "$out" "$url"
+    fi
+  }
 
   local result=0
-  if [[ "$downloaded" != true ]] || ! bash "$getter_script" --install-dir "$dotnetup_dir"; then
+  if ! DownloadDotnetupFile "$getter_url" "$getter_script"; then
+    echo "Failed to download dotnetup installer from $getter_url" >&2
     result=1
+  elif ! DownloadDotnetupFile "$checksum_url" "$checksum_file"; then
+    echo "Failed to download dotnetup installer checksum from $checksum_url" >&2
+    result=1
+  else
+    local expected actual
+    expected="$(awk '{print tolower($1)}' "$checksum_file")"
+    if command -v sha512sum > /dev/null 2>&1; then
+      actual="$(sha512sum "$getter_script" | awk '{print tolower($1)}')"
+    elif command -v shasum > /dev/null 2>&1; then
+      actual="$(shasum -a 512 "$getter_script" | awk '{print tolower($1)}')"
+    else
+      echo "Cannot verify dotnetup installer: neither 'sha512sum' nor 'shasum' is available on PATH." >&2
+      result=1
+    fi
+
+    if [[ "$result" -eq 0 && "$expected" != "$actual" ]]; then
+      echo "get-dotnetup.sh checksum mismatch." >&2
+      echo "  Expected: $expected" >&2
+      echo "  Actual:   $actual" >&2
+      result=1
+    fi
+
+    if [[ "$result" -eq 0 ]]; then
+      echo "get-dotnetup.sh checksum verified."
+      if ! bash "$getter_script" --install-dir "$dotnetup_dir"; then
+        result=1
+      fi
+    fi
   fi
 
-  rm -f "$getter_script"
+  rm -f "$getter_script" "$checksum_file"
   return $result
 }
 


### PR DESCRIPTION
## Summary

The eng bootstrap helpers (`Install-DotnetupFromAkaMs` / `AcquireDotnetup`) download the `get-dotnetup` installer script from the mutable `aka.ms/dotnet/dotnetup/daily` shortlink and run it **without verifying its integrity**. This adds a SHA-512 check of the downloaded script.

Because the daily shortlink is a moving pointer, fetching the script and its `.sha512` as two separate requests can straddle a build publish and yield a spurious mismatch (the same race fixed for the dotnetup binary in the standalone `get-dotnetup` script). To avoid that, the shortlink is resolved to its concrete versioned build once, and both the script and checksum URLs are derived from that single build so they always match.

## Changes
- `eng/dotnetup-shared.ps1` / `eng/dotnetup-shared.sh`:
  - Resolve `.../daily/get-dotnetup.*` → concrete `.../public/.../get-dotnetup.*` via a redirect-following HEAD.
  - Derive the checksum URL from the same build (`/public/` → `/public-checksums/` + `.sha512`).
  - Download both, compute SHA-512, compare, and only run the script on a match.

## Notes
- **Checks kept separate:** this is a standalone copy of the resolve/verify logic in the eng helpers — no shared import and no SYNC-block coupling to `scripts/get-dotnetup.*` (which does not exist on `main` and must stand alone).
- The repo-local getter path used by `release/dnup` is unchanged (that script is already trusted in-repo).

## Validation
- PS: parse-checks clean; `Get-DotnetupSha512` matches `Get-FileHash`; end-to-end over a local HTTP mock accepts a valid checksum (runs the script) and rejects a tampered one.
- Bash: `bash -n` clean; cross-tool SHA parity with PS confirmed; end-to-end `file://` mock accepts valid, rejects tampered.
