### PR TITLE
[release/8.0.1xx] Disable network isolation on internal PR builds; enforce CFSClean3 on official

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -59,6 +59,15 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      settings:
+        networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+    ${{ else }}:
+      # Internal PR builds run under the 1ES Unofficial template. They restore from
+      # public feeds (nuget.org, npm, yarn), so network isolation is not applicable
+      # and is disabled to avoid spurious CFS clean violations.
+      settings:
+        networkIsolationMode: None
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
Port of the 1ES network isolation / CFS clean change to `release/8.0.1xx`.

## What
Scopes the 1ES `settings` in `.vsts-ci.yml` by `Build.Reason`:
- **Official builds** (`Build.Reason != PullRequest`): `networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3`.
- **Internal PR / unofficial builds** (`Build.Reason == PullRequest`): `networkIsolationMode: None` so network isolation does not run.

## Why
Internal PR builds extend the 1ES Unofficial template but still inject Network Isolation (default `Enforce`) and restore from public feeds, producing spurious CFS clean `NOT COMPLIANT` reports. Network isolation is not applicable to internal PR validation, so it is disabled there while CFS clean policy remains on official builds.

Companion to the internal `main` and `internal/release/6.0.4xx` changes.