### PR TITLE
Add dotnet test environment variable parity

### DIFF
--- a/documentation/specs/dotnet-run-for-maui.md
+++ b/documentation/specs/dotnet-run-for-maui.md
@@ -173,9 +173,10 @@ device selection:
 
 * **`--list-devices`** works the same as with `dotnet run`.
 
-* **`-e` / `--environment`** — `dotnet test` already supports `-e` to
-  pass environment variables to the test process. This existing
-  behavior is unchanged.
+* **`-e` / `--environment`** — environment variables are passed to the test
+  process and, for projects that declare the `RuntimeEnvironmentVariableSupport`
+  capability, to the build, deployment, and `ComputeRunArguments` targets as
+  `@(RuntimeEnvironmentVariable)` items, matching `dotnet run`.
 
 ## New Command-line Switches
 
@@ -219,11 +220,12 @@ A new `--device` switch will:
 
 ## Environment Variables
 
-The `dotnet run` command supports passing environment variables via the
+The `dotnet run` and `dotnet test` commands support passing environment variables via the
 `-e` or `--environment` option:
 
 ```dotnetcli
 dotnet run -e FOO=BAR -e ANOTHER=VALUE
+dotnet test -e FOO=BAR -e ANOTHER=VALUE
 ```
 
 These environment variables are:
@@ -264,7 +266,7 @@ Workloads can consume these items in their MSBuild targets:
 
 ```xml
 <Target Name="DeployToDevice">
-  <!-- Access environment variables from dotnet run -e -->
+  <!-- Access environment variables from dotnet run/test -e -->
   <Message Text="Environment: @(RuntimeEnvironmentVariable->'%(Identity)=%(Value)')" />
 </Target>
 ```
@@ -273,14 +275,18 @@ Workloads can consume these items in their MSBuild targets:
 
 For the **build step**, which uses out-of-process MSBuild via `dotnet build`,
 environment variables are injected by creating a temporary `.props` file.
-The file is created in the project's `$(IntermediateOutputPath)` directory
-(e.g., `obj/Debug/net11.0-android/dotnet-run-env.props`). The path is
-obtained from the project evaluation performed during target framework and
-device selection. If `IntermediateOutputPath` is not available, the file
-falls back to the `obj/` directory.
+The file is created under the selected project intermediate output directory,
+or under the project's `obj/` directory when no intermediate output path is
+available (for example, `obj/dotnet-run-env.props` for `dotnet run` or
+`obj/dotnet-test-env.props` for `dotnet test`).
 
 The file is passed to MSBuild via the `CustomBeforeMicrosoftCommonProps` property,
-ensuring the items are available early in evaluation.
+ensuring the items are available during project evaluation. The CLI creates this
+file only after evaluating a project and confirming that it declares the
+`RuntimeEnvironmentVariableSupport` capability. Build-time injection is not
+performed for solution builds because the capability cannot be evaluated and
+applied independently to each solution child through a single global MSBuild
+property.
 The temporary file is automatically deleted after the build completes.
 
 The generated props file looks like:

