### PR TITLE
Disable packing of Microsoft.Dotnet.Installation

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -9,12 +9,10 @@
     <!-- SYSLIB1054: Suppress for DllImport in shared NativeWrapper code we don't own -->
     <NoWarn>$(NoWarn);CS8002;CS1591;SYSLIB1054</NoWarn>
 
-    <!-- Microsoft.Dotnet.Installation is a pure managed, RID-agnostic library. In our pipelines,
-         we only want to publish one copy of it, but we have different legs for each RID to 
-         produce the nativeAOT dotnetup binary.  So we'll set IsPackable to false for all
-         but one of those legs.-->
-    <IsPackable>true</IsPackable>
-    <IsPackable Condition="'$(TargetRid)' != '' and '$(TargetRid)' != 'win-x64'">false</IsPackable>
+    <!-- Disable packaging / publishing of Microsoft.Dotnet.Installation, since it's currently
+         only consumed in-repo, and there is an arcade issue causing Maestro promotion to
+         dotnet-tools to fail. -->
+    <IsPackable>false</IsPackable>
     
     <IncludeSymbols>true</IncludeSymbols>
     <PackageId>Microsoft.Dotnet.Installation</PackageId>


### PR DESCRIPTION
There seems to be an issue with promoting packages to the dotnet-tools feed (see failure in https://dev.azure.com/dnceng/internal/_build/results?buildId=3029979&view=results).  This is preventing dotnetup daily builds from being published.  Since we don't have any external consumers of the Microsoft.Dotnet.Installation package, we can just disable packing and publishing it.