### PR TITLE
Preserve whitespace paths in static web asset tasks

### DIFF
--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetEndpointsPropsFile.cs
@@ -91,7 +91,7 @@ public class GenerateStaticWebAssetEndpointsPropsFile : Task, IMultiThreadableTa
 
     private void WriteFile(byte[] data)
     {
-        var targetPropsFilePath = string.IsNullOrWhiteSpace(TargetPropsFilePath) ? TargetPropsFilePath : TaskEnvironment.GetAbsolutePath(TargetPropsFilePath).Value;
+        var targetPropsFilePath = string.IsNullOrEmpty(TargetPropsFilePath) ? TargetPropsFilePath : TaskEnvironment.GetAbsolutePath(TargetPropsFilePath).Value;
         var dataHash = ComputeHash(data);
         var fileExists = File.Exists(targetPropsFilePath);
         var existingFileHash = fileExists ? ComputeHash(File.ReadAllBytes(targetPropsFilePath)) : "";

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsManifest.cs
@@ -129,8 +129,8 @@ public class GenerateStaticWebAssetsManifest : Task, IMultiThreadableTask
     private void PersistManifest(StaticWebAssetsManifest manifest)
     {
         // Absolutize once; preserve original paths for log messages.
-        string absolutizedManifestPath = !string.IsNullOrWhiteSpace(ManifestPath) ? TaskEnvironment.GetAbsolutePath(ManifestPath) : ManifestPath;
-        bool isManifestCacheFileConfigured = !string.IsNullOrWhiteSpace(ManifestCacheFilePath);
+        string absolutizedManifestPath = !string.IsNullOrEmpty(ManifestPath) ? TaskEnvironment.GetAbsolutePath(ManifestPath) : ManifestPath;
+        bool isManifestCacheFileConfigured = !string.IsNullOrEmpty(ManifestCacheFilePath);
         string absolutizedManifestCacheFilePath = isManifestCacheFileConfigured ? TaskEnvironment.GetAbsolutePath(ManifestCacheFilePath) : ManifestCacheFilePath;
         var cacheFileExists = isManifestCacheFileConfigured && File.Exists(absolutizedManifestCacheFilePath);
         var manifestFileExists = File.Exists(absolutizedManifestPath);

--- a/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsPropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/GenerateStaticWebAssetsPropsFile.cs
@@ -160,7 +160,7 @@ public class GenerateStaticWebAssetsPropsFile : Task, IMultiThreadableTask
     private void WriteFile(byte[] data)
     {
         var dataHash = ComputeHash(data);
-        var targetPropsAbsoluteFilePath = string.IsNullOrWhiteSpace(TargetPropsFilePath) ? TargetPropsFilePath : TaskEnvironment.GetAbsolutePath(TargetPropsFilePath).Value;
+        var targetPropsAbsoluteFilePath = string.IsNullOrEmpty(TargetPropsFilePath) ? TargetPropsFilePath : TaskEnvironment.GetAbsolutePath(TargetPropsFilePath).Value;
 
         var fileExists = File.Exists(targetPropsAbsoluteFilePath);
         var existingFileHash = fileExists ? ComputeHash(File.ReadAllBytes(targetPropsAbsoluteFilePath)) : "";

--- a/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
@@ -95,7 +95,7 @@ public class ConcatenateCssFiles : Task, IMultiThreadableTask
 
         var content = builder.ToString();
 
-        string outputFile = string.IsNullOrWhiteSpace(OutputFile) ? OutputFile : TaskEnvironment.GetAbsolutePath(OutputFile);
+        string outputFile = string.IsNullOrEmpty(OutputFile) ? OutputFile : TaskEnvironment.GetAbsolutePath(OutputFile);
         if (!File.Exists(outputFile) || !SameContent(content, outputFile))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));

--- a/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
+++ b/src/StaticWebAssetsSdk/Tasks/ScopedCss/ConcatenateCssFiles.cs
@@ -95,7 +95,7 @@ public class ConcatenateCssFiles : Task, IMultiThreadableTask
 
         var content = builder.ToString();
 
-        string outputFile = string.IsNullOrEmpty(OutputFile) ? OutputFile : TaskEnvironment.GetAbsolutePath(OutputFile);
+        string outputFile = string.IsNullOrWhiteSpace(OutputFile) ? OutputFile : TaskEnvironment.GetAbsolutePath(OutputFile);
         if (!File.Exists(outputFile) || !SameContent(content, outputFile))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));

