### PR TITLE
Stop shipping dnx from the SDK component on Windows

### DIFF
--- a/src/Layout/redist/dnx.cmd
+++ b/src/Layout/redist/dnx.cmd
@@ -14,4 +14,4 @@ set "SDK_PATH=%~dp0sdk\%SDK_VERSION%\dotnet.dll"
 
 "%DOTNET%" exec "%SDK_PATH%" dnx %*
 
-endlocal
+endlocal & exit /b %ERRORLEVEL%

--- a/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -123,11 +123,13 @@
           DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <!-- Copy dnx script to root dotnet folder (which will map to DOTNETHOME).
-         Skipped on macOS: the sharedhost pkg (from dotnet/runtime) now installs dnx
-         at the same location, so shipping it here creates overlapping component packages. -->
+         Skipped on macOS and Windows: the sharedhost pkg/MSI (from dotnet/runtime) now
+         installs dnx at the same location, so shipping it here creates overlapping
+         component packages. LayoutDnxShim still emits it into the base redist layout
+         (tarball/zip). -->
     <Copy SourceFiles="@(DnxShimSource)"
           DestinationFolder="$(IntermediateSdkInstallerOutputPath)"
-          Condition="!$([MSBuild]::IsOSPlatform('OSX'))" />
+          Condition="!$([MSBuild]::IsOSPlatform('OSX')) and !$([MSBuild]::IsOSPlatform('Windows'))" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Windows follow-up to #55241 (macOS) and #55116.

Today on Windows, `dnx.cmd` is shipped only by the SDK `dev` MSI; the runtime sharedhost MSI does not ship it. The runtime sharedhost is taking ownership of `dnx.cmd` (dotnet/runtime#130686), matching how the Unix `dnx` shim already lives in the host. This change stops the SDK `dev` MSI from also shipping it, so the two MSIs never write the same `dnx.cmd` into the install root.

This extends the `PrepareIntermediateSdkInstallerOutput` skip in `GenerateInstallerLayout.targets` to also skip Windows, mirroring the existing macOS/Linux cleanup. `LayoutDnxShim` and `src/Layout/redist/dnx.cmd` are intentionally kept because the base redist (zip) layout still needs the shim. `src/Layout/redist/dnx.cmd` is also updated to end with `endlocal & exit /b %ERRORLEVEL%` so the shim propagates `dnx`'s exit code instead of resetting it to 0.

This is the SDK half of a coordinated pair. It must ship in the same release as the dotnet/runtime change that adds `dnx.cmd` to the sharedhost MSI. Because Windows MSI does not hard-fail on cross-MSI overlap, the two changes must land together: shipping the runtime add without this SDK removal would leave `dnx.cmd` with two owners (overlap), while merging this alone (without the runtime side) would leave Windows installs without a `dnx.cmd` at all.