### PR TITLE
Backport MTP handshake failure diagnostics

### DIFF
--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2724,6 +2724,10 @@ Proceed?</value>
   <data name="DurationColon" xml:space="preserve">
     <value>duration:</value>
   </data>
+  <data name="HandshakeFailuresHeader" xml:space="preserve">
+    <value>Handshake failures:</value>
+    <comment>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</comment>
+  </data>
   <data name="WorkloadSetHasMissingManifests" xml:space="preserve">
     <value>Workload set version {0} has missing manifests likely removed by package management. Run "dotnet workload repair" to fix this.</value>
     <comment>{0} is the workload set version. {Locked="dotnet workload repair"}</comment>

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2726,7 +2726,7 @@ Proceed?</value>
   </data>
   <data name="HandshakeFailuresHeader" xml:space="preserve">
     <value>Handshake failures:</value>
-    <comment>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</comment>
+    <comment>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</comment>
   </data>
   <data name="WorkloadSetHasMissingManifests" xml:space="preserve">
     <value>Workload set version {0} has missing manifests likely removed by package management. Run "dotnet workload repair" to fix this.</value>

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -839,7 +839,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             if (!string.IsNullOrWhiteSpace(output))
             {
-                AppendIndentedLine(terminal, $"{description}: {output}", SingleIndentation);
+                AppendIndentedLine(terminal, $"{description}: {NormalizeSpecialCharacters(output)}", SingleIndentation);
             }
         }
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -36,6 +36,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private int _handshakeFailuresCount;
 
+    private readonly object _handshakeFailuresLock = new();
+    private readonly List<HandshakeFailureRecord> _handshakeFailures = [];
+
     private readonly uint? _originalConsoleMode;
     private bool _isDiscovery;
     private bool _isHelp;
@@ -166,6 +169,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         NativeMethods.RestoreConsoleMode(_originalConsoleMode);
         _assemblies.Clear();
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Clear();
+        }
+        _handshakeFailuresCount = 0;
         _buildErrorsCount = 0;
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;
@@ -226,11 +234,20 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.MinimumExpectedTestsPolicyViolation, totalTests, _options.MinimumExpectedTests));
         }
+        else if (anyTestFailed || HasHandshakeFailure)
+        {
+            // Handshake failures take precedence over "Zero tests ran": when an assembly failed to
+            // hand-shake we want the headline to reflect that the run failed, not that no tests ran
+            // (which would imply a benign empty run). We intentionally do NOT escalate the broader
+            // anyAssemblyFailed here, because a project that legitimately contains zero tests exits
+            // with ExitCodes.ZeroTests (non-zero) and would otherwise be misclassified as a failure.
+            terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Failed));
+        }
         else if (allTestsWereSkipped)
         {
             terminal.Append(CliCommandStrings.ZeroTestsRan);
         }
-        else if (anyTestFailed || anyAssemblyFailed)
+        else if (anyAssemblyFailed)
         {
             terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Failed));
         }
@@ -347,6 +364,35 @@ internal sealed partial class TerminalTestReporter : IDisposable
         terminal.AppendLine();
 
         AppendExitCodeAndUrl(terminal, exitCode, isRun: true);
+
+        AppendHandshakeFailureRecap(terminal);
+    }
+
+    private void AppendHandshakeFailureRecap(ITerminal terminal)
+    {
+        HandshakeFailureRecord[] failures;
+        lock (_handshakeFailuresLock)
+        {
+            if (_handshakeFailures.Count == 0)
+            {
+                return;
+            }
+
+            failures = _handshakeFailures.ToArray();
+        }
+
+        terminal.AppendLine();
+        terminal.SetColor(TerminalColor.DarkRed);
+        terminal.AppendLine(CliCommandStrings.HandshakeFailuresHeader);
+        terminal.ResetColor();
+
+        foreach (HandshakeFailureRecord failure in failures)
+        {
+            terminal.Append(SingleIndentation);
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, failure.AssemblyPath, failure.TargetFramework, architecture: null);
+            terminal.AppendLine();
+            AppendExecutableSummary(terminal, failure.ExitCode, failure.OutputData, failure.ErrorData);
+        }
     }
 
     private static void AppendExitCodeAndUrl(ITerminal terminal, int? exitCode, bool isRun)
