### PR TITLE
Tolerate renamed-away source files in the Hot Reload file watcher

### DIFF
--- a/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/HotReloadDotNetWatcher.cs
@@ -337,13 +337,27 @@ internal sealed class HotReloadDotNetWatcher
                         var changedFiles = NormalizePathChanges(changedPaths)
                             .Select(changedPath =>
                             {
+                                var changeKind = changedPath.Kind;
+
+                                // A change reported as Add or Update may target a file that has already been
+                                // deleted or renamed away by the time we process the change. This happens when a
+                                // source file is renamed via delete+create (the deletion of the old file may be
+                                // reported as an Update, or a delete-...-add sequence may be normalized to Update),
+                                // or when the OS file watcher coalesces/reorders events. Reading such a file to
+                                // apply the change would throw FileNotFoundException, so treat a missing file as a
+                                // deletion instead.
+                                if (changeKind is ChangeKind.Add or ChangeKind.Update && !File.Exists(changedPath.Path))
+                                {
+                                    changeKind = ChangeKind.Delete;
+                                }
+
                                 // On macOS may report Update followed by Add when a new file is created or just updated.
                                 // We normalize Update + Add to just Add and Update + Add + Delete to Update above.
                                 // To distinguish between an addition and an update we check if the file exists.
 
                                 if (evaluationResult.Files.TryGetValue(changedPath.Path, out var existingFileItem))
                                 {
-                                    var changeKind = changedPath.Kind == ChangeKind.Add ? ChangeKind.Update : changedPath.Kind;
+                                    changeKind = changeKind == ChangeKind.Add ? ChangeKind.Update : changeKind;
 
                                     return new ChangedFile(existingFileItem, changeKind);
                                 }
@@ -352,7 +366,7 @@ internal sealed class HotReloadDotNetWatcher
                                 // The file could have been deleted and Add + Delete sequence could have been normalized to Update.
                                 return new ChangedFile(
                                     new FileItem() { FilePath = changedPath.Path, ContainingProjectPaths = [] },
-                                    changedPath.Kind);
+                                    changeKind);
                             })
                             .ToList();
 


### PR DESCRIPTION
Fixes #55137

## Root cause

The flaky test is `test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.cs` → `RenameSourceFile(useMove: false)`. It renames a dependency source file by deleting `Foo.cs` and creating `Renamed.cs`, then asserts that hot reload prints `> Renamed.cs`.

On the macOS arm64 Helix leg it intermittently fails with:

```
dotnet watch An unexpected error occurred: System.IO.FileNotFoundException: Could not find file '.../Dependency/Foo.cs'.
```

The chain of events:

1. The test performs a non-atomic rename: `File.Delete(Foo.cs)` followed by `File.WriteAllText(Renamed.cs, ...)`.
2. macOS `FileSystemWatcher` is backed by FSEvents, which coalesces and can reorder events. The deletion of `Foo.cs` can surface as an `Update`, and a `delete-…-add` sequence for the same path is normalized to `Update` by `NormalizePathChanges`.
3. In `HotReloadDotNetWatcher.CaptureChangedFilesSnapshot`, `Foo.cs` is present in the evaluation result, so its change is kept as `Update`. When no change in the batch is classified as `Add`, `evaluationRequired == false`, so the code takes the `UpdateFileContentAsync` path instead of a full re-evaluation.
4. `HotReloadMSBuildWorkspace.UpdateFileContentAsync` reads file content for `Add`/`Update` changes. Reading the already-deleted `Foo.cs` throws `FileNotFoundException`, which escapes to `Program.cs` ("An unexpected error occurred"), aborting the iteration so the `> Renamed.cs` hot-reload output is never produced.

It is **intermittent** because it depends entirely on how and when the OS coalesces/orders the delete of `Foo.cs` versus the create of `Renamed.cs`. When the create of `Renamed.cs` is seen as an `Add`, dotnet-watch does a full re-evaluation (reloading the graph from disk) and never reads the missing `Foo.cs`; that ordering passes. The failure reproduced only on macOS and passed on retry, confirming flakiness rather than a product regression. (`useMove: true` remains skipped per #43320.)

## Why this is a product bug, not just a test bug

Renaming a watched source file via delete+create is a legitimate scenario (several editors/tools rename files exactly this way). dotnet-watch crashing with an unhandled `FileNotFoundException` when a watched file disappears is a real robustness gap. Fixing the product keeps the test exercising the delete-then-add path; reordering the test to create-before-delete would only mask the fragility and reduce coverage.

## The fix

In `CaptureChangedFilesSnapshot`, when a change is classified as `Add` or `Update` but the target file no longer exists on disk, downgrade it to `Delete`:

```csharp
if (changeKind is ChangeKind.Add or ChangeKind.Update && !File.Exists(changedPath.Path))
{
    changeKind = ChangeKind.Delete;
}
```

A file that is not present cannot be added or updated — it was removed or renamed away — so the workspace should drop the document rather than attempt (and fail) to read it. With this change, the deleted `Foo.cs` is treated as a `Delete` (its document is removed, no read), while the new `Renamed.cs` still exists and is processed normally, so the expected hot-reload output is produced.

## Why it is correct

- **Deterministic:** the existence check runs at snapshot-capture time (after debcounce/normalization). In the rename race `Foo.cs` is gone for good, so it is reliably reclassified as `Delete`.
- **No lost updates:** for the transient temp-write/rename-over pattern, if a file is momentarily missing at capture time we emit `Delete` now and the subsequent `Add`/`Update` event re-adds it, so content still converges. The workspace already handles `Delete` followed by a later `Add`.
- **Surgical:** one localized change in the change-classification path; no behavioral change when files exist. Build of `Microsoft.DotNet.HotReload.Watch.csproj` succeeds with 0 warnings/0 errors.

Note: the repro is macOS-specific and cannot be reproduced on the Windows dev box; correctness is established by reasoning about the event flow plus the existing integration test `RenameSourceFile(false)`, which exercises this exact delete+create rename path.