--- a/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackagePropsFile.cs
+++ b/src/StaticWebAssetsSdk/Tasks/StaticWebAssetsGeneratePackagePropsFile.cs
@@ -24,7 +24,7 @@ public class StaticWebAssetsGeneratePackagePropsFile : Task, IMultiThreadableTas
 
     public override bool Execute()
     {
-        var buildTargetPath = string.IsNullOrWhiteSpace(BuildTargetPath) ? BuildTargetPath : TaskEnvironment.GetAbsolutePath(BuildTargetPath).Value;
+        var buildTargetPath = string.IsNullOrEmpty(BuildTargetPath) ? BuildTargetPath : TaskEnvironment.GetAbsolutePath(BuildTargetPath).Value;
 
         var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"));
         var elements = (AdditionalImports ?? []).Select(e => e.ItemSpec).Prepend(PropsFileImport)

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
@@ -50,10 +50,10 @@ public class ConcatenateCssFilesMultiThreadingTest
                 OutputFile = relativeOutputFile
             };
 
-            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeOutputFile))
+            if (string.IsNullOrWhiteSpace(relativeOutputFile))
             {
                 Action execute = () => task.Execute();
-                execute.Should().Throw<Exception>();
+                execute.Should().Throw<ArgumentException>();
                 return;
             }
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
@@ -16,10 +16,41 @@ namespace Microsoft.AspNetCore.Razor.Tasks;
 [TestClass]
 public class ConcatenateCssFilesMultiThreadingTest
 {
+    private const string InputContents = ".counter { color: red; }";
+
     [TestMethod]
-    [DataRow("obj/scoped.styles.css")]
-    [DataRow(" ")]
-    public void ReadsInputsAndWritesBundleRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeOutputFile)
+    public void ReadsInputsAndWritesBundleRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory() =>
+        AssertWritesBundleRelativeToTaskEnvironmentProjectDirectory("obj/scoped.styles.css");
+
+    [TestMethod]
+    public void WhitespaceOutputFilePreservesPreMigrationFailure()
+    {
+        WithTask(" ", (task, _, _) =>
+        {
+            Action execute = () => task.Execute();
+            execute.Should().Throw<ArgumentException>();
+        });
+    }
+
+    private static void AssertWritesBundleRelativeToTaskEnvironmentProjectDirectory(string relativeOutputFile)
+    {
+        WithTask(relativeOutputFile, (task, projectDir, spawnDir) =>
+        {
+            task.Execute().Should().BeTrue("the task must run to completion when TaskEnvironment.ProjectDirectory differs from the process CWD");
+
+            var expectedOutput = Path.Combine(projectDir, relativeOutputFile);
+            File.Exists(expectedOutput).Should().BeTrue("the bundle should be written under the project dir, not the process CWD");
+
+            var incorrectOutput = Path.Combine(spawnDir, relativeOutputFile);
+            File.Exists(incorrectOutput).Should().BeFalse();
+
+            File.ReadAllText(expectedOutput).Should().Contain(InputContents);
+        });
+    }
+
+    private static void WithTask(
+        string outputFile,
+        Action<ConcatenateCssFiles, string, string> assertion)
     {
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(ConcatenateCssFilesMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
@@ -29,8 +60,7 @@ public class ConcatenateCssFilesMultiThreadingTest
 
         // The scoped css input lives under the project directory and is referenced with a relative
         // ItemSpec. It must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD.
-        const string inputContents = ".counter { color: red; }";
-        File.WriteAllText(Path.Combine(projectDir, "Counter.razor.rz.scp.css"), inputContents);
+        File.WriteAllText(Path.Combine(projectDir, "Counter.razor.rz.scp.css"), InputContents);
 
         var originalCurrentDirectory = Directory.GetCurrentDirectory();
         try
@@ -47,26 +77,10 @@ public class ConcatenateCssFilesMultiThreadingTest
                 ],
                 ProjectBundles = [],
                 ScopedCssBundleBasePath = "/",
-                OutputFile = relativeOutputFile
+                OutputFile = outputFile
             };
 