@@ -763,6 +809,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
 
         Interlocked.Increment(ref _handshakeFailuresCount);
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Add(new HandshakeFailureRecord(assemblyPath, targetFramework, exitCode, outputData, errorData));
+        }
+
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
             terminal.ResetColor();
@@ -797,6 +848,13 @@ internal sealed partial class TerminalTestReporter : IDisposable
         => text?.Replace('\0', '\x2400')
             // escape char
             .Replace('\x001b', '\x241b');
+
+    private readonly record struct HandshakeFailureRecord(
+        string AssemblyPath,
+        string? TargetFramework,
+        int ExitCode,
+        string OutputData,
+        string ErrorData);
 
     private static void AppendAssemblySummary(TestProgressState assemblyRun, ITerminal terminal)
     {

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Verze souboru global.json</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json Version</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Versión de Global.json</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json Version</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Versione Global.json</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json のバージョン</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json 버전</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Wersja Global.json</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Versão de global.json</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json Version</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json Sürümü</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DÖKÜM_TÜRÜ</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json 版本</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -1444,7 +1444,7 @@ Make the profile names distinct.</target>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
-        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to handshake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
       </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -1441,6 +1441,11 @@ Make the profile names distinct.</target>
         <target state="translated">Global.json 版本</target>
         <note />
       </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note>Section header printed at the end of a 'dotnet test' run when one or more test hosts failed to hand-shake with the SDK. Followed by per-assembly exit code, stdout and stderr.</note>
+      </trans-unit>
       <trans-unit id="HangDumpTypeArgumentName">
         <source>DUMP_TYPE</source>
         <target state="translated">DUMP_TYPE</target>

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Test;
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
@@ -38,8 +39,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             File.WriteAllText(
                 Path.Combine(testInstance.Path, "Program.cs"),
                 """
-                System.Console.Out.WriteLine("Usage: ConsoleAppDoesNothing [options]");
-                System.Console.Error.WriteLine("Option '--unsupported-option' is not recognized.");
+                System.Console.Out.WriteLine("Usage: ConsoleAppDoesNothing [options]\0");
+                System.Console.Error.WriteLine("\u001bOption '--unsupported-option' is not recognized.");
                 return 5;
                 """);
 
@@ -50,25 +51,27 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.GenericFailure);
             result.StdOut.Should().Contain("Usage: ConsoleAppDoesNothing [options]");
             result.StdOut.Should().Contain("Option '--unsupported-option' is not recognized.");
+            result.StdOut.Should().NotContain("\0");
+            result.StdOut.Should().NotContain("\u001b");
 
-            int recapHeaderIndex = result.StdOut.IndexOf("Handshake failures:", StringComparison.Ordinal);
+            int recapHeaderIndex = result.StdOut.IndexOf(CliCommandStrings.HandshakeFailuresHeader, StringComparison.Ordinal);
             recapHeaderIndex.Should().BeGreaterThanOrEqualTo(0);
 
             string recap = result.StdOut.Substring(recapHeaderIndex);
             recap.Should().Contain("ConsoleAppDoesNothing");
-            recap.Should().Contain("Exit code: 5");
+            recap.Should().Contain($"{CliCommandStrings.ExitCode}: 5");
             recap.Should().Contain("Usage: ConsoleAppDoesNothing [options]");
             recap.Should().Contain("Option '--unsupported-option' is not recognized.");
 