--- a/src/Cli/dotnet/Commands/Run/EnvironmentVariablesToMSBuild.cs
+++ b/src/Cli/dotnet/Commands/Run/EnvironmentVariablesToMSBuild.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 /// </summary>
 internal static class EnvironmentVariablesToMSBuild
 {
-    private const string PropsFileName = "dotnet-run-env.props";
     private const string ValueMetadataName = "Value";
 
     /// <summary>
@@ -83,8 +82,13 @@ internal static class EnvironmentVariablesToMSBuild
     /// Optional intermediate output path where the file will be created.
     /// If null or empty, defaults to "obj" subdirectory of the project directory.
     /// </param>
+    /// <param name="propsFileName">The name of the generated props file.</param>
     /// <returns>The full path to the created props file, or null if no environment variables were specified or projectFilePath is null.</returns>
-    public static string? CreatePropsFile(string? projectFilePath, IReadOnlyDictionary<string, string> environmentVariables, string? intermediateOutputPath = null)
+    public static string? CreatePropsFile(
+        string? projectFilePath,
+        IReadOnlyDictionary<string, string> environmentVariables,
+        string propsFileName,
+        string? intermediateOutputPath = null)
     {
         if (string.IsNullOrEmpty(projectFilePath) || environmentVariables.Count == 0)
         {
@@ -103,7 +107,7 @@ internal static class EnvironmentVariablesToMSBuild
         Directory.CreateDirectory(objDir);
 
         // Ensure we return a full path for MSBuild property usage
-        string propsFilePath = Path.GetFullPath(Path.Combine(objDir, PropsFileName));
+        string propsFilePath = Path.GetFullPath(Path.Combine(objDir, propsFileName));
         using (var stream = File.Create(propsFilePath))
         {
             WritePropsFileContent(stream, environmentVariables);
@@ -178,7 +182,6 @@ internal static class EnvironmentVariablesToMSBuild
             writer.WriteAttributeString(ValueMetadataName, value);
             writer.WriteEndElement();
         }
-
         writer.WriteEndElement(); // ItemGroup
         writer.WriteEndElement(); // Project
     }

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -488,7 +488,7 @@ public class RunCommand
             // This avoids invalidating incremental builds for projects that don't consume the items.
             // Use IntermediateOutputPath from earlier project evaluation (via RunCommandSelector), defaulting to "obj" if not available.
             string? envPropsFile = hasRuntimeEnvironmentVariableSupport
-                ? EnvironmentVariablesToMSBuild.CreatePropsFile(ProjectFileFullPath, EnvironmentVariables, intermediateOutputPath)
+                ? EnvironmentVariablesToMSBuild.CreatePropsFile(ProjectFileFullPath, EnvironmentVariables, "dotnet-run-env.props", intermediateOutputPath)
                 : null;
             try
             {

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.CommandLine;
 using System.Runtime.CompilerServices;
+using Microsoft.Build.Definition;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
@@ -259,7 +260,8 @@ internal static class MSBuildUtility
             otherArgs,
             msbuildArgs,
             Device: parseResult.GetValue(definition.DeviceOption),
-            ListDevices: parseResult.GetValue(definition.ListDevicesOption));
+            ListDevices: parseResult.GetValue(definition.ListDevicesOption),
+            EnvironmentVariables: parseResult.GetValue(definition.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
     }
 
     private static (string? PositionalProjectOrSolution, string? PositionalTestModules) GetPositionalArguments(ref ImmutableArray<string> otherArgs)
@@ -338,6 +340,7 @@ internal static class MSBuildUtility
         return (positionalProjectOrSolution, positionalTestModules);
     }
 
+    [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
     private static int BuildOrRestoreProjectOrSolution(string filePath, BuildOptions buildOptions)
     {
         if (buildOptions.HasNoBuild)
@@ -360,7 +363,37 @@ internal static class MSBuildUtility
             CommonOptions.CreateVerbosityOption(),
             CommonOptions.CreateNoLogoOption());
 
-        return new RestoringCommand(parsedMSBuildArgs, buildOptions.HasNoRestore).Execute();
+        string? envPropsFile = null;
+        try
+        {
+            if (buildOptions.EnvironmentVariables.Count > 0 &&
+                Path.GetExtension(filePath).EndsWith("proj", StringComparison.OrdinalIgnoreCase))
+            {
+                var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(parsedMSBuildArgs);
+                using var collection = new ProjectCollection(globalProperties);
+                var project = ProjectInstance.FromFile(filePath, new ProjectOptions
+                {
+                    GlobalProperties = globalProperties,
+                    ProjectCollection = collection,
+                });
+
+                if (EnvironmentVariablesToMSBuild.HasRuntimeEnvironmentVariableSupport(project))
+                {
+                    envPropsFile = EnvironmentVariablesToMSBuild.CreatePropsFile(
+                        filePath,
+                        buildOptions.EnvironmentVariables,
+                        "dotnet-test-env.props",
+                        project.GetPropertyValue(Constants.IntermediateOutputPath));
+                    parsedMSBuildArgs = EnvironmentVariablesToMSBuild.AddPropsFileToArgs(parsedMSBuildArgs, envPropsFile);
+                }
+            }
+
+            return new RestoringCommand(parsedMSBuildArgs, buildOptions.HasNoRestore).Execute();
+        }
+        finally
+        {
+            EnvironmentVariablesToMSBuild.DeletePropsFile(envPropsFile);
+        }
     }
 
     [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.CommandLine;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Definition;
@@ -77,8 +76,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         var testOptions = new TestOptions(
             IsHelp: isHelp,
-            IsDiscovery: parseResult.HasOption(definition.ListTestsOption),
-            EnvironmentVariables: parseResult.GetValue(definition.EnvOption) ?? ImmutableDictionary<string, string>.Empty);
+            IsDiscovery: parseResult.HasOption(definition.ListTestsOption));
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);
         using var ctrlC = new CtrlCCancellationManager(output.StartCancelling);
