### PR TITLE
Support extension members in API diff

### DIFF
--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -589,6 +589,17 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
 
     private static SyntaxNode GetChildlessNode(MemberDeclarationSyntax node)
     {
+        if (node is ExtensionBlockDeclarationSyntax { ParameterList.Parameters: [var receiver] } extensionBlock &&
+            string.IsNullOrEmpty(receiver.Identifier.ValueText))
+        {
+            node = extensionBlock.WithParameterList(
+                extensionBlock.ParameterList.WithParameters(
+                    SyntaxFactory.SingletonSeparatedList(
+                        receiver.WithType(receiver.Type!.WithoutTrailingTrivia())
+                                .WithIdentifier(default)
+                                .WithoutTrailingTrivia())));
+        }
+
         SyntaxNode childlessNode = node.RemoveNodes(node.ChildNodes().Where(
                 c => c is MemberDeclarationSyntax or BaseTypeDeclarationSyntax or DelegateDeclarationSyntax), SyntaxRemoveOptions.KeepNoTrivia)!;
 
@@ -651,6 +662,7 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
 
     private static bool IsEnumMemberOrHasPublicOrProtectedModifierOrIsDestructor(MemberDeclarationSyntax m) =>
         // Destructors don't have visibility modifiers so they're special-cased
+        m is ExtensionBlockDeclarationSyntax ||
         m.Modifiers.Any(SyntaxKind.PublicKeyword) || m.Modifiers.Any(SyntaxKind.ProtectedKeyword) ||
         // Enum member declarations don't have any modifiers
         m is EnumMemberDeclarationSyntax ||

--- a/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
+++ b/src/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff/MemoryOutputDiffGenerator.cs
@@ -661,8 +661,9 @@ public class MemoryOutputDiffGenerator : IDiffGenerator
     }
 
     private static bool IsEnumMemberOrHasPublicOrProtectedModifierOrIsDestructor(MemberDeclarationSyntax m) =>
-        // Destructors don't have visibility modifiers so they're special-cased
-        m is ExtensionBlockDeclarationSyntax ||
+        // Extension blocks don't have visibility modifiers, so only include a block with visible members.
+        m is ExtensionBlockDeclarationSyntax extensionBlock && GetMembersOfType<MemberDeclarationSyntax>(extensionBlock).Any() ||
+        // Destructors don't have visibility modifiers so they're special-cased.
         m.Modifiers.Any(SyntaxKind.PublicKeyword) || m.Modifiers.Any(SyntaxKind.ProtectedKeyword) ||
         // Enum member declarations don't have any modifiers
         m is EnumMemberDeclarationSyntax ||

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -341,18 +341,23 @@ public sealed class CSharpAssemblyDocumentGenerator
     {
         IMethodSymbol? accessor = isSetter ? extensionProperty.SetMethod : extensionProperty.GetMethod;
         int receiverParameterCount = extensionProperty.IsStatic ? 0 : 1;
+        int indexerParameterCount = extensionProperty.Parameters.Length;
         int valueParameterCount = isSetter ? 1 : 0;
         if (accessor is null ||
             implementation.Name != accessor.Name ||
             implementation.Arity != extensionBlock.Arity ||
-            implementation.Parameters.Length != receiverParameterCount + valueParameterCount)
+            implementation.Parameters.Length != receiverParameterCount + indexerParameterCount + valueParameterCount)
         {
             return false;
         }
 
-        return isSetter
+        bool hasMatchingIndexerParameters = extensionProperty.Parameters
+            .Zip(implementation.Parameters.Skip(receiverParameterCount))
+            .All(static parameters => HasMatchingType(parameters.First.Type, parameters.Second.Type));
+
+        return hasMatchingIndexerParameters && (isSetter
             ? implementation.ReturnsVoid && HasMatchingType(implementation.Parameters[^1].Type, extensionProperty.Type)
-            : HasMatchingType(implementation.ReturnType, extensionProperty.Type);
+            : HasMatchingType(implementation.ReturnType, extensionProperty.Type));
     }
 
     private static bool HasMatchingType(ITypeSymbol first, ITypeSymbol second) =>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -323,7 +323,8 @@ public sealed class CSharpAssemblyDocumentGenerator
         if (implementation.Name != extensionMethod.Name ||
             implementation.Arity != extensionBlock.Arity + extensionMethod.Arity ||
             implementation.Parameters.Length != extensionMethod.Parameters.Length + receiverParameterCount ||
-            !HasMatchingType(implementation.ReturnType, extensionMethod.ReturnType))
+        !HasMatchingType(implementation.ReturnType, extensionMethod.ReturnType) ||
+        !HasMatchingReceiver(implementation, extensionBlock, receiverParameterCount))
         {
             return false;
         }
@@ -346,7 +347,8 @@ public sealed class CSharpAssemblyDocumentGenerator
         if (accessor is null ||
             implementation.Name != accessor.Name ||
             implementation.Arity != extensionBlock.Arity ||
-            implementation.Parameters.Length != receiverParameterCount + indexerParameterCount + valueParameterCount)
+            implementation.Parameters.Length != receiverParameterCount + indexerParameterCount + valueParameterCount ||
+            !HasMatchingReceiver(implementation, extensionBlock, receiverParameterCount))
         {
             return false;
         }
@@ -358,6 +360,21 @@ public sealed class CSharpAssemblyDocumentGenerator
         return hasMatchingIndexerParameters && (isSetter
             ? implementation.ReturnsVoid && HasMatchingType(implementation.Parameters[^1].Type, extensionProperty.Type)
             : HasMatchingType(implementation.ReturnType, extensionProperty.Type));
+    }
+
+    private bool HasMatchingReceiver(
+        IMethodSymbol implementation,
+        INamedTypeSymbol extensionBlock,
+        int receiverParameterCount)
+    {
+        if (receiverParameterCount == 0)
+        {
+            return true;
+        }
+
+        return _syntaxGenerator.Declaration(extensionBlock) is ExtensionBlockDeclarationSyntax { ParameterList.Parameters: [var receiver] } &&
+            receiver.Type is not null &&
+            SyntaxFactory.AreEquivalent(receiver.Type, _syntaxGenerator.TypeExpression(implementation.Parameters[0].Type));
     }
 
     private static bool HasMatchingType(ITypeSymbol first, ITypeSymbol second) =>

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -197,7 +197,10 @@ public sealed class CSharpAssemblyDocumentGenerator
 
     private SyntaxNode Visit(SyntaxNode namedTypeNode, INamedTypeSymbol namedType)
     {
-        IEnumerable<ISymbol> members = namedType.GetMembers().Where(_options.SymbolFilter.Include);
+        INamedTypeSymbol[] extensionBlocks = [.. namedType.GetTypeMembers().Where(static type => string.IsNullOrEmpty(type.Name))];
+        IEnumerable<ISymbol> members = namedType.GetMembers()
+            .Where(_options.SymbolFilter.Include)
+            .Where(member => !IsExtensionBlockImplementation(member, extensionBlocks));
 
         // If it's a value type
         if (namedType.TypeKind == TypeKind.Struct)
@@ -275,6 +278,46 @@ public sealed class CSharpAssemblyDocumentGenerator
         }
 
         return namedTypeNode;
+    }
+
+    private static bool IsExtensionBlockImplementation(ISymbol member, IEnumerable<INamedTypeSymbol> extensionBlocks)
+    {
+        if (member is not IMethodSymbol implementation)
+        {
+            return false;
+        }
+
+        foreach (INamedTypeSymbol extensionBlock in extensionBlocks)
+        {
+            foreach (ISymbol extensionMember in extensionBlock.GetMembers())
+            {
+                if (extensionMember is IMethodSymbol extensionMethod &&
+                    implementation.Name == extensionMethod.Name &&
+                    implementation.Arity == extensionBlock.Arity + extensionMethod.Arity &&
+                    implementation.Parameters.Length == extensionMethod.Parameters.Length + (extensionMethod.IsStatic ? 0 : 1))
+                {
+                    return true;
+                }
+
+                if (extensionMember is IPropertySymbol extensionProperty &&
+                    implementation.Name == extensionProperty.GetMethod?.Name &&
+                    implementation.Arity == extensionBlock.Arity &&
+                    implementation.Parameters.Length == (extensionProperty.IsStatic ? 0 : 1))
+                {
+                    return true;
+                }
+
+                if (extensionMember is IPropertySymbol propertyWithSetter &&
+                    implementation.Name == propertyWithSetter.SetMethod?.Name &&
+                    implementation.Arity == extensionBlock.Arity &&
+                    implementation.Parameters.Length == (propertyWithSetter.IsStatic ? 1 : 2))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private SyntaxNode GenerateAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -280,7 +280,7 @@ public sealed class CSharpAssemblyDocumentGenerator
         return namedTypeNode;
     }
 
-    private static bool IsExtensionBlockImplementation(ISymbol member, IEnumerable<INamedTypeSymbol> extensionBlocks)
+    private bool IsExtensionBlockImplementation(ISymbol member, IEnumerable<INamedTypeSymbol> extensionBlocks)
     {
         if (member is not IMethodSymbol implementation)
         {
@@ -292,25 +292,19 @@ public sealed class CSharpAssemblyDocumentGenerator
             foreach (ISymbol extensionMember in extensionBlock.GetMembers())
             {
                 if (extensionMember is IMethodSymbol extensionMethod &&
-                    implementation.Name == extensionMethod.Name &&
-                    implementation.Arity == extensionBlock.Arity + extensionMethod.Arity &&
-                    implementation.Parameters.Length == extensionMethod.Parameters.Length + (extensionMethod.IsStatic ? 0 : 1))
+                    IsMatchingExtensionMethod(implementation, extensionMethod, extensionBlock))
                 {
                     return true;
                 }
 
                 if (extensionMember is IPropertySymbol extensionProperty &&
-                    implementation.Name == extensionProperty.GetMethod?.Name &&
-                    implementation.Arity == extensionBlock.Arity &&
-                    implementation.Parameters.Length == (extensionProperty.IsStatic ? 0 : 1))
+                    IsMatchingExtensionPropertyAccessor(implementation, extensionProperty, extensionBlock, isSetter: false))
                 {
                     return true;
                 }
 
                 if (extensionMember is IPropertySymbol propertyWithSetter &&
-                    implementation.Name == propertyWithSetter.SetMethod?.Name &&
-                    implementation.Arity == extensionBlock.Arity &&
-                    implementation.Parameters.Length == (propertyWithSetter.IsStatic ? 1 : 2))
+                    IsMatchingExtensionPropertyAccessor(implementation, propertyWithSetter, extensionBlock, isSetter: true))
                 {
                     return true;
                 }
@@ -319,6 +313,51 @@ public sealed class CSharpAssemblyDocumentGenerator
 
         return false;
     }
+
+    private bool IsMatchingExtensionMethod(
+        IMethodSymbol implementation,
+        IMethodSymbol extensionMethod,
+        INamedTypeSymbol extensionBlock)
+    {
+        int receiverParameterCount = extensionMethod.IsStatic ? 0 : 1;
+        if (implementation.Name != extensionMethod.Name ||
+            implementation.Arity != extensionBlock.Arity + extensionMethod.Arity ||
+            implementation.Parameters.Length != extensionMethod.Parameters.Length + receiverParameterCount ||
+            !HasMatchingType(implementation.ReturnType, extensionMethod.ReturnType))
+        {
+            return false;
+        }
+
+        return extensionMethod.Parameters
+            .Zip(implementation.Parameters.Skip(receiverParameterCount))
+            .All(static parameters => HasMatchingType(parameters.First.Type, parameters.Second.Type));
+    }
+
+    private bool IsMatchingExtensionPropertyAccessor(
+        IMethodSymbol implementation,
+        IPropertySymbol extensionProperty,
+        INamedTypeSymbol extensionBlock,
+        bool isSetter)
+    {
+        IMethodSymbol? accessor = isSetter ? extensionProperty.SetMethod : extensionProperty.GetMethod;
+        int receiverParameterCount = extensionProperty.IsStatic ? 0 : 1;
+        int valueParameterCount = isSetter ? 1 : 0;
+        if (accessor is null ||
+            implementation.Name != accessor.Name ||
+            implementation.Arity != extensionBlock.Arity ||
+            implementation.Parameters.Length != receiverParameterCount + valueParameterCount)
+        {
+            return false;
+        }
+
+        return isSetter
+            ? implementation.ReturnsVoid && HasMatchingType(implementation.Parameters[^1].Type, extensionProperty.Type)
+            : HasMatchingType(implementation.ReturnType, extensionProperty.Type);
+    }
+
+    private static bool HasMatchingType(ITypeSymbol first, ITypeSymbol second) =>
+        SymbolEqualityComparer.Default.Equals(first, second) ||
+        first.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == second.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
     private SyntaxNode GenerateAssemblyAttributes(IAssemblySymbol assembly, SyntaxNode compilationUnit)
     {

--- a/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
+++ b/src/Compatibility/GenAPI/Microsoft.DotNet.GenAPI/CSharpAssemblyDocumentGenerator.cs
@@ -331,7 +331,7 @@ public sealed class CSharpAssemblyDocumentGenerator
 
         return extensionMethod.Parameters
             .Zip(implementation.Parameters.Skip(receiverParameterCount))
-            .All(static parameters => HasMatchingType(parameters.First.Type, parameters.Second.Type));
+            .All(static parameters => HasMatchingParameter(parameters.First, parameters.Second));
     }
 
     private bool IsMatchingExtensionPropertyAccessor(
@@ -342,23 +342,21 @@ public sealed class CSharpAssemblyDocumentGenerator
     {
         IMethodSymbol? accessor = isSetter ? extensionProperty.SetMethod : extensionProperty.GetMethod;
         int receiverParameterCount = extensionProperty.IsStatic ? 0 : 1;
-        int indexerParameterCount = extensionProperty.Parameters.Length;
-        int valueParameterCount = isSetter ? 1 : 0;
         if (accessor is null ||
             implementation.Name != accessor.Name ||
             implementation.Arity != extensionBlock.Arity ||
-            implementation.Parameters.Length != receiverParameterCount + indexerParameterCount + valueParameterCount ||
+            implementation.Parameters.Length != receiverParameterCount + accessor.Parameters.Length ||
             !HasMatchingReceiver(implementation, extensionBlock, receiverParameterCount))
         {
             return false;
         }
 
-        bool hasMatchingIndexerParameters = extensionProperty.Parameters
+        bool hasMatchingParameters = accessor.Parameters
             .Zip(implementation.Parameters.Skip(receiverParameterCount))
-            .All(static parameters => HasMatchingType(parameters.First.Type, parameters.Second.Type));
+            .All(static parameters => HasMatchingParameter(parameters.First, parameters.Second));
 
-        return hasMatchingIndexerParameters && (isSetter
-            ? implementation.ReturnsVoid && HasMatchingType(implementation.Parameters[^1].Type, extensionProperty.Type)
+        return hasMatchingParameters && (isSetter
+            ? implementation.ReturnsVoid
             : HasMatchingType(implementation.ReturnType, extensionProperty.Type));
     }
 
@@ -374,8 +372,32 @@ public sealed class CSharpAssemblyDocumentGenerator
 
         return _syntaxGenerator.Declaration(extensionBlock) is ExtensionBlockDeclarationSyntax { ParameterList.Parameters: [var receiver] } &&
             receiver.Type is not null &&
+            GetRefKind(receiver) == implementation.Parameters[0].RefKind &&
             SyntaxFactory.AreEquivalent(receiver.Type, _syntaxGenerator.TypeExpression(implementation.Parameters[0].Type));
     }
+
+    private static RefKind GetRefKind(ParameterSyntax parameter)
+    {
+        if (parameter.Modifiers.Any(SyntaxKind.OutKeyword))
+        {
+            return RefKind.Out;
+        }
+
+        if (parameter.Modifiers.Any(SyntaxKind.InKeyword))
+        {
+            return RefKind.In;
+        }
+
+        if (parameter.Modifiers.Any(SyntaxKind.RefKeyword))
+        {
+            return parameter.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) ? RefKind.RefReadOnly : RefKind.Ref;
+        }
+
+        return RefKind.None;
+    }
+
+    private static bool HasMatchingParameter(IParameterSymbol first, IParameterSymbol second) =>
+        first.RefKind == second.RefKind && HasMatchingType(first.Type, second.Type);
 
     private static bool HasMatchingType(ITypeSymbol first, ITypeSymbol second) =>
         SymbolEqualityComparer.Default.Equals(first, second) ||

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Base.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.Base.Tests.cs
@@ -22,14 +22,16 @@ public abstract class DiffBaseTests
                            string expectedCode,
                            string[]? attributesToExclude = null,
                            string[]? apisToExclude = null,
-                           bool addPartialModifier = false)
+                           bool addPartialModifier = false,
+                           bool usePreviewLanguageVersion = false)
         => RunTestAsync(
                    before: [($"{AssemblyName}.dll", beforeCode)],
                    after: [($"{AssemblyName}.dll", afterCode)],
                    expected: new() { { AssemblyName, expectedCode } },
                    attributesToExclude,
                    apisToExclude,
-                   addPartialModifier);
+                   addPartialModifier,
+                   usePreviewLanguageVersion);
 
     protected async Task RunTestAsync(
                            (string, string)[] before,
@@ -37,15 +39,24 @@ public abstract class DiffBaseTests
                            Dictionary<string, string> expected,
                            string[]? attributesToExclude = null,
                            string[]? apisToExclude = null,
-                           bool addPartialModifier = false)
+                           bool addPartialModifier = false,
+                           bool usePreviewLanguageVersion = false)
     {
         // CreateFromTexts will assert on any loader diagnostics via SyntaxFactory.
 
         (IAssemblySymbolLoader beforeLoader, Dictionary<string, IAssemblySymbol> beforeAssemblySymbols)
-            = TestAssemblyLoaderFactory.CreateFromTexts(_log.Object, assemblyTexts: before, diagnosticOptions: DiffGeneratorFactory.DefaultDiagnosticOptions);
+            = TestAssemblyLoaderFactory.CreateFromTexts(
+                _log.Object,
+                assemblyTexts: before,
+                diagnosticOptions: DiffGeneratorFactory.DefaultDiagnosticOptions,
+                usePreviewLanguageVersion: usePreviewLanguageVersion);
 
         (IAssemblySymbolLoader afterLoader, Dictionary<string, IAssemblySymbol> afterAssemblySymbols)
-            = TestAssemblyLoaderFactory.CreateFromTexts(_log.Object, assemblyTexts: after, diagnosticOptions: DiffGeneratorFactory.DefaultDiagnosticOptions);
+            = TestAssemblyLoaderFactory.CreateFromTexts(
+                _log.Object,
+                assemblyTexts: after,
+                diagnosticOptions: DiffGeneratorFactory.DefaultDiagnosticOptions,
+                usePreviewLanguageVersion: usePreviewLanguageVersion);
 
         using MemoryStream outputStream = new();
 

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ApiDiff.Tests;
+
+[TestClass]
+public class DiffExtensionMemberTests : DiffBaseTests
+{
+    [TestMethod]
+    public Task InstanceExtensionMembersAdd() => RunTestAsync(
+        beforeCode: """
+            namespace MyNamespace
+            {
+                public static class MyExtensions
+                {
+                }
+            }
+            """,
+        afterCode: """
+            namespace MyNamespace
+            {
+                public static class MyExtensions
+                {
+                    extension(int value)
+                    {
+                        public int Increment() => value + 1;
+                        public bool IsEven => value % 2 == 0;
+                    }
+                }
+            }
+            """,
+        expectedCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+            +         extension(int value)
+            +         {
+            +             public int Increment();
+            +             public bool IsEven { get; }
+            +         }
+                  }
+              }
+            """);
+
+    [TestMethod]
+    public Task StaticExtensionMembersAdd() => RunTestAsync(
+        beforeCode: """
+            namespace MyNamespace
+            {
+                public static class MyExtensions
+                {
+                }
+            }
+            """,
+        afterCode: """
+            namespace MyNamespace
+            {
+                public static class MyExtensions
+                {
+                    extension(int)
+                    {
+                        public static int Add(int left, int right) => left + right;
+                        public static int Zero => 0;
+                    }
+                }
+            }
+            """,
+        expectedCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+            +         extension(int)
+            +         {
+            +             public static int Add(int left, int right);
+            +             public static int Zero { get; }
+            +         }
+                  }
+              }
+            """);
+
+    [TestMethod]
+    public Task InstanceExtensionMembersChangeAndDelete() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int value)
+                      {
+                          public int Increment() => value + 1;
+                          public bool IsEven => value % 2 == 0;
+                      }
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int value)
+                      {
+                          public long Increment() => value + 1;
+                          public string Describe() => value.ToString();
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+                        extension(int value)
+                        {
+              -             public int Increment();
+              +             public long Increment();
+              -             public bool IsEven { get; }
+              +             public string Describe();
+                        }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task ExtensionBlockDoesNotHideConventionalStaticMembers() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      public static int Classic(this int value) => value;
+                      public static int Ordinary() => 0;
+
+                      extension(int value)
+                      {
+                          public int Increment() => value + 1;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         public static int Classic(this int value);
+              +         public static int Ordinary();
+              +         extension(int value)
+              +         {
+              +             public int Increment();
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task GenericExtensionMemberAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T value)
+                      {
+                          public T Identity() => value;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T value)
+              +         {
+              +             public T Identity();
+              +         }
+                    }
+                }
+              """);
+}

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -609,4 +609,42 @@ public class DiffExtensionMemberTests : DiffBaseTests
                 }
               """,
         usePreviewLanguageVersion: true);
+
+    [TestMethod]
+    public Task ExtensionPropertyDoesNotHideAccessorNamedMethods() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      public static int get_First(string value) => value.Length;
+
+                      extension(int[] values)
+                      {
+                          public int First => values[0];
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         public static int get_First(string value);
+              +         extension(int[] values)
+              +         {
+              +             public int First { get; }
+              +         }
+                    }
+                }
+              """);
 }

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -198,4 +198,330 @@ public class DiffExtensionMemberTests : DiffBaseTests
                     }
                 }
               """);
+
+    [TestMethod]
+    public Task ExtensionMembersForDifferentTargetTypesAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int value)
+                      {
+                          public int Increment() => value + 1;
+                      }
+
+                      extension(string text)
+                      {
+                          public int Length() => text.Length;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension(string text)
+              +         {
+              +             public int Length();
+              +         }
+              +         extension(int value)
+              +         {
+              +             public int Increment();
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task ExtensionMembersForSameTargetTypeInSeparateBlocksAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int value)
+                      {
+                          public int Increment() => value + 1;
+                      }
+
+                      extension(int number)
+                      {
+                          public int Double() => number * 2;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension(int number)
+              +         {
+              +             public int Double();
+              +         }
+              +         extension(int value)
+              +         {
+              +             public int Increment();
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task ExtensionMembersWithAlternatingTargetTypesAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int first)
+                      {
+                          public int Increment() => first + 1;
+                      }
+
+                      extension(string text)
+                      {
+                          public int Length() => text.Length;
+                      }
+
+                      extension(int second)
+                      {
+                          public int Double() => second * 2;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension(string text)
+              +         {
+              +             public int Length();
+              +         }
+              +         extension(int second)
+              +         {
+              +             public int Double();
+              +         }
+              +         extension(int first)
+              +         {
+              +             public int Increment();
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task GenericStaticExtensionMemberAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T)
+                      {
+                          public static TResult Create<TResult>(TResult value) => value;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T)
+              +         {
+              +             public static TResult Create<TResult>(TResult value);
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task GenericInstanceExtensionMemberAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T value)
+                      {
+                          public TResult Convert<TResult>(TResult result) => result;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T value)
+              +         {
+              +             public TResult Convert<TResult>(TResult result);
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task ConstrainedGenericInstanceExtensionMemberAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T value)
+                          where T : class
+                      {
+                          public TResult Convert<TResult>(TResult result)
+                              where TResult : class
+                              => result;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T value)
+              +             where T : class
+              +         {
+              +             public TResult Convert<TResult>(TResult result)
+              +                 where TResult : class;
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task GenericStaticExtensionMemberWithTypeLevelGenericAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T)
+                      {
+                          public static T Default() => throw new System.NotImplementedException();
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T)
+              +         {
+              +             public static T Default();
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task ConstrainedGenericStaticExtensionMemberAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension<T>(T)
+                          where T : class
+                      {
+                          public static TResult Create<TResult>(TResult value)
+                              where TResult : class
+                              => value;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension<T>(T)
+              +             where T : class
+              +         {
+              +             public static TResult Create<TResult>(TResult value)
+              +                 where TResult : class;
+              +         }
+                    }
+                }
+              """);
 }

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -524,4 +524,42 @@ public class DiffExtensionMemberTests : DiffBaseTests
                     }
                 }
               """);
+
+    [TestMethod]
+    public Task ExtensionBlockDoesNotHideStaticOverloads() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      public static void Foo(int value) { }
+
+                      extension(int)
+                      {
+                          public static void Foo(bool value) { }
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         public static void Foo(int value);
+              +         extension(int)
+              +         {
+              +             public static void Foo(bool value);
+              +         }
+                    }
+                }
+              """);
 }

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -562,4 +562,51 @@ public class DiffExtensionMemberTests : DiffBaseTests
                     }
                 }
               """);
+
+    [TestMethod]
+    public Task SettableExtensionPropertyAndIndexerAdd() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int[] values)
+                      {
+                          public int First
+                          {
+                              get => values[0];
+                              set => values[0] = value;
+                          }
+
+                          public int this[int index]
+                          {
+                              get => values[index];
+                              set => values[index] = value;
+                          }
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         extension(int[] values)
+              +         {
+              +             public int First { get; set; }
+              +             public int this[int index] { get { } set { } }
+              +         }
+                    }
+                }
+              """,
+        usePreviewLanguageVersion: true);
 }

--- a/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
+++ b/test/Microsoft.DotNet.ApiDiff.Tests/Diff.ExtensionMember.Tests.cs
@@ -647,4 +647,104 @@ public class DiffExtensionMemberTests : DiffBaseTests
                     }
                 }
               """);
+
+    [TestMethod]
+    public Task NonPublicExtensionMembersAreExcluded() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      extension(int value)
+                      {
+                          internal int Increment() => value + 1;
+                      }
+                  }
+              }
+              """,
+        expectedCode: "");
+
+    [TestMethod]
+    public Task ExtensionBlockDoesNotHideRefOverloads() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      public static void Update(ref int value) { }
+
+                      extension(int)
+                      {
+                          public static void Update(int value) { }
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         public static void Update(ref int value);
+              +         extension(int)
+              +         {
+              +             public static void Update(int value);
+              +         }
+                    }
+                }
+              """);
+
+    [TestMethod]
+    public Task RefExtensionReceiverDoesNotHideValueOverloads() => RunTestAsync(
+        beforeCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                  }
+              }
+              """,
+        afterCode: """
+              namespace MyNamespace
+              {
+                  public static class MyExtensions
+                  {
+                      public static void Increment(int value) { }
+
+                      extension(ref int value)
+                      {
+                          public void Increment() => value++;
+                      }
+                  }
+              }
+              """,
+        expectedCode: """
+                namespace MyNamespace
+                {
+                    public static class MyExtensions
+                    {
+              +         public static void Increment(int value);
+              +         extension(ref int value)
+              +         {
+              +             public void Increment();
+              +         }
+                    }
+                }
+              """);
 }

--- a/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
+++ b/test/Microsoft.DotNet.ApiSymbolExtensions.Tests/SymbolFactory.cs
@@ -35,9 +35,17 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             bool enableNullable = false,
             byte[] publicKey = null,
             [CallerMemberName] string assemblyName = "",
-            bool allowUnsafe = false)
+            bool allowUnsafe = false,
+            bool usePreviewLanguageVersion = false)
         {
-            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
+            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(
+                syntax,
+                assemblyName,
+                enableNullable,
+                publicKey,
+                allowUnsafe,
+                diagnosticOptions,
+                usePreviewLanguageVersion);
 
             AssertNoDiagnostics(compilation);
 
@@ -87,10 +95,17 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             }
         }
 
-        private static CSharpCompilation CreateCSharpCompilationFromSyntax(string syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
+        private static CSharpCompilation CreateCSharpCompilationFromSyntax(
+            string syntax,
+            string name,
+            bool enableNullable,
+            byte[] publicKey,
+            bool allowUnsafe,
+            IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null,
+            bool usePreviewLanguageVersion = false)
         {
             CSharpCompilation compilation = CreateCSharpCompilation(name, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
-            return compilation.AddSyntaxTrees(GetSyntaxTree(syntax));
+            return compilation.AddSyntaxTrees(GetSyntaxTree(syntax, usePreviewLanguageVersion));
         }
 
         private static CSharpCompilation CreateCSharpCompilationFromSyntax(IEnumerable<string> syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe)
@@ -100,7 +115,10 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             return compilation.AddSyntaxTrees(syntaxTrees);
         }
 
-        private static SyntaxTree GetSyntaxTree(string syntax) => CSharpSyntaxTree.ParseText(syntax, ParseOptions);
+        private static SyntaxTree GetSyntaxTree(string syntax, bool usePreviewLanguageVersion = false) =>
+            CSharpSyntaxTree.ParseText(
+                syntax,
+                usePreviewLanguageVersion ? ParseOptions.WithLanguageVersion(LanguageVersion.Preview) : ParseOptions);
 
         private static CSharpCompilation CreateCSharpCompilation(string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
         {

--- a/test/Microsoft.DotNet.GenAPI.Tests/SymbolFactory.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/SymbolFactory.cs
@@ -35,9 +35,17 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             bool enableNullable = false,
             byte[] publicKey = null,
             [CallerMemberName] string assemblyName = "",
-            bool allowUnsafe = false)
+            bool allowUnsafe = false,
+            bool usePreviewLanguageVersion = false)
         {
-            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(syntax, assemblyName, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
+            CSharpCompilation compilation = CreateCSharpCompilationFromSyntax(
+                syntax,
+                assemblyName,
+                enableNullable,
+                publicKey,
+                allowUnsafe,
+                diagnosticOptions,
+                usePreviewLanguageVersion);
 
             Assert.IsEmpty(compilation.GetDiagnostics());
 
@@ -77,10 +85,17 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             return compilation.Assembly;
         }
 
-        private static CSharpCompilation CreateCSharpCompilationFromSyntax(string syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
+        private static CSharpCompilation CreateCSharpCompilationFromSyntax(
+            string syntax,
+            string name,
+            bool enableNullable,
+            byte[] publicKey,
+            bool allowUnsafe,
+            IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null,
+            bool usePreviewLanguageVersion = false)
         {
             CSharpCompilation compilation = CreateCSharpCompilation(name, enableNullable, publicKey, allowUnsafe, diagnosticOptions);
-            return compilation.AddSyntaxTrees(GetSyntaxTree(syntax));
+            return compilation.AddSyntaxTrees(GetSyntaxTree(syntax, usePreviewLanguageVersion));
         }
 
         private static CSharpCompilation CreateCSharpCompilationFromSyntax(IEnumerable<string> syntax, string name, bool enableNullable, byte[] publicKey, bool allowUnsafe)
@@ -90,7 +105,10 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Tests
             return compilation.AddSyntaxTrees(syntaxTrees);
         }
 
-        private static SyntaxTree GetSyntaxTree(string syntax) => CSharpSyntaxTree.ParseText(syntax, ParseOptions);
+        private static SyntaxTree GetSyntaxTree(string syntax, bool usePreviewLanguageVersion = false) =>
+            CSharpSyntaxTree.ParseText(
+                syntax,
+                usePreviewLanguageVersion ? ParseOptions.WithLanguageVersion(LanguageVersion.Preview) : ParseOptions);
 
         private static CSharpCompilation CreateCSharpCompilation(string name, bool enableNullable, byte[] publicKey, bool allowUnsafe, IEnumerable<KeyValuePair<string, ReportDiagnostic>> diagnosticOptions = null)
         {

--- a/test/Microsoft.DotNet.GenAPI.Tests/TestAssemblyLoaderFactory.cs
+++ b/test/Microsoft.DotNet.GenAPI.Tests/TestAssemblyLoaderFactory.cs
@@ -16,7 +16,8 @@ public class TestAssemblyLoaderFactory
         (string, string)[] assemblyTexts,
         bool respectInternals = false,
         bool allowUnsafe = false,
-        IEnumerable<KeyValuePair<string, ReportDiagnostic>>? diagnosticOptions = null)
+        IEnumerable<KeyValuePair<string, ReportDiagnostic>>? diagnosticOptions = null,
+        bool usePreviewLanguageVersion = false)
     {
         if (assemblyTexts.Length == 0)
         {
@@ -32,7 +33,13 @@ public class TestAssemblyLoaderFactory
         foreach ((string assemblyName, string assemblyText) in assemblyTexts)
         {
             string actualAssemblyName = assemblyName.Replace(".dll", string.Empty);
-            using Stream assemblyStream = SymbolFactory.EmitAssemblyStreamFromSyntax(assemblyText, diagnosticOptions, enableNullable: true, allowUnsafe: allowUnsafe, assemblyName: assemblyName);
+            using Stream assemblyStream = SymbolFactory.EmitAssemblyStreamFromSyntax(
+                assemblyText,
+                diagnosticOptions,
+                enableNullable: true,
+                allowUnsafe: allowUnsafe,
+                assemblyName: assemblyName,
+                usePreviewLanguageVersion: usePreviewLanguageVersion);
             if (loader.LoadAssembly(actualAssemblyName, assemblyStream) is IAssemblySymbol assemblySymbol)
             {
                 assemblySymbols.Add(actualAssemblyName, assemblySymbol);


### PR DESCRIPTION
Preserves C# extension blocks in API diffs, suppresses compiler-generated implementation methods, and adds extension-member test coverage.

Original context: [API diff between .NET 11 Preview 5 and .NET 11 Preview 6 (dotnet/core#10485)](https://github.com/dotnet/core/pull/10485/changes#r3609512748)