### PR TITLE
Expose --no-banner in MTP dotnet test help

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -183,6 +183,7 @@ internal abstract partial class TestCommandDefinition
             Options.Add(VerbosityOption);
             Options.Add(NoRestoreOption);
             Options.Add(NoBuildOption);
+            NoLogoOption.Aliases.Add("--no-banner");
             Options.Add(NoLogoOption);
             Options.Add(NoDependenciesOption);
             Options.Add(ArtifactsPathOption);

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         [DataRow("--nologo")]
         [DataRow("-nologo")]
         [DataRow("/nologo")]
+        [DataRow("--no-banner")]
         public void MTPCommandTranslatesNoLogoOptionToNoBanner(string optionAlias)
         {
             var command = new TestCommandDefinition.MicrosoftTestingPlatform();

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -33,7 +33,7 @@ Options:
   -v, -verbosity <LEVEL>                          Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
   --no-restore                                    Do not restore the project before building. [default: False]
   --no-build                                      Do not build the project before testing. Implies --no-restore. [default: False]
-  -nologo, --no-logo                              Run test(s), without displaying Microsoft Testplatform banner [default: False]
+  -nologo, --no-banner, --no-logo                 Run test(s), without displaying Microsoft Testplatform banner [default: False]
   --no-dependencies                               Do not build project-to-project references and only build the specified project. [default: False]
   --artifacts-path <ARTIFACTS_DIR>                The artifacts path. All output from the project, including build, publish, and pack output, will go in subfolders under the specified path.
   --ucr, --use-current-runtime                    Use current runtime as the target runtime. [default: False]


### PR DESCRIPTION
## Summary

- expose MTP's `--no-banner` switch as an explicit alias of `dotnet test --no-logo`
- include `--no-banner` in the MTP help output
- cover the alias in parser tests

Follow-up to #55376 and [this review comment](https://github.com/dotnet/sdk/pull/55376#discussion_r3630958938).

## Validation

- Built the Debug SDK redist
- Passed all 64 `TestCommandDefinitionTests` and `MTPHelpSnapshotTests.VerifyMTPHelpOutput` tests