### PR TITLE
Sync vendored dotnet test wire contract from testfx (Expected/Actual field ids)

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -10,8 +10,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "631a17e14d3222969c638302c318fb5dd3894ee3",
+          "baseline_ref_sha": "59d0f9b9f8604e7f366b9ab340a5d194adf85544",
+          "baseline_blob_sha": "f964693792a513c07bef616e35d4754b79257edb",
           "scope": "entire file; ids must match exactly"
         }
       ]

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -105,6 +105,14 @@ internal static class FailedTestResultMessageFieldsId
     public const ushort StandardOutput = 7;
     public const ushort ErrorOutput = 8;
     public const ushort SessionUid = 9;
+
+    // Optional assertion diff fields. They carry the structured expected/actual values captured by
+    // assertion libraries (e.g. MSTest's Assert stores them on Exception.Data["assert.expected"] /
+    // ["assert.actual"]) so the SDK's TerminalTestReporter can render the same expected-vs-actual diff
+    // for multi-assembly `dotnet test` runs that it already renders for single-assembly runs. Added
+    // after SessionUid; older readers skip unrecognized field ids, so this stays backwards compatible.
+    public const ushort Expected = 10;
+    public const ushort Actual = 11;
 }
 
 internal static class ExceptionMessageFieldsId


### PR DESCRIPTION
## What

Reconciles the vendored `dotnet test` ↔ Microsoft.Testing.Platform wire contract with `microsoft/testfx` `main`.

The scheduled vendored-files drift check reported exactly one drifted source: `src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs` (tracked against testfx's `ServerMode/DotnetTest/IPC/ObjectFieldIds.cs`). Upstream added two optional assertion-diff fields on `FailedTestResultMessageFieldsId`:

```csharp
public const ushort Expected = 10;
public const ushort Actual = 11;
```

These carry the structured expected/actual values captured by assertion libraries so the terminal reporter can render an expected-vs-actual diff for multi-assembly runs. This PR ports those two field-id reservations to keep the named-pipe contract byte-aligned with testfx, and bumps the entry's `baseline_ref_sha`/`baseline_blob_sha` in `eng/vendored-files.json` so the drift workflow goes quiet.

The additions are appended after existing ids, and the serializer skips unrecognized field ids, so this is fully backwards compatible.

## Deliberately not ported

- The upstream local-adaptation differences we always diverge on (file header, namespace, `[Embedded]` attributes).
- Upstream serializer ids **13** (`WaitForServerControlRequest`) and **14** (`ServerControlMessage`) — these belong to the reverse server-control pipe (protocol 1.4.0) and remain intentionally out of scope, as already noted in the local file.

## Verification

`python .github/scripts/check_vendored_files.py validate` → `Manifest OK: 30 entries, 38 sources.`
`python .github/scripts/check_vendored_files.py check --dry-run` → `Summary: 0 drifted, 0 errors.`

## Note on the MSTest/MTP version bump

The other half of the original request — bumping MSTest/MTP to "latest 3.4/2.4" — was not actioned here because it could not be resolved unambiguously: MSTest `3.4.3` (latest `3.4.x`) is already present on the `release/9.0.x` branches, no `Microsoft.Testing.Platform` `2.4.x` is published (latest public is `2.3.1`), and these versions normally flow into the SDK automatically via darc/Maestro from the VMR rather than via a hand-authored PR. Happy to follow up once the target branch/exact versions are confirmed.