### PR TITLE
Keep MSTest.Sdk in sync with MSTest framework to fix NativeAOT test discovery

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -195,7 +195,13 @@ extends:
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             windowsJobParameterSets:
+            # TEMPORARILY DISABLED (disableJob: true): the win-arm64 NativeAOT cross-link fails with
+            # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)'
+            # because the ILCompiler-produced object isn't split into per-function sections, so the
+            # MSVC arm64 linker cannot apply the erratum fixup. This leg has never passed. Re-enable
+            # once the ILCompiler fix lands.
             - categoryName: AoT
+              disableJob: true
               runAoTTests: true
               targetArchitecture: arm64
               runtimeIdentifier: win-arm64

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -72,6 +72,10 @@ stages:
   # its mstat/dgml size-analysis artifacts (that step is gated on runAoTTests). It is build-only
   # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
   # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
+  # TEMPORARILY DISABLED (disableJob: true): the win-arm64 NativeAOT cross-link fails with
+  # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)' because
+  # the ILCompiler-produced object isn't split into per-function sections, so the MSVC arm64 linker
+  # cannot apply the erratum fixup. This leg has never passed. Re-enable once the ILCompiler fix lands.
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
     parameters:
       pool:
@@ -81,6 +85,7 @@ stages:
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
       windowsJobParameterSets:
       - categoryName: AoT
+        disableJob: true
         runAoTTests: true
         targetArchitecture: arm64
         runtimeIdentifier: win-arm64

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -549,6 +549,11 @@
       <Uri>https://github.com/microsoft/testfx</Uri>
       <Sha>f19af28482c9d0101cc2a380fb05e2483460d703</Sha>
     </Dependency>
+    <!-- MSTest.Sdk is consumed from global.json's msbuild-sdks (not as a PackageReference). -->
+    <Dependency Name="MSTest.Sdk" Version="4.4.0-preview.26360.5">
+      <Uri>https://github.com/microsoft/testfx</Uri>
+      <Sha>f19af28482c9d0101cc2a380fb05e2483460d703</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-preview.7.26363.117">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>b25932e8d128b5242f1d89691f8e8171b82774c0</Sha>

--- a/global.json
+++ b/global.json
@@ -29,6 +29,6 @@
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Build.Traversal": "4.1.82",
     "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6",
-    "MSTest.Sdk": "4.3.0-preview.26325.12"
+    "MSTest.Sdk": "4.4.0-preview.26360.5"
   }
 }


### PR DESCRIPTION
We had mismatched versions of the MSTest.Sdk and the MSTest package references.  Apparently this no longer works when using NativeAOT tests.  So this adds a declared dependency to MSTest.Sdk so the reference in global.json will get updated in sync.

**EDIT:** Also updated to temporarily disable win-arm64 NativeAOT (AoT) CI leg.  This was added in #55205 but has never passed, and is failing with errors like

```
dotnet-aot.obj : fatal error LNK1322: cannot avoid potential ARM hazard
   (Cortex-A53 MPCore processor bug #843419) in section 0x2; consider compiler option /Gy
error MSB3073: ...Hostx64\arm64\link.exe ... exited with code 1322
```

# Verbose Copilot description

The `test/dotnet-aot.Tests` project publishes as **NativeAOT** and relies on the MSTest **source generator** for test discovery (reflection-based discovery isn't AOT-safe). That requires two versions to stay coherent:

- **`MSTest.Sdk`** — the MSBuild SDK, pinned in `global.json` (`msbuild-sdks`), which provides the NativeAOT discovery targets + source generator.
- **`MSTestPackageVersion`** (the `MSTest` framework/runtime packages) — flowed by darc from `microsoft/testfx`.

A `dotnet/dotnet` flow bumped `MSTestPackageVersion` `4.3.0-preview.26355.11` → **`4.4.0-preview.26360.5`**, but `MSTest.Sdk` stayed pinned at **`4.3.0-preview.26325.12`** in `global.json`. Shortly after, #54719 enabled the `Run NativeAOT CLI Tests` leg for the first time.

With the SDK (4.3.0) and framework (4.4.0) skewed, the MSTest source generator registers **zero tests**, so the AOT binary reports `Test run summary: Zero tests ran` and exits with MTP code **8** — failing the leg on every `main` build. (Normal reflection-based MSTest runs tolerate the skew, so only the AOT leg breaks.)

#54719 itself was green because it was validated while MSTest was still coherent at 4.3.0; it merged into a `main` that had already moved the framework to 4.4.0.

## Fix

1. **`global.json`** — bump `MSTest.Sdk` to `4.4.0-preview.26360.5` (same `microsoft/testfx` build as the `MSTest` framework packages), re-cohering the source generator with the runtime.
2. **`eng/Version.Details.xml`** — track `MSTest.Sdk` as a darc dependency from `microsoft/testfx`, next to `MSTest`.

## Why this keeps them in sync going forward

`Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix.Sdk` already live in **both** `global.json` `msbuild-sdks` **and** `eng/Version.Details.xml`, so darc keeps their `global.json` versions updated in lockstep with the flow. `MSTest.Sdk` was the odd one out — `global.json` only, hand-bumped, free to drift. Tracking it in `Version.Details.xml` makes darc update `MSTest.Sdk` in `global.json` **together with** the `MSTest` framework packages on every `testfx` flow. Since `testfx` publishes both at the same build/version string, they can no longer drift apart.

## Verification

- `darc get-dependencies` parses the new `MSTest.Sdk` dependency.
- `global.json` is valid JSON; `eng/Version.Details.xml` is well-formed.
- `MSTest.Sdk 4.4.0-preview.26360.5` is present on the `dotnet-tools` / `test-tools` feeds and matches `MSTest 4.4.0-preview.26360.5` (build `f19af28`).

Fixes the `Run NativeAOT CLI Tests` failures introduced alongside #54719.