### PR TITLE
Forward Azure DevOps log commands and host display messages to dotnet test (protocol 1.2.0/1.3.0)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -44,6 +44,14 @@ internal static class SessionEventTypes
     internal const byte TestSessionEnd = 1;
 }
 
+internal static class DisplayMessageLevels
+{
+    // These values flow over IPC as a single byte and must stay stable.
+    internal const byte Information = 0;
+    internal const byte Warning = 1;
+    internal const byte Error = 2;
+}
+
 internal static class HandshakeMessagePropertyNames
 {
     internal const byte PID = 0;
@@ -83,7 +91,10 @@ internal static class ProtocolConstants
     /// <summary>
     /// The protocol versions that are supported by the current SDK. Multiple versions can be present and be semicolon separated.
     /// </summary>
-    internal const string SupportedVersions = "1.0.0;1.1.0";
+    // 1.2.0 adds AzureDevOpsLogMessage (serializer id 11) forwarding; 1.3.0 adds DisplayMessage (serializer id 12) forwarding.
+    // NOTE: 1.4.0 (the reverse server-control pipe / server-initiated cancellation) is intentionally NOT advertised yet:
+    // it is a separate, larger feature that is out of scope here.
+    internal const string SupportedVersions = "1.0.0;1.1.0;1.2.0;1.3.0";
 }
 
 internal static class ProjectProperties

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/AzureDevOpsLogMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/AzureDevOpsLogMessage.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+internal sealed record AzureDevOpsLogMessage(string? ExecutionId, string? InstanceId, string? LogText) : IRequest;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/DisplayMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/DisplayMessage.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+internal sealed record DisplayMessage(string? ExecutionId, string? InstanceId, byte Level, string? Text) : IRequest;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -161,3 +161,26 @@ internal static class TestInProgressMessageFieldsId
     public const ushort Uid = 1;
     public const ushort DisplayName = 2;
 }
