### PR TITLE
Default BuildProjectReferences to false when NoBuild is true

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -35,6 +35,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- User-facing configuration-agnostic defaults -->
   <PropertyGroup>
+    <BuildProjectReferences Condition="'$(BuildProjectReferences)' == '' and '$(NoBuild)' == 'true'">false</BuildProjectReferences>
     <OutputType Condition=" '$(OutputType)' == '' ">Library</OutputType>
     <FileAlignment Condition=" '$(FileAlignment)' == '' ">512</FileAlignment>
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>

--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs
@@ -289,6 +289,40 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
+        public void It_does_not_build_project_references_when_no_build_is_requested()
+        {
+            var referencedProject = new TestProject()
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+            var referencingProject = new TestProject()
+            {
+                Name = "ReferencingProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+            };
+            referencingProject.ReferencedProjects.Add(referencedProject);
+
+            var testAsset = TestAssetsManager.CreateTestProject(referencingProject);
+            var buildCommand = new BuildCommand(testAsset);
+            buildCommand.Execute().Should().Pass();
+
+            var resolveReferencesCommand = new MSBuildCommand(Log, "ResolveReferences", buildCommand.FullPathProjectFile);
+
+            resolveReferencesCommand
+                .Execute("/p:NoBuild=true")
+                .Should()
+                .Pass();
+
+            resolveReferencesCommand
+                .Execute("/p:NoBuild=true", "/p:BuildProjectReferences=true")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("NETSDK1085");
+        }
+
+        [TestMethod]
         public void It_conditionally_references_project_based_on_tfm()
         {
             var testProjectA = new TestProject()


### PR DESCRIPTION
## Summary

- Default `BuildProjectReferences` to `false` for SDK projects when `NoBuild=true`.
- Prevent project-to-project reference resolution from invoking `Build` and triggering NETSDK1085 during no-build operations.
- Preserve explicit `BuildProjectReferences=true` behavior.
- Add regression coverage that exercises `ResolveReferences` on a prebuilt project-reference graph and verifies the explicit opt-in failure path.

## Testing

- `Microsoft.NET.Build.Tests.GivenThatWeWantToReferenceAProject.It_does_not_build_project_references_when_no_build_is_requested`

Fixes #55176