-            if (string.IsNullOrWhiteSpace(relativeOutputFile))
-            {
-                Action execute = () => task.Execute();
-                execute.Should().Throw<ArgumentException>();
-                return;
-            }
-
-            task.Execute().Should().BeTrue("the task must run to completion when TaskEnvironment.ProjectDirectory differs from the process CWD");
-
-            var expectedOutput = Path.Combine(projectDir, relativeOutputFile);
-            File.Exists(expectedOutput).Should().BeTrue("the bundle should be written under the project dir, not the process CWD");
-
-            var incorrectOutput = Path.Combine(spawnDir, relativeOutputFile);
-            File.Exists(incorrectOutput).Should().BeFalse();
-
-            // The input file content must have been read from the project directory.
-            File.ReadAllText(expectedOutput).Should().Contain(inputContents);
+            assertion(task, projectDir, spawnDir);
         }
         finally
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
@@ -17,8 +17,15 @@ namespace Microsoft.AspNetCore.Razor.Tasks;
 public class ConcatenateCssFilesMultiThreadingTest
 {
     [TestMethod]
-    public void ReadsInputsAndWritesBundleRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
+    [DataRow("obj/scoped.styles.css")]
+    [DataRow(" ")]
+    public void ReadsInputsAndWritesBundleRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeOutputFile)
     {
+        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeOutputFile))
+        {
+            return;
+        }
+
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(ConcatenateCssFilesMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -29,8 +36,6 @@ public class ConcatenateCssFilesMultiThreadingTest
         // ItemSpec. It must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD.
         const string inputContents = ".counter { color: red; }";
         File.WriteAllText(Path.Combine(projectDir, "Counter.razor.rz.scp.css"), inputContents);
-
-        var relativeOutputFile = Path.Combine("obj", "scoped.styles.css");
 
         var originalCurrentDirectory = Directory.GetCurrentDirectory();
         try

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
@@ -21,11 +21,6 @@ public class ConcatenateCssFilesMultiThreadingTest
     [DataRow(" ")]
     public void ReadsInputsAndWritesBundleRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeOutputFile)
     {
-        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeOutputFile))
-        {
-            return;
-        }
-
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(ConcatenateCssFilesMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -54,6 +49,13 @@ public class ConcatenateCssFilesMultiThreadingTest
                 ScopedCssBundleBasePath = "/",
                 OutputFile = relativeOutputFile
             };
+
+            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeOutputFile))
+            {
+                Action execute = () => task.Execute();
+                execute.Should().Throw<Exception>();
+                return;
+            }
 
             task.Execute().Should().BeTrue("the task must run to completion when TaskEnvironment.ProjectDirectory differs from the process CWD");
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -167,8 +167,15 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
     }
 
     [TestMethod]
-    public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory()
+    [DataRow("endpoints.props")]
+    [DataRow(" ")]
+    public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
     {
+        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
+        {
+            return;
+        }
+
         WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
         {
             // Arrange
@@ -198,7 +205,7 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
                         Path.Combine("wwwroot", "js", "sample.js"))
                 ],
                 PackagePathPrefix = "staticwebassets",
-                TargetPropsFilePath = "endpoints.props",
+                TargetPropsFilePath = relativeTargetPropsFilePath,
             };
 
             // Act
@@ -207,9 +214,9 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
             // Assert
             result.Should().BeTrue();
             errorMessages.Should().BeEmpty();
-            new FileInfo(Path.Combine(projectDir, "endpoints.props")).Should().Exist(
+            new FileInfo(Path.Combine(projectDir, relativeTargetPropsFilePath)).Should().Exist(
                 "a relative TargetPropsFilePath must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD");
-            File.Exists(Path.Combine(spawnDir, "endpoints.props")).Should().BeFalse();
+            File.Exists(Path.Combine(spawnDir, relativeTargetPropsFilePath)).Should().BeFalse();
         });
     }
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -167,59 +167,74 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
     }
 
     [TestMethod]