+
+internal static class AzureDevOpsLogMessageFieldsId
+{
+    public const int MessagesSerializerId = 11;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort LogText = 3;
+}
+
+internal static class DisplayMessageFieldsId
+{
+    public const int MessagesSerializerId = 12;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort Level = 3;
+    public const ushort Text = 4;
+}
+
+// NOTE: Serializer ids 13 (WaitForServerControlRequest) and 14 (ServerControlMessage) exist upstream
+// in testfx but are intentionally not vendored here yet: they belong to the reverse server-control pipe
+// / server-initiated cancellation feature (protocol 1.4.0), which is out of scope for this contract.

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+/*
+    |---FieldCount---| 2 bytes
+
+    |---ExecutionId Id---| (2 bytes)
+    |---ExecutionId Size---| (4 bytes)
+    |---ExecutionId Value---| (n bytes)
+
+    |---InstanceId Id---| (2 bytes)
+    |---InstanceId Size---| (4 bytes)
+    |---InstanceId Value---| (n bytes)
+
+    |---LogText Id---| (2 bytes)
+    |---LogText Size---| (4 bytes)
+    |---LogText Value---| (n bytes)
+*/
+
+internal sealed class AzureDevOpsLogMessageSerializer : BaseSerializer, INamedPipeSerializer
+{
+    public int Id => AzureDevOpsLogMessageFieldsId.MessagesSerializerId;
+
+    public object Deserialize(Stream stream)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+        string? logText = null;
+
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case AzureDevOpsLogMessageFieldsId.ExecutionId:
+                    executionId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case AzureDevOpsLogMessageFieldsId.InstanceId:
+                    instanceId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case AzureDevOpsLogMessageFieldsId.LogText:
+                    logText = ReadStringValue(stream, fieldSize);
+                    break;
+
+                default:
+                    // If we don't recognize the field id, skip the payload corresponding to that field
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
+            }
+        }
+
+        return new AzureDevOpsLogMessage(executionId, instanceId, logText);
+    }
+
+    public void Serialize(object objectToSerialize, Stream stream)
+    {
+        Debug.Assert(stream.CanSeek, "We expect a seekable stream.");
+
+        var message = (AzureDevOpsLogMessage)objectToSerialize;
+
+        WriteUShort(stream, GetFieldCount(message));
+
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.ExecutionId, message.ExecutionId);
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.InstanceId, message.InstanceId);
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.LogText, message.LogText);
+    }
+
+    private static ushort GetFieldCount(AzureDevOpsLogMessage message) =>
+        (ushort)((message.ExecutionId is null ? 0 : 1) +
+        (message.InstanceId is null ? 0 : 1) +
+        (message.LogText is null ? 0 : 1));
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/DisplayMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/DisplayMessageSerializer.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+/*
+    |---FieldCount---| 2 bytes
+
+    |---ExecutionId Id---| (2 bytes)
+    |---ExecutionId Size---| (4 bytes)
+    |---ExecutionId Value---| (n bytes)
+
+    |---InstanceId Id---| (2 bytes)
+    |---InstanceId Size---| (4 bytes)
+    |---InstanceId Value---| (n bytes)
+
+    |---Level Id---| (2 bytes)
+    |---Level Size---| (4 bytes)
+    |---Level Value---| (1 byte)
+
+    |---Text Id---| (2 bytes)
+    |---Text Size---| (4 bytes)
+    |---Text Value---| (n bytes)
+*/
+
+internal sealed class DisplayMessageSerializer : BaseSerializer, INamedPipeSerializer
+{
+    public int Id => DisplayMessageFieldsId.MessagesSerializerId;
+
+    public object Deserialize(Stream stream)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+        byte level = DisplayMessageLevels.Information;
+        string? text = null;
+
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case DisplayMessageFieldsId.ExecutionId:
+                    executionId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case DisplayMessageFieldsId.InstanceId:
+                    instanceId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case DisplayMessageFieldsId.Level:
+                    level = ReadByte(stream);
+
+                    // Level is a single byte today, but honor the declared field size so that a future
+                    // protocol revision that widens it (or a frame that reports a different size) does not
+                    // leave extra bytes unread and misalign the remaining fields.
+                    if (fieldSize > 1)
+                    {
+                        SetPosition(stream, stream.Position + (fieldSize - 1));
+                    }
+
+                    break;
+
+                case DisplayMessageFieldsId.Text:
+                    text = ReadStringValue(stream, fieldSize);
+                    break;
+
+                default:
+                    // If we don't recognize the field id, skip the payload corresponding to that field
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
+            }
+        }
+
+        return new DisplayMessage(executionId, instanceId, level, text);
+    }
+
+    public void Serialize(object objectToSerialize, Stream stream)
+    {
+        Debug.Assert(stream.CanSeek, "We expect a seekable stream.");
+
+        var message = (DisplayMessage)objectToSerialize;
+
+        WriteUShort(stream, GetFieldCount(message));
+
+        WriteField(stream, DisplayMessageFieldsId.ExecutionId, message.ExecutionId);
+        WriteField(stream, DisplayMessageFieldsId.InstanceId, message.InstanceId);
+        WriteField(stream, DisplayMessageFieldsId.Level, message.Level);
+        WriteField(stream, DisplayMessageFieldsId.Text, message.Text);
+    }
+
+    // Level is always written (it is a non-nullable byte); the two id strings and the text are optional.
+    private static ushort GetFieldCount(DisplayMessage message) =>
+        (ushort)((message.ExecutionId is null ? 0 : 1) +
+        (message.InstanceId is null ? 0 : 1) +
+        1 +
+        (message.Text is null ? 0 : 1));
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
@@ -19,6 +19,8 @@ namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
  * TestSessionEventSerializer: 8
  * HandshakeMessageSerializer: 9
  * TestInProgressMessagesSerializer: 10
+ * AzureDevOpsLogMessageSerializer: 11
+ * DisplayMessageSerializer: 12
  */
 
 internal static class RegisterSerializers
@@ -33,5 +35,7 @@ internal static class RegisterSerializers
         namedPipeBase.RegisterSerializer(new TestSessionEventSerializer(), typeof(TestSessionEvent));
         namedPipeBase.RegisterSerializer(new HandshakeMessageSerializer(), typeof(HandshakeMessage));
         namedPipeBase.RegisterSerializer(new TestInProgressMessagesSerializer(), typeof(TestInProgressMessages));
