### PR TITLE
[release/11.0.1xx-preview7] Support Microsoft.Build.Traversal projects in dotnet test (MTP)

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -118,4 +118,6 @@ internal static class ProjectProperties
     internal const string AppDesignerFolder = "AppDesignerFolder";
     internal const string TestTfmsInParallel = "TestTfmsInParallel";
     internal const string BuildInParallel = "BuildInParallel";
+    internal const string IsTraversal = "IsTraversal";
+    internal const string ProjectReferenceItemName = "ProjectReference";
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -292,10 +292,12 @@ internal static class MSBuildUtility
                     throw new GracefulException(CliCommandStrings.TestCommandUseSolution);
                 }
             }
-            else if ((token.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
-                     token.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase) ||
-                     token.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)) && File.Exists(token))
+            else if (Path.GetExtension(token).EndsWith("proj", StringComparison.OrdinalIgnoreCase) && File.Exists(token))
             {
+                // Any MSBuild project extension ending in "proj" (.csproj, .vbproj, .fsproj, and traversal
+                // container projects such as dirs.proj / *.proj). This mirrors ValidateProjectOrSolutionPath,
+                // which accepts any "*proj" extension. Recognizing it here ensures the project path is not
+                // accidentally forwarded to the test application as an argument.
                 if (i == 0)
                 {
                     positionalProjectOrSolution = token;

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -240,10 +240,40 @@ internal static class SolutionAndProjectUtility
         BuildOptions buildOptions,
         FacadeLogger? logger,
         string? configuration,
-        string? platform)
+        string? platform,
+        HashSet<string>? visitedTraversalProjects = null)
     {
         var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
         ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform);
+
+        // Traversal projects (e.g. Microsoft.Build.Traversal "dirs.proj") are not test projects themselves.
+        // They act as a container that forwards build/test operations to their ProjectReference items.
+        // Special-case them the same way solutions are handled: expand into the referenced projects and
+        // evaluate each of them. This is done recursively so that nested traversal projects work as well.
+        if (IsTraversalProject(projectInstance))
+        {
+            // Track visited (project, configuration, platform) tuples across the whole traversal graph so
+            // that a project referenced by multiple traversal projects with the same configuration/platform
+            // (a "diamond") is only tested once, while the same project referenced with a *different*
+            // configuration/platform is still tested for each distinct combination. This also guards against
+            // cycles (a traversal project that transitively references itself).
+            visitedTraversalProjects ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            visitedTraversalProjects.Add(GetTraversalVisitKey(Path.GetFullPath(projectFilePath), configuration, platform));
+
+            foreach (var reference in GetTraversalReferencedProjects(projectInstance, configuration, platform))
+            {
+                if (!visitedTraversalProjects.Add(GetTraversalVisitKey(reference.FullPath, reference.Configuration, reference.Platform)))
+                {
+                    // Already handled via another traversal path (diamond) or a cycle, with the same
+                    // configuration/platform combination.
+                    continue;
+                }
+
+                projects.AddRange(GetProjectProperties(reference.FullPath, projectCollection, evaluationContext, buildOptions, logger, reference.Configuration, reference.Platform, visitedTraversalProjects));
+            }
+
+            return projects;
+        }
 
         var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
         var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
@@ -312,7 +342,60 @@ internal static class SolutionAndProjectUtility
     }
 
     /// <summary>
