### PR TITLE
Enable MSBuild server by default in MSBuildForwardingApp

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -17,12 +17,12 @@ internal sealed class MSBuildForwardingAppWithoutLogging
     private static readonly bool AlwaysExecuteMSBuildOutOfProc = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_RUN_MSBUILD_OUTOFPROC");
 
     /// <summary>
-    /// An override flag that determines whether to use the MSBuild server - a persistent central node that can serve
+    /// A flag that determines whether to use the MSBuild server - a persistent central node that can serve
     /// as a place to cache data and prevent re-doing CoreCLR startup/JITting for small builds.
-    /// By default, the MSBuild server is disabled due to stability/correctness concerns with some 1P tasks that keep static state around,
-    /// but it can be used by users that are confident they will not encounter those issues.
+    /// By default, the MSBuild server is enabled, but users that hit stability/correctness concerns with some
+    /// 1P tasks that keep static state around can opt out by setting this to false.
     /// </summary>
-    private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", false);
+    private static readonly bool UseMSBuildServer = Env.GetEnvironmentVariableAsBool("DOTNET_CLI_USE_MSBUILD_SERVER", true);
 
     /// <summary>
     /// What the SDK's opinion is on the default terminal logger. The SDK defaults to '<c>auto</c>' which will use the terminal logger if the output is going to a terminal, otherwise it will use the console logger.
@@ -98,9 +98,10 @@ internal sealed class MSBuildForwardingAppWithoutLogging
 
         MSBuildPath = msbuildPath ?? defaultMSBuildPath;
 
-        // Only force MSBUILDUSESERVER on when DOTNET_CLI_USE_MSBUILD_SERVER opts in; otherwise leave
-        // any user-provided MSBUILDUSESERVER value untouched so it can toggle the server on its own.
-        if (UseMSBuildServer)
+        // The MSBuild server is enabled by default. Force MSBUILDUSESERVER on unless the user has opted out
+        // via DOTNET_CLI_USE_MSBUILD_SERVER, or has already set MSBUILDUSESERVER themselves - in which case we
+        // leave their value untouched so it can toggle the server on its own.
+        if (UseMSBuildServer && Env.GetEnvironmentVariable("MSBUILDUSESERVER") is null)
         {
             EnvironmentVariable("MSBUILDUSESERVER", "1");
         }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
@@ -95,5 +95,21 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath)
                 .GetProcessStartInfo().WorkingDirectory.Should().Be("");
         }
+
+        [TestMethod]
+        public void ItEnablesMSBuildServerByDefault()
+        {
+            //  The SDK enables the MSBuild server by default. Only assert this when the ambient environment
+            //  hasn't already expressed an opinion via MSBUILDUSESERVER or DOTNET_CLI_USE_MSBUILD_SERVER.
+            if (Environment.GetEnvironmentVariable("MSBUILDUSESERVER") != null ||
+                Environment.GetEnvironmentVariable("DOTNET_CLI_USE_MSBUILD_SERVER") != null)
+            {
+                return;
+            }
+
+            var msbuildPath = "<msbuildpath>";
+            var startInfo = new MSBuildForwardingApp(new string[0], msbuildPath).GetProcessStartInfo();
+            startInfo.Environment["MSBUILDUSESERVER"].Should().Be("1");
+        }
     }
 }


### PR DESCRIPTION
## Summary
2. in https://github.com/dotnet/msbuild/issues/14311
Makes the MSBuild server enabled by default in `MSBuildForwardingApp`. When the user hasn't specified anything about the MSBuild server, it is now turned on.

## Changes

- `DOTNET_CLI_USE_MSBUILD_SERVER` now defaults to `true` (was `false`).
- `MSBUILDUSESERVER=1` is only forced on when the user hasn't already set `MSBUILDUSESERVER` themselves, so an explicit opt-out (`MSBUILDUSESERVER=0`) or `DOTNET_CLI_USE_MSBUILD_SERVER=false` is still respected.
- Added `ItEnablesMSBuildServerByDefault` test verifying the default-on behavior.

## Behavior change

:warning: This is a **user-visible behavior change**: the MSBuild server is now on by default. Opt out via `DOTNET_CLI_USE_MSBUILD_SERVER=false` or `MSBUILDUSESERVER=0`.

## Testing

Ran `GivenMsbuildForwardingApp` locally against a full Debug build; the new test passes and existing server-related tests pass.