@@ -278,7 +276,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
             projectPath,
             isInteractive,
             standardArgs,
-            ImmutableDictionary<string, string>.Empty,
+            buildOptions.EnvironmentVariables,
             commandName: "dotnet test",
             logger);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Models.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Models.cs
@@ -111,4 +111,12 @@ internal sealed class ParallelizableTestModuleGroupWithSequentialInnerModules : 
     }
 }
 
-internal sealed record TestModule(RunProperties RunProperties, string? ProjectFullPath, string? TargetFramework, bool IsTestingPlatformApplication, LaunchProfile? LaunchSettings, string TargetPath, string? DotnetRootArchVariableName);
+internal sealed record TestModule(
+    RunProperties RunProperties,
+    string? ProjectFullPath,
+    string? TargetFramework,
+    bool IsTestingPlatformApplication,
+    LaunchProfile? LaunchSettings,
+    string TargetPath,
+    string? DotnetRootArchVariableName,
+    IReadOnlyDictionary<string, string> EnvironmentVariables);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
-internal record TestOptions(bool IsHelp, bool IsDiscovery, IReadOnlyDictionary<string, string> EnvironmentVariables);
+internal record TestOptions(bool IsHelp, bool IsDiscovery);
 
 internal record PathOptions(string? ProjectOrSolutionPath, string? SolutionPath, string? TestModules, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 
@@ -19,4 +19,5 @@ internal record BuildOptions(
     ImmutableArray<string> TestApplicationArguments,
     IEnumerable<string> MSBuildArgs,
     string? Device,
-    bool ListDevices);
+    bool ListDevices,
+    IReadOnlyDictionary<string, string> EnvironmentVariables);

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Definition;
@@ -427,7 +426,7 @@ internal static class SolutionAndProjectUtility
             projectFilePath,
             isInteractive,
             msbuildArgs,
-            ImmutableDictionary<string, string>.Empty,
+            buildOptions.EnvironmentVariables,
             commandName: "dotnet test",
             logger);
 
@@ -468,9 +467,14 @@ internal static class SolutionAndProjectUtility
 
         // Only get run properties if IsTestingPlatformApplication is true
         RunProperties runProperties;
+        IReadOnlyDictionary<string, string> runtimeEnvironmentVariables;
         if (isTestingPlatformApplication)
         {
-            runProperties = DeployAndGetRunProperties(project, logger);
+            runProperties = DeployAndGetRunProperties(
+                project,
+                logger,
+                buildOptions.EnvironmentVariables,
+                out runtimeEnvironmentVariables);
 
             // dotnet run throws the same if RunCommand is null or empty.
             // In dotnet test, we are additionally checking that RunCommand is not dll.
@@ -493,6 +497,7 @@ internal static class SolutionAndProjectUtility
                 project.GetPropertyValue(ProjectProperties.TargetPath),
                 null,
                 null);
+            runtimeEnvironmentVariables = buildOptions.EnvironmentVariables;
         }
 
         // TODO: Support --launch-profile and pass it here.
@@ -508,12 +513,22 @@ internal static class SolutionAndProjectUtility
             rootVariableName = null;
         }
 
