### PR TITLE
Enable cross-architecture Native AOT tool packaging

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -63,7 +63,7 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     <_IsRidSpecific>false</_IsRidSpecific>
     <_IsRidSpecific Condition="'$(RuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' != 'any'">true</_IsRidSpecific>
     <!-- We need to know if the inner builds are _intended_ to be AOT even if we then explicitly disable AOT for the outer builds.
-      Knowing this lets us correctly decide to create the RID-specific inner tools or not when packaging the outer tool. -->
+      Knowing this lets us determine which RID-specific inner tools can be created on the current host. -->
     <_InnerToolsPublishAot>false</_InnerToolsPublishAot>
     <_InnerToolsPublishAot Condition="$(CreateRidSpecificToolPackages) and '$(PublishAot)' == 'true'">true</_InnerToolsPublishAot>
 
@@ -436,19 +436,52 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     </PropertyGroup>
   </Target>
 
-  <!-- Orchestrator for making the N RID-specific tool packages if this Tool supports that mode.
-       We can't call this for AOT'd tools because we can't AOT cross-architecture and cross-platform in .NET today. -->
-  <Target Name="_CreateRIDSpecificToolPackages"
-    Condition="'$(RuntimeIdentifier)' == ''
-      and $(CreateRidSpecificToolPackages)
-      and !$(_InnerToolsPublishAot)">
+  <!--
+    Extensibility point for determining which RID-specific tool packages can be built.
+
+    This target is intentionally empty. Consumers can define a target with
+    BeforeTargets="ComputeToolPackageRuntimeIdentifiersToPack" to inspect the tool packaging
+    inputs, including ToolPackageRuntimeIdentifiers and RuntimeIdentifiers, and add one
+    ToolPackageRuntimeIdentifiersToPack item for each RID that should be packaged. The SDK
+    subsequently orchestrates a Pack inner build for every ToolPackageRuntimeIdentifiersToPack
+    item.
+
+    If the consumer does not provide any ToolPackageRuntimeIdentifiersToPack items, the SDK
+    computes a default set based on the requested RIDs and the current host's build capabilities.
+  -->
+  <Target Name="ComputeToolPackageRuntimeIdentifiersToPack"
+          Condition="'$(RuntimeIdentifier)' == ''
+            and $(CreateRidSpecificToolPackages)" />
+
+  <!-- Apply the SDK defaults after consumers have had an opportunity to provide their own results. -->
+  <Target Name="_ComputeDefaultToolPackageRuntimeIdentifiersToPack"
+          Condition="'$(RuntimeIdentifier)' == ''
+            and $(CreateRidSpecificToolPackages)
+            and '@(ToolPackageRuntimeIdentifiersToPack)' == ''">
     <PropertyGroup>
-        <_PackageRids>$(ToolPackageRuntimeIdentifiers)</_PackageRids>
-        <_PackageRids Condition="'$(_PackageRids)' == ''">$(RuntimeIdentifiers)</_PackageRids>
+      <_PackageRids>$(ToolPackageRuntimeIdentifiers)</_PackageRids>
+      <_PackageRids Condition="'$(_PackageRids)' == ''">$(RuntimeIdentifiers)</_PackageRids>
     </PropertyGroup>
 
     <ItemGroup>
-        <_rids Include="$(_PackageRids)" />
+      <_RequestedToolPackageRuntimeIdentifier Include="$(_PackageRids)" />
+
+      <ToolPackageRuntimeIdentifiersToPack Include="@(_RequestedToolPackageRuntimeIdentifier)"
+                                           Condition="!$(_InnerToolsPublishAot)
+                                             or '%(Identity)' == '$(NETCoreSdkPortableRuntimeIdentifier)'
+                                             or ('$(NETCoreSdkPortableRuntimeIdentifier)' == 'win-x64' and '%(Identity)' == 'win-arm64')
+                                             or (($(NETCoreSdkPortableRuntimeIdentifier.StartsWith('osx-')))
+                                               and ('%(Identity)' == 'osx-x64' or '%(Identity)' == 'osx-arm64'))" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Orchestrator for making the RID-specific tool packages buildable on the current host. -->
+  <Target Name="_CreateRIDSpecificToolPackages"
+    DependsOnTargets="ComputeToolPackageRuntimeIdentifiersToPack;_ComputeDefaultToolPackageRuntimeIdentifiersToPack"
+    Condition="'$(RuntimeIdentifier)' == ''
+      and $(CreateRidSpecificToolPackages)">
+    <ItemGroup>
+        <_rids Include="@(ToolPackageRuntimeIdentifiersToPack)" />
         <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.PackTool.targets
