### PR TITLE
Enable NativeAOT dotnet CLI for Source Build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -50,8 +50,15 @@
         Update="Microsoft.NETCore.App"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
-    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler"
-        ILCompilerPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
+    <!-- Exact pack RID matches do not require the distro-specific RID to be in the portable RID graph. -->
+    <KnownFrameworkReference Update="Microsoft.NETCore.App"
+        Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(TargetRid)' != ''">
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
+    </KnownFrameworkReference>
+    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
+      <ILCompilerPackVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</ILCompilerPackVersion>
+      <ILCompilerRuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(TargetRid)' != ''">%(ILCompilerRuntimeIdentifiers);$(TargetRid)</ILCompilerRuntimeIdentifiers>
+    </KnownILCompilerPack>
     <KnownILLinkPack Update="Microsoft.NET.ILLink.Tasks"
         ILLinkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
     <KnownWebAssemblySdkPack Update="Microsoft.NET.Sdk.WebAssembly.Pack"
@@ -64,6 +71,7 @@
     <KnownFrameworkReference Update="Microsoft.AspNetCore.App">
       <LatestRuntimeFrameworkVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</LatestRuntimeFrameworkVersion>
       <RuntimePackRuntimeIdentifiers>$(SupportedRuntimeIdentifiers)</RuntimePackRuntimeIdentifiers>
+      <RuntimePackRuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(TargetRid)' != ''">%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
       <TargetingPackVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</TargetingPackVersion>
       <DefaultRuntimeFrameworkVersion>$(MicrosoftAspNetCoreAppRefPackageVersion)</DefaultRuntimeFrameworkVersion>
     </KnownFrameworkReference>

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -52,29 +52,11 @@
       Declare RuntimeIdentifier so that centralized NuGet restore (via sdk.slnx) generates
       the RID-specific target (e.g. net11.0/win-x64) in project.assets.json. Without this,
       the assets file only has the TFM target and Publish fails with NETSDK1047.
-
-      Source Build can use a distro-specific TargetRid that isn't in the portable RID graph.
-      Publish against its portable parent while selecting the distro-specific runtime packs below.
+      Conditioned to platforms where NativeAOT publish is supported.
     -->
-    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">$(TargetRid)</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">$(PortableTargetRid)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true'">$(TargetRid)</RuntimeIdentifier>
     <UseCommonLocateNativeCompilerTarget Condition="'$(NativeAotSupported)' == 'true' and !$(TargetRid.StartsWith('win'))">true</UseCommonLocateNativeCompilerTarget>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
-    <!--
-      The Source Build runtime packs contain assets for TargetRid, but the application publish uses
-      PortableTargetRid. Map that portable RID to the exact source-built packages without requiring
-      the legacy RID graph.
-    -->
-    <KnownFrameworkReference Update="Microsoft.NETCore.App">
-      <RuntimePackNamePatterns>Microsoft.NETCore.App.Runtime.$(TargetRid)</RuntimePackNamePatterns>
-      <RuntimePackRuntimeIdentifiers>$(PortableTargetRid)</RuntimePackRuntimeIdentifiers>
-    </KnownFrameworkReference>
-    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
-      <ILCompilerRuntimePackNamePattern>Microsoft.NETCore.App.Runtime.NativeAOT.$(TargetRid)</ILCompilerRuntimePackNamePattern>
-    </KnownILCompilerPack>
-  </ItemGroup>
 
   <Import Project="AotSourceFiles.props" />
 

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -52,11 +52,29 @@
       Declare RuntimeIdentifier so that centralized NuGet restore (via sdk.slnx) generates
       the RID-specific target (e.g. net11.0/win-x64) in project.assets.json. Without this,
       the assets file only has the TFM target and Publish fails with NETSDK1047.
-      Conditioned to platforms where NativeAOT publish is supported.
+
+      Source Build can use a distro-specific TargetRid that isn't in the portable RID graph.
+      Publish against its portable parent while selecting the distro-specific runtime packs below.
     -->