+        namedPipeBase.RegisterSerializer(new AzureDevOpsLogMessageSerializer(), typeof(AzureDevOpsLogMessage));
+        namedPipeBase.RegisterSerializer(new DisplayMessageSerializer(), typeof(DisplayMessage));
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -969,6 +969,22 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.Append(text);
         });
 
+    internal void WriteWarningMessage(string text) =>
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.SetColor(TerminalColor.DarkYellow);
+            terminal.AppendLine(text);
+            terminal.ResetColor();
+        });
+
+    internal void WriteErrorMessage(string text) =>
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.AppendLine(text);
+            terminal.ResetColor();
+        });
+
     /// <summary>
     /// Let the user know that cancellation was triggered.
     /// </summary>

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -319,6 +319,14 @@ internal sealed class TestApplication(
                         OnSessionEvent(sessionEvent);
                         break;
 
+                    case AzureDevOpsLogMessage azureDevOpsLogMessage:
+                        OnAzureDevOpsLogMessage(azureDevOpsLogMessage);
+                        break;
+
+                    case DisplayMessage displayMessage:
+                        OnDisplayMessage(displayMessage);
+                        break;
+
                     // If we don't recognize the message, log and skip it
                     case UnknownMessage unknownMessage:
                         Logger.LogTrace($"Request '{request.GetType()}' with Serializer ID = {unknownMessage.SerializerId} is unsupported.");
@@ -452,6 +460,12 @@ internal sealed class TestApplication(
 
     private void OnSessionEvent(TestSessionEvent sessionEvent)
         => _handler.OnSessionEventReceived(sessionEvent);
+
+    private void OnAzureDevOpsLogMessage(AzureDevOpsLogMessage azureDevOpsLogMessage)
+        => _handler.OnAzureDevOpsLogReceived(azureDevOpsLogMessage);
+
+    private void OnDisplayMessage(DisplayMessage displayMessage)
+        => _handler.OnDisplayMessageReceived(displayMessage);
 
     private sealed class ProcessOutputCollector(int liveOutputTailLineCount, Action<string> writeOutput)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -434,6 +434,48 @@ internal sealed class TestApplicationHandler
         }
     }
 