-        return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, isTestingPlatformApplication, launchSettings, project.GetPropertyValue(ProjectProperties.TargetPath), rootVariableName);
+        return new TestModule(runProperties, PathUtility.FixFilePath(projectFullPath), targetFramework, isTestingPlatformApplication, launchSettings, project.GetPropertyValue(ProjectProperties.TargetPath), rootVariableName, runtimeEnvironmentVariables);
 
         [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
         [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary unblock for dotnet/msbuild#14064 (MSBuild build APIs are now [RequiresUnreferencedCode]). dotnet CLI runs MSBuild in-proc (not trimmed). Remove when dotnet/sdk#55225 is fixed.")]
-        static RunProperties DeployAndGetRunProperties(ProjectInstance project, FacadeLogger? logger)
+        static RunProperties DeployAndGetRunProperties(
+            ProjectInstance project,
+            FacadeLogger? logger,
+            IReadOnlyDictionary<string, string> environmentVariables,
+            out IReadOnlyDictionary<string, string> runtimeEnvironmentVariables)
         {
+            bool hasRuntimeEnvironmentVariableSupport = EnvironmentVariablesToMSBuild.HasRuntimeEnvironmentVariableSupport(project);
+            if (hasRuntimeEnvironmentVariableSupport)
+            {
+                EnvironmentVariablesToMSBuild.AddAsItems(project, environmentVariables);
+            }
+
             // Build API cannot be called in parallel, even if the projects are different.
             // Otherwise, BuildManager in MSBuild will fail:
             // System.InvalidOperationException: The operation cannot be completed because a build is already in progress.
@@ -533,6 +548,9 @@ internal static class SolutionAndProjectUtility
                 }
             }
 
+            runtimeEnvironmentVariables = hasRuntimeEnvironmentVariableSupport
+                ? EnvironmentVariablesToMSBuild.ReadFromItems(project)
+                : environmentVariables;
             return RunProperties.FromProject(project);
         }
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -184,8 +184,9 @@ internal sealed class TestApplication(
             }
         }
 
-        // Env variables specified on command line override those specified in launch profile:
-        foreach (var (name, value) in TestOptions.EnvironmentVariables)
+        // Command-line variables (including changes made by opted-in MSBuild targets)
+        // override variables specified in the launch profile.
+        foreach (var (name, value) in Module.EnvironmentVariables)
         {
             processStartInfo.Environment[name] = value;
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Commands.Run;
@@ -15,12 +16,15 @@ internal sealed class TestModulesFilterHandler : ITestHandler
     private readonly string _testModules;
     private readonly string? _testModulesRoot;
     private readonly List<string> _testModulePaths;
+    private readonly IReadOnlyDictionary<string, string> _environmentVariables;
 
     public TestModulesFilterHandler(string testModules, ParseResult parseResult)
     {
         _testModules = testModules;
 
         var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
+        _environmentVariables = parseResult.GetValue(definition.EnvOption)
+            ?? ImmutableDictionary<string, string>.Empty;
 
         // If the module path pattern(s) was provided, we will use that to filter the test modules
         // If the root directory was provided, we will use that to search for the test modules
@@ -66,7 +70,15 @@ internal sealed class TestModulesFilterHandler : ITestHandler
                 ? new RunProperties(muxerPath, $@"exec ""{testModule}""", null)
                 : new RunProperties(testModule, null, null);
 
-            var testApp = new ParallelizableTestModuleGroupWithSequentialInnerModules(new TestModule(runProperties, null, null, true, null, testModule, DotnetRootArchVariableName: null));
+            var testApp = new ParallelizableTestModuleGroupWithSequentialInnerModules(new TestModule(
+                runProperties,
+                null,
+                null,
+                true,
+                null,
+                testModule,
+                DotnetRootArchVariableName: null,
+                EnvironmentVariables: _environmentVariables));
             // Write the test application to the channel
             actionQueue.Enqueue(testApp);
         }

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -16,6 +16,8 @@
 
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <ProjectCapability Include="RuntimeEnvironmentVariableSupport"
+                       Condition="'$(EnableRuntimeEnvironmentVariableSupport)' != 'false'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,11 +42,35 @@
 
   <Target Name="DeployToDevice">
     <Message Text="DeployToDevice: Deployed $(TargetFramework) to device $(Device) with RuntimeIdentifier $(RuntimeIdentifier)" />
+    <Message Text="DeployToDevice: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
     <Error Condition="'$(FailDeployToDevice)' == 'true'" Text="DeployToDevice failed as requested." />
     <WriteLinesToFile
       File="$(IntermediateOutputPath)dotnet-test-deploy.marker"
       Lines="$(Device)|$(RuntimeIdentifier)"
       Overwrite="true" />
+  </Target>
+
+  <Target Name="_LogRuntimeEnvironmentVariableDuringBuild"
+          BeforeTargets="_MTPBuild"
+          Condition="'@(RuntimeEnvironmentVariable)' != ''">
+    <Message Text="Build: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
+  </Target>
+
+  <Target Name="_ModifyRuntimeEnvironmentVariable"
+          BeforeTargets="ComputeRunArguments"
+          Condition="'$(ModifyRuntimeEnvironmentVariable)' == 'true'">
+    <ItemGroup>
+      <RuntimeEnvironmentVariable Remove="FOO" />
+      <RuntimeEnvironmentVariable Include="FOO" Value="modified-by-target" />
+      <RuntimeEnvironmentVariable Include="INJECTED" Value="injected-by-target" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_LogRuntimeEnvironmentVariableDuringComputeRunArguments"
+          BeforeTargets="ComputeRunArguments"
+          AfterTargets="_ModifyRuntimeEnvironmentVariable"
+          Condition="'@(RuntimeEnvironmentVariable)' != ''">
+    <Message Text="ComputeRunArguments: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
   </Target>
 
 </Project>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
@@ -6,6 +6,9 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 
+Console.WriteLine(
+    $"Runtime environment variables: FOO={Environment.GetEnvironmentVariable("FOO")}, INJECTED={Environment.GetEnvironmentVariable("INJECTED")}");
+
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());

