### PR TITLE
Fix CS0579 flake: exclude nested project dirs from parent project default item globs

### DIFF
--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDir/App.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDir/App.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);src\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirToRemove/App.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirToRemove/App.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);src\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVS/foo/foo.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVS/foo/foo.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);bar\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Second.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Second.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Third\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Test.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Third\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/TestCollision.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Second/TestCollision.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Third\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Test.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Second\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/TestCollision.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirVSErrors/Base/TestCollision.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Second\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/TestAppWithSlnAndLastCsprojInSubDirToRemove/App.csproj
+++ b/test/TestAssets/TestProjects/TestAppWithSlnAndLastCsprojInSubDirToRemove/App.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <DefaultItemExcludes>$(DefaultItemExcludes);src\**</DefaultItemExcludes>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Fixes intermittent CS0579 "duplicate assembly attribute" errors in CI, tracked in #55358.

## Root Cause

Several test assets contain a parent project file (e.g. `App.csproj`) that physically nests a child project in a subdirectory (e.g. `src/Lib/Lib.csproj`). The SDK's default item glob (`**/*.cs`) is scoped to exclude only the parent's own `obj/` directory. When MSBuild schedules the child project to build *before* the parent in a solution build (which is non-deterministic), the child's generated files (`AssemblyInfo.cs`, `.NETStandard...AssemblyAttributes.cs`) are written to `src/Lib/obj/` — which falls inside the parent's glob — and get double-compiled into the parent, producing CS0579.

The failure is intermittent because project build ordering in a solution is scheduler-dependent: when the parent builds first (its `obj/` doesn't yet contain the child's artifacts), it passes cleanly.

## Fix

Add `<DefaultItemExcludes>$(DefaultItemExcludes);{subdir}\**</DefaultItemExcludes>` to each parent project that physically contains a child project, excluding the nested subtree entirely from the parent's default globs. The solution still builds the child correctly because MSBuild drives it from the child's own `.csproj`.

### Files changed

| Asset | Parent project | Exclusion added |
|---|---|---|
| `TestAppWithSlnAndCsprojInSubDirVS` | `foo/foo.csproj` | `bar\**` |
| `TestAppWithSlnAndCsprojInSubDir` | `App.csproj` | `src\**` |
| `TestAppWithSlnAndCsprojInSubDirToRemove` | `App.csproj` | `src\**` |
| `TestAppWithSlnAndLastCsprojInSubDirToRemove` | `App.csproj` | `src\**` |
| `TestAppWithSlnAndCsprojInSubDirVSErrors` | `Base/Test.csproj` | `Second\**` |
| `TestAppWithSlnAndCsprojInSubDirVSErrors` | `Base/TestCollision.csproj` | `Second\**` |
| `TestAppWithSlnAndCsprojInSubDirVSErrors` | `Base/Second/Test.csproj` | `Third\**` |
| `TestAppWithSlnAndCsprojInSubDirVSErrors` | `Base/Second/Second.csproj` | `Third\**` |
| `TestAppWithSlnAndCsprojInSubDirVSErrors` | `Base/Second/TestCollision.csproj` | `Third\**` |