### PR TITLE
Add 7-day grace period for new Known Build Error issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           script: |
             const CLOSE_KBE_AFTER_DAYS = 7;
+            const NEW_ISSUE_GRACE_DAYS = 7;
             const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
             const issues = await github.paginate(
@@ -55,6 +56,14 @@ jobs:
             for (const issue of issues) {
               if (issue.pull_request) continue;
               if (issue.labels.some(l => l.name === process.env.KEEP_OPEN_LABEL)) continue;
+
+              // Skip issues within the grace period so newly-opened KBEs
+              // aren't immediately marked stale before they can accumulate hits.
+              const issueAgeDays = (Date.now() - new Date(issue.created_at).getTime()) / MS_PER_DAY;
+              if (issueAgeDays < NEW_ISSUE_GRACE_DAYS) {
+                console.log(`  #${issue.number}: skipping (created ${issueAgeDays.toFixed(1)} days ago, within ${NEW_ISSUE_GRACE_DAYS}-day grace period)`);
+                continue;
+              }
 
               // Parse the hit count summary table from the issue body.
               // Format: |24-Hour Hit Count|7-Day Hit Count|1-Month Count|


### PR DESCRIPTION
## Summary

Adds a grace period to the `stale-known-build-errors` job in the stale workflow so that newly-opened Known Build Error issues aren't immediately marked stale before they've had time to accumulate any hits.

## Problem

When a new KBE issue is opened, it naturally has 0 hits in the 1-month count. The stale workflow runs twice daily and would immediately label the issue as stale and post the warning comment — even though the issue was just created and hasn't had a chance to be matched against any builds yet.

This was observed in #55215, where the issue was marked stale on the same day it was opened.

## Fix

Skip any issue whose `created_at` is less than 7 days ago (`NEW_ISSUE_GRACE_DAYS`). The resulting timeline for a new KBE with 0 hits:

- **Days 0–7**: Grace period — completely ignored by stale logic
- **Day 7+**: Gets labeled `stale` + warning comment
- **Day 14+**: Auto-closed (7 days after stale label was applied)