### PR TITLE
Enable wasm-tools workload for CoreCLR WASM targets

### DIFF
--- a/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -10,6 +10,7 @@
         "Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}",
         "Microsoft.NET.Sdk.WebAssembly.Pack.${NetVersion}",
         "Microsoft.NETCore.App.Runtime.Mono.${NetVersion}.browser-wasm",
+        "Microsoft.NETCore.App.Runtime.${NetVersion}.browser-wasm",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.${NetVersion}.browser-wasm"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
@@ -456,6 +457,13 @@
       "version": "${RuntimeVersion}",
       "alias-to": {
         "any": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm"
+      }
+    },
+    "Microsoft.NETCore.App.Runtime.${NetVersion}.browser-wasm" : {
+      "kind": "framework",
+      "version": "${RuntimeVersion}",
+      "alias-to": {
+        "any": "Microsoft.NETCore.App.Runtime.browser-wasm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.multithread.${NetVersion}.browser-wasm" : {

--- a/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -158,7 +158,7 @@
 
   <!-- start of TFM specific logic, make sure every node has a TargetsCurrent/TargetsNet* condition -->
 
-  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true' or '$(UsingWasiRuntimeWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task.${NetVersion}" />
+  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and '$(UseMonoRuntime)' != 'false' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true' or '$(UsingWasiRuntimeWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task.${NetVersion}" />
 
   <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(_IsAndroidLibraryMode)' == 'true')">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
@@ -209,12 +209,20 @@
     <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.${NetVersion}.tvossimulator-x64" />
   </ImportGroup>
 
-  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
+  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(UseMonoRuntime)' != 'false'">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
     <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.${NetVersion}.browser-wasm" />
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.${NetVersion}" />
+  </ImportGroup>
+
+  <!-- CoreCLR browser-wasm: only needs the WebAssembly.Sdk (build targets + emscripten).
+       No MonoTargets.Sdk, no MonoAOTCompiler, no AOT.Cross pack — the SDK resolves
+       the CoreCLR runtime pack and crossgen2 via its own KnownRuntimePack/KnownCrossgen2Pack. -->
+  <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(UseMonoRuntime)' == 'false'">
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk.${NetVersion}" />
   </ImportGroup>
 
   <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and '$(RuntimeIdentifier)' == 'wasi-wasm' and '$(UsingWasiRuntimeWorkload)' == 'true'">


### PR DESCRIPTION
## Summary

Mirrors the workload manifest changes from dotnet/runtime#130380 into the SDK's copy of the **Current** (net11) Mono toolchain workload manifest. This enables the existing `wasm-tools` workload to target CoreCLR `browser-wasm`, in addition to Mono, by including the CoreCLR WASM runtime pack.

The workload manifests are authored in this repo under `src/Workloads/Manifests/`. The runtime PR changed the equivalent `.in` templates on its side; this PR reflects those same changes here so the shipped manifest stays in sync.

## Changes

`src/Workloads/Manifests/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/`:

- **WorkloadManifest.json.in**
  - Add `Microsoft.NETCore.App.Runtime.${NetVersion}.browser-wasm` (the CoreCLR runtime pack) to the `wasm-tools` workload's pack list.
  - Add the corresponding `framework` pack definition aliasing to `Microsoft.NETCore.App.Runtime.browser-wasm`.
- **WorkloadManifest.targets.in**
  - Gate the Mono-only imports on `'$(UseMonoRuntime)' != 'false'`:
    - the `MonoAOTCompiler.Task` import, and
    - the `browser-wasm` ImportGroup that pulls in `MonoTargets.Sdk` and the `AOT.Cross` pack.
  - Add a CoreCLR (`'$(UseMonoRuntime)' == 'false'`) `browser-wasm` ImportGroup that only imports the `WebAssembly.Sdk` (build targets + Emscripten). The CoreCLR runtime pack and crossgen2 are resolved by the SDK via its own `KnownRuntimePack`/`KnownCrossgen2Pack`, so no `MonoTargets.Sdk`, `MonoAOTCompiler`, or `AOT.Cross` pack is needed.

## Notes

- Only the **Current** (net11) manifest is changed. The frozen net10/net9/… bands are intentionally left as-is, matching the runtime PR which targeted `main`.
- Pack version tokens use this repo's `${RuntimeVersion}` convention (resolving to the runtime pack package version) rather than runtime's `${PackageVersion}`, consistent with the surrounding Mono framework pack entries.

## Related

- dotnet/runtime#130380 — Enable wasm-tools workload for CoreCLR WASM targets
- Contributes to dotnet/runtime#126100