-    [DataRow("endpoints.props")]
-    [DataRow(" ")]
-    public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
+    public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory() =>
+        AssertWritesEndpointsPropsFileRelativeToTaskEnvironmentProjectDirectory("endpoints.props");
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Execute_WhitespaceTargetPropsFilePath_FailsOnWindows()
     {
         WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
         {
-            // Arrange
-            var errorMessages = new List<string>();
-            var buildEngine = new Mock<IBuildEngine>();
-            buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
-                .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+            var (task, _) = CreateTask(projectDir, " ");
+            Action execute = () => task.Execute();
+            execute.Should().Throw<Exception>();
+        });
+    }
 
-            var task = new GenerateStaticWebAssetEndpointsPropsFile
-            {
-                BuildEngine = buildEngine.Object,
-                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
-                StaticWebAssets =
-                [
-                    CreateStaticWebAsset(
-                        Path.Combine("wwwroot", "js", "sample.js"),
-                        "MyLibrary",
-                        "Discovered",
-                        Path.Combine("js", "sample.js"),
-                        "All",
-                        "All")
-                ],
-                StaticWebAssetEndpoints =
-                [
-                    CreateStaticWebAssetEndpoint(
-                        Path.Combine("js", "sample.js").Replace('\\', '/'),
-                        Path.Combine("wwwroot", "js", "sample.js"))
-                ],
-                PackagePathPrefix = "staticwebassets",
-                TargetPropsFilePath = relativeTargetPropsFilePath,
-            };
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void Execute_WhitespaceTargetPropsFilePath_WritesRelativeToTaskEnvironmentProjectDirectoryOnUnix() =>
+        AssertWritesEndpointsPropsFileRelativeToTaskEnvironmentProjectDirectory(" ");
 
-            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
-            {
-                Action execute = () => task.Execute();
-                execute.Should().Throw<Exception>();
-                return;
-            }
+    private static void AssertWritesEndpointsPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeTargetPropsFilePath)
+    {
+        WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
+        {
+            var (task, errorMessages) = CreateTask(projectDir, relativeTargetPropsFilePath);
 
-            // Act
-            var result = task.Execute();
-
-            // Assert
-            result.Should().BeTrue();
+            task.Execute().Should().BeTrue();
             errorMessages.Should().BeEmpty();
             new FileInfo(Path.Combine(projectDir, relativeTargetPropsFilePath)).Should().Exist(
                 "a relative TargetPropsFilePath must be resolved against TaskEnvironment.ProjectDirectory, not the process CWD");
             File.Exists(Path.Combine(spawnDir, relativeTargetPropsFilePath)).Should().BeFalse();
         });
