### PR TITLE
Apply dotnet test zero-tests verdict at the whole-run level

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -100,6 +100,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 exitCode = ExitCode.MinimumExpectedTestsPolicyViolation;
             }
             else if (exitCode == ExitCode.Success &&
+                !isHelp &&
                 !parseResult.HasOption(definition.MinimumExpectedTestsOption) &&
                 output.TotalTests == 0)
             {

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -99,6 +99,18 @@ internal partial class MicrosoftTestingPlatformTestCommand
             {
                 exitCode = ExitCode.MinimumExpectedTestsPolicyViolation;
             }
+            else if (exitCode == ExitCode.Success &&
+                !parseResult.HasOption(definition.MinimumExpectedTestsOption) &&
+                output.TotalTests == 0)
+            {
+                // Whole-run "zero tests ran" verdict. Individual modules that matched no tests return exit
+                // code 8, but TestApplicationActionQueue normalizes that to success so a single empty module
+                // does not fail the whole run (e.g. with --test-modules or a global --filter). The aggregate
+                // zero-tests case is decided here so it surfaces once at the run level instead of once per
+                // module. A stricter per-module minimum via -- --minimum-expected-tests N still fails that
+                // module with exit code 9. See https://github.com/microsoft/testfx/issues/7457.
+                exitCode = ExitCode.ZeroTests;
+            }
 
             return exitCode.Value;
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -453,16 +453,18 @@ internal sealed partial class TerminalTestReporter : IDisposable
     /// </summary>
     private static void AppendAssemblyResult(ITerminal terminal, TestProgressState state)
     {
-        if (!state.Success)
+        if (state.ExitCode == ExitCode.ZeroTests)
         {
             terminal.SetColor(TerminalColor.DarkRed);
-            // If the build failed, we print one of three red strings.
-            string text = (state.FailedTests > 0, state.TotalTests == 0) switch
-            {
-                (true, _) => string.Format(CultureInfo.CurrentCulture, CliCommandStrings.FailedWithErrors, state.FailedTests),
-                (false, true) => CliCommandStrings.ZeroTestsRan,
-                (false, false) => CliCommandStrings.FailedLowercase,
-            };
+            terminal.Append(CliCommandStrings.ZeroTestsRan);
+            terminal.ResetColor();
+        }
+        else if (!state.Success)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            string text = state.FailedTests > 0
+                ? string.Format(CultureInfo.CurrentCulture, CliCommandStrings.FailedWithErrors, state.FailedTests)
+                : CliCommandStrings.FailedLowercase;
             terminal.Append(text);
             terminal.ResetColor();
         }
@@ -831,6 +833,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             return;
         }
 
+        assemblyRun.ExitCode = exitCode;
         assemblyRun.Success = (exitCode == ExitCode.Success || exitCode == ExitCode.ZeroTests)
             && assemblyRun.FailedTests == 0;
         assemblyRun.Stopwatch.Stop();

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -831,7 +831,8 @@ internal sealed partial class TerminalTestReporter : IDisposable
             return;
         }
 
-        assemblyRun.Success = exitCode == 0 && assemblyRun.FailedTests == 0;
+        assemblyRun.Success = (exitCode == ExitCode.Success || exitCode == ExitCode.ZeroTests)
+            && assemblyRun.FailedTests == 0;
         assemblyRun.Stopwatch.Stop();
 
         _terminalWithProgress.RemoveWorker(assemblyRun.SlotIndex);

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -144,6 +144,8 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         }
     }
 
+    public int? ExitCode { get; internal set; }
+
     public bool IsDiscovery { get; } = isDiscovery;
 
     public int TryCount

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -75,11 +75,6 @@ internal class TestApplicationActionQueue
                         result = ExitCode.GenericFailure;
                     }
 
-                    if (result == ExitCode.Success && testApp.HasFailureDuringDispose)
-                    {
-                        result = ExitCode.GenericFailure;
-                    }
-
                     // A module that ran zero tests (exit code 8) is not, by itself, a whole-run failure.
                     // With --test-modules or a global --filter, some modules may legitimately match no tests.
                     // Normalize it to success here; the aggregate "zero tests ran" verdict is decided once at
@@ -87,10 +82,7 @@ internal class TestApplicationActionQueue
                     // stricter per-module minimum requested via -- --minimum-expected-tests N still fails that
                     // module with ExitCode.MinimumExpectedTestsPolicyViolation (9) and is preserved.
                     // See https://github.com/microsoft/testfx/issues/7457.
-                    if (result == ExitCode.ZeroTests)
-                    {
-                        result = ExitCode.Success;
-                    }
+                    result = NormalizeExitCode(result, testApp.HasFailureDuringDispose);
 
                     lock (_lock)
                     {
@@ -122,6 +114,7 @@ internal class TestApplicationActionQueue
                     }
                 }
             }
+
         }
         catch (OperationCanceledException) when (ctrlC.Token.IsCancellationRequested)
         {
@@ -130,5 +123,17 @@ internal class TestApplicationActionQueue
             // (and report final session state via IPC); a second Ctrl+C is what force-kills them
             // via the CtrlCCancellationManager.
         }
+    }
+
+    internal static int NormalizeExitCode(int result, bool hasFailureDuringDispose)
+    {
+        if (result == ExitCode.ZeroTests)
+        {
+            result = ExitCode.Success;
+        }
+
+        return result == ExitCode.Success && hasFailureDuringDispose
+            ? ExitCode.GenericFailure
+            : result;
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Channels;
@@ -78,6 +78,18 @@ internal class TestApplicationActionQueue
                     if (result == ExitCode.Success && testApp.HasFailureDuringDispose)
                     {
                         result = ExitCode.GenericFailure;
+                    }
+
+                    // A module that ran zero tests (exit code 8) is not, by itself, a whole-run failure.
+                    // With --test-modules or a global --filter, some modules may legitimately match no tests.
+                    // Normalize it to success here; the aggregate "zero tests ran" verdict is decided once at
+                    // the whole-run level in MicrosoftTestingPlatformTestCommand from the total test count. A
+                    // stricter per-module minimum requested via -- --minimum-expected-tests N still fails that
+                    // module with ExitCode.MinimumExpectedTestsPolicyViolation (9) and is preserved.
+                    // See https://github.com/microsoft/testfx/issues/7457.
+                    if (result == ExitCode.ZeroTests)
+                    {
+                        result = ExitCode.Success;
                     }
 
                     lock (_lock)

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/AnotherTestProject/AnotherTestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/AnotherTestProject/AnotherTestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/AnotherTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/AnotherTestProject/Program.cs
@@ -1,0 +1,46 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/MultiTestProjectSolutionWithZeroTestsAndPassingTests.sln
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/MultiTestProjectSolutionWithZeroTestsAndPassingTests.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35415.258 main
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{3A1C1B98-E445-473C-9697-691D6F512878}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnotherTestProject", "AnotherTestProject\AnotherTestProject.csproj", "{688D935E-DA1D-40F4-BE84-61FF7364A643}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3A1C1B98-E445-473C-9697-691D6F512878}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A1C1B98-E445-473C-9697-691D6F512878}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A1C1B98-E445-473C-9697-691D6F512878}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A1C1B98-E445-473C-9697-691D6F512878}.Release|Any CPU.Build.0 = Release|Any CPU
+		{688D935E-DA1D-40F4-BE84-61FF7364A643}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{688D935E-DA1D-40F4-BE84-61FF7364A643}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{688D935E-DA1D-40F4-BE84-61FF7364A643}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{688D935E-DA1D-40F4-BE84-61FF7364A643}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/TestProject/Program.cs
@@ -1,0 +1,38 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => [];
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		context.Complete();
+		await Task.CompletedTask;
+	}
+}

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/global.json
+++ b/test/TestAssets/TestProjects/MultiTestProjectSolutionWithZeroTestsAndPassingTests/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
@@ -290,7 +290,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]
-        public void RunMultipleTestProjectsWithDifferentFailures_ShouldReturnExitCodeGenericFailure(string configuration)
+        public void RunMultipleTestProjectsWithDifferentFailures_ShouldReturnExitCodeAtLeastOneTestFailed(string configuration)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithDifferentFailures", Guid.NewGuid().ToString())
                 .WithSource();
@@ -328,7 +328,10 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("skipped: 1");
             }
 
-            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+            // The empty module (TestProject) reports exit code 8 (ZeroTests) but is normalized to success at
+            // the aggregate level (microsoft/testfx#7457), so it no longer collides with the failing module's
+            // exit code 2 to produce GenericFailure (1). The run's verdict is now AtLeastOneTestFailed (2).
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
         [DataRow(TestingConstants.Debug)]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -337,6 +337,37 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]
+        public void RunMultipleTestProjectsWhereOneRanZeroTests_ShouldReturnExitCodeSuccess(string configuration)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithZeroTestsAndPassingTests", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("-c", configuration);
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                // One module matched no tests (its process returns exit code 8) while the other ran a passing
+                // test, so the whole run still executed one test and its verdict is a pass.
+                result.StdOut
+                    .Should().Contain("Exit code: 8")
+                    .And.Contain("Test run summary: Passed!")
+                    .And.Contain("total: 1")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 0");
+            }
+
+            // The empty module reports exit code 8 (ZeroTests) but is normalized to success at the aggregate
+            // level, and because the whole run executed at least one test the run-level zero-tests verdict does
+            // not apply either. The overall verdict is Success (microsoft/testfx#7457).
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
+        [DataRow(TestingConstants.Debug)]
+        [DataRow(TestingConstants.Release)]
+        [TestMethod]
         public void RunTestProjectsWithHybridModeTestRunners_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("HybridTestRunnerTestProjects", Guid.NewGuid().ToString())

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -177,6 +177,7 @@ public class TerminalTestReporterTests
 
         string output = StripAnsi(capturingConsole.GetOutput());
         output.Should().Contain("Test run summary: Passed!");
+        GetAssemblySummaryLine(output, emptyAssembly).Should().Contain("Zero tests ran");
         output.Should().NotContain("error:");
     }
 

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -147,6 +147,39 @@ public class TerminalTestReporterTests
         GetAssemblySummaryLine(output, assemblyB).Should().Contain("[+5/x0/?2]");
     }
 
+    [TestMethod]
+    public void TestExecutionCompleted_WithZeroTestsAndPassingAssemblies_PrintsPassedSummary()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        var options = new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 2, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string emptyAssembly = "/repo/bin/Debug/net9.0/Empty.Tests.dll";
+        const string passingAssembly = "/repo/bin/Debug/net9.0/Passing.Tests.dll";
+
+        reporter.AssemblyRunStarted(emptyAssembly, "net9.0", "x64", executionId: "exec-empty", instanceId: "inst-empty");
+        reporter.AssemblyRunStarted(passingAssembly, "net9.0", "x64", executionId: "exec-passing", instanceId: "inst-passing");
+        ReportTest(reporter, passingAssembly, executionId: "exec-passing", instanceId: "inst-passing", testUid: "passing-1", TestOutcome.Passed);
+
+        reporter.AssemblyRunCompleted(executionId: "exec-empty", exitCode: ExitCode.ZeroTests, outputData: null, errorData: null);
+        reporter.AssemblyRunCompleted(executionId: "exec-passing", exitCode: ExitCode.Success, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: ExitCode.Success);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+        output.Should().Contain("Test run summary: Passed!");
+        output.Should().NotContain("error:");
+    }
+
     /// <summary>
     /// When an assembly's tests were retried, the per-assembly summary should append a
     /// "/r{N}" segment to the compact counts block so users can tell the final counts came from retries.

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationActionQueueTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationActionQueueTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+using TestExitCode = Microsoft.DotNet.Cli.Commands.Test.ExitCode;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestApplicationActionQueueTests
+{
+    [TestMethod]
+    public void NormalizeExitCode_ZeroTestsWithDisposeFailure_ReturnsGenericFailure()
+    {
+        int result = TestApplicationActionQueue.NormalizeExitCode(
+            TestExitCode.ZeroTests,
+            hasFailureDuringDispose: true);
+
+        result.Should().Be(TestExitCode.GenericFailure);
+    }
+}


### PR DESCRIPTION
A test run should not fail just because one module matched no tests when other modules executed successfully. The current per-module exit code aggregation also leaves the terminal summary inconsistent: the command exits successfully, but reports the run as failed.

This change:
- normalizes per-module `ZeroTests` results before aggregate exit-code calculation
- decides the zero-tests verdict once from the whole-run test count
- treats an empty module as successful in terminal summary accounting while retaining its `Exit code: 8` diagnostic
- preserves explicit minimum-test policy failures
- adds end-to-end and focused reporter coverage for an empty module alongside a passing module

This implements the SDK side of microsoft/testfx#7457.