### PR TITLE
Fix multi-arch container label parsing

### DIFF
--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -375,8 +375,8 @@
         Include="$(_ContainerLabel)"/>
       <ContainerLabel
         Condition="@(_ParsedContainerLabel->Count()) > 0 "
-        Include="$([System.String]::Copy('%(_ParsedContainerLabel.Identity)').Split(':')[0])"
-        Value="$([System.String]::Copy('%(_ParsedContainerLabel.Identity)').Split(':')[1])" />
+        Include="$([System.String]::Copy('%(_ParsedContainerLabel.Identity)').Split(':', 2)[0])"
+        Value="$([System.String]::Copy('%(_ParsedContainerLabel.Identity)').Split(':', 2)[1])" />
 
       <_ParsedContainerPort
         Condition="'$(_ContainerPort)' != ':'"

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -140,6 +140,34 @@ public class TargetsTests
 
     private static bool LabelMatch(string label, string value, ProjectItemInstance item) => item.EvaluatedInclude == label && item.GetMetadata("Value") is { } v && v.EvaluatedValue == value;
 
+    [TestMethod]
+    public void MultiArchContainerLabelsPreserveColonsInValues()
+    {
+        var expectedLabels = new Dictionary<string, string>
+        {
+            ["org.opencontainers.image.source"] = "https://github.com/dotnet/sdk",
+            ["org.opencontainers.image.created"] = "2026-07-22T12:34:56.7890000Z",
+        };
+        var serializedLabels = string.Join(';', expectedLabels.Select(label => $"{label.Key}:{label.Value}"));
+
+        var (project, logger, d) = ProjectInitializer.InitProject(new()
+        {
+            ["_ContainerLabel"] = serializedLabels,
+        }, projectName: nameof(MultiArchContainerLabelsPreserveColonsInValues));
+        using var _ = d;
+        var instance = project.CreateProjectInstance(ProjectInstanceSettings.None);
+
+        instance.Build(["_ParseItemsForPublishingSingleContainer"], [logger])
+            .Should().BeTrue("Build should have succeeded but failed due to {0}", string.Join('\n', logger.AllMessages));
+
+        var labels = instance.GetItems(ContainerLabel);
+        labels.Should().HaveCount(expectedLabels.Count);
+        foreach (var expectedLabel in expectedLabels)
+        {
+            labels.Should().ContainSingle(label => LabelMatch(expectedLabel.Key, expectedLabel.Value, label));
+        }
+    }
+
     [DataRow(true)]
     [DataRow(false)]
     [TestMethod]


### PR DESCRIPTION
## Summary

- split serialized multi-architecture container labels only on the first colon
- preserve URLs, RFC 3339 timestamps, and other values containing colons
- add regression coverage for source and creation-time labels

## Root cause

Multi-architecture inner builds receive labels serialized as `key:value`. `_ParseItemsForPublishingSingleContainer` used an unrestricted `Split(':')` and selected element 1, truncating everything after the next colon.

Fixes #52732.

## Validation

- `containers.slnf` builds successfully with zero warnings or errors
- focused integration test project builds
- direct MSBuild execution of `_ParseItemsForPublishingSingleContainer` preserves both URL and RFC 3339 values

The repository test runner requires a built redist SDK; the attempted redist build was blocked by an unrelated missing `project.assets.json` in the Static Web Assets tool chain.