### PR TITLE
`dotnetup` issue template should use label rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/30_dotnetup.yml
+++ b/.github/ISSUE_TEMPLATE/30_dotnetup.yml
@@ -1,6 +1,6 @@
 name: 🆙 dotnetup issue
 description: Report a bug or request a feature for dotnetup
-labels: ["dotnetup", "untriaged"]
+labels: ["Area-dotnetup", "untriaged"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/30_dotnetup.yml
+++ b/.github/ISSUE_TEMPLATE/30_dotnetup.yml
@@ -16,7 +16,7 @@ body:
       options:
         - label: I have read the [dotnetup documentation](https://github.com/dotnet/sdk/tree/release/dnup/documentation/general/dotnetup).
           required: true
-        - label: I have searched for [existing dotnetup issues](https://github.com/dotnet/sdk/issues?q=is%3Aissue%20state%3Aopen%20label%3Adotnetup).
+        - label: I have searched for [existing dotnetup issues](https://github.com/dotnet/sdk/issues?q=is%3Aissue%20state%3Aopen%20label%3AArea-dotnetup).
           required: true
         - label: I have searched for [existing dotnetup discussions](https://github.com/dotnet/sdk/discussions/categories/dotnetup).
           required: true


### PR DESCRIPTION
Area-* is the pattern used across the repo, so we should match that pattern. 

https://github.com/dotnet/sdk/pull/55244 the agentic triage workflow needed specific instructions due to  this deviance so I changed it. 

I admit it's a little  more annoying since the typing doesn't come up as dotnetup immediately but think this is the right call.