### PR TITLE
Temporarily disable It_builds_deps_correctly_when_projects_do_not_get_restored (msbuild#14274 regression)

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToBuildAnAppWithTransitiveNonSdkProjectRefs.cs
@@ -28,6 +28,7 @@ namespace Microsoft.NET.Build.Tests
         [OSCondition(OperatingSystems.Windows)]
         [DataRow("")]
         [DataRow("TestApp.")]
+        [Ignore("https://github.com/dotnet/sdk/issues/55263")]
         public void It_builds_deps_correctly_when_projects_do_not_get_restored(string prefix)
         {
             // NOTE the projects created by CreateTestProject:


### PR DESCRIPTION
Temporarily disables `It_builds_deps_correctly_when_projects_do_not_get_restored` (`Microsoft.NET.Build.Tests`), which regresses under the MSBuild flow that includes [dotnet/msbuild#14274](https://github.com/dotnet/msbuild/pull/14274) (`ExcludeRestorePackageImports=true` during implicit restore, change wave 18.10).

This is the same root cause as `ItCanTestAMultiTFMProjectWithImplicitRestore`, which was already disabled under #55263. For the `[DataRow("TestApp.")]` case, `TestApp.deps.json` now lists transitive non-SDK project references (excluded from restore via `_IsProjectRestoreSupported`) by their project name instead of their overridden `AssemblyName`.

Confirmed locally (rebuilding the SDK with MSBuild `18.10.0-1.26360.102`): fails with change wave 18.10 enabled, passes with `MSBUILDDISABLEFEATURESFROMVERSION=18.10`.

The MSBuild change is being reverted in [dotnet/msbuild#14349](https://github.com/dotnet/msbuild/pull/14349). Tracked for re-enable (alongside the other test) in #55263.
