### PR TITLE
Preserve dotnetup output and return only the exit code from Invoke-DotnetupNativeCommand

### DIFF
--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -68,7 +68,15 @@ function Invoke-DotnetupNativeCommand([scriptblock]$Command) {
     $ErrorActionPreference = 'Continue'
     $PSNativeCommandUseErrorActionPreference = $false
     try {
-        & $Command
+        # Route the command's output to the host rather than this function's
+        # pipeline. This keeps dotnetup's progress and any error/diagnostic output
+        # visible (and preserved) in the build log, and -- critically -- prevents
+        # that output from being returned alongside the exit code. If it were
+        # captured, the caller would receive an object array (every stdout line
+        # plus the exit code) instead of a single integer, so an '-ne 0' check
+        # would always be truthy and a successful install (exit code 0) would be
+        # misreported as a failure.
+        & $Command | Out-Host
         return $LASTEXITCODE
     }
     catch {

--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -68,14 +68,7 @@ function Invoke-DotnetupNativeCommand([scriptblock]$Command) {
     $ErrorActionPreference = 'Continue'
     $PSNativeCommandUseErrorActionPreference = $false
     try {
-        # Route the command's output to the host rather than this function's
-        # pipeline. This keeps dotnetup's progress and any error/diagnostic output
-        # visible (and preserved) in the build log, and -- critically -- prevents
-        # that output from being returned alongside the exit code. If it were
-        # captured, the caller would receive an object array (every stdout line
-        # plus the exit code) instead of a single integer, so an '-ne 0' check
-        # would always be truthy and a successful install (exit code 0) would be
-        # misreported as a failure.
+        # Write command output to the host and prevent it from being returned alongside the exit code 
         & $Command | Out-Host
         return $LASTEXITCODE
     }


### PR DESCRIPTION
## Concern addressed
Fixes the root cause behind spurious `(InitializeToolset) Failed to install .NET SDK(s) ... using dotnetup` failures seen across multiple legs (e.g. [build 1499925](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1499925&view=results), PR #53715), where the reported *exit code* was actually the whole dotnetup install log ending in `0`.

## Root cause
`Invoke-DotnetupNativeCommand` (`eng/dotnetup-shared.ps1`) ran the dotnetup executable with `& \` and then `return \0`. A PowerShell function returns **all** pipeline output, so the return value was an `Object[]` = every stdout line from dotnetup **plus** the exit code, not a single integer.

At both call sites (`configure-toolset.ps1` bootstrap install and `restore-toolset.ps1` runtime install):
- `\ -ne 0` compared an **array** to 0 -> always truthy, so a **successful** install (exit 0) was **misreported as a failure**. dotnetup was not actually failing.
- dotnetup's real progress/diagnostic output was swallowed into the return value and only surfaced, mangled, inside the `(exit code '...')` text.

Repro:
```
STRINGIFIED: 'Installing SDK...  Installed at X: .NET SDK 11  0'
(-ne 0) => treated as failure? True     # even though exit code was 0
```

## Fix
Route the command's output to the host (`| Out-Host`) so it is preserved in the build log, and return only `\0` so callers get a real integer. Verified: success -> `Int32 0` (not a failure); genuine failure -> `Int32 7` (failure) with stderr preserved.

The bash path (`RunWithoutErrexit`) already captures `\True` correctly and is unaffected.

Draft for CI validation.