--- a/test/dotnet.Tests/CommandTests/Run/EnvironmentVariablesToMSBuildTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/EnvironmentVariablesToMSBuildTests.cs
@@ -138,6 +138,48 @@ public sealed class EnvironmentVariablesToMSBuildTests
         EnvironmentVariablesToMSBuild.ReadFromItems(project).Should().BeEquivalentTo(environmentVariables);
     }
 
+    [TestMethod]
+    public void CreatePropsFile_WritesWellFormedEnvironmentVariableItems()
+    {
+        string testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        string? propsFile = null;
+
+        try
+        {
+            propsFile = EnvironmentVariablesToMSBuild.CreatePropsFile(
+                Path.Combine(testDirectory, "TestProject.csproj"),
+                new Dictionary<string, string>
+                {
+                    ["FOO"] = "BAR",
+                    ["ANOTHER"] = "VALUE",
+                },
+                "dotnet-test-env.props");
+
+            propsFile.Should().NotBeNull();
+            var document = new XmlDocument();
+            document.Load(propsFile!);
+
+            document.SelectNodes($"/Project/ItemGroup/{Constants.RuntimeEnvironmentVariable}")!
+                .Cast<XmlElement>()
+                .Select(element => new KeyValuePair<string, string>(
+                    element.GetAttribute("Include"),
+                    element.GetAttribute("Value")))
+                .Should().BeEquivalentTo(new Dictionary<string, string>
+                {
+                    ["FOO"] = "BAR",
+                    ["ANOTHER"] = "VALUE",
+                });
+        }
+        finally
+        {
+            EnvironmentVariablesToMSBuild.DeletePropsFile(propsFile);
+            if (Directory.Exists(testDirectory))
+            {
+                Directory.Delete(testDirectory, recursive: true);
+            }
+        }
+    }
+
     private static ProjectInstance CreateProjectInstance(string projectXml)
     {
         var collection = new ProjectCollection();

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunSelectsDevice.cs
@@ -519,7 +519,6 @@ public class GivenDotnetRunSelectsDevice : SdkTest
             });
 
         // Verify no props file was created (since opt-in is false)
-        string tempPropsFile = Path.Combine(testInstance.Path, "obj", "Debug", ToolsetInfo.CurrentTargetFramework, "dotnet-run-env.props");
         var build = BinaryLog.ReadBuild(buildBinlogPath);
         var propsFile = build.SourceFiles?.FirstOrDefault(f => f.FullPath.EndsWith("dotnet-run-env.props", StringComparison.OrdinalIgnoreCase));
         propsFile.Should().BeNull("dotnet-run-env.props should NOT be created when not opted in");

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -110,6 +110,61 @@ public class GivenDotnetTestSelectsDevice : SdkTest
     }
 
     [TestMethod]
