### PR TITLE
Sync latest vendored TestFx protocol changes

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -10,8 +10,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs",
-          "baseline_ref_sha": "59d0f9b9f8604e7f366b9ab340a5d194adf85544",
-          "baseline_blob_sha": "f964693792a513c07bef616e35d4754b79257edb",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "9abf6c1c70ab832033cfca805078df74ee87cc9b",
           "scope": "entire file; ids must match exactly"
         }
       ]
@@ -25,8 +25,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "145ed7b998f5a7dcc1d2388e650d2379227e7df3",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "5c71c4fb437bb4f9898fd89dea17b30bbf99d16e",
           "scope": "wire constants (TestStates, SessionEventTypes, HandshakeMessage*, ProtocolConstants)"
         }
       ]
@@ -80,32 +80,32 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "9e356aaa82691ef0b2143a92f13d114747fcd947",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "f60f6e6844e0ce77e3c16696bfd541e7e5a02c15",
           "scope": "reporter partial"
         },
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "5807f3f16ce9304c1b0348b745e06bb7ac6c3839",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "e4d77d967be687b0c84804d711c44c98e87741f7",
           "scope": "reporter partial"
         },
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "b03abc643e27c9c5b956b3aef96c32f469b18300",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "9987fc30e3b7f0ab2948b10e3ef4572d83d87aa4",
           "scope": "reporter partial"
         },
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "7824a5b256401a784ccfb64b79a0512aba42f16d",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "b8aee10a39ad8b5a7a64d6b9d5b2e1571de1f698",
           "scope": "reporter partial"
         }
       ]
@@ -284,8 +284,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleTerminalBase.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "d4d63f11a20f72f676a1378376fea41a9d1aa536",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "3f305c8240d5e9caef94dde9c7eb396e84813b0e",
           "scope": "entire file"
         }
       ]
@@ -314,8 +314,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterOptions.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "a496e9600ded4666e298caa27bf6138914a09e87",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "42c7a4a688c504966089741d2c7079424b5ad354",
           "scope": "entire file"
         }
       ]
@@ -374,8 +374,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs",
-          "baseline_ref_sha": "4a09ad6aa3ab876a5a9dd4bf346f654d037166d9",
-          "baseline_blob_sha": "ec860abdf7a1ae5d242101334f26c23809601e50",
+          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
+          "baseline_blob_sha": "e0f365e72626f3479b17887a57c94b9012943967",
           "scope": "entire file"
         }
       ]

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -72,6 +72,11 @@ internal static class HandshakeMessagePropertyNames
     // Optional property — older Microsoft.Testing.Platform versions don't send
     // it, in which case the SDK falls back to its previous (no-validation) behavior.
     internal const byte ExecutionMode = 10;
+
+    // Optional 1-based retry attempt number. Multiple test host instances, such as shards,
+    // can belong to the same attempt. Older hosts omit it, so the SDK retains instance-based
+    // retry inference as a compatibility fallback.
+    internal const byte AttemptNumber = 13;
 }
 
 internal static class HandshakeMessageExecutionModes

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/FileArtifactMessages.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/FileArtifactMessages.cs
@@ -3,6 +3,6 @@
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 
-internal sealed record FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid);
+internal sealed record FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid, string? Kind);
 
 internal sealed record FileArtifactMessages(string? ExecutionId, string? InstanceId, FileArtifactMessage[] FileArtifacts) : IRequest;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -139,6 +139,7 @@ internal static class FileArtifactMessageFieldsId
     public const ushort TestUid = 4;
     public const ushort TestDisplayName = 5;
     public const ushort SessionUid = 6;
+    public const ushort Kind = 7;
 }
 
 internal static class TestSessionEventFieldsId

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -47,6 +47,10 @@ namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
     |---FileArtifactMessageList[0].SessionUid Id---| (2 bytes)
     |---FileArtifactMessageList[0].SessionUid Size---| (4 bytes)
     |---FileArtifactMessageList[0].SessionUid Value---| (n bytes)
+
+    |---FileArtifactMessageList[0].Kind Id---| (2 bytes)
+    |---FileArtifactMessageList[0].Kind Size---| (4 bytes)
+    |---FileArtifactMessageList[0].Kind Value---| (n bytes)
 */
 
 internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPipeSerializer
@@ -97,7 +101,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         int length = ReadInt(stream);
         for (int i = 0; i < length; i++)
         {
-            string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null;
+            string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null, kind = null;
 
             int fieldCount = ReadUShort(stream);
 
@@ -132,13 +136,17 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
                         sessionUid = ReadStringValue(stream, fieldSize);
                         break;
 
+                    case FileArtifactMessageFieldsId.Kind:
+                        kind = ReadStringValue(stream, fieldSize);
+                        break;
+
                     default:
                         SetPosition(stream, stream.Position + fieldSize);
                         break;
                 }
             }
 
-            fileArtifactMessages.Add(new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid));
+            fileArtifactMessages.Add(new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid, kind));
         }
 
         return fileArtifactMessages;
@@ -182,6 +190,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
             WriteField(stream, FileArtifactMessageFieldsId.TestUid, fileArtifactMessage.TestUid);
             WriteField(stream, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
             WriteField(stream, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
+            WriteField(stream, FileArtifactMessageFieldsId.Kind, fileArtifactMessage.Kind);
         }
 
         // NOTE: We are able to seek only if we are using a MemoryStream
@@ -200,5 +209,6 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         (fileArtifactMessage.Description is null ? 0 : 1) +
         (fileArtifactMessage.TestUid is null ? 0 : 1) +
         (fileArtifactMessage.TestDisplayName is null ? 0 : 1) +
-        (fileArtifactMessage.SessionUid is null ? 0 : 1));
+        (fileArtifactMessage.SessionUid is null ? 0 : 1) +
+        (fileArtifactMessage.Kind is null ? 0 : 1));
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/SimpleTerminalBase.cs
@@ -161,7 +161,7 @@ internal abstract class SimpleTerminal : ITerminal
         // nop
     }
 
-    // TODO: Refactor NonAnsiTerminal and AnsiTerminal such that we don't need StartUpdate/StopUpdate.
+    // NonAnsiTerminal and AnsiTerminal could be refactored such that we don't need StartUpdate/StopUpdate.
     // It's much better if we use lock C# keyword instead of manually calling Monitor.Enter/Exit
     // Using lock also ensures we don't accidentally have `await`s in between that could cause Exit to be on a different thread.
     public void StartUpdate()

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -29,6 +29,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     internal Func<IStopwatch> CreateStopwatch { get; set; } = SystemStopwatch.StartNew;
 
     private readonly ConcurrentDictionary<string, TestProgressState> _assemblies = new();
+    private readonly Lock _assembliesLock = new();
 
     private readonly List<TestRunArtifact> _artifacts = [];
 
@@ -118,9 +119,24 @@ internal sealed partial class TerminalTestReporter : IDisposable
     }
 
     public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId)
+        => AssemblyRunStarted(assembly, targetFramework, architecture, executionId, instanceId, attemptNumber: null);
+
+    public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId, int attemptNumber)
+        => AssemblyRunStarted(assembly, targetFramework, architecture, executionId, instanceId, (int?)attemptNumber);
+
+    private void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId, int? attemptNumber)
     {
         var assemblyRun = GetOrAddAssemblyRun(assembly, targetFramework, architecture, executionId);
-        assemblyRun.NotifyHandshake(instanceId);
+        if (attemptNumber.HasValue)
+        {
+            assemblyRun.NotifyHandshake(instanceId, attemptNumber.Value);
+        }
+        else
+        {
+            assemblyRun.NotifyHandshake(instanceId);
+        }
+
+        int currentAttemptNumber = assemblyRun.GetAttemptNumber(instanceId);
 
         // If we fail to parse out the parameter correctly this will enable retry on re-run of the assembly within the same execution.
         // Not good enough for general use, because we want to show (try 1) even on the first try, but this will at
@@ -134,7 +150,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
                 if (_isRetry)
                 {
                     terminal.SetColor(TerminalColor.DarkGray);
-                    terminal.Append($"({string.Format(CliCommandStrings.Try, assemblyRun.TryCount)}) ");
+                    terminal.Append($"({string.Format(CliCommandStrings.Try, currentAttemptNumber)}) ");
                     terminal.ResetColor();
                 }
 
@@ -148,15 +164,26 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private TestProgressState GetOrAddAssemblyRun(string assembly, string? targetFramework, string? architecture, string executionId)
     {
-        return _assemblies.GetOrAdd(executionId, _ =>
+        if (_assemblies.TryGetValue(executionId, out TestProgressState? result))
         {
-            IStopwatch sw = CreateStopwatch();
-            var assemblyRun = new TestProgressState(Interlocked.Increment(ref _counter), assembly, targetFramework, architecture, sw, _isDiscovery);
-            int slotIndex = _terminalWithProgress.AddWorker(assemblyRun);
-            assemblyRun.SlotIndex = slotIndex;
+            return result;
+        }
 
-            return assemblyRun;
-        });
+        lock (_assembliesLock)
+        {
+            if (_assemblies.TryGetValue(executionId, out result))
+            {
+                return result;
+            }
+
+            IStopwatch sw = CreateStopwatch();
+            result = new TestProgressState(Interlocked.Increment(ref _counter), assembly, targetFramework, architecture, sw, _isDiscovery);
+            int slotIndex = _terminalWithProgress.AddWorker(result);
+            result.SlotIndex = slotIndex;
+            _assemblies[executionId] = result;
+
+            return result;
+        }
     }
 
     public void TestExecutionCompleted(DateTimeOffset endTime, int? exitCode)