+    internal void OnAzureDevOpsLogReceived(AzureDevOpsLogMessage azureDevOpsLogMessage)
+    {
+        LogAzureDevOpsLog(azureDevOpsLogMessage);
+
+        // These messages carry verbatim Azure DevOps logging commands (e.g. ##[group] / ##[endgroup] / ##vso[...])
+        // that must reach the terminal unchanged so the AzDO agent can render them. They are informational and are
+        // not tied to a session, so - unlike the test-result handlers - we do not require a handshake and we are
+        // lenient about missing/empty content (we simply skip it) instead of failing the run.
+        if (!string.IsNullOrEmpty(azureDevOpsLogMessage.LogText))
+        {
+            _output.WriteMessage(azureDevOpsLogMessage.LogText);
+        }
+    }
+
+    internal void OnDisplayMessageReceived(DisplayMessage displayMessage)
+    {
+        LogDisplayMessage(displayMessage);
+
+        // Generic host diagnostics (hang/crash dump, retry summaries, extension/framework warnings and errors)
+        // forwarded outside of test results. They are informational and not tied to a session, so we do not require
+        // a handshake and we stay lenient about missing content.
+        if (string.IsNullOrEmpty(displayMessage.Text))
+        {
+            return;
+        }
+
+        switch (displayMessage.Level)
+        {
+            case DisplayMessageLevels.Warning:
+                _output.WriteWarningMessage(displayMessage.Text);
+                break;
+
+            case DisplayMessageLevels.Error:
+                _output.WriteErrorMessage(displayMessage.Text);
+                break;
+
+            default:
+                _output.WriteMessage(displayMessage.Text);
+                break;
+        }
+    }
+
     private (int TestSessionStartCount, int TestSessionEndCount) IncreaseTestSessionStart(string sessionUid)
     {
         _ = _testSessionEventCountPerSessionUid.TryGetValue(sessionUid, out var count);
@@ -650,6 +692,37 @@ internal sealed class TestApplicationHandler
         logMessageBuilder.AppendLine($"TestSessionEvent.SessionType: {testSessionEvent.SessionType}");
         logMessageBuilder.AppendLine($"TestSessionEvent.SessionUid: {testSessionEvent.SessionUid}");
         logMessageBuilder.AppendLine($"TestSessionEvent.ExecutionId: {testSessionEvent.ExecutionId}");
+        Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());
+    }
+
+    private static void LogAzureDevOpsLog(AzureDevOpsLogMessage azureDevOpsLogMessage)
+    {
+        if (!Logger.TraceEnabled)
+        {
+            return;
+        }
+
+        var logMessageBuilder = new StringBuilder();
+
+        logMessageBuilder.AppendLine($"AzureDevOpsLogMessage.ExecutionId: {azureDevOpsLogMessage.ExecutionId}");
+        logMessageBuilder.AppendLine($"AzureDevOpsLogMessage.InstanceId: {azureDevOpsLogMessage.InstanceId}");
+        logMessageBuilder.AppendLine($"AzureDevOpsLogMessage.LogText: {azureDevOpsLogMessage.LogText}");
+        Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());
+    }
+
+    private static void LogDisplayMessage(DisplayMessage displayMessage)
+    {
+        if (!Logger.TraceEnabled)
+        {
+            return;
+        }
+
+        var logMessageBuilder = new StringBuilder();
+
+        logMessageBuilder.AppendLine($"DisplayMessage.ExecutionId: {displayMessage.ExecutionId}");
+        logMessageBuilder.AppendLine($"DisplayMessage.InstanceId: {displayMessage.InstanceId}");
+        logMessageBuilder.AppendLine($"DisplayMessage.Level: {displayMessage.Level}");
+        logMessageBuilder.AppendLine($"DisplayMessage.Text: {displayMessage.Text}");
         Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -444,7 +444,10 @@ internal sealed class TestApplicationHandler
         // lenient about missing/empty content (we simply skip it) instead of failing the run.
         if (!string.IsNullOrEmpty(azureDevOpsLogMessage.LogText))
         {
-            _output.WriteMessage(azureDevOpsLogMessage.LogText);
+            // WriteMessage appends the payload verbatim without a trailing newline (the process-output streaming
+            // path supplies its own newlines). An Azure DevOps logging command must sit on its own line to be
+            // recognized, so terminate the line here without otherwise altering the payload.
+            _output.WriteMessage(EnsureTrailingNewLine(azureDevOpsLogMessage.LogText));
         }
     }
 
@@ -463,6 +466,7 @@ internal sealed class TestApplicationHandler
         switch (displayMessage.Level)
         {
             case DisplayMessageLevels.Warning:
+                // WriteWarningMessage/WriteErrorMessage terminate the line themselves (AppendLine).
                 _output.WriteWarningMessage(displayMessage.Text);
                 break;
 
@@ -471,10 +475,18 @@ internal sealed class TestApplicationHandler
                 break;
 
             default:
-                _output.WriteMessage(displayMessage.Text);
+                // The information path uses the verbatim WriteMessage, which does not append a newline, so
+                // terminate the line here to keep it from running together with subsequent terminal output.
+                _output.WriteMessage(EnsureTrailingNewLine(displayMessage.Text));
                 break;
         }
     }
