### PR TITLE
Fix ValidatePatternBaseDir for wildcard-in-directory-name patterns

### DIFF
--- a/scripts/EvaluateConditionalTestScopes.cs
+++ b/scripts/EvaluateConditionalTestScopes.cs
@@ -323,8 +323,12 @@ static void ValidatePatternBaseDir(string repoRoot, string pattern, string conte
         return;
     }
 
-    // Get the directory portion before the first wildcard
-    var baseDir = normalized[..firstWildcard].TrimEnd('/');
+    // Get the directory portion before the first wildcard. The wildcard may appear
+    // within a path segment (e.g. "test/dotnet-format.*/**"), so trim back to the last
+    // '/' to avoid treating a partial segment name as a real directory.
+    var prefixBeforeWildcard = normalized[..firstWildcard];
+    var lastSlash = prefixBeforeWildcard.LastIndexOf('/');
+    var baseDir = lastSlash >= 0 ? prefixBeforeWildcard[..lastSlash] : "";
     if (string.IsNullOrEmpty(baseDir))
     {
         return;

--- a/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
@@ -401,6 +401,33 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     }
 
     [TestMethod]
+    public async Task Validation_WildcardInDirectoryName_ValidatesParentSegment()
+    {
+        // A wildcard can appear within a path segment (e.g. "test/dotnet-format.*/**").
+        // Validation should trim back to the last complete directory segment ("test")
+        // rather than treating the partial segment ("test/dotnet-format.") as a directory.
+        var props = """
+            <Project>
+              <ItemGroup>
+                <ConditionalTestScope Include="WildcardDirName">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/*.csproj</TestProjects>
+                  <TriggerPaths>test/dotnet-format.*/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+              </ItemGroup>
+            </Project>
+            """;
+
+        // The parent segment "test" exists, but no "test/dotnet-format." directory does.
+        using var repo = new TestRepo(props, "test");
+
+        var result = await RunScript(repo.Root, targetBranch: null, buildReason: "PullRequest");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdOut + result.StdErr);
+    }
+
+    [TestMethod]
     public async Task RenamedFile_OutOfTriggerPath_ScopeRuns()
     {
         // A file renamed OUT of a trigger path should still trigger that scope


### PR DESCRIPTION
## Summary

`ValidatePatternBaseDir` in `scripts/EvaluateConditionalTestScopes.cs` derived the base directory of a glob pattern by taking everything before the first wildcard and trimming a trailing `/`. When a wildcard appears *within* a path segment (e.g. `test/dotnet-format.*/**`), this produced a bogus base directory like `test/dotnet-format.`, which never exists on disk — causing a spurious validation error.

This change trims the prefix back to the last complete `/` boundary, so the base directory is the nearest real parent segment (`test` in the example above).

## Changes

- `scripts/EvaluateConditionalTestScopes.cs`: derive the base directory from the last `/` before the first wildcard instead of the raw prefix.
- `test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs`: add `Validation_WildcardInDirectoryName_ValidatesParentSegment` covering a `test/dotnet-format.*/**` pattern where only the parent `test` directory exists.

## Related

This issue was discovered while working on #55399 — this PR is a follow-up fix that came out of that work.