@@ -464,8 +491,6 @@ internal sealed partial class TerminalTestReporter : IDisposable
         string? errorOutput)
     {
         TestProgressState asm = _assemblies[executionId];
-        var attempt = asm.TryCount;
-
         if (_showActiveTests)
         {
             asm.TestNodeResultsState?.RemoveRunningTestNode(instanceId, testNodeUid);
@@ -487,6 +512,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
                 break;
         }
 
+        int attempt = asm.GetAttemptNumber(instanceId);
         _terminalWithProgress.UpdateWorker(asm.SlotIndex);
         if (outcome != TestOutcome.Passed || _options.ShowPassedTests)
         {
@@ -1038,11 +1064,12 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         foreach (TestProgressState assembly in assemblies)
         {
-            terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.DiscoveredTestsInAssembly, assembly.DiscoveredTestNames.Count));
+            List<(string? DisplayName, string? UID, string? FilePath, int? LineNumber)> discoveredTestNames = assembly.DiscoveredTestNames;
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.DiscoveredTestsInAssembly, discoveredTestNames.Count));
             terminal.Append(" - ");
             AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly.Assembly, assembly.TargetFramework, assembly.Architecture);
             terminal.AppendLine();
-            foreach ((string? displayName, string? uid, string? filePath, int? lineNumber) in assembly.DiscoveredTestNames)
+            foreach ((string? displayName, string? uid, string? filePath, int? lineNumber) in discoveredTestNames)
             {
                 if (displayName is not null)
                 {
@@ -1128,8 +1155,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         if (_showActiveTests)
         {
-            asm.TestNodeResultsState ??= new(Interlocked.Increment(ref _counter));
-            asm.TestNodeResultsState.AddRunningTestNode(
+            TestNodeResultsState testNodeResultsState = asm.GetOrCreateTestNodeResultsState(
+                () => new(Interlocked.Increment(ref _counter)));
+            testNodeResultsState.AddRunningTestNode(
                 Interlocked.Increment(ref _counter), instanceId, testNodeUid, displayName, CreateStopwatch());
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -8,11 +8,18 @@ namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 
 internal sealed class TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch, bool isDiscovery)
 {
+    private readonly Lock _lock = new();
     private readonly Dictionary<string, TestNodeInfoEntry> _testUidToResults = new();
-
-    // In most cases, retries don't happen. So we start with a capacity of 1.
-    // Resizes will be rare and will be okay with such small sizes.
-    private readonly List<string> _orderedInstanceIds = new(capacity: 1);
+    private readonly Dictionary<string, int> _instanceIdToAttemptNumber = new();
+    private readonly List<(string? DisplayName, string? UID, string? FilePath, int? LineNumber)> _discoveredTestNames = [];
+    private int _discoveredTests;
+    private int _failedTests;
+    private int _passedTests;
+    private int _skippedTests;
+    private int _retriedFailedTests;
+    private int _tryCount;
+    private TestNodeResultsState? _testNodeResultsState;
+    private bool _success;
 
     public string Assembly { get; } = assembly;
 
@@ -24,19 +31,82 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     public IStopwatch Stopwatch { get; } = stopwatch;
 
-    public int DiscoveredTests { get; private set; }
+    public int DiscoveredTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _discoveredTests;
+            }
+        }
+    }
 
-    public int FailedTests { get; private set; }
+    public int FailedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _failedTests;
+            }
+        }
+    }
 
