### PR TITLE
Stop shipping dnx from the SDK component on macOS

### DIFF
--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -122,8 +122,12 @@
           SourceFiles="@(SdkOutputFile)"
           DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <!-- Copy dnx script to root dotnet folder (which will map to DOTNETHOME) -->
-    <Copy SourceFiles="@(DnxShimSource)" DestinationFolder="$(IntermediateSdkInstallerOutputPath)" />
+    <!-- Copy dnx script to root dotnet folder (which will map to DOTNETHOME).
+         Skipped on macOS: the sharedhost pkg (from dotnet/runtime) now installs dnx
+         at the same location, so shipping it here creates overlapping component packages. -->
+    <Copy SourceFiles="@(DnxShimSource)"
+          DestinationFolder="$(IntermediateSdkInstallerOutputPath)"
+          Condition="!$([MSBuild]::IsOSPlatform('OSX'))" />
   </Target>
 
 </Project>


### PR DESCRIPTION
The `sharedhost` pkg (from [dotnet/runtime](https://github.com/dotnet/runtime)) now installs `dnx` at `/usr/local/share/dotnet`, so the SDK dev component emitting its own copy creates overlapping component packages in the macOS `.pkg`. Skip the `dnx` copy in `PrepareIntermediateSdkInstallerOutput` on macOS, mirroring the Linux cleanup in #54688. `LayoutDnxShim` and `src/Layout/redist/dnx` are kept for the tarball and Windows layouts.

Fixes #55116