### PR TITLE
Use VS 2026 and re-enable Windows arm64 NativeAOT CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -118,7 +118,7 @@ extends:
         parameters:
           pool:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2022.amd64
+            image: windows.vs2026.amd64
             os: windows
           helixTargetQueue: windows.amd64.vs2026.pre.scout
           oneESCompat:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -180,13 +180,14 @@ extends:
       # produces the dotnet-aot .dll plus its mstat/dgml size-analysis artifacts (that step is gated
       # on the AoT category). It is build-only (runTests: false): there is no wired windows arm64 Helix
       # queue yet, so running the *.AoT.Tests on arm64 hardware is a follow-up pending a
-      # windows.11.arm64 queue. Runs for internal PRs and test builds.
+      # windows.11.arm64 queue. The VS 2026 build image is required for the arm64 linker used by this
+      # cross-build. Runs for internal PRs and test builds.
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
           parameters:
             pool:
               name: $(DncEngInternalBuildPool)
-              image: windows.vs2022.amd64
+              image: windows.vs2026.amd64
               os: windows
             helixTargetQueue: windows.amd64.vs2026.pre.scout
             oneESCompat:
@@ -195,13 +196,7 @@ extends:
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             windowsJobParameterSets:
-            # TEMPORARILY DISABLED (disableJob: true): the win-arm64 NativeAOT cross-link fails with
-            # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)'
-            # because the ILCompiler-produced object isn't split into per-function sections, so the
-            # MSVC arm64 linker cannot apply the erratum fixup. This leg has never passed. Re-enable
-            # once the ILCompiler fix lands. Tracked by dotnet/sdk#55298.
             - categoryName: AoT
-              disableJob: true
               targetArchitecture: arm64
               runtimeIdentifier: win-arm64
               osProperties: /p:CrossBuild=true

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -61,7 +61,7 @@ stages:
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022.amd64.open
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -72,21 +72,16 @@ stages:
   # its mstat/dgml size-analysis artifacts (that step is gated on the AoT category). It is build-only
   # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
   # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
-  # TEMPORARILY DISABLED (disableJob: true): the win-arm64 NativeAOT cross-link fails with
-  # 'LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)' because
-  # the ILCompiler-produced object isn't split into per-function sections, so the MSVC arm64 linker
-  # cannot apply the erratum fixup. This leg has never passed. Re-enable once the ILCompiler fix lands.
-  # Tracked by dotnet/sdk#55298.
+  # The VS 2026 build image is required for the arm64 linker used by this cross-build.
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022.amd64.open
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
       windowsJobParameterSets:
       - categoryName: AoT
-        disableJob: true
         targetArchitecture: arm64
         runtimeIdentifier: win-arm64
         osProperties: /p:CrossBuild=true


### PR DESCRIPTION
## Summary

- move public and internal SDK Windows build matrices from VS 2022 to VS 2026
- re-enable the win-arm64 NativeAOT cross-build on the VS 2026 toolchain
- preserve build-only ARM64 behavior and unrelated `1es-windows-2022` SDL/signing pools

The migration of currently enabled Windows builds and the arm64 job activation are kept in separate commits.

Fixes #55298