### PR TITLE
Normalize SDK build leg naming

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,10 +30,6 @@ parameters:
   displayName: Run A Test Build
   type: boolean
   default: false
-- name: enableArm64Job
-  displayName: Enables the ARM64 job
-  type: boolean
-  default: false
 
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml
@@ -78,7 +74,7 @@ extends:
       azureLinux30Amd64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
       # Cross-compilation prereq image (clang + /crossrootfs/arm64 sysroot) used by the Linux arm64
-      # AoT leg. NativeAOT cross-links dotnet-aot for linux-arm64 from an x64 host; the container
+      # AOT leg. NativeAOT cross-links dotnet-aot for linux-arm64 from an x64 host; the container
       # provides the native toolchain + sysroot and sets ROOTFS_DIR, and the leg passes
       # /p:CrossBuild=true so ILC emits --sysroot/--target.
       azureLinuxCrossArm64:
@@ -178,7 +174,7 @@ extends:
       # arm64 linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is
       # required). This leg therefore BUILDS on the existing win-x64 pool with /p:CrossBuild=true and
       # produces the dotnet-aot .dll plus its mstat/dgml size-analysis artifacts (that step is gated
-      # on the AoT category). It is build-only (runTests: false): there is no wired windows arm64 Helix
+      # on the AOT category). It is build-only (runTests: false): there is no wired windows arm64 Helix
       # queue yet, so running the *.AoT.Tests on arm64 hardware is a follow-up pending a
       # windows.11.arm64 queue. The VS 2026 build image is required for the arm64 linker used by this
       # cross-build. Runs for internal PRs and test builds.
@@ -290,7 +286,7 @@ extends:
       # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
       # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
       # /crossrootfs/arm64 sysroot and sets ROOTFS_DIR) and passes /p:CrossBuild=true. Consistent
-      # with the other linux-arm64 legs, this only performs the build (the x64 AoT leg provides the
+      # with the other linux-arm64 legs, this only performs the build (the x64 AOT leg provides the
       # running test coverage). Runs for internal PRs and test builds; official builds publish via
       # the Official legs above and don't need it.
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -346,9 +342,9 @@ extends:
       # dotnet-aot is built with NativeAOT, which can cross-compile osx-x64 -> osx-arm64 (clang/link
       # on macOS are multi-target and need no extra sysroot). This leg therefore BUILDS on the x64
       # macOS pool (the Official osx-arm64 leg already cross-builds on macOS-latest/x64) with
-      # /p:CrossBuild=true. Because AoT tests are dispatched to Helix (runTests passes
+      # /p:CrossBuild=true. Because AOT tests are dispatched to Helix (runTests passes
       # -test /p:CustomHelixTargetQueue=...), the *.AoT.Tests still execute on the osx.15.arm64
-      # Helix queue, so there is no macOS AoT test-coverage loss. Runs for internal PRs and test
+      # Helix queue, so there is no macOS AOT test-coverage loss. Runs for internal PRs and test
       # builds; official builds publish via the Official legs above and don't need it.
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
@@ -369,20 +365,6 @@ extends:
               targetArchitecture: arm64
               runtimeIdentifier: osx-arm64
               osProperties: /p:CrossBuild=true
