### PR TITLE
Honor Configuration environment variable in CLI options

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
@@ -196,13 +196,35 @@ internal static class CommonOptions
 
     public const string ConfigurationOptionName = "--configuration";
 
-    public static Option<string?> CreateConfigurationOption(string description) =>
-        new Option<string?>(ConfigurationOptionName, "-c")
+    public static Option<string?> CreateConfigurationOption(string description)
+    {
+        var option = new Option<string?>(ConfigurationOptionName, "-c")
         {
             Description = description,
             HelpName = CommandDefinitionStrings.ConfigurationArgumentName,
-            IsDynamic = true
-        }.ForwardAsSingle(o => $"--property:Configuration={o}");
+            IsDynamic = true,
+            DefaultValueFactory = _ => Environment.GetEnvironmentVariable("Configuration")
+        };
+
+        return option.SetForwardingFunction((configuration, parseResult) =>
+        {
+            if (configuration is null)
+            {
+                return [];
+            }
+
+            var propertyOption = parseResult.CommandResult.Command.Options.FirstOrDefault(o => o.Name == "--property");
+            if (parseResult.GetResult(option) is OptionResult { Implicit: true } &&
+                propertyOption is not null &&
+                parseResult.GetResult(propertyOption) is OptionResult propertyResult &&
+                propertyResult.GetValueOrDefault<ReadOnlyDictionary<string, string>?>()?.ContainsKey("Configuration") is true)
+            {
+                return [];
+            }
+
+            return [$"--property:Configuration={configuration}"];
+        });
+    }
 
     public static Option<string> CreateVersionSuffixOption() =>
         new Option<string>("--version-suffix")
@@ -380,4 +402,3 @@ internal static class CommonOptions
         Arity = ArgumentArity.Zero
     };
 }
-

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Common/CommonOptions.cs
@@ -196,35 +196,18 @@ internal static class CommonOptions
 
     public const string ConfigurationOptionName = "--configuration";
 
-    public static Option<string?> CreateConfigurationOption(string description)
-    {
-        var option = new Option<string?>(ConfigurationOptionName, "-c")
+    public static Option<string?> CreateConfigurationOption(string description) =>
+        new Option<string?>(ConfigurationOptionName, "-c")
         {
             Description = description,
             HelpName = CommandDefinitionStrings.ConfigurationArgumentName,
             IsDynamic = true,
-            DefaultValueFactory = _ => Environment.GetEnvironmentVariable("Configuration")
-        };
-
-        return option.SetForwardingFunction((configuration, parseResult) =>
-        {
-            if (configuration is null)
+            DefaultValueFactory = _ =>
             {
-                return [];
+                string? configuration = Environment.GetEnvironmentVariable("Configuration");
+                return string.IsNullOrWhiteSpace(configuration) ? null : configuration;
             }
-
-            var propertyOption = parseResult.CommandResult.Command.Options.FirstOrDefault(o => o.Name == "--property");
-            if (parseResult.GetResult(option) is OptionResult { Implicit: true } &&
-                propertyOption is not null &&
-                parseResult.GetResult(propertyOption) is OptionResult propertyResult &&
-                propertyResult.GetValueOrDefault<ReadOnlyDictionary<string, string>?>()?.ContainsKey("Configuration") is true)
-            {
-                return [];
-            }
-
-            return [$"--property:Configuration={configuration}"];
-        });
-    }
+        }.ForwardAsSingle(o => $"--property:Configuration={o}");
 
     public static Option<string> CreateVersionSuffixOption() =>
         new Option<string>("--version-suffix")

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Help/HelpBuilder.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Help/HelpBuilder.cs
@@ -253,8 +253,10 @@ public partial class HelpBuilder
 
             var isSingleArgument = defaultArguments.Length == 1;
             var argumentDefaultValues = defaultArguments
-                .Select(argument => GetArgumentDefaultValue(symbol, argument, isSingleArgument, context));
-            return $"[{string.Join(", ", argumentDefaultValues)}]";
+                .Select(argument => GetArgumentDefaultValue(symbol, argument, isSingleArgument, context))
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToArray();
+            return argumentDefaultValues.Length == 0 ? "" : $"[{string.Join(", ", argumentDefaultValues)}]";
         }
     }
 

--- a/test/dotnet.Tests/CliSchemaTests.cs
+++ b/test/dotnet.Tests/CliSchemaTests.cs
@@ -77,7 +77,7 @@ public class CliSchemaTests : SdkTest
       ],
       "helpName": "CONFIGURATION",
       "valueType": "System.String",
-      "hasDefaultValue": false,
+      "hasDefaultValue": true,
       "arity": {
         "minimum": 1,
         "maximum": 1
@@ -799,7 +799,7 @@ public class CliSchemaTests : SdkTest
       ],
       "helpName": "CONFIGURATION",
       "valueType": "System.String",
-      "hasDefaultValue": false,
+      "hasDefaultValue": true,
       "arity": {
         "minimum": 1,
         "maximum": 1

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTestsWithDifferentOptions.cs
@@ -55,6 +55,21 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
         }
 