@@ -481,8 +481,8 @@ NOTE: This file is imported from the following contexts, so be aware when writin
     Condition="'$(RuntimeIdentifier)' == ''
       and $(CreateRidSpecificToolPackages)">
     <ItemGroup>
-        <_rids Include="@(ToolPackageRuntimeIdentifiersToPack)" />
-        <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
+      <_rids Include="@(ToolPackageRuntimeIdentifiersToPack)" />
+      <_RidSpecificToolPackageProject Include="$(MSBuildProjectFullPath)" AdditionalProperties="RuntimeIdentifier=%(_rids.Identity);" />
     </ItemGroup>
 
     <MSBuild BuildInParallel="true" Projects="@(_RidSpecificToolPackageProject)" Targets="Pack">

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -327,6 +327,116 @@ namespace Microsoft.NET.ToolPack.Tests
         }
 
         [TestMethod]
+        public void Non_AOT_tools_can_pack_all_requested_runtime_identifiers()
+        {
+            ComputeToolPackageRuntimeIdentifiersToPack(
+                publishAot: false,
+                hostRuntimeIdentifier: "linux-x64")
+                .Should().Be("win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64");
+        }
+
+        [TestMethod]
+        [DataRow("win-x64", "win-x64;win-arm64")]
+        [DataRow("win-arm64", "win-arm64")]
+        [DataRow("osx-x64", "osx-x64;osx-arm64")]
+        [DataRow("osx-arm64", "osx-x64;osx-arm64")]
+        [DataRow("linux-x64", "linux-x64")]
+        [DataRow("linux-arm64", "linux-arm64")]
+        public void AOT_tools_only_pack_runtime_identifiers_supported_by_the_host(
+            string hostRuntimeIdentifier,
+            string expectedRuntimeIdentifiers)
+        {
+            ComputeToolPackageRuntimeIdentifiersToPack(
+                publishAot: true,
+                hostRuntimeIdentifier)
+                .Should().Be(expectedRuntimeIdentifiers);
+        }
+
+        [TestMethod]
+        public void Predefined_items_prevent_default_tool_package_runtime_identifier_computation()
+        {
+            ComputeToolPackageRuntimeIdentifiersToPack(
+                publishAot: true,
+                hostRuntimeIdentifier: "linux-x64",
+                predefinedRuntimeIdentifiersToPack: "win-arm64;osx-arm64")
+                .Should().Be("win-arm64;osx-arm64");
+        }
+
+        [TestMethod]
+        public void Custom_target_can_override_tool_package_runtime_identifiers_to_pack()
+        {
+            ComputeToolPackageRuntimeIdentifiersToPack(
+                publishAot: true,
+                hostRuntimeIdentifier: "linux-x64",
+                customTargetRuntimeIdentifiersToPack: "win-arm64;osx-arm64")
+                .Should().Be("win-arm64;osx-arm64");
+        }
+
+        private string ComputeToolPackageRuntimeIdentifiersToPack(
+            bool publishAot,
+            string hostRuntimeIdentifier,
+            string predefinedRuntimeIdentifiersToPack = null,
+            string customTargetRuntimeIdentifiersToPack = null,
+            [CallerMemberName] string callingMethod = "")
+        {
+            TestAsset testAsset = TestAssetsManager
+                .CopyTestAsset("PortableTool", $"{callingMethod}-{hostRuntimeIdentifier}")
+                .WithSource();
+
+            if (predefinedRuntimeIdentifiersToPack is not null || customTargetRuntimeIdentifiersToPack is not null)
+            {
+                testAsset.WithProjectChanges(project =>
+                {
+                    XNamespace ns = project.Root.Name.Namespace;
+
+                    if (predefinedRuntimeIdentifiersToPack is not null)
+                    {
+                        project.Root.Add(
+                            new XElement(
+                                ns + "ItemGroup",
+                                new XElement(
+                                    ns + "ToolPackageRuntimeIdentifiersToPack",
+                                    new XAttribute("Include", predefinedRuntimeIdentifiersToPack))));
+                    }
+
+                    if (customTargetRuntimeIdentifiersToPack is not null)
+                    {
+                        project.Root.Add(
+                            new XElement(
+                                ns + "Target",
+                                new XAttribute("Name", "OverrideToolPackageRuntimeIdentifiersToPack"),
+                                new XAttribute("BeforeTargets", "ComputeToolPackageRuntimeIdentifiersToPack"),
+                                new XElement(
+                                    ns + "ItemGroup",
+                                    new XElement(
+                                        ns + "ToolPackageRuntimeIdentifiersToPack",
+                                        new XAttribute("Include", customTargetRuntimeIdentifiersToPack)))));
+                    }
+                });
+            }
+
+            List<string> arguments =
+            [
+                $"/p:PublishAot={publishAot}",
+                "/p:ToolPackageRuntimeIdentifiers=\"win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64\"",
+                $"/p:NETCoreSdkPortableRuntimeIdentifier={hostRuntimeIdentifier}",
+                "/p:RuntimeIdentifier=",
+                "-getItem:ToolPackageRuntimeIdentifiersToPack",
+                $"/bl:{callingMethod}-{hostRuntimeIdentifier}.binlog",
+            ];
+
+            CommandResult result = new MSBuildCommand(
+                testAsset,
+                "ComputeToolPackageRuntimeIdentifiersToPack;_ComputeDefaultToolPackageRuntimeIdentifiersToPack")
+                .ExecuteWithoutRestore([.. arguments]);
+            result.Should().Pass();
+            return string.Join(
+                ";",
+                JObject.Parse(result.StdOut)["Items"]["ToolPackageRuntimeIdentifiersToPack"]
+                    .Select(item => item["Identity"].Value<string>()));
+        }
+
+        [TestMethod]
         public void It_packs_with_RuntimeIdentifier()
         {
             var testProject = new TestProject("ToolWithRuntimeIdentifier")

--- a/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
+++ b/test/Microsoft.NET.ToolPack.Tests/GivenThatWeWantToPackAToolProject.cs
@@ -383,42 +383,42 @@ namespace Microsoft.NET.ToolPack.Tests
                 .CopyTestAsset("PortableTool", $"{callingMethod}-{hostRuntimeIdentifier}")
                 .WithSource();
 
-            if (predefinedRuntimeIdentifiersToPack is not null || customTargetRuntimeIdentifiersToPack is not null)
+            testAsset.WithProjectChanges(project =>
             {
-                testAsset.WithProjectChanges(project =>
-                {
-                    XNamespace ns = project.Root.Name.Namespace;
+                XNamespace ns = project.Root.Name.Namespace;
+                XElement propertyGroup = project.Root.Elements(ns + "PropertyGroup").First();
+                propertyGroup.SetElementValue(
+                    ns + "ToolPackageRuntimeIdentifiers",
+                    "win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64");
 
-                    if (predefinedRuntimeIdentifiersToPack is not null)
-                    {
-                        project.Root.Add(
+                if (predefinedRuntimeIdentifiersToPack is not null)
+                {
+                    project.Root.Add(
+                        new XElement(
+                            ns + "ItemGroup",
+                            new XElement(
+                                ns + "ToolPackageRuntimeIdentifiersToPack",
+                                new XAttribute("Include", predefinedRuntimeIdentifiersToPack))));
+                }
+
+                if (customTargetRuntimeIdentifiersToPack is not null)
+                {
+                    project.Root.Add(
+                        new XElement(
+                            ns + "Target",
+                            new XAttribute("Name", "OverrideToolPackageRuntimeIdentifiersToPack"),
+                            new XAttribute("BeforeTargets", "ComputeToolPackageRuntimeIdentifiersToPack"),
                             new XElement(
                                 ns + "ItemGroup",
                                 new XElement(
                                     ns + "ToolPackageRuntimeIdentifiersToPack",
-                                    new XAttribute("Include", predefinedRuntimeIdentifiersToPack))));
-                    }
-
-                    if (customTargetRuntimeIdentifiersToPack is not null)
-                    {
-                        project.Root.Add(
-                            new XElement(
-                                ns + "Target",
-                                new XAttribute("Name", "OverrideToolPackageRuntimeIdentifiersToPack"),
-                                new XAttribute("BeforeTargets", "ComputeToolPackageRuntimeIdentifiersToPack"),
-                                new XElement(
-                                    ns + "ItemGroup",
-                                    new XElement(
-                                        ns + "ToolPackageRuntimeIdentifiersToPack",
-                                        new XAttribute("Include", customTargetRuntimeIdentifiersToPack)))));
-                    }
-                });
-            }
+                                    new XAttribute("Include", customTargetRuntimeIdentifiersToPack)))));
+                }
+            });
 
             List<string> arguments =
             [
                 $"/p:PublishAot={publishAot}",
-                "/p:ToolPackageRuntimeIdentifiers=\"win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64\"",
                 $"/p:NETCoreSdkPortableRuntimeIdentifier={hostRuntimeIdentifier}",
                 "/p:RuntimeIdentifier=",
                 "-getItem:ToolPackageRuntimeIdentifiersToPack",


### PR DESCRIPTION
## Why

The .NET Tool packaging pipeline can create a pointer package plus RID-specific implementation packages in one invocation. Native AOT tools have historically been excluded from that orchestration because the base SDK cannot publish every requested RID from every host.

That restriction also blocks external packages from expanding the SDK's native cross-compilation capabilities. Packages such as [AotAnywhere](https://github.com/slang25/AotAnywhere) can provide additional Native AOT targets through toolchains such as Zig, but the Tool packaging pipeline currently has no supported way for them to tell the SDK which requested RIDs they can build. As a result, those packages cannot participate in multi-RID Native AOT tool packaging even when they can successfully publish all of the requested targets.

This change separates two responsibilities:

- A toolchain determines which requested RIDs are buildable on the current host.
- The SDK orchestrates one RID-specific inner `Pack` build for each selected RID.

## What changed

- Adds the empty `ComputeToolPackageRuntimeIdentifiersToPack` marker target as an extensibility point.
- Consumers can run a target with `BeforeTargets="ComputeToolPackageRuntimeIdentifiersToPack"`, inspect inputs such as `ToolPackageRuntimeIdentifiers` and `RuntimeIdentifiers`, and emit one `ToolPackageRuntimeIdentifiersToPack` item per supported RID.
- If no consumer supplies items, the base SDK computes a conservative default set:
  - non-AOT tools can package every requested RID;
  - Windows x64 can package `win-x64` and `win-arm64` Native AOT tools;
  - macOS x64 and Arm64 can package both `osx-x64` and `osx-arm64` Native AOT tools;
  - other Native AOT hosts package only their current host RID.
- `_CreateRIDSpecificToolPackages` then performs the existing inner-package orchestration for the selected items.

This keeps the base SDK's behavior limited to combinations supported by its native toolchain while allowing packages such as AotAnywhere to replace that capability decision without replacing the packaging pipeline.

## Testing

- Added coverage for non-AOT tools, the default Native AOT host/RID matrix, evaluation-time item overrides, and `BeforeTargets` customization.
- `GivenThatWeWantToPackAToolProject`: 91 passed, 4 skipped.