### PR TITLE
Run wasm test hosts standalone under `dotnet test` (MTP)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -9,6 +9,11 @@ internal static class CliConstants
     public const string HelpOptionKey = "--help";
     public const string DotNetTestPipeOptionKey = "--dotnet-test-pipe";
 
+    // Microsoft.Testing.Extensions.TrxReport options. Used to request an on-disk TRX from
+    // standalone (wasm) test hosts that cannot stream results back over the named pipe.
+    public const string ReportTrxOptionKey = "--report-trx";
+    public const string ReportTrxFileNameOptionKey = "--report-trx-filename";
+
     public const string ServerOptionValue = "dotnettestcli";
 
     public const string SemiColon = ";";

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -103,6 +103,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
             else if (exitCode == ExitCode.Success &&
                 !isHelp &&
                 !parseResult.HasOption(definition.MinimumExpectedTestsOption) &&
+                !output.HasExitCodeOnlyResult &&
                 output.TotalTests == 0)
             {
                 // Whole-run "zero tests ran" verdict. Individual modules that matched no tests return exit
@@ -111,6 +112,10 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 // zero-tests case is decided here so it surfaces once at the run level instead of once per
                 // module. A stricter per-module minimum via -- --minimum-expected-tests N still fails that
                 // module with exit code 9. See https://github.com/microsoft/testfx/issues/7457.
+                //
+                // Standalone hosts that report only an exit code (e.g. wasm today) have no test count, so a
+                // passing run legitimately has TotalTests == 0; HasExitCodeOnlyResult excludes them here so
+                // their pass is not reclassified as ZeroTests.
                 exitCode = ExitCode.ZeroTests;
             }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -53,6 +53,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private readonly bool _showActiveTests;
 
     private int _handshakeFailuresCount;
+    private int _exitCodeOnlyResultsCount;
 
     private readonly object _handshakeFailuresLock = new();
     private readonly List<HandshakeFailureRecord> _handshakeFailures = new();
@@ -70,7 +71,16 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private bool _wasCancelled;
 
     public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
+
+    // A standalone host (e.g. a wasm runtime) that reports pass/fail solely via its process exit
+    // code — with no per-test results — has no known test count, so a passing run legitimately ends
+    // with TotalTests == 0. Track that so the whole-run "zero tests ran" verdict is not applied to
+    // it (which would otherwise turn a passing run into ExitCode.ZeroTests). See
+    // MicrosoftTestingPlatformTestCommand.
+    public bool HasExitCodeOnlyResult => Volatile.Read(ref _exitCodeOnlyResultsCount) > 0;
     public int TotalTests => _assemblies.Values.Sum(a => a.TotalTests);
+
+    internal void ReportExitCodeOnlyResult() => Interlocked.Increment(ref _exitCodeOnlyResultsCount);
 
     // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
     // thread suspends, so the regex gets blamed incorrectly.

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -73,10 +73,27 @@ internal sealed class TestApplication(
         (runtimeIdentifier.StartsWith("browser", StringComparison.OrdinalIgnoreCase) ||
          runtimeIdentifier.StartsWith("wasi", StringComparison.OrdinalIgnoreCase));
 
+    // TrxReport's TrxResultStreamingStore starts a background thread (SystemTask.RunLongRunning,
+    // which is [UnsupportedOSPlatform("browser")]) in its constructor, so requesting --report-trx
+    // crashes a standalone wasm host with PlatformNotSupportedException before results are written
+    // (confirmed on Microsoft.Testing.Extensions.TrxReport shipped with MSTest 4.4.0-preview /
+    // MTP 2.4.0-preview). Emitting --report-trx to a wasm host therefore breaks a run that would
+    // otherwise pass on its exit code. Until TrxReport guards that thread on single-threaded wasm
+    // (microsoft/testfx browser-enablement track), we do NOT request a TRX from wasm hosts and
+    // report pass/fail from the exit code instead. The TRX reader (TrxTestResultParser /
+    // TestApplicationHandler.ReportStandaloneResults) stays in place for when this flips.
+    // TODO: flip to true (or gate on a detected TrxReport version / host capability) once the
+    // streaming-store fix ships in a Microsoft.Testing.Extensions.TrxReport release.
+    private const bool WasmReportTrxSupported = false;
+
+    // True when we should ask a standalone (wasm) host to write an on-disk TRX. Off today because
+    // of the TrxReport single-threaded-wasm crash above; see WasmReportTrxSupported.
+    private bool EmitTrxForStandaloneHost => LaunchTestHostStandalone && WasmReportTrxSupported;
+
     // The results directory passed to a standalone (wasm) host, and where dotnet test reads the
     // resulting TRX from after the host exits. Only meaningful when LaunchTestHostStandalone is true.
     private string StandaloneResultsDirectory =>
-        GetStandaloneResultsDirectory(_buildOptions.PathOptions.ResultsDirectoryPath, launchStandalone: true, Directory.GetCurrentDirectory())!;
+        GetStandaloneResultsDirectory(_buildOptions.PathOptions.ResultsDirectoryPath, defaultForStandalone: true, Directory.GetCurrentDirectory())!;
 
     private string StandaloneTrxFilePath => Path.Combine(StandaloneResultsDirectory, WasmTestTrxFileName);
 
@@ -158,9 +175,11 @@ internal sealed class TestApplication(
 
             if (LaunchTestHostStandalone)
             {
-                // Standalone wasm hosts don't use the pipe; recover results from the on-disk TRX
-                // the host wrote (a bridge host / runner copies it back to the results directory).
-                _handler.ReportStandaloneResults(exitCode, StandaloneTrxFilePath, stdOutBuilder.GetOutput(), stdErrBuilder.GetOutput());
+                // Standalone wasm hosts don't use the pipe. When TRX is enabled (see
+                // EmitTrxForStandaloneHost) recover per-test results from the on-disk TRX the host
+                // wrote; otherwise (today) report pass/fail from the exit code alone.
+                string? trxFilePath = EmitTrxForStandaloneHost ? StandaloneTrxFilePath : null;
+                _handler.ReportStandaloneResults(exitCode, trxFilePath, stdOutBuilder.GetOutput(), stdErrBuilder.GetOutput());
                 return exitCode;
             }
 
@@ -265,11 +284,13 @@ internal sealed class TestApplication(
             builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName}");
         }
 
-        // Wasm hosts have no live pipe; they report through an on-disk TRX. Ensure a results
-        // directory is always set for them (default it when the user didn't pass one) so the host
-        // that writes the TRX and dotnet test that reads it back agree on the location.
+        // A standalone (wasm) host reports through an on-disk TRX, so when TRX is enabled default a
+        // results directory for it (the host writes the TRX there and dotnet test reads it back).
+        // Today TRX is gated off for wasm (see EmitTrxForStandaloneHost / WasmReportTrxSupported),
+        // so this only defaults once TrxReport supports single-threaded wasm; non-wasm runs keep the
+        // existing behavior of setting it only when explicitly requested.
         string? resultsDirectoryPath = GetStandaloneResultsDirectory(
-            _buildOptions.PathOptions.ResultsDirectoryPath, LaunchTestHostStandalone, Directory.GetCurrentDirectory());
+            _buildOptions.PathOptions.ResultsDirectoryPath, EmitTrxForStandaloneHost, Directory.GetCurrentDirectory());
 
         if (resultsDirectoryPath is not null)
         {
@@ -292,37 +313,48 @@ internal sealed class TestApplication(
         }
 
         // Server mode makes the test host connect back to our named pipe. On wasm runtimes the
-        // sandbox can't open a pipe, so we skip those options and run the host standalone, asking
-        // it to write an on-disk TRX instead. A bridge host / runner copies that TRX back to the
-        // results directory, and dotnet test reads results from it. This assumes the test project
-        // includes the Microsoft.Testing.Extensions.TrxReport extension (MSTest.Sdk does by
-        // default). See LaunchTestHostStandalone.
+        // sandbox can't open a pipe, so we run the host standalone. When TRX is enabled we also ask
+        // it to write an on-disk TRX (which dotnet test reads back); when it isn't, the host runs
+        // bare and results come from the exit code. This assumes the test project includes the
+        // Microsoft.Testing.Extensions.TrxReport extension (MSTest.Sdk does by default).
         //
         // KNOWN LIMITATION (Blazor `dotnet test`, dotnet/sdk#54091): as of MSTest 4.4.0-preview /
         // Microsoft.Testing.Platform 2.4.0-preview, requesting `--report-trx` crashes a wasm host
         // because TrxReport's TrxResultStreamingStore starts a background Thread, which throws
-        // PlatformNotSupportedException on single-threaded wasm. Until TrxReport guards that thread
-        // on single-threaded wasm (tracked with the browser-enablement work in microsoft/testfx),
-        // the on-disk TRX path is not usable on wasm and only the exit-code result is reliable.
-        // A follow-up should gate the `--report-trx` emission on that fix (or a host capability)
-        // so wasm runs that pass on exit code are not regressed.
-        builder.Append($" {GetHostModeArguments(LaunchTestHostStandalone, _pipeName, WasmTestTrxFileName)}");
+        // PlatformNotSupportedException on single-threaded wasm. So `--report-trx` is currently
+        // NOT emitted for wasm (WasmReportTrxSupported == false) to avoid regressing a run that
+        // passes on its exit code; per-test TRX reporting lights up once TrxReport guards that
+        // thread (microsoft/testfx browser-enablement track) and WasmReportTrxSupported flips.
+        string hostModeArguments = GetHostModeArguments(LaunchTestHostStandalone, EmitTrxForStandaloneHost, _pipeName, WasmTestTrxFileName);
+        if (hostModeArguments.Length > 0)
+        {
+            builder.Append($" {hostModeArguments}");
+        }
 
         return builder.ToString();
     }
 