+        [TestMethod]
+        public void RunWithSolutionPath_ShouldUseConfigurationEnvironmentVariable()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString()).WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnvironmentVariable("Configuration", TestingConstants.Release)
+                                    .Execute("--solution", "MultiTestProjectSolutionWithTests.sln");
+
+            Assert.MatchesRegex(RegexPatternHelper.GenerateProjectRegexPattern("TestProject", TestingConstants.Failed, true, TestingConstants.Release), result.StdOut);
+            Assert.MatchesRegex(RegexPatternHelper.GenerateProjectRegexPattern("OtherTestProject", TestingConstants.Passed, true, TestingConstants.Release), result.StdOut);
+            result.ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
+        }
+
         [TestMethod, CombinatorialData]
         public void RunWithSolutionFilterPathWithFailingTests_ShouldReturnExitCodeGenericFailure(
             [CombinatorialValues(TestingConstants.Debug, TestingConstants.Release)] string configuration,

--- a/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
@@ -59,23 +59,24 @@ public class CommonOptionsTests
     }
 
     [TestMethod]
-    public void ExplicitConfigurationPropertyOverridesEnvironmentVariable()
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("\t")]
+    public void EmptyOrWhitespaceConfigurationEnvironmentVariableIsIgnored(string configuration)
     {
         string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
 
         try
         {
-            Environment.SetEnvironmentVariable("Configuration", "EnvironmentConfiguration");
+            Environment.SetEnvironmentVariable("Configuration", configuration);
             var command = new RootCommand();
-            var propertyOption = CommonOptions.CreatePropertyOption();
-            var configurationOption = CommonOptions.CreateConfigurationOption("Configuration");
-            command.Options.Add(propertyOption);
-            command.Options.Add(configurationOption);
+            var option = CommonOptions.CreateConfigurationOption("Configuration");
+            command.Options.Add(option);
 
-            var result = command.Parse(["--property:Configuration=PropertyConfiguration"]);
+            var result = command.Parse([]);
 
-            result.OptionValuesToBeForwarded(command).Should().ContainSingle()
-                .Which.Should().Be("--property:Configuration=PropertyConfiguration");
+            result.GetValue(option).Should().BeNull();
+            result.OptionValuesToBeForwarded(command).Should().BeEmpty();
         }
         finally
         {

--- a/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
@@ -3,12 +3,86 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
 
 namespace Microsoft.DotNet.Tests.ParserTests;
 
 [TestClass]
 public class CommonOptionsTests
 {
+    [TestMethod]
+    public void ConfigurationDefaultsToEnvironmentVariable()
+    {
+        string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("Configuration", "EnvironmentConfiguration");
+            var command = new RootCommand();
+            var option = CommonOptions.CreateConfigurationOption("Configuration");
+            command.Options.Add(option);
+
+            var result = command.Parse([]);
+
+            result.GetValue(option).Should().Be("EnvironmentConfiguration");
+            result.OptionValuesToBeForwarded(command).Should().ContainSingle()
+                .Which.Should().Be("--property:Configuration=EnvironmentConfiguration");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Configuration", originalConfiguration);
+        }
+    }
+
+    [TestMethod]
+    public void ExplicitConfigurationOverridesEnvironmentVariable()
+    {
+        string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("Configuration", "EnvironmentConfiguration");
+            var command = new RootCommand();
+            var option = CommonOptions.CreateConfigurationOption("Configuration");
+            command.Options.Add(option);
+
+            var result = command.Parse(["--configuration", "ExplicitConfiguration"]);
+
+            result.GetValue(option).Should().Be("ExplicitConfiguration");
+            result.OptionValuesToBeForwarded(command).Should().ContainSingle()
+                .Which.Should().Be("--property:Configuration=ExplicitConfiguration");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Configuration", originalConfiguration);
+        }
+    }
+
+    [TestMethod]
+    public void ExplicitConfigurationPropertyOverridesEnvironmentVariable()
+    {
+        string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("Configuration", "EnvironmentConfiguration");
+            var command = new RootCommand();
+            var propertyOption = CommonOptions.CreatePropertyOption();
+            var configurationOption = CommonOptions.CreateConfigurationOption("Configuration");
+            command.Options.Add(propertyOption);
+            command.Options.Add(configurationOption);
+
+            var result = command.Parse(["--property:Configuration=PropertyConfiguration"]);
+
+            result.OptionValuesToBeForwarded(command).Should().ContainSingle()
+                .Which.Should().Be("--property:Configuration=PropertyConfiguration");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Configuration", originalConfiguration);
+        }
+    }
+
     [TestMethod]
     public void Duplicates()
     {


### PR DESCRIPTION
Addresses the `Configuration` environment-variable regression in #52358.

## Summary

- seed the shared `-c`/`--configuration` option from the `Configuration` environment variable
- ignore empty or whitespace-only environment values
- preserve precedence for an explicit `--configuration` value
- avoid rendering empty dynamic defaults as `[]` in custom help
- update CLI schema expectations for the new default factory
- add parser coverage and an end-to-end MTP solution regression test

This follows the approach suggested in the issue discussion and applies consistently to commands using the shared configuration option. A standalone `Platform` environment variable remains outside this change because there is no equivalent shared CLI option.

## Validation

- `build.cmd`
- 21 focused `dotnet.Tests` tests covering `CommonOptionsTests`, CLI schema output, MTP help, and the MTP solution regression scenario