-    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true'">$(TargetRid)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">$(TargetRid)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">$(PortableTargetRid)</RuntimeIdentifier>
     <UseCommonLocateNativeCompilerTarget Condition="'$(NativeAotSupported)' == 'true' and !$(TargetRid.StartsWith('win'))">true</UseCommonLocateNativeCompilerTarget>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
+    <!--
+      The Source Build runtime packs contain assets for TargetRid, but the application publish uses
+      PortableTargetRid. Map that portable RID to the exact source-built packages without requiring
+      the legacy RID graph.
+    -->
+    <KnownFrameworkReference Update="Microsoft.NETCore.App">
+      <RuntimePackNamePatterns>Microsoft.NETCore.App.Runtime.$(TargetRid)</RuntimePackNamePatterns>
+      <RuntimePackRuntimeIdentifiers>$(PortableTargetRid)</RuntimePackRuntimeIdentifiers>
+    </KnownFrameworkReference>
+    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
+      <ILCompilerRuntimePackNamePattern>Microsoft.NETCore.App.Runtime.NativeAOT.$(TargetRid)</ILCompilerRuntimePackNamePattern>
+    </KnownILCompilerPack>
+  </ItemGroup>
 
   <Import Project="AotSourceFiles.props" />
 

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -38,17 +38,15 @@
           inputs (CrossBuild/TargetArchitecture/TargetRid) are forwarded to the child dotnet-aot
           Publish in GenerateLayout.targets; ROOTFS_DIR flows via the environment on Linux.
     -->
-    <_DotnetAotTargetRidSupported Condition="$(PortableTargetRid.StartsWith('win')) or $(PortableTargetRid.StartsWith('linux')) or $(PortableTargetRid.StartsWith('osx'))">true</_DotnetAotTargetRidSupported>
+    <_DotnetAotTargetOSSupported Condition="'$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'osx'">true</_DotnetAotTargetOSSupported>
 
     <!-- The target OS equals the build host OS. NativeAOT can only target the host OS, so this is
          a prerequisite for both native and cross-arch publishing. -->
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('WINDOWS')) and '$(TargetOS)' == 'windows'">true</_DotnetAotIsSameOSBuild>
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(TargetOS)' == 'osx'">true</_DotnetAotIsSameOSBuild>
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('LINUX')) and '$(TargetOS)' == 'linux'">true</_DotnetAotIsSameOSBuild>
+    <_DotnetAotIsSameOSBuild Condition="'$(TargetOS)' == '$(HostOS)'">true</_DotnetAotIsSameOSBuild>
 
     <!-- Native: same OS and same architecture as the build host (and not an explicit cross-build).
          linux-musl is excluded because its NativeAOT toolchain is not wired up here. -->
-    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(CrossBuild)' != 'true' and !$(PortableTargetRid.StartsWith('linux-musl'))">true</_DotnetAotIsNativeBuild>
+    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(CrossBuild)' != 'true' and '$(OSName)' != 'linux-musl'">true</_DotnetAotIsNativeBuild>
 
     <!-- Cross: same OS but a different architecture from the build host. On Windows/macOS the cross
          toolchain (MSVC arm64 linker / clang) is multi-target, so an architecture mismatch alone is
@@ -57,9 +55,9 @@
          azurelinux cross-prereq container (providing clang + the sysroot via ROOTFS_DIR). Without
          that guard the regular linux-arm64 legs (e.g. TestBuild), which build on the x64 pool with
          no arm64 sysroot, would try to cross-link and fail. -->
-    <_DotnetAotIsCrossBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' != '$(BuildArchitecture)' and !$(PortableTargetRid.StartsWith('linux-musl')) and !($(PortableTargetRid.StartsWith('linux')) and '$(CrossBuild)' != 'true')">true</_DotnetAotIsCrossBuild>
+    <_DotnetAotIsCrossBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(OSName)' != 'linux-musl' and !('$(TargetOS)' == 'linux' and '$(CrossBuild)' != 'true')">true</_DotnetAotIsCrossBuild>
 