-    public int PassedTests { get; private set; }
+    public int PassedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _passedTests;
+            }
+        }
+    }
 
-    public int SkippedTests { get; private set; }
+    public int SkippedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _skippedTests;
+            }
+        }
+    }
 
-    public int TotalTests => IsDiscovery ? DiscoveredTests : PassedTests + SkippedTests + FailedTests;
+    public int TotalTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return IsDiscovery ? _discoveredTests : _passedTests + _skippedTests + _failedTests;
+            }
+        }
+    }
 
-    public int RetriedFailedTests { get; private set; }
+    public int RetriedFailedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _retriedFailedTests;
+            }
+        }
+    }
 
-    public TestNodeResultsState? TestNodeResultsState { get; internal set; }
+    public TestNodeResultsState? TestNodeResultsState
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _testNodeResultsState;
+            }
+        }
+    }
 
     public int SlotIndex { get; internal set; }
 
@@ -44,13 +114,48 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     public long Version { get; internal set; }
 
-    public List<(string? DisplayName, string? UID, string? FilePath, int? LineNumber)> DiscoveredTestNames { get; internal set; } = [];
+    public List<(string? DisplayName, string? UID, string? FilePath, int? LineNumber)> DiscoveredTestNames
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _discoveredTestNames];
+            }
+        }
+    }
 
-    public bool Success { get; internal set; }
+    public bool Success
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _success;
+            }
+        }
 
-    public bool IsDiscovery = isDiscovery;
+        internal set
+        {
+            lock (_lock)
+            {
+                _success = value;
+            }
+        }
+    }
 
-    public int TryCount { get; private set; }
+    public bool IsDiscovery { get; } = isDiscovery;
+
+    public int TryCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _tryCount;
+            }
+        }
+    }
 
     private void ReportGenericTestResult(
         string testNodeUid,
@@ -58,43 +163,36 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         Func<TestNodeInfoEntry, TestNodeInfoEntry> incrementTestNodeInfoEntry,
         Action<TestProgressState> incrementCountAction)
     {
-        var currentAttemptNumber = GetAttemptNumberFromInstanceId(instanceId);
-
-        if (_testUidToResults.TryGetValue(testNodeUid, out var value))
+        lock (_lock)
         {
-            // We received a result for this test node uid before.
-            if (value.LastAttemptNumber == currentAttemptNumber)
+            int currentAttemptNumber = GetAttemptNumberCore(instanceId);
+
+            if (_testUidToResults.TryGetValue(testNodeUid, out var value))
             {
-                // We are getting a test result for the same attempt.
-                // This means that the test framework is reporting multiple results for the same test node uid.
-                // We will just increment the count of the result.
-                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
-            }
-            else if (currentAttemptNumber > value.LastAttemptNumber)
-            {
-                // This is a retry!
-                // We are getting a test result for a different instance id.
-                // This means that the test was retried.
-                // We discard the results from the previous instance id
-                RetriedFailedTests += value.Failed;
-                PassedTests -= value.Passed;
-                SkippedTests -= value.Skipped;
-                FailedTests -= value.Failed;
-                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+                if (value.LastAttemptNumber == currentAttemptNumber)
+                {
+                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
+                }
+                else if (currentAttemptNumber > value.LastAttemptNumber)
+                {
+                    _retriedFailedTests += value.Failed;
+                    _passedTests -= value.Passed;
+                    _skippedTests -= value.Skipped;
+                    _failedTests -= value.Failed;
+                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+                }
+                else
+                {
+                    throw new UnreachableException($"Unexpected test result for attempt '{currentAttemptNumber}' while the last attempt is '{value.LastAttemptNumber}'");
+                }
             }
             else
             {
-                // This is an unexpected case where we received a result for an instance id that is older than the last one we saw.
-                throw new UnreachableException($"Unexpected test result for attempt '{currentAttemptNumber}' while the last attempt is '{value.LastAttemptNumber}'");
+                _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
             }
-        }
-        else
-        {
-            // This is the first time we see this test node.
-            _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
-        }
 
-        incrementCountAction(this);
+            incrementCountAction(this);
+        }
     }
 
     public void ReportPassingTest(string testNodeUid, string instanceId)
