### PR TITLE
[dotnet-watch tests] Cap output-wait timeout below the MTP hang-dump

### DIFF
--- a/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
+++ b/test/Microsoft.DotNet.HotReload.Test.Utilities/AwaitableProcess.cs
@@ -10,9 +10,30 @@ namespace Microsoft.DotNet.Watch.UnitTests
 {
     internal sealed class AwaitableProcess : IAsyncDisposable
     {
-        // cancel just before we hit timeout used on CI (TestWorkItemTimeout value in test/UnitTests.proj)
-        private static readonly TimeSpan s_timeout = Environment.GetEnvironmentVariable("HELIX_WORK_ITEM_TIMEOUT") is { } value
-            ? TimeSpan.Parse(value).Subtract(TimeSpan.FromSeconds(10)) : TimeSpan.FromMinutes(10);
+        // Per-wait timeout for expected process output. A single wait should never take anywhere near the
+        // CI work-item timeout, so this is capped well below Microsoft.Testing.Platform's hang-dump timeout
+        // (which fires at ~80% of the work-item timeout, e.g. 48 min for the 60-min work items configured by
+        // TestWorkItemTimeout in test/UnitTests.proj). Without the cap, deriving the value directly from
+        // HELIX_WORK_ITEM_TIMEOUT (60 min - 10 s = 59:50) means the hang-dump always fires first, converting a
+        // single wedged test into a work-item-wide hang that kills the whole run and loses all results. With
+        // the cap, a genuinely wedged wait fails *this* test fast with a useful "Output not found" message.
+        // See https://github.com/dotnet/sdk/issues/55258 and https://github.com/dotnet/sdk/issues/55044.
+        private static readonly TimeSpan s_timeout = GetOutputWaitTimeout();
+
+        private static TimeSpan GetOutputWaitTimeout()
+        {
+            var cap = TimeSpan.FromMinutes(10);
+
+            // Honor a shorter work-item timeout (fire just before it), but never exceed the cap.
+            if (Environment.GetEnvironmentVariable("HELIX_WORK_ITEM_TIMEOUT") is { } value &&
+                TimeSpan.TryParse(value, out var workItemTimeout))
+            {
+                var derived = workItemTimeout.Subtract(TimeSpan.FromSeconds(10));
+                return derived < cap ? derived : cap;
+            }
+
+            return cap;
+        }
 
         private readonly List<string> _lines = [];
 


### PR DESCRIPTION
## Summary

Follow-up to the CI analysis on #55297. Fixes the test-infra half of the intermittent `dotnet-watch.Tests` hangs that kill an entire Helix work item (exit code 7) instead of failing a single test.

## Problem

`AwaitableProcess` (the dotnet-watch test harness) derived its per-output-wait timeout directly from the Helix work-item timeout:

```csharp
s_timeout = HELIX_WORK_ITEM_TIMEOUT is set ? (workItemTimeout - 10s) : 10 min;
```

With `TestWorkItemTimeout = 60min` (`test/UnitTests.proj`), that is **59:50**. But Microsoft.Testing.Platform''s hang-dump fires at ~**80%** of the work-item timeout (**48:00**). So the hang-dump always wins the race against the graceful per-wait `Assert.Fail("Output not found within …")`.

Result: when a single test wedges on an output wait (e.g. the intermittent WebSocket hot-reload connection hang in `HotReload_WithWebSocketCapability` — see #55258, #55044, #53289), the whole work item hangs ~48 min until the hang-dump, is killed with exit code 7, and **loses all results** — instead of that one test failing fast with a useful message.

## Fix

Cap the per-wait timeout at **10 minutes** (still honoring a shorter work-item timeout when configured), well below the 48-min hang-dump. A single output wait never legitimately needs more than a few minutes, so a genuinely wedged wait now fails *that* test fast with `Output not found within 00:10:00`, and the rest of the work item''s results are preserved.

This does not fix the underlying WebSocket connection flakiness (that''s a product-side change in the hot-reload agent — raise/retry the 5s connect timeout and surface the failure; deferred pending owner input). It only ensures the flake fails gracefully instead of nuking the work item.

## Validation

- `Microsoft.DotNet.HotReload.Test.Utilities` builds clean (0 warnings / 0 errors).
- Change is confined to test infrastructure; no product code affected.

cc @tmat
