### PR TITLE
Add PartitionByClass support to Helix test scheduling

### DIFF
--- a/test/HelixTasks/AssemblyScheduler.cs
+++ b/test/HelixTasks/AssemblyScheduler.cs
@@ -193,6 +193,30 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
             return assemblyInfoList;
         }
 
+        /// <summary>
+        /// Produces one partition per schedulable public class candidate in the assembly, rather
+        /// than grouping classes together up to a method-count limit. Type discovery uses the same
+        /// heuristic as <see cref="Schedule(string, bool, bool)"/>, which may include public classes
+        /// with no directly-declared test methods (to account for inherited tests). If the assembly
+        /// contains no schedulable types, a single unpartitioned representation is returned.
+        /// </summary>
+        public IEnumerable<AssemblyPartitionInfo> PartitionByClass(string assemblyPath)
+        {
+            var typeInfoList = GetTypeInfoList(assemblyPath);
+            if (typeInfoList.Count == 0)
+            {
+                return new[] { CreateAssemblyInfo(assemblyPath) };
+            }
+
+            var assemblyName = Path.GetFileName(assemblyPath);
+            return typeInfoList
+                .Select(typeInfo => new AssemblyPartitionInfo(
+                    assemblyPath,
+                    displayName: $"{assemblyName}.{typeInfo.FullName}",
+                    classListArgumentString: $"{typeInfo.FullName}."))
+                .ToList();
+        }
+
         public AssemblyPartitionInfo CreateAssemblyInfo(string assemblyPath)
         {
             return new AssemblyPartitionInfo(assemblyPath);

--- a/test/HelixTasks/CreateHelixTestWorkItems.cs
+++ b/test/HelixTasks/CreateHelixTestWorkItems.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
         /// - [Optional] Arguments: a string of arguments to be passed to the test runner
         /// - [Optional] MethodLimitMultiplier: a positive integer multiplier applied to BaseMethodLimit
         ///   used for partitioning tests into Helix shards
+        /// - [Optional] PartitionByClass: when set to "true", bypasses the method-count scheduler and creates
+        ///   one Helix work item per schedulable public test-class candidate discovered in the assembly
         /// The two required parameters will be automatically created if TestProject.Identity is set to the path of the test csproj file
         /// </summary>
         [Required]
@@ -208,27 +210,39 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 msbuildAdditionalSdkResolverFolder = "";
             }
 
-            var methodLimit = BaseMethodLimit;
-            if (testProject.TryGetMetadata("MethodLimitMultiplier", out string multiplierStr))
+            // When PartitionByClass is "true", bypass the method-count scheduler and create one
+            // Helix work item per test class. The MethodLimitMultiplier metadata only affects
+            // method-count scheduling, so it is intentionally read only in the else branch.
+            testProject.TryGetMetadata("PartitionByClass", out string partitionByClassMetadata);
+            IEnumerable<AssemblyPartitionInfo> assemblyPartitionInfos;
+            if (string.Equals(partitionByClassMetadata, "true", StringComparison.OrdinalIgnoreCase))
             {
-                if (int.TryParse(multiplierStr, out int multiplier) && multiplier > 0)
+                assemblyPartitionInfos = new AssemblyScheduler().PartitionByClass(targetPath);
+            }
+            else
+            {
+                var methodLimit = BaseMethodLimit;
+                if (testProject.TryGetMetadata("MethodLimitMultiplier", out string multiplierStr))
                 {
-                    methodLimit *= multiplier;
+                    if (int.TryParse(multiplierStr, out int multiplier) && multiplier > 0)
+                    {
+                        methodLimit *= multiplier;
+                    }
+                    else
+                    {
+                        Log.LogWarning($"Invalid MethodLimitMultiplier \"{multiplierStr}\" for {assemblyName}; must be a positive integer. Using default method limit.");
+                    }
                 }
-                else
-                {
-                    Log.LogWarning($"Invalid MethodLimitMultiplier \"{multiplierStr}\" for {assemblyName}; must be a positive integer. Using default method limit.");
-                }
+
+                assemblyPartitionInfos = new AssemblyScheduler(methodLimit: methodLimit).Schedule(targetPath);
             }
 
-            var scheduler = new AssemblyScheduler(methodLimit: methodLimit);
-            var assemblyPartitionInfos = scheduler.Schedule(targetPath);
+            string formattedArguments = string.IsNullOrEmpty(arguments) ? "" : "-- " + arguments;
 
             var partitionedWorkItem = new List<ITaskItem>();
             foreach (var assemblyPartitionInfo in assemblyPartitionInfos)
             {
                 string enableDiagLogging = IsPosixShell ? "-d $HELIX_WORKITEM_UPLOAD_ROOT//dotnetTestLog.log" : "-d %HELIX_WORKITEM_UPLOAD_ROOT%\\dotnetTestLog.log";
-                arguments = string.IsNullOrEmpty(arguments) ? "" : "-- " + arguments;
 
                 var testFilter = string.IsNullOrEmpty(assemblyPartitionInfo.ClassListArgumentString) ? "" : $"--filter \"{assemblyPartitionInfo.ClassListArgumentString}\"";
 
@@ -322,7 +336,7 @@ namespace Microsoft.DotNet.SdkCustomHelix.Sdk
                 else
                 {
                     command = $"{additionalPayloadPreCommand}{chmodPrefix}{codesignPrefix}{driver} test {assemblyName} -e HELIX_WORK_ITEM_TIMEOUT={timeout} {testExecutionDirectory} {msbuildAdditionalSdkResolverFolder} " +
-                              $"{(TestArguments != null ? " " + TestArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout {blameHangTimeout.TotalMinutes:0}m {testFilter} {enableDiagLogging} {arguments}";
+                              $"{(TestArguments != null ? " " + TestArguments : "")} --results-directory .{Path.DirectorySeparatorChar} --logger trx --logger \"console;verbosity=detailed\" --blame-hang --blame-hang-timeout {blameHangTimeout.TotalMinutes:0}m {testFilter} {enableDiagLogging} {formattedArguments}";
                 }
 
                 Log.LogMessage($"Creating work item with properties Identity: {assemblyName}, PayloadDirectory: {publishDirectory}, Command: {command}");


### PR DESCRIPTION
## Summary

Adds a per-class Helix work-item partitioning mode to the SDK's custom Helix test scheduling.

- **`AssemblyScheduler.PartitionByClass(assemblyPath)`** — produces one `AssemblyPartitionInfo` per public test class in the assembly (rather than grouping classes together up to a method-count limit). Falls back to a single unpartitioned representation when the assembly has no schedulable types.
- **`CreateHelixTestWorkItems`** — opts a test project into per-class partitioning when it carries `PartitionByClass=true` metadata; otherwise the existing method-count scheduling is unchanged. `MethodLimitMultiplier` is only read on the method-count path.
- **Bug fix** — the trailing test `arguments` were reformatted inside the work-item `foreach`, prepending an extra `-- ` on every partition after the first. The formatting is now computed once (`formattedArguments`) before the loop.

## Validation

- `dotnet build test/HelixTasks/HelixTasks.csproj` succeeds with 0 warnings / 0 errors.

---

Required and tested by #55399; pulled into a separate PR for easier reviewability and to work incrementally.