+    public void ItPassesEnvironmentVariablesToBuildDeployAndRunArgumentsTargets()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", "EnvironmentVariables")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute(
+                "--framework", ToolsetInfo.CurrentTargetFramework,
+                "--device", "test-device-1",
+                "-e", "FOO=BAR",
+                "-p:ModifyRuntimeEnvironmentVariable=true",
+                "-bl");
+
+        result.Should().Pass()
+            .And.HaveStdOutContaining("Runtime environment variables: FOO=modified-by-target, INJECTED=injected-by-target");
+
+        string buildBinlogPath = Path.Combine(testInstance.Path, "msbuild.binlog");
+        string testBinlogPath = Path.Combine(testInstance.Path, "msbuild-dotnet-test.binlog");
+
+        AssertTargetInBinlog(
+            buildBinlogPath,
+            "_LogRuntimeEnvironmentVariableDuringBuild",
+            targets => targets.SelectMany(target => target.FindChildrenRecursive<Message>())
+                .Should().Contain(message =>
+                    message.Text != null &&
+                    message.Text.Contains("FOO=BAR", StringComparison.Ordinal)));
+        AssertTargetInBinlog(
+            testBinlogPath,
+            "DeployToDevice",
+            targets => targets.SelectMany(target => target.FindChildrenRecursive<Message>())
+                .Should().Contain(message =>
+                    message.Text != null &&
+                    message.Text.Contains("FOO=BAR", StringComparison.Ordinal)));
+        AssertTargetInBinlog(
+            testBinlogPath,
+            "_LogRuntimeEnvironmentVariableDuringComputeRunArguments",
+            targets => targets.SelectMany(target => target.FindChildrenRecursive<Message>())
+                .Should().Contain(message =>
+                    message.Text != null &&
+                    message.Text.Contains("FOO=modified-by-target", StringComparison.Ordinal) &&
+                    message.Text.Contains("INJECTED=injected-by-target", StringComparison.Ordinal)));
+
+        var build = BinaryLog.ReadBuild(buildBinlogPath);
+        build.SourceFiles.Should().Contain(file =>
+            file.FullPath.EndsWith("dotnet-test-env.props", StringComparison.OrdinalIgnoreCase));
+        File.Exists(Path.Combine(
+            testInstance.Path,
+            "obj",
+            "Debug",
+            ToolsetInfo.CurrentTargetFramework,
+            "dotnet-test-env.props")).Should().BeFalse();
+    }
+
+    [TestMethod]
     public void ItDoesNotPromptForDeviceWhenComputeAvailableDevicesTargetDoesNotExist()
     {
         var testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithTests")

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -57,9 +57,10 @@ public class TestApplicationHandlerTests : IDisposable
             IsTestingPlatformApplication: true,
             LaunchSettings: null,
             TargetPath: targetPath,
-            DotnetRootArchVariableName: null);
+            DotnetRootArchVariableName: null,
+            EnvironmentVariables: new Dictionary<string, string>());
 
-        var testOptions = new TestOptions(IsHelp: false, IsDiscovery: false, EnvironmentVariables: new Dictionary<string, string>());
+        var testOptions = new TestOptions(IsHelp: false, IsDiscovery: false);
 
         var handler = new TestApplicationHandler(reporter, module, testOptions);
 
@@ -322,9 +323,10 @@ public class TestApplicationHandlerTests : IDisposable
             IsTestingPlatformApplication: true,
             LaunchSettings: null,
             TargetPath: TargetPath,
-            DotnetRootArchVariableName: null);
+            DotnetRootArchVariableName: null,
+            EnvironmentVariables: new Dictionary<string, string>());
 
-        var testOptions = new TestOptions(IsHelp: isHelp, IsDiscovery: isDiscovery, EnvironmentVariables: new Dictionary<string, string>());
+        var testOptions = new TestOptions(IsHelp: isHelp, IsDiscovery: isDiscovery);
 
         return (new TestApplicationHandler(reporter, module, testOptions), reporter, capturingConsole);
     }


### PR DESCRIPTION
`dotnet test -e NAME=VALUE` already passed variables to test processes, but MAUI-style projects could not consume them during build, device selection, deployment, or `ComputeRunArguments` like `dotnet run` can.

This change carries parsed environment variables through the MTP project pipeline, exposes them as `@(RuntimeEnvironmentVariable)` items for projects that declare `RuntimeEnvironmentVariableSupport`, and preserves target-side modifications when launching the test process. Out-of-process project builds use the same temporary props mechanism as `dotnet run`; solution builds intentionally skip build-time injection because capability opt-in cannot be applied independently through one global MSBuild property.

The MAUI command specification and focused integration coverage are updated for build, deployment, run-argument mutation, and final process output.

Validation:
- Full managed SDK build (`build.cmd /p:NativeAotSupported=false /p:PublishAot=false`)
- 69 focused helper, launch, MTP device, integration, and `dotnet run` regression tests

NativeAOT publishing was disabled because the validation machine does not have the Visual Studio C++ workload required by the finalizer project.