-    /// Performs device selection for each TFM BEFORE the build, so that device-provided
+    /// Determines whether the evaluated project is a traversal project (e.g. a
+    /// <c>Microsoft.Build.Traversal</c> "dirs.proj"). Traversal projects set the
+    /// <c>IsTraversal</c> property to <c>true</c> and merely forward operations to their
+    /// <c>ProjectReference</c> items rather than producing a test module of their own.
+    /// </summary>
+    private static bool IsTraversalProject(ProjectInstance projectInstance)
+        => bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.IsTraversal), out bool isTraversal) && isTraversal;
+
+    /// <summary>
+    /// Builds a stable key identifying a (project, configuration, platform) combination for
+    /// traversal-graph de-duplication and cycle detection.
+    /// </summary>
+    private static string GetTraversalVisitKey(string fullPath, string? configuration, string? platform)
+        => $"{fullPath}|{configuration}|{platform}";
+
+    /// <summary>
+    /// Returns the projects a traversal project references. The globs and conditions in the traversal
+    /// project are already expanded by MSBuild during evaluation, so the resolved <c>ProjectReference</c>
+    /// items represent the effective set of projects to test. Per-reference <c>Configuration</c>/
+    /// <c>Platform</c> metadata is honored when present (falling back to the values inherited from the
+    /// traversal project), mirroring how MSBuild lets a <c>ProjectReference</c> target a specific
+    /// configuration or platform.
+    /// </summary>
+    private static IEnumerable<(string FullPath, string? Configuration, string? Platform)> GetTraversalReferencedProjects(
+        ProjectInstance projectInstance,
+        string? inheritedConfiguration,
+        string? inheritedPlatform)
+    {
+        // Resolve reference paths relative to the traversal project's directory (not the process working
+        // directory). MSBuild's "FullPath" well-known metadata is normally already absolute, but resolving
+        // against the project directory explicitly keeps us correct even if a relative value is returned or
+        // the current directory differs from the project directory.
+        var projectDirectory = projectInstance.Directory;
+
+        foreach (ProjectItemInstance projectReference in projectInstance.GetItems(ProjectProperties.ProjectReferenceItemName))
+        {
+            // "FullPath" is a well-known item metadata that MSBuild computes relative to the project directory.
+            var fullPath = projectReference.GetMetadataValue("FullPath");
+            if (string.IsNullOrEmpty(fullPath))
+            {
+                continue;
+            }
+
+            var configurationMetadata = projectReference.GetMetadataValue(ProjectProperties.Configuration);
+            var platformMetadata = projectReference.GetMetadataValue(ProjectProperties.Platform);
+
+            yield return (
+                Path.GetFullPath(fullPath, projectDirectory),
+                string.IsNullOrEmpty(configurationMetadata) ? inheritedConfiguration : configurationMetadata,
+                string.IsNullOrEmpty(platformMetadata) ? inheritedPlatform : platformMetadata);
+        }
+    }
+
+    /// <summary>
     /// RuntimeIdentifiers are included in the build. Returns a result with device mappings
     /// and TestTfmsInParallel setting, or null if no device selection is needed.
     /// When projectCollection/evaluationContext are provided, reuses them to avoid redundant evaluation.

--- a/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
+++ b/src/Layout/redist/MSBuildImports/Current/Microsoft.Common.targets/ImportAfter/Microsoft.TestPlatform.ImportAfter.targets
@@ -19,5 +19,23 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Condition="Exists('$(VSTestTargets)')" Project="$(VSTestTargets)" />
   <Target Name="_MTPBuild">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Condition="'$(IsTestingPlatformApplication)'=='true'" />