-    <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == '' and '$(_DotnetAotTargetRidSupported)' == 'true' and '$(NativeAotSupported)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and ('$(_DotnetAotIsNativeBuild)' == 'true' or '$(_DotnetAotIsCrossBuild)' == 'true')">true</_ShouldPublishDotnetAot>
+    <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == '' and '$(_DotnetAotTargetOSSupported)' == 'true' and '$(NativeAotSupported)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and ('$(_DotnetAotIsNativeBuild)' == 'true' or '$(_DotnetAotIsCrossBuild)' == 'true')">true</_ShouldPublishDotnetAot>
     <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == ''">false</_ShouldPublishDotnetAot>
   </PropertyGroup>
 

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -13,6 +13,8 @@
     <IsRPMBasedDistro Condition="$(HostRid.StartsWith('centos'))">true</IsRPMBasedDistro>
   </PropertyGroup>
 
+  <Import Project="$(RepositoryEngineeringDir)common\native\NativeAotSupported.props" />
+
   <PropertyGroup>
     <!--
       Whether to publish the dotnet-aot NativeAOT shared library (see the PublishDotnetAot target
@@ -22,13 +24,12 @@
       NativeAOT can produce the dotnet-aot library for the build host's operating system, either
       natively (targeting the host architecture) or cross-compiling to another architecture of the
       *same* OS. Cross-compilation across operating systems is not supported. We therefore publish
-      for supported win/linux/osx RIDs whenever the target OS equals the build host OS:
+      for supported Windows, Linux, and macOS RIDs whenever the target OS equals the build host OS.
+      PortableTargetRid is used for platform checks because Source Build can use a distro-specific
+      TargetRid (for example, azurelinux.3-x64) while its portable parent is linux-x64:
         * native builds, where the target architecture matches the build host architecture
-          (TargetArchitecture == BuildArchitecture). We do not compare TargetRid == HostRid
-          directly: on Linux HostRid is the distro-specific RID (e.g. azurelinux.3-x64) while
-          TargetRid is the portable RID (e.g. linux-x64), so an exact comparison fails even for a
-          native build. TargetArchitecture vs BuildArchitecture is the canonical native-vs-cross
-          signal across all platforms.
+          (TargetArchitecture == BuildArchitecture). TargetArchitecture vs BuildArchitecture is
+          the canonical native-vs-cross signal across all platforms.
         * same-OS cross-arch builds, where NativeAOT targets a different architecture from the build
           host (TargetArchitecture != BuildArchitecture). This is supported on all three operating
           systems: win-x64 -> win-arm64 and osx-x64 -> osx-arm64 (clang/link are multi-target and
@@ -37,17 +38,17 @@
           inputs (CrossBuild/TargetArchitecture/TargetRid) are forwarded to the child dotnet-aot
           Publish in GenerateLayout.targets; ROOTFS_DIR flows via the environment on Linux.
     -->
-    <_DotnetAotTargetRidSupported Condition="$(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx'))">true</_DotnetAotTargetRidSupported>
+    <_DotnetAotTargetRidSupported Condition="$(PortableTargetRid.StartsWith('win')) or $(PortableTargetRid.StartsWith('linux')) or $(PortableTargetRid.StartsWith('osx'))">true</_DotnetAotTargetRidSupported>
 
-    <!-- The target OS (from the TargetRid prefix) equals the build host OS. NativeAOT can only
-         target the host OS, so this is a prerequisite for both native and cross-arch publishing. -->
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('WINDOWS')) and $(TargetRid.StartsWith('win'))">true</_DotnetAotIsSameOSBuild>
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('OSX')) and $(TargetRid.StartsWith('osx'))">true</_DotnetAotIsSameOSBuild>
-    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('LINUX')) and $(TargetRid.StartsWith('linux'))">true</_DotnetAotIsSameOSBuild>
+    <!-- The target OS equals the build host OS. NativeAOT can only target the host OS, so this is
+         a prerequisite for both native and cross-arch publishing. -->
+    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('WINDOWS')) and '$(TargetOS)' == 'windows'">true</_DotnetAotIsSameOSBuild>
+    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('OSX')) and '$(TargetOS)' == 'osx'">true</_DotnetAotIsSameOSBuild>
+    <_DotnetAotIsSameOSBuild Condition="$([MSBuild]::IsOSPlatform('LINUX')) and '$(TargetOS)' == 'linux'">true</_DotnetAotIsSameOSBuild>
 
     <!-- Native: same OS and same architecture as the build host (and not an explicit cross-build).
          linux-musl is excluded because its NativeAOT toolchain is not wired up here. -->