+
+    // WriteMessage writes text verbatim (no trailing newline). Forwarded host messages arrive as individual
+    // lines without a terminator, so ensure one is present - but leave already-terminated payloads untouched
+    // to avoid introducing blank lines.
+    private static string EnsureTrailingNewLine(string text)
+        => text.EndsWith('\n') ? text : text + Environment.NewLine;
 
     private (int TestSessionStartCount, int TestSessionEndCount) IncreaseTestSessionStart(string sessionUid)
     {

--- a/test/dotnet.Tests/CommandTests/Test/AzureDevOpsLogMessageSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/AzureDevOpsLogMessageSerializerTests.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class AzureDevOpsLogMessageSerializerTests
+{
+    [TestMethod]
+    public void RoundTrips_WithAllFieldsPopulated()
+    {
+        var serializer = new AzureDevOpsLogMessageSerializer();
+        var original = new AzureDevOpsLogMessage(
+            ExecutionId: "exec-123",
+            InstanceId: "inst-456",
+            LogText: "##[group]My group");
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (AzureDevOpsLogMessage)serializer.Deserialize(stream);
+
+        Assert.AreEqual(original.ExecutionId, deserialized.ExecutionId);
+        Assert.AreEqual(original.InstanceId, deserialized.InstanceId);
+        Assert.AreEqual(original.LogText, deserialized.LogText);
+    }
+
+    [TestMethod]
+    public void RoundTrips_OmitsNullFields()
+    {
+        var serializer = new AzureDevOpsLogMessageSerializer();
+        var original = new AzureDevOpsLogMessage(
+            ExecutionId: null,
+            InstanceId: null,
+            LogText: "##[endgroup]");
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (AzureDevOpsLogMessage)serializer.Deserialize(stream);
+
+        Assert.IsNull(deserialized.ExecutionId);
+        Assert.IsNull(deserialized.InstanceId);
+        Assert.AreEqual("##[endgroup]", deserialized.LogText);
+    }
+
+    [TestMethod]
+    public void SerializerId_IsEleven()
+    {
+        // The IPC protocol reserves serializer IDs across SDK and MTP.
+        // ID 11 is the contract - keep this assertion to prevent accidental changes.
+        Assert.AreEqual(11, new AzureDevOpsLogMessageSerializer().Id);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/DisplayMessageSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/DisplayMessageSerializerTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class DisplayMessageSerializerTests
+{
+    [TestMethod]
+    public void RoundTrips_WithAllFieldsPopulated()
+    {
+        var serializer = new DisplayMessageSerializer();
+        var original = new DisplayMessage(
+            ExecutionId: "exec-123",
+            InstanceId: "inst-456",
+            Level: DisplayMessageLevels.Warning,
+            Text: "A warning from the host");
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (DisplayMessage)serializer.Deserialize(stream);
+
+        Assert.AreEqual(original.ExecutionId, deserialized.ExecutionId);
+        Assert.AreEqual(original.InstanceId, deserialized.InstanceId);
+        Assert.AreEqual(original.Level, deserialized.Level);
+        Assert.AreEqual(original.Text, deserialized.Text);
+    }
+
+    [TestMethod]
+    public void RoundTrips_OmitsNullStringFields_ButAlwaysWritesLevel()
+    {
+        var serializer = new DisplayMessageSerializer();
+        var original = new DisplayMessage(
+            ExecutionId: null,
+            InstanceId: null,
+            Level: DisplayMessageLevels.Error,
+            Text: null);
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (DisplayMessage)serializer.Deserialize(stream);
+
+        Assert.IsNull(deserialized.ExecutionId);
+        Assert.IsNull(deserialized.InstanceId);
+        Assert.AreEqual(DisplayMessageLevels.Error, deserialized.Level);
+        Assert.IsNull(deserialized.Text);
+    }
+
+    [TestMethod]
+    public void RoundTrips_InformationLevel()
+    {
+        var serializer = new DisplayMessageSerializer();
+        var original = new DisplayMessage(
+            ExecutionId: "exec-1",
+            InstanceId: "inst-1",
+            Level: DisplayMessageLevels.Information,
+            Text: "info");
+
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var deserialized = (DisplayMessage)serializer.Deserialize(stream);
+
+        Assert.AreEqual(DisplayMessageLevels.Information, deserialized.Level);
+        Assert.AreEqual("info", deserialized.Text);
+    }
+
+    [TestMethod]
+    public void SerializerId_IsTwelve()
+    {
+        // The IPC protocol reserves serializer IDs across SDK and MTP.
+        // ID 12 is the contract - keep this assertion to prevent accidental changes.
+        Assert.AreEqual(12, new DisplayMessageSerializer().Id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **consumer (SDK) side** of the `dotnet test` (Microsoft.Testing.Platform pipe protocol) feature that lets Azure DevOps log grouping — and other forwarded host messages — reach the pipeline log. The **host half already shipped in [microsoft/testfx](https://github.com/microsoft/testfx)**; this is the previously-missing `dotnet/sdk` half.

Under `dotnet test` with MTP, the test host runs as a child process and talks to the SDK over a named pipe. The host installs a forwarding output device that forwards two message classes over the pipe, **gated on the negotiated protocol version**:

- `AzureDevOpsLogMessage` (serializer id **11**, protocol **1.2.0+**) — verbatim Azure DevOps logging commands (`##[group]` / `##[endgroup]` / `##vso[...]`) produced by the AzureDevOpsReport extension. Must be written verbatim so AzDO renders the collapsible group.
- `DisplayMessage` (serializer id **12**, protocol **1.3.0+**) — generic host warning/error/info diagnostics produced outside test results (hang/crash dump, retry summaries, generic extension/framework warnings+errors).

The SDK previously advertised only `1.0.0;1.1.0`, so the host silently swallowed all of it. That was the core blocker.

## Changes

- **`CliConstants.cs`**: `ProtocolConstants.SupportedVersions` bumped `1.0.0;1.1.0` → `1.0.0;1.1.0;1.2.0;1.3.0`. Added `DisplayMessageLevels` (Information=0, Warning=1, Error=2). `1.4.0` (reverse server-control pipe / server-initiated cancellation) is intentionally **not** advertised — separate, larger feature, out of scope (noted in a comment).
- **`ObjectFieldIds.cs`** (vendored from testfx): added the id-11 (`AzureDevOpsLogMessageFieldsId`) and id-12 (`DisplayMessageFieldsId`) field classes. Ids 13/14 (server control, 1.4.0) intentionally omitted. The vendored baseline blob SHA in `eng/vendored-files.json` already matches upstream HEAD, so no manifest bump is needed.
- **Models** (`IPC/Models/`): `AzureDevOpsLogMessage(ExecutionId, InstanceId, LogText)` and `DisplayMessage(ExecutionId, InstanceId, byte Level, Text)`.
- **Serializers** (`IPC/Serializers/`): `AzureDevOpsLogMessageSerializer` and `DisplayMessageSerializer`, mirroring the SDK's `BaseSerializer` + `INamedPipeSerializer` style. Wire layout matches testfx byte-for-byte (Level always written as a single byte; deserialize honors `fieldSize` so a future widening won't misalign). Both registered in `RegisterSerializers.cs`.
- **Dispatch** (`TestApplication.cs`): route id 11 → `OnAzureDevOpsLogReceived`, id 12 → `OnDisplayMessageReceived`.
- **`TestApplicationHandler.cs`**: verbatim write of `LogText` for AzDO; `Level`-mapped write for display messages (0→message, 1→warning, 2→error). Lenient — these are informational, not tied to a session, so they don't require the TestHost handshake and don't fail the run on missing content. Added matching trace-logging helpers.
- **`TerminalTestReporter.cs`**: added `WriteWarningMessage` (DarkYellow) and `WriteErrorMessage` (DarkRed) sinks — the reporter previously only had a plain `WriteMessage`, so there was no clean warning/error sink for the display-message path.
- **Tests**: serializer round-trip tests for both new serializers (populated fields, null-field omission, always-present Level byte, serializer-id contract).

## Verification

- Production CLI (`src/Cli/dotnet/dotnet.csproj`) builds clean: **0 warnings, 0 errors**.
- New serializer round-trip tests pass (`--filter FullyQualifiedName~SerializerTests`): **15/15 passed, 0 failed**, covering ExecutionId/InstanceId/LogText and ExecutionId/InstanceId/Level/Text preservation including null-field omission and the always-present Level byte.

## Notes

- `ObjectFieldIds.cs` is vendored from testfx (`src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs`) and tracked in `eng/vendored-files.json`.
- Left as **draft** per request.