+
+    <!-- Traversal projects (Microsoft.Build.Traversal) are containers that don't build themselves;
+         forward the MTP build to their referenced projects so the referenced test projects get built.
+         Per-reference Configuration/Platform metadata is forwarded as global properties so a reference
+         that pins a specific configuration/platform builds consistently with the dotnet test evaluation
+         logic (which reads the same metadata). The values are precomputed here so empty metadata does not
+         emit a "Configuration=" assignment that would clear the inherited global property; empty segments
+         and leading/trailing ';' in Properties are ignored by MSBuild. -->
+    <ItemGroup Condition="'$(IsTraversal)'=='true'">
+      <_MTPTraversalReference Include="@(ProjectReference)">
+        <_ConfigurationProperty Condition="'%(ProjectReference.Configuration)' != ''">Configuration=%(ProjectReference.Configuration)</_ConfigurationProperty>
+        <_PlatformProperty Condition="'%(ProjectReference.Platform)' != ''">Platform=%(ProjectReference.Platform)</_PlatformProperty>
+      </_MTPTraversalReference>
+    </ItemGroup>
+    <MSBuild Projects="@(_MTPTraversalReference)"
+             Targets="_MTPBuild"
+             Properties="%(_MTPTraversalReference._ConfigurationProperty);%(_MTPTraversalReference._PlatformProperty)"
+             Condition="'$(IsTraversal)'=='true'" />
   </Target>
 </Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjects/OtherTestProject/OtherTestProject.csproj
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/OtherTestProject/OtherTestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjects/OtherTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/OtherTestProject/Program.cs
@@ -1,0 +1,38 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => [];
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		context.Complete();
+		await Task.CompletedTask;
+	}
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjects/TestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/TestProject/Program.cs
@@ -1,0 +1,38 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => [];
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		context.Complete();
+		await Task.CompletedTask;
+	}
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjects/TestProject/TestProject.csproj
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/TestProject/TestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjects/dirs.proj
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/dirs.proj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.82">
+  <ItemGroup>
+    <ProjectReference Include="TestProject\TestProject.csproj" />
+    <ProjectReference Include="OtherTestProject\OtherTestProject.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjects/global.json
+++ b/test/TestAssets/TestProjects/TraversalTestProjects/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/LeafTestProject/LeafTestProject.csproj
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/LeafTestProject/LeafTestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/LeafTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/LeafTestProject/Program.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+// Drop a uniquely-named marker file per process launch so tests can deterministically count how many
+// times this test application actually ran (used to validate traversal de-duplication).
+var markerDir = Environment.GetEnvironmentVariable("TRAVERSAL_MARKER_DIR");
+if (!string.IsNullOrEmpty(markerDir))
+{
+	Directory.CreateDirectory(markerDir);
+	var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
+	File.WriteAllText(Path.Combine(markerDir, $"{assemblyName}-{Guid.NewGuid():N}.marker"), assemblyName);
+}
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => [];
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		context.Complete();
+		await Task.CompletedTask;
+	}
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/SharedTestProject/Program.cs
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/SharedTestProject/Program.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+// Drop a uniquely-named marker file per process launch so tests can deterministically count how many
+// times this test application actually ran (used to validate traversal de-duplication).
+var markerDir = Environment.GetEnvironmentVariable("TRAVERSAL_MARKER_DIR");
+if (!string.IsNullOrEmpty(markerDir))
+{
+	Directory.CreateDirectory(markerDir);
+	var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
+	File.WriteAllText(Path.Combine(markerDir, $"{assemblyName}-{Guid.NewGuid():N}.marker"), assemblyName);
+}
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => [];
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		context.Complete();
+		await Task.CompletedTask;
+	}
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/SharedTestProject/SharedTestProject.csproj
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/SharedTestProject/SharedTestProject.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GenerateProgramFile>false</GenerateProgramFile>
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/dirs.proj
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/dirs.proj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.82">
+  <ItemGroup>
+    <!-- Nested traversal project. -->
+    <ProjectReference Include="sub\dirs.proj" />
+    <!-- SharedTestProject is also referenced by sub\dirs.proj, forming a diamond. It must be tested only once. -->
+    <ProjectReference Include="SharedTestProject\SharedTestProject.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/global.json
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/TestAssets/TestProjects/TraversalTestProjectsNested/sub/dirs.proj
+++ b/test/TestAssets/TestProjects/TraversalTestProjectsNested/sub/dirs.proj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.82">
+  <ItemGroup>
+    <ProjectReference Include="..\SharedTestProject\SharedTestProject.csproj" />
+    <ProjectReference Include="..\LeafTestProject\LeafTestProject.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -448,6 +448,62 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]
+        public void RunTraversalProject_ShouldRunReferencedTestProjects(string configuration)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TraversalTestProjects", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("dirs.proj", "-c", configuration);
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                // The traversal project itself is not a test project. It should expand to its referenced
+                // test projects, both of which run (and report zero tests via the dummy adapter).
+                result.StdOut
+                    .Should().Contain("Test run summary: Zero tests ran")
+                    .And.Contain("total: 0")
+                    .And.Contain("succeeded: 0")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 0");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
+        }
+
+        [DataRow(TestingConstants.Debug)]
+        [DataRow(TestingConstants.Release)]
+        [TestMethod]
+        public void RunNestedTraversalProjectWithDiamond_ShouldRunSharedProjectOnce(string configuration)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TraversalTestProjectsNested", Guid.NewGuid().ToString())
+                .WithSource();
+
+            // Each test-host launch drops a uniquely-named marker file, giving a deterministic count of
+            // how many times each referenced project actually ran (robust to terminal progress re-rendering).
+            string markerDir = Path.Combine(testInstance.Path, "run-markers");
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnvironmentVariable("TRAVERSAL_MARKER_DIR", markerDir)
+                                    .Execute("dirs.proj", "-c", configuration);
+
+            // SharedTestProject is referenced by both the top-level dirs.proj and the nested sub\dirs.proj
+            // (a diamond). Cross-recursion de-duplication must ensure it is only run once, while the leaf
+            // project reachable only through the nested traversal must also run (proving recursion works).
+            int sharedRuns = Directory.Exists(markerDir) ? Directory.GetFiles(markerDir, "SharedTestProject-*.marker").Length : 0;
+            int leafRuns = Directory.Exists(markerDir) ? Directory.GetFiles(markerDir, "LeafTestProject-*.marker").Length : 0;
+
+            sharedRuns.Should().Be(1);
+            leafRuns.Should().Be(1);
+
+            result.ExitCode.Should().Be(ExitCodes.ZeroTests);
+        }
+
+        [DataRow(TestingConstants.Debug)]
+        [DataRow(TestingConstants.Release)]
+        [TestMethod]
         public void RunOnProjectWithSolutionFile_ShouldReturnExitCodeGenericFailure(string configuration)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectFileAndSolutionFile", Guid.NewGuid().ToString())


### PR DESCRIPTION
Backport of #55297 to `release/11.0.1xx-preview7`.

## Summary
- support Microsoft.Build.Traversal projects in `dotnet test` with Microsoft.Testing.Platform
- expand nested traversal graphs while de-duplicating diamond references
- forward per-reference Configuration and Platform metadata during build and evaluation
- add direct and nested traversal integration coverage

## Validation
- `build.cmd -c Debug`
- `dotnet.Tests` incremental build
- traversal MTP tests: 4 passed (Debug and Release for both direct and nested/diamond scenarios)