-    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(CrossBuild)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true' and !$(TargetRid.StartsWith('linux-musl'))">true</_DotnetAotIsNativeBuild>
+    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(CrossBuild)' != 'true' and !$(PortableTargetRid.StartsWith('linux-musl'))">true</_DotnetAotIsNativeBuild>
 
     <!-- Cross: same OS but a different architecture from the build host. On Windows/macOS the cross
          toolchain (MSVC arm64 linker / clang) is multi-target, so an architecture mismatch alone is
@@ -56,9 +57,9 @@
          azurelinux cross-prereq container (providing clang + the sysroot via ROOTFS_DIR). Without
          that guard the regular linux-arm64 legs (e.g. TestBuild), which build on the x64 pool with
          no arm64 sysroot, would try to cross-link and fail. -->
-    <_DotnetAotIsCrossBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(DotNetBuildSourceOnly)' != 'true' and !$(TargetRid.StartsWith('linux-musl')) and !($(TargetRid.StartsWith('linux')) and '$(CrossBuild)' != 'true')">true</_DotnetAotIsCrossBuild>
+    <_DotnetAotIsCrossBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' != '$(BuildArchitecture)' and !$(PortableTargetRid.StartsWith('linux-musl')) and !($(PortableTargetRid.StartsWith('linux')) and '$(CrossBuild)' != 'true')">true</_DotnetAotIsCrossBuild>
 
-    <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == '' and '$(_DotnetAotTargetRidSupported)' == 'true' and ('$(_DotnetAotIsNativeBuild)' == 'true' or '$(_DotnetAotIsCrossBuild)' == 'true')">true</_ShouldPublishDotnetAot>
+    <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == '' and '$(_DotnetAotTargetRidSupported)' == 'true' and '$(NativeAotSupported)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and ('$(_DotnetAotIsNativeBuild)' == 'true' or '$(_DotnetAotIsCrossBuild)' == 'true')">true</_ShouldPublishDotnetAot>
     <_ShouldPublishDotnetAot Condition="'$(_ShouldPublishDotnetAot)' == ''">false</_ShouldPublishDotnetAot>
   </PropertyGroup>
 
@@ -97,8 +98,6 @@
        $(TargetRid.StartsWith('linux-musl'))
       )">true</SkipBuildingInstallers>
   </PropertyGroup>
-
-  <Import Project="$(RepositoryEngineeringDir)common\native\NativeAotSupported.props" />
 
   <PropertyGroup>
     <GenerateSdkBundleOnly Condition="'$(DotNetBuildPass)' == '3' and '$(OS)' == 'Windows_NT'">true</GenerateSdkBundleOnly>

--- a/src/Layout/Directory.Build.props
+++ b/src/Layout/Directory.Build.props
@@ -25,8 +25,9 @@
       natively (targeting the host architecture) or cross-compiling to another architecture of the
       *same* OS. Cross-compilation across operating systems is not supported. We therefore publish
       for supported Windows, Linux, and macOS RIDs whenever the target OS equals the build host OS.