+    }
+
+    private static (GenerateStaticWebAssetEndpointsPropsFile Task, List<string> ErrorMessages) CreateTask(
+        string projectDir,
+        string targetPropsFilePath)
+    {
+        var errorMessages = new List<string>();
+        var buildEngine = new Mock<IBuildEngine>();
+        buildEngine.Setup(e => e.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+            .Callback<BuildErrorEventArgs>(args => errorMessages.Add(args.Message));
+
+        var task = new GenerateStaticWebAssetEndpointsPropsFile
+        {
+            BuildEngine = buildEngine.Object,
+            TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
+            StaticWebAssets =
+            [
+                CreateStaticWebAsset(
+                    Path.Combine("wwwroot", "js", "sample.js"),
+                    "MyLibrary",
+                    "Discovered",
+                    Path.Combine("js", "sample.js"),
+                    "All",
+                    "All")
+            ],
+            StaticWebAssetEndpoints =
+            [
+                CreateStaticWebAssetEndpoint(
+                    Path.Combine("js", "sample.js").Replace('\\', '/'),
+                    Path.Combine("wwwroot", "js", "sample.js"))
+            ],
+            PackagePathPrefix = "staticwebassets",
+            TargetPropsFilePath = targetPropsFilePath,
+        };
+
+        return (task, errorMessages);
     }
 
     private static ITaskItem CreateStaticWebAsset(

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -171,11 +171,6 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
     [DataRow(" ")]
     public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
     {
-        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
-        {
-            return;
-        }
-
         WithDecoyCwdAndProjectDirectory((projectDir, spawnDir) =>
         {
             // Arrange
@@ -207,6 +202,13 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
                 PackagePathPrefix = "staticwebassets",
                 TargetPropsFilePath = relativeTargetPropsFilePath,
             };
+
+            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
+            {
+                Action execute = () => task.Execute();
+                execute.Should().Throw<Exception>();
+                return;
+            }
 
             // Act
             var result = task.Execute();

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -13,11 +13,47 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 public class GenerateStaticWebAssetsManifestMultiThreadingTest
 {
     [TestMethod]
-    [DataRow("output/manifest.json", "output/manifest.cache")]
-    [DataRow(" ", "  ")]
-    public void WritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(
+    public void WritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory() =>
+        AssertWritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory("output/manifest.json", "output/manifest.cache");
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void WhitespaceManifestAndCachePathsFailOnWindows()
+    {
+        WithTask(" ", "  ", (task, errorMessages, _, _) =>
+        {
+            task.Execute().Should().BeFalse();
+            errorMessages.Should().NotBeEmpty();
+        });
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void WhitespaceManifestAndCachePathsWriteRelativeToTaskEnvironmentProjectDirectoryOnUnix() =>
+        AssertWritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory(" ", "  ");
+
+    private static void AssertWritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory(
         string relativeManifestPath,
         string relativeManifestCacheFilePath)
+    {
+        WithTask(relativeManifestPath, relativeManifestCacheFilePath, (task, errorMessages, projectDir, spawnDir) =>
+        {
+            task.Execute().Should().BeTrue(string.Join("; ", errorMessages));
+
+            var expectedManifest = Path.Combine(projectDir, relativeManifestPath);
+            var expectedCache = Path.Combine(projectDir, relativeManifestCacheFilePath);
+            File.Exists(expectedManifest).Should().BeTrue("manifest must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
+            File.Exists(expectedCache).Should().BeTrue("cache must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
+
+            File.Exists(Path.Combine(spawnDir, relativeManifestPath)).Should().BeFalse();
+            File.Exists(Path.Combine(spawnDir, relativeManifestCacheFilePath)).Should().BeFalse();
+        });
+    }
+
+    private static void WithTask(
+        string manifestPath,
+        string manifestCacheFilePath,
+        Action<GenerateStaticWebAssetsManifest, List<string>, string, string> assertion)
     {
         // Layout: place project and decoy in disjoint subtrees so that the same
         // relative path produces different absolute paths from each root.
@@ -53,27 +89,11 @@ public class GenerateStaticWebAssetsManifestMultiThreadingTest
                 Source = "MyProject",
                 ManifestType = "Build",
                 Mode = "Default",
-                ManifestPath = relativeManifestPath,
-                ManifestCacheFilePath = relativeManifestCacheFilePath,
+                ManifestPath = manifestPath,
+                ManifestCacheFilePath = manifestCacheFilePath,
             };
 
-            if (OperatingSystem.IsWindows() &&
-                (string.IsNullOrWhiteSpace(relativeManifestPath) || string.IsNullOrWhiteSpace(relativeManifestCacheFilePath)))
-            {
-                task.Execute().Should().BeFalse();
-                errorMessages.Should().NotBeEmpty();
-                return;
-            }
-
-            task.Execute().Should().BeTrue(string.Join("; ", errorMessages));
-
-            var expectedManifest = Path.Combine(projectDir, relativeManifestPath);
-            var expectedCache = Path.Combine(projectDir, relativeManifestCacheFilePath);
-            File.Exists(expectedManifest).Should().BeTrue("manifest must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
-            File.Exists(expectedCache).Should().BeTrue("cache must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
-
-            File.Exists(Path.Combine(spawnDir, relativeManifestPath)).Should().BeFalse();
-            File.Exists(Path.Combine(spawnDir, relativeManifestCacheFilePath)).Should().BeFalse();
+            assertion(task, errorMessages, projectDir, spawnDir);
         }
         finally
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -13,8 +13,18 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 public class GenerateStaticWebAssetsManifestMultiThreadingTest
 {
     [TestMethod]
-    public void WritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
+    [DataRow("output/manifest.json", "output/manifest.cache")]
+    [DataRow(" ", "  ")]
+    public void WritesManifestAndCacheRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(
+        string relativeManifestPath,
+        string relativeManifestCacheFilePath)
     {
+        if (OperatingSystem.IsWindows() &&
+            (string.IsNullOrWhiteSpace(relativeManifestPath) || string.IsNullOrWhiteSpace(relativeManifestCacheFilePath)))
+        {
+            return;
+        }
+
         // Layout: place project and decoy in disjoint subtrees so that the same
         // relative path produces different absolute paths from each root.
         //   <testRoot>/project/output/   <-- TaskEnvironment.ProjectDirectory
@@ -49,19 +59,19 @@ public class GenerateStaticWebAssetsManifestMultiThreadingTest
                 Source = "MyProject",
                 ManifestType = "Build",
                 Mode = "Default",
-                ManifestPath = Path.Combine("output", "manifest.json"),
-                ManifestCacheFilePath = Path.Combine("output", "manifest.cache"),
+                ManifestPath = relativeManifestPath,
+                ManifestCacheFilePath = relativeManifestCacheFilePath,
             };
 
             task.Execute().Should().BeTrue(string.Join("; ", errorMessages));
 
-            var expectedManifest = Path.Combine(projectOutputDir, "manifest.json");
-            var expectedCache = Path.Combine(projectOutputDir, "manifest.cache");
+            var expectedManifest = Path.Combine(projectDir, relativeManifestPath);
+            var expectedCache = Path.Combine(projectDir, relativeManifestCacheFilePath);
             File.Exists(expectedManifest).Should().BeTrue("manifest must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
             File.Exists(expectedCache).Should().BeTrue("cache must be written under TaskEnvironment.ProjectDirectory, not the process CWD");
 
-            File.Exists(Path.Combine(spawnOutputDir, "manifest.json")).Should().BeFalse();
-            File.Exists(Path.Combine(spawnOutputDir, "manifest.cache")).Should().BeFalse();
+            File.Exists(Path.Combine(spawnDir, relativeManifestPath)).Should().BeFalse();
+            File.Exists(Path.Combine(spawnDir, relativeManifestCacheFilePath)).Should().BeFalse();
         }
         finally
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -19,12 +19,6 @@ public class GenerateStaticWebAssetsManifestMultiThreadingTest
         string relativeManifestPath,
         string relativeManifestCacheFilePath)
     {
-        if (OperatingSystem.IsWindows() &&
-            (string.IsNullOrWhiteSpace(relativeManifestPath) || string.IsNullOrWhiteSpace(relativeManifestCacheFilePath)))
-        {
-            return;
-        }
-
         // Layout: place project and decoy in disjoint subtrees so that the same
         // relative path produces different absolute paths from each root.
         //   <testRoot>/project/output/   <-- TaskEnvironment.ProjectDirectory
@@ -62,6 +56,14 @@ public class GenerateStaticWebAssetsManifestMultiThreadingTest
                 ManifestPath = relativeManifestPath,
                 ManifestCacheFilePath = relativeManifestCacheFilePath,
             };
+
+            if (OperatingSystem.IsWindows() &&
+                (string.IsNullOrWhiteSpace(relativeManifestPath) || string.IsNullOrWhiteSpace(relativeManifestCacheFilePath)))
+            {
+                task.Execute().Should().BeFalse();
+                errorMessages.Should().NotBeEmpty();
+                return;
+            }
 
             task.Execute().Should().BeTrue(string.Join("; ", errorMessages));
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -14,9 +14,42 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 {
     [TestMethod]
-    [DataRow("output/build.props")]
-    [DataRow(" ")]
-    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
+    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory() =>
+        AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory("output/build.props");
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void WhitespaceTargetPropsFilePathFailsOnWindows()
+    {
+        WithTask(" ", (task, _, _) =>
+        {
+            Action execute = () => task.Execute();
+            execute.Should().Throw<Exception>();
+        });
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void WhitespaceTargetPropsFilePathWritesRelativeToTaskEnvironmentProjectDirectoryOnUnix() =>
+        AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory(" ");
+
+    private static void AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeTargetPropsFilePath)
+    {
+        WithTask(relativeTargetPropsFilePath, (task, projectDir, spawnDir) =>
+        {
+            task.Execute().Should().BeTrue();
+
+            var expectedPath = Path.Combine(projectDir, relativeTargetPropsFilePath);
+            File.Exists(expectedPath).Should().BeTrue("the props file should be written under TaskEnvironment.ProjectDirectory, not the process CWD");
+
+            var incorrectPath = Path.Combine(spawnDir, relativeTargetPropsFilePath);
+            File.Exists(incorrectPath).Should().BeFalse("the props file must NOT be written relative to the process CWD");
+        });
+    }
+
+    private static void WithTask(
+        string targetPropsFilePath,
+        Action<GenerateStaticWebAssetsPropsFile, string, string> assertion)
     {
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(GenerateStaticWebAssetsPropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
@@ -36,7 +69,7 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
             {
                 BuildEngine = buildEngine.Object,
                 TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
-                TargetPropsFilePath = relativeTargetPropsFilePath,
+                TargetPropsFilePath = targetPropsFilePath,
                 StaticWebAssets = new TaskItem[]
                 {
                     new TaskItem(Path.Combine("wwwroot", "js", "app.js"), new Dictionary<string, string>
@@ -63,20 +96,7 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
                 }
             };
 
-            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
-            {
-                Action execute = () => task.Execute();
-                execute.Should().Throw<Exception>();
-                return;
-            }
-
-            task.Execute().Should().BeTrue();
-
-            var expectedPath = Path.Combine(projectDir, relativeTargetPropsFilePath);
-            File.Exists(expectedPath).Should().BeTrue("the props file should be written under TaskEnvironment.ProjectDirectory, not the process CWD");
-
-            var incorrectPath = Path.Combine(spawnDir, relativeTargetPropsFilePath);
-            File.Exists(incorrectPath).Should().BeFalse("the props file must NOT be written relative to the process CWD");
+            assertion(task, projectDir, spawnDir);
         }
         finally
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -18,11 +18,6 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
     [DataRow(" ")]
     public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
     {
-        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
-        {
-            return;
-        }
-
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(GenerateStaticWebAssetsPropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -67,6 +62,13 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
                     }),
                 }
             };
+
+            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
+            {
+                Action execute = () => task.Execute();
+                execute.Should().Throw<Exception>();
+                return;
+            }
 
             task.Execute().Should().BeTrue();
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -14,8 +14,15 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 {
     [TestMethod]
-    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory()
+    [DataRow("output/build.props")]
+    [DataRow(" ")]
+    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory_NotProcessCurrentDirectory(string relativeTargetPropsFilePath)
     {
+        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeTargetPropsFilePath))
+        {
+            return;
+        }
+
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(GenerateStaticWebAssetsPropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -34,7 +41,7 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
             {
                 BuildEngine = buildEngine.Object,
                 TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
-                TargetPropsFilePath = Path.Combine("output", "build.props"),
+                TargetPropsFilePath = relativeTargetPropsFilePath,
                 StaticWebAssets = new TaskItem[]
                 {
                     new TaskItem(Path.Combine("wwwroot", "js", "app.js"), new Dictionary<string, string>
@@ -63,10 +70,10 @@ public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 
             task.Execute().Should().BeTrue();
 
-            var expectedPath = Path.Combine(projectDir, "output", "build.props");
+            var expectedPath = Path.Combine(projectDir, relativeTargetPropsFilePath);
             File.Exists(expectedPath).Should().BeTrue("the props file should be written under TaskEnvironment.ProjectDirectory, not the process CWD");
 
-            var incorrectPath = Path.Combine(spawnDir, "output", "build.props");
+            var incorrectPath = Path.Combine(spawnDir, relativeTargetPropsFilePath);
             File.Exists(incorrectPath).Should().BeFalse("the props file must NOT be written relative to the process CWD");
         }
         finally

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
@@ -23,11 +23,6 @@ public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
     [DataRow(" ")]
     public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeBuildTargetPath)
     {
-        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeBuildTargetPath))
-        {
-            return;
-        }
-
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -49,6 +44,13 @@ public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
                 PropsFileImport = "Microsoft.AspNetCore.StaticWebAssets.props",
                 BuildTargetPath = relativeBuildTargetPath
             };
+
+            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeBuildTargetPath))
+            {
+                Action execute = () => task.Execute();
+                execute.Should().Throw<Exception>();
+                return;
+            }
 
             task.Execute().Should().BeTrue();
 

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
@@ -19,9 +19,42 @@ namespace Microsoft.AspNetCore.Razor.Tasks;
 public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
 {
     [TestMethod]
-    [DataRow("output/props.xml")]
-    [DataRow(" ")]
-    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeBuildTargetPath)
+    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory() =>
+        AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory("output/props.xml");
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void WhitespaceBuildTargetPathFailsOnWindows()
+    {
+        WithTask(" ", (task, _, _) =>
+        {
+            Action execute = () => task.Execute();
+            execute.Should().Throw<Exception>();
+        });
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void WhitespaceBuildTargetPathWritesRelativeToTaskEnvironmentProjectDirectoryOnUnix() =>
+        AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory(" ");
+
+    private static void AssertWritesPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeBuildTargetPath)
+    {
+        WithTask(relativeBuildTargetPath, (task, projectDir, spawnDir) =>
+        {
+            task.Execute().Should().BeTrue();
+
+            var expectedPath = Path.Combine(projectDir, relativeBuildTargetPath);
+            File.Exists(expectedPath).Should().BeTrue("the file should be written under the project dir, not the process CWD");
+
+            var incorrectPath = Path.Combine(spawnDir, relativeBuildTargetPath);
+            File.Exists(incorrectPath).Should().BeFalse();
+        });
+    }
+
+    private static void WithTask(
+        string buildTargetPath,
+        Action<StaticWebAssetsGeneratePackagePropsFile, string, string> assertion)
     {
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
@@ -42,23 +75,10 @@ public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
                 BuildEngine = buildEngine.Object,
                 TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
                 PropsFileImport = "Microsoft.AspNetCore.StaticWebAssets.props",
-                BuildTargetPath = relativeBuildTargetPath
+                BuildTargetPath = buildTargetPath
             };
 
-            if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeBuildTargetPath))
-            {
-                Action execute = () => task.Execute();
-                execute.Should().Throw<Exception>();
-                return;
-            }
-
-            task.Execute().Should().BeTrue();
-
-            var expectedPath = Path.Combine(projectDir, relativeBuildTargetPath);
-            File.Exists(expectedPath).Should().BeTrue("the file should be written under the project dir, not the process CWD");
-
-            var incorrectPath = Path.Combine(spawnDir, relativeBuildTargetPath);
-            File.Exists(incorrectPath).Should().BeFalse();
+            assertion(task, projectDir, spawnDir);
         }
         finally
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
@@ -19,8 +19,15 @@ namespace Microsoft.AspNetCore.Razor.Tasks;
 public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
 {
     [TestMethod]
-    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory()
+    [DataRow("output/props.xml")]
+    [DataRow(" ")]
+    public void WritesPropsFileRelativeToTaskEnvironmentProjectDirectory(string relativeBuildTargetPath)
     {
+        if (OperatingSystem.IsWindows() && string.IsNullOrWhiteSpace(relativeBuildTargetPath))
+        {
+            return;
+        }
+
         var testRoot = Path.Combine(AppContext.BaseDirectory, nameof(StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest), Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(testRoot, "project");
         var spawnDir = Path.Combine(testRoot, "spawn");
@@ -40,15 +47,15 @@ public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
                 BuildEngine = buildEngine.Object,
                 TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir),
                 PropsFileImport = "Microsoft.AspNetCore.StaticWebAssets.props",
-                BuildTargetPath = Path.Combine("output", "props.xml")
+                BuildTargetPath = relativeBuildTargetPath
             };
 
             task.Execute().Should().BeTrue();
 
-            var expectedPath = Path.Combine(projectDir, "output", "props.xml");
+            var expectedPath = Path.Combine(projectDir, relativeBuildTargetPath);
             File.Exists(expectedPath).Should().BeTrue("the file should be written under the project dir, not the process CWD");
 
-            var incorrectPath = Path.Combine(spawnDir, "output", "props.xml");
+            var incorrectPath = Path.Combine(spawnDir, relativeBuildTargetPath);
             File.Exists(incorrectPath).Should().BeFalse();
         }
         finally


### PR DESCRIPTION
### Context

Whitespace-only paths are valid on Unix, but only when the downstream file operations accepted them before task migration. In previous task migration the chose of using "isNullOrWhitespace" over "isNullOrEmpty" guard was done incorrectly in some cases.

### Changes Made

Use `IsNullOrEmpty` for four direct-write tasks. 
Keep `IsNullOrWhiteSpace` in `ConcatenateCssFiles` because its directory creation previously rejected whitespace, so absolutizing it would change behavior.

### Testing

- Separate Windows failure and Unix success tests