-      ### ARM64 TESTBUILD ###
-      - ${{ if and(or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')), eq(parameters.enableArm64Job, true)) }}:
-        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-          parameters:
-            pool:
-              name: Azure Pipelines
-              vmImage: macOS-latest
-              os: macOS
-            helixTargetQueue: osx.15.arm64
-            populateInternalRuntimeVariables: true
-            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-            macOSJobParameterSets:
-            - targetArchitecture: arm64
-              runtimeIdentifier: osx-arm64
 
       ############### DOTNET-FORMAT ###############
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -152,7 +152,7 @@ extends:
               runTests: false
               variables:
                 _SignType: real
-              dependsOn: Official_windows_x64
+              dependsOn: Windows_x64_Official
               downloadManifestMsiPackages: true
             - categoryName: Official
               targetArchitecture: arm64
@@ -162,7 +162,7 @@ extends:
               runTests: false
               variables:
                 _SignType: real
-              dependsOn: Official_windows_x64
+              dependsOn: Windows_x64_Official
               downloadManifestMsiPackages: true
             ### TestTemplatesCG ###
             # Note: This job is only used to allow the test templates to be built locally on the agent as opposed to Helix.
@@ -196,7 +196,7 @@ extends:
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             windowsJobParameterSets:
-            - categoryName: AoT
+            - categoryName: AOT
               targetArchitecture: arm64
               runtimeIdentifier: win-arm64
               osProperties: /p:CrossBuild=true
@@ -308,7 +308,7 @@ extends:
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             timeoutInMinutes: 90
             linuxJobParameterSets:
-            - categoryName: AoT
+            - categoryName: AOT
               container: azureLinuxCrossArm64
               targetArchitecture: arm64
               runtimeIdentifier: linux-arm64
@@ -364,7 +364,7 @@ extends:
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             macOSJobParameterSets:
-            - categoryName: AoT
+            - categoryName: AOT
               runAoTTests: true
               targetArchitecture: arm64
               runtimeIdentifier: osx-arm64
@@ -381,8 +381,7 @@ extends:
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
             macOSJobParameterSets:
-            - categoryName: TestBuild
-              targetArchitecture: arm64
+            - targetArchitecture: arm64
               runtimeIdentifier: osx-arm64
 
       ############### DOTNET-FORMAT ###############

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -40,7 +40,7 @@ resources:
   - container: azureLinux30Amd64
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
   # Cross-compilation prereq image (clang + /crossrootfs/arm64 sysroot) used by the Linux arm64
-  # AoT leg. NativeAOT cross-links dotnet-aot for linux-arm64 from an x64 host; the container
+  # AOT leg. NativeAOT cross-links dotnet-aot for linux-arm64 from an x64 host; the container
   # provides the native toolchain + sysroot and sets ROOTFS_DIR, and the leg passes
   # /p:CrossBuild=true so ILC emits --sysroot/--target.
   - container: azureLinuxCrossArm64
@@ -65,11 +65,11 @@ stages:
         os: windows
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
 
-  ### AoT (win-arm64 cross-build) ###
+  ### AOT (win-arm64 cross-build) ###
   # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC arm64
   # linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is required).
   # This leg BUILDS on the win-x64 pool with /p:CrossBuild=true and produces the dotnet-aot .dll plus
-  # its mstat/dgml size-analysis artifacts (that step is gated on the AoT category). It is build-only
+  # its mstat/dgml size-analysis artifacts (that step is gated on the AOT category). It is build-only
   # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
   # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
   # The VS 2026 build image is required for the arm64 linker used by this cross-build.
@@ -96,12 +96,12 @@ stages:
         os: linux
       helixTargetQueue: ubuntu.2204.amd64.open
 
-  ### AoT (linux-arm64 cross-build) ###
+  ### AOT (linux-arm64 cross-build) ###
   # dotnet-aot is built with NativeAOT, which can cross-compile for linux-arm64 from an x64 host
   # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
   # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
   # /crossrootfs/arm64 sysroot and sets ROOTFS_DIR) and passes /p:CrossBuild=true. Consistent with
-  # the other linux-arm64 legs, this only performs the build (the x64 AoT leg provides the running
+  # the other linux-arm64 legs, this only performs the build (the x64 AOT leg provides the running
   # test coverage).
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
@@ -127,11 +127,11 @@ stages:
         vmImage: macOS-latest
         os: macOS
       helixTargetQueue: osx.15.arm64.open
-  ### AoT (osx-arm64 cross-build) ###
+  ### AOT (osx-arm64 cross-build) ###
   # dotnet-aot is built with NativeAOT, which can cross-compile osx-x64 -> osx-arm64 (clang/link on
   # macOS are multi-target and need no extra sysroot). This leg BUILDS on the x64 macOS pool with
-  # /p:CrossBuild=true; because AoT tests are dispatched to Helix, the *.AoT.Tests still run on the
-  # osx.15.arm64 Helix queue, so there is no macOS AoT test-coverage loss.
+  # /p:CrossBuild=true; because AOT tests are dispatched to Helix, the *.AoT.Tests still run on the
+  # osx.15.arm64 Helix queue, so there is no macOS AOT test-coverage loss.
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
       pool:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -81,7 +81,7 @@ stages:
         os: windows
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
       windowsJobParameterSets:
-      - categoryName: AoT
+      - categoryName: AOT
         targetArchitecture: arm64
         runtimeIdentifier: win-arm64
         osProperties: /p:CrossBuild=true
@@ -112,7 +112,7 @@ stages:
       helixTargetQueue: ubuntu.2204.amd64.open
       timeoutInMinutes: 90
       linuxJobParameterSets:
-      - categoryName: AoT
+      - categoryName: AOT
         container: azureLinuxCrossArm64
         targetArchitecture: arm64
         runtimeIdentifier: linux-arm64
@@ -140,7 +140,7 @@ stages:
         os: macOS
       helixTargetQueue: osx.15.arm64.open
       macOSJobParameterSets:
-      - categoryName: AoT
+      - categoryName: AOT
         runAoTTests: true
         targetArchitecture: arm64
         runtimeIdentifier: osx-arm64
@@ -155,8 +155,7 @@ stages:
           os: macOS
         helixTargetQueue: osx.15.amd64.open
         macOSJobParameterSets:
-        - categoryName: TestBuild
-          runtimeIdentifier: osx-x64
+        - runtimeIdentifier: osx-x64
 
   ############### DOTNET-FORMAT ###############
   - template: /eng/dotnet-format/dotnet-format-integration.yml

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -26,7 +26,7 @@ parameters:
   # These publish the test assembly as a NativeAOT binary and run it on the same architecture,
   # validating the AOT CLI entry-point code under NativeAOT compilation. Only enabled where the
   # agent architecture matches the target (the produced native binary must run on the agent);
-  # cross-arch AoT legs leave it false.
+  # cross-arch AOT legs leave it false.
   runNativeAotCliTests: false
   ### MSBUILD ###
   targetArchitecture: x64

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -291,9 +291,9 @@ jobs:
       continueOnError: true
       condition: always()
 
-    # Only the AoT legs build the dotnet-aot NativeAOT library, so only they produce the
-    # size-analysis files. Gate on the AoT category so these steps run on every AoT leg (including
-    # the build-only cross-arch legs) and never upload empty artifacts on non-AoT legs.
+    # Only the AOT legs build the dotnet-aot NativeAOT library, so only they produce the
+    # size-analysis files. Gate on the AOT category so these steps run on every AOT leg (including
+    # the build-only cross-arch legs) and never upload empty artifacts on non-AOT legs.
     - ${{ if eq(parameters.categoryName, 'AOT') }}:
       - task: CopyFiles@2
         displayName: 🟣 Copy NativeAOT Size Analysis Files

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -7,7 +7,8 @@ parameters:
     publishTaskPrefix: ''
   container: ''
   helixTargetContainer: ''
-  categoryName: Build
+  categoryName: ''
+  platformName: ''
   runTests: true
   testProjects: $(Build.SourcesDirectory)/test/UnitTests.proj
   publishRetryConfig: false
@@ -44,12 +45,12 @@ parameters:
 jobs:
 - template: /eng/common/${{ parameters.oneESCompat.templateFolderName }}/job/job.yml
   parameters:
-    ${{ if eq(parameters.container, '') }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.targetArchitecture }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.targetArchitecture }})'
+    ${{ if eq(parameters.categoryName, '') }}:
+      name: ${{ parameters.platformName }}_${{ parameters.targetArchitecture }}
+      displayName: '${{ parameters.platformName }} ${{ parameters.targetArchitecture }}'
     ${{ else }}:
-      name: ${{ parameters.categoryName }}_${{ parameters.pool.os }}_${{ parameters.targetArchitecture }}_${{ parameters.container }}
-      displayName: '${{ parameters.categoryName }}: ${{ parameters.pool.os }} (${{ parameters.targetArchitecture }}) [${{ parameters.container }}]'
+      name: ${{ parameters.platformName }}_${{ parameters.targetArchitecture }}_${{ parameters.categoryName }}
+      displayName: '${{ parameters.platformName }} ${{ parameters.targetArchitecture }} ${{ parameters.categoryName }}'
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
     strategy: ${{ parameters.strategy }}
@@ -292,9 +293,8 @@ jobs:
 
     # Only the AoT legs build the dotnet-aot NativeAOT library, so only they produce the
     # size-analysis files. Gate on the AoT category so these steps run on every AoT leg (including
-    # the build-only cross-arch legs) and never upload empty artifacts on non-AoT legs like the
-    # TestBuild/FullFramework jobs.
-    - ${{ if eq(parameters.categoryName, 'AoT') }}:
+    # the build-only cross-arch legs) and never upload empty artifacts on non-AoT legs.
+    - ${{ if eq(parameters.categoryName, 'AOT') }}:
       - task: CopyFiles@2
         displayName: 🟣 Copy NativeAOT Size Analysis Files
         inputs:

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -19,9 +19,9 @@ parameters:
     osProperties: $(linuxOsglibcProperties)
     # Don't run the tests on arm64. Only perform the build itself.
     runTests: false
-  # The x64 AoT leg runs on native x64 hardware (HostRid == TargetRid == linux-x64) so it can both
+  # The x64 AOT leg runs on native x64 hardware (HostRid == TargetRid == linux-x64) so it can both
   # build dotnet-aot via NativeAOT (producing the .so and its mstat/dgml size-analysis output) and
-  # run the *.AoT.Tests.csproj test projects. linux-arm64 AoT is covered by a separate cross-build
+  # run the *.AoT.Tests.csproj test projects. linux-arm64 AOT is covered by a separate cross-build
   # leg (see .vsts-pr.yml / .vsts-ci.yml).
   - categoryName: AOT
     runAoTTests: true

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -4,20 +4,17 @@ parameters:
   locBranch: ''
   ### WINDOWS ###
   windowsJobParameterSets:
-  - categoryName: TestBuild
-    publishRetryConfig: true
+  - publishRetryConfig: true
     runNativeAotCliTests: true
+  - categoryName: AOT
+    runAoTTests: true
   - categoryName: FullFramework
     testFullMSBuild: true
-  - categoryName: AoT
-    runAoTTests: true
   ### LINUX ###
   linuxJobParameterSets:
-  - categoryName: TestBuild
-    osProperties: $(linuxOsglibcProperties)
+  - osProperties: $(linuxOsglibcProperties)
     runNativeAotCliTests: true
-  - categoryName: TestBuild
-    targetArchitecture: arm64
+  - targetArchitecture: arm64
     runtimeIdentifier: linux-arm64
     osProperties: $(linuxOsglibcProperties)
     # Don't run the tests on arm64. Only perform the build itself.
@@ -26,7 +23,7 @@ parameters:
   # build dotnet-aot via NativeAOT (producing the .so and its mstat/dgml size-analysis output) and
   # run the *.AoT.Tests.csproj test projects. linux-arm64 AoT is covered by a separate cross-build
   # leg (see .vsts-pr.yml / .vsts-ci.yml).
-  - categoryName: AoT
+  - categoryName: AOT
     runAoTTests: true
     osProperties: $(linuxOsglibcProperties)
   - categoryName: ContainerBased
@@ -37,8 +34,7 @@ parameters:
     disableJob: true
   ### MACOS ###
   macOSJobParameterSets:
-  - categoryName: TestBuild
-    targetArchitecture: arm64
+  - targetArchitecture: arm64
     runtimeIdentifier: osx-arm64
     runNativeAotCliTests: true
 
@@ -62,6 +58,7 @@ jobs:
         parameters:
           ${{ insert }}: ${{ parameters }}
           ${{ insert }}: ${{ jobParameters }}
+          platformName: Windows
 - ${{ if eq(parameters.pool.os, 'linux') }}:
   - ${{ each jobParameters in parameters.linuxJobParameterSets }}:
     - ${{ if not(jobParameters.disableJob) }}:
@@ -69,6 +66,7 @@ jobs:
         parameters:
           ${{ insert }}: ${{ parameters }}
           ${{ insert }}: ${{ jobParameters }}
+          platformName: Linux
 - ${{ if eq(parameters.pool.os, 'macOS') }}:
   - ${{ each jobParameters in parameters.macOSJobParameterSets }}:
     - ${{ if not(jobParameters.disableJob) }}:
@@ -76,3 +74,4 @@ jobs:
         parameters:
           ${{ insert }}: ${{ parameters }}
           ${{ insert }}: ${{ jobParameters }}
+          platformName: Mac


### PR DESCRIPTION
## Build leg naming simplification for SDK pipeline legs

This change simplifies SDK build leg names in AzDO so they’re easier to scan and easier to map to artifacts.

### What changed

1. Leg names are now emitted as **`<PlatformName>_<arch>[_category]`** and display labels as **`<PlatformName> <arch> [category]`**.
2. Platform tokens are now consistently title-cased via template mapping: **`Windows`**, **`Linux`**, **`Mac`**.
3. Default build legs now use an empty category, so **`TestBuild` is no longer shown** in leg names.
4. `AoT` was changed to **`AOT`** to align with .NET terminology (for example, “Native AOT” in docs/SDK usage).
5. Container suffixes were removed from leg names.
6. `dependsOn` references were updated to match the new normalized job names.

### Why this helps scanning

Before this change, build legs were grouped/sorted by OS in the pipeline view, but OS was not the first token in the leg name. Putting platform first aligns leg text with UI grouping, and consistent platform casing improves readability.

### Before vs after (build legs)

| Before | After |
|---|---|
| `TestBuild: windows (x64)` | `Windows x64` |
| `FullFramework: windows (x64)` | `Windows x64 FullFramework` |
| `AoT: windows (x64)` | `Windows x64 AOT` |
| `AoT: windows (arm64)` | `Windows arm64 AOT` |
| `TestBuild: linux (x64)` | `Linux x64` |
| `TestBuild: linux (arm64)` | `Linux arm64` |
| `AoT: linux (x64)` | `Linux x64 AOT` |
| `AoT: linux (arm64) [azureLinuxCrossArm64]` | `Linux arm64 AOT` |
| `TestBuild: macOS (arm64)` | `Mac arm64` |
| `AoT: macOS (arm64)` | `Mac arm64 AOT` |

### Why drop `TestBuild` from the name

`TestBuild` is the default path, not a distinguishing variant. Omitting it keeps names short and makes actual variants stand out.

### Why drop container from the name

Container choice is currently an implementation detail for these legs, not a required differentiator. Removing it avoids truncation/noise while keeping container details available in job configuration and logs.