-      PortableTargetRid is used for platform checks because Source Build can use a distro-specific
-      TargetRid (for example, azurelinux.3-x64) while its portable parent is linux-x64:
+      TargetOS and HostOS are used for platform checks because Source Build can use a
+      distro-specific TargetRid (for example, azurelinux.3-x64); OSName distinguishes
+      linux-musl targets, which are excluded below:
         * native builds, where the target architecture matches the build host architecture
           (TargetArchitecture == BuildArchitecture). TargetArchitecture vs BuildArchitecture is
           the canonical native-vs-cross signal across all platforms.
@@ -35,8 +36,9 @@
           systems: win-x64 -> win-arm64 and osx-x64 -> osx-arm64 (clang/link are multi-target and
           need no extra sysroot), and Linux via the azurelinux cross-prereq containers, which
           provide a cross toolchain and target sysroot (CrossBuild=true with ROOTFS_DIR). The cross
-          inputs (CrossBuild/TargetArchitecture/TargetRid) are forwarded to the child dotnet-aot
-          Publish in GenerateLayout.targets; ROOTFS_DIR flows via the environment on Linux.
+          child dotnet-aot Publish inherits TargetArchitecture and TargetRid as global properties;
+          GenerateLayout.targets adds CrossBuild=true, while ROOTFS_DIR flows via the environment
+          on Linux.
     -->
     <_DotnetAotTargetOSSupported Condition="'$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'osx'">true</_DotnetAotTargetOSSupported>
 

--- a/src/Layout/redist/redist.csproj
+++ b/src/Layout/redist/redist.csproj
@@ -88,10 +88,10 @@
          race over shared bin\ and obj\ directories. This ProjectReference sequences the outer
          Build to complete before redist's GenerateSdkLayout target runs.
 
-         Conditioned on the same check as the PublishDotnetAot target itself (_ShouldPublishDotnetAot);
-         when NativeAOT publish doesn't run (e.g. source-build with TargetRid like centos.10-x64),
-         pulling dotnet-aot.csproj into the restore graph would demand the ILCompiler RID-specific
-         runtime pack, which isn't available from source-built feeds (NU1100). -->
+         Conditioned on the same check as the PublishDotnetAot target itself (_ShouldPublishDotnetAot)
+         so unsupported target platforms don't pull NativeAOT compiler/runtime packs into the restore
+         graph. Supported Source Build configurations produce these packs from source and retain this
+         project reference. -->
     <ProjectReference Include="$(RepoRoot)src\Cli\dotnet-aot\dotnet-aot.csproj"
                       Condition="'$(_ShouldPublishDotnetAot)' == 'true'"
                       ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -532,11 +532,11 @@
     them entirely in native code, falling back to the managed dotnet.dll for other commands.
     The output is placed next to dotnet.dll so it's packaged with the SDK.
 
-    Runs for native builds (target OS/arch match the build host) on supported platforms, and for
-    same-OS cross-arch builds where NativeAOT targets a different architecture from the build host
-    (win-x64 -> win-arm64, osx-x64 -> osx-arm64, and Linux via the azurelinux cross containers that
-    provide a cross toolchain and target sysroot via ROOTFS_DIR). See the _ShouldPublishDotnetAot
-    property in src/Layout/Directory.Build.props.
+    Runs for native builds (target OS/arch match the build host) on supported platforms, including
+    Source Build with a distro-specific RID, and for same-OS cross-arch builds where NativeAOT targets
+    a different architecture from the build host (win-x64 -> win-arm64, osx-x64 -> osx-arm64, and
+    Linux via the azurelinux cross containers that provide a cross toolchain and target sysroot via
+    ROOTFS_DIR). See the _ShouldPublishDotnetAot property in src/Layout/Directory.Build.props.
   -->
   <Target Name="PublishDotnetAot"
           Condition="'$(_ShouldPublishDotnetAot)' == 'true'">
@@ -550,14 +550,16 @@
 
       <!--
         Global properties for the dotnet-aot Publish below. _IsPublishing=true is always required
