### PR TITLE
Add ApiCompat conditional test scope

### DIFF
--- a/test/ConditionalTests.props
+++ b/test/ConditionalTests.props
@@ -12,6 +12,7 @@
        Use for shared infrastructure that all code/tests depend on. -->
   <PropertyGroup>
     <GlobalTriggerPaths>
+      eng/Version.Details.xml;
       test/Microsoft.NET.TestFramework/**;
       test/Microsoft.NET.TestFramework.MSTest/**
     </GlobalTriggerPaths>
@@ -30,6 +31,19 @@
          RunAlways:    Conditions under which the scope always runs regardless of changed files.
                        Supported values: CI (non-PR builds). -->
   <ItemGroup>
+    <ConditionalTestScope Include="ApiCompat">
+      <Mechanism>project</Mechanism>
+      <TestProjects>test/Compatibility/**/*.csproj</TestProjects>
+      <TriggerPaths>
+        src/Compatibility/**;
+        test/Compatibility/**;
+        test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/**;
+        test/TestAssets/TestProjects/GenAPITaskTestProject/**;
+        test/TestAssets/TestProjects/PackageValidationTestProject/**
+      </TriggerPaths>
+      <RunAlways>CI</RunAlways>
+    </ConditionalTestScope>
+
     <ConditionalTestScope Include="TemplateEngine">
       <Mechanism>project</Mechanism>
       <TestProjects>test/TemplateEngine/**/*.csproj</TestProjects>


### PR DESCRIPTION
﻿Related to #55203

Adds an `ApiCompat` conditional test scope to `test/ConditionalTests.props` so the Compatibility test suite (ApiCompat, ApiCompatibility, ApiDiff, GenAPI, ApiSymbolExtensions, PackageValidation) only runs in PR validation when relevant files change, reducing PR validation time.

### Scope definition

The `ApiCompat` scope covers all test projects under `test/Compatibility/` and triggers when any of the following change:

- `src/Compatibility/**` — the compatibility source components under test
- `test/Compatibility/**` — the compatibility test projects themselves
- The three test assets consumed by these tests (`ApiCompatValidateAssembliesTestProject`, `GenAPITaskTestProject`, `PackageValidationTestProject`)

`RunAlways` is set to `CI` so the full suite always runs in non-PR (CI) builds.

### Global dependency-flow trigger

Adds `eng/Version.Details.xml` to `GlobalTriggerPaths` so every conditional scope runs on dependency-flow PRs. This is copied from #55397 so the two PRs aren't dependent on each other; that PR adds the full documentation for the trigger.