-    // Resolves the results directory to pass to the host. Wasm hosts always need one (they report
-    // via an on-disk TRX), so default it when the user didn't pass one; non-wasm hosts keep the
-    // existing behavior of only setting it when explicitly requested.
-    internal static string? GetStandaloneResultsDirectory(string? userResultsDirectory, bool launchStandalone, string currentDirectory) =>
-        userResultsDirectory ?? (launchStandalone ? Path.Combine(currentDirectory, WasmDefaultResultsDirectoryName) : null);
+    // Resolves the results directory to pass to the host. When defaultForStandalone is true (a wasm
+    // host that will write a TRX) default it if the user didn't pass one, so the host and dotnet
+    // test agree on the location; otherwise only set it when explicitly requested.
+    internal static string? GetStandaloneResultsDirectory(string? userResultsDirectory, bool defaultForStandalone, string currentDirectory) =>
+        userResultsDirectory ?? (defaultForStandalone ? Path.Combine(currentDirectory, WasmDefaultResultsDirectoryName) : null);
 
-    // Trailing host arguments that depend on run mode: standalone (wasm) hosts are asked to write
-    // an on-disk TRX; all others get the server-mode named-pipe options.
-    internal static string GetHostModeArguments(bool launchStandalone, string pipeName, string trxFileName) =>
-        launchStandalone
+    // Trailing host arguments that depend on run mode:
+    //  - non-standalone: the server-mode named-pipe options;
+    //  - standalone (wasm) with TRX enabled: request an on-disk TRX;
+    //  - standalone (wasm) with TRX disabled: nothing (run bare, report from the exit code).
+    internal static string GetHostModeArguments(bool launchStandalone, bool reportTrx, string pipeName, string trxFileName)
+    {
+        if (!launchStandalone)
+        {
+            return $"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}";
+        }
+
+        return reportTrx
             ? $"{CliConstants.ReportTrxOptionKey} {CliConstants.ReportTrxFileNameOptionKey} {ArgumentEscaper.EscapeSingleArg(trxFileName)}"
-            : $"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}";
+            : string.Empty;
+    }
 
     private async Task WaitConnectionAsync(CancellationToken token)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -25,10 +25,12 @@ internal sealed class TestApplication(
     private static readonly Version ProtocolVersion_1_1 = new(1, 1, 0);
     private const int LiveOutputTailLineCount = 200;
 
-    // Deterministic TRX name requested from standalone wasm test hosts. A fixed, host-controlled
-    // basename lets dotnet test (and a bridge host copying the file back) agree on the artifact
-    // without trusting a device/VFS directory listing.
-    private const string WasmTestTrxFileName = "blazor-wasm.trx";
+    // A per-run TRX basename requested from a standalone wasm test host. Unique per TestApplication
+    // so concurrently-running modules never share a file, and freshly GUID-stamped each run so a
+    // stale TRX from an earlier run can never be replayed. dotnet test (and a bridge host copying the
+    // file back) agree on the artifact via this SDK-provided --report-trx-filename, not by trusting a
+    // device/VFS directory listing.
+    private readonly string _wasmTestTrxFileName = $"blazor-wasm-{Guid.NewGuid():N}.trx";
     private const string WasmDefaultResultsDirectoryName = "TestResults";
 
     private readonly Lock _requestLock = new();
@@ -95,7 +97,25 @@ internal sealed class TestApplication(
     private string StandaloneResultsDirectory =>
         GetStandaloneResultsDirectory(_buildOptions.PathOptions.ResultsDirectoryPath, defaultForStandalone: true, Directory.GetCurrentDirectory())!;
 
-    private string StandaloneTrxFilePath => Path.Combine(StandaloneResultsDirectory, WasmTestTrxFileName);
+    private string StandaloneTrxFilePath => Path.Combine(StandaloneResultsDirectory, _wasmTestTrxFileName);
+
+    // Best-effort removal of a pre-existing standalone TRX before launch so a stale artifact is never
+    // replayed. Swallows IO errors: if the file can't be deleted the missing/again-stale file is
+    // handled by ReportStandaloneResults (a requested-but-unreadable TRX routes to a handshake failure).
+    private void DeleteStandaloneTrxIfExists()
+    {
+        try
+        {
+            string path = StandaloneTrxFilePath;
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
 
     public async Task<int> RunAsync(CtrlCCancellationManager ctrlC)
     {
@@ -105,6 +125,15 @@ internal sealed class TestApplication(
         }
 
         var processStartInfo = CreateProcessStartInfo();
+
+        // When we ask a standalone host to write a TRX, remove any pre-existing file at the
+        // destination first so a stale TRX (e.g. from a prior run, or a host that crashes before
+        // writing) can never be mistaken for this run's results. The filename is GUID-unique per
+        // TestApplication, so this is defense-in-depth against reuse.
+        if (EmitTrxForStandaloneHost)
+        {
+            DeleteStandaloneTrxIfExists();
+        }
 
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
@@ -325,7 +354,7 @@ internal sealed class TestApplication(
         // NOT emitted for wasm (WasmReportTrxSupported == false) to avoid regressing a run that
         // passes on its exit code; per-test TRX reporting lights up once TrxReport guards that
         // thread (microsoft/testfx browser-enablement track) and WasmReportTrxSupported flips.
-        string hostModeArguments = GetHostModeArguments(LaunchTestHostStandalone, EmitTrxForStandaloneHost, _pipeName, WasmTestTrxFileName);
+        string hostModeArguments = GetHostModeArguments(LaunchTestHostStandalone, EmitTrxForStandaloneHost, _pipeName, _wasmTestTrxFileName);
         if (hostModeArguments.Length > 0)
         {
             builder.Append($" {hostModeArguments}");
@@ -535,6 +564,11 @@ internal sealed class TestApplication(
     }
 
     private bool? GetLiveOutputStreamingState() =>
+        // A standalone (wasm) host performs no protocol handshake, so _protocolNegotiated never
+        // flips and the collector would otherwise buffer stdout/stderr unbounded and then drop it
+        // on success. Decide streaming up front for standalone: stream the output tail live and keep
+        // it bounded (TrimToBoundedTail). Non-standalone runs still wait for protocol negotiation.
+        LaunchTestHostStandalone ? true :
         Volatile.Read(ref _protocolNegotiated) == 0 ? null : IsProtocol_1_1_OrHigher;
 
     private void FlushBufferedOutputIfLiveStreamingEnabled()

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -73,6 +73,13 @@ internal sealed class TestApplication(
         (runtimeIdentifier.StartsWith("browser", StringComparison.OrdinalIgnoreCase) ||
          runtimeIdentifier.StartsWith("wasi", StringComparison.OrdinalIgnoreCase));
 
+    // The results directory passed to a standalone (wasm) host, and where dotnet test reads the
+    // resulting TRX from after the host exits. Only meaningful when LaunchTestHostStandalone is true.
+    private string StandaloneResultsDirectory =>
+        GetStandaloneResultsDirectory(_buildOptions.PathOptions.ResultsDirectoryPath, launchStandalone: true, Directory.GetCurrentDirectory())!;
+
+    private string StandaloneTrxFilePath => Path.Combine(StandaloneResultsDirectory, WasmTestTrxFileName);
+
     public async Task<int> RunAsync(CtrlCCancellationManager ctrlC)
     {
         if (Interlocked.Exchange(ref _hasRun, 1) != 0)
@@ -148,6 +155,15 @@ internal sealed class TestApplication(
             }
 
             var exitCode = process.ExitCode;
+
+            if (LaunchTestHostStandalone)
+            {
+                // Standalone wasm hosts don't use the pipe; recover results from the on-disk TRX
+                // the host wrote (a bridge host / runner copies it back to the results directory).
+                _handler.ReportStandaloneResults(exitCode, StandaloneTrxFilePath, stdOutBuilder.GetOutput(), stdErrBuilder.GetOutput());
+                return exitCode;
+            }
+
             _handler.OnTestProcessExited(exitCode, stdOutBuilder.GetOutput(), stdErrBuilder.GetOutput());
 
             // This condition is to prevent considering the test app as successful when we didn't receive test session end.

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -25,6 +25,12 @@ internal sealed class TestApplication(
     private static readonly Version ProtocolVersion_1_1 = new(1, 1, 0);
     private const int LiveOutputTailLineCount = 200;
 
+    // Deterministic TRX name requested from standalone wasm test hosts. A fixed, host-controlled
+    // basename lets dotnet test (and a bridge host copying the file back) agree on the artifact
+    // without trusting a device/VFS directory listing.
+    private const string WasmTestTrxFileName = "blazor-wasm.trx";
+    private const string WasmDefaultResultsDirectoryName = "TestResults";
+
     private readonly Lock _requestLock = new();
     private readonly BuildOptions _buildOptions = buildOptions;
     private readonly Action<CommandLineOptionMessages> _onHelpRequested = onHelpRequested;
@@ -243,7 +249,13 @@ internal sealed class TestApplication(
             builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName}");
         }
 
-        if (_buildOptions.PathOptions.ResultsDirectoryPath is { } resultsDirectoryPath)
+        // Wasm hosts have no live pipe; they report through an on-disk TRX. Ensure a results
+        // directory is always set for them (default it when the user didn't pass one) so the host
+        // that writes the TRX and dotnet test that reads it back agree on the location.
+        string? resultsDirectoryPath = GetStandaloneResultsDirectory(
+            _buildOptions.PathOptions.ResultsDirectoryPath, LaunchTestHostStandalone, Directory.GetCurrentDirectory());
+
+        if (resultsDirectoryPath is not null)
         {
             builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ResultsDirectoryOptionName} {ArgumentEscaper.EscapeSingleArg(resultsDirectoryPath)}");
         }
@@ -264,15 +276,28 @@ internal sealed class TestApplication(
         }
 
         // Server mode makes the test host connect back to our named pipe. On wasm runtimes the
-        // sandbox can't open a pipe, so we skip these options and run the host standalone
-        // (results come from the process exit code and stdout). See LaunchTestHostStandalone.
-        if (!LaunchTestHostStandalone)
-        {
-            builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
-        }
+        // sandbox can't open a pipe, so we skip those options and run the host standalone, asking
+        // it to write an on-disk TRX instead. A bridge host / runner copies that TRX back to the
+        // results directory, and dotnet test reads results from it. This assumes the test project
+        // includes the Microsoft.Testing.Extensions.TrxReport extension (MSTest.Sdk does by
+        // default). See LaunchTestHostStandalone.
+        builder.Append($" {GetHostModeArguments(LaunchTestHostStandalone, _pipeName, WasmTestTrxFileName)}");
 
         return builder.ToString();
     }
+
+    // Resolves the results directory to pass to the host. Wasm hosts always need one (they report
+    // via an on-disk TRX), so default it when the user didn't pass one; non-wasm hosts keep the
+    // existing behavior of only setting it when explicitly requested.
+    internal static string? GetStandaloneResultsDirectory(string? userResultsDirectory, bool launchStandalone, string currentDirectory) =>
+        userResultsDirectory ?? (launchStandalone ? Path.Combine(currentDirectory, WasmDefaultResultsDirectoryName) : null);
+
+    // Trailing host arguments that depend on run mode: standalone (wasm) hosts are asked to write
+    // an on-disk TRX; all others get the server-mode named-pipe options.
+    internal static string GetHostModeArguments(bool launchStandalone, string pipeName, string trxFileName) =>
+        launchStandalone
+            ? $"{CliConstants.ReportTrxOptionKey} {CliConstants.ReportTrxFileNameOptionKey} {ArgumentEscaper.EscapeSingleArg(trxFileName)}"
+            : $"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}";
 
     private async Task WaitConnectionAsync(CancellationToken token)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -297,6 +297,15 @@ internal sealed class TestApplication(
         // results directory, and dotnet test reads results from it. This assumes the test project
         // includes the Microsoft.Testing.Extensions.TrxReport extension (MSTest.Sdk does by
         // default). See LaunchTestHostStandalone.
+        //
+        // KNOWN LIMITATION (Blazor `dotnet test`, dotnet/sdk#54091): as of MSTest 4.4.0-preview /
+        // Microsoft.Testing.Platform 2.4.0-preview, requesting `--report-trx` crashes a wasm host
+        // because TrxReport's TrxResultStreamingStore starts a background Thread, which throws
+        // PlatformNotSupportedException on single-threaded wasm. Until TrxReport guards that thread
+        // on single-threaded wasm (tracked with the browser-enablement work in microsoft/testfx),
+        // the on-disk TRX path is not usable on wasm and only the exit-code result is reliable.
+        // A follow-up should gate the `--report-trx` emission on that fix (or a host capability)
+        // so wasm runs that pass on exit code are not regressed.
         builder.Append($" {GetHostModeArguments(LaunchTestHostStandalone, _pipeName, WasmTestTrxFileName)}");
 
         return builder.ToString();

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -50,6 +50,23 @@ internal sealed class TestApplication(
         _negotiatedProtocolVersion is { } negotiatedProtocolVersion &&
         negotiatedProtocolVersion.CompareTo(ProtocolVersion_1_1) >= 0;
 
+    // Microsoft.Testing.Platform's server mode (the "--server dotnettestcli --dotnet-test-pipe"
+    // options) requires the test host to connect back to a named pipe. On wasm runtimes
+    // (browser/wasi) the sandbox cannot open a named pipe, so requesting server mode makes the
+    // host throw PlatformNotSupportedException before any test runs (see
+    // microsoft/testfx DotnetTestConnection, which hard-instantiates a NamedPipeClient). For
+    // these modules we launch the host standalone and rely on its process exit code (and the
+    // streamed stdout tail) instead of the live pipe.
+    // TODO: when a bridge host (e.g. the Blazor Gateway) fronts the wasm app and can relay the
+    // pipe, gate this on a host-declared capability instead of the runtime identifier so server
+    // mode (and live per-test reporting) can be re-enabled.
+    private bool LaunchTestHostStandalone => IsWasmRuntimeIdentifier(Module.RunProperties.RuntimeIdentifier);
+
+    internal static bool IsWasmRuntimeIdentifier(string? runtimeIdentifier) =>
+        runtimeIdentifier is not null &&
+        (runtimeIdentifier.StartsWith("browser", StringComparison.OrdinalIgnoreCase) ||
+         runtimeIdentifier.StartsWith("wasi", StringComparison.OrdinalIgnoreCase));
+
     public async Task<int> RunAsync(CtrlCCancellationManager ctrlC)
     {
         if (Interlocked.Exchange(ref _hasRun, 1) != 0)
@@ -61,7 +78,12 @@ internal sealed class TestApplication(
 
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
-        var testAppPipeConnectionLoop = Task.Run(async () => await WaitConnectionAsync(cancellationToken));
+
+        // Standalone wasm hosts never connect back (server mode is not requested for them), so
+        // don't spin up a named-pipe server that nobody will connect to.
+        var testAppPipeConnectionLoop = LaunchTestHostStandalone
+            ? Task.CompletedTask
+            : Task.Run(async () => await WaitConnectionAsync(cancellationToken));
 
         Process? process = null;
         try
@@ -241,7 +263,13 @@ internal sealed class TestApplication(
             builder.Append($" {ArgumentEscaper.EscapeSingleArg(arg)}");
         }
 
-        builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
+        // Server mode makes the test host connect back to our named pipe. On wasm runtimes the
+        // sandbox can't open a pipe, so we skip these options and run the host standalone
+        // (results come from the process exit code and stdout). See LaunchTestHostStandalone.
+        if (!LaunchTestHostStandalone)
+        {
+            builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
+        }
 
         return builder.ToString();
     }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -564,6 +564,58 @@ internal sealed class TestApplicationHandler
         LogTestProcessExit(exitCode, outputData, errorData);
     }
 
+    /// <summary>
+    /// Reports results for a standalone (wasm) test host that ran without the named pipe. There is
+    /// no handshake or streamed messages, so results are read from the on-disk TRX the host wrote
+    /// and replayed into the reporter as if they had arrived over the pipe. A missing TRX means the
+    /// host crashed before finishing (TRX present ⇒ ran to completion), so we surface the process
+    /// output and exit code via <see cref="TerminalTestReporter.HandshakeFailure"/> instead.
+    /// </summary>
+    internal void ReportStandaloneResults(int exitCode, string trxFilePath, string outputData, string errorData)
+    {
+        TrxReport? report = TrxTestResultParser.TryParse(trxFilePath);
+        if (report is null)
+        {
+            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
+            LogTestProcessExit(exitCode, outputData, errorData);
+            return;
+        }
+
+        string executionId = Guid.NewGuid().ToString();
+        string instanceId = Guid.NewGuid().ToString();
+        string? architecture = GetWasmArchitecture(_module.RunProperties.RuntimeIdentifier);
+
+        _output.AssemblyRunStarted(_module.TargetPath, _module.TargetFramework, architecture, executionId, instanceId);
+
+        foreach (TrxTestResult result in report.Results)
+        {
+            // TRX has no structured expected/actual (only inline in the message), so both are null.
+            Terminal.FlatException[]? exceptions = result.ErrorMessage is not null || result.StackTrace is not null
+                ? [new Terminal.FlatException(result.ErrorMessage, ErrorType: null, result.StackTrace)]
+                : null;
+
+            _output.TestCompleted(
+                _module.TargetPath,
+                _module.TargetFramework,
+                architecture,
+                executionId,
+                instanceId,
+                testNodeUid: result.Uid,
+                displayName: result.DisplayName,
+                informativeMessage: null,
+                ToOutcome(result.Outcome),
+                result.Duration,
+                exceptions,
+                expected: null,
+                actual: null,
+                standardOutput: result.StandardOutput,
+                errorOutput: result.ErrorOutput);
+        }
+
+        _output.AssemblyRunCompleted(executionId, exitCode, outputData, errorData);
+        LogTestProcessExit(exitCode, outputData, errorData);
+    }
+
     private static TestOutcome ToOutcome(byte? testState) => testState switch
     {
         TestStates.Passed => TestOutcome.Passed,
@@ -574,6 +626,30 @@ internal sealed class TestApplicationHandler
         TestStates.Cancelled => TestOutcome.Canceled,
         _ => throw new ArgumentOutOfRangeException(nameof(testState), $"Invalid test state value {testState}")
     };
+
+    // Maps a TRX <UnitTestResult> @outcome to a reporter outcome. MTP's TRX only emits
+    // Passed/Failed/NotExecuted (Timeout/Error/Cancelled collapse to Failed at the result level),
+    // but a few extra values are mapped defensively. Unknown/other values are treated as failures
+    // so problems are never silently hidden.
+    internal static TestOutcome ToOutcome(string trxOutcome) => trxOutcome switch
+    {
+        "Passed" => TestOutcome.Passed,
+        "NotExecuted" => TestOutcome.Skipped,
+        "Timeout" => TestOutcome.Timeout,
+        "Aborted" => TestOutcome.Canceled,
+        "Error" => TestOutcome.Error,
+        _ => TestOutcome.Fail,
+    };
+
+    // Derives a short architecture label (e.g. "wasm") from a runtime identifier such as
+    // "browser-wasm" / "wasi-wasm" for display in the reporter.
+    private static string? GetWasmArchitecture(string runtimeIdentifier)
+    {
+        int dash = runtimeIdentifier.LastIndexOf('-');
+        return dash >= 0 && dash < runtimeIdentifier.Length - 1
+            ? runtimeIdentifier[(dash + 1)..]
+            : runtimeIdentifier;
+    }
 
     private static void LogHandshake(HandshakeMessage handshakeMessage)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -596,6 +596,14 @@ internal sealed class TestApplicationHandler
 
         _output.AssemblyRunStarted(_module.TargetPath, _module.TargetFramework, architecture, executionId, instanceId);
 
+        if (report is null)
+        {
+            // Exit-code-only path (no TRX requested, e.g. wasm today): there are no per-test results,
+            // so the reporter's test count stays 0. Flag it so a passing run isn't reclassified as
+            // ExitCode.ZeroTests at the run level.
+            _output.ReportExitCodeOnlyResult();
+        }
+
         // With a TRX, replay per-test results; without one (exit-code-only path, e.g. wasm today),
         // report only the assembly-level pass/fail that AssemblyRunCompleted derives from the exit code.
         foreach (TrxTestResult result in report?.Results ?? [])

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -566,15 +566,24 @@ internal sealed class TestApplicationHandler
 
     /// <summary>
     /// Reports results for a standalone (wasm) test host that ran without the named pipe. There is
-    /// no handshake or streamed messages, so results are read from the on-disk TRX the host wrote
-    /// and replayed into the reporter as if they had arrived over the pipe. A missing TRX means the
-    /// host crashed before finishing (TRX present ⇒ ran to completion), so we surface the process
-    /// output and exit code via <see cref="TerminalTestReporter.HandshakeFailure"/> instead.
+    /// no handshake or streamed messages, so we report from what's available:
+    /// <list type="bullet">
+    /// <item><paramref name="trxFilePath"/> is <see langword="null"/> (TRX not requested — the
+    /// current wasm default; see <c>WasmReportTrxSupported</c>): report assembly-level pass/fail
+    /// from the process exit code, with no per-test detail.</item>
+    /// <item><paramref name="trxFilePath"/> is set and the TRX exists: replay its per-test results
+    /// into the reporter as if they had arrived over the pipe.</item>
+    /// <item><paramref name="trxFilePath"/> is set but the TRX is missing: the host crashed before
+    /// finishing (TRX present ⇒ ran to completion), so surface the process output and exit code via
+    /// <see cref="TerminalTestReporter.HandshakeFailure"/>.</item>
+    /// </list>
     /// </summary>
-    internal void ReportStandaloneResults(int exitCode, string trxFilePath, string outputData, string errorData)
+    internal void ReportStandaloneResults(int exitCode, string? trxFilePath, string outputData, string errorData)
     {
-        TrxReport? report = TrxTestResultParser.TryParse(trxFilePath);
-        if (report is null)
+        TrxReport? report = trxFilePath is not null ? TrxTestResultParser.TryParse(trxFilePath) : null;
+
+        // A requested-but-missing TRX means the host crashed before writing results.
+        if (trxFilePath is not null && report is null)
         {
             _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
             LogTestProcessExit(exitCode, outputData, errorData);
@@ -587,7 +596,9 @@ internal sealed class TestApplicationHandler
 
         _output.AssemblyRunStarted(_module.TargetPath, _module.TargetFramework, architecture, executionId, instanceId);
 
-        foreach (TrxTestResult result in report.Results)
+        // With a TRX, replay per-test results; without one (exit-code-only path, e.g. wasm today),
+        // report only the assembly-level pass/fail that AssemblyRunCompleted derives from the exit code.
+        foreach (TrxTestResult result in report?.Results ?? [])
         {
             // TRX has no structured expected/actual (only inline in the message), so both are null.
             Terminal.FlatException[]? exceptions = result.ErrorMessage is not null || result.StackTrace is not null

--- a/src/Cli/dotnet/Commands/Test/MTP/TrxTestResultParser.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TrxTestResultParser.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Cli.Commands.Test;
+
+/// <summary>
+/// Parses a Microsoft.Testing.Platform TRX report (Microsoft.Testing.Extensions.TrxReport) into a
+/// minimal model. Used for standalone (wasm) test hosts that cannot stream results back over the
+/// named pipe: the host writes an on-disk TRX, which the SDK reads to drive the terminal reporter.
+/// </summary>
+internal static class TrxTestResultParser
+{
+    private static readonly XNamespace s_ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+    /// <summary>
+    /// Reads and parses the TRX at <paramref name="filePath"/>. Returns <see langword="null"/> when
+    /// the file is missing or cannot be parsed (e.g. a crashed host that never wrote a full TRX).
+    /// </summary>
+    public static TrxReport? TryParse(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            XDocument document;
+            using (var stream = File.OpenRead(filePath))
+            {
+                document = XDocument.Load(stream);
+            }
+
+            var results = new List<TrxTestResult>();
+            foreach (var element in document.Descendants(s_ns + "UnitTestResult"))
+            {
+                results.Add(ParseResult(element));
+            }
+
+            string? runOutcome = document.Descendants(s_ns + "ResultSummary").FirstOrDefault()?.Attribute("outcome")?.Value;
+
+            return new TrxReport(results, runOutcome);
+        }
+        catch (Exception ex) when (ex is System.Xml.XmlException or IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static TrxTestResult ParseResult(XElement element)
+    {
+        string displayName = element.Attribute("testName")?.Value ?? string.Empty;
+        string outcome = element.Attribute("outcome")?.Value ?? string.Empty;
+        // testId is a stable GUID; fall back to the display name so the reporter always has a uid.
+        string uid = element.Attribute("testId")?.Value is { Length: > 0 } testId ? testId : displayName;
+
+        TimeSpan? duration = null;
+        if (element.Attribute("duration")?.Value is { Length: > 0 } durationValue &&
+            TimeSpan.TryParse(durationValue, CultureInfo.InvariantCulture, out var parsedDuration))
+        {
+            duration = parsedDuration;
+        }
+
+        XElement? output = element.Element(s_ns + "Output");
+        string? standardOutput = output?.Element(s_ns + "StdOut")?.Value;
+        string? errorOutput = output?.Element(s_ns + "StdErr")?.Value;
+
+        XElement? errorInfo = output?.Element(s_ns + "ErrorInfo");
+        string? errorMessage = errorInfo?.Element(s_ns + "Message")?.Value;
+        string? stackTrace = errorInfo?.Element(s_ns + "StackTrace")?.Value;
+
+        return new TrxTestResult(uid, displayName, outcome, duration, standardOutput, errorOutput, errorMessage, stackTrace);
+    }
+}
+
+internal sealed record TrxReport(IReadOnlyList<TrxTestResult> Results, string? RunOutcome);
+
+internal sealed record TrxTestResult(
+    string Uid,
+    string DisplayName,
+    string Outcome,
+    TimeSpan? Duration,
+    string? StandardOutput,
+    string? ErrorOutput,
+    string? ErrorMessage,
+    string? StackTrace);

--- a/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
@@ -74,6 +74,20 @@ public class StandaloneTestResultReportingTests : IDisposable
         console.GetOutput().Should().Contain("crash-out");
     }
 
+    // TRX not requested (the wasm default today — TrxReport crashes single-threaded wasm) => report
+    // pass/fail from the exit code, NOT a handshake failure. A missing TRX here is expected, not a crash.
+    [TestMethod]
+    public void ReportStandaloneResults_NoTrxRequested_ReportsFromExitCodeNotHandshakeFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler();
+        handler.ReportStandaloneResults(exitCode: 0, trxFilePath: null, outputData: "run-out", errorData: "");
+        reporter.HasHandshakeFailure.Should().BeFalse();
+
+        (TestApplicationHandler failHandler, TerminalTestReporter failReporter, _) = CreateHandler();
+        failHandler.ReportStandaloneResults(exitCode: 1, trxFilePath: null, outputData: "run-out", errorData: "");
+        failReporter.HasHandshakeFailure.Should().BeFalse();
+    }
+
     private (TestApplicationHandler, TerminalTestReporter, CapturingConsole) CreateHandler()
     {
         var console = new CapturingConsole();

--- a/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
@@ -76,6 +76,8 @@ public class StandaloneTestResultReportingTests : IDisposable
 
     // TRX not requested (the wasm default today — TrxReport crashes single-threaded wasm) => report
     // pass/fail from the exit code, NOT a handshake failure. A missing TRX here is expected, not a crash.
+    // The exit-code-only path also flags HasExitCodeOnlyResult so a passing run (which has no test count,
+    // TotalTests == 0) is not reclassified as ExitCode.ZeroTests by MicrosoftTestingPlatformTestCommand.
     [TestMethod]
     public void ReportStandaloneResults_NoTrxRequested_ReportsFromExitCodeNotHandshakeFailure()
     {
@@ -83,9 +85,39 @@ public class StandaloneTestResultReportingTests : IDisposable
         handler.ReportStandaloneResults(exitCode: 0, trxFilePath: null, outputData: "run-out", errorData: "");
         reporter.HasHandshakeFailure.Should().BeFalse();
 
+        // A passing exit-code-only run: no per-test results, so the count is zero but the run passed.
+        reporter.TotalTests.Should().Be(0);
+        reporter.HasExitCodeOnlyResult.Should().BeTrue();
+        // This is exactly the guard MicrosoftTestingPlatformTestCommand uses: a Success run with zero
+        // tests is only reclassified as ZeroTests when it is NOT an exit-code-only result.
+        bool wouldBeZeroTests = reporter.TotalTests == 0 && !reporter.HasExitCodeOnlyResult;
+        wouldBeZeroTests.Should().BeFalse();
+
         (TestApplicationHandler failHandler, TerminalTestReporter failReporter, _) = CreateHandler();
         failHandler.ReportStandaloneResults(exitCode: 1, trxFilePath: null, outputData: "run-out", errorData: "");
         failReporter.HasHandshakeFailure.Should().BeFalse();
+        failReporter.HasExitCodeOnlyResult.Should().BeTrue();
+    }
+
+    // When a TRX is replayed there ARE per-test results, so this is not an exit-code-only run and the
+    // ZeroTests guard must not be engaged.
+    [TestMethod]
+    public void ReportStandaloneResults_WithTrx_DoesNotFlagExitCodeOnly()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, _) = CreateHandler();
+
+        string trxPath = WriteTempTrx(OneFailingTestTrx);
+        try
+        {
+            handler.ReportStandaloneResults(exitCode: 1, trxPath, outputData: "std-out", errorData: "std-err");
+        }
+        finally
+        {
+            File.Delete(trxPath);
+        }
+
+        reporter.HasExitCodeOnlyResult.Should().BeFalse();
+        reporter.TotalTests.Should().Be(1);
     }
 
     private (TestApplicationHandler, TerminalTestReporter, CapturingConsole) CreateHandler()

--- a/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/StandaloneTestResultReportingTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class StandaloneTestResultReportingTests : IDisposable
+{
+    private readonly List<IDisposable> _disposables = new();
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    private const string OneFailingTestTrx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Results>
+            <UnitTestResult testId="22222222-2222-2222-2222-222222222222" testName="MyTests.FailingTest" outcome="Failed" duration="00:00:00.0050000">
+              <Output>
+                <ErrorInfo>
+                  <Message>Assert.AreEqual failed. Expected:&lt;4&gt;. Actual:&lt;5&gt;.</Message>
+                  <StackTrace>at MyTests.FailingTest()</StackTrace>
+                </ErrorInfo>
+              </Output>
+            </UnitTestResult>
+          </Results>
+          <ResultSummary outcome="Completed"><Counters total="1" executed="1" passed="0" failed="1" /></ResultSummary>
+        </TestRun>
+        """;
+
+    [TestMethod]
+    public void ReportStandaloneResults_WithTrx_RendersResultsNotHandshakeFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler();
+
+        string trxPath = WriteTempTrx(OneFailingTestTrx);
+        try
+        {
+            handler.ReportStandaloneResults(exitCode: 1, trxPath, outputData: "std-out", errorData: "std-err");
+        }
+        finally
+        {
+            File.Delete(trxPath);
+        }
+
+        // Results were replayed into the reporter, so this must NOT be treated as a handshake failure.
+        reporter.HasHandshakeFailure.Should().BeFalse();
+
+        string rendered = console.GetOutput();
+        rendered.Should().Contain("MyTests.FailingTest");
+        rendered.Should().Contain("Expected:<4>");
+    }
+
+    [TestMethod]
+    public void ReportStandaloneResults_MissingTrx_RoutesToHandshakeFailure()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler();
+
+        // A missing TRX means the host crashed before finishing; surface it as a handshake failure.
+        string missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".trx");
+        handler.ReportStandaloneResults(exitCode: 139, missing, outputData: "crash-out", errorData: "crash-err");
+
+        reporter.HasHandshakeFailure.Should().BeTrue();
+        console.GetOutput().Should().Contain("crash-out");
+    }
+
+    private (TestApplicationHandler, TerminalTestReporter, CapturingConsole) CreateHandler()
+    {
+        var console = new CapturingConsole();
+        var reporter = new TerminalTestReporter(console, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        });
+        _disposables.Add(reporter);
+
+        const string targetPath = "/repo/bin/Debug/net11.0-browser/MyTest.dll";
+        var module = new TestModule(
+            RunProperties: new RunProperties("dotnet", targetPath, "/repo", "browser-wasm", string.Empty, string.Empty),
+            ProjectFullPath: "/repo/MyTest.csproj",
+            TargetFramework: "net11.0-browser",
+            IsTestingPlatformApplication: true,
+            LaunchSettings: null,
+            TargetPath: targetPath,
+            DotnetRootArchVariableName: null,
+            EnvironmentVariables: new Dictionary<string, string>());
+
+        var handler = new TestApplicationHandler(reporter, module, new TestOptions(IsHelp: false, IsDiscovery: false, ListTestsFormat: TestListFormat.Text));
+        return (handler, reporter, console);
+    }
+
+    private static string WriteTempTrx(string content)
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".trx");
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using Microsoft.DotNet.Cli.Commands.Test;
 
 namespace dotnet.Tests.CommandTests.Test;
@@ -28,5 +29,56 @@ public class TestApplicationTests
     public void IsWasmRuntimeIdentifier_DetectsWasmRuntimes(string? runtimeIdentifier, bool expected)
     {
         TestApplication.IsWasmRuntimeIdentifier(runtimeIdentifier).Should().Be(expected);
+    }
+
+    // Wasm (standalone) hosts can't open a named pipe, so they must NOT get server mode; instead
+    // they're asked to write an on-disk TRX. Non-wasm hosts keep the server-mode pipe options.
+    [TestMethod]
+    public void GetHostModeArguments_Standalone_RequestsTrxAndSkipsServerMode()
+    {
+        var args = TestApplication.GetHostModeArguments(launchStandalone: true, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
+
+        args.Should().Contain("--report-trx");
+        args.Should().Contain("--report-trx-filename");
+        args.Should().Contain("blazor-wasm.trx");
+        args.Should().NotContain("--server");
+        args.Should().NotContain("--dotnet-test-pipe");
+    }
+
+    [TestMethod]
+    public void GetHostModeArguments_NonStandalone_UsesServerModeAndSkipsTrx()
+    {
+        var args = TestApplication.GetHostModeArguments(launchStandalone: false, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
+
+        args.Should().Contain("--server");
+        args.Should().Contain("dotnettestcli");
+        args.Should().Contain("--dotnet-test-pipe");
+        args.Should().Contain("/tmp/abc");
+        args.Should().NotContain("--report-trx");
+    }
+
+    // Wasm hosts always need a results directory (they report via TRX), so it's defaulted when the
+    // user didn't pass one; non-wasm runs are unchanged (null unless explicitly requested).
+    [TestMethod]
+    public void GetStandaloneResultsDirectory_DefaultsForWasmWhenUnset()
+    {
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, launchStandalone: true, currentDirectory: "/work")
+            .Should().Be(Path.Combine("/work", "TestResults"));
+    }
+
+    [TestMethod]
+    public void GetStandaloneResultsDirectory_KeepsUserValue()
+    {
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", launchStandalone: true, currentDirectory: "/work")
+            .Should().Be("/custom");
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", launchStandalone: false, currentDirectory: "/work")
+            .Should().Be("/custom");
+    }
+
+    [TestMethod]
+    public void GetStandaloneResultsDirectory_NullForNonWasmWhenUnset()
+    {
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, launchStandalone: false, currentDirectory: "/work")
+            .Should().BeNull();
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
@@ -31,12 +31,13 @@ public class TestApplicationTests
         TestApplication.IsWasmRuntimeIdentifier(runtimeIdentifier).Should().Be(expected);
     }
 
-    // Wasm (standalone) hosts can't open a named pipe, so they must NOT get server mode; instead
-    // they're asked to write an on-disk TRX. Non-wasm hosts keep the server-mode pipe options.
+    // Wasm (standalone) hosts can't open a named pipe, so they must NOT get server mode. When TRX
+    // is enabled they're asked to write an on-disk TRX; when it's disabled (the wasm default today)
+    // they run bare and report from the exit code. Non-wasm hosts keep the server-mode pipe options.
     [TestMethod]
-    public void GetHostModeArguments_Standalone_RequestsTrxAndSkipsServerMode()
+    public void GetHostModeArguments_StandaloneWithTrx_RequestsTrxAndSkipsServerMode()
     {
-        var args = TestApplication.GetHostModeArguments(launchStandalone: true, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
+        var args = TestApplication.GetHostModeArguments(launchStandalone: true, reportTrx: true, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
 
         args.Should().Contain("--report-trx");
         args.Should().Contain("--report-trx-filename");
@@ -45,10 +46,19 @@ public class TestApplicationTests
         args.Should().NotContain("--dotnet-test-pipe");
     }
 
+    // TRX gated off for wasm (TrxReport crashes single-threaded wasm): neither server mode NOR TRX.
+    [TestMethod]
+    public void GetHostModeArguments_StandaloneWithoutTrx_EmitsNeitherServerNorTrx()
+    {
+        var args = TestApplication.GetHostModeArguments(launchStandalone: true, reportTrx: false, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
+
+        args.Should().BeEmpty();
+    }
+
     [TestMethod]
     public void GetHostModeArguments_NonStandalone_UsesServerModeAndSkipsTrx()
     {
-        var args = TestApplication.GetHostModeArguments(launchStandalone: false, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
+        var args = TestApplication.GetHostModeArguments(launchStandalone: false, reportTrx: false, pipeName: "/tmp/abc", trxFileName: "blazor-wasm.trx");
 
         args.Should().Contain("--server");
         args.Should().Contain("dotnettestcli");
@@ -62,23 +72,23 @@ public class TestApplicationTests
     [TestMethod]
     public void GetStandaloneResultsDirectory_DefaultsForWasmWhenUnset()
     {
-        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, launchStandalone: true, currentDirectory: "/work")
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, defaultForStandalone: true, currentDirectory: "/work")
             .Should().Be(Path.Combine("/work", "TestResults"));
     }
 
     [TestMethod]
     public void GetStandaloneResultsDirectory_KeepsUserValue()
     {
-        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", launchStandalone: true, currentDirectory: "/work")
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", defaultForStandalone: true, currentDirectory: "/work")
             .Should().Be("/custom");
-        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", launchStandalone: false, currentDirectory: "/work")
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: "/custom", defaultForStandalone: false, currentDirectory: "/work")
             .Should().Be("/custom");
     }
 
     [TestMethod]
     public void GetStandaloneResultsDirectory_NullForNonWasmWhenUnset()
     {
-        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, launchStandalone: false, currentDirectory: "/work")
+        TestApplication.GetStandaloneResultsDirectory(userResultsDirectory: null, defaultForStandalone: false, currentDirectory: "/work")
             .Should().BeNull();
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationTests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestApplicationTests
+{
+    // Microsoft.Testing.Platform server mode ("--server dotnettestcli --dotnet-test-pipe") makes
+    // the test host connect back to a named pipe, which wasm runtimes (browser/wasi) cannot open.
+    // TestApplication uses IsWasmRuntimeIdentifier to decide whether to launch the host standalone
+    // (skipping the server-mode options) so the host runs and reports via exit code + stdout
+    // instead of throwing PlatformNotSupportedException. This guards that decision.
+    [TestMethod]
+    [DataRow("browser-wasm", true)]
+    [DataRow("wasi-wasm", true)]
+    [DataRow("browser", true)]
+    [DataRow("wasi", true)]
+    [DataRow("BROWSER-WASM", true)]
+    [DataRow("win-x64", false)]
+    [DataRow("linux-x64", false)]
+    [DataRow("osx-arm64", false)]
+    [DataRow("linux-musl-arm64", false)]
+    [DataRow("", false)]
+    [DataRow(null, false)]
+    public void IsWasmRuntimeIdentifier_DetectsWasmRuntimes(string? runtimeIdentifier, bool expected)
+    {
+        TestApplication.IsWasmRuntimeIdentifier(runtimeIdentifier).Should().Be(expected);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TrxTestResultParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TrxTestResultParserTests.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TrxTestResultParserTests
+{
+    private const string SampleTrx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Results>
+            <UnitTestResult testId="11111111-1111-1111-1111-111111111111" testName="MyTests.PassingTest" outcome="Passed" duration="00:00:00.0120000">
+              <Output><StdOut>hello from test</StdOut></Output>
+            </UnitTestResult>
+            <UnitTestResult testId="22222222-2222-2222-2222-222222222222" testName="MyTests.FailingTest" outcome="Failed" duration="00:00:00.0050000">
+              <Output>
+                <ErrorInfo>
+                  <Message>Assert.AreEqual failed. Expected:&lt;4&gt;. Actual:&lt;5&gt;.</Message>
+                  <StackTrace>at MyTests.FailingTest()</StackTrace>
+                </ErrorInfo>
+              </Output>
+            </UnitTestResult>
+            <UnitTestResult testId="33333333-3333-3333-3333-333333333333" testName="MyTests.SkippedTest" outcome="NotExecuted" />
+          </Results>
+          <ResultSummary outcome="Completed">
+            <Counters total="3" executed="2" passed="1" failed="1" notExecuted="1" />
+          </ResultSummary>
+        </TestRun>
+        """;
+
+    [TestMethod]
+    public void TryParse_ReadsResultsSummaryAndPerTestDetails()
+    {
+        string path = WriteTempTrx(SampleTrx);
+        try
+        {
+            var report = TrxTestResultParser.TryParse(path);
+
+            report.Should().NotBeNull();
+            report!.RunOutcome.Should().Be("Completed");
+            report.Results.Should().HaveCount(3);
+
+            var passing = report.Results[0];
+            passing.DisplayName.Should().Be("MyTests.PassingTest");
+            passing.Uid.Should().Be("11111111-1111-1111-1111-111111111111");
+            passing.Outcome.Should().Be("Passed");
+            passing.Duration.Should().Be(TimeSpan.FromMilliseconds(12));
+            passing.StandardOutput.Should().Be("hello from test");
+            passing.ErrorMessage.Should().BeNull();
+
+            var failing = report.Results[1];
+            failing.Outcome.Should().Be("Failed");
+            failing.ErrorMessage.Should().Contain("Expected:<4>. Actual:<5>.");
+            failing.StackTrace.Should().Be("at MyTests.FailingTest()");
+
+            var skipped = report.Results[2];
+            skipped.Outcome.Should().Be("NotExecuted");
+            skipped.Duration.Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    public void TryParse_ReturnsNullWhenFileMissing()
+    {
+        TrxTestResultParser.TryParse(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".trx"))
+            .Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TryParse_ReturnsNullForMalformedXml()
+    {
+        string path = WriteTempTrx("<TestRun><not-closed>");
+        try
+        {
+            TrxTestResultParser.TryParse(path).Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // MTP's TRX only emits Passed/Failed/NotExecuted; unknown/other values must map to a failure so
+    // problems are never hidden. "Completed" is a run-level outcome and never a per-test @outcome.
+    // Compared on the enum name because TestOutcome is internal to the CLI assembly.
+    [TestMethod]
+    [DataRow("Passed", "Passed")]
+    [DataRow("Failed", "Fail")]
+    [DataRow("NotExecuted", "Skipped")]
+    [DataRow("Timeout", "Timeout")]
+    [DataRow("Aborted", "Canceled")]
+    [DataRow("Error", "Error")]
+    [DataRow("SomethingUnknown", "Fail")]
+    [DataRow("", "Fail")]
+    public void ToOutcome_MapsTrxOutcomeStrings(string trxOutcome, string expected)
+    {
+        TestApplicationHandler.ToOutcome(trxOutcome).ToString().Should().Be(expected);
+    }
+
+    private static string WriteTempTrx(string content)
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".trx");
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TrxTestResultParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TrxTestResultParserTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Text;
 using Microsoft.DotNet.Cli.Commands.Test;
 
 namespace dotnet.Tests.CommandTests.Test;
@@ -28,6 +29,53 @@ public class TrxTestResultParserTests
           </Results>
           <ResultSummary outcome="Completed">
             <Counters total="3" executed="2" passed="1" failed="1" notExecuted="1" />
+          </ResultSummary>
+        </TestRun>
+        """;
+
+    // A verbatim TRX produced by a real browser-wasm MSTest run (net10.0|browser-wasm, MSTest 4.4.0
+    // with the Microsoft.Testing.Extensions.TrxReport synchronous-on-wasm streaming store). This is the
+    // exact shape the SDK reads back from a standalone wasm test host once WasmReportTrxSupported is
+    // enabled, so it guards the real MTP/MSTest schema — full TestDefinitions/TestEntries/TestLists,
+    // executionId/testType attributes the parser must ignore, and a NotExecuted result whose duration is
+    // present-but-zero. Volatile GUID/timestamp values are irrelevant to the parser and left as captured.
+    private const string RealBrowserWasmTrx = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <TestRun id="d0c7e570-5fbb-4dd2-ad72-f2aa4751691d" name="@localhost 2026-07-21 01:58:05.2890000" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Times creation="2026-07-21T01:58:05.226Z" queuing="2026-07-21T01:58:05.226Z" start="2026-07-21T01:58:05.226Z" finish="2026-07-21T01:58:05.289Z" />
+          <TestSettings name="default" id="4871e377-f7f5-4f12-a3e6-ad49097c11d2">
+            <Deployment runDeploymentRoot="_localhost_2026-07-21_01_58_05.2890000" />
+          </TestSettings>
+          <Results>
+            <UnitTestResult executionId="665dabec-8d94-41db-be3e-2a981e676d7e" testId="17e4c638-a4df-85a5-b266-6eedc4b8ca6b" testName="Passing" computerName="localhost" duration="00:00:00.0019845" startTime="2026-07-21T01:58:05.2640000+00:00" endTime="2026-07-21T01:58:05.2750000+00:00" testType="13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B" outcome="Passed" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" relativeResultsDirectory="665dabec-8d94-41db-be3e-2a981e676d7e" />
+            <UnitTestResult executionId="8616215e-6b70-4edc-ae80-360781f19be7" testId="17abf7bd-da20-8281-8836-7b7705c0d362" testName="AnotherPassing" computerName="localhost" duration="00:00:00.0002051" startTime="2026-07-21T01:58:05.2790000+00:00" endTime="2026-07-21T01:58:05.2800000+00:00" testType="13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B" outcome="Passed" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" relativeResultsDirectory="8616215e-6b70-4edc-ae80-360781f19be7" />
+            <UnitTestResult executionId="28cccab9-53b2-43ac-a0aa-b8e263a15685" testId="1b1d234c-8165-8069-9afd-885083345e54" testName="SkippedTest" computerName="localhost" duration="00:00:00.0000000" startTime="2026-07-21T01:58:05.2800000+00:00" endTime="2026-07-21T01:58:05.2810000+00:00" testType="13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B" outcome="NotExecuted" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" relativeResultsDirectory="28cccab9-53b2-43ac-a0aa-b8e263a15685" />
+          </Results>
+          <TestDefinitions>
+            <UnitTest name="Passing" storage="wasmtests.dll" id="17e4c638-a4df-85a5-b266-6eedc4b8ca6b">
+              <Execution id="665dabec-8d94-41db-be3e-2a981e676d7e" />
+              <TestMethod codeBase="WasmTests.dll" adapterTypeName="executor://MSTestExtension/4.4.0-dev" className="WasmTests.SampleTests" name="Passing" />
+            </UnitTest>
+            <UnitTest name="AnotherPassing" storage="wasmtests.dll" id="17abf7bd-da20-8281-8836-7b7705c0d362">
+              <Execution id="8616215e-6b70-4edc-ae80-360781f19be7" />
+              <TestMethod codeBase="WasmTests.dll" adapterTypeName="executor://MSTestExtension/4.4.0-dev" className="WasmTests.SampleTests" name="AnotherPassing" />
+            </UnitTest>
+            <UnitTest name="SkippedTest" storage="wasmtests.dll" id="1b1d234c-8165-8069-9afd-885083345e54">
+              <Execution id="28cccab9-53b2-43ac-a0aa-b8e263a15685" />
+              <TestMethod codeBase="WasmTests.dll" adapterTypeName="executor://MSTestExtension/4.4.0-dev" className="WasmTests.SampleTests" name="SkippedTest" />
+            </UnitTest>
+          </TestDefinitions>
+          <TestEntries>
+            <TestEntry testId="17e4c638-a4df-85a5-b266-6eedc4b8ca6b" executionId="665dabec-8d94-41db-be3e-2a981e676d7e" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" />
+            <TestEntry testId="17abf7bd-da20-8281-8836-7b7705c0d362" executionId="8616215e-6b70-4edc-ae80-360781f19be7" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" />
+            <TestEntry testId="1b1d234c-8165-8069-9afd-885083345e54" executionId="28cccab9-53b2-43ac-a0aa-b8e263a15685" testListId="8C84FA94-04C1-424b-9868-57A2D4851A1D" />
+          </TestEntries>
+          <TestLists>
+            <TestList name="Results Not in a List" id="8C84FA94-04C1-424b-9868-57A2D4851A1D" />
+            <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+          </TestLists>
+          <ResultSummary outcome="Completed">
+            <Counters total="3" executed="2" passed="2" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="1" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
           </ResultSummary>
         </TestRun>
         """;
@@ -60,6 +108,47 @@ public class TrxTestResultParserTests
             var skipped = report.Results[2];
             skipped.Outcome.Should().Be("NotExecuted");
             skipped.Duration.Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // Guards the real MSTest-on-wasm TRX shape end-to-end: the SDK reads this exact schema back from a
+    // standalone browser-wasm test host (via the Gateway/test-host POST) once WasmReportTrxSupported is
+    // enabled. Written with a UTF-8 BOM to match what the TrxReport writer emits. The parser must ignore
+    // the surrounding TestDefinitions/TestEntries/TestLists and the extra UnitTestResult attributes and
+    // still surface the three per-test results and the run outcome.
+    [TestMethod]
+    public void TryParse_ReadsRealBrowserWasmMSTestTrx()
+    {
+        string path = WriteTempTrx(RealBrowserWasmTrx, withBom: true);
+        try
+        {
+            var report = TrxTestResultParser.TryParse(path);
+
+            report.Should().NotBeNull();
+            report!.RunOutcome.Should().Be("Completed");
+            report.Results.Should().HaveCount(3);
+
+            var passing = report.Results[0];
+            passing.DisplayName.Should().Be("Passing");
+            passing.Uid.Should().Be("17e4c638-a4df-85a5-b266-6eedc4b8ca6b");
+            passing.Outcome.Should().Be("Passed");
+            passing.Duration.Should().Be(TimeSpan.Parse("00:00:00.0019845"));
+
+            report.Results[1].DisplayName.Should().Be("AnotherPassing");
+            report.Results[1].Outcome.Should().Be("Passed");
+
+            var skipped = report.Results[2];
+            skipped.DisplayName.Should().Be("SkippedTest");
+            skipped.Outcome.Should().Be("NotExecuted");
+            // A real wasm skip emits duration="00:00:00.0000000" (present-but-zero), not an absent attribute.
+            skipped.Duration.Should().Be(TimeSpan.Zero);
+
+            report.Results.Select(r => TestApplicationHandler.ToOutcome(r.Outcome).ToString())
+                .Should().Equal("Passed", "Passed", "Skipped");
         }
         finally
         {
@@ -105,10 +194,10 @@ public class TrxTestResultParserTests
         TestApplicationHandler.ToOutcome(trxOutcome).ToString().Should().Be(expected);
     }
 
-    private static string WriteTempTrx(string content)
+    private static string WriteTempTrx(string content, bool withBom = false)
     {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".trx");
-        File.WriteAllText(path, content);
+        File.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: withBom));
         return path;
     }
 }


### PR DESCRIPTION
## Summary

Foundational SDK work for Blazor `dotnet test` support (#54091): run **wasm** test hosts (`browser-wasm` / `wasi-wasm`) under `dotnet test` and report their results, instead of crashing with `PlatformNotSupportedException`.

The **exit-code path works on wasm today** (validated end-to-end). The richer **per-test TRX path is in place but gated off**, pending a Microsoft.Testing.Extensions.TrxReport single-threaded-wasm fix — flipping one flag lights it up. Kept **draft** until that lands.

## What it does

For wasm modules (detected via `RunProperties.RuntimeIdentifier` starting with `browser`/`wasi`):
- **Skips MTP server mode** (`--server dotnettestcli --dotnet-test-pipe`). wasm sandboxes can't open a named pipe, so testfx's `DotnetTestConnection` otherwise throws `PlatformNotSupportedException` at host build. The host now runs **standalone** and reports via **process exit code**.
- **Reports pass/fail from the exit code** (`AssemblyRunStarted` + `AssemblyRunCompleted`) — no per-test detail without a pipe or TRX, but correct assembly-level results.
- **Does NOT emit `--report-trx`** (see Known limitation). A `WasmReportTrxSupported` flag gates the TRX emission + results-directory defaulting; a nullable TRX path in `ReportStandaloneResults` distinguishes "TRX not requested → exit-code result" from "TRX requested but missing → crash".

The per-test TRX machinery (`TrxTestResultParser` + the TRX replay in `ReportStandaloneResults`) is retained as **forward-looking**: flipping `WasmReportTrxSupported` once TrxReport supports wasm enables full per-test reporting with no other change.

## Validated end-to-end

Booting a real `browser-wasm` MSTest host (net10, MSTest 4.4.0-preview) under node:
```
Test run summary: Passed!
  total: 3, succeeded: 2, skipped: 1   ->  exit 0
```
The SDK↔bridge contract was also validated against the real Blazor Gateway (dotnet/aspnetcore) over real sockets + headless Chrome (serve, browser launch, console streaming, exit code).

## Known limitation — TRX path gated off on wasm (why this stays draft)

`--report-trx` currently **crashes** a wasm host: TrxReport's `TrxResultStreamingStore` ctor starts a background `Thread` (`SystemTask.RunLongRunning`, `[UnsupportedOSPlatform("browser")]`), which throws `PlatformNotSupportedException` on single-threaded wasm (confirmed on MSTest 4.4.0-preview.26367.7 / MTP 2.4.0-preview.26367.7):
```
System.Threading.Thread.ThrowIfNoThreadStart
System.Threading.Thread.Start
Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxResultStreamingStore..ctor
```
The MTP owners (testfx) confirmed this is a real, previously-untested bug and are implementing an inline-writer fallback for single-threaded wasm on the browser-enablement track. Until that ships, emitting `--report-trx` would regress a wasm run that passes on its exit code, so this PR **gates it off** (`WasmReportTrxSupported = false`) and relies on the exit code. The Blazor Gateway's TRX-POST path is blocked by the same bug — a shared dependency.

**When the TrxReport fix ships:** flip `WasmReportTrxSupported` (or gate on a detected TrxReport version / host capability) and the full per-test TRX path activates.

## Scoping findings for #54091

- A "properly configured" browser-wasm test project needs the **net10-band wasm packs** (the net11 preview.5 `WasmGenerateAppBundle` target is an empty stub), **MSTest 4.4.0-preview+** (browser guards for the MSBuild + RunSettings host-controller extensions; 4.3.2 crashes), and a browser-compatible test registration. That configuration belongs in the **Blazor/wasm test SDK or template**, not the `dotnet test` CLI.
- The CLI change itself is TFM-agnostic and small.

## Tests (all passing)

- `TestApplicationTests` — wasm RID detection; host-mode arg emission for standalone-with-TRX, standalone-without-TRX (neither server nor TRX), and non-standalone (server); results-directory defaulting.
- `TrxTestResultParserTests` — TRX parse, missing/malformed handling, outcome mapping.
- `StandaloneTestResultReportingTests` — TRX replay; missing-requested-TRX → handshake-failure (crash); no-TRX-requested → exit-code reporting (not a crash).
- Existing `TestApplicationHandlerTests` unaffected.

## Notes

- User-visible: wasm test hosts run under `dotnet test` (exit-code results today; per-test TRX results once TrxReport supports wasm) instead of erroring with `PlatformNotSupportedException`.
- No change to any non-wasm runtime identifier.
- The browser-fronted (Blazor Gateway) path and the V2 live-streaming transport (testfx `StreamMessageClient` seam over a duplex `Stream`) are tracked separately under #54091.