### PR TITLE
Escape semicolons in conditional test scope pipeline variable

### DIFF
--- a/documentation/project-docs/pr-test-filtering.md
+++ b/documentation/project-docs/pr-test-filtering.md
@@ -108,7 +108,12 @@ projects they control.
 2. **`scripts/EvaluateConditionalTestScopes.cs`** — C# script that runs before test
    submission. It reads `ConditionalTests.props`, computes the git diff against the
    target branch, and determines which scopes to skip. It outputs the
-   `SkippedTestScopes` Azure DevOps pipeline variable.
+   `SkippedTestScopes` Azure DevOps pipeline variable. When more than one scope is
+   skipped, the scope names are joined with `|` rather than `;`. Azure DevOps decodes
+   `%3B` back to `;` when it parses the `##vso[task.setvariable]` command, so an escaped
+   semicolon cannot survive, and a raw `;` would be split by MSBuild's `/p:` property-list
+   parser when the pipeline passes `/p:SkippedTestScopes=<value>`. `ConditionalTests.targets`
+   normalizes `|` back to `;`.
 
 3. **`test/UnitTests.proj`** — imports `ConditionalTests.props` and defines a Target
    (`RemoveSkippedConditionalTestProjects`) that removes skipped test projects from

--- a/scripts/EvaluateConditionalTestScopes.cs
+++ b/scripts/EvaluateConditionalTestScopes.cs
@@ -15,7 +15,11 @@
 // Output variable format (set via ##vso when running in Azure Pipelines):
 //   - Empty string: no scopes skipped, all tests run.
 //   - "__all__": every defined scope is skipped.
-//   - Semicolon-separated scope names (e.g. "TemplateEngine;ILLink"): only listed scopes are skipped.
+//   - '|'-separated scope names (e.g. "TemplateEngine|ILLink"): only listed scopes are skipped.
+//     '|' is used rather than ';' so the list survives Azure DevOps (which decodes '%3B' back to ';'
+//     in ##vso commands) and MSBuild's /p: property-list parser. ConditionalTests.targets converts
+//     '|' back to ';'.
+//     The human-readable log line below ("Skipped test scopes: ...") still uses ';' for readability.
 
 using System.Diagnostics;
 using System.Text.RegularExpressions;
@@ -161,7 +165,9 @@ var result = skippedScopes.Count > 0 && skippedScopes.Count == scopes.Count ? "_
 // Set Azure DevOps pipeline variable if running in CI and output variable was specified
 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD")) && !string.IsNullOrEmpty(outputVariable))
 {
-    Console.WriteLine($"##vso[task.setvariable variable={outputVariable}]{result}");
+    // Join with '|' as the separator (see the output-format note at the top of this file).
+    var pipelineValue = result.Replace(";", "|");
+    Console.WriteLine($"##vso[task.setvariable variable={outputVariable}]{pipelineValue}");
 }
 
 Console.WriteLine($"Skipped test scopes: {(result == "" ? "(none)" : result)}");

--- a/test/ConditionalTests.targets
+++ b/test/ConditionalTests.targets
@@ -21,10 +21,14 @@
        property functions in ItemGroup conditions. -->
   <Target Name="_CollectSkippedTestProjects" Outputs="%(ConditionalTestScope.Identity)" Condition="'$(SkippedTestScopes)' != ''">
     <PropertyGroup>
+      <!-- The pipeline passes a '|'-separated list (see EvaluateConditionalTestScopes.cs); normalize
+           it to ';' here. This must be in the target, not a static <PropertyGroup>, because
+           SkippedTestScopes is a global /p: property that a project-level assignment can't override. -->
+      <_NormalizedSkippedScopes>$(SkippedTestScopes.Replace('|',';'))</_NormalizedSkippedScopes>
       <_CurrentScope>%(ConditionalTestScope.Identity)</_CurrentScope>
       <_CurrentTestProjects>%(ConditionalTestScope.TestProjects)</_CurrentTestProjects>
       <_CurrentMechanism>%(ConditionalTestScope.Mechanism)</_CurrentMechanism>
-      <_ShouldSkip Condition="'$(_CurrentMechanism)' == 'project' and ('$(SkippedTestScopes)' == '__all__' or $([System.String]::Concat(';','$(SkippedTestScopes)',';').Contains(';$(_CurrentScope);')))">true</_ShouldSkip>
+      <_ShouldSkip Condition="'$(_CurrentMechanism)' == 'project' and ('$(_NormalizedSkippedScopes)' == '__all__' or $([System.String]::Concat(';','$(_NormalizedSkippedScopes)',';').Contains(';$(_CurrentScope);')))">true</_ShouldSkip>
       <_ShouldSkip Condition="'$(_ShouldSkip)' != 'true'">false</_ShouldSkip>
       <!-- Prepend $(RepoRoot) to each semicolon-separated relative path for glob resolution.
            Replace() escapes semicolons internally, so Unescape restores them for item splitting. -->

--- a/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
@@ -168,6 +168,54 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     }
 
     [TestMethod]
+    public async Task PRBuild_MultipleScopesSkipped_PipelineVariableUsesPipeSeparator()
+    {
+        // Two of three scopes are skipped, so the pipeline variable lists both, separated by '|'
+        // (see EvaluateConditionalTestScopes.cs for why '|' rather than ';').
+        var props = """
+            <Project>
+              <PropertyGroup>
+                <GlobalTriggerPaths>shared/**</GlobalTriggerPaths>
+              </PropertyGroup>
+              <ItemGroup>
+                <ConditionalTestScope Include="FeatureA">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureA.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureA/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+                <ConditionalTestScope Include="FeatureB">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureB.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureB/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+                <ConditionalTestScope Include="FeatureC">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureC.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureC/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+              </ItemGroup>
+            </Project>
+            """;
+
+        using var repo = new TestRepo(props, "shared", "src/FeatureA", "src/FeatureB", "src/FeatureC",
+            "test/FeatureA.Tests", "test/FeatureB.Tests", "test/FeatureC.Tests");
+        repo.AddAndCommitFiles("main", "src/Unrelated/file.cs");
+        // Only change files in FeatureC → FeatureA and FeatureB are skipped
+        repo.CreateBranchWithChanges("pr-branch", "src/FeatureC/Code.cs");
+
+        var result = await RunScript(repo.Root, targetBranch: "main", buildReason: "PullRequest", outputVariable: "SkippedTestScopes");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdErr);
+        // The '|'-separated pipeline variable carries both skipped scopes.
+        Assert.Contains("##vso[task.setvariable variable=SkippedTestScopes]FeatureA|FeatureB", result.StdOut);
+        // The human-readable log line stays semicolon-separated for readability.
+        Assert.Contains("Skipped test scopes: FeatureA;FeatureB", result.StdOut);
+    }
+
+    [TestMethod]
     public async Task GlobMatches_DoubleStarSlash_MatchesZeroSegments()
     {
         // Verify **/ pattern matches files directly in the parent (zero intermediate segments)
@@ -392,12 +440,16 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     private static readonly string[] BasicPropsDirs =
         ["test/Microsoft.NET.TestFramework", "src/MyFeature", "test/MyFeature.Tests"];
 
-    private async Task<ScriptResult> RunScript(string repoRoot, string? targetBranch, string buildReason)
+    private async Task<ScriptResult> RunScript(string repoRoot, string? targetBranch, string buildReason, string? outputVariable = null)
     {
         var args = $"run \"{_scriptPath}\" -- --repo-root \"{repoRoot}\" --build-reason \"{buildReason}\"";
         if (targetBranch != null)
         {
             args += $" --target-branch \"{targetBranch}\"";
+        }
+        if (outputVariable != null)
+        {
+            args += $" --output-variable \"{outputVariable}\"";
         }
 
         var psi = new ProcessStartInfo(_dotnetPath, args)
@@ -406,6 +458,13 @@ public class EvaluateConditionalTestScopesTests : SdkTest
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
+
+        // The script only emits the ##vso[task.setvariable] line when TF_BUILD is set
+        // (i.e. running under Azure Pipelines). Simulate that when an output variable is requested.
+        if (outputVariable != null)
+        {
+            psi.Environment["TF_BUILD"] = "true";
+        }
 
         // Remove test-framework env vars that interfere with child dotnet processes
         // (e.g., causing NETSDK1207 AOT errors). SdkTestContext.Initialize() sets these

--- a/test/Microsoft.NET.Infrastructure.Tests/RemoveSkippedConditionalTestProjectsTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/RemoveSkippedConditionalTestProjectsTests.cs
@@ -73,11 +73,58 @@ public class RemoveSkippedConditionalTestProjectsTests : SdkTest
     {
         using var env = new TestEnvironment(TestAssetsManager, CreateTwoScopeProps());
 
-        var remaining = await RunRemovalTarget(env, skippedScopes: "FeatureA;FeatureB");
+        var remaining = await RunRemovalTarget(env, skippedScopes: "FeatureA|FeatureB");
 
         AssertNoneContain(remaining, "FeatureA", "FeatureA should be removed");
         AssertNoneContain(remaining, "FeatureB", "FeatureB should be removed");
         AssertAnyContains(remaining, "Unrelated", "Unrelated should remain");
+    }
+
+    [TestMethod]
+    public async Task MultipleScopesSkipped_UnskippedScopeKept()
+    {
+        // Three defined scopes; skip two of them and verify both are removed while the third
+        // (not in the skip list) keeps its test project.
+        var props = """
+            <Project>
+              <PropertyGroup>
+                <GlobalTriggerPaths>shared/**</GlobalTriggerPaths>
+              </PropertyGroup>
+              <ItemGroup>
+                <ConditionalTestScope Include="FeatureA">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureA.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureA/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+                <ConditionalTestScope Include="FeatureB">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureB.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureB/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+                <ConditionalTestScope Include="FeatureC">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/FeatureC.Tests/*.csproj</TestProjects>
+                  <TriggerPaths>src/FeatureC/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+              </ItemGroup>
+            </Project>
+            """;
+
+        using var env = new TestEnvironment(TestAssetsManager, props, new[]
+        {
+            "test/FeatureA.Tests/FeatureA.Tests.csproj",
+            "test/FeatureB.Tests/FeatureB.Tests.csproj",
+            "test/FeatureC.Tests/FeatureC.Tests.csproj"
+        });
+
+        var remaining = await RunRemovalTarget(env, skippedScopes: "FeatureA|FeatureB");
+
+        AssertNoneContain(remaining, "FeatureA", "FeatureA should be removed");
+        AssertNoneContain(remaining, "FeatureB", "FeatureB should be removed");
+        AssertAnyContains(remaining, "FeatureC", "FeatureC should remain (not in skip list)");
     }
 
     [TestMethod]
@@ -185,14 +232,10 @@ public class RemoveSkippedConditionalTestProjectsTests : SdkTest
         // Use forward slash to avoid the trailing-backslash-before-quote issue on Windows.
         var testRepoRoot = env.Root.TrimEnd(Path.DirectorySeparatorChar) + "/";
 
-        // Escape semicolons in SkippedTestScopes with %3B for the command line.
-        // ConditionalTestRemoval.proj unescapes them via $([MSBuild]::Unescape(...)).
-        var escapedScopes = skippedScopes.Replace(";", "%3B");
-
         var args = $"msbuild \"{_testProjPath}\" /t:VerifyRemoval " +
                    $"/p:TestRepoRoot={testRepoRoot} " +
                    $"/p:RealRepoRoot={_targetsRoot} " +
-                   $"/p:SkippedTestScopes={escapedScopes} " +
+                   $"/p:SkippedTestScopes={skippedScopes} " +
                    $"/p:TestProjectItemsFile={itemsFile} " +
                    $"/v:normal";
 

--- a/test/TestAssets/TestProjects/ConditionalTestRemoval/ConditionalTestRemoval.proj
+++ b/test/TestAssets/TestProjects/ConditionalTestRemoval/ConditionalTestRemoval.proj
@@ -5,6 +5,9 @@
   Usage:
     dotnet msbuild ConditionalTestRemoval.proj /p:SkippedTestScopes=<value> /p:TestRepoRoot=<path> /p:RealRepoRoot=<path> /p:TestProjectItemsFile=<path> /t:VerifyRemoval
 
+    <value> is a single scope name, "__all__", or multiple scopes separated by '|' (e.g.
+    "FeatureA|FeatureB"). Use '|', not ';': a raw ';' is split by MSBuild's /p: parser.
+
   This project simulates what UnitTests.proj does: imports ConditionalTests.props and
   ConditionalTests.targets, defines SDKCustomTestProject items, runs the removal target,
   and prints what remains.
@@ -14,8 +17,6 @@
   <PropertyGroup>
     <!-- RepoRoot is what the targets use for glob expansion and to locate ConditionalTests.props -->
     <RepoRoot>$(TestRepoRoot)</RepoRoot>
-    <!-- Unescape %3B back to ; since MSBuild's CLI parser splits on raw semicolons -->
-    <SkippedTestScopes>$([MSBuild]::Unescape('$(SkippedTestScopes)'))</SkippedTestScopes>
   </PropertyGroup>
 
   <!-- Import the REAL removal targets from the repo (single source of truth).


### PR DESCRIPTION
## Problem

The conditional test filtering framework (see #55203) skips whole test scopes on a PR when no relevant files changed. When **more than one** scope is skipped, the `SkippedTestScopes` value carried the scope names as a **semicolon-separated** list. The pipeline passes it to MSBuild as `/p:SkippedTestScopes="<value>"`, and MSBuild's `/p:` parser treats `;` as a **property-list separator**. So only the first scope survived; the remaining (should-be-skipped) suites still ran — and, depending on the scope, MSBuild treated the trailing token as a bogus switch:

```
MSBUILD : error MSB1006: Property is not valid.
Switch: NetAnalyzers
```

Single-scope and `__all__` cases have no separator, which is why the bug stayed hidden.

## Why `%3B` escaping does not work

The intuitive fix — emit the separator as the MSBuild escape `%3B` — fails on Azure DevOps. AzDO **percent-decodes** `%3B` (and `%0D`, `%0A`, `%5D`, `%25`) back to `;` when it parses the `##vso[task.setvariable]` logging command, so the escape is gone before the value is ever stored. The variable reaches MSBuild with raw semicolons again → same `MSB1006`.

## Fix

Carry the list with **`|`** as the separator:

- **`scripts/EvaluateConditionalTestScopes.cs`** — the pipeline variable value joins scopes with `|` (AzDO leaves it untouched; MSBuild's `/p:` parser does not split on it). The human-readable log line keeps `;` for readability.
- **`test/ConditionalTests.targets`** — normalizes `|` back to `;` into a **local property inside the batching target**. It cannot be done in a static `<PropertyGroup>` because `SkippedTestScopes` arrives as a **global** `/p:` property, which a project-level assignment cannot override.
- **`test/TestAssets/TestProjects/ConditionalTestRemoval/ConditionalTestRemoval.proj`** — comment updated to match.

## Tests

- `EvaluateConditionalTestScopesTests.PRBuild_MultipleScopesSkipped_PipelineVariableUsesPipeSeparator` — asserts the `##vso` variable is `|`-separated (not raw `;`), and the log line stays `;`.
- `RemoveSkippedConditionalTestProjectsTests.MultipleScopesSkipped_UnskippedScopeKept` — end-to-end MSBuild removal driving the real `ConditionalTests.targets` with a global `/p:SkippedTestScopes=FeatureA|FeatureB`, verifying skipped scopes are removed and the unskipped one is kept.

All 23 tests in the two affected classes pass locally.

Related to #55203