-        (see the note below). For same-OS cross-arch builds (win/osx/linux) we also forward the
-        cross-compilation inputs: the MSBuild task doesn't flow the outer build's global properties
-        to the child project, so CrossBuild and the target architecture/RID must be passed
-        explicitly. On Linux the child then maps SysRoot from the ROOTFS_DIR environment variable
-        via LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
+        (see the note below). Source Build and same-OS cross-arch builds also need the outer build's
+        target properties forwarded explicitly. This preserves a Source Build distro-specific RID
+        and supplies cross-compilation inputs when applicable. On Linux the child maps SysRoot from
+        the ROOTFS_DIR environment variable via LocateNativeCompiler.targets; on Windows/macOS no
+        sysroot is needed.
       -->
       <_DotnetAotPublishProperties>_IsPublishing=true</_DotnetAotPublishProperties>
-      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);CrossBuild=true;TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid)</_DotnetAotPublishProperties>
+      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid)</_DotnetAotPublishProperties>
+      <_DotnetAotPublishProperties Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);DotNetBuildSourceOnly=true</_DotnetAotPublishProperties>
+      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);CrossBuild=true</_DotnetAotPublishProperties>
     </PropertyGroup>
 
     <!--

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -550,16 +550,13 @@
 
       <!--
         Global properties for the dotnet-aot Publish below. _IsPublishing=true is always required
-        (see the note below). Source Build and same-OS cross-arch builds also need the outer build's
-        target properties forwarded explicitly. This preserves a Source Build distro-specific RID
-        and supplies cross-compilation inputs when applicable. On Linux the child maps SysRoot from
-        the ROOTFS_DIR environment variable via LocateNativeCompiler.targets; on Windows/macOS no
-        sysroot is needed.
+        (see the note below). Source Build properties are already global and are inherited by the
+        MSBuild task. Same-OS cross-arch builds also need the outer build's target properties and
+        CrossBuild=true forwarded explicitly. On Linux the child maps SysRoot from the ROOTFS_DIR
+        environment variable via LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
       -->
       <_DotnetAotPublishProperties>_IsPublishing=true</_DotnetAotPublishProperties>
-      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid)</_DotnetAotPublishProperties>
-      <_DotnetAotPublishProperties Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);DotNetBuildSourceOnly=true</_DotnetAotPublishProperties>
-      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);CrossBuild=true</_DotnetAotPublishProperties>
+      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid);CrossBuild=true</_DotnetAotPublishProperties>
     </PropertyGroup>
 
     <!--

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -551,11 +551,10 @@
       <!--
         Global properties for the dotnet-aot Publish below. _IsPublishing=true is always required
         (see the note below). Source Build and same-OS cross-arch builds also need the outer build's
-        target properties forwarded explicitly. The dotnet-aot project uses PortableTargetRid as its
-        Source Build RuntimeIdentifier while selecting the NativeAOT runtime pack produced for
-        TargetRid. The remaining properties supply cross-compilation inputs when applicable. On Linux
-        the child maps SysRoot from the ROOTFS_DIR environment variable via
-        LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
+        target properties forwarded explicitly. This preserves a Source Build distro-specific RID
+        and supplies cross-compilation inputs when applicable. On Linux the child maps SysRoot from
+        the ROOTFS_DIR environment variable via LocateNativeCompiler.targets; on Windows/macOS no
+        sysroot is needed.
       -->
       <_DotnetAotPublishProperties>_IsPublishing=true</_DotnetAotPublishProperties>
       <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid)</_DotnetAotPublishProperties>

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -550,13 +550,13 @@
 
       <!--
         Global properties for the dotnet-aot Publish below. _IsPublishing=true is always required
-        (see the note below). Source Build properties are already global and are inherited by the
-        MSBuild task. Same-OS cross-arch builds also need the outer build's target properties and
-        CrossBuild=true forwarded explicitly. On Linux the child maps SysRoot from the ROOTFS_DIR
-        environment variable via LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
+        (see the note below). The outer build's target properties are already global and are inherited
+        by the MSBuild task. Same-OS cross-arch builds only need CrossBuild=true added explicitly. On
+        Linux the child maps SysRoot from the ROOTFS_DIR environment variable via
+        LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
       -->
       <_DotnetAotPublishProperties>_IsPublishing=true</_DotnetAotPublishProperties>
-      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid);CrossBuild=true</_DotnetAotPublishProperties>
+      <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true'">$(_DotnetAotPublishProperties);CrossBuild=true</_DotnetAotPublishProperties>
     </PropertyGroup>
 
     <!--

--- a/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/Layout/redist/targets/GenerateLayout.targets
@@ -551,10 +551,11 @@
       <!--
         Global properties for the dotnet-aot Publish below. _IsPublishing=true is always required
         (see the note below). Source Build and same-OS cross-arch builds also need the outer build's
-        target properties forwarded explicitly. This preserves a Source Build distro-specific RID
-        and supplies cross-compilation inputs when applicable. On Linux the child maps SysRoot from
-        the ROOTFS_DIR environment variable via LocateNativeCompiler.targets; on Windows/macOS no
-        sysroot is needed.
+        target properties forwarded explicitly. The dotnet-aot project uses PortableTargetRid as its
+        Source Build RuntimeIdentifier while selecting the NativeAOT runtime pack produced for
+        TargetRid. The remaining properties supply cross-compilation inputs when applicable. On Linux
+        the child maps SysRoot from the ROOTFS_DIR environment variable via
+        LocateNativeCompiler.targets; on Windows/macOS no sysroot is needed.
       -->
       <_DotnetAotPublishProperties>_IsPublishing=true</_DotnetAotPublishProperties>
       <_DotnetAotPublishProperties Condition="'$(_DotnetAotIsCrossBuild)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">$(_DotnetAotPublishProperties);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);TargetRid=$(TargetRid);PortableTargetRid=$(PortableTargetRid)</_DotnetAotPublishProperties>


### PR DESCRIPTION
## Summary

- enable the NativeAOT `dotnet` CLI library for supported Source Build configurations
- make Source Build `TargetRid` an exact supported RID for the regular runtime packs and ILCompiler pack, matching the existing Arcade/ASP.NET Core pattern without enabling the legacy RID graph
- reuse the existing `HostOS`, `TargetOS`, `OSName`, `BuildArchitecture`, `TargetArchitecture`, `CrossBuild`, and `NativeAotSupported` properties when deciding whether the layout can publish `dotnet-aot`
- rely on the nested MSBuild invocation to inherit Source Build and target global properties; pass only `_IsPublishing=true` and, for same-OS cross-architecture publishing, `CrossBuild=true` explicitly
- preserve linux-musl, Mono, cross-OS, unsupported-architecture, and Linux cross-toolchain exclusions

## Validation

- [unified build 1514187](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1514187) succeeded, including `VMR Source-Only Build` and `SB_CentOSStream10_Online_MsftSdk_x64`
- verified the CentOS Source Build publishes with `RuntimeIdentifier=centos.10-x64` and `UseRidGraph=false`
- verified exact resolution of `Microsoft.NETCore.App.Runtime.centos.10-x64`, `Microsoft.AspNetCore.App.Runtime.centos.10-x64`, and `Microsoft.NETCore.App.Runtime.NativeAOT.centos.10-x64`
- verified the produced CentOS SDK tarball contains `dotnet.dll` and `libdotnet-aot.so` together under `sdk/11.0.100-ci/`
- verified a nested MSBuild invocation passing only `_IsPublishing=true` inherits the Source Build target properties and retains the same runtime-pack inference
- built and NativeAOT-published `dotnet-aot.csproj` for `win-x64`, and ran the NativeAOT CLI parser tests
- [standard PR build 1514172](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1514172) succeeded

Fixes #55283