### PR TITLE
dotnetup: classify PATH dotnet by managed hive; fix env config doc

### DIFF
--- a/documentation/general/dotnetup/designs/dotnetup-env.md
+++ b/documentation/general/dotnetup/designs/dotnetup-env.md
@@ -154,9 +154,11 @@ DotnetAccessMode.Shell      = old ShellProfile         // shell profile file onl
 DotnetAccessMode.Everywhere = old FullPathReplacement  // env-var PATH + shell profile
 ```
 
-The JSON serialization writes the new lowercase names (`none` / `shell` / `everywhere`).
-On read, the converter also accepts the legacy spellings (`full`, `fullpathreplacement`,
-etc.) so configs written by earlier internal builds keep their chosen mode.
+The JSON serialization writes the new lowercase names (`none` / `shell` / `everywhere`)
+via the built-in string-enum converter (camel-case, integer values rejected). Legacy
+spellings from earlier internal builds (`full` / `fullpathreplacement`, and the old
+`pathPreference` property) are **not** accepted: an unrecognized value is treated as a
+corrupt config, which re-defaults on the next write rather than silently mapping to a mode.
 
 ## `dotnetup` on PATH: an orthogonal setting
 

--- a/src/Installer/dotnetup.Library/Commands/Dotnet/DotnetCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/Dotnet/DotnetCommand.cs
@@ -65,7 +65,7 @@ internal class DotnetCommand : CommandBase
     private string ResolveDotnetPath()
     {
         var configuredRoot = _dotnetEnvironment.GetCurrentPathConfiguration();
-        if (configuredRoot is not null && configuredRoot.InstallType == InstallType.User)
+        if (configuredRoot is { IsDotnetupHive: true })
         {
             return configuredRoot.Path;
         }

--- a/src/Installer/dotnetup.Library/Commands/Dotnet/DotnetCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/Dotnet/DotnetCommand.cs
@@ -59,8 +59,8 @@ internal class DotnetCommand : CommandBase
     }
 
     /// <summary>
-    /// Resolves the dotnet installation path using the same logic as other dotnetup commands:
-    /// configured install type (user install) falls back to the default install path.
+    /// Resolves the dotnet installation path: when the PATH-resolved install is a
+    /// dotnetup-managed hive, use it; otherwise fall back to the default install path.
     /// </summary>
     private string ResolveDotnetPath()
     {

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflows.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflows.cs
@@ -446,9 +446,10 @@ internal class InitWorkflows
             return [];
         }
 
-        // Find the system install path for display purposes
+        // Find the system install path for display purposes. Whether the dotnet winning on PATH is
+        // a dotnetup hive is irrelevant here; we want its location only when it is a system install.
         var currentInstall = dotnetEnvironment.GetCurrentPathConfiguration();
-        string systemPath = currentInstall?.InstallType == InstallType.System
+        string systemPath = currentInstall is not null && InstallPathClassifier.IsAdminInstallPath(currentInstall.Path)
             ? currentInstall.Path
             : DotnetEnvironmentManager.GetSystemDotnetPaths().FirstOrDefault() ?? "the system .NET location";
 

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallPathClassifier.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallPathClassifier.cs
@@ -10,9 +10,12 @@ namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 internal static class InstallPathClassifier
 {
     /// <summary>
-    /// Determines whether the given path is an admin/system-managed .NET install location.
-    /// These locations are managed by system package managers or OS installers and should not
-    /// be used by dotnetup for user-level installations.
+    /// Determines whether the given path is in a well-known system/admin .NET install location
+    /// (for example <c>Program Files\dotnet</c> on Windows).  These locations are usually managed
+    /// by system package managers or OS installers and should not be used by dotnetup.
+    /// 
+    /// This is a location heuristic only, it doesn't verify that the install there is actually managed
+    /// by an OS installer or package manager.
     /// </summary>
     public static bool IsAdminInstallPath(string path)
     {

--- a/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/InstallWorkflow.cs
@@ -338,7 +338,7 @@ internal class InstallWorkflow
         _command.SetCommandTag(TelemetryTagNames.InstallRequestedVersion, VersionSanitizer.Sanitize(requestedVersionOrChannel));
         _command.SetCommandTag(TelemetryTagNames.InstallPathExplicit, (explicitInstallPath is not null).ToString());
         _command.SetCommandTag(TelemetryTagNames.InstallHasGlobalJson, (globalJson?.GlobalJsonPath is not null).ToString());
-        _command.SetCommandTag(TelemetryTagNames.InstallExistingInstallType, currentInstallRoot?.InstallType.ToString() ?? "none");
+        _command.SetCommandTag(TelemetryTagNames.InstallExistingInstallType, currentInstallRoot is null ? "none" : InstallPathClassifier.ClassifyInstallPath(currentInstallRoot.Path));
         _command.SetCommandTag(TelemetryTagNames.InstallPathType, InstallPathClassifier.ClassifyInstallPath(pathResolution.ResolvedInstallPath, pathResolution.PathSource));
         _command.SetCommandTag(TelemetryTagNames.InstallPathSource, pathResolution.PathSource.ToString().ToLowerInvariant());
         _command.SetCommandTag(TelemetryTagNames.InstallResolvedVersion, resolved.ResolvedVersion.ToString());

--- a/src/Installer/dotnetup.Library/Commands/Shared/UninstallWorkflow.cs
+++ b/src/Installer/dotnetup.Library/Commands/Shared/UninstallWorkflow.cs
@@ -155,7 +155,9 @@ internal class UninstallWorkflow
 
     /// <summary>
     /// Resolves the install path for uninstall using the same logic as the install command:
-    /// only use the configured path if it's a user install, otherwise fall back to default.
+    /// only use the configured path if it is a dotnetup-managed hive, otherwise fall back to
+    /// default. This prevents uninstall from targeting a dotnet that dotnetup does not own (e.g.
+    /// a system install or a hand-extracted dotnet that happens to win on PATH).
     /// </summary>
     internal static string ResolveInstallPath(string? explicitInstallPath, IDotnetEnvironmentManager dotnetEnvironment)
     {
@@ -165,7 +167,7 @@ internal class UninstallWorkflow
         }
 
         var configuredInstall = dotnetEnvironment.GetCurrentPathConfiguration();
-        if (configuredInstall is { InstallType: InstallType.User })
+        if (configuredInstall is { IsDotnetupHive: true })
         {
             return configuredInstall.Path;
         }

--- a/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
@@ -49,7 +49,14 @@ internal class DotnetEnvironmentManager : IDotnetEnvironmentManager
         // default install path; configurable hives are tracked in
         // https://github.com/dotnet/sdk/issues/55346, at which point this check would also consult
         // the persisted root.
-        bool isDotnetupHive = DotnetupUtilities.PathsEqual(currentInstallRoot.Path, GetDefaultDotnetInstallPath());
+        //
+        // Resolve the default path's symlinks too so the comparison is symmetric: currentInstallRoot.Path
+        // is already realpath-resolved above, and the default path's base (LocalApplicationData /
+        // XDG_DATA_HOME, which is not required to be a real directory) may itself be a symlink. Without
+        // this, a symlinked data directory would make dotnetup fail to recognize its own hive.
+        string defaultInstallPath = GetDefaultDotnetInstallPath();
+        string resolvedDefaultInstallPath = ExecutablePathResolver.ResolveRealPath(defaultInstallPath) ?? defaultInstallPath;
+        bool isDotnetupHive = DotnetupUtilities.PathsEqual(currentInstallRoot.Path, resolvedDefaultInstallPath);
         return new(currentInstallRoot, isDotnetupHive);
     }
 

--- a/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
@@ -43,11 +43,15 @@ internal class DotnetEnvironmentManager : IDotnetEnvironmentManager
             ResolveCurrentInstallRootPath(foundDotnet),
             InstallerUtilities.GetDefaultInstallArchitecture());
 
-        // Classify the resolved dotnet by location. InstallPathClassifier.IsAdminInstallPath is the
-        // canonical "is this a system/admin-managed install?" check (Program Files on Windows; the
-        // standard /usr and /opt locations on Unix) used across dotnetup, so both platforms share it.
-        bool isAdminInstall = InstallPathClassifier.IsAdminInstallPath(currentInstallRoot.Path);
-        return new(currentInstallRoot, isAdminInstall ? InstallType.System : InstallType.User);
+        // Report whether the resolved dotnet is a dotnetup-managed hive — an install dotnetup owns
+        // and may run or uninstall from — rather than classifying it as "system vs user". A dotnet
+        // that merely lives in a user-writable location (e.g. a hand-extracted C:\dotnet on PATH) is
+        // NOT dotnetup's and must not be treated as such. Today the only supported hive is the
+        // default install path; configurable hives are tracked in
+        // https://github.com/dotnet/sdk/issues/55346, at which point this check would also consult
+        // the persisted root.
+        bool isDotnetupHive = DotnetupUtilities.PathsEqual(currentInstallRoot.Path, GetDefaultDotnetInstallPath());
+        return new(currentInstallRoot, isDotnetupHive);
     }
 
     public string GetDefaultDotnetInstallPath()

--- a/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Dotnet.Installation.Internal;
-using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
 using Microsoft.DotNet.Tools.Bootstrapper.Shell;
 using Microsoft.DotNet.Tools.Bootstrapper.Telemetry;
 using Spectre.Console;

--- a/src/Installer/dotnetup.Library/DotnetupPaths.cs
+++ b/src/Installer/dotnetup.Library/DotnetupPaths.cs
@@ -128,8 +128,6 @@ internal static class DotnetupPaths
     {
         get
         {
-            // Allow override for testing — lets tests point the managed hive at a temp directory
-            // without touching the real user profile.
             var overridePath = Environment.GetEnvironmentVariable("DOTNET_TESTHOOK_DEFAULT_DOTNET_PATH");
             if (!string.IsNullOrEmpty(overridePath))
             {

--- a/src/Installer/dotnetup.Library/DotnetupPaths.cs
+++ b/src/Installer/dotnetup.Library/DotnetupPaths.cs
@@ -121,10 +121,21 @@ internal static class DotnetupPaths
     /// Gets the default dotnet install path managed by dotnetup.
     /// This is the user-local dotnet root (e.g. %LOCALAPPDATA%\dotnet on Windows).
     /// </summary>
+    /// <remarks>
+    /// Can be overridden via DOTNET_TESTHOOK_DEFAULT_DOTNET_PATH environment variable.
+    /// </remarks>
     public static string DefaultDotnetInstallPath
     {
         get
         {
+            // Allow override for testing — lets tests point the managed hive at a temp directory
+            // without touching the real user profile.
+            var overridePath = Environment.GetEnvironmentVariable("DOTNET_TESTHOOK_DEFAULT_DOTNET_PATH");
+            if (!string.IsNullOrEmpty(overridePath))
+            {
+                return overridePath;
+            }
+
             var baseDir = GetBaseDirectory();
             if (string.IsNullOrEmpty(baseDir))
             {

--- a/src/Installer/dotnetup.Library/ExecutablePathResolver.cs
+++ b/src/Installer/dotnetup.Library/ExecutablePathResolver.cs
@@ -22,13 +22,28 @@ internal static class ExecutablePathResolver
     /// </summary>
     public static string? ResolveRealDirectory(string? executablePath)
     {
-        if (string.IsNullOrEmpty(executablePath))
+        string? resolvedPath = ResolveRealPath(executablePath);
+        return resolvedPath is null ? null : Path.GetDirectoryName(resolvedPath);
+    }
+
+    /// <summary>
+    /// Returns <paramref name="path"/> itself with symlinks resolved (unlike
+    /// <see cref="ResolveRealDirectory"/>, which resolves the containing directory of an
+    /// executable). Use this to canonicalize a directory that may be reached through a symlinked
+    /// parent, such as a dotnet install root under a symlinked <c>LocalApplicationData</c> /
+    /// <c>XDG_DATA_HOME</c>. Returns <c>null</c> when the path is null or empty.
+    /// <see cref="FileInterop.ResolveRealPath"/> is a no-op on Windows, and on Unix returns
+    /// <c>null</c> for a path that does not yet exist; in both cases the normalized full path is
+    /// returned so callers still get a usable value.
+    /// </summary>
+    public static string? ResolveRealPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
         {
             return null;
         }
 
-        string fullPath = Path.GetFullPath(executablePath);
-        string resolvedPath = FileInterop.ResolveRealPath(fullPath) ?? fullPath;
-        return Path.GetDirectoryName(resolvedPath);
+        string fullPath = Path.GetFullPath(path);
+        return FileInterop.ResolveRealPath(fullPath) ?? fullPath;
     }
 }

--- a/src/Installer/dotnetup.Library/IDotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/IDotnetEnvironmentManager.cs
@@ -16,6 +16,11 @@ internal interface IDotnetEnvironmentManager
 {
     string GetDefaultDotnetInstallPath();
 
+    /// <summary>
+    /// Resolves the <c>dotnet</c> that currently wins on <c>PATH</c> and reports whether it is a
+    /// dotnetup-managed hive (i.e. an install dotnetup owns and may run or uninstall from).
+    /// Returns <c>null</c> when no <c>dotnet</c> is found on <c>PATH</c>.
+    /// </summary>
     DotnetInstallRootConfiguration? GetCurrentPathConfiguration();
 
     string? GetLatestInstalledSystemVersion();
@@ -75,7 +80,7 @@ public class GlobalJsonInfo
 
 public record DotnetInstallRootConfiguration(
     DotnetInstallRoot InstallRoot,
-    InstallType InstallType)
+    bool IsDotnetupHive)
 {
     public string Path => InstallRoot.Path;
 }

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -163,7 +163,7 @@
     <value>Arguments to forward to dotnet.</value>
   </data>
   <data name="DotnetCommandDotnetNotFound" xml:space="preserve">
-    <value>Error: dotnet executable not found at '{0}'.</value>
+    <value>dotnet executable not found at '{0}'.</value>
   </data>
   <data name="DotnetCommandInstallFirst" xml:space="preserve">
     <value>Run 'dotnetup install' to install a .NET SDK first.</value>

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -283,7 +283,7 @@ Or open a new terminal.</value>
     <value>Open a new terminal for the change to take effect.</value>
   </data>
   <data name="EnvOpenNewTerminalForOtherSurfaces" xml:space="preserve">
-    <value>Open a new terminal for the change to take effect in other terminals and applications.</value>
+    <value>Other open terminals and applications will pick up this change after they're restarted.</value>
   </data>
   <data name="EnvShellRequiredForProfile" xml:space="preserve">
     <value>Could not detect the current shell, which is required to update the dotnetup profile entry. Re-run with --shell &lt;{0}&gt; to specify it explicitly.</value>

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetNotFound">
-        <source>Error: dotnet executable not found at '{0}'.</source>
-        <target state="new">Error: dotnet executable not found at '{0}'.</target>
+        <source>dotnet executable not found at '{0}'.</source>
+        <target state="new">dotnet executable not found at '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotnetCommandDotnetStartFailed">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -107,8 +107,8 @@ Or open a new terminal.</target>
         <note>{Locked="shell"}</note>
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalForOtherSurfaces">
-        <source>Open a new terminal for the change to take effect in other terminals and applications.</source>
-        <target state="new">Open a new terminal for the change to take effect in other terminals and applications.</target>
+        <source>Other open terminals and applications will pick up this change after they're restarted.</source>
+        <target state="new">Other open terminals and applications will pick up this change after they're restarted.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvOpenNewTerminalToTakeEffect">

--- a/test/dotnetup.Tests/DotnetCommandStdinForwardingTests.cs
+++ b/test/dotnetup.Tests/DotnetCommandStdinForwardingTests.cs
@@ -48,9 +48,11 @@ public class DotnetCommandStdinForwardingTests
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
 
-            // Prepend our temp dir to PATH so dotnetup resolves our fake dotnet
-            var currentPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-            process.StartInfo.Environment["PATH"] = tempDir.FullName + Path.PathSeparator + currentPath;
+            // Point dotnetup's managed hive at our temp dir so it resolves our fake dotnet.
+            // dotnetup resolves the dotnet to run from its managed hive (not from PATH), so the
+            // fake dotnet must live at <hive>/dotnet[.exe] — which is exactly where
+            // CreateStdinEchoFakeDotnet placed it.
+            process.StartInfo.Environment["DOTNET_TESTHOOK_DEFAULT_DOTNET_PATH"] = tempDir.FullName;
             process.StartInfo.Environment["DOTNET_NOLOGO"] = "1";
             process.StartInfo.Environment["NO_COLOR"] = "1";
 

--- a/test/dotnetup.Tests/DotnetCommandTests.cs
+++ b/test/dotnetup.Tests/DotnetCommandTests.cs
@@ -150,9 +150,9 @@ public class DotnetCommandTests
     }
 
     [TestMethod]
-    public void DotnetCommand_UsesConfiguredInstallType_WhenUserInstall()
+    public void DotnetCommand_UsesConfiguredPath_WhenDotnetupHive()
     {
-        // Arrange - two paths: a configured user install path and a default path
+        // Arrange - two paths: a configured dotnetup hive path and a default path
         var userDir = Directory.CreateTempSubdirectory("dotnetup-user-test");
         var defaultDir = Directory.CreateTempSubdirectory("dotnetup-default-test");
         try
@@ -164,13 +164,13 @@ public class DotnetCommandTests
                 defaultInstallPath: defaultDir.FullName,
                 configuredRoot: new DotnetInstallRootConfiguration(
                     new DotnetInstallRoot(userDir.FullName, InstallArchitecture.x64),
-                    InstallType.User));
+                    IsDotnetupHive: true));
 
             var parseResult = Parser.Parse(["dotnet", "--version"]);
             var command = new TestableDotnetCommand(parseResult, mock);
             var exitCode = command.Execute();
 
-            // Should succeed because it used the configured user path, not the default
+            // Should succeed because it used the configured hive path, not the default
             exitCode.Should().Be(0);
         }
         finally
@@ -206,9 +206,10 @@ public class DotnetCommandTests
     }
 
     [TestMethod]
-    public void DotnetCommand_FallsBackToDefault_WhenAdminInstall()
+    public void DotnetCommand_FallsBackToDefault_WhenNotDotnetupHive()
     {
-        // Arrange - configured install is Admin, not User; should fall back to default
+        // Arrange - configured install is not a dotnetup hive (e.g. an admin or loose install);
+        // should fall back to default
         var adminDir = Directory.CreateTempSubdirectory("dotnetup-admin-test");
         var defaultDir = Directory.CreateTempSubdirectory("dotnetup-default-test");
         try
@@ -220,7 +221,7 @@ public class DotnetCommandTests
                 defaultInstallPath: defaultDir.FullName,
                 configuredRoot: new DotnetInstallRootConfiguration(
                     new DotnetInstallRoot(adminDir.FullName, InstallArchitecture.x64),
-                    InstallType.System));
+                    IsDotnetupHive: false));
 
             var parseResult = Parser.Parse(["dotnet", "--version"]);
             var command = new TestableDotnetCommand(parseResult, mock);

--- a/test/dotnetup.Tests/InstallPathResolverTests.cs
+++ b/test/dotnetup.Tests/InstallPathResolverTests.cs
@@ -178,6 +178,32 @@ public class InstallPathResolverTests
         resolvedRoot.Should().Be(actualRoot);
     }
 
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void ResolveRealPath_ResolvesSymlinkedDirectoryToItsRealPath()
+    {
+        // Mirrors a symlinked data directory (e.g. LocalApplicationData / XDG_DATA_HOME pointing
+        // through a symlink): the resolved path must be the real directory so that a default install
+        // path can be compared symmetrically against the realpath-resolved current install root.
+        using var testEnvironment = new TestEnvironment();
+        string actualDir = Path.Combine(testEnvironment.TempRoot, "real-data", "dotnet");
+        Directory.CreateDirectory(actualDir);
+
+        string symlinkedParent = Path.Combine(testEnvironment.TempRoot, "linked-data");
+        Directory.CreateSymbolicLink(symlinkedParent, Path.Combine(testEnvironment.TempRoot, "real-data"));
+
+        string resolved = ExecutablePathResolver.ResolveRealPath(Path.Combine(symlinkedParent, "dotnet"))!;
+
+        resolved.Should().Be(actualDir);
+    }
+
+    [TestMethod]
+    public void ResolveRealPath_ReturnsNull_WhenPathIsNullOrEmpty()
+    {
+        ExecutablePathResolver.ResolveRealPath(null).Should().BeNull();
+        ExecutablePathResolver.ResolveRealPath(string.Empty).Should().BeNull();
+    }
+
     private static GlobalJsonInfo CreateGlobalJsonInfo(string sdkPath)
     {
         // GlobalJsonInfo.SdkPath is computed from GlobalJsonContents.Sdk.Paths relative to GlobalJsonPath

--- a/test/dotnetup.Tests/UninstallWorkflowTests.cs
+++ b/test/dotnetup.Tests/UninstallWorkflowTests.cs
@@ -20,8 +20,8 @@ public class UninstallWorkflowTests
 
     /// <summary>
     /// When no explicit path is provided and dotnet on PATH resolves to an admin install,
-    /// the uninstall should fall back to the default user install path — not the admin path.
-    /// Regression test: previously, GetConfiguredInstallType().Path was used unconditionally,
+    /// the uninstall should fall back to the default hive — not the admin path.
+    /// Regression test: previously, the configured path was used unconditionally,
     /// causing uninstall to target "C:\Program Files\dotnet" when the user meant their user install.
     /// </summary>
     [TestMethod]
@@ -29,27 +29,44 @@ public class UninstallWorkflowTests
     {
         var mock = new MockDotnetInstallManager(
             defaultInstallPath: DefaultUserPath,
-            configuredRoot: CreateConfig(AdminPath, InstallType.System));
+            configuredRoot: CreateConfig(AdminPath, isDotnetupHive: false));
 
         var result = UninstallWorkflow.ResolveInstallPath(null, mock);
 
-        result.Should().Be(DefaultUserPath, "system installs on PATH should not be used; default user path should be used instead");
+        result.Should().Be(DefaultUserPath, "installs on PATH that dotnetup does not own should not be used; default hive should be used instead");
     }
 
     /// <summary>
-    /// When dotnet on PATH resolves to a user install, the uninstall should use that path.
+    /// When dotnet on PATH resolves to the dotnetup-managed hive, the uninstall should use that path.
     /// </summary>
     [TestMethod]
-    public void ResolveInstallPath_UserInstall_UsesConfiguredPath()
+    public void ResolveInstallPath_DotnetupHive_UsesConfiguredPath()
     {
-        string userPath = "/home/user/custom-dotnet";
         var mock = new MockDotnetInstallManager(
             defaultInstallPath: DefaultUserPath,
-            configuredRoot: CreateConfig(userPath, InstallType.User));
+            configuredRoot: CreateConfig(DefaultUserPath, isDotnetupHive: true));
 
         var result = UninstallWorkflow.ResolveInstallPath(null, mock);
 
-        result.Should().Be(userPath, "user install path from configuration should be used");
+        result.Should().Be(DefaultUserPath, "the dotnetup hive on PATH should be used");
+    }
+
+    /// <summary>
+    /// A dotnet that lives in a user-writable location but is not a dotnetup hive (e.g. a
+    /// hand-extracted C:\dotnet that happens to win on PATH) must not be treated as dotnetup's;
+    /// uninstall should fall back to the default hive rather than target the unmanaged install.
+    /// </summary>
+    [TestMethod]
+    public void ResolveInstallPath_UnmanagedUserInstall_FallsBackToDefault()
+    {
+        string looseUserPath = "/home/user/custom-dotnet";
+        var mock = new MockDotnetInstallManager(
+            defaultInstallPath: DefaultUserPath,
+            configuredRoot: CreateConfig(looseUserPath, isDotnetupHive: false));
+
+        var result = UninstallWorkflow.ResolveInstallPath(null, mock);
+
+        result.Should().Be(DefaultUserPath, "a non-hive install on PATH should not be uninstalled; default hive should be used");
     }
 
     /// <summary>
@@ -60,7 +77,7 @@ public class UninstallWorkflowTests
     {
         var mock = new MockDotnetInstallManager(
             defaultInstallPath: DefaultUserPath,
-            configuredRoot: CreateConfig(AdminPath, InstallType.System));
+            configuredRoot: CreateConfig(AdminPath, isDotnetupHive: false));
 
         var result = UninstallWorkflow.ResolveInstallPath(ExplicitPath, mock);
 
@@ -82,9 +99,9 @@ public class UninstallWorkflowTests
         result.Should().Be(DefaultUserPath);
     }
 
-    private static DotnetInstallRootConfiguration CreateConfig(string path, InstallType installType)
+    private static DotnetInstallRootConfiguration CreateConfig(string path, bool isDotnetupHive)
     {
         var installRoot = new DotnetInstallRoot(path, InstallerUtilities.GetDefaultInstallArchitecture());
-        return new DotnetInstallRootConfiguration(installRoot, installType);
+        return new DotnetInstallRootConfiguration(installRoot, isDotnetupHive);
     }
 }


### PR DESCRIPTION
Follow-up to #54545 addressing review feedback (especially https://github.com/dotnet/sdk/pull/54545#discussion_r3599474868).  Also includes improvement to some wording I noticed when testing.

Copilot description:

## Changes

### 1. Classify the PATH dotnet by "is it a dotnetup-managed hive?" (not system vs user)
`GetCurrentPathConfiguration` previously returned an `InstallType` (`User`/`System`) derived from `IsAdminInstallPath`. But the consumers actually need to know whether the `dotnet` winning on `PATH` is **a hive dotnetup owns** — something it may run or uninstall from. Under the old axis, a `dotnet` that merely lives in a user-writable location (e.g. a hand-extracted `C:\dotnet` on `PATH`) was labeled `User`, so `dotnetup dotnet` and `dotnetup uninstall` (without `--install-path`) would run or target an install dotnetup does not own.

- `DotnetInstallRootConfiguration.InstallType` → `bool IsDotnetupHive`.
- `IsDotnetupHive` is `true` only when the resolved root is dotnetup's managed hive (today, the default install path; configurable hives tracked in #55346).
- Consumers realigned: `DotnetCommand` / `UninstallWorkflow` act on the configured path only when it's the hive; `InitWorkflows` uses `InstallPathClassifier.IsAdminInstallPath` directly where it genuinely needs "is this a system install?"; install telemetry records the existing install's location bucket via `ClassifyInstallPath`.
- Tests updated to the hive semantics, plus a new test locking in that an unmanaged user install falls back to the default hive.

**Behavior change:** `dotnetup dotnet` / `uninstall` no longer act on a non-managed `dotnet` that happens to win on `PATH`; they fall back to the managed hive.

### 2. Doc fix: `DotnetAccessMode` legacy spellings are not accepted
The `dotnetup env` design doc claimed the JSON converter accepts legacy spellings (`full` / `fullpathreplacement`). It does not — `DotnetAccessModeJsonConverter` is a plain camel-case string-enum converter (integer values rejected), and unrecognized values are treated as a corrupt config that re-defaults on next write. Corrected the doc to match the code and the rest of the doc.

## Testing
Built `dotnetup.Tests` (Release); the affected `UninstallWorkflowTests` and `DotnetCommandTests` pass (23/23).