### PR TITLE
Fix DownloadBlobAsync retry tests failing in internal builds

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -90,7 +90,7 @@ internal sealed class Registry
     public string RegistryName { get; }
 
     internal Registry(string registryName, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null, Func<TimeSpan>? retryDelayProvider = null) :
-        this(new Uri($"https://{registryName}"), logger, registryAPI, settings)
+        this(new Uri($"https://{registryName}"), logger, registryAPI, settings, retryDelayProvider)
     { }
 
     internal Registry(string registryName, ILogger logger, RegistryMode mode, RegistrySettings? settings = null) :
@@ -99,7 +99,7 @@ internal sealed class Registry
 
 
     internal Registry(Uri baseUri, ILogger logger, IRegistryAPI registryAPI, RegistrySettings? settings = null, Func<TimeSpan>? retryDelayProvider = null) :
-        this(baseUri, logger, new RegistryApiFactory(registryAPI), settings)
+        this(baseUri, logger, new RegistryApiFactory(registryAPI), settings, retryDelayProvider)
     { }
 
     internal Registry(Uri baseUri, ILogger logger, RegistryMode mode, RegistrySettings? settings = null) :

--- a/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -552,7 +552,10 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_RetriesOnFailure));
 
         var repoName = "testRepo";
-        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
+        // Use a unique, valid SHA-256 digest so this test doesn't share a ContentStore
+        // path with tests running in parallel, and provide the matching response bytes.
+        var responseBytes = new byte[] { 1, 2, 3 };
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81", 1234);
         var cancellationToken = CancellationToken.None;
 
         var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);
@@ -560,7 +563,7 @@ public class RegistryTests : IDisposable
             .SetupSequence(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken))
             .ThrowsAsync(new Exception("Simulated failure 1")) // First attempt fails
             .ThrowsAsync(new Exception("Simulated failure 2")) // Second attempt fails
-            .ReturnsAsync(new MemoryStream(new byte[] { 1, 2, 3 })); // Third attempt succeeds
+            .ReturnsAsync(new MemoryStream(responseBytes)); // Third attempt succeeds
 
         Registry registry = new(repoName, logger, mockRegistryAPI.Object, null, () => TimeSpan.Zero);
 
@@ -592,7 +595,7 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_ThrowsAfterMaxRetries));
 
         var repoName = "testRepo";
-        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2", 1234);
         var cancellationToken = CancellationToken.None;
 
         var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);


### PR DESCRIPTION
Ports the fix from the internal PR [dnceng/internal dotnet-sdk!62124](https://dev.azure.com/dnceng/internal/_git/dotnet-sdk/pullrequest/62124) to the public `release/9.0.1xx` branch.

Two bugs fixed:

1. **`Registry.cs`** — The `Registry` constructor chain did not forward the `retryDelayProvider` parameter through the intermediate constructors, so it was always `null` at the private constructor and fell back to the default 1-second delay instead of the caller's value. This meant the injected `() => TimeSpan.Zero` in the retry tests was ignored (making the tests slow), and in internal builds the divergence contributed to the retry-test failure.

2. **`RegistryTests.cs`** — Both `DownloadBlobAsync_RetriesOnFailure` and `DownloadBlobAsync_ThrowsAfterMaxRetries` used the invalid, non-hex digest `sha256:testdigest1234`, so they shared the same `ContentStore` path and could interfere when running in parallel. Each test now uses a unique, valid 64-char SHA-256 digest.

/cc @lbussell