### PR TITLE
Bump OpenTelemetry pins to match SBRP (core/Http 1.16.0, Runtime 1.15.1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="$(MicrosoftBuildTaskAuthoringAnalyzerPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryDotnetPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryDotnetPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryDotnetContribPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationHttpPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryDotnetContribPackageVersion)" />
     <!-- roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,8 +60,9 @@
     <!-- When updating MicrosoftVisualStudioSolutionPersistenceVersion make sure to sync with dotnet/msbuild, dotnet/source-build-externals and NuGet/NuGet.Client -->
     <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
     <AzureMonitorOpenTelemetryExporterPackageVersion>1.4.0</AzureMonitorOpenTelemetryExporterPackageVersion>
-    <OpenTelemetryDotnetPackageVersion>1.15.3</OpenTelemetryDotnetPackageVersion>
+    <OpenTelemetryDotnetPackageVersion>1.16.0</OpenTelemetryDotnetPackageVersion>
     <OpenTelemetryDotnetContribPackageVersion>1.15.1</OpenTelemetryDotnetContribPackageVersion>
+    <OpenTelemetryInstrumentationHttpPackageVersion>1.16.0</OpenTelemetryInstrumentationHttpPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="MicroBuild.Core version">


### PR DESCRIPTION
## Summary

Aligns the SDK's OpenTelemetry package pins with the versions now shipped by source-built reference packages (SBRP) in dotnet/source-build-assets#1742.

The VMR codeflow PR dotnet/dotnet#7604 fails its source-only build leg (`SB_CentOSStream10`) with 6x `CS1705` errors in `src/sdk/src/Cli/dotnet/dotnet.csproj`: the source-built OpenTelemetry core assemblies (now 1.16.0, `AssemblyVersion 1.0.0.0`) conflict with the SDK still pinning the old 1.15.3 core packages. Bumping the SDK's pins to match SBRP resolves the skew.

## Version changes

| Package(s) | Old | New |
| --- | --- | --- |
| OpenTelemetry core — Api, Exporter.OpenTelemetryProtocol, Exporter.InMemory | 1.15.3 | **1.16.0** |
| OpenTelemetry.Instrumentation.Http | 1.15.1 | **1.16.0** |
| OpenTelemetry.Instrumentation.Runtime | 1.15.1 | 1.15.1 (unchanged — no 1.16.0 release exists on NuGet) |
| Azure.Monitor.OpenTelemetry.Exporter | 1.4.0 | 1.4.0 (unchanged) |

## Implementation notes

`OpenTelemetryDotnetContribPackageVersion` previously backed **both** `Instrumentation.Http` and `Instrumentation.Runtime`. Since Http (1.16.0) and Runtime (1.15.1) now diverge — and there is no 1.16.0 release of `Instrumentation.Runtime` — the shared variable had to be split. Http now uses a new `OpenTelemetryInstrumentationHttpPackageVersion`; `OpenTelemetryDotnetContribPackageVersion` now represents Runtime only.

These pins are manual/external (not tracked in `eng/Version.Details.xml`), so editing them directly is correct.

## Validation

Restored `src/Cli/dotnet/dotnet.csproj` cleanly with the new versions. The resolved graph in `project.assets.json` confirms the intended end state:

- `OpenTelemetry.Api` / `Exporter.OpenTelemetryProtocol` / `Exporter.InMemory` → 1.16.0
- `OpenTelemetry.Instrumentation.Http` → 1.16.0
- `OpenTelemetry.Instrumentation.Runtime` → 1.15.1

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>