### PR TITLE
File-based apps: set default properties after SDK imports to match the converted project

### DIFF
--- a/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectTools/VirtualProjectBuilder.cs
@@ -607,15 +607,6 @@ public sealed class VirtualProjectBuilder
                     """);
             }
 
-            // Write default properties before importing SDKs so they can be overridden by SDKs
-            // (and implicit build files which are imported by the default .NET SDK).
-            foreach (var (name, value) in defaultProperties)
-            {
-                writer.WriteLine($"""
-                        <{name}>{EscapeValue(value)}</{name}>
-                    """);
-            }
-
             writer.WriteLine($"""
                   </PropertyGroup>
 
@@ -683,28 +674,25 @@ public sealed class VirtualProjectBuilder
                 """);
 
             // First write the default properties except those specified by the user.
-            if (!isVirtualProject)
+            var customPropertyNames = propertyDirectives
+                .Select(static d => d.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (name, value) in defaultProperties)
             {
-                var customPropertyNames = propertyDirectives
-                    .Select(static d => d.Name)
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-                foreach (var (name, value) in defaultProperties)
-                {
-                    if (!customPropertyNames.Contains(name))
-                    {
-                        writer.WriteLine($"""
-                                <{name}>{EscapeValue(value)}</{name}>
-                            """);
-                    }
-                }
-
-                if (userSecretsId != null && !customPropertyNames.Contains("UserSecretsId"))
+                if (!customPropertyNames.Contains(name))
                 {
                     writer.WriteLine($"""
-                            <UserSecretsId>{EscapeValue(userSecretsId)}</UserSecretsId>
+                            <{name}>{EscapeValue(value)}</{name}>
                         """);
                 }
+            }
+
+            if (userSecretsId != null && !customPropertyNames.Contains("UserSecretsId"))
+            {
+                writer.WriteLine($"""
+                        <UserSecretsId>{EscapeValue(userSecretsId)}</UserSecretsId>
+                    """);
             }
 
             // Write custom properties.

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -76,6 +76,68 @@ public sealed class DotnetProjectConvertTests : SdkTest
             .And.StartWith("""<Project Sdk="Microsoft.NET.Sdk">""");
     }
 
+    [TestMethod]
+    public void DefaultProperties()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+            <Project>
+              <PropertyGroup>
+                <DefineConstants Condition="'$(Nullable)' == 'enable'">$(DefineConstants);NULLABLE_ENABLED_PROPS</DefineConstants>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.targets"), """
+            <Project>
+              <PropertyGroup>
+                <DefineConstants Condition="'$(Nullable)' == 'enable'">$(DefineConstants);NULLABLE_ENABLED_TARGETS</DefineConstants>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var expectedOutput = """
+            Not defined in props
+            Defined in targets
+            """;
+
+        // File-based app.
+        var fileBasedAppDir = Path.Join(testInstance.Path, "FileBasedApp");
+        Directory.CreateDirectory(fileBasedAppDir);
+        File.WriteAllText(Path.Join(fileBasedAppDir, "app.cs"), """
+            #if NULLABLE_ENABLED_PROPS
+            Console.WriteLine("Defined in props");
+            #else
+            Console.WriteLine("Not defined in props");
+            #endif
+            #if NULLABLE_ENABLED_TARGETS
+            Console.WriteLine("Defined in targets");
+            #else
+            Console.WriteLine("Not defined in targets");
+            #endif
+            """);
+
+        new DotnetCommand(Log, "run", "app.cs")
+            .WithWorkingDirectory(fileBasedAppDir)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+
+        // Converted project.
+        var convertedDir = Path.Join(testInstance.Path, "Converted");
+        new DotnetCommand(Log, "project", "convert", "app.cs", "-o", convertedDir)
+            .WithWorkingDirectory(fileBasedAppDir)
+            .Execute()
+            .Should().Pass();
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(convertedDir)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(expectedOutput);
+    }
+
     [TestMethod] // https://github.com/dotnet/sdk/issues/50832
     [DataRow("File", "File", "Lib", "../Lib", "Project", "..{/}Lib{/}lib.csproj")]
     [DataRow(".", ".", "Lib", "./Lib", "Project", "..{/}Lib{/}lib.csproj")]

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -1401,12 +1401,6 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                         <FileBasedProgramsItemMapping>.cs=Compile;.resx=EmbeddedResource;.json=None;.razor=Content;.dll=Reference</FileBasedProgramsItemMapping>
                         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                         <DisableDefaultItemsInProjectFolder>true</DisableDefaultItemsInProjectFolder>
-                        <OutputType>Exe</OutputType>
-                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <PublishAot>true</PublishAot>
-                        <PackAsTool>true</PackAsTool>
                       </PropertyGroup>
 
                       <ItemGroup>
@@ -1417,6 +1411,11 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                       <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="9.1.0" />
 
                       <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <Nullable>enable</Nullable>
+                        <PublishAot>true</PublishAot>
+                        <PackAsTool>true</PackAsTool>
                         <TargetFramework>net5.0</TargetFramework>
                         <LangVersion>preview</LangVersion>
                         <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
@@ -1488,12 +1487,6 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                         <DisableDefaultItemsInProjectFolder>true</DisableDefaultItemsInProjectFolder>
                         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
                         <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-                        <OutputType>Exe</OutputType>
-                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <PublishAot>true</PublishAot>
-                        <PackAsTool>true</PackAsTool>
                       </PropertyGroup>
 
                       <ItemGroup>
@@ -1503,6 +1496,12 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                       <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
                       <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <Nullable>enable</Nullable>
+                        <PublishAot>true</PublishAot>
+                        <PackAsTool>true</PackAsTool>
                         <P1>cs</P1>
                         <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
                         <Features>$(Features);FileBasedProgram</Features>
@@ -1564,12 +1563,6 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                         <DisableDefaultItemsInProjectFolder>true</DisableDefaultItemsInProjectFolder>
                         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
                         <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-                        <OutputType>Exe</OutputType>
-                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <PublishAot>true</PublishAot>
-                        <PackAsTool>true</PackAsTool>
                       </PropertyGroup>
 
                       <ItemGroup>
@@ -1579,6 +1572,12 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                       <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
                       <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <Nullable>enable</Nullable>
+                        <PublishAot>true</PublishAot>
+                        <PackAsTool>true</PackAsTool>
                         <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
                         <Features>$(Features);FileBasedProgram</Features>
                       </PropertyGroup>
@@ -1639,12 +1638,6 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                         <DisableDefaultItemsInProjectFolder>true</DisableDefaultItemsInProjectFolder>
                         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
                         <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-                        <OutputType>Exe</OutputType>
-                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <PublishAot>true</PublishAot>
-                        <PackAsTool>true</PackAsTool>
                       </PropertyGroup>
 
                       <ItemGroup>
@@ -1654,6 +1647,12 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
                       <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
                       <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <Nullable>enable</Nullable>
+                        <PublishAot>true</PublishAot>
+                        <PackAsTool>true</PackAsTool>
                         <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
                         <Features>$(Features);FileBasedProgram</Features>
                       </PropertyGroup>


### PR DESCRIPTION
The way default properties like `TargetFramework` and `Nullable=enabled` were set in the virtual vs converted project was inconsistent; this PR fixes that.