@@ -103,7 +201,7 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         {
             entry.Passed++;
             return entry;
-        }, static @this => @this.PassedTests++);
+        }, static @this => @this._passedTests++);
     }
 
     public void ReportSkippedTest(string testNodeUid, string instanceId)
@@ -112,7 +210,7 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         {
             entry.Skipped++;
             return entry;
-        }, static @this => @this.SkippedTests++);
+        }, static @this => @this._skippedTests++);
     }
 
     public void ReportFailedTest(string testNodeUid, string instanceId)
@@ -121,41 +219,67 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         {
             entry.Failed++;
             return entry;
-        }, static @this => @this.FailedTests++);
+        }, static @this => @this._failedTests++);
     }
 
     public void DiscoverTest(string? displayName, string? uid, string? filePath, int? lineNumber)
     {
-        DiscoveredTests++;
-        DiscoveredTestNames.Add(new(displayName, uid, filePath, lineNumber));
+        lock (_lock)
+        {
+            _discoveredTests++;
+            _discoveredTestNames.Add(new(displayName, uid, filePath, lineNumber));
+        }
     }
 
     internal void NotifyHandshake(string instanceId)
+        => NotifyHandshakeCore(instanceId, attemptNumber: null);
+
+    internal void NotifyHandshake(string instanceId, int attemptNumber)
+        => NotifyHandshakeCore(instanceId, attemptNumber);
+
+    private void NotifyHandshakeCore(string instanceId, int? attemptNumber)
     {
-        var index = _orderedInstanceIds.IndexOf(instanceId);
-        if (index < 0)
+        lock (_lock)
         {
-            // New instanceId for a retry. We add it to _orderedInstanceIds.
-            _orderedInstanceIds.Add(instanceId);
-            TryCount++;
-        }
-        else if (index != _orderedInstanceIds.Count - 1)
-        {
-            // This is an unexpected case where we received a handshake for an instance id that is not the last one we saw.
-            // This means that the test framework is trying to report results for an instance id that is not the last one.
-            throw new UnreachableException($"Unexpected handshake for instance id '{instanceId}' at index '{index}' while the last index is '{_orderedInstanceIds.Count - 1}'");
+            if (_instanceIdToAttemptNumber.TryGetValue(instanceId, out int registeredAttemptNumber))
+            {
+                if (attemptNumber.HasValue && attemptNumber.Value != registeredAttemptNumber)
+                {
+                    throw new UnreachableException($"Instance id '{instanceId}' was already registered for attempt '{registeredAttemptNumber}', not '{attemptNumber.Value}'.");
+                }
+
+                return;
+            }
+
+            int resolvedAttemptNumber = attemptNumber ?? _tryCount + 1;
+            if (resolvedAttemptNumber < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(attemptNumber));
+            }
+
+            _instanceIdToAttemptNumber.Add(instanceId, resolvedAttemptNumber);
+            _tryCount = Math.Max(_tryCount, resolvedAttemptNumber);
         }
     }
 
-    private int GetAttemptNumberFromInstanceId(string instanceId)
+    internal int GetAttemptNumber(string instanceId)
     {
-        var index = _orderedInstanceIds.IndexOf(instanceId);
-        if (index < 0)
+        lock (_lock)
         {
-            throw new UnreachableException($"The instanceId '{instanceId}' not found.");
+            return GetAttemptNumberCore(instanceId);
         }
-
-        // Attempt numbers are 1-based, so we add 1 to the index.
-        return index + 1;
     }
+
+    internal TestNodeResultsState GetOrCreateTestNodeResultsState(Func<TestNodeResultsState> factory)
+    {
+        lock (_lock)
+        {
+            return _testNodeResultsState ??= factory();
+        }
+    }
+
+    private int GetAttemptNumberCore(string instanceId)
+        => _instanceIdToAttemptNumber.TryGetValue(instanceId, out int attemptNumber)
+            ? attemptNumber
+            : throw new UnreachableException($"The instanceId '{instanceId}' not found.");
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -82,12 +82,28 @@ internal sealed class TestApplicationHandler
 
         if (hostType == "TestHost")
         {
+            int? attemptNumber = null;
+            // Invalid values fall back to legacy instance-based inference. Testfx normalizes malformed
+            // environment values to attempt 1 before sending them, and older hosts omit this property.
+            if (handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.AttemptNumber, out string? attemptNumberValue) &&
+                int.TryParse(attemptNumberValue, out int parsedAttemptNumber) &&
+                parsedAttemptNumber > 0)
+            {
+                attemptNumber = parsedAttemptNumber;
+            }
+
             _receivedTestHostHandshake = true;