-            int summaryIndex = result.StdOut.IndexOf("Test run summary:", StringComparison.Ordinal);
+            int summaryIndex = result.StdOut.IndexOf(CliCommandStrings.TestRunSummary, StringComparison.Ordinal);
             summaryIndex.Should().BeGreaterThanOrEqualTo(0);
             int summaryEnd = result.StdOut.IndexOf('\n', summaryIndex);
             string summaryLine = summaryEnd < 0
                 ? result.StdOut.Substring(summaryIndex)
                 : result.StdOut.Substring(summaryIndex, summaryEnd - summaryIndex);
 
-            summaryLine.Should().Contain("Failed!");
-            summaryLine.Should().NotContain("Zero tests ran");
+            summaryLine.Should().Contain($"{CliCommandStrings.Failed}!");
+            summaryLine.Should().NotContain(CliCommandStrings.ZeroTestsRan);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestRunsConsoleAppWithoutHandshake.cs
@@ -29,5 +29,46 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             result.ExitCode.Should().Be(ExitCodes.GenericFailure, "dotnet test should fail with a meaningful error when run against console app without MTP handshake");
         }
+
+        [Fact]
+        public void RunConsoleAppWithInvalidOptionError_ShouldSurfaceFailureDetails()
+        {
+            TestAsset testInstance = _testAssetsManager.CopyTestAsset("ConsoleAppDoesNothing", Guid.NewGuid().ToString())
+                .WithSource();
+            File.WriteAllText(
+                Path.Combine(testInstance.Path, "Program.cs"),
+                """
+                System.Console.Out.WriteLine("Usage: ConsoleAppDoesNothing [options]");
+                System.Console.Error.WriteLine("Option '--unsupported-option' is not recognized.");
+                return 5;
+                """);
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("--unsupported-option");
+
+            result.ExitCode.Should().Be(ExitCodes.GenericFailure);
+            result.StdOut.Should().Contain("Usage: ConsoleAppDoesNothing [options]");
+            result.StdOut.Should().Contain("Option '--unsupported-option' is not recognized.");
+
+            int recapHeaderIndex = result.StdOut.IndexOf("Handshake failures:", StringComparison.Ordinal);
+            recapHeaderIndex.Should().BeGreaterThanOrEqualTo(0);
+
+            string recap = result.StdOut.Substring(recapHeaderIndex);
+            recap.Should().Contain("ConsoleAppDoesNothing");
+            recap.Should().Contain("Exit code: 5");
+            recap.Should().Contain("Usage: ConsoleAppDoesNothing [options]");
+            recap.Should().Contain("Option '--unsupported-option' is not recognized.");
+
+            int summaryIndex = result.StdOut.IndexOf("Test run summary:", StringComparison.Ordinal);
+            summaryIndex.Should().BeGreaterThanOrEqualTo(0);
+            int summaryEnd = result.StdOut.IndexOf('\n', summaryIndex);
+            string summaryLine = summaryEnd < 0
+                ? result.StdOut.Substring(summaryIndex)
+                : result.StdOut.Substring(summaryIndex, summaryEnd - summaryIndex);
+
+            summaryLine.Should().Contain("Failed!");
+            summaryLine.Should().NotContain("Zero tests ran");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Backports the minimal Microsoft.Testing.Platform handshake diagnostics from #54501 to `release/10.0.1xx`.

When an unmatched option is forwarded to an MTP test application and the application exits before the handshake (for example with `InvalidCommandLine` / exit code 5), `dotnet test` now:

- surfaces the already-captured child stdout and stderr
- reports the overall summary as `Failed!` instead of `Zero tests ran`
- reprints actionable handshake failures after the summary so they remain visible at the end of verbose runs

This is the diagnostic companion/backport for #55309. It is intentionally distinct from #55376, which maps `--nologo` to MTP's `--no-banner` on `main`.

The new recap heading is localized through the normal generated XLF workflow.

## Validation

- `GivenDotnetTestRunsConsoleAppWithoutHandshake`: 3 passed
- focused unsupported-option regression verifies stdout, stderr, exit code 5, failed summary, and end-of-run recap