### PR TITLE
Simplify MacAddressGetter to use NetworkInterface API directly

### DIFF
--- a/src/Cli/dotnet/Telemetry/MacAddressGetter.cs
+++ b/src/Cli/dotnet/Telemetry/MacAddressGetter.cs
@@ -1,147 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Net.NetworkInformation;
-using System.Text.RegularExpressions;
-using Microsoft.DotNet.Cli.Utils.Extensions;
 
 namespace Microsoft.DotNet.Cli.Telemetry;
 
 internal static class MacAddressGetter
 {
-    private const string MacRegex = @"(?:[a-z0-9]{2}[:\-]){5}[a-z0-9]{2}";
-    private const string ZeroRegex = @"(?:00[:\-]){5}00";
-    private const int ErrorFileNotFound = 0x2;
-    public static string GetMacAddress()
+    private static readonly byte[] AllZeroBytes = new byte[] { 0, 0, 0, 0, 0, 0 };
+
+    public static string? GetMacAddress()
     {
         try
         {
-            var shelloutput = GetShellOutMacAddressOutput();
-            if (shelloutput == null)
-            {
-                return null;
-            }
-
-            return ParseMACAddress(shelloutput);
+            return GetMacAddressByNetworkInterface();
         }
-        catch (Win32Exception e)
-        {
-            if (e.NativeErrorCode == ErrorFileNotFound)
-            {
-                return GetMacAddressByNetworkInterface();
-            }
-            else
-            {
-                throw;
-            }
-        }
-    }
-
-    private static string ParseMACAddress(string shelloutput)
-    {
-        string macAddress = null;
-        foreach (Match match in Regex.Matches(shelloutput, MacRegex, RegexOptions.IgnoreCase))
-        {
-            if (!Regex.IsMatch(match.Value, ZeroRegex))
-            {
-                macAddress = match.Value;
-                break;
-            }
-        }
-
-        if (macAddress != null)
-        {
-            return macAddress;
-        }
-        return null;
-    }
-
-    private static string GetIpCommandOutput()
-    {
-        var fileName = File.Exists(@"/usr/bin/ip") ? @"/usr/bin/ip" :
-                       File.Exists(@"/usr/sbin/ip") ? @"/usr/sbin/ip" :
-                       File.Exists(@"/sbin/ip") ? @"/sbin/ip" :
-                       "ip";
-        var ipResult = new ProcessStartInfo
-        {
-            FileName = fileName,
-            Arguments = "link",
-            UseShellExecute = false
-        }.ExecuteAndCaptureOutput(out string ipStdOut, out _);
-
-        if (ipResult == 0)
-        {
-            return ipStdOut;
-        }
-        else
+        catch
         {
             return null;
         }
     }
 
-    private static string GetShellOutMacAddressOutput()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            var result = new ProcessStartInfo
-            {
-                FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "getmac.exe"),
-                UseShellExecute = false
-            }.ExecuteAndCaptureOutput(out string stdOut, out _);
-
-            if (result == 0)
-            {
-                return stdOut;
-            }
-            else
-            {
-                return null;
-            }
-        }
-        else
-        {
-            try
-            {
-                var fileName = File.Exists("/sbin/ifconfig") ? "/sbin/ifconfig" :
-                               File.Exists("/usr/sbin/ifconfig") ? "/usr/sbin/ifconfig" :
-                               File.Exists("/usr/bin/ifconfig") ? "/usr/bin/ifconfig" :
-                               "ifconfig";
-
-                var ifconfigResult = new ProcessStartInfo
-                {
-                    FileName = fileName,
-                    Arguments = "-a",
-                    UseShellExecute = false
-                }.ExecuteAndCaptureOutput(out string ifconfigStdOut, out string ifconfigStdErr);
-
-                if (ifconfigResult == 0)
-                {
-                    return ifconfigStdOut;
-                }
-                else
-                {
-                    return GetIpCommandOutput();
-                }
-            }
-            catch (Win32Exception e)
-            {
-                if (e.NativeErrorCode == ErrorFileNotFound)
-                {
-                    return GetIpCommandOutput();
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-    }
-
-    private static string GetMacAddressByNetworkInterface()
+    private static string? GetMacAddressByNetworkInterface()
     {
         return GetMacAddressesByNetworkInterface().FirstOrDefault();
     }
@@ -153,22 +33,24 @@ internal static class MacAddressGetter
 
         if (nics == null || nics.Length < 1)
         {
-            macs.Add(string.Empty);
             return macs;
         }
 
         foreach (NetworkInterface adapter in nics)
         {
-            IPInterfaceProperties properties = adapter.GetIPProperties();
+            byte[] bytes = adapter.GetPhysicalAddress().GetAddressBytes();
+            if (bytes.Length == 0 || bytes.SequenceEqual(AllZeroBytes))
+            {
+                continue;
+            }
 
-            PhysicalAddress address = adapter.GetPhysicalAddress();
-            byte[] bytes = address.GetAddressBytes();
             macs.Add(string.Join("-", bytes.Select(x => x.ToString("X2"))));
             if (macs.Count >= 10)
             {
                 break;
             }
         }
+
         return macs;
     }
 }

