### PR TITLE
dotnetup: Improve "everywhere" access mode

### DIFF
--- a/src/Installer/dotnetup.Library/Commands/ElevatedAdminPath/ElevatedAdminPathCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/ElevatedAdminPath/ElevatedAdminPathCommand.cs
@@ -10,11 +10,13 @@ internal class ElevatedAdminPathCommand : CommandBase
 {
     private readonly string _operation;
     private readonly string _outputFile;
+    private readonly string? _dotnetDir;
 
     public ElevatedAdminPathCommand(ParseResult result) : base(result)
     {
         _operation = result.GetValue(ElevatedAdminPathCommandParser.OperationArgument)!;
         _outputFile = result.GetValue(ElevatedAdminPathCommandParser.OutputFile)!;
+        _dotnetDir = result.GetValue(ElevatedAdminPathCommandParser.DotnetDir);
     }
 
     private void Log(string message)
@@ -50,8 +52,8 @@ internal class ElevatedAdminPathCommand : CommandBase
             // SetExitCode is the documented escape hatch for forwarding cases.
             SetExitCode(_operation.ToLowerInvariant() switch
             {
-                "removedotnet" => RemoveDotnet(),
-                "adddotnet" => AddDotnet(),
+                "insertdotnet" => InsertDotnet(_dotnetDir!),
+                "removedotnet" => RemoveDotnet(_dotnetDir!),
                 _ => throw new InvalidOperationException($"Unknown operation: {_operation}")
             });
         }
@@ -66,16 +68,16 @@ internal class ElevatedAdminPathCommand : CommandBase
     }
 
     [SupportedOSPlatform("windows")]
-    private static int RemoveDotnet()
+    private static int InsertDotnet(string dotnetDir)
     {
         using var pathHelper = new WindowsPathHelper();
-        return pathHelper.RemoveDotnetFromAdminPath();
+        return pathHelper.InsertDotnetIntoSystemPath(dotnetDir);
     }
 
     [SupportedOSPlatform("windows")]
-    private static int AddDotnet()
+    private static int RemoveDotnet(string dotnetDir)
     {
         using var pathHelper = new WindowsPathHelper();
-        return pathHelper.AddDotnetToAdminPath();
+        return pathHelper.RemoveDotnetFromSystemPath(dotnetDir);
     }
 }

--- a/src/Installer/dotnetup.Library/Commands/ElevatedAdminPath/ElevatedAdminPathCommandParser.cs
+++ b/src/Installer/dotnetup.Library/Commands/ElevatedAdminPath/ElevatedAdminPathCommandParser.cs
@@ -10,7 +10,7 @@ internal static class ElevatedAdminPathCommandParser
     public static readonly Argument<string> OperationArgument = new("operation")
     {
         HelpName = "OPERATION",
-        Description = "The operation to perform: 'removedotnet' or 'adddotnet'",
+        Description = "The operation to perform: 'insertdotnet' or 'removedotnet'",
         Arity = ArgumentArity.ExactlyOne,
     };
 
@@ -19,6 +19,15 @@ internal static class ElevatedAdminPathCommandParser
         HelpName = "OUTPUT_FILE",
         Description = "A file where any output that should be displayed to the user should be written.",
         Arity = ArgumentArity.ExactlyOne,
+    };
+
+    public static readonly Option<string> DotnetDir = new("--dotnet-dir")
+    {
+        HelpName = "DOTNET_DIR",
+        Description = "The dotnet directory to insert into or remove from the system PATH. "
+            + "Required because the elevated process may run under a different account and cannot "
+            + "recompute the invoking user's directory.",
+        Required = true,
     };
 
     private static readonly Command s_elevatedAdminPathCommand = ConstructCommand();
@@ -35,6 +44,7 @@ internal static class ElevatedAdminPathCommandParser
 
         command.Arguments.Add(OperationArgument);
         command.Arguments.Add(OutputFile);
+        command.Options.Add(DotnetDir);
 
         command.SetAction(parseResult => new ElevatedAdminPathCommand(parseResult).Execute());
 

--- a/src/Installer/dotnetup.Library/Commands/ElevatedSystemPath/ElevatedSystemPathCommand.cs
+++ b/src/Installer/dotnetup.Library/Commands/ElevatedSystemPath/ElevatedSystemPathCommand.cs
@@ -4,19 +4,19 @@
 using System.CommandLine;
 using System.Runtime.Versioning;
 
-namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedAdminPath;
+namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedSystemPath;
 
-internal class ElevatedAdminPathCommand : CommandBase
+internal class ElevatedSystemPathCommand : CommandBase
 {
     private readonly string _operation;
     private readonly string _outputFile;
     private readonly string? _dotnetDir;
 
-    public ElevatedAdminPathCommand(ParseResult result) : base(result)
+    public ElevatedSystemPathCommand(ParseResult result) : base(result)
     {
-        _operation = result.GetValue(ElevatedAdminPathCommandParser.OperationArgument)!;
-        _outputFile = result.GetValue(ElevatedAdminPathCommandParser.OutputFile)!;
-        _dotnetDir = result.GetValue(ElevatedAdminPathCommandParser.DotnetDir);
+        _operation = result.GetValue(ElevatedSystemPathCommandParser.OperationArgument)!;
+        _outputFile = result.GetValue(ElevatedSystemPathCommandParser.OutputFile)!;
+        _dotnetDir = result.GetValue(ElevatedSystemPathCommandParser.DotnetDir);
     }
 
     private void Log(string message)
@@ -25,14 +25,14 @@ internal class ElevatedAdminPathCommand : CommandBase
         File.AppendAllText(_outputFile, message + Environment.NewLine);
     }
 
-    protected override string GetCommandName() => "elevatedadminpath";
+    protected override string GetCommandName() => "elevatedsystempath";
 
     protected override void ExecuteCore()
     {
         // This command only works on Windows
         if (!OperatingSystem.IsWindows())
         {
-            const string message = "The elevatedadminpath command is only supported on Windows.";
+            const string message = "The elevatedsystempath command is only supported on Windows.";
             Log("Error: " + message);
             throw new DotnetInstallException(DotnetInstallErrorCode.PlatformNotSupported, message);
         }

--- a/src/Installer/dotnetup.Library/Commands/ElevatedSystemPath/ElevatedSystemPathCommandParser.cs
+++ b/src/Installer/dotnetup.Library/Commands/ElevatedSystemPath/ElevatedSystemPathCommandParser.cs
@@ -3,9 +3,9 @@
 
 using System.CommandLine;
 
-namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedAdminPath;
+namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedSystemPath;
 
-internal static class ElevatedAdminPathCommandParser
+internal static class ElevatedSystemPathCommandParser
 {
     public static readonly Argument<string> OperationArgument = new("operation")
     {
@@ -30,23 +30,23 @@ internal static class ElevatedAdminPathCommandParser
         Required = true,
     };
 
-    private static readonly Command s_elevatedAdminPathCommand = ConstructCommand();
+    private static readonly Command s_elevatedSystemPathCommand = ConstructCommand();
 
     public static Command GetCommand()
     {
-        return s_elevatedAdminPathCommand;
+        return s_elevatedSystemPathCommand;
     }
 
     private static Command ConstructCommand()
     {
-        Command command = new("elevatedadminpath", "Modifies the machine-wide admin PATH (requires elevated privileges)");
+        Command command = new("elevatedsystempath", "Modifies the machine-wide system PATH (requires elevated privileges)");
         command.Hidden = true;
 
         command.Arguments.Add(OperationArgument);
         command.Arguments.Add(OutputFile);
         command.Options.Add(DotnetDir);
 
-        command.SetAction(parseResult => new ElevatedAdminPathCommand(parseResult).Execute());
+        command.SetAction(parseResult => new ElevatedSystemPathCommand(parseResult).Execute());
 
         return command;
     }

--- a/src/Installer/dotnetup.Library/Commands/Init/DotnetAccessModeDisplay.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/DotnetAccessModeDisplay.cs
@@ -24,13 +24,13 @@ internal static class DotnetAccessModeDisplay
     };
 
     /// <summary>
-    /// Returns the display name, appending the localized "(Suggested)" hint only for the suggested
-    /// mode (<see cref="DotnetAccessMode.Shell"/> / Terminal Mode). The hint is a separate,
-    /// independently localizable string (rather than baked into the name) so translations are not
-    /// forced to follow the "(...)" convention or a particular word order.
+    /// Returns the display name, appending the localized "(Suggested)" hint only when the given
+    /// mode is the current default (see <see cref="InitWorkflowDefaults.GetDefaultAccessMode"/>).
+    /// The hint is a separate, independently localizable string (rather than baked into the name)
+    /// so translations are not forced to follow the "(...)" convention or a particular word order.
     /// </summary>
     public static string GetNameWithSuggestedHint(DotnetAccessMode accessMode)
-        => accessMode is DotnetAccessMode.Shell
+        => accessMode == InitWorkflowDefaults.GetDefaultAccessMode()
             ? string.Format(
                 CultureInfo.InvariantCulture,
                 "{0} {1}",

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
@@ -82,12 +82,22 @@ internal static class InitWorkflowDefaults
     }
 
     /// <summary>
-    /// Returns the recommended access mode without prompting: terminal-profile mode when a
-    /// supported shell is available, otherwise isolation mode. This is the value shown in the
-    /// summary and used by the "proceed with defaults" branch.
+    /// Returns the recommended access mode without prompting. On Windows this is everywhere mode;
+    /// otherwise it is terminal-profile mode when a supported shell is available, and isolation mode
+    /// when it is not. This is the value shown in the summary and used by the "proceed with
+    /// defaults" branch.
     /// </summary>
     public static DotnetAccessMode GetDefaultAccessMode(IEnvShellProvider? shellProvider = null)
     {
+        // On Windows, everywhere mode is the default: it inserts the user (dotnetup) dotnet
+        // directory into the system PATH ahead of any machine-wide install, so every application
+        // resolves the dotnetup .NET, not just shells that load the profile. This does not depend
+        // on shell detection, so it takes precedence over the no-shell fallback below.
+        if (OperatingSystem.IsWindows())
+        {
+            return DotnetAccessMode.Everywhere;
+        }
+
         if ((shellProvider ?? ShellDetection.GetCurrentShellProvider()) is null)
         {
             return DotnetAccessMode.None;

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
@@ -89,10 +89,7 @@ internal static class InitWorkflowDefaults
     /// </summary>
     public static DotnetAccessMode GetDefaultAccessMode(IEnvShellProvider? shellProvider = null)
     {
-        // On Windows, everywhere mode is the default: it inserts the user (dotnetup) dotnet
-        // directory into the system PATH ahead of any machine-wide install, so every application
-        // resolves the dotnetup .NET, not just shells that load the profile. This does not depend
-        // on shell detection, so it takes precedence over the no-shell fallback below.
+        // Default to Everywhere mode on Windows
         if (OperatingSystem.IsWindows())
         {
             return DotnetAccessMode.Everywhere;

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflows.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflows.cs
@@ -367,6 +367,7 @@ internal class InitWorkflows
             ? Strings.PathTooltipShell + " " + Strings.PathTooltipShellWindowsNote
             : Strings.PathTooltipShell;
 
+        var modes = new List<DotnetAccessMode> { DotnetAccessMode.None, DotnetAccessMode.Shell };
         var options = new List<SelectableOption>
         {
             new(Strings.AccessModeNone, Strings.PathDescriptionNone, isolationTooltip),
@@ -375,17 +376,17 @@ internal class InitWorkflows
 
         if (isWindows)
         {
+            modes.Add(DotnetAccessMode.Everywhere);
             options.Add(new(Strings.AccessModeEverywhere, Strings.PathDescriptionEverywhere, Strings.PathTooltipEverywhere));
         }
 
-        int selected = InteractiveOptionSelector.Show("How would you like to use dotnetup?", options, defaultIndex: 1);
+        // Highlight the recommended mode by default so the customize prompt agrees with the summary
+        // (e.g. Everywhere on Windows), rather than always defaulting to a fixed option.
+        int defaultIndex = Math.Max(0, modes.IndexOf(InitWorkflowDefaults.GetDefaultAccessMode()));
 
-        return selected switch
-        {
-            0 => DotnetAccessMode.None,
-            1 => DotnetAccessMode.Shell,
-            _ => DotnetAccessMode.Everywhere,
-        };
+        int selected = InteractiveOptionSelector.Show("How would you like to use dotnetup?", options, defaultIndex);
+
+        return modes[selected];
     }
 
     /// <summary>

--- a/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
+++ b/src/Installer/dotnetup.Library/DotnetEnvironmentManager.cs
@@ -259,9 +259,9 @@ internal class DotnetEnvironmentManager : IDotnetEnvironmentManager
                     break;
 
                 case InstallType.System:
-                    var adminChanges = installRootManager.GetAdminInstallRootChanges();
-                    InstallRootManager.ApplyAdminInstallRoot(
-                        adminChanges,
+                    var systemChanges = installRootManager.GetSystemInstallRootChanges();
+                    InstallRootManager.ApplySystemInstallRoot(
+                        systemChanges,
                         AnsiConsole.MarkupLine);
                     break;
 

--- a/src/Installer/dotnetup.Library/EnvSettingsApplier.cs
+++ b/src/Installer/dotnetup.Library/EnvSettingsApplier.cs
@@ -15,10 +15,10 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 ///
 /// Composition:
 /// <list type="bullet">
-///   <item>The managed profile block wires dotnet iff <c>env ∈ {Shell, All}</c> and adds the
+///   <item>The managed profile block wires dotnet iff <c>env ∈ {Shell, Everywhere}</c> and adds the
 ///     dotnetup directory iff <c>dotnetupOnPath</c>. When it would wire neither, the block is
 ///     removed.</item>
-///   <item>On Windows, <c>All</c> additionally writes the user dotnet directory to the system
+///   <item>On Windows, <c>Everywhere</c> additionally writes the user dotnet directory to the system
 ///     PATH (ahead of the machine-wide install) and sets user-scope DOTNET_ROOT, and
 ///     <c>dotnetupOnPath</c> additionally writes the dotnetup directory to the user PATH (so
 ///     cmd.exe and GUI apps see it).</item>
@@ -47,10 +47,10 @@ internal static class EnvSettingsApplier
                 $"{nameof(DotnetAccessMode)}.{nameof(DotnetAccessMode.Everywhere)} is only supported on Windows.");
         }
 
-        // Windows user-scope dotnet env vars (PATH + DOTNET_ROOT) are wired only by All mode.
+        // Windows user-scope dotnet env vars (PATH + DOTNET_ROOT) are wired only by Everywhere mode.
         bool nowWritesDotnetEnvVars = targetEnv == DotnetAccessMode.Everywhere;
 
-        // The managed profile block wires dotnet for Shell/All, and dotnetup when dotnetupOnPath.
+        // The managed profile block wires dotnet for Shell/Everywhere, and dotnetup when dotnetupOnPath.
         bool nowProfileDotnet = targetEnv is DotnetAccessMode.Shell or DotnetAccessMode.Everywhere;
         bool nowProfileDotnetup = targetDotnetupOnPath;
         bool nowHasProfileBlock = nowProfileDotnet || nowProfileDotnetup;

--- a/src/Installer/dotnetup.Library/EnvSettingsApplier.cs
+++ b/src/Installer/dotnetup.Library/EnvSettingsApplier.cs
@@ -18,7 +18,8 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 ///   <item>The managed profile block wires dotnet iff <c>env ∈ {Shell, All}</c> and adds the
 ///     dotnetup directory iff <c>dotnetupOnPath</c>. When it would wire neither, the block is
 ///     removed.</item>
-///   <item>On Windows, <c>All</c> additionally writes user-scope env-var PATH/DOTNET_ROOT, and
+///   <item>On Windows, <c>All</c> additionally writes the user dotnet directory to the system
+///     PATH (ahead of the machine-wide install) and sets user-scope DOTNET_ROOT, and
 ///     <c>dotnetupOnPath</c> additionally writes the dotnetup directory to the user PATH (so
 ///     cmd.exe and GUI apps see it).</item>
 /// </list>
@@ -59,8 +60,8 @@ internal static class EnvSettingsApplier
         // 1. Windows dotnet env-var wiring (PATH + DOTNET_ROOT): apply it when we now want it,
         //    otherwise remove an observed wiring when we no longer do. These are the two mutually
         //    exclusive branches of the same decision. ApplyEnvironmentModifications(InstallType.System)
-        //    is the inverse of (InstallType.User): it removes the user dotnet from user PATH, restores
-        //    the Program Files dotnet to system PATH, and unsets the user-scope DOTNET_ROOT. The apply
+        //    is the inverse of (InstallType.User): it removes the user dotnet directory from the system
+        //    PATH and unsets the user-scope DOTNET_ROOT. The apply
         //    path is idempotent (each change is gated), so re-applying an already-correct state — e.g.
         //    re-syncing after a system installer clobbered PATH — is safe.
         if (nowWritesDotnetEnvVars)

--- a/src/Installer/dotnetup.Library/EnvironmentStateInspector.cs
+++ b/src/Installer/dotnetup.Library/EnvironmentStateInspector.cs
@@ -39,9 +39,9 @@ internal sealed class EnvironmentStateInspector : IEnvironmentStateInspector
         {
             var installRootManager = new InstallRootManager(_environment);
 
-            // Residual user-scope dotnet wiring exists exactly when switching to the admin/system
-            // state would still need to change something (remove the user PATH entry, unset
-            // DOTNET_ROOT, restore the Program Files dotnet to system PATH).
+            // Residual dotnet wiring exists exactly when switching to the admin/system state would
+            // still need to change something (remove the user dotnet from the system PATH, or unset
+            // DOTNET_ROOT).
             dotnetUserEnvVarsPresent = installRootManager.GetAdminInstallRootChanges().NeedsChange();
 
             // Fully wired as 'full' when configuring the user install root would be a no-op.

--- a/src/Installer/dotnetup.Library/EnvironmentStateInspector.cs
+++ b/src/Installer/dotnetup.Library/EnvironmentStateInspector.cs
@@ -39,10 +39,10 @@ internal sealed class EnvironmentStateInspector : IEnvironmentStateInspector
         {
             var installRootManager = new InstallRootManager(_environment);
 
-            // Residual dotnet wiring exists exactly when switching to the admin/system state would
+            // Residual dotnet wiring exists exactly when switching to the system state would
             // still need to change something (remove the user dotnet from the system PATH, or unset
             // DOTNET_ROOT).
-            dotnetUserEnvVarsPresent = installRootManager.GetAdminInstallRootChanges().NeedsChange();
+            dotnetUserEnvVarsPresent = installRootManager.GetSystemInstallRootChanges().NeedsChange();
 
             // Fully wired as 'full' when configuring the user install root would be a no-op.
             dotnetUserEnvVarsComplete = !installRootManager.GetUserInstallRootChanges().NeedsChange();

--- a/src/Installer/dotnetup.Library/InstallRootManager.cs
+++ b/src/Installer/dotnetup.Library/InstallRootManager.cs
@@ -7,7 +7,7 @@ using Spectre.Console;
 namespace Microsoft.DotNet.Tools.Bootstrapper;
 
 /// <summary>
-/// Manages the dotnet installation root configuration, including switching between user and admin installations.
+/// Manages the dotnet installation root configuration, including switching between user and system installations.
 /// </summary>
 internal class InstallRootManager
 {
@@ -57,13 +57,13 @@ internal class InstallRootManager
     }
 
     /// <summary>
-    /// Gets the changes needed to configure admin install root.
+    /// Gets the changes needed to configure system install root.
     /// </summary>
-    public AdminInstallRootChanges GetAdminInstallRootChanges()
+    public SystemInstallRootChanges GetSystemInstallRootChanges()
     {
         if (!OperatingSystem.IsWindows())
         {
-            throw new PlatformNotSupportedException("Admin install root configuration is only supported on Windows.");
+            throw new PlatformNotSupportedException("System install root configuration is only supported on Windows.");
         }
 
         // Get the user (dotnetup) dotnet installation path
@@ -80,7 +80,7 @@ internal class InstallRootManager
 
         bool needToUnsetDotnetRoot = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.User));
 
-        return new AdminInstallRootChanges(
+        return new SystemInstallRootChanges(
             needToRemoveUserDotnetFromSystemPath,
             needToUnsetDotnetRoot,
             userDotnetPath);
@@ -106,11 +106,11 @@ internal class InstallRootManager
     }
 
     /// <summary>
-    /// Applies the admin install root configuration. Throws
+    /// Applies the system install root configuration. Throws
     /// <see cref="DotnetInstallException"/> if the user declines an elevation prompt.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public static void ApplyAdminInstallRoot(AdminInstallRootChanges changes, Action<string> writeOutput)
+    public static void ApplySystemInstallRoot(SystemInstallRootChanges changes, Action<string> writeOutput)
     {
         if (changes.NeedsRemoveUserDotnetFromSystemPath)
         {
@@ -187,15 +187,15 @@ internal record UserInstallRootChanges(
 }
 
 /// <summary>
-/// Represents the changes needed to configure admin install root.
+/// Represents the changes needed to configure system install root.
 /// </summary>
-internal record AdminInstallRootChanges(
+internal record SystemInstallRootChanges(
     bool NeedsRemoveUserDotnetFromSystemPath,
     bool NeedsUnsetDotnetRoot,
     string UserDotnetPath)
 {
     /// <summary>
-    /// Checks if any changes are needed to configure admin install root.
+    /// Checks if any changes are needed to configure system install root.
     /// </summary>
     public bool NeedsChange() => NeedsRemoveUserDotnetFromSystemPath || NeedsUnsetDotnetRoot;
 }

--- a/src/Installer/dotnetup.Library/InstallRootManager.cs
+++ b/src/Installer/dotnetup.Library/InstallRootManager.cs
@@ -29,26 +29,31 @@ internal class InstallRootManager
         }
 
         string userDotnetPath = _dotnetEnvironment.GetDefaultDotnetInstallPath();
-        bool needToRemoveAdminPath = WindowsPathHelper.AdminPathContainsProgramFilesDotnet(out var foundDotnetPaths);
 
-        // Read both expanded and unexpanded user PATH from registry
-        string unexpandedUserPath = WindowsPathHelper.ReadUserPath(expand: false);
-        string expandedUserPath = WindowsPathHelper.ReadUserPath(expand: true);
-
-        // Use the helper method to add the path while preserving unexpanded variables
-        string newUserPath = WindowsPathHelper.AddPathEntry(unexpandedUserPath, expandedUserPath, userDotnetPath, "dotnet");
-        bool needToAddToUserPath = newUserPath != unexpandedUserPath;
+        // everywhere mode inserts the user (dotnetup) dotnet directory into the system PATH
+        // immediately before the machine-wide Program Files dotnet entry (or appends it when there
+        // is none), rather than removing the Program Files entry. A later machine-wide install
+        // appends its own PATH entry, so it lands after the user entry and the user install keeps
+        // precedence.
+        //
+        // Windows composes the effective PATH as system-then-user, so this system-PATH entry makes
+        // the user install win for every process. No matching user-scope PATH entry is needed; only
+        // DOTNET_ROOT is set at user scope (for apphost/runtime resolution).
+        string unexpandedSystemPath = WindowsPathHelper.ReadSystemPath(expand: false);
+        string expandedSystemPath = WindowsPathHelper.ReadSystemPath(expand: true);
+        string newSystemPath = WindowsPathHelper.InsertPathEntryBeforeProgramFilesDotnet(
+            unexpandedSystemPath, expandedSystemPath, userDotnetPath);
+        bool needToInsertUserDotnetIntoSystemPath = !string.Equals(newSystemPath, unexpandedSystemPath, StringComparison.Ordinal);
+        bool systemPathHasProgramFilesDotnet = WindowsPathHelper.SystemPathContainsProgramFilesDotnet();
 
         var existingDotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.User);
         bool needToSetDotnetRoot = !string.Equals(userDotnetPath, existingDotnetRoot, StringComparison.OrdinalIgnoreCase);
 
         return new UserInstallRootChanges(
             userDotnetPath,
-            needToRemoveAdminPath,
-            needToAddToUserPath,
+            needToInsertUserDotnetIntoSystemPath,
             needToSetDotnetRoot,
-            newUserPath,
-            foundDotnetPaths);
+            systemPathHasProgramFilesDotnet);
     }
 
     /// <summary>
@@ -61,39 +66,24 @@ internal class InstallRootManager
             throw new PlatformNotSupportedException("Admin install root configuration is only supported on Windows.");
         }
 
-        var programFilesDotnetPaths = WindowsPathHelper.GetProgramFilesDotnetPaths();
-
-        // When no dotnet is installed in Program Files, there is no admin path to reference or modify.
-        string primaryProgramFilesDotnetPath = programFilesDotnetPaths.FirstOrDefault() ?? string.Empty;
-
-        // Use PathContainsDotnet, as that handles differences in trailing directory separators
-        // GetProgramFilesDotnetPaths trims the trailing separator while the .NET installer writes
-        // the system PATH entry *with* one (e.g. "C:\Program Files\dotnet\")
-        bool needToModifyAdminPath = programFilesDotnetPaths.Count > 0
-            && !WindowsPathHelper.PathContainsDotnet(
-                WindowsPathHelper.SplitPath(WindowsPathHelper.ReadAdminPath(expand: true)),
-                programFilesDotnetPaths);
-
-        // Get the user dotnet installation path
+        // Get the user (dotnetup) dotnet installation path
         string userDotnetPath = _dotnetEnvironment.GetDefaultDotnetInstallPath();
 
-        // Read both expanded and unexpanded user PATH from registry to preserve environment variables
-        string unexpandedUserPath = WindowsPathHelper.ReadUserPath(expand: false);
-        string expandedUserPath = WindowsPathHelper.ReadUserPath(expand: true);
-
-        // Use the helper method to remove the path while preserving unexpanded variables
-        string newUserPath = WindowsPathHelper.RemovePathEntries(unexpandedUserPath, expandedUserPath, [userDotnetPath]);
-        bool needToModifyUserPath = newUserPath != unexpandedUserPath;
+        // Switching away from everywhere mode removes the user (dotnetup) dotnet directory that
+        // everywhere mode inserted into the system PATH. The machine-wide Program Files dotnet entry
+        // was never removed, so there is nothing to restore.
+        string unexpandedSystemPath = WindowsPathHelper.ReadSystemPath(expand: false);
+        string expandedSystemPath = WindowsPathHelper.ReadSystemPath(expand: true);
+        string newSystemPath = WindowsPathHelper.RemovePathEntries(
+            unexpandedSystemPath, expandedSystemPath, [userDotnetPath]);
+        bool needToRemoveUserDotnetFromSystemPath = !string.Equals(newSystemPath, unexpandedSystemPath, StringComparison.Ordinal);
 
         bool needToUnsetDotnetRoot = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_ROOT", EnvironmentVariableTarget.User));
 
         return new AdminInstallRootChanges(
-            primaryProgramFilesDotnetPath,
-            needToModifyAdminPath,
-            needToModifyUserPath,
+            needToRemoveUserDotnetFromSystemPath,
             needToUnsetDotnetRoot,
-            userDotnetPath,
-            newUserPath);
+            userDotnetPath);
     }
 
     /// <summary>
@@ -103,15 +93,9 @@ internal class InstallRootManager
     [SupportedOSPlatform("windows")]
     public static void ApplyUserInstallRoot(UserInstallRootChanges changes, Action<string> writeOutput)
     {
-        if (changes.NeedsRemoveAdminPath)
+        if (changes.NeedsInsertUserDotnetIntoSystemPath)
         {
-            RemoveAdminPathIfNeeded(changes.FoundAdminDotnetPaths!, writeOutput);
-        }
-
-        if (changes.NeedsAddToUserPath)
-        {
-            writeOutput($"Adding {Highlight(changes.UserDotnetPath)} to user PATH.");
-            WindowsPathHelper.WriteUserPath(changes.NewUserPath!);
+            InsertUserDotnetIntoSystemPathIfNeeded(changes.UserDotnetPath, changes.SystemPathHasProgramFilesDotnet, writeOutput);
         }
 
         if (changes.NeedsSetDotnetRoot)
@@ -128,15 +112,9 @@ internal class InstallRootManager
     [SupportedOSPlatform("windows")]
     public static void ApplyAdminInstallRoot(AdminInstallRootChanges changes, Action<string> writeOutput)
     {
-        if (changes.NeedsModifyAdminPath)
+        if (changes.NeedsRemoveUserDotnetFromSystemPath)
         {
-            AddAdminPathIfNeeded(changes.ProgramFilesDotnetPath, writeOutput);
-        }
-
-        if (changes.NeedsModifyUserPath)
-        {
-            writeOutput($"Removing {Highlight(changes.UserDotnetPath)} from user PATH.");
-            WindowsPathHelper.WriteUserPath(changes.NewUserPath!);
+            RemoveUserDotnetFromSystemPathIfNeeded(changes.UserDotnetPath, writeOutput);
         }
 
         if (changes.NeedsUnsetDotnetRoot)
@@ -147,62 +125,44 @@ internal class InstallRootManager
     }
 
     [SupportedOSPlatform("windows")]
-    private static void RemoveAdminPathIfNeeded(List<string> foundDotnetPaths, Action<string> writeOutput)
+    private static void InsertUserDotnetIntoSystemPathIfNeeded(string userDotnetPath, bool systemPathHasProgramFilesDotnet, Action<string> writeOutput)
     {
+        // When a machine-wide install is present the entry is inserted just ahead of it; otherwise
+        // it is appended to the end of the system PATH.
+        string target = systemPathHasProgramFilesDotnet
+            ? "system PATH, ahead of the machine-wide .NET install"
+            : "system PATH";
+
         if (Environment.IsPrivilegedProcess)
         {
-            if (foundDotnetPaths.Count == 1)
-            {
-                writeOutput($"Removing {Highlight(foundDotnetPaths[0])} from system PATH.");
-            }
-            else
-            {
-                writeOutput("Removing the following dotnet paths from system PATH:");
-                foreach (var path in foundDotnetPaths)
-                {
-                    writeOutput($"  - {Highlight(path)}");
-                }
-            }
-
-            // We're already elevated, modify the admin PATH directly
+            // We're already elevated, modify the system PATH directly
+            writeOutput($"Adding {Highlight(userDotnetPath)} to {target}.");
             using var pathHelper = new WindowsPathHelper();
-            pathHelper.RemoveDotnetFromAdminPath();
+            pathHelper.InsertDotnetIntoSystemPath(userDotnetPath);
         }
         else
         {
             // Not elevated, shell out to elevated process
-            if (foundDotnetPaths.Count == 1)
-            {
-                writeOutput($"Launching elevated process to remove {Highlight(foundDotnetPaths[0])} from system PATH.");
-            }
-            else
-            {
-                writeOutput("Launching elevated process to remove the following dotnet paths from system PATH:");
-                foreach (var path in foundDotnetPaths)
-                {
-                    writeOutput($"  - {Highlight(path)}");
-                }
-            }
-
-            WindowsPathHelper.StartElevatedProcess("removedotnet");
+            writeOutput($"Launching elevated process to add {Highlight(userDotnetPath)} to {target}.");
+            WindowsPathHelper.StartElevatedProcess("insertdotnet", userDotnetPath);
         }
     }
 
     [SupportedOSPlatform("windows")]
-    private static void AddAdminPathIfNeeded(string programFilesDotnetPath, Action<string> writeOutput)
+    private static void RemoveUserDotnetFromSystemPathIfNeeded(string userDotnetPath, Action<string> writeOutput)
     {
         if (Environment.IsPrivilegedProcess)
         {
-            // We're already elevated, modify the admin PATH directly
-            writeOutput($"Adding {Highlight(programFilesDotnetPath)} to system PATH.");
+            // We're already elevated, modify the system PATH directly
+            writeOutput($"Removing {Highlight(userDotnetPath)} from system PATH.");
             using var pathHelper = new WindowsPathHelper();
-            pathHelper.AddDotnetToAdminPath();
+            pathHelper.RemoveDotnetFromSystemPath(userDotnetPath);
         }
         else
         {
             // Not elevated, shell out to elevated process
-            writeOutput($"Launching elevated process to add {Highlight(programFilesDotnetPath)} to system PATH.");
-            WindowsPathHelper.StartElevatedProcess("adddotnet");
+            writeOutput($"Launching elevated process to remove {Highlight(userDotnetPath)} from system PATH.");
+            WindowsPathHelper.StartElevatedProcess("removedotnet", userDotnetPath);
         }
     }
 
@@ -216,31 +176,26 @@ internal class InstallRootManager
 /// </summary>
 internal record UserInstallRootChanges(
     string UserDotnetPath,
-    bool NeedsRemoveAdminPath,
-    bool NeedsAddToUserPath,
+    bool NeedsInsertUserDotnetIntoSystemPath,
     bool NeedsSetDotnetRoot,
-    string? NewUserPath,
-    List<string>? FoundAdminDotnetPaths)
+    bool SystemPathHasProgramFilesDotnet)
 {
     /// <summary>
     /// Checks if any changes are needed to configure user install root.
     /// </summary>
-    public bool NeedsChange() => NeedsRemoveAdminPath || NeedsAddToUserPath || NeedsSetDotnetRoot;
+    public bool NeedsChange() => NeedsInsertUserDotnetIntoSystemPath || NeedsSetDotnetRoot;
 }
 
 /// <summary>
 /// Represents the changes needed to configure admin install root.
 /// </summary>
 internal record AdminInstallRootChanges(
-    string ProgramFilesDotnetPath,
-    bool NeedsModifyAdminPath,
-    bool NeedsModifyUserPath,
+    bool NeedsRemoveUserDotnetFromSystemPath,
     bool NeedsUnsetDotnetRoot,
-    string UserDotnetPath,
-    string? NewUserPath)
+    string UserDotnetPath)
 {
     /// <summary>
     /// Checks if any changes are needed to configure admin install root.
     /// </summary>
-    public bool NeedsChange() => NeedsModifyAdminPath || NeedsModifyUserPath || NeedsUnsetDotnetRoot;
+    public bool NeedsChange() => NeedsRemoveUserDotnetFromSystemPath || NeedsUnsetDotnetRoot;
 }

--- a/src/Installer/dotnetup.Library/ObservedEnvironmentState.cs
+++ b/src/Installer/dotnetup.Library/ObservedEnvironmentState.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 /// it against the configured settings to report drift.
 /// </summary>
 /// <param name="DotnetUserEnvVarsPresent">
-/// True when user-scope dotnet env-var wiring (user PATH entry and/or DOTNET_ROOT) that
-/// <c>all</c> mode creates is currently present. Always false off Windows.
+/// True when the dotnet wiring that <c>everywhere</c> mode creates (the user dotnet directory on
+/// the system PATH and/or the user-scope DOTNET_ROOT) is currently present. Always false off Windows.
 /// </param>
 /// <param name="DotnetUserEnvVarsComplete">
 /// True when the user-scope dotnet env vars are fully in the <c>all</c>-mode state (nothing left

--- a/src/Installer/dotnetup.Library/ObservedEnvironmentState.cs
+++ b/src/Installer/dotnetup.Library/ObservedEnvironmentState.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.Tools.Bootstrapper;
 /// the system PATH and/or the user-scope DOTNET_ROOT) is currently present. Always false off Windows.
 /// </param>
 /// <param name="DotnetUserEnvVarsComplete">
-/// True when the user-scope dotnet env vars are fully in the <c>all</c>-mode state (nothing left
-/// to wire). Always false off Windows. Used to detect a configured-<c>all</c>-but-incomplete drift.
+/// True when the user-scope dotnet env vars are fully in the <c>everywhere</c>-mode state (nothing left
+/// to wire). Always false off Windows. Used to detect a configured-<c>everywhere</c>-but-incomplete drift.
 /// </param>
 /// <param name="ProfileBlock">
 /// Whether the managed dotnetup block exists in the shell profile, or

--- a/src/Installer/dotnetup.Library/Parser.cs
+++ b/src/Installer/dotnetup.Library/Parser.cs
@@ -7,7 +7,7 @@ using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.Reflection;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Dotnet;
-using Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedAdminPath;
+using Microsoft.DotNet.Tools.Bootstrapper.Commands.ElevatedSystemPath;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Env;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Info;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
@@ -57,7 +57,7 @@ internal class Parser
         rootCommand.Subcommands.Add(SdkInstallCommandParser.GetRootInstallCommand());
         rootCommand.Subcommands.Add(SdkUpdateCommandParser.GetRootUpdateCommand());
         rootCommand.Subcommands.Add(SdkUninstallCommandParser.GetRootUninstallCommand());
-        rootCommand.Subcommands.Add(ElevatedAdminPathCommandParser.GetCommand());
+        rootCommand.Subcommands.Add(ElevatedSystemPathCommandParser.GetCommand());
         rootCommand.Subcommands.Add(EnvCommandParser.GetCommand());
         // Hidden top-level alias for `env script`. Kept for backwards
         // compatibility with anything that scripted against `dotnetup print-env-script`.

--- a/src/Installer/dotnetup.Library/Shell/PowerShellEnvShellProvider.cs
+++ b/src/Installer/dotnetup.Library/Shell/PowerShellEnvShellProvider.cs
@@ -74,7 +74,7 @@ public class PowerShellEnvShellProvider : IEnvShellProvider
     //
     // We want dotnetup to be available "everywhere".  On Windows we would modify the
     // PATH if we could and that would apply to cmd also, but there's not a good way
-    // to override the Admin PATH that the MSI / Program Files installers set.
+    // to override the system PATH that the MSI / Program Files installers set.
     //
     // Worth noting:
     //   * Most install scripts (rustup, conda init, oh-my-posh, dotnet-install) write to the

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -188,7 +188,7 @@
     <comment>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</comment>
   </data>
   <data name="AccessModeEverywhere" xml:space="preserve">
-    <value>Replacement Mode</value>
+    <value>Everywhere Mode</value>
   </data>
   <data name="PathGuidanceNone" xml:space="preserve">
     <value>You can run .NET commands with 'dotnetup dotnet &lt;command&gt;' (or 'dotnetup do &lt;command&gt;' for short).</value>
@@ -209,7 +209,7 @@
     <value>Configure the current shell profile to use installs managed by dotnetup.</value>
   </data>
   <data name="PathDescriptionEverywhere" xml:space="preserve">
-    <value>The system will be configured to use dotnetup installs over any other installs.</value>
+    <value>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</value>
   </data>
   <data name="PathTooltipNone" xml:space="preserve">
     <value>Recommended for users without admin rights, or for users who want to keep their system managed installs (e.g. {0}) as the default.</value>
@@ -221,10 +221,10 @@
     <value>Only PowerShell will work in this mode. CMD has no profile file.</value>
   </data>
   <data name="PathTooltipEverywhere" xml:space="preserve">
-    <value>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</value>
+    <value>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</value>
   </data>
   <data name="PathReplacementModeUnixError" xml:space="preserve">
-    <value>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</value>
+    <value>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</value>
   </data>
   <data name="HelpOptionsTitle" xml:space="preserve">
     <value>Options:</value>

--- a/src/Installer/dotnetup.Library/WindowsPathHelper.cs
+++ b/src/Installer/dotnetup.Library/WindowsPathHelper.cs
@@ -207,6 +207,30 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
+    /// Verifies that the PATH-editing helpers can safely map entries between the expanded and
+    /// unexpanded PATH by index. Those helpers detect entries against the expanded PATH but apply
+    /// the edit to the unexpanded PATH by position, which is only valid when the two lists are
+    /// element-aligned. Alignment holds exactly when every unexpanded entry expands to a single
+    /// non-empty segment. A variable that expands to a value containing ';' (adding entries) or to
+    /// nothing (dropping an entry) breaks that invariant, so rather than silently corrupt the PATH
+    /// we fail loudly.
+    /// </summary>
+    /// <param name="unexpandedEntries">The unexpanded PATH split into entries.</param>
+    private static void EnsureExpandedPathAligned(List<string> unexpandedEntries)
+    {
+        foreach (var entry in unexpandedEntries)
+        {
+            if (SplitPath(Environment.ExpandEnvironmentVariables(entry)).Count != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot safely modify PATH: the entry '{entry}' expands to a value that is empty or " +
+                    "contains ';', changing the number of ';'-separated entries. Entries cannot be reliably " +
+                    "matched between the expanded and unexpanded PATH.");
+            }
+        }
+    }
+
+    /// <summary>
     /// Finds the indices of entries in a PATH that match the specified paths.
     /// This method is designed for unit testing without registry access.
     /// </summary>
@@ -279,6 +303,7 @@ internal sealed partial class WindowsPathHelper : IDisposable
     {
         var expandedEntries = SplitPath(expandedPath);
         var unexpandedEntries = SplitPath(unexpandedPath);
+        EnsureExpandedPathAligned(unexpandedEntries);
 
         // Check if the command already resolves to the pathToAdd using EnvironmentProvider
         var envProvider = new Microsoft.DotNet.Cli.Utils.EnvironmentProvider(searchPathsOverride: expandedEntries);
@@ -356,6 +381,7 @@ internal sealed partial class WindowsPathHelper : IDisposable
     {
         var expandedEntries = SplitPath(expandedPath);
         var unexpandedEntries = SplitPath(unexpandedPath);
+        EnsureExpandedPathAligned(unexpandedEntries);
 
         var normalizedPathToInsert = Path.TrimEndingDirectorySeparator(pathToInsert);
 
@@ -403,6 +429,8 @@ internal sealed partial class WindowsPathHelper : IDisposable
     public static string RemovePathEntries(string unexpandedPath, string expandedPath, List<string> pathsToRemove)
     {
         var expandedEntries = SplitPath(expandedPath);
+        var unexpandedEntries = SplitPath(unexpandedPath);
+        EnsureExpandedPathAligned(unexpandedEntries);
 
         // Find indices to remove using the expanded path
         var indicesToRemove = FindPathIndices(expandedEntries, pathsToRemove);

--- a/src/Installer/dotnetup.Library/WindowsPathHelper.cs
+++ b/src/Installer/dotnetup.Library/WindowsPathHelper.cs
@@ -578,7 +578,7 @@ internal sealed partial class WindowsPathHelper : IDisposable
 
         try
         {
-            string arguments = $"elevatedadminpath {operation} \"{outputFilePath}\" --dotnet-dir \"{dotnetDir}\"";
+            string arguments = $"elevatedsystempath {operation} \"{outputFilePath}\" --dotnet-dir \"{dotnetDir}\"";
 
             var startInfo = new ProcessStartInfo
             {

--- a/src/Installer/dotnetup.Library/WindowsPathHelper.cs
+++ b/src/Installer/dotnetup.Library/WindowsPathHelper.cs
@@ -72,10 +72,10 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
-    /// Reads the machine-wide PATH environment variable from the registry.
+    /// Reads the machine-wide (system) PATH environment variable from the registry.
     /// </summary>
     /// <param name="expand">If true, expands environment variables in the PATH value.</param>
-    public static string ReadAdminPath(bool expand = false)
+    public static string ReadSystemPath(bool expand = false)
     {
         using var key = Registry.LocalMachine.OpenSubKey(RegistryEnvironmentPath, writable: false);
         if (key == null)
@@ -88,9 +88,9 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
-    /// Writes the machine-wide PATH environment variable to the registry.
+    /// Writes the machine-wide (system) PATH environment variable to the registry.
     /// </summary>
-    public static void WriteAdminPath(string path)
+    public static void WriteSystemPath(string path)
     {
         using var key = Registry.LocalMachine.OpenSubKey(RegistryEnvironmentPath, writable: true);
         if (key == null)
@@ -265,57 +265,6 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
-    /// Removes the Program Files dotnet path from the given PATH strings.
-    /// Uses the expanded PATH for detection but modifies the unexpanded PATH to preserve environment variables.
-    /// </summary>
-    /// <param name="unexpandedPath">The unexpanded PATH string to modify.</param>
-    /// <param name="expandedPath">The expanded PATH string to use for detection.</param>
-    /// <returns>The modified unexpanded PATH string.</returns>
-    public static string RemoveProgramFilesDotnetFromPath(string unexpandedPath, string expandedPath)
-    {
-        // Find indices to remove using the expanded path
-        var programFilesDotnetPaths = GetProgramFilesDotnetPaths();
-
-        // Remove those indices from the unexpanded path
-        return RemovePathEntries(unexpandedPath, expandedPath, programFilesDotnetPaths);
-    }
-
-    /// <summary>
-    /// Gets the admin PATH with Program Files dotnet path removed while preserving unexpanded environment variables.
-    /// This does not modify the registry, only returns the modified PATH string.
-    /// </summary>
-    /// <returns>The modified unexpanded PATH string.</returns>
-    public static string GetAdminPathWithProgramFilesDotnetRemoved()
-    {
-        // Read both expanded and unexpanded versions
-        string expandedPath = ReadAdminPath(expand: true);
-        string unexpandedPath = ReadAdminPath(expand: false);
-
-        return RemoveProgramFilesDotnetFromPath(unexpandedPath, expandedPath);
-    }
-
-    /// <summary>
-    /// Adds the Program Files dotnet path to the given PATH strings if it's not already present.
-    /// Uses the expanded PATH for detection but modifies the unexpanded PATH to preserve environment variables.
-    /// </summary>
-    /// <param name="unexpandedPath">The unexpanded PATH string to modify.</param>
-    /// <param name="expandedPath">The expanded PATH string to use for detection.</param>
-    /// <returns>The modified unexpanded PATH string.</returns>
-    public static string AddProgramFilesDotnetToPath(string unexpandedPath, string expandedPath)
-    {
-        var programFilesDotnetPaths = GetProgramFilesDotnetPaths();
-
-        // Get the primary Program Files dotnet path (non-x86)
-        string primaryDotnetPath = programFilesDotnetPaths.FirstOrDefault() ?? string.Empty;
-        if (string.IsNullOrEmpty(primaryDotnetPath))
-        {
-            return unexpandedPath;
-        }
-
-        return AddPathEntry(unexpandedPath, expandedPath, primaryDotnetPath, "dotnet");
-    }
-
-    /// <summary>
     /// Adds a path entry to the given PATH strings if it's not already present.
     /// Uses the expanded PATH for detection but modifies the unexpanded PATH to preserve environment variables.
     /// If the command already resolves to the pathToAdd, no changes are made.
@@ -371,6 +320,79 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
+    /// Inserts a path entry into the given PATH strings immediately before the machine-wide
+    /// Program Files dotnet entry. When no Program Files dotnet entry is present, the path is
+    /// appended to the end instead, so that a machine-wide install added later lands after the
+    /// inserted entry, which therefore keeps precedence.
+    /// Uses the expanded PATH for detection but modifies the unexpanded PATH to preserve
+    /// environment variables. If the entry is already positioned ahead of the Program Files
+    /// dotnet entry (or is already present when there is no Program Files dotnet entry), the PATH
+    /// is returned unchanged.
+    /// </summary>
+    /// <param name="unexpandedPath">The unexpanded PATH string to modify.</param>
+    /// <param name="expandedPath">The expanded PATH string to use for detection.</param>
+    /// <param name="pathToInsert">The path to insert (e.g. the user's dotnet directory).</param>
+    /// <returns>The modified unexpanded PATH string.</returns>
+    public static string InsertPathEntryBeforeProgramFilesDotnet(string unexpandedPath, string expandedPath, string pathToInsert)
+    {
+        var programFilesDotnetPaths = GetProgramFilesDotnetPaths();
+        return InsertPathEntryBeforeDotnet(unexpandedPath, expandedPath, pathToInsert, programFilesDotnetPaths);
+    }
+
+    /// <summary>
+    /// Testable core of <see cref="InsertPathEntryBeforeProgramFilesDotnet"/> that takes the
+    /// machine-wide dotnet paths as an argument instead of reading them from the registry.
+    /// </summary>
+    /// <param name="unexpandedPath">The unexpanded PATH string to modify.</param>
+    /// <param name="expandedPath">The expanded PATH string to use for detection.</param>
+    /// <param name="pathToInsert">The path to insert.</param>
+    /// <param name="programFilesDotnetPaths">The machine-wide dotnet paths to position ahead of.</param>
+    /// <returns>The modified unexpanded PATH string.</returns>
+    public static string InsertPathEntryBeforeDotnet(
+        string unexpandedPath,
+        string expandedPath,
+        string pathToInsert,
+        List<string> programFilesDotnetPaths)
+    {
+        var expandedEntries = SplitPath(expandedPath);
+        var unexpandedEntries = SplitPath(unexpandedPath);
+
+        var normalizedPathToInsert = Path.TrimEndingDirectorySeparator(pathToInsert);
+
+        var programFilesIndices = FindPathIndices(expandedEntries, programFilesDotnetPaths);
+        int firstProgramFilesIndex = programFilesIndices.Count > 0 ? programFilesIndices.Min() : -1;
+
+        int existingIndex = expandedEntries.FindIndex(expandedEntry =>
+            Path.TrimEndingDirectorySeparator(expandedEntry).Equals(normalizedPathToInsert, StringComparison.OrdinalIgnoreCase));
+
+        if (existingIndex >= 0)
+        {
+            // Already positioned ahead of the Program Files dotnet entry (or already present when
+            // there is no Program Files dotnet entry at all) — the inserted entry already wins.
+            if (firstProgramFilesIndex < 0 || existingIndex < firstProgramFilesIndex)
+            {
+                return unexpandedPath;
+            }
+
+            // Present, but after the Program Files dotnet entry. Remove it so it can be
+            // re-inserted immediately before that entry. It sits after firstProgramFilesIndex, so
+            // removing it does not shift that index.
+            unexpandedEntries.RemoveAt(existingIndex);
+        }
+
+        if (firstProgramFilesIndex >= 0)
+        {
+            unexpandedEntries.Insert(firstProgramFilesIndex, pathToInsert);
+        }
+        else
+        {
+            unexpandedEntries.Add(pathToInsert);
+        }
+
+        return string.Join(';', unexpandedEntries);
+    }
+
+    /// <summary>
     /// Removes a specific path entry from the given PATH strings.
     /// Uses the expanded PATH for detection but modifies the unexpanded PATH to preserve environment variables.
     /// </summary>
@@ -390,24 +412,24 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
-    /// Checks if the admin PATH contains the Program Files dotnet path.
+    /// Checks if the system PATH contains the Program Files dotnet path.
     /// Uses the expanded PATH for accurate detection.
     /// </summary>
-    public static bool AdminPathContainsProgramFilesDotnet()
+    public static bool SystemPathContainsProgramFilesDotnet()
     {
-        return AdminPathContainsProgramFilesDotnet(out _);
+        return SystemPathContainsProgramFilesDotnet(out _);
     }
 
     /// <summary>
-    /// Checks if the admin PATH contains the Program Files dotnet path.
+    /// Checks if the system PATH contains the Program Files dotnet path.
     /// Uses the expanded PATH for accurate detection.
     /// </summary>
-    /// <param name="foundDotnetPaths">The list of dotnet paths found in the admin PATH.</param>
+    /// <param name="foundDotnetPaths">The list of dotnet paths found in the system PATH.</param>
     /// <returns>True if any dotnet path is found, false otherwise.</returns>
-    public static bool AdminPathContainsProgramFilesDotnet(out List<string> foundDotnetPaths)
+    public static bool SystemPathContainsProgramFilesDotnet(out List<string> foundDotnetPaths)
     {
-        var adminPath = ReadAdminPath(expand: true);
-        var pathEntries = SplitPath(adminPath);
+        var systemPath = ReadSystemPath(expand: true);
+        var pathEntries = SplitPath(systemPath);
         var programFilesDotnetPaths = GetProgramFilesDotnetPaths();
 
         foundDotnetPaths = [];
@@ -422,83 +444,85 @@ internal sealed partial class WindowsPathHelper : IDisposable
     }
 
     /// <summary>
-    /// Removes the Program Files dotnet path from the admin PATH.
-    /// This is the main orchestrating method that should be called by commands.
+    /// Inserts the dotnet directory into the system PATH immediately before the machine-wide
+    /// Program Files dotnet entry (or appends it to the end when there is no machine-wide dotnet on
+    /// the system PATH). This is the main orchestrating method that should be called by commands.
     /// </summary>
+    /// <param name="dotnetDir">The dotnet directory to insert. Must be supplied by the
+    /// caller because this can run in an elevated child process under a different account, where the
+    /// current user's directory cannot be recomputed.</param>
     /// <returns>0 on success, 1 on failure.</returns>
-    public int RemoveDotnetFromAdminPath()
+    public int InsertDotnetIntoSystemPath(string dotnetDir)
     {
         try
         {
-            LogMessage("Starting RemoveDotnetFromAdminPath operation");
+            LogMessage($"Starting InsertDotnetIntoSystemPath operation for {dotnetDir}");
 
-            string oldPath = ReadAdminPath(expand: false);
-            LogMessage($"Old PATH (unexpanded): {oldPath}");
+            string unexpandedPath = ReadSystemPath(expand: false);
+            string expandedPath = ReadSystemPath(expand: true);
+            LogMessage($"Old PATH (unexpanded): {unexpandedPath}");
 
-            if (!AdminPathContainsProgramFilesDotnet())
+            string newPath = InsertPathEntryBeforeProgramFilesDotnet(unexpandedPath, expandedPath, dotnetDir);
+            if (string.Equals(newPath, unexpandedPath, StringComparison.Ordinal))
             {
-                LogMessage("No changes needed - dotnet path not found");
+                LogMessage("No changes needed - dotnet directory already positioned ahead of Program Files dotnet");
                 return 0;
             }
 
-            LogMessage("Removing dotnet paths from admin PATH");
-            string newPath = GetAdminPathWithProgramFilesDotnetRemoved();
             LogMessage($"New PATH (unexpanded): {newPath}");
-
-            WriteAdminPath(newPath);
+            WriteSystemPath(newPath);
             LogMessage("PATH written to registry");
 
-            // Broadcast environment change
             BroadcastEnvironmentChange();
 
-            LogMessage("RemoveDotnetFromAdminPath operation completed successfully");
+            LogMessage("InsertDotnetIntoSystemPath operation completed successfully");
             return 0;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Error: Failed to remove dotnet from admin PATH: {ex.Message}");
+            Console.Error.WriteLine($"Error: Failed to insert dotnet directory into system PATH: {ex.Message}");
             LogMessage($"ERROR: {ex.ToString()}");
             return 1;
         }
     }
 
     /// <summary>
-    /// Adds the Program Files dotnet path to the admin PATH.
-    /// This is the main orchestrating method that should be called by commands.
+    /// Removes the dotnet directory from the system PATH. This undoes
+    /// <see cref="InsertDotnetIntoSystemPath"/> and is the main orchestrating method that
+    /// should be called by commands.
     /// </summary>
+    /// <param name="dotnetDir">The dotnet directory to remove. Must be supplied by the
+    /// caller because this can run in an elevated child process under a different account.</param>
     /// <returns>0 on success, 1 on failure.</returns>
-    public int AddDotnetToAdminPath()
+    public int RemoveDotnetFromSystemPath(string dotnetDir)
     {
         try
         {
-            LogMessage("Starting AddDotnetToAdminPath operation");
+            LogMessage($"Starting RemoveDotnetFromSystemPath operation for {dotnetDir}");
 
-            string unexpandedPath = ReadAdminPath(expand: false);
-            string expandedPath = ReadAdminPath(expand: true);
+            string unexpandedPath = ReadSystemPath(expand: false);
+            string expandedPath = ReadSystemPath(expand: true);
             LogMessage($"Old PATH (unexpanded): {unexpandedPath}");
 
-            if (AdminPathContainsProgramFilesDotnet())
+            string newPath = RemovePathEntries(unexpandedPath, expandedPath, [dotnetDir]);
+            if (string.Equals(newPath, unexpandedPath, StringComparison.Ordinal))
             {
-                LogMessage("No changes needed - dotnet path already exists");
+                LogMessage("No changes needed - dotnet directory not present on system PATH");
                 return 0;
             }
 
-            LogMessage("Adding dotnet path to admin PATH");
-            string newPath = AddProgramFilesDotnetToPath(unexpandedPath, expandedPath);
             LogMessage($"New PATH (unexpanded): {newPath}");
-
-            WriteAdminPath(newPath);
+            WriteSystemPath(newPath);
             LogMessage("PATH written to registry");
 
-            // Broadcast environment change
             BroadcastEnvironmentChange();
 
-            LogMessage("AddDotnetToAdminPath operation completed successfully");
+            LogMessage("RemoveDotnetFromSystemPath operation completed successfully");
             return 0;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Error: Failed to add dotnet to admin PATH: {ex.Message}");
+            Console.Error.WriteLine($"Error: Failed to remove dotnet directory from system PATH: {ex.Message}");
             LogMessage($"ERROR: {ex.ToString()}");
             return 1;
         }
@@ -531,9 +555,15 @@ internal sealed partial class WindowsPathHelper : IDisposable
     /// <summary>
     /// Starts an elevated process to modify the system PATH and waits for it to complete.
     /// </summary>
+    /// <param name="operation">The elevated operation to perform (<c>insertdotnet</c>/<c>removedotnet</c>).</param>
+    /// <param name="dotnetDir">The dotnet directory the elevated process should insert into or remove
+    /// from the system PATH. This must be supplied by the caller because the elevated process can run
+    /// under a different account than the invoking user — when a standard user elevates by supplying
+    /// an administrator's credentials, the child runs as that administrator, whose per-user directory
+    /// (e.g. %LOCALAPPDATA%) differs — so the invoking user's directory cannot be recomputed there.</param>
     /// <exception cref="DotnetInstallException">Thrown when the user declines the UAC elevation prompt.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the process cannot be started or returns a non-zero exit code.</exception>
-    public static void StartElevatedProcess(string operation)
+    public static void StartElevatedProcess(string operation, string dotnetDir)
     {
         var processPath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(processPath))
@@ -548,7 +578,7 @@ internal sealed partial class WindowsPathHelper : IDisposable
 
         try
         {
-            string arguments = $"elevatedadminpath {operation} \"{outputFilePath}\"";
+            string arguments = $"elevatedadminpath {operation} \"{outputFilePath}\" --dotnet-dir \"{dotnetDir}\"";
 
             var startInfo = new ProcessStartInfo
             {

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
       <trans-unit id="AccessModeEverywhere">
-        <source>Replacement Mode</source>
-        <target state="new">Replacement Mode</target>
+        <source>Everywhere Mode</source>
+        <target state="new">Everywhere Mode</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessModeNone">
@@ -392,8 +392,8 @@ Or open a new terminal.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionEverywhere">
-        <source>The system will be configured to use dotnetup installs over any other installs.</source>
-        <target state="new">The system will be configured to use dotnetup installs over any other installs.</target>
+        <source>Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</source>
+        <target state="new">Add dotnetup's .NET to the system PATH, ahead of any machine-wide install, so every application uses it. Requires elevation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathDescriptionNone">
@@ -432,13 +432,13 @@ Or open a new terminal.</target>
         <note>Hint appended after the recommended mode name in the init summary, e.g. "Terminal Mode (Suggested)".</note>
       </trans-unit>
       <trans-unit id="PathReplacementModeUnixError">
-        <source>Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
-        <target state="new">Replacement Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
+        <source>Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</source>
+        <target state="new">Everywhere Mode is not supported on this operating system. Please choose Isolation Mode or Terminal Mode instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipEverywhere">
-        <source>Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</source>
-        <target state="new">Recommended for users who want all of their debuggers, applications, and IDEs to use dotnetup installs by default. Admin privileges are required. Enables 'cmd' functionality by default. Other user accounts on this machine will be impacted and applications may break.</target>
+        <source>Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</source>
+        <target state="new">Recommended if you want all applications, debuggers, and IDEs — not just terminals launched from your shell — to use dotnetup's .NET installs. Requires administrator privileges to update the system PATH; any existing machine-wide install stays on the PATH behind it.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooltipNone">

--- a/test/dotnetup.Tests/InitWorkflowTests.cs
+++ b/test/dotnetup.Tests/InitWorkflowTests.cs
@@ -197,11 +197,18 @@ public class InitWorkflowTests : IDisposable
 
     // ── GetDefaultAccessMode ──
 
-    [TestMethod]
-    public void GetDefaultAccessMode_ReturnsShell_WhenShellProviderIsAvailable()
+    [TestMethod, OSCondition(OperatingSystems.Linux | OperatingSystems.OSX | OperatingSystems.FreeBSD)]
+    public void GetDefaultAccessMode_ReturnsShell_WhenShellProviderIsAvailableOnNonWindows()
     {
         InitWorkflowDefaults.GetDefaultAccessMode(new BashEnvShellProvider())
             .Should().Be(DotnetAccessMode.Shell);
+    }
+
+    [TestMethod, OSCondition(OperatingSystems.Windows)]
+    public void GetDefaultAccessMode_ReturnsEverywhere_WhenShellProviderIsAvailableOnWindows()
+    {
+        InitWorkflowDefaults.GetDefaultAccessMode(new BashEnvShellProvider())
+            .Should().Be(DotnetAccessMode.Everywhere);
     }
 
     // The no-shell isolation fallback (which reads the SHELL environment variable) is covered

--- a/test/dotnetup.Tests/ParserTests.cs
+++ b/test/dotnetup.Tests/ParserTests.cs
@@ -125,7 +125,12 @@ public class ParserTests
     public void Parser_ShouldParseElevatedAdminPathCommand()
     {
         // Arrange
-        var args = new[] { "elevatedadminpath", "removedotnet", @"C:\Users\User\AppData\Local\Temp\dotnetup_elevated\output.txt" };
+        var args = new[]
+        {
+            "elevatedadminpath", "removedotnet",
+            @"C:\Users\User\AppData\Local\Temp\dotnetup_elevated\output.txt",
+            "--dotnet-dir", @"C:\Users\User\AppData\Local\dotnet"
+        };
 
         // Act
         var parseResult = Parser.Parse(args);
@@ -133,6 +138,24 @@ public class ParserTests
         // Assert
         parseResult.Should().NotBeNull();
         parseResult.Errors.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Parser_ElevatedAdminPathCommand_RequiresDotnetDir()
+    {
+        // Arrange - omit the required --dotnet-dir option
+        var args = new[]
+        {
+            "elevatedadminpath", "insertdotnet",
+            @"C:\Users\User\AppData\Local\Temp\dotnetup_elevated\output.txt"
+        };
+
+        // Act
+        var parseResult = Parser.Parse(args);
+
+        // Assert
+        parseResult.Should().NotBeNull();
+        parseResult.Errors.Should().NotBeEmpty();
     }
 
     [TestMethod]

--- a/test/dotnetup.Tests/ParserTests.cs
+++ b/test/dotnetup.Tests/ParserTests.cs
@@ -122,12 +122,12 @@ public class ParserTests
     }
 
     [TestMethod]
-    public void Parser_ShouldParseElevatedAdminPathCommand()
+    public void Parser_ShouldParseElevatedSystemPathCommand()
     {
         // Arrange
         var args = new[]
         {
-            "elevatedadminpath", "removedotnet",
+            "elevatedsystempath", "removedotnet",
             @"C:\Users\User\AppData\Local\Temp\dotnetup_elevated\output.txt",
             "--dotnet-dir", @"C:\Users\User\AppData\Local\dotnet"
         };
@@ -141,12 +141,12 @@ public class ParserTests
     }
 
     [TestMethod]
-    public void Parser_ElevatedAdminPathCommand_RequiresDotnetDir()
+    public void Parser_ElevatedSystemPathCommand_RequiresDotnetDir()
     {
         // Arrange - omit the required --dotnet-dir option
         var args = new[]
         {
-            "elevatedadminpath", "insertdotnet",
+            "elevatedsystempath", "insertdotnet",
             @"C:\Users\User\AppData\Local\Temp\dotnetup_elevated\output.txt"
         };
 

--- a/test/dotnetup.Tests/WindowsPathHelperTests.cs
+++ b/test/dotnetup.Tests/WindowsPathHelperTests.cs
@@ -264,4 +264,109 @@ public class WindowsPathHelperTests
         result.Should().Contain("%SystemRoot%");
         result.Should().Contain("%USERPROFILE%");
     }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void AddPathEntry_ThrowsWhenEntryExpandsToMultipleSegments()
+    {
+        // Arrange - a PATH variable whose value itself contains ';' expands to multiple entries,
+        // so the expanded and unexpanded PATH can no longer be matched by index.
+        const string varName = "DOTNETUP_TEST_MULTI";
+        Environment.SetEnvironmentVariable(varName, "C:\\x;C:\\y");
+        try
+        {
+            string unexpandedPath = $"%{varName}%;C:\\bin";
+            string expandedPath = "C:\\x;C:\\y;C:\\bin";
+
+            // Act
+            Action act = () => WindowsPathHelper.AddPathEntry(unexpandedPath, expandedPath, "C:\\new", "some-command");
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_ThrowsWhenEntryExpandsToEmpty()
+    {
+        // Arrange - a PATH variable that expands to nothing drops an entry from the expanded PATH,
+        // so the expanded and unexpanded PATH can no longer be matched by index.
+        const string varName = "DOTNETUP_TEST_EMPTY";
+        Environment.SetEnvironmentVariable(varName, " ");
+        try
+        {
+            string unexpandedPath = $"%{varName}%;C:\\bin";
+            string expandedPath = "C:\\bin";
+            var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+            // Act
+            Action act = () => WindowsPathHelper.InsertPathEntryBeforeDotnet(unexpandedPath, expandedPath, "C:\\new", programFilesDotnet);
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void RemovePathEntries_ThrowsWhenEntryExpandsToMultipleSegments()
+    {
+        // Arrange - a PATH variable whose value itself contains ';' misaligns the two PATH forms.
+        const string varName = "DOTNETUP_TEST_MULTI";
+        Environment.SetEnvironmentVariable(varName, "C:\\x;C:\\y");
+        try
+        {
+            string unexpandedPath = $"%{varName}%;C:\\bin";
+            string expandedPath = "C:\\x;C:\\y;C:\\bin";
+            var pathsToRemove = new List<string> { "C:\\bin" };
+
+            // Act
+            Action act = () => WindowsPathHelper.RemovePathEntries(unexpandedPath, expandedPath, pathsToRemove);
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void AddPathEntry_ThrowsWhenEmptyAndMultiSegmentExpansionsCancelOut()
+    {
+        // Arrange - one variable expands to nothing and another to multiple segments, so the
+        // expanded and unexpanded PATH split into the same number of entries yet are misaligned.
+        // A whole-string entry-count comparison would miss this; per-entry validation catches it.
+        const string emptyVar = "DOTNETUP_TEST_EMPTY";
+        const string multiVar = "DOTNETUP_TEST_MULTI";
+        Environment.SetEnvironmentVariable(emptyVar, " ");
+        Environment.SetEnvironmentVariable(multiVar, "C:\\x;C:\\y");
+        try
+        {
+            string unexpandedPath = $"%{emptyVar}%;%{multiVar}%";
+            string expandedPath = "C:\\x;C:\\y";
+
+            // Act
+            Action act = () => WindowsPathHelper.AddPathEntry(unexpandedPath, expandedPath, "C:\\new", "some-command");
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(emptyVar, null);
+            Environment.SetEnvironmentVariable(multiVar, null);
+        }
+    }
 }

--- a/test/dotnetup.Tests/WindowsPathHelperTests.cs
+++ b/test/dotnetup.Tests/WindowsPathHelperTests.cs
@@ -12,76 +12,6 @@ public class WindowsPathHelperTests
 {
     [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
-    public void RemoveProgramFilesDotnetFromPath_RemovesCorrectPath()
-    {
-        // Arrange
-        string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        string dotnetPath = Path.Combine(programFiles, "dotnet");
-        string path = $"C:\\SomeOtherPath;{dotnetPath};C:\\AnotherPath";
-
-        // Act - pass the same path for both since no environment variables are used
-        string result = WindowsPathHelper.RemoveProgramFilesDotnetFromPath(path, path);
-
-        // Assert
-        result.Should().NotContain(dotnetPath);
-        result.Should().Contain("C:\\SomeOtherPath");
-        result.Should().Contain("C:\\AnotherPath");
-    }
-
-    [TestMethod]
-    [OSCondition(OperatingSystems.Windows)]
-    public void RemoveProgramFilesDotnetFromPath_HandlesEmptyPath()
-    {
-        // Arrange
-        string path = string.Empty;
-
-        // Act - pass the same path for both since no environment variables are used
-        string result = WindowsPathHelper.RemoveProgramFilesDotnetFromPath(path, path);
-
-        // Assert
-        result.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    [OSCondition(OperatingSystems.Windows)]
-    public void AddProgramFilesDotnetToPath_AddsCorrectPath()
-    {
-        // Arrange
-        string unexpandedPath = "C:\\SomeOtherPath;C:\\AnotherPath";
-        string expandedPath = unexpandedPath; // No environment variables to expand in test
-
-        // Act
-        string result = WindowsPathHelper.AddProgramFilesDotnetToPath(unexpandedPath, expandedPath);
-
-        // Assert
-        string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        string dotnetPath = Path.Combine(programFiles, "dotnet");
-        result.Should().Contain(dotnetPath);
-        result.Should().Contain("C:\\SomeOtherPath");
-        result.Should().Contain("C:\\AnotherPath");
-    }
-
-    [TestMethod]
-    [OSCondition(OperatingSystems.Windows)]
-    public void AddProgramFilesDotnetToPath_DoesNotAddDuplicatePath()
-    {
-        // Arrange
-        string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        string dotnetPath = Path.Combine(programFiles, "dotnet");
-        string unexpandedPath = $"C:\\SomeOtherPath;{dotnetPath};C:\\AnotherPath";
-        string expandedPath = unexpandedPath; // No environment variables to expand in test
-
-        // Act
-        string result = WindowsPathHelper.AddProgramFilesDotnetToPath(unexpandedPath, expandedPath);
-
-        // Assert
-        // Count occurrences of dotnetPath in result
-        int count = result.Split(';').Count(p => p.Equals(dotnetPath, StringComparison.OrdinalIgnoreCase));
-        count.Should().Be(1);
-    }
-
-    [TestMethod]
-    [OSCondition(OperatingSystems.Windows)]
     public void GetProgramFilesDotnetPaths_ReturnsValidPaths()
     {
         // Act
@@ -216,6 +146,121 @@ public class WindowsPathHelperTests
 
         // Assert
         result.Should().Be("%SystemRoot%\\system32;%USERPROFILE%\\bin");
+        result.Should().Contain("%SystemRoot%");
+        result.Should().Contain("%USERPROFILE%");
+    }
+
+    // ── InsertPathEntryBeforeDotnet ──
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_InsertsImmediatelyBeforeProgramFilesDotnet()
+    {
+        // Arrange
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = "C:\\Windows;C:\\Program Files\\dotnet;C:\\tools";
+        var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        // Assert - dotnetup dir sits directly before the Program Files entry, not at the front
+        result.Should().Be($"C:\\Windows;{dotnetDir};C:\\Program Files\\dotnet;C:\\tools");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_MatchesProgramFilesEntryWithTrailingSeparator()
+    {
+        // The .NET installer writes the system PATH entry with a trailing separator.
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = "C:\\Windows;C:\\Program Files\\dotnet\\;C:\\tools";
+        var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        result.Should().Be($"C:\\Windows;{dotnetDir};C:\\Program Files\\dotnet\\;C:\\tools");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_AppendsToEndWhenNoProgramFilesDotnet()
+    {
+        // Arrange - no machine-wide dotnet on PATH
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = "C:\\Windows;C:\\tools";
+        var programFilesDotnet = new List<string>();
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        // Assert - appended to the end so a later machine-wide install lands after it
+        result.Should().Be($"C:\\Windows;C:\\tools;{dotnetDir}");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_NoChangeWhenAlreadyAheadOfProgramFilesDotnet()
+    {
+        // Arrange - dotnetup dir already precedes the Program Files entry
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = $"C:\\Windows;{dotnetDir};C:\\Program Files\\dotnet;C:\\tools";
+        var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        // Assert - unchanged
+        result.Should().Be(path);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_MovesEntryWhenPresentAfterProgramFilesDotnet()
+    {
+        // Arrange - dotnetup dir present but AFTER the Program Files entry, so it does not win
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = $"C:\\Windows;C:\\Program Files\\dotnet;{dotnetDir};C:\\tools";
+        var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        // Assert - moved to immediately before the Program Files entry
+        result.Should().Be($"C:\\Windows;{dotnetDir};C:\\Program Files\\dotnet;C:\\tools");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_NoChangeWhenAlreadyPresentAndNoProgramFilesDotnet()
+    {
+        // Arrange - already appended and no machine-wide dotnet present
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string path = $"C:\\Windows;C:\\tools;{dotnetDir}";
+        var programFilesDotnet = new List<string>();
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(path, path, dotnetDir, programFilesDotnet);
+
+        // Assert - unchanged
+        result.Should().Be(path);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InsertPathEntryBeforeDotnet_PreservesUnexpandedVariables()
+    {
+        // Arrange - unexpanded PATH retains %VAR% entries
+        string dotnetDir = "C:\\Users\\me\\AppData\\Local\\dotnet";
+        string unexpandedPath = "%SystemRoot%\\system32;C:\\Program Files\\dotnet;%USERPROFILE%\\bin";
+        string expandedPath = "C:\\Windows\\system32;C:\\Program Files\\dotnet;C:\\Users\\me\\bin";
+        var programFilesDotnet = new List<string> { "C:\\Program Files\\dotnet" };
+
+        // Act
+        string result = WindowsPathHelper.InsertPathEntryBeforeDotnet(unexpandedPath, expandedPath, dotnetDir, programFilesDotnet);
+
+        // Assert
+        result.Should().Be($"%SystemRoot%\\system32;{dotnetDir};C:\\Program Files\\dotnet;%USERPROFILE%\\bin");
         result.Should().Contain("%SystemRoot%");
         result.Should().Contain("%USERPROFILE%");
     }


### PR DESCRIPTION
In everywhere mode, insert user dotnet path on the system PATH before the Program Files dotnet path.

This should prevent it from being overridden when the system-installed .NET is updated

This implements Phase 1 of the ["Happy Path" design](https://github.com/dotnet/designs/blob/dotnetup-system-integration/accepted/2026/dotnetup/dotnetup-system-integration.md)

Also changed terminology from "admin PATH" to "system PATH", which I believe is more correct.