-            // AssemblyRunStarted counts "retry count", and writes to terminal "(Try <number-of-try>) Running tests from <assembly>"
-            // So, we want to call it only for test host, and not for test host controller (or orchestrator, if in future it will handshake as well)
-            // Calling it for both test host and test host controllers means we will count retries incorrectly, and will messages twice.
+            // Only test hosts represent an assembly attempt. Controllers and orchestrators must not
+            // register runs, otherwise retries are counted and start messages are rendered twice.
             var handshakeInfo = _handshakeInfo.Value;
-            _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId!);
+            if (attemptNumber.HasValue)
+            {
+                _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId!, attemptNumber.Value);
+            }
+            else
+            {
+                _output.AssemblyRunStarted(_module.TargetPath, handshakeInfo.TargetFramework, handshakeInfo.Architecture, handshakeInfo.ExecutionId, instanceId!);
+            }
         }
 
         // Validate the optional ExecutionMode property last (after AssemblyRunStarted) so that any
@@ -182,6 +198,7 @@ internal sealed class TestApplicationHandler
             HandshakeMessagePropertyNames.InstanceId => nameof(HandshakeMessagePropertyNames.InstanceId),
             HandshakeMessagePropertyNames.IsIDE => nameof(HandshakeMessagePropertyNames.IsIDE),
             HandshakeMessagePropertyNames.ExecutionMode => nameof(HandshakeMessagePropertyNames.ExecutionMode),
+            HandshakeMessagePropertyNames.AttemptNumber => nameof(HandshakeMessagePropertyNames.AttemptNumber),
             _ => string.Empty,
         };
 
@@ -659,7 +676,7 @@ internal sealed class TestApplicationHandler
         {
             logMessageBuilder.AppendLine($"FileArtifact: {fileArtifactMessage.FullPath}, {fileArtifactMessage.DisplayName}, " +
                 $"{fileArtifactMessage.Description}, {fileArtifactMessage.TestUid}, {fileArtifactMessage.TestDisplayName}, " +
-                $"{fileArtifactMessage.SessionUid}");
+                $"{fileArtifactMessage.SessionUid}, {fileArtifactMessage.Kind}");
         }
 
         Logger.LogTrace(logMessageBuilder, static logMessageBuilder => logMessageBuilder.ToString());

--- a/test/dotnet.Tests/CommandTests/Test/FileArtifactMessagesSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/FileArtifactMessagesSerializerTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class FileArtifactMessagesSerializerTests
+{
+    [TestMethod]
+    public void RoundTrip_PreservesArtifactKind()
+    {
+        var original = new FileArtifactMessages(
+            ExecutionId: "exec-1",
+            InstanceId: "instance-1",
+            FileArtifacts:
+            [
+                new FileArtifactMessage(
+                    FullPath: "/repo/TestResults/results.trx",
+                    DisplayName: "results.trx",
+                    Description: "Test results",
+                    TestUid: null,
+                    TestDisplayName: null,
+                    SessionUid: "session-1",
+                    Kind: "trx"),
+            ]);
+
+        var serializer = new FileArtifactMessagesSerializer();
+        using var stream = new MemoryStream();
+        serializer.Serialize(original, stream);
+        stream.Position = 0;
+
+        var roundTripped = (FileArtifactMessages)serializer.Deserialize(stream);
+
+        roundTripped.FileArtifacts.Should().ContainSingle();
+        roundTripped.FileArtifacts[0].Kind.Should().Be("trx");
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
@@ -133,6 +134,25 @@ public class TestApplicationHandlerTests : IDisposable
 
         accepted.Should().BeTrue();
         reporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void OnHandshakeReceived_WithExplicitAttemptNumber_UsesReportedAttempt()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            showAssembly: true);
+
+        var handshake = BuildHandshake(
+            executionMode: HandshakeMessageExecutionModes.Run,
+            attemptNumber: 3);
+
+        bool accepted = handler.OnHandshakeReceived(handshake, gotSupportedVersion: true);
+
+        accepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+        console.GetOutput().Should().Contain("(try 3)");
     }
 
     /// <summary>
@@ -297,7 +317,7 @@ public class TestApplicationHandlerTests : IDisposable
     private const string ProjectPath = "/repo/MyTest.csproj";
     private const string TargetFramework = "net9.0";
 
-    private (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery)
+    private (TestApplicationHandler Handler, TerminalTestReporter Reporter, CapturingConsole Console) CreateHandler(bool isHelp, bool isDiscovery, bool showAssembly = false)
     {
         var capturingConsole = new CapturingConsole();
 
@@ -305,6 +325,8 @@ public class TestApplicationHandlerTests : IDisposable
         {
             AnsiMode = AnsiMode.SimpleAnsi,
             ShowProgress = false,
+            ShowAssembly = showAssembly,
+            ShowAssemblyStartAndComplete = showAssembly,
         };
 
         var reporter = new TerminalTestReporter(capturingConsole, reporterOptions);
@@ -329,7 +351,7 @@ public class TestApplicationHandlerTests : IDisposable
         return (new TestApplicationHandler(reporter, module, testOptions), reporter, capturingConsole);
     }
 
-    private static HandshakeMessage BuildHandshake(string? executionMode, string hostType = "TestHost", bool includeInstanceId = true)
+    private static HandshakeMessage BuildHandshake(string? executionMode, string hostType = "TestHost", bool includeInstanceId = true, int? attemptNumber = null)
     {
         var properties = new Dictionary<byte, string>
         {
@@ -351,6 +373,11 @@ public class TestApplicationHandlerTests : IDisposable
         if (executionMode is not null)
         {
             properties[HandshakeMessagePropertyNames.ExecutionMode] = executionMode;
+        }
+
+        if (attemptNumber.HasValue)
+        {
+            properties[HandshakeMessagePropertyNames.AttemptNumber] = attemptNumber.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         return new HandshakeMessage(properties);

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -41,6 +41,45 @@ public class TestProgressStateTests
         state.TotalTests.Should().Be(1);
     }
 
+    [TestMethod]
+    public void ExplicitAttemptNumber_AllowsMultipleInstancesInSameAttempt()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("shard-a", attemptNumber: 1);
+        state.NotifyHandshake("shard-b", attemptNumber: 1);
+
+        Parallel.For(0, 100, i =>
+        {
+            string instanceId = i % 2 == 0 ? "shard-a" : "shard-b";
+            state.ReportPassingTest($"test-{i}", instanceId);
+        });
+
+        state.TryCount.Should().Be(1);
+        state.PassedTests.Should().Be(100);
+        state.TotalTests.Should().Be(100);
+        state.GetAttemptNumber("shard-a").Should().Be(1);
+        state.GetAttemptNumber("shard-b").Should().Be(1);
+    }
+
+    [TestMethod]
+    public void ExplicitAttemptNumber_ReplacesPreviousAttemptResults()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("attempt-1-shard", attemptNumber: 1);
+        state.ReportFailedTest("flaky-test", "attempt-1-shard");
+        state.NotifyHandshake("attempt-2-shard", attemptNumber: 2);
+        state.ReportPassingTest("flaky-test", "attempt-2-shard");
+
+        state.TryCount.Should().Be(2);
+        state.RetriedFailedTests.Should().Be(1);
+        state.FailedTests.Should().Be(0);
+        state.PassedTests.Should().Be(1);
+    }
+
     /// <summary>
     /// Tests that reporting a skipped test with a previously seen instance after retry throws.
     /// </summary>


### PR DESCRIPTION
## Summary

- synchronize tracked TestFx files and vendored baselines to `microsoft/testfx@dba319b212caae2a325800de8a5570ebe787b06d`
- consume optional retry `AttemptNumber` handshake metadata so multiple test-host instances can share one attempt, while retaining instance-based inference for older hosts
- synchronize file-artifact `Kind` field ID, model, and serializer support
- make retry state updates thread-safe for concurrent test-host shards

Fixes #55255

## Compatibility

Both protocol additions are optional and additive. Older peers continue to omit them, and unknown fields remain skippable.

## Validation

- built `src\Cli\dotnet\dotnet.csproj`
- built `test\dotnet.Tests\dotnet.Tests.csproj`
- 43 focused dotnet.Tests passed
- vendored manifest validation and dry-run drift check report 30 entries, 38 sources, and 0 drift