--- a/src/Cli/dotnet/Telemetry/MacAddressGetter.cs
+++ b/src/Cli/dotnet/Telemetry/MacAddressGetter.cs
@@ -29,28 +29,18 @@ internal static class MacAddressGetter
     private static List<string> GetMacAddressesByNetworkInterface()
     {
         NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
-        var macs = new List<string>();
 
         if (nics == null || nics.Length < 1)
         {
-            return macs;
+            return new List<string>();
         }
 
-        foreach (NetworkInterface adapter in nics)
-        {
-            byte[] bytes = adapter.GetPhysicalAddress().GetAddressBytes();
-            if (bytes.Length == 0 || bytes.SequenceEqual(AllZeroBytes))
-            {
-                continue;
-            }
-
-            macs.Add(string.Join("-", bytes.Select(x => x.ToString("X2"))));
-            if (macs.Count >= 10)
-            {
-                break;
-            }
-        }
-
-        return macs;
+        return nics
+            .Where(nic => nic.NetworkInterfaceType != NetworkInterfaceType.Loopback &&
+                          nic.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
+            .Select(nic => nic.GetPhysicalAddress().GetAddressBytes())
+            .Where(bytes => bytes.Length == 6 && !bytes.SequenceEqual(AllZeroBytes))
+            .Select(bytes => string.Join("-", bytes.Select(b => b.ToString("X2"))))
+            .ToList();
     }
 }


### PR DESCRIPTION
## Summary

Remove the shell-out-first strategy that spawned platform-specific processes (`getmac.exe`, `ifconfig`, `ip link`) to obtain MAC addresses. Instead, use the .NET `NetworkInterface` API directly, which was already present as a fallback.

## Motivation

- **Reliability:** The shell-out approach depends on external binaries existing at expected paths, which is fragile on minimal containers, distroless images, and exotic distros. The `NetworkInterface` API is built into the runtime and works everywhere .NET runs.
- **Simplicity:** This eliminates ~120 lines of process-spawning, path-probing, and regex-parsing code.
- **Performance:** No child process creation — just an in-process API call.
- **Post-.NET 8 context:** The primary device identifier is now `devdeviceid` (via `DeviceIdGetter`), not the MAC-based `MachineId`. The MAC address is only used for the legacy `MachineId`/`MachineIdOld` telemetry properties.

## Safety

- `GetMacAddress()` is wrapped in a catch-all `try/catch` returning `null` on any failure.
- Callers already handle `null` gracefully: `TelemetryCommonProperties.GetMachineId()` falls back to `Guid.NewGuid()` on `null` or `NetworkInformationException`.
- Telemetry can never break the CLI.

## Changes

- **`MacAddressGetter.cs`**: Simplified to use `NetworkInterface.GetAllNetworkInterfaces()` directly. Removed `GetShellOutMacAddressOutput()`, `GetIpCommandOutput()`, `ParseMACAddress()`, and all related constants/imports. Added filtering for all-zero and empty MAC addresses for parity with the old regex-based filtering.

No signature changes — both callers (`TelemetryCommonProperties.cs`, `WindowsUtils.cs`) are unaffected.