### PR TITLE
Fix dotnetup CI builds

### DIFF
--- a/.vsts-dnup-ci.yml
+++ b/.vsts-dnup-ci.yml
@@ -157,10 +157,10 @@ extends:
           parameters:
             pool:
               name: $(DncEngInternalBuildPool)
-              image: windows.vs2022.amd64
+              image: windows.vs2026.amd64
               os: windows
               emoji: 🪟
-            helixTargetQueue: windows.amd64.vs2022.pre
+            helixTargetQueue: windows.amd64.vs2026.pre.scout
             oneESCompat:
               templateFolderName: templates-official
               publishTaskPrefix: 1ES.
@@ -194,7 +194,7 @@ extends:
           parameters:
             pool:
               name: $(DncEngInternalBuildPool)
-              image: windows.vs2022.amd64
+              image: windows.vs2026.amd64
               os: windows
             oneESCompat:
               templateFolderName: templates-official

--- a/.vsts-dnup-pr.yml
+++ b/.vsts-dnup-pr.yml
@@ -30,7 +30,7 @@ stages:
       displayName: '📏 dotnetup style check'
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022.amd64.open
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
       helixRepo: dotnet/sdk
       timeoutInMinutes: 15
@@ -61,10 +61,10 @@ stages:
     parameters:
       pool:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022.amd64.open
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
         emoji: 🪟
-      helixTargetQueue: windows.amd64.vs2022.pre.open
+      helixTargetQueue: windows.amd64.vs2026.pre.scout.open
 
   ############### LINUX ###############
   - template: /eng/pipelines/templates/jobs/dotnetup/dotnetup-tests.yml@self

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -1,17 +1,6 @@
 # Shared dotnetup acquisition helpers (architecture detection, cache freshness, download).
 . (Join-Path $PSScriptRoot 'dotnetup-shared.ps1')
 
-function Get-DotNetInstallFallbackArchitecture {
-    if (-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) {
-        $nativeArch = Get-NativeMachineArchitecture
-        if ($env:TARGET_ARCHITECTURE -ne $nativeArch) {
-            return $env:TARGET_ARCHITECTURE
-        }
-    }
-
-    return ""
-}
-
 function InitializeCustomSDKToolset {
     if ($env:TestFullMSBuild -eq "true") {
         $env:DOTNET_SDK_TEST_MSBUILD_PATH = InitializeVisualStudioMSBuild -install:$true -vsRequirements:$GlobalJson.tools.'vs-opt'
@@ -37,14 +26,33 @@ function InitializeCustomSDKToolset {
     # The following shared frameworks are only needed for testing.
     # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
     if ($env:DOTNET_INSTALL_TEST_RUNTIMES -ne 'false') {
-        $fallbackArchitecture = Get-DotNetInstallFallbackArchitecture
-        $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
-        if ([string]::IsNullOrEmpty($fallbackArchitecture)) {
-            # Also install the exact runtime versions that arcade's toolset requires
-            # (from Version.Details.props) so tests can target those specific versions.
-            $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
+        $nativeArch = Get-NativeMachineArchitecture
+        $installArch = ""
+        $installTestRuntimes = $true
+
+        if ((-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) -and ($env:TARGET_ARCHITECTURE -ne $nativeArch)) {
+            # The build targets an architecture that differs from the host machine. These shared
+            # frameworks are installed into the host .dotnet so the host can run tests against them,
+            # so they must be an architecture the host can actually execute. For a genuine
+            # cross-compile (e.g. an x64 agent building arm64) the host cannot run the
+            # target-architecture runtimes: installing them would pollute the host .dotnet with
+            # un-runnable binaries (breaking host tools such as the NuGet credential provider) and
+            # would serve no purpose, since cross-build legs do not run tests locally. Skip the
+            # install in that case. (macOS/arm64 running x64 under Rosetta 2 is handled in
+            # restore-toolset.sh; this script only runs on Windows.)
+            $installTestRuntimes = $false
+            Write-Host "Skipping test-runtime install: host architecture '$nativeArch' cannot run target architecture '$($env:TARGET_ARCHITECTURE)' runtimes on this cross-build leg."
         }
-        InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -Architecture $fallbackArchitecture
+
+        if ($installTestRuntimes) {
+            $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
+            if ([string]::IsNullOrEmpty($installArch)) {
+                # Also install the exact runtime versions that arcade's toolset requires
+                # (from Version.Details.props) so tests can target those specific versions.
+                $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
+            }
+            InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -Architecture $installArch
+        }
     }
 
     CreateBuildEnvScripts

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -31,30 +31,49 @@ function InitializeCustomSDKToolset {
   # The following shared frameworks are only needed for testing.
   # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
   if [[ "${DOTNET_INSTALL_TEST_RUNTIMES:-true}" != "false" ]]; then
-    local install_script_arch=""
     local native_arch
     native_arch=$(GetNativeMachineArchitecture)
+    local install_script_arch=""
+    local install_test_runtimes=true
+
     if [[ -n "${TARGET_ARCHITECTURE:-}" && "$TARGET_ARCHITECTURE" != "$native_arch" ]]; then
-      install_script_arch="$TARGET_ARCHITECTURE"
+      # The build targets an architecture that differs from the host machine. These
+      # shared frameworks are installed into the host .dotnet so the host can run tests
+      # against them, so they must be an architecture the host can actually execute.
+      # The only case where a host runs a different architecture is macOS on Apple
+      # Silicon, which runs x64 binaries via Rosetta 2. For a genuine cross-compile
+      # (e.g. an x64 Linux/Windows agent building arm64) the host cannot run the
+      # target-architecture runtimes: installing them would pollute the host .dotnet
+      # with un-runnable binaries (breaking host tools such as the NuGet credential
+      # provider) and would serve no purpose, since cross-build legs do not run tests
+      # locally. Skip the install in that case.
+      if [[ "$(uname)" == "Darwin" && "$native_arch" == "arm64" && "$TARGET_ARCHITECTURE" == "x64" ]]; then
+        install_script_arch="$TARGET_ARCHITECTURE"
+      else
+        install_test_runtimes=false
+        echo "Skipping test-runtime install: host architecture '$native_arch' cannot run target architecture '$TARGET_ARCHITECTURE' runtimes on this cross-build leg."
+      fi
     fi
 
-    local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
-    if [[ -z "$install_script_arch" ]]; then
-      # Also install the exact runtime versions that arcade's toolset requires
-      # (from Version.Details.props) so tests can target those specific versions.
-      local runtime_version
-      runtime_version=$(ReadVersionDetailsProperty "MicrosoftNETCoreAppRefPackageVersion")
-      local aspnetcore_version
-      aspnetcore_version=$(ReadVersionDetailsProperty "MicrosoftAspNetCoreAppRefPackageVersion")
-      if [[ -n "$runtime_version" ]]; then
-        runtime_specs+=("$runtime_version")
+    if [[ "$install_test_runtimes" == true ]]; then
+      local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
+      if [[ -z "$install_script_arch" ]]; then
+        # Also install the exact runtime versions that arcade's toolset requires
+        # (from Version.Details.props) so tests can target those specific versions.
+        local runtime_version
+        runtime_version=$(ReadVersionDetailsProperty "MicrosoftNETCoreAppRefPackageVersion")
+        local aspnetcore_version
+        aspnetcore_version=$(ReadVersionDetailsProperty "MicrosoftAspNetCoreAppRefPackageVersion")
+        if [[ -n "$runtime_version" ]]; then
+          runtime_specs+=("$runtime_version")
+        fi
+        if [[ -n "$aspnetcore_version" ]]; then
+          runtime_specs+=("aspnetcore@$aspnetcore_version")
+        fi
       fi
-      if [[ -n "$aspnetcore_version" ]]; then
-        runtime_specs+=("aspnetcore@$aspnetcore_version")
-      fi
-    fi
 
-    InstallDotNetSharedFrameworks "$install_script_arch" "${runtime_specs[@]}"
+      InstallDotNetSharedFrameworks "$install_script_arch" "${runtime_specs[@]}"
+    fi
   fi
 
   CreateBuildEnvScript


### PR DESCRIPTION
- Don't install mismatched architecture runtimes on cross-compile container builds
- Update to VS2026 images to fix LNK1322 error

https://github.com/dotnet/sdk/pull/55159 brought in changes to the repo install scripts from main which install test runtimes using the target architecture.  This breaks cross-build container builds which run in the host architecture, as you end up with a dotnet folder with a mix of architectures.

So this PR simply skips installing those test runtimes when the target architecture differs from the host architecture (except in the MacOS/Rosetta case, where the output is runnable).  Since the architectures differ the built product shouldn't be run on the same machine and those runtimes shouldn't be needed for testing anyway.

Probably these changes to the scripts should be applied to main, but I think we should check them in to release/dnup first to unblock getting updated daily builds (which stopped around July 13th).