### PR TITLE
Fix Native AOT SDK version lookup

### DIFF
--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -65,7 +65,7 @@ but inside that process the BCL "where am I" APIs do **not** point there:
 So deriving an SDK-relative path (`MSBuild.dll`, `Sdks/`, `DotnetTools/`, targets) from
 `AppContext.BaseDirectory` or a dll path is **wrong** in the AOT bubble. Instead:
 
-- **In-repo:** read `SdkPaths.SdkDirectory` (in `Microsoft.DotNet.Cli.Utils`), which resolves the
+- **In-repo:** read `SdkPaths.SdkDirectory` (in `Microsoft.DotNet.Cli.CoreUtils`), which resolves the
   `Microsoft.DotNet.Sdk.Root` AppContext value -> SDK assembly directory -> `AppContext.BaseDirectory`
   (once, cached).
 - `NativeEntryPoint.ExecuteCore` resolves the SDK directory once (host `sdk_dir`, else self-locating the

--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/DotnetFiles.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/DotnetFiles.cs
@@ -9,15 +9,13 @@ namespace Microsoft.DotNet.Cli.Utils;
 
 public static class DotnetFiles
 {
-    private static string SdkRootFolder => AppContext.BaseDirectory;
-
     private static readonly Lazy<DotnetVersionFile> s_versionFileObject =
         new(() => new DotnetVersionFile(VersionFile));
 
     /// <summary>
     /// The SDK ships with a .version file that stores the commit information and SDK version
     /// </summary>
-    public static string VersionFile => Path.GetFullPath(Path.Combine(SdkRootFolder, ".version"));
+    public static string VersionFile => Path.GetFullPath(Path.Combine(SdkPaths.SdkDirectory, ".version"));
 
     public static DotnetVersionFile VersionFileObject => s_versionFileObject.Value;
 }

--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/Microsoft.DotNet.Cli.CoreUtils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/Microsoft.DotNet.Cli.CoreUtils.csproj
@@ -6,4 +6,10 @@
     <Nullable>enable</Nullable>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="dotnet" />
+    <InternalsVisibleTo Include="dotnet-aot" />
+    <InternalsVisibleTo Include="dotnet-aot.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/SdkPaths.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/SdkPaths.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.Utils;
 ///  <para>
 ///   Under the Native AOT CLI (<c>dotnet-aot</c> loaded directly by the muxer) the BCL location APIs do
 ///   NOT point at the versioned SDK directory: <see cref="System.AppContext.BaseDirectory"/> and
-///   <see cref="System.Environment.ProcessPath"/> resolve to the install root (the muxer's own
+///   <c>Environment.ProcessPath</c> resolve to the install root (the muxer's own
 ///   directory) and <c>Assembly.Location</c> is empty. The AOT entry point therefore publishes the
 ///   resolved SDK directory as the <c>Microsoft.DotNet.Sdk.Root</c> AppContext value, which this helper
 ///   reads first. Code that needs an SDK-relative path (MSBuild, tasks, tools, forwarders) should use
@@ -66,7 +66,7 @@ internal static class SdkPaths
             return sdkRoot;
         }
 
-        // The SDK assemblies ship in the versioned SDK directory, so the location of this assembly is that
+        // CoreUtils ships in the versioned SDK directory, so the location of this assembly is that
         // directory for the JIT-compiled managed CLI. Under a single-file / NativeAOT deployment
         // Assembly.Location is empty (which is what the IL3000 analyzer flags); fall through to
         // AppContext.BaseDirectory in that case - the AOT bridge sets the AppContext value (preferred above).

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -165,7 +165,12 @@ public partial class AotIntegrationTests
         Directory.CreateDirectory(sdkSubDir);
         try
         {
+            // These are synthetic sentinel values; only their end-to-end appearance in --version matters.
+            const string expectedVersion = "11.0.100-preview.7.12345.67";
             File.Copy(aotSource, Path.Combine(sdkSubDir, aotLib));
+            File.WriteAllLines(
+                Path.Combine(sdkSubDir, ".version"),
+                ["0123456789abcdef", expectedVersion]);
 
             var env = new Dictionary<string, string> { ["DOTNET_AOT_SDK_DIR"] = sdkSubDir };
             if (selfLocate)
@@ -189,6 +194,10 @@ public partial class AotIntegrationTests
 
             Assert.IsTrue(basePathReferencesSdkDir,
                 $"--info Base Path did not reference the resolved SDK directory '{sdkSubDir}'. Output:\n{stdout}");
+
+            var (versionExitCode, versionOutput, _) = RunDn(["--version"], enableAot: true, extraEnv: env);
+            Assert.AreEqual(0, versionExitCode);
+            Assert.AreEqual(expectedVersion, versionOutput.Trim());
         }
         finally
         {


### PR DESCRIPTION
## Summary

- move `SdkPaths` into CoreUtils so `DotnetFiles` can use it without reversing the existing project dependency
- resolve the SDK `.version` file from `SdkPaths.SdkDirectory`, making `Product.Version` correct in both managed and Native AOT hosts
- verify separated Native AOT layouts (like the muxer) report the version from the resolved SDK directory

Fixes dotnet/dotnet#7901

## Testing

- `dotnet build src/Cli/Microsoft.DotNet.Cli.CoreUtils/Microsoft.DotNet.Cli.CoreUtils.csproj -c Debug`
- `dotnet build test/dotnet-aot.Tests/dotnet-aot.Tests.csproj -c Debug`
- Native AOT `dn --version` against a separated SDK layout with a synthetic `.version` file