### PR TITLE
[release/dnup] Fail loudly instead of masking a broken dotnetup with dotnet-install fallback

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -35,8 +35,11 @@ function InstallBootstrapSdkWithDotnetup() {
             Install-DotnetupFromAkaMs $dotnetupDir
         }
         catch {
-            Write-Host "Failed to acquire dotnetup: $($_.Exception.Message). Will fall back to standard dotnet-install script." -ForegroundColor Yellow
-            return
+            # On release/dnup we deliberately do NOT fall back to the standard
+            # dotnet-install script when dotnetup cannot be acquired or is broken.
+            # Failing loudly here is how CI detects that dotnetup is badly broken.
+            Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to acquire dotnetup: $($_.Exception.Message)."
+            ExitWithExitCode 1
         }
     }
 

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -241,9 +241,11 @@ function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$archite
             Install-DotnetupFromAkaMs $dotnetupDir
         }
         catch {
-            Write-Host "Failed to acquire dotnetup ($($_.Exception.Message)); falling back to dotnet install script." -ForegroundColor Yellow
-            InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
-            return
+            # On release/dnup we deliberately do NOT fall back to the dotnet-install
+            # script when dotnetup cannot be acquired or is broken. Failing loudly
+            # here is how CI detects that dotnetup is badly broken.
+            Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to acquire dotnetup: $($_.Exception.Message)."
+            ExitWithExitCode 1
         }
     }
 
@@ -251,8 +253,8 @@ function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$archite
     & $dotnetupExe runtime install @runtimeSpecsToInstall --install-path $dotnetRoot --set-default-install false --untracked --interactive false
 
     if ($lastExitCode -ne 0) {
-        Write-Host "Failed to install shared frameworks ($($runtimeSpecsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode'); falling back to dotnet install script." -ForegroundColor Yellow
-        InstallDotNetSharedFrameworksWithInstallScript -RuntimeSpecs $runtimeSpecsToInstall -DotNetRoot $dotnetRoot -Architecture $architecture
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install shared frameworks ($($runtimeSpecsToInstall -join ', ')) to '$dotnetRoot' using dotnetup (exit code '$lastExitCode')."
+        ExitWithExitCode $lastExitCode
     }
 }
 

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -149,9 +149,11 @@ function InstallDotNetSharedFrameworks {
 
   if ! ShouldUseCachedDotnetup "$dotnetup_exe"; then
     if ! AcquireDotnetup "$dotnetup_dir"; then
-      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup; falling back to dotnet install script."
-      InstallDotNetSharedFrameworksWithInstallScript "$dotnet_root" "$arch" "${specs_to_install[@]}"
-      return
+      # On release/dnup we deliberately do NOT fall back to the dotnet-install
+      # script when dotnetup cannot be acquired or is broken. Failing loudly
+      # here is how CI detects that dotnetup is badly broken.
+      Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to acquire dotnetup."
+      ExitWithExitCode 1
     fi
   fi
 
@@ -167,8 +169,8 @@ function InstallDotNetSharedFrameworks {
   fi
 
   if [[ $lastexitcode != 0 ]]; then
-    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install shared frameworks (${specs_to_install[*]}) to '$dotnet_root' using dotnetup (exit code '$lastexitcode'); falling back to dotnet install script."
-    InstallDotNetSharedFrameworksWithInstallScript "$dotnet_root" "$arch" "${specs_to_install[@]}"
+    Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install shared frameworks (${specs_to_install[*]}) to '$dotnet_root' using dotnetup (exit code '$lastexitcode')."
+    ExitWithExitCode $lastexitcode
   fi
 }
 


### PR DESCRIPTION
## Concern addressed
On the `release/dnup` canary branch, a badly-broken dotnetup should surface as a **hard CI failure** instead of being silently masked by falling back to the standard dotnet-install script. Today several fallbacks quietly hide dotnetup breakage, so we cannot tell from a green build whether dotnetup actually worked.

## Change
Remove the dotnet-install *fallbacks* that mask dotnetup failures, replacing them with a categorized `Write-PipelineTelemetryError` + `ExitWithExitCode`:

- `eng/configure-toolset.ps1` - bootstrap SDK **acquire** path (previously `Write-Host ... return` -> arcade silently fell back).
- `eng/restore-toolset.ps1` / `eng/restore-toolset.sh` - test-runtime **acquire** and **install** paths (previously fell back to `InstallDotNetSharedFrameworksWithInstallScript`).

The bootstrap **install** failure path already hard-failed; this makes the acquire and runtime paths consistent.

## Deliberately preserved
The cross-architecture install-script path (`if arch`) is kept - that is a dotnetup capability gap (no `--architecture` override), **not** a dotnetup failure, so it must not hard-fail.

## Related
The companion fix for the misleading `exit code` output/false failures lives in main: dotnet/sdk#55208.

Draft for CI validation.