### PR TITLE
Support --nologo in Microsoft.Testing.Platform test mode

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -88,6 +88,11 @@ internal abstract partial class TestCommandDefinition
             Description = CommandDefinitionStrings.CmdNoBuildDescription
         };
 
+        public readonly Option<bool> NoLogoOption = CommonOptions.CreateNoLogoOption(
+            defaultValue: false,
+            forwardAs: null,
+            description: CommandDefinitionStrings.TestCmdNoLogo);
+
         public readonly Option<bool> UseCurrentRuntimeOption = CommonOptions.CreateUseCurrentRuntimeOption(CommandDefinitionStrings.CmdCurrentRuntimeOptionDescription);
 
         public readonly Option<bool> NoDependenciesOption = new Option<bool>("--no-dependencies")
@@ -178,6 +183,7 @@ internal abstract partial class TestCommandDefinition
             Options.Add(VerbosityOption);
             Options.Add(NoRestoreOption);
             Options.Add(NoBuildOption);
+            Options.Add(NoLogoOption);
             Options.Add(NoDependenciesOption);
             Options.Add(ArtifactsPathOption);
             Options.Add(UseCurrentRuntimeOption);

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
@@ -349,15 +349,17 @@ internal static class CommonOptions
     /// </list>
     /// Finally, if neither the option nor the environment variable is set, the option will default to the provided <paramref name="defaultValue"/>.
     /// </summary>
-    public static Option<bool> CreateNoLogoOption(bool defaultValue = true, string forwardAs = "--nologo", string? description = null)
+    public static Option<bool> CreateNoLogoOption(bool defaultValue = true, string? forwardAs = "--nologo", string? description = null)
     {
-        return new Option<bool>("--no-logo", "--nologo", "-nologo", "/nologo")
+        Option<bool> option = new("--no-logo", "--nologo", "-nologo", "/nologo")
         {
             Description = description ?? CommandDefinitionStrings.NoLogoOptionDescription,
             DefaultValueFactory = (ar) => EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable("DOTNET_NOLOGO"), defaultValue),
             CustomParser = (ar) => true,
             Arity = ArgumentArity.Zero
-        }.ForwardIfEnabled(forwardAs);
+        };
+
+        return forwardAs is null ? option : option.ForwardIfEnabled(forwardAs);
     }
 
     public static void ValidateSelfContainedOptions(bool hasSelfContainedOption, bool hasNoSelfContainedOption)
@@ -378,5 +380,4 @@ internal static class CommonOptions
         Arity = ArgumentArity.Zero
     };
 }
-
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -210,6 +210,11 @@ internal static class MSBuildUtility
 
         LoggerUtility.SeparateLoggerArguments(parseResult.UnmatchedTokens, out var loggerArgs, out var otherArgs);
 
+        if (parseResult.GetValue(definition.NoLogoOption) && !otherArgs.Contains("--no-banner"))
+        {
+            otherArgs = otherArgs.Add("--no-banner");
+        }
+
         var (positionalProjectOrSolution, positionalTestModules) = GetPositionalArguments(ref otherArgs);
 
         var msbuildArgs = parseResult.OptionValuesToBeForwarded(definition)

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -80,5 +80,26 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 summaryLine.Should().NotContain("Zero tests ran", "the summary headline must not mask a handshake failure as an empty run");
             }
         }
+
+        [TestMethod]
+        public void RunConsoleAppWithInvalidOptionError_ShouldSurfaceErrorOutput()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("ConsoleAppDoesNothing", Guid.NewGuid().ToString())
+                .WithSource();
+            File.WriteAllText(
+                Path.Combine(testInstance.Path, "Program.cs"),
+                """
+                Console.Error.WriteLine("Option '--unsupported-option' is not recognized.");
+                return 5;
+                """);
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("--unsupported-option");
+
+            result.ExitCode.Should().Be(5);
+            result.StdOut.Should().Contain("Option '--unsupported-option' is not recognized.");
+            result.StdOut.Should().Contain("Test run summary: Failed!");
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             File.WriteAllText(
                 Path.Combine(testInstance.Path, "Program.cs"),
                 """
-                Console.Error.WriteLine("Option '--unsupported-option' is not recognized.");
+                System.Console.Error.WriteLine("Option '--unsupported-option' is not recognized.");
                 return 5;
                 """);
 

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using Moq;
+using TestExitCode = Microsoft.DotNet.Cli.Commands.Test.ExitCode;
 
 namespace dotnet.Tests.CommandTests.Test;
 
@@ -173,9 +174,9 @@ public class TerminalTestReporterTests
         reporter.AssemblyRunStarted(passingAssembly, "net9.0", "x64", executionId: "exec-passing", instanceId: "inst-passing");
         ReportTest(reporter, passingAssembly, executionId: "exec-passing", instanceId: "inst-passing", testUid: "passing-1", TestOutcome.Passed);
 
-        reporter.AssemblyRunCompleted(executionId: "exec-empty", exitCode: ExitCode.ZeroTests, outputData: null, errorData: null);
-        reporter.AssemblyRunCompleted(executionId: "exec-passing", exitCode: ExitCode.Success, outputData: null, errorData: null);
-        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: ExitCode.Success);
+        reporter.AssemblyRunCompleted(executionId: "exec-empty", exitCode: TestExitCode.ZeroTests, outputData: null, errorData: null);
+        reporter.AssemblyRunCompleted(executionId: "exec-passing", exitCode: TestExitCode.Success, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: TestExitCode.Success);
 
         string output = StripAnsi(capturingConsole.GetOutput());
         output.Should().Contain("Test run summary: Passed!");

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -92,6 +92,60 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [DataRow("--no-logo")]
+        [DataRow("--nologo")]
+        [DataRow("-nologo")]
+        [DataRow("/nologo")]
+        public void MTPCommandTranslatesNoLogoOptionToNoBanner(string optionAlias)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse([optionAlias]);
+
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+            buildOptions.TestApplicationArguments.Should().ContainSingle("--no-banner");
+            buildOptions.MSBuildArgs.Should().NotContain("--no-banner");
+            buildOptions.MSBuildArgs.Should().NotContain(optionAlias);
+        }
+
+        [TestMethod]
+        public void MTPCommandDoesNotDuplicateNoBannerOption()
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--nologo", "--no-banner"]);
+
+            var buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+
+            buildOptions.TestApplicationArguments.Should().ContainSingle("--no-banner");
+        }
+
+        [TestMethod]
+        public void MTPCommandHonorsDotnetNoLogoEnvironmentVariable()
+        {
+            string? previousValue = Environment.GetEnvironmentVariable("DOTNET_NOLOGO");
+            try
+            {
+                Environment.SetEnvironmentVariable("DOTNET_NOLOGO", "true");
+                var enabledCommand = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var enabledBuildOptions = MSBuildUtility.GetBuildOptions(enabledCommand.Parse([]));
+
+                enabledBuildOptions.TestApplicationArguments.Should().ContainSingle("--no-banner");
+
+                Environment.SetEnvironmentVariable("DOTNET_NOLOGO", "false");
+                var disabledCommand = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var disabledBuildOptions = MSBuildUtility.GetBuildOptions(disabledCommand.Parse([]));
+
+                disabledBuildOptions.TestApplicationArguments.Should().NotContain("--no-banner");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("DOTNET_NOLOGO", previousValue);
+            }
+        }
+
+        [TestMethod]
         [DataRow("--use-current-runtime")]
         [DataRow("--ucr")]
         public void MTPCommandForwardsUseCurrentRuntimeOption(string optionAlias)

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -33,6 +33,7 @@ Options:
   -v, -verbosity <LEVEL>                          Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
   --no-restore                                    Do not restore the project before building. [default: False]
   --no-build                                      Do not build the project before testing. Implies --no-restore. [default: False]
+  -nologo, --no-logo                              Run test(s), without displaying Microsoft Testplatform banner [default: False]
   --no-dependencies                               Do not build project-to-project references and only build the specified project. [default: False]
   --artifacts-path <ARTIFACTS_DIR>                The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path.
   --ucr, --use-current-runtime                    Use current runtime as the target runtime. [default: False]


### PR DESCRIPTION
Fixes #55309.

## Summary

When `dotnet test` uses Microsoft.Testing.Platform, `--nologo` is currently treated as an unmatched extension option and forwarded unchanged to each test application. MTP recognizes `--no-banner` instead, so it exits with code 5 before test discovery.

This change:

- recognizes the common `--no-logo`, `--nologo`, `-nologo`, and `/nologo` aliases in MTP mode
- translates the enabled option to MTP's `--no-banner`
- honors `DOTNET_NOLOGO` while preserving the default behavior when it is unset
- avoids duplicating an explicitly supplied `--no-banner`
- updates MTP help output
- adds coverage that unsupported extension options continue flowing to the test application and that pre-handshake command-line errors are surfaced by the SDK

Unknown options must continue to flow through because MTP extensions dynamically contribute command-line options; the SDK cannot reject them during its initial parse. The SDK's existing handshake-failure path on `main` captures and reports the child application's actionable stderr. That diagnostic improvement should also be considered for backport to .NET 10, where the reported opaque output occurs.

## Validation

- Built `src/Cli/dotnet/dotnet.csproj`
- Passed 62 `TestCommandDefinitionTests`
- Verified through a child-process argument capture that `--nologo` becomes `--no-banner` and is not forwarded to MSBuild
- Verified an unsupported child option's stderr is included in the failed summary and handshake-failure recap