### PR TITLE
Revert "Work around Roslyn HotReload project-level analysis being disabled"

### DIFF
--- a/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/CompilationHandler.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Reflection;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Graph;
 using Microsoft.CodeAnalysis;
@@ -65,19 +64,6 @@ internal sealed class CompilationHandler : IDisposable
         _context = context;
         Workspace = new HotReloadMSBuildWorkspace(context.Logger, projectFile => (instances: _projectInstances.GetValueOrDefault(projectFile, []), project: null));
         _hotReloadService = new HotReloadService(Workspace.CurrentSolution.Services, () => ValueTask.FromResult(GetAggregateCapabilities()));
-        EnableRoslynProjectLevelAnalysis();
-    }
-
-    // Workaround for https://github.com/dotnet/roslyn/issues/81728: Roslyn PR #81729 gated project-level
-    // Hot Reload analysis behind a flag that is only enabled in HotReloadService(HostWorkspaceServices,
-    // ImmutableArray<string>). dotnet-watch uses the other constructor, so we enable it via reflection.
-    private static void EnableRoslynProjectLevelAnalysis()
-    {
-        const string TypeName = "Microsoft.CodeAnalysis.EditAndContinue.AbstractEditAndContinueAnalyzer";
-        var type = AppDomain.CurrentDomain.GetAssemblies()
-            .Select(a => a.GetType(TypeName, throwOnError: false))
-            .FirstOrDefault(t => t != null);
-        type?.GetField("EnableProjectLevelAnalysis", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, true);
     }
 
     public void Dispose()


### PR DESCRIPTION
This reverts commit 9a7cdc5f0c61c325c13f3e6ec3d04ab888a6be2b from PR https://github.com/dotnet/sdk/pull/55000 The roslyn issue was fixed.