### PR TITLE
Add Native AOT infrastructure for MSBuild evaluation

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/Microsoft.DotNet.Cli.CoreUtils.csproj
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/Microsoft.DotNet.Cli.CoreUtils.csproj
@@ -11,5 +11,7 @@
     <InternalsVisibleTo Include="dotnet" />
     <InternalsVisibleTo Include="dotnet-aot" />
     <InternalsVisibleTo Include="dotnet-aot.Tests" />
+    <InternalsVisibleTo Include="Microsoft.DotNet.Cli.Utils" />
+    <InternalsVisibleTo Include="Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver" Key="$(MicrosoftSharedPublicKey)" />
   </ItemGroup>
 </Project>

--- a/src/Cli/Microsoft.DotNet.Cli.CoreUtils/SdkPaths.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CoreUtils/SdkPaths.cs
@@ -44,11 +44,13 @@ internal static class SdkPaths
     private static string? s_sdkDirectory;
 
     /// <summary>
-    ///  The versioned SDK directory, resolved once and cached. Prefers the <c>Microsoft.DotNet.Sdk.Root</c>
-    ///  AppContext value (published by the AOT bridge); otherwise the directory of the SDK assembly, else
-    ///  <see cref="System.AppContext.BaseDirectory"/>.
+    ///  The versioned SDK directory, resolved once and cached. Prefers the
+    ///  <c>Microsoft.DotNet.Sdk.Root</c> AppContext value (published by the AOT bridge); otherwise the
+    ///  directory of the SDK assembly, falling back to <see cref="System.AppContext.BaseDirectory"/>.
     /// </summary>
     public static string SdkDirectory => s_sdkDirectory ??= ResolveSdkDirectory();
+
+    internal static void ClearSdkDirectoryCacheForTests() => s_sdkDirectory = null;
 
 #if NET
     [UnconditionalSuppressMessage("AOT", "IL3000",
@@ -63,7 +65,7 @@ internal static class SdkPaths
         // value; prefer it.
         if (AppContext.GetData(DataName) is string sdkRoot && sdkRoot.Length > 0)
         {
-            return sdkRoot;
+            return TrimEndingDirectorySeparator(sdkRoot);
         }
 
         // CoreUtils ships in the versioned SDK directory, so the location of this assembly is that
@@ -71,6 +73,22 @@ internal static class SdkPaths
         // Assembly.Location is empty (which is what the IL3000 analyzer flags); fall through to
         // AppContext.BaseDirectory in that case - the AOT bridge sets the AppContext value (preferred above).
         string? assemblyDirectory = Path.GetDirectoryName(typeof(SdkPaths).Assembly.Location);
-        return string.IsNullOrEmpty(assemblyDirectory) ? AppContext.BaseDirectory : assemblyDirectory;
+        return TrimEndingDirectorySeparator(
+            string.IsNullOrEmpty(assemblyDirectory) ? AppContext.BaseDirectory : assemblyDirectory);
+    }
+
+    private static string TrimEndingDirectorySeparator(string path)
+    {
+        if (path.Length == 0)
+        {
+            return path;
+        }
+
+        string? root = Path.GetPathRoot(path);
+        char last = path[path.Length - 1];
+        return path.Length > (root?.Length ?? 0)
+            && (last == Path.DirectorySeparatorChar || last == Path.AltDirectorySeparatorChar)
+                ? path.Substring(0, path.Length - 1)
+                : path;
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -257,7 +257,7 @@ internal sealed class MSBuildForwardingAppWithoutLogging
     private static string GetMSBuildExePath()
     {
         return Path.Combine(
-            AppContext.BaseDirectory,
+            SdkPaths.SdkDirectory,
             MSBuildExeName);
     }
 
@@ -276,7 +276,7 @@ internal sealed class MSBuildForwardingAppWithoutLogging
         }
 
         return Path.Combine(
-            AppContext.BaseDirectory,
+            SdkPaths.SdkDirectory,
             SdksDirectoryName);
     }
 
@@ -295,7 +295,7 @@ internal sealed class MSBuildForwardingAppWithoutLogging
     {
         return new()
         {
-            { "MSBuildExtensionsPath", MSBuildExtensionsPathTestHook ?? Environment.GetEnvironmentVariable("MSBuildExtensionsPath") ?? AppContext.BaseDirectory },
+            { "MSBuildExtensionsPath", MSBuildExtensionsPathTestHook ?? Environment.GetEnvironmentVariable("MSBuildExtensionsPath") ?? SdkPaths.SdkDirectory },
             { "MSBuildSDKsPath", GetMSBuildSDKsPath() },
             { "DOTNET_HOST_PATH", GetDotnetPath() },
         };

--- a/src/Cli/dotnet-aot/AotDependencies.props
+++ b/src/Cli/dotnet-aot/AotDependencies.props
@@ -1,0 +1,59 @@
+<Project>
+
+  <!--
+    Dependencies and runtime configuration shared by the Native AOT product and tests.
+    Keep AotSourceFiles.props limited to source and resource inputs.
+  -->
+
+  <!-- ASP.NET Core HTTPS developer-certificate package, used by the AOT first-run path's in-process
+       dev-cert generation. When IncludeAspNetCoreRuntime is false, EXCLUDE_ASPNETCORE compiles the
+       generator body away, so the package is not needed. -->
+  <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">
+    <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" />
+  </ItemGroup>
+
+  <!--
+    MSBuild object-model support. The info command reads ProjectCollection.DisplayVersion, while
+    in-process evaluation needs Microsoft.Build.Utilities.Core for SDK property functions and the
+    NuGet SDK resolver for package-based SDK references.
+    Cli.Utils references Microsoft.Build with ExcludeAssets="runtime" / PrivateAssets="all", so it does
+    not flow transitively; reference it directly here. Microsoft.Build.Framework is also direct so its
+    trim-safe feature-switch defaults can be imported by the AOT consumer.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Framework" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Credentials" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" Condition="'$(TargetOS)' == 'windows'" />
+  </ItemGroup>
+
+  <!-- Use NuGet's source-generated System.Text.Json deserialization path and let ILC remove
+       the legacy Newtonsoft.Json deserialization path. -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
+                                    Value="true"
+                                    Trim="true" />
+  </ItemGroup>
+
+  <!-- The package's TFM-specific _._ prevents NuGet from importing its root buildTransitive target.
+       Remove this workaround when https://github.com/dotnet/msbuild/issues/14467 is fixed. -->
+  <Import Project="$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets"
+          Condition="Exists('$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets')" />
+
+  <!-- 'dotnet sdk check' command dependency. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
+  </ItemGroup>
+
+  <!-- 'dotnet sln' command dependencies. -->
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Cli.Definitions\Microsoft.DotNet.Cli.Definitions.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
+  </ItemGroup>
+
+</Project>

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -97,19 +97,35 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\dotnet\CliStrings.resx" Link="CliStrings.resx" GenerateSource="true" Namespace="Microsoft.DotNet.Cli" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\CliCommandStrings.resx" Link="CliCommandStrings.resx" GenerateSource="true" Namespace="Microsoft.DotNet.Cli.Commands" />
+    <EmbeddedResource Include="$(RepoRoot)src\Tasks\Common\Resources\Strings.resx" Link="Resources\Strings.resx" GenerateSource="true" Namespace="Microsoft.NET.Build.Tasks" />
   </ItemGroup>
 
   <!--
-    The "MSBuild version:" line of the info command: MSBuildForwardingAppWithoutLogging.MSBuildVersion
-    (in Microsoft.DotNet.Cli.Utils) reads Microsoft.Build.Evaluation.ProjectCollection.DisplayVersion,
-    so the AOT binary needs the Microsoft.Build runtime assembly for ILC to compile that path.
+    MSBuild object-model support. The info command reads ProjectCollection.DisplayVersion, while
+    in-process evaluation needs Microsoft.Build.Utilities.Core for SDK property functions and the
+    NuGet SDK resolver for package-based SDK references.
     Cli.Utils references Microsoft.Build with ExcludeAssets="runtime" / PrivateAssets="all", so it does
-    not flow transitively; reference it directly here. Microsoft.Build is only partially annotated
-    for trimming/AOT; its analysis warnings are rolled up and suppressed in dotnet-aot.csproj.
+    not flow transitively; reference it directly here. Microsoft.Build.Framework is also direct so its
+    trim-safe feature-switch defaults can be imported by the AOT consumer.
   -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Framework" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
+  <!-- Use NuGet's source-generated System.Text.Json deserialization path and let ILC remove
+       the legacy Newtonsoft.Json deserialization path. Keep this in the shared props so the
+       product and Native AOT tests compile with the same feature switch. -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
+                                    Value="true"
+                                    Trim="true" />
+  </ItemGroup>
+  <!-- The package's TFM-specific _._ prevents NuGet from importing its root buildTransitive target.
+       Remove this workaround when https://github.com/dotnet/msbuild/issues/14467 is fixed. -->
+  <Import Project="$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets"
+          Condition="Exists('$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets')" />
 
   <!--
     Workload reporting for the info command: WorkloadInfoHelper.GetWorkloadsVersion() and

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -81,7 +81,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\WorkloadInstallDetector.cs" Link="WorkloadInstallDetector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\IWorkloadInstallationRecordRepository.cs" Link="IWorkloadInstallationRecordRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\FileBasedInstallationRecordInstaller.cs" Link="FileBasedInstallationRecordInstaller.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\RegistryWorkloadInstallationRecordRepository.cs" Link="RegistryWorkloadInstallationRecordRepository.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" Link="ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Microsoft.TemplateEngine.Cli\SymbolExtensions.cs" Link="SymbolExtensions.cs" />
   </ItemGroup>
 

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -79,9 +79,11 @@
     <!-- Read-only workload install detection (no NuGet/MSBuild/crypto) used by the AOT first-run path to
          decide whether the workload integrity repair must be deferred to the managed CLI. -->
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\WorkloadInstallDetector.cs" Link="WorkloadInstallDetector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\FileBasedWorkloadInstallationRecordRepositoryFactory.cs" Link="FileBasedWorkloadInstallationRecordRepositoryFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\IWorkloadInstallationRecordRepository.cs" Link="IWorkloadInstallationRecordRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\FileBasedInstallationRecordInstaller.cs" Link="FileBasedInstallationRecordInstaller.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" Link="ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\WindowsWorkloadInstallationRecordReader.cs" Link="WindowsWorkloadInstallationRecordReader.cs" />
     <!-- Background workload advertising and SDK vulnerability updates. -->
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\IWorkloadManifestInstaller.cs" Link="IWorkloadManifestInstaller.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadManifestUpdater.cs" Link="WorkloadManifestUpdater.cs" />
@@ -123,52 +125,12 @@
     <Using Include="System.Collections.Generic.Dictionary%3CMicrosoft.NET.Sdk.WorkloadManifestReader.WorkloadId, Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadDefinition%3E" Alias="WorkloadCollection" />
   </ItemGroup>
 
-  <!-- ASP.NET Core HTTPS developer-certificate package, used by the AOT first-run path's in-process
-       dev-cert generation (AspNetCoreCertificateGenerator). Mirrors the condition in dotnet.csproj:
-       when IncludeAspNetCoreRuntime is false, EXCLUDE_ASPNETCORE is defined and the generator body
-       compiles away, so the package is not needed. -->
-  <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">
-    <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" />
-  </ItemGroup>
-
   <!-- Common AOT scaffolding: generated string resources referenced by command sources. -->
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\dotnet\CliStrings.resx" Link="CliStrings.resx" GenerateSource="true" Namespace="Microsoft.DotNet.Cli" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\CliCommandStrings.resx" Link="CliCommandStrings.resx" GenerateSource="true" Namespace="Microsoft.DotNet.Cli.Commands" />
     <EmbeddedResource Include="$(RepoRoot)src\Tasks\Common\Resources\Strings.resx" Link="Resources\Strings.resx" GenerateSource="true" Namespace="Microsoft.NET.Build.Tasks" />
   </ItemGroup>
-
-  <!--
-    MSBuild object-model support. The info command reads ProjectCollection.DisplayVersion, while
-    in-process evaluation needs Microsoft.Build.Utilities.Core for SDK property functions and the
-    NuGet SDK resolver for package-based SDK references.
-    Cli.Utils references Microsoft.Build with ExcludeAssets="runtime" / PrivateAssets="all", so it does
-    not flow transitively; reference it directly here. Microsoft.Build.Framework is also direct so its
-    trim-safe feature-switch defaults can be imported by the AOT consumer.
-  -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Framework" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <PackageReference Include="NuGet.Configuration" />
-    <PackageReference Include="NuGet.Credentials" />
-    <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="NuGet.Protocol" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" Condition="'$(TargetOS)' == 'windows'" />
-  </ItemGroup>
-  <!-- Use NuGet's source-generated System.Text.Json deserialization path and let ILC remove
-       the legacy Newtonsoft.Json deserialization path. Keep this in the shared props so the
-       product and Native AOT tests compile with the same feature switch. -->
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
-                                    Value="true"
-                                    Trim="true" />
-  </ItemGroup>
-  <!-- The package's TFM-specific _._ prevents NuGet from importing its root buildTransitive target.
-       Remove this workaround when https://github.com/dotnet/msbuild/issues/14467 is fixed. -->
-  <Import Project="$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets"
-          Condition="Exists('$(PkgMicrosoft_Build_Framework)\buildTransitive\Microsoft.Build.Framework.targets')" />
 
   <!--
     Workload reporting for the info command: WorkloadInfoHelper.GetWorkloadsVersion() and
@@ -217,11 +179,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Sdk\Check\RuntimeOutputWriter.cs" Link="Commands\Sdk\Check\RuntimeOutputWriter.cs" />
   </ItemGroup>
 
-  <!-- 'dotnet sdk check' command: command-specific dependencies. -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
-  </ItemGroup>
-
   <!-- 'dotnet sln' command: command-specific sources and helpers. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\SlnFileFactory.cs" Link="SlnFileFactory.cs" />
@@ -238,12 +195,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\CliCompletion.cs" Link="CliCompletion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Extensions\ProjectInstanceExtensions.cs" Link="Extensions\ProjectInstanceExtensions.cs" />
-  </ItemGroup>
-
-  <!-- 'dotnet sln' command: command-specific dependencies. -->
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Cli.Definitions\Microsoft.DotNet.Cli.Definitions.csproj" GlobalPropertiesToRemove="PublishDir" />
-    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
   </ItemGroup>
 
   <!--

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -191,6 +191,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Solution\Remove\SolutionRemoveCommand.cs" Link="Commands\Solution\Remove\SolutionRemoveCommand.cs" />
   </ItemGroup>
 
+  <!-- Project-backed command completions. -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\CliCompletion.cs" Link="CliCompletion.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Extensions\ProjectInstanceExtensions.cs" Link="Extensions\ProjectInstanceExtensions.cs" />
+  </ItemGroup>
+
   <!-- 'dotnet sln' command: command-specific dependencies. -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.DotNet.Cli.Definitions\Microsoft.DotNet.Cli.Definitions.csproj" GlobalPropertiesToRemove="PublishDir" />

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -82,7 +82,45 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\IWorkloadInstallationRecordRepository.cs" Link="IWorkloadInstallationRecordRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\FileBasedInstallationRecordInstaller.cs" Link="FileBasedInstallationRecordInstaller.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadInstallRecords\ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" Link="ReadOnlyWindowsWorkloadInstallationRecordRepository.cs" />
+    <!-- Background workload advertising and SDK vulnerability updates. -->
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\IWorkloadManifestInstaller.cs" Link="IWorkloadManifestInstaller.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadManifestUpdater.cs" Link="WorkloadManifestUpdater.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WorkloadAdvertisingManifestUpdater.cs" Link="WorkloadAdvertisingManifestUpdater.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\ManifestUpdateWithWorkloads.cs" Link="ManifestUpdateWithWorkloads.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\NullReporter.cs" Link="NullReporter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\FileBasedManifestInstaller.cs" Link="FileBasedManifestInstaller.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\Install\WindowsMsiManifestInstaller.cs" Link="WindowsMsiManifestInstaller.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\WorkloadUtilities.cs" Link="WorkloadUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Workload\SignCheck_Windows.cs" Link="SignCheck_Windows.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\MsiManifest.cs" Link="MsiManifest.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\MsiManifestJsonSerializerContext.cs" Link="MsiManifestJsonSerializerContext.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\MsiPackageData.cs" Link="MsiPackageData.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\RelatedProduct.cs" Link="RelatedProduct.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\UpgradeAttributes.cs" Link="UpgradeAttributes.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\ISetupLogger.cs" Link="ISetupLogger.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Installer\Windows\Security\Signature.cs" Link="Signature.cs" Condition="'$(TargetOS)' == 'windows'" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\INuGetPackageDownloader.cs" Link="INuGetPackageDownloader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\NuGetPackageDownloader.cs" Link="NuGetPackageDownloader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\NuGetPackagePathResolver.cs" Link="NuGetPackagePathResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\NuGetConsoleLogger.cs" Link="NuGetConsoleLogger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\PackageSourceLocation.cs" Link="PackageSourceLocation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\RestoreActionConfig.cs" Link="RestoreActionConfig.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\ToolPackageException.cs" Link="ToolPackageException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\WorkloadUnixFilePermissionsFileList.cs" Link="WorkloadUnixFilePermissionsFileList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\IFirstPartyNuGetPackageSigningVerifier.cs" Link="IFirstPartyNuGetPackageSigningVerifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\NugetPackageDownloader\FirstPartyNuGetPackageSigningVerifier.cs" Link="FirstPartyNuGetPackageSigningVerifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\IFilePermissionSetter.cs" Link="IFilePermissionSetter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\FilePermissionSetter.cs" Link="FilePermissionSetter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\CommandFactory\CommandFactory.cs" Link="CommandFactory\CommandFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\CommandFactory\ICommandFactory.cs" Link="CommandFactory\ICommandFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\DotNetCommandFactory.cs" Link="Commands\DotNetCommandFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\LoggerUtility.cs" Link="LoggerUtility.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\SdkVulnerability\SdkVulnerabilityNotifier.cs" Link="SdkVulnerabilityNotifier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\SdkVulnerability\SdkReleaseMetadataCache.cs" Link="SdkReleaseMetadataCache.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\SdkVulnerability\SdkVulnerabilityChecker.cs" Link="SdkVulnerabilityChecker.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\SdkVulnerability\SdkVulnerabilityInfo.cs" Link="SdkVulnerabilityInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Microsoft.TemplateEngine.Cli\SymbolExtensions.cs" Link="SymbolExtensions.cs" />
+    <Using Include="System.Collections.Generic.Dictionary%3CMicrosoft.NET.Sdk.WorkloadManifestReader.WorkloadId, Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadDefinition%3E" Alias="WorkloadCollection" />
   </ItemGroup>
 
   <!-- ASP.NET Core HTTPS developer-certificate package, used by the AOT first-run path's in-process
@@ -113,6 +151,11 @@
     <PackageReference Include="Microsoft.Build.Framework" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Credentials" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Win32.Msi\Microsoft.Win32.Msi.csproj" Condition="'$(TargetOS)' == 'windows'" />
   </ItemGroup>
   <!-- Use NuGet's source-generated System.Text.Json deserialization path and let ILC remove
        the legacy Newtonsoft.Json deserialization path. Keep this in the shared props so the

--- a/src/Cli/dotnet-aot/DESIGN.md
+++ b/src/Cli/dotnet-aot/DESIGN.md
@@ -4,22 +4,26 @@ This document describes the design for adding a NativeAOT-compiled entry point
 to the .NET SDK CLI. The goal is to achieve near-instant startup for common
 commands while preserving full functionality through the managed CLI.
 
-The current implementation uses a standalone `dn.exe` host that lives alongside
-the existing `dotnet` CLI. `dn.exe` emulates the muxer's `try_invoke_aot_sdk`
+The `dotnet` muxer invokes the Native AOT CLI through its `try_invoke_aot_sdk`
 function — see
 [dotnet/runtime#126171](https://github.com/dotnet/runtime/issues/126171). The
 muxer looks for `dotnet-aot` in the resolved SDK directory and, when found,
-calls `dotnet_execute` directly. `dn.exe` follows the same contract and serves
-as a local development and testing entry point. The AOT fast path is enabled by
-default on all platforms (see [Opting out](#opting-out-dotnet_cli_enableaot));
+calls `dotnet_execute` directly. The standalone `dn.exe` host follows the same
+contract for focused bridge development and debugging, but full redist
+`dotnet.exe` is the authoritative integration entry point. The AOT fast path is
+enabled by default on all platforms (see [Opting out](#opting-out-dotnet_cli_enableaot));
 setting `DOTNET_CLI_ENABLEAOT=false` (or `0`/`no`/`off`) opts out, and the bridge
 falls through to the managed CLI immediately.
 
 ## Opting out (`DOTNET_CLI_ENABLEAOT`)
 
-The AOT command-handling fast path is **enabled by default on all platforms**. The
-fast path is designed to be behaviorally identical to the managed CLI, transparently
-deferring to it for anything it cannot handle, so it should require no action from users.
+The AOT command-handling fast path is **enabled by default on all platforms**. It
+preserves command semantics and transparently defers to the managed CLI for unsupported
+functionality. Restore-based AOT commands run the same background workload advertising-
+manifest and SDK vulnerability-cache refreshes, and display the same workload update
+notification, as the managed CLI. The native closure contains only the workload
+advertising services; workload installation, repair, and elevated MSI IPC still defer to
+the managed CLI.
 
 If you need to bypass the AOT path entirely — for example to diagnose a suspected parity
 issue — set the `DOTNET_CLI_ENABLEAOT` environment variable to a falsy value before
@@ -47,22 +51,22 @@ debugged differently.
 
 | Layer | Project | Output | Compilation |
 |-------|---------|--------|-------------|
-| 1 — Native Host | `src/Cli/dn/` | `dn.exe` | NativeAOT (`PublishAot`, `OutputType=Exe`) |
+| 1 — Native Host | `dotnet` muxer (`src/native/corehost`) | `dotnet.exe` | Native host |
 | 2 — AOT Bridge | `src/Cli/dotnet-aot/` | `dotnet-aot.dll` / `.so` / `.dylib` | NativeAOT (`PublishAot`, `NativeLib=Shared`) |
 | 3 — Managed CLI | `src/Cli/dotnet/` | `dotnet.dll` | Standard managed build |
 
 ```mermaid
 graph TD
-    User["User runs dn.exe"] --> L1
+    User["User runs dotnet.exe"] --> L1
 
-    subgraph L1["Layer 1 · dn.exe  (Native AOT Executable)"]
-        Resolve["Resolve DOTNET_ROOT, hostfxr path"]
+    subgraph L1["Layer 1 · dotnet muxer"]
+        Resolve["Resolve SDK, DOTNET_ROOT, hostfxr path"]
         Marshal["Marshal args to native strings"]
-        PInvoke["P/Invoke: dotnet_execute()"]
-        Resolve --> Marshal --> PInvoke
+        NativeExport["Call native export: dotnet_execute()"]
+        Resolve --> Marshal --> NativeExport
     end
 
-    PInvoke -->|"DLL import"| L2
+    NativeExport --> L2
 
     subgraph L2["Layer 2 · dotnet-aot.dll  (Native AOT Shared Library)"]
         Entry["NativeEntryPoint.Execute()"]
@@ -92,11 +96,12 @@ graph TD
     style L3 fill:#2d6b3a,stroke:#27ae60,color:#fff
 ```
 
-### Layer 1 — `dn.exe` (Native Host)
+### Layer 1 — `dotnet` muxer (Native Host)
 
-A minimal NativeAOT executable whose only job is to locate the .NET installation,
-resolve `hostfxr`, marshal command-line arguments into platform-native strings,
-and call into Layer 2 via P/Invoke.
+The existing native muxer resolves the .NET installation and selected SDK, then
+loads Layer 2 and calls its native export. `src/Cli/dn` provides a smaller
+development host for debugging the same contract, but is not the end-to-end test
+harness.
 
 Key responsibilities:
 
@@ -117,8 +122,9 @@ bridge builds the
 **full** command tree (the same `DotNetCommandDefinition` used by the managed
 CLI) so that parsing and `--help` match the managed CLI exactly. Commands that
 can run entirely in AOT (`--version`, `--info`, and the AOT-capable `sln`
-subcommands) execute immediately and return. Every other built-in command is
-wired with a fallback action that throws `CommandNotAvailableInAotException`;
+subcommands) execute immediately and return.
+Every other built-in command is wired with a fallback action that throws
+`CommandNotAvailableInAotException`;
 the bridge catches it (and any unexpected parse-time failure) and transparently
 falls through to the managed CLI.
 
@@ -139,6 +145,17 @@ its full resolver set, deferral produces identical user-facing behavior. Out-of-
 process invocation only happens after a non-null spec, so a command is never
 executed twice.
 
+**MSBuild evaluation infrastructure** — The Native AOT closure includes the
+SDK-shipped workload and NuGet SDK resolvers and a reflection-free project evaluator
+that uses MSBuild's static resolver registration APIs. SDK-relative paths
+(`MSBuild.dll`, `Sdks`, `MSBuildExtensionsPath`, and the telemetry logger) come from
+`SdkPaths.SdkDirectory`, not `AppContext.BaseDirectory`. This infrastructure is
+available to command handlers but is not registered or invoked during Native AOT
+startup yet. The shared `RestoringCommand` starts workload advertising and
+vulnerability-cache maintenance in both modes. Its AOT closure reuses the existing
+NuGet downloader, file-based and administrative-MSI manifest extraction, and read-only
+workload records without linking workload install/repair or elevated MSI IPC.
+
 **Slow path** — When `DOTNET_CLI_ENABLEAOT` is disabled (`false`/`0`/`no`/`off`)
 or the AOT bridge does
 not handle the command, the bridge calls `ManagedHost.RunApp()`, which uses the
@@ -150,7 +167,7 @@ exactly as the muxer would configure it for an SDK command.
 
 ```mermaid
 sequenceDiagram
-    participant dn as dn.exe (Layer 1)
+    participant dn as dotnet muxer (Layer 1)
     participant aot as dotnet-aot.dll (Layer 2)
     participant tool as external tool / process
     participant hfxr as hostfxr
@@ -219,9 +236,11 @@ In the shared files:
   (msbuild/nuget/vstest/format/fsi) renders from AOT because those forwarding
   apps use AOT-friendly out-of-process codepaths under `#if CLI_AOT`.
 - **`ParserOptionActions.cs`** — The shared `--help`/`--version`/`--info` option
-  actions. `PrintInfoAction` uses `#if !CLI_AOT` to omit the workload and MSBuild
-  details that aren't AOT-compatible yet; the diagnostics and `--cli-schema`
-  actions are `#if !CLI_AOT` (the AOT build defers those to the managed CLI).
+  actions. `PrintInfoAction` reports the workload and MSBuild details in both modes;
+  the AOT build substitutes its runtime RID and resolved versioned SDK directory
+  where the managed implementation relies on hostfxr state. The diagnostics and
+  `--cli-schema` actions are `#if !CLI_AOT` (the AOT build defers those to the
+  managed CLI).
 
 The two projects have **different entry-point shapes and do not share a
 `Program.cs`**:
@@ -522,11 +541,9 @@ dialog (or auto-attaches in configured environments).
 
 ## Future Work
 
-- **Muxer integration** — The muxer's `try_invoke_aot_sdk` function
-  ([dotnet/runtime#126171](https://github.com/dotnet/runtime/issues/126171))
-  already calls `dotnet_execute` from the resolved SDK directory, passing
-  `host_path`, `dotnet_root`, `sdk_dir`, and `hostfxr_path`. `dn.exe`
-  emulates this same contract for local development and testing.
+- **Broaden muxer-path coverage** — Continue validating new AOT command handlers
+  through a full redist `dotnet.exe`, using `dn.exe` only for focused native-host
+  development and debugging.
 - **Remove AOT commands from managed package** — After the AOT path is
   validated and shipping, the `#if CLI_AOT` implementations in `Parser.cs`
   can be removed from the managed `dotnet.dll` build.

--- a/src/Cli/dotnet-aot/MSBuildSdkResolverRegistration.cs
+++ b/src/Cli/dotnet-aot/MSBuildSdkResolverRegistration.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver;
+using NuGetSdkResolver = Microsoft.Build.NuGetSdkResolver.NuGetSdkResolver;
+
+namespace Microsoft.DotNet.Cli;
+
+/// <summary>
+/// Registers the SDK resolvers needed by in-process MSBuild evaluations in the Native AOT CLI.
+/// </summary>
+/// <remarks>
+/// Managed MSBuild normally discovers resolver assemblies dynamically from the versioned SDK layout.
+/// Native AOT disables that reflection-based loading, so the resolver types linked into the native
+/// image must instead be registered through MSBuild's static registration API. Registration happens
+/// before the first evaluation because MSBuild snapshots the available resolvers when SDK resolution
+/// is initialized.
+/// </remarks>
+internal static class MSBuildSdkResolverRegistration
+{
+    private static readonly object s_registrationLock = new();
+    private static bool s_registered;
+
+    internal static void Register()
+    {
+        lock (s_registrationLock)
+        {
+            if (s_registered)
+            {
+                return;
+            }
+
+            // Resolves SDKs supplied by installed workload manifests.
+            SdkResolver.Register(new WorkloadSdkResolver());
+
+            // Resolves versioned, package-based SDK references through NuGet.
+            SdkResolver.Register(new NuGetSdkResolver());
+            s_registered = true;
+        }
+    }
+}

--- a/src/Cli/dotnet-aot/SdkRootResolution.md
+++ b/src/Cli/dotnet-aot/SdkRootResolution.md
@@ -63,15 +63,26 @@ the module self-locates.
   `Microsoft.DotNet.Cli.Utils`), which resolves the `Microsoft.DotNet.Sdk.Root`
   AppContext value -> the SDK assembly directory -> `AppContext.BaseDirectory` (once,
   cached). Out-of-repo code (MSBuild tasks, NuGet, the runtime) reads the
-  `Microsoft.DotNet.Sdk.Root` AppContext value first, else its existing BCL logic.
+  `Microsoft.DotNet.Sdk.Root` AppContext value first, else its existing BCL logic. The
+  workload MSBuild SDK resolver follows this contract so it can be constructed and
+  registered directly in the AOT host without relying on `Assembly.Location`.
 
-The managed CLI keeps using `AppContext.BaseDirectory`, where it is correct.
+The same forwarding code is shared by both CLIs and therefore consistently uses
+`SdkPaths.SdkDirectory`; this remains equivalent to `AppContext.BaseDirectory` in
+the normal managed SDK layout.
 
 ## Testing
 
-`dn.exe` and `run-dn.ps1` provide a separated layout that places `dotnet-aot.dll`
-in a `sdk\<version>\` subdirectory while `dn.exe` stays in the parent, mirroring the
-deployed muxer. A flat layout hides SDK-directory bugs because
-`AppContext.BaseDirectory` equals `sdk_dir` there by accident. Tests assert that
-`--info`'s `Base Path` is the SDK subdirectory in both the passed-`sdk_dir` and
-self-locate cases.
+The authoritative integration layout is produced by the full Debug redist build:
+`artifacts\bin\redist\Debug\dotnet\dotnet.exe` remains in the install root while
+`dotnet-aot.dll`, `dotnet.dll`, `MSBuild.dll`, and `Sdks\` are under
+`sdk\<version>\`. A flat layout hides SDK-directory bugs because
+`AppContext.BaseDirectory` equals `sdk_dir` there by accident. Redist validation
+must invoke that `dotnet.exe` from outside the repository so the repository
+`global.json` cannot select the bootstrap SDK.
+
+Focused Native AOT tests register the compiled-in resolvers explicitly and evaluate a
+stock `Microsoft.NET.Sdk` project against the bootstrap SDK, proving that the workload
+resolver handles the SDK's workload-locator imports through `SdkResolver.Register`
+without reflective plugin loading. Command handlers do not activate this evaluator in
+the shipping Native AOT entry point yet.

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -38,6 +38,12 @@
     <!-- Ignore checking for OS API compatibility as we aren't targeting just the Windows platform  -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
 
+    <!-- NuGet's AOT feature switch is configured in AotSourceFiles.props. NuGet.Packaging still
+         exposes Newtonsoft.Json-backed runtime-model APIs in the SDK resolver closure, while the
+         runtime dynamic assemblies also produce AOT rollups. Keep dependency rollups visible but
+         non-fatal; first-party IL warnings and all other warning codes remain errors. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2104;IL3053</WarningsNotAsErrors>
+
     <!--
       Enable control flow guard
       https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
@@ -62,6 +68,7 @@
 
   <ItemGroup>
     <Compile Include="NativeEntryPoint.cs" />
+    <Compile Include="MSBuildSdkResolverRegistration.cs" />
     <Compile Include="SdkRootLocator.cs" />
     <Compile Include="ManagedHost.cs" />
   </ItemGroup>
@@ -78,6 +85,9 @@
     <!-- Lean (Releases + System.Text.Json) reader providing SdkFeatureBand / WorkloadInstallType for
          the in-process, read-only workload install detection (WorkloadInstallDetector). -->
     <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <!-- Registered directly with MSBuild during AOT startup so workload-locator SDK imports do not
+         require reflection-based resolver discovery. -->
+    <ProjectReference Include="..\..\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" GlobalPropertiesToRemove="PublishDir" />
   </ItemGroup>
 
   <ItemGroup>
@@ -90,21 +100,6 @@
   <!-- Azure Monitor dependencies aren't part of source build yet - see file://../../../Directory.Build.props#L85 for details -->
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
-  </ItemGroup>
-
-  <!--
-    Select the System.Text.Json source-generated deserialization path in the NuGet client
-    libraries (NuGet.Packaging, NuGet.ProjectModel, NuGet.Configuration, etc.) instead of the
-    reflection-based Newtonsoft.Json path, which is not trim- or AOT-safe.
-
-    NuGet defines this as a [FeatureSwitchDefinition], so Trim="true" tells the trimmer/ILC the
-    value is a compile-time constant. That lets it dead-code-eliminate the Newtonsoft.Json branch
-    and avoid IL2026/IL2104/IL3050/IL3053 warnings when publishing this AOT binary.
-  -->
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="NuGet.UseSystemTextJsonDeserialization"
-                                    Value="true"
-                                    Trim="true" />
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)common\native\LocateNativeCompiler.targets"

--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -38,12 +38,6 @@
     <!-- Ignore checking for OS API compatibility as we aren't targeting just the Windows platform  -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
 
-    <!-- NuGet's AOT feature switch is configured in AotSourceFiles.props. NuGet.Packaging still
-         exposes Newtonsoft.Json-backed runtime-model APIs in the SDK resolver closure, while the
-         runtime dynamic assemblies also produce AOT rollups. Keep dependency rollups visible but
-         non-fatal; first-party IL warnings and all other warning codes remain errors. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2104;IL3053</WarningsNotAsErrors>
-
     <!--
       Enable control flow guard
       https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
@@ -64,6 +58,7 @@
     <UseCommonLocateNativeCompilerTarget Condition="'$(NativeAotSupported)' == 'true' and !$(TargetRid.StartsWith('win'))">true</UseCommonLocateNativeCompilerTarget>
   </PropertyGroup>
 
+  <Import Project="AotDependencies.props" />
   <Import Project="AotSourceFiles.props" />
 
   <ItemGroup>

--- a/src/Cli/dotnet/Commands/DotNetCommandFactory.cs
+++ b/src/Cli/dotnet/Commands/DotNetCommandFactory.cs
@@ -48,6 +48,7 @@ public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string? curre
         return false;
     }
 
+#if !CLI_AOT
     internal static CommandBase CreateVirtualOrPhysicalCommand(
         System.CommandLine.Command commandDefinition,
         Argument<string[]> catchAllUserInputArgument,
@@ -137,4 +138,5 @@ public class DotNetCommandFactory(bool alwaysRunOutOfProc = false, string? curre
             yield return arg;
         }
     }
+#endif
 }

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -51,7 +51,7 @@ public class MSBuildForwardingApp : CommandBase
 #else
                 string loggerTypeFullName = "Microsoft.DotNet.Cli.Commands.MSBuild.MSBuildLogger";
                 string forwardingLoggerTypeFullName = "Microsoft.DotNet.Cli.Commands.MSBuild.MSBuildForwardingLogger";
-                string loggerTypeLocation = Path.Combine(AppContext.BaseDirectory, "dotnet.dll");
+                string loggerTypeLocation = Path.Combine(SdkPaths.SdkDirectory, "dotnet.dll");
                 string forwardingLoggerTypeLocation = loggerTypeLocation;
 #endif
 

--- a/src/Cli/dotnet/Commands/Workload/FileBasedWorkloadInstallationRecordRepositoryFactory.cs
+++ b/src/Cli/dotnet/Commands/Workload/FileBasedWorkloadInstallationRecordRepositoryFactory.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload;
+
+/// <summary>
+///  Builds a <see cref="FileBasedInstallationRecordRepository"/> for a given dotnet root without
+///  needing the full workload installer.
+///
+///  <para>
+///  Shared by <see cref="WorkloadInstallDetector"/>, the CLI_AOT construction path of
+///  <see cref="WorkloadInfoHelper"/>, and the lightweight background advertising-manifest updater,
+///  so the file-based-versus-user-local layout logic is defined in exactly one place.
+///  </para>
+/// </summary>
+internal static class FileBasedWorkloadInstallationRecordRepositoryFactory
+{
+    /// <summary>
+    ///  Equivalent to <see cref="WorkloadFileBasedInstall.IsUserLocal(string, string)"/>, inlined here
+    ///  to avoid pulling in that type's workload-history helpers, which are not needed for read-only
+    ///  record lookup.
+    /// </summary>
+    public static bool IsUserLocal(string dotnetDir, SdkFeatureBand sdkFeatureBand)
+        => File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand.ToString(), "userlocal"));
+
+    /// <summary>
+    ///  Constructs the file-based installation record repository for <paramref name="sdkFeatureBand"/>,
+    ///  choosing between the user-profile and dotnet-root metadata locations the same way
+    ///  <see cref="Install.FileBasedInstaller"/> does.
+    /// </summary>
+    public static FileBasedInstallationRecordRepository Create(string dotnetDir, SdkFeatureBand sdkFeatureBand, string userProfileDir)
+    {
+        var workloadRootDir = IsUserLocal(dotnetDir, sdkFeatureBand) ? userProfileDir : dotnetDir;
+        return new FileBasedInstallationRecordRepository(Path.Combine(workloadRootDir, "metadata", "workloads"));
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/FileBasedInstaller.cs
@@ -41,6 +41,7 @@ internal class FileBasedInstaller : IInstaller
     private readonly FileBasedInstallationRecordRepository _installationRecordRepository;
     private readonly PackageSourceLocation _packageSourceLocation;
     private readonly RestoreActionConfig _restoreActionConfig;
+    private readonly FileBasedManifestInstaller _manifestInstaller;
 
     public int ExitCode => 0;
 
@@ -75,6 +76,7 @@ internal class FileBasedInstaller : IInstaller
         _workloadResolver = workloadResolver;
         _installationRecordRepository = new FileBasedInstallationRecordRepository(_workloadMetadataDir);
         _packageSourceLocation = packageSourceLocation;
+        _manifestInstaller = new FileBasedManifestInstaller(_nugetPackageDownloader, _tempPackagesDir);
     }
 
     public IWorkloadInstallationRecordRepository GetWorkloadInstallationRecordRepository()
@@ -650,44 +652,10 @@ internal class FileBasedInstaller : IInstaller
     }
 
     public PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand)
-    {
-        if (manifestId.ToString().Equals("Microsoft.NET.Workloads", StringComparison.OrdinalIgnoreCase))
-        {
-            return new PackageId($"{manifestId}.{featureBand}");
-        }
-        else
-        {
-            return new PackageId($"{manifestId}.Manifest-{featureBand}");
-        }
-    }
+        => _manifestInstaller.GetManifestPackageId(manifestId, featureBand);
 
-    public async Task ExtractManifestAsync(string nupkgPath, string targetPath)
-    {
-        var extractionPath = Path.Combine(_tempPackagesDir.Value, "dotnet-sdk-advertising-temp", $"{Path.GetFileName(nupkgPath)}-extracted");
-        if (Directory.Exists(extractionPath))
-        {
-            Directory.Delete(extractionPath, true);
-        }
-
-        try
-        {
-            Directory.CreateDirectory(extractionPath);
-            await _nugetPackageDownloader.ExtractPackageAsync(nupkgPath, new DirectoryPath(extractionPath));
-            if (Directory.Exists(targetPath))
-            {
-                Directory.Delete(targetPath, true);
-            }
-            Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
-            FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(Path.Combine(extractionPath, "data"), targetPath));
-        }
-        finally
-        {
-            if (!string.IsNullOrEmpty(extractionPath) && Directory.Exists(extractionPath))
-            {
-                Directory.Delete(extractionPath, true);
-            }
-        }
-    }
+    public Task ExtractManifestAsync(string nupkgPath, string targetPath)
+        => _manifestInstaller.ExtractManifestAsync(nupkgPath, targetPath);
 
     private bool PackIsInstalled(PackInfo packInfo)
     {

--- a/src/Cli/dotnet/Commands/Workload/Install/FileBasedManifestInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/FileBasedManifestInstaller.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+/// <summary>
+///  The <see cref="IWorkloadManifestInstaller"/> behavior for file-based (non-MSI) workload installs:
+///  computing the NuGet package ID that carries a manifest/workload-set, and extracting the "data"
+///  directory of a downloaded manifest package to the advertising/installed manifest location.
+///
+///  <para>
+///  Extracted out of <see cref="FileBasedInstaller"/> so this narrow, dependency-light behavior can be
+///  shared by the full file-based installer and by lightweight consumers - such as the background
+///  advertising-manifest updater - that only need to resolve/extract manifest packages and must not
+///  pull in the rest of <see cref="FileBasedInstaller"/> (pack installation, transactions, workload
+///  records, etc.).
+///  </para>
+/// </summary>
+internal class FileBasedManifestInstaller(INuGetPackageDownloader nugetPackageDownloader, DirectoryPath tempPackagesDir) : IWorkloadManifestInstaller
+{
+    public PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand)
+    {
+        if (manifestId.ToString().Equals(WorkloadManifestUpdater.WorkloadSetManifestId, StringComparison.OrdinalIgnoreCase))
+        {
+            return new PackageId($"{manifestId}.{featureBand}");
+        }
+        else
+        {
+            return new PackageId($"{manifestId}.Manifest-{featureBand}");
+        }
+    }
+
+    public async Task ExtractManifestAsync(string nupkgPath, string targetPath)
+    {
+        var extractionPath = Path.Combine(tempPackagesDir.Value, "dotnet-sdk-advertising-temp", $"{Path.GetFileName(nupkgPath)}-extracted");
+        if (Directory.Exists(extractionPath))
+        {
+            Directory.Delete(extractionPath, true);
+        }
+
+        try
+        {
+            Directory.CreateDirectory(extractionPath);
+            await nugetPackageDownloader.ExtractPackageAsync(nupkgPath, new DirectoryPath(extractionPath));
+            if (Directory.Exists(targetPath))
+            {
+                Directory.Delete(targetPath, true);
+            }
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(Path.Combine(extractionPath, "data"), targetPath));
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(extractionPath) && Directory.Exists(extractionPath))
+            {
+                Directory.Delete(extractionPath, true);
+            }
+        }
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/IInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/IInstaller.cs
@@ -63,15 +63,6 @@ internal interface IInstaller : IWorkloadManifestInstaller
     void RecordWorkloadSetInGlobalJson(SdkFeatureBand sdkFeatureBand, string globalJsonPath, string workloadSetVersion);
 }
 
-// Interface to pass to workload manifest updater
-internal interface IWorkloadManifestInstaller
-{
-    PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand);
-
-    //  Extract the contents of the manifest (IE what's in the data directory in the file-based NuGet package) to the targetPath
-    Task ExtractManifestAsync(string nupkgPath, string targetPath);
-}
-
 public class WorkloadDownload(string id, string nuGetPackageId, string nuGetPackageVersion)
 {
     /// <summary>

--- a/src/Cli/dotnet/Commands/Workload/Install/IWorkloadManifestInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/IWorkloadManifestInstaller.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+internal interface IWorkloadManifestInstaller
+{
+    PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand);
+
+    Task ExtractManifestAsync(string nupkgPath, string targetPath);
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/IWorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/IWorkloadManifestUpdater.cs
@@ -27,5 +27,3 @@ internal interface IWorkloadManifestUpdater
 
     void DeleteUpdatableWorkloadsFile();
 }
-
-internal record ManifestUpdateWithWorkloads(ManifestVersionUpdate ManifestUpdate, WorkloadCollection Workloads);

--- a/src/Cli/dotnet/Commands/Workload/Install/ManifestUpdateWithWorkloads.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/ManifestUpdateWithWorkloads.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+internal record ManifestUpdateWithWorkloads(ManifestVersionUpdate ManifestUpdate, WorkloadCollection Workloads);

--- a/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/NetSdkMsiInstallerClient.cs
@@ -37,6 +37,8 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
 
     private readonly string _dependent;
 
+    private readonly WindowsMsiManifestInstaller _manifestInstaller;
+
     public int ExitCode => Restart ? unchecked((int)Error.SUCCESS_REBOOT_REQUIRED) : unchecked((int)Error.SUCCESS);
 
     /// <summary>
@@ -59,6 +61,7 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
         _sdkFeatureBand = sdkFeatureBand;
         _workloadResolver = workloadResolver;
         _dependent = $"{DependentPrefix},{sdkFeatureBand},{HostArchitecture}";
+        _manifestInstaller = new WindowsMsiManifestInstaller(_nugetPackageDownloader, Log, LogError);
 
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
@@ -736,92 +739,10 @@ internal partial class NetSdkMsiInstallerClient : MsiInstallerBase, IInstaller
     }
 
     public PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand)
-    {
-        if (manifestId.ToString().Equals("Microsoft.NET.Workloads", StringComparison.OrdinalIgnoreCase))
-        {
-            return new PackageId($"{manifestId}.{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}");
-        }
-        else
-        {
-            return new PackageId($"{manifestId}.Manifest-{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}");
-        }
-    }
+        => _manifestInstaller.GetManifestPackageId(manifestId, featureBand);
 
-    private static readonly object _msiAdminInstallLock = new();
-
-    public async Task ExtractManifestAsync(string nupkgPath, string targetPath)
-    {
-        Log?.LogMessage($"ExtractManifestAsync: Extracting '{nupkgPath}' to '{targetPath}'");
-        string extractionPath = TemporaryDirectory.CreateSubdirectory();
-
-        try
-        {
-            Log?.LogMessage($"ExtractManifestAsync: Temporary extraction path: '{extractionPath}'");
-            await _nugetPackageDownloader.ExtractPackageAsync(nupkgPath, new DirectoryPath(extractionPath));
-            if (Directory.Exists(targetPath))
-            {
-                Directory.Delete(targetPath, true);
-            }
-
-            string extractedManifestPath = Path.Combine(extractionPath, "data", "extractedManifest");
-            if (Directory.Exists(extractedManifestPath))
-            {
-                Log?.LogMessage($"ExtractManifestAsync: Copying manifest from '{extractionPath}' to '{targetPath}'");
-                Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
-                FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(extractedManifestPath, targetPath));
-            }
-            else
-            {
-                string packageDataPath = Path.Combine(extractionPath, "data");
-                if (!Cache.TryGetMsiPathFromPackageData(packageDataPath, out string msiPath, out _))
-                {
-                    throw new FileNotFoundException(string.Format(CliCommandStrings.ManifestMsiNotFoundInNuGetPackage, extractionPath));
-                }
-                string msiExtractionPath = Path.Combine(extractionPath, "msi");
-
-
-                lock (_msiAdminInstallLock)
-                {
-                    string adminInstallLog = GetMsiLogNameForAdminInstall(msiPath);
-
-                    Log?.LogMessage($"ExtractManifestAsync: Running admin install for '{msiExtractionPath}'.  Log file: '{adminInstallLog}'");
-
-                    ConfigureInstall(adminInstallLog);
-
-                    var result = WindowsInstaller.InstallProduct(msiPath, $"TARGETDIR={msiExtractionPath} ACTION=ADMIN");
-
-                    if (result != Error.SUCCESS)
-                    {
-                        Log?.LogMessage($"ExtractManifestAsync: Admin install failed: {result}");
-                        throw new GracefulException(string.Format(CliCommandStrings.FailedToExtractMsi, msiPath));
-                    }
-                }
-
-                var manifestsFolder = Path.Combine(msiExtractionPath, "dotnet", "sdk-manifests");
-
-                string manifestFolder = null;
-                string manifestsFeatureBandFolder = Directory.GetDirectories(manifestsFolder).SingleOrDefault();
-                if (manifestsFeatureBandFolder != null)
-                {
-                    manifestFolder = Directory.GetDirectories(manifestsFeatureBandFolder).SingleOrDefault();
-                }
-
-                if (manifestFolder == null)
-                {
-                    throw new GracefulException(string.Format(CliCommandStrings.ExpectedSingleManifest, nupkgPath));
-                }
-
-                FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(manifestFolder, targetPath));
-            }
-        }
-        finally
-        {
-            if (!string.IsNullOrEmpty(extractionPath) && Directory.Exists(extractionPath))
-            {
-                Directory.Delete(extractionPath, true);
-            }
-        }
-    }
+    public Task ExtractManifestAsync(string nupkgPath, string targetPath)
+        => _manifestInstaller.ExtractManifestAsync(nupkgPath, targetPath);
 
     private void LogPackInfo(PackInfo packInfo)
     {

--- a/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Runtime.Versioning;
+using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+using Microsoft.DotNet.Cli.Installer.Windows;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.Win32.Msi;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+/// <summary>
+///  The <see cref="IWorkloadManifestInstaller"/> behavior for MSI-based workload installs: computing
+///  the architecture-qualified NuGet package ID that carries a manifest/workload-set MSI, and
+///  extracting it via an administrative MSI install (<c>ACTION=ADMIN</c>), which unpacks the MSI's
+///  file layout to the target path without installing/registering anything on the machine.
+///
+///  <para>
+///  Extracted out of <see cref="NetSdkMsiInstallerClient"/> so this narrow behavior can be shared by
+///  the full MSI installer and by lightweight consumers - such as the background advertising-manifest
+///  updater - that only need to resolve/extract manifest packages and must not pull in the rest of
+///  <see cref="NetSdkMsiInstallerClient"/> (pack installation, elevation-driven IPC, garbage collection,
+///  etc.). Notably, extraction here never calls <c>Elevate()</c>/the IPC dispatcher: the admin install
+///  below runs in-process using whatever privileges the current process already has.
+///  </para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal class WindowsMsiManifestInstaller(
+    INuGetPackageDownloader nugetPackageDownloader,
+    ISetupLogger? log = null,
+    Action<uint, string>? logError = null) : IWorkloadManifestInstaller
+{
+    private static readonly object s_msiAdminInstallLock = new();
+
+    /// <summary>
+    ///  Builds a <see cref="WindowsMsiManifestInstaller"/> (and a matching read-only-oriented
+    ///  <see cref="IWorkloadInstallationRecordRepository"/>) for lightweight consumers - such as the
+    ///  background advertising-manifest updater - that need MSI-based manifest package resolution and
+    ///  extraction without the full <see cref="NetSdkMsiInstallerClient"/> (pack installation, elevated
+    ///  garbage collection, etc.).
+    ///
+    ///  <para>
+    ///  This path constructs no logger, package cache, elevation context, or IPC client. It reads the
+    ///  MSI payload description directly from the downloaded package and uses the in-process
+    ///  administrative extraction path when necessary.
+    ///  </para>
+    /// </summary>
+    public static WindowsMsiManifestInstaller CreateForAdvertisingManifestUpdates(
+        INuGetPackageDownloader nugetPackageDownloader,
+        out IWorkloadInstallationRecordRepository workloadRecordRepo)
+    {
+        workloadRecordRepo = new ReadOnlyWindowsWorkloadInstallationRecordRepository();
+        return new WindowsMsiManifestInstaller(nugetPackageDownloader);
+    }
+
+    /// <summary>
+    ///  <see langword="true"/> if the most recent <see cref="ExtractManifestAsync(string, string)"/>
+    ///  call observed an MSI reboot-required/initiated result while configuring install logging. Only
+    ///  updated when no <paramref name="logError"/> callback was supplied (i.e. for standalone callers
+    ///  with no restart state of their own to update); callers that pass their own <c>LogError</c>
+    ///  method (like <see cref="NetSdkMsiInstallerClient"/>) update their own restart state instead, to
+    ///  preserve the previous in-class behavior exactly.
+    /// </summary>
+    public bool RestartRequired { get; private set; }
+
+    public PackageId GetManifestPackageId(ManifestId manifestId, SdkFeatureBand featureBand)
+    {
+        if (manifestId.ToString().Equals(WorkloadManifestUpdater.WorkloadSetManifestId, StringComparison.OrdinalIgnoreCase))
+        {
+            return new PackageId($"{manifestId}.{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}");
+        }
+        else
+        {
+            return new PackageId($"{manifestId}.Manifest-{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}");
+        }
+    }
+
+    public async Task ExtractManifestAsync(string nupkgPath, string targetPath)
+    {
+        log?.LogMessage($"ExtractManifestAsync: Extracting '{nupkgPath}' to '{targetPath}'");
+        string extractionPath = TemporaryDirectory.CreateSubdirectory();
+
+        try
+        {
+            log?.LogMessage($"ExtractManifestAsync: Temporary extraction path: '{extractionPath}'");
+            await nugetPackageDownloader.ExtractPackageAsync(nupkgPath, new DirectoryPath(extractionPath));
+            if (Directory.Exists(targetPath))
+            {
+                Directory.Delete(targetPath, true);
+            }
+
+            string extractedManifestPath = Path.Combine(extractionPath, "data", "extractedManifest");
+            if (Directory.Exists(extractedManifestPath))
+            {
+                log?.LogMessage($"ExtractManifestAsync: Copying manifest from '{extractionPath}' to '{targetPath}'");
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(extractedManifestPath, targetPath));
+            }
+            else
+            {
+                string packageDataPath = Path.Combine(extractionPath, "data");
+                if (!MsiPackageData.TryGetMsiPath(packageDataPath, out string? msiPath, out _, message => log?.LogMessage(message)))
+                {
+                    throw new FileNotFoundException(string.Format(CliCommandStrings.ManifestMsiNotFoundInNuGetPackage, extractionPath));
+                }
+                string resolvedMsiPath = msiPath!;
+                string msiExtractionPath = Path.Combine(extractionPath, "msi");
+
+                lock (s_msiAdminInstallLock)
+                {
+                    string adminInstallLog = GetMsiLogNameForAdminInstall(resolvedMsiPath);
+
+                    log?.LogMessage($"ExtractManifestAsync: Running admin install for '{msiExtractionPath}'.  Log file: '{adminInstallLog}'");
+
+                    ConfigureInstall(adminInstallLog);
+
+                    var result = WindowsInstaller.InstallProduct(resolvedMsiPath, $"TARGETDIR={msiExtractionPath} ACTION=ADMIN");
+
+                    if (result != Error.SUCCESS)
+                    {
+                        log?.LogMessage($"ExtractManifestAsync: Admin install failed: {result}");
+                        throw new GracefulException(string.Format(CliCommandStrings.FailedToExtractMsi, resolvedMsiPath));
+                    }
+                }
+
+                var manifestsFolder = Path.Combine(msiExtractionPath, "dotnet", "sdk-manifests");
+
+                string? manifestFolder = null;
+                string? manifestsFeatureBandFolder = Directory.GetDirectories(manifestsFolder).SingleOrDefault();
+                if (manifestsFeatureBandFolder != null)
+                {
+                    manifestFolder = Directory.GetDirectories(manifestsFeatureBandFolder).SingleOrDefault();
+                }
+
+                if (manifestFolder == null)
+                {
+                    throw new GracefulException(string.Format(CliCommandStrings.ExpectedSingleManifest, nupkgPath));
+                }
+
+                FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(manifestFolder, targetPath));
+            }
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(extractionPath) && Directory.Exists(extractionPath))
+            {
+                Directory.Delete(extractionPath, true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Equivalent to <see cref="MsiInstallerBase.GetMsiLogNameForAdminInstall(string)"/>.
+    /// </summary>
+    private string GetMsiLogNameForAdminInstall(string msiPath)
+    {
+        if (string.IsNullOrWhiteSpace(log?.LogPath))
+        {
+            return Path.Combine(
+                Path.GetTempPath(),
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Microsoft.NET.Workload_{Environment.ProcessId}_{DateTime.Now:yyyyMMdd_HHmmss_fff}_{Path.GetFileNameWithoutExtension(msiPath)}_AdminInstall.log"));
+        }
+
+        return Path.Combine(Path.GetDirectoryName(log!.LogPath)!,
+            Path.GetFileNameWithoutExtension(log.LogPath) + $"_{Path.GetFileNameWithoutExtension(msiPath)}_AdminInstall.log");
+    }
+
+    /// <summary>
+    ///  Equivalent to <see cref="MsiInstallerBase.ConfigureInstall(string)"/>.
+    /// </summary>
+    private void ConfigureInstall(string logFile)
+    {
+        string validatedLogFile = WindowsUtils.ValidateLogFilePath(logFile);
+
+        // Turn off the MSI UI.
+        _ = WindowsInstaller.SetInternalUI(InstallUILevel.None);
+
+        // The log file must be created before calling MsiEnableLog and we should avoid having active handles
+        // against it.
+        FileStream logFileStream = File.Create(validatedLogFile);
+        logFileStream.Close();
+        uint error = WindowsInstaller.EnableLog(InstallLogMode.DEFAULT | InstallLogMode.VERBOSE, validatedLogFile, InstallLogAttributes.NONE);
+
+        // We can report issues with the log file creation, but shouldn't fail the workload operation.
+        // Prefer the caller-supplied LogError (e.g. NetSdkMsiInstallerClient's, which updates its own
+        // Restart property) so behavior is identical to before extraction; fall back to the local
+        // bookkeeping below for standalone callers that have no restart state of their own.
+        if (logError is not null)
+        {
+            logError(error, $"Failed to configure log file: {validatedLogFile}");
+        }
+        else
+        {
+            LogError(error, $"Failed to configure log file: {validatedLogFile}");
+        }
+    }
+
+    /// <summary>
+    ///  Equivalent to <see cref="MsiInstallerBase.LogError(uint, string)"/>, tracking restart state
+    ///  locally in <see cref="RestartRequired"/> instead of a shared installer-wide property. Only used
+    ///  when no <paramref name="logError"/> callback was supplied to the constructor.
+    /// </summary>
+    private void LogError(uint error, string message)
+    {
+        if (!Error.Success(error))
+        {
+            log?.LogMessage($"{message} Error: 0x{error:x8}.");
+        }
+
+        RestartRequired |= error == Error.SUCCESS_REBOOT_INITIATED || error == Error.SUCCESS_REBOOT_REQUIRED;
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
@@ -178,7 +178,13 @@ internal class WindowsMsiManifestInstaller(
     /// </summary>
     private void ConfigureInstall(string logFile)
     {
+#if CLI_AOT
+        // The AOT advertising path creates this log under Path.GetTempPath() and has no elevated IPC
+        // caller; WindowsUtils validation depends on trusted temp-directory state owned by the full installer.
+        string validatedLogFile = Path.GetFullPath(logFile);
+#else
         string validatedLogFile = WindowsUtils.ValidateLogFilePath(logFile);
+#endif
 
         // Turn off the MSI UI.
         _ = WindowsInstaller.SetInternalUI(InstallUILevel.None);

--- a/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WindowsMsiManifestInstaller.cs
@@ -94,12 +94,12 @@ internal class WindowsMsiManifestInstaller(
             {
                 Directory.Delete(targetPath, true);
             }
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
 
             string extractedManifestPath = Path.Combine(extractionPath, "data", "extractedManifest");
             if (Directory.Exists(extractedManifestPath))
             {
                 log?.LogMessage($"ExtractManifestAsync: Copying manifest from '{extractionPath}' to '{targetPath}'");
-                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
                 FileAccessRetrier.RetryOnMoveAccessFailure(() => DirectoryPath.MoveDirectory(extractedManifestPath, targetPath));
             }
             else

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
 
 /// <summary>
 ///  Advertising-manifest behavior shared between the managed workload commands (via
-///  <see cref="WorkloadManifestUpdater"/>) and, eventually, a NativeAOT closure: background
+///  <see cref="WorkloadManifestUpdater"/>) and the NativeAOT closure: background
 ///  disable/interval/sentinel handling, checking for newer manifest packages, downloading/extracting
 ///  advertising manifests, serializing/deleting the "updatable workloads" file used to display the
 ///  update notification, workload-set mode, and the overlay/update calculations used by

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
@@ -1,0 +1,376 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+using Microsoft.DotNet.Cli.Commands.Workload.List;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli.Utils.Extensions;
+using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+/// <summary>
+///  Advertising-manifest behavior shared between the managed workload commands (via
+///  <see cref="WorkloadManifestUpdater"/>) and, eventually, a NativeAOT closure: background
+///  disable/interval/sentinel handling, checking for newer manifest packages, downloading/extracting
+///  advertising manifests, serializing/deleting the "updatable workloads" file used to display the
+///  update notification, workload-set mode, and the overlay/update calculations used by
+///  <c>dotnet workload list</c>/<c>update</c>.
+///
+///  <para>
+///  This type intentionally has no dependency on <see cref="WorkloadInstallerFactory"/>,
+///  <see cref="FileBasedInstaller"/>, or <see cref="NetSdkMsiInstallerClient"/> - only the narrow
+///  abstractions (<see cref="IWorkloadResolver"/>, <see cref="INuGetPackageDownloader"/>,
+///  <see cref="IWorkloadInstallationRecordRepository"/>, <see cref="IWorkloadManifestInstaller"/>) it
+///  needs to do its work, so it (and its background-update entry point) can eventually be compiled into
+///  a NativeAOT closure that never links the full workload installer or Windows MSI elevation/IPC.
+///  </para>
+///
+///  Rollback, workload-set-from-history, and other install-command-specific manifest computations are
+///  intentionally NOT part of this type; they remain on <see cref="WorkloadManifestUpdater"/>.
+/// </summary>
+internal class WorkloadAdvertisingManifestUpdater(
+    IReporter reporter,
+    IWorkloadResolver workloadResolver,
+    INuGetPackageDownloader nugetPackageDownloader,
+    string userProfileDir,
+    IWorkloadInstallationRecordRepository workloadRecordRepo,
+    IWorkloadManifestInstaller workloadManifestInstaller,
+    PackageSourceLocation? packageSourceLocation = null,
+    Func<string, string?>? getEnvironmentVariable = null,
+    bool displayManifestUpdates = true,
+    SdkFeatureBand? sdkFeatureBand = null)
+{
+    private readonly IReporter _reporter = reporter;
+    private readonly IWorkloadResolver _workloadResolver = workloadResolver;
+    private readonly INuGetPackageDownloader _nugetPackageDownloader = nugetPackageDownloader;
+    private readonly SdkFeatureBand _sdkFeatureBand = sdkFeatureBand ?? new SdkFeatureBand(workloadResolver.GetSdkFeatureBand());
+    private readonly string _userProfileDir = userProfileDir;
+    private readonly PackageSourceLocation? _packageSourceLocation = packageSourceLocation;
+    private readonly Func<string, string?> _getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
+    private readonly IWorkloadInstallationRecordRepository _workloadRecordRepo = workloadRecordRepo;
+    private readonly IWorkloadManifestInstaller _workloadManifestInstaller = workloadManifestInstaller;
+    private readonly bool _displayManifestUpdates = displayManifestUpdates;
+
+    public async Task UpdateAdvertisingManifestsAsync(bool includePreviews, bool useWorkloadSets = false, DirectoryPath? offlineCache = null)
+    {
+        if (useWorkloadSets)
+        {
+            await UpdateManifestWithVersionAsync(WorkloadManifestUpdater.WorkloadSetManifestId, includePreviews, _sdkFeatureBand, null, offlineCache);
+        }
+        else
+        {
+            // this updates all the manifests
+            var manifests = _workloadResolver.GetInstalledManifests();
+            await Task.WhenAll(manifests.Select(manifest => UpdateAdvertisingManifestAsync(manifest, includePreviews, offlineCache))).ConfigureAwait(false);
+            WriteUpdatableWorkloadsFile();
+        }
+    }
+
+    public async Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync()
+    {
+        if (!BackgroundUpdatesAreDisabled() &&
+            AdManifestSentinelIsDueForUpdate() &&
+            UpdatedAdManifestPackagesExistAsync().GetAwaiter().GetResult())
+        {
+            await UpdateAdvertisingManifestsAsync(false, ShouldUseWorkloadSetMode(_sdkFeatureBand, _userProfileDir));
+            var sentinelPath = GetAdvertisingManifestSentinelPath(_sdkFeatureBand);
+            if (File.Exists(sentinelPath))
+            {
+                File.SetLastAccessTime(sentinelPath, DateTime.Now);
+            }
+            else
+            {
+                File.Create(sentinelPath).Close();
+            }
+        }
+    }
+
+    public static bool ShouldUseWorkloadSetMode(SdkFeatureBand sdkFeatureBand, string dotnetDir)
+    {
+        string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, dotnetDir), "default.json");
+        var installStateContents = File.Exists(path) ? InstallStateContents.FromString(File.ReadAllText(path)) : new InstallStateContents();
+        return installStateContents.ShouldUseWorkloadSets();
+    }
+
+    private void WriteUpdatableWorkloadsFile()
+    {
+        var installedWorkloads = _workloadRecordRepo.GetInstalledWorkloads(_sdkFeatureBand);
+        var updatableWorkloads = GetUpdatableWorkloadsToAdvertise(installedWorkloads);
+        var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
+        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
+        if (Directory.Exists(Path.GetDirectoryName(filePath)))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        }
+        File.WriteAllText(filePath, jsonContent);
+    }
+
+    public void DeleteUpdatableWorkloadsFile()
+    {
+        var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    public string? GetAdvertisedWorkloadSetVersion()
+    {
+        var advertisedPath = GetAdvertisingManifestPath(_sdkFeatureBand, new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId));
+        var workloadSetVersionFilePath = Path.Combine(advertisedPath, Constants.workloadSetVersionFileName);
+        if (File.Exists(workloadSetVersionFilePath))
+        {
+            return File.ReadAllText(workloadSetVersionFilePath);
+        }
+        return null;
+    }
+
+    public IEnumerable<ManifestUpdateWithWorkloads> CalculateManifestUpdates()
+    {
+        var currentManifestIds = GetInstalledManifestIds();
+        foreach (var manifestId in currentManifestIds)
+        {
+            var advertisingInfo = GetAdvertisingManifestVersionAndWorkloads(manifestId);
+            if (advertisingInfo == null)
+            {
+                continue;
+            }
+
+            var (installedVersion, installedBand) = GetInstalledManifestVersion(manifestId);
+            var ((adVersion, adBand), adWorkloads) = advertisingInfo.Value;
+            if (adVersion.CompareTo(installedVersion) > 0 && adBand.Equals(installedBand) ||
+                adBand.CompareTo(installedBand) > 0)
+            {
+                var update = new ManifestVersionUpdate(manifestId, adVersion, adBand.ToString());
+                yield return new(update, adWorkloads);
+            }
+        }
+    }
+
+    public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads)
+    {
+        try
+        {
+#if TARGET_WINDOWS
+            if (OperatingSystem.IsWindows())
+            {
+                //  Also advertise updates for workloads installed by Visual Studio
+                InstalledWorkloadsCollection installedVSWorkloads = new InstalledWorkloadsCollection();
+                VisualStudioWorkloads.GetInstalledWorkloads(_workloadResolver, installedVSWorkloads, _sdkFeatureBand);
+                installedWorkloads = [.. installedWorkloads.Concat(installedVSWorkloads.AsEnumerable().Select(kvp => new WorkloadId(kvp.Key))).Distinct()];
+            }
+#endif
+
+            var overlayProvider = new TempDirectoryWorkloadManifestProvider(Path.Combine(_userProfileDir, "sdk-advertising", _sdkFeatureBand.ToString()), _sdkFeatureBand.ToString());
+            var advertisingManifestResolver = _workloadResolver.CreateOverlayResolver(overlayProvider);
+            return _workloadResolver.GetUpdatedWorkloads(advertisingManifestResolver, installedWorkloads);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private IEnumerable<ManifestId> GetInstalledManifestIds() => _workloadResolver.GetInstalledManifests().Select(manifest => new ManifestId(manifest.Id));
+
+    private async Task<bool> UpdateManifestWithVersionAsync(
+        string id,
+        bool includePreviews,
+        SdkFeatureBand band,
+        NuGetVersion? packageVersion = null,
+        DirectoryPath? offlineCache = null)
+    {
+        var manifestId = new ManifestId(id);
+        string? packagePath = null;
+        try
+        {
+            var manifestPackageId = _workloadManifestInstaller.GetManifestPackageId(manifestId, band);
+            try
+            {
+                // If an offline cache is present, use that. Otherwise, try to acquire the package online.
+                packagePath = offlineCache != null ?
+                    Directory.GetFiles(offlineCache.Value.Value)
+                        .Where(path =>
+                        path.EndsWith(".nupkg") &&
+                        Path.GetFileName(path).StartsWith(manifestPackageId.ToString(), StringComparison.OrdinalIgnoreCase) &&
+                        (packageVersion == null || path.Contains(packageVersion.ToString())))
+                        .Max() :
+                    await _nugetPackageDownloader.DownloadPackageAsync(manifestPackageId, packageVersion: packageVersion, packageSourceLocation: _packageSourceLocation, includePreview: includePreviews);
+            }
+            catch (NuGetPackageNotFoundException)
+            {
+            }
+
+            if (packagePath is null)
+            {
+                return false;
+            }
+
+            var adManifestPath = GetAdvertisingManifestPath(_sdkFeatureBand, manifestId);
+            await _workloadManifestInstaller.ExtractManifestAsync(packagePath, adManifestPath);
+
+            // add file that contains the advertised manifest feature band so GetAdvertisingManifestVersionAndWorkloads will use correct feature band, regardless of if rollback occurred or not
+            File.WriteAllText(Path.Combine(adManifestPath, "AdvertisedManifestFeatureBand.txt"), band.ToString());
+
+            if (id.Equals(WorkloadManifestUpdater.WorkloadSetManifestId))
+            {
+                // Create version file later used as part of installing the workload set in the file-based installer and in the msi-based installer
+                using PackageArchiveReader packageReader = new(packagePath);
+                var downloadedPackageVersion = packageReader.NuspecReader.GetVersion();
+                if (packageVersion != null && !downloadedPackageVersion.Equals(packageVersion))
+                {
+                    throw new NuGetPackageNotFoundException($"Requested workload version {packageVersion} of {id} but found version {downloadedPackageVersion} instead.");
+                }
+
+                var workloadSetVersion = band.GetWorkloadSetPackageVersion(downloadedPackageVersion.ToString());
+                File.WriteAllText(Path.Combine(adManifestPath, Constants.workloadSetVersionFileName), workloadSetVersion);
+            }
+
+            if (_displayManifestUpdates)
+            {
+                _reporter.WriteLine(CliCommandStrings.AdManifestUpdated, manifestId);
+            }
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            _reporter.WriteLine(CliCommandStrings.FailedAdManifestUpdate, manifestId, e.Message);
+            return false;
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(packagePath) && File.Exists(packagePath) && (offlineCache == null || !offlineCache.HasValue))
+            {
+                File.Delete(packagePath);
+            }
+            if (!string.IsNullOrEmpty(packagePath) && (offlineCache == null || !offlineCache.HasValue))
+            {
+                var versionDir = Path.GetDirectoryName(packagePath);
+
+                if (Directory.Exists(versionDir) && !Directory.GetFileSystemEntries(versionDir).Any())
+                {
+                    Directory.Delete(versionDir);
+                    var idDir = Path.GetDirectoryName(versionDir);
+                    if (Directory.Exists(idDir) && !Directory.GetFileSystemEntries(idDir).Any())
+                    {
+                        Directory.Delete(idDir);
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task UpdateAdvertisingManifestAsync(WorkloadManifestInfo manifest, bool includePreviews, DirectoryPath? offlineCache = null)
+    {
+        var fallbackFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
+        // The bands should be checked in the order defined here.
+        SdkFeatureBand[] bands = [_sdkFeatureBand, fallbackFeatureBand];
+        foreach (var band in bands.Distinct())
+        {
+            if (await UpdateManifestWithVersionAsync(manifest.Id, includePreviews, band, null, offlineCache))
+            {
+                return;
+            }
+        }
+
+        _reporter.WriteLine(CliCommandStrings.AdManifestPackageDoesNotExist, manifest.Id);
+    }
+
+    private (ManifestVersionWithBand ManifestWithBand, WorkloadCollection Workloads)? GetAdvertisingManifestVersionAndWorkloads(ManifestId manifestId)
+    {
+        var manifestPath = Path.Combine(GetAdvertisingManifestPath(_sdkFeatureBand, manifestId), "WorkloadManifest.json");
+        if (!File.Exists(manifestPath))
+        {
+            return null;
+        }
+
+        using FileStream fsSource = new(manifestPath, FileMode.Open, FileAccess.Read);
+        var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId.ToString(), fsSource, manifestPath);
+        // we need to know the feature band of the advertised manifest (read it from the AdvertisedManifestFeatureBand.txt file)
+        // if we don't find the file then use the current feature band
+        var adManifestFeatureBandPath = Path.Combine(GetAdvertisingManifestPath(_sdkFeatureBand, manifestId), "AdvertisedManifestFeatureBand.txt");
+
+        SdkFeatureBand adManifestFeatureBand = _sdkFeatureBand;
+        if (File.Exists(adManifestFeatureBandPath))
+        {
+            adManifestFeatureBand = new SdkFeatureBand(File.ReadAllText(adManifestFeatureBandPath));
+        }
+
+        ManifestVersionWithBand manifestWithBand = new(new ManifestVersion(manifest.Version), adManifestFeatureBand);
+        var workloads = manifest.Workloads.Values.OfType<WorkloadDefinition>().ToDictionary(w => w.Id);
+        return (manifestWithBand, workloads);
+    }
+
+    private ManifestVersionWithBand GetInstalledManifestVersion(ManifestId manifestId)
+    {
+        return new(new ManifestVersion(_workloadResolver.GetManifestVersion(manifestId.ToString())), new SdkFeatureBand(_workloadResolver.GetManifestFeatureBand(manifestId.ToString())));
+    }
+
+    private bool BackgroundUpdatesAreDisabled() => bool.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE), out var disableEnvVar) && disableEnvVar;
+
+    private bool AdManifestSentinelIsDueForUpdate()
+    {
+        var sentinelPath = GetAdvertisingManifestSentinelPath(_sdkFeatureBand);
+        if (!int.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS), out int updateIntervalHours))
+        {
+            updateIntervalHours = 24;
+        }
+
+        if (File.Exists(sentinelPath))
+        {
+            var lastAccessTime = File.GetLastAccessTime(sentinelPath);
+            if (lastAccessTime.AddHours(updateIntervalHours) > DateTime.Now)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> UpdatedAdManifestPackagesExistAsync()
+    {
+        var manifests = GetInstalledManifestIds();
+        //  TODO: This doesn't seem to account for differing feature bands
+        var availableUpdates = await Task.WhenAll(manifests.Select(manifest => NewerManifestPackageExists(manifest))).ConfigureAwait(false);
+        return availableUpdates.Any();
+    }
+
+    private async Task<bool> NewerManifestPackageExists(ManifestId manifest)
+    {
+        try
+        {
+            var currentVersion = NuGetVersion.Parse(_workloadResolver.GetManifestVersion(manifest.ToString()));
+            var latestVersion = await _nugetPackageDownloader.GetLatestPackageVersion(_workloadManifestInstaller.GetManifestPackageId(manifest, _sdkFeatureBand));
+            return latestVersion > currentVersion;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private string GetAdvertisingManifestSentinelPath(SdkFeatureBand featureBand) => Path.Combine(_userProfileDir, $".workloadAdvertisingManifestSentinel{featureBand}");
+
+    private string GetAdvertisingWorkloadsFilePath(SdkFeatureBand featureBand) => GetAdvertisingWorkloadsFilePath(_userProfileDir, featureBand);
+
+    internal static string GetAdvertisingWorkloadsFilePath(string userProfileDir, SdkFeatureBand featureBand) => Path.Combine(userProfileDir, $".workloadAdvertisingUpdates{featureBand}");
+
+    private string GetAdvertisingManifestPath(SdkFeatureBand featureBand, ManifestId manifestId) => Path.Combine(_userProfileDir, "sdk-advertising", featureBand.ToString(), manifestId.ToString());
+}
+
+internal record ManifestVersionWithBand(ManifestVersion Version, SdkFeatureBand Band);
+
+[JsonSerializable(typeof(string[]))]
+internal partial class WorkloadManifestUpdaterJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadAdvertisingManifestUpdater.cs
@@ -80,9 +80,11 @@ internal class WorkloadAdvertisingManifestUpdater(
     {
         if (!BackgroundUpdatesAreDisabled() &&
             AdManifestSentinelIsDueForUpdate() &&
-            UpdatedAdManifestPackagesExistAsync().GetAwaiter().GetResult())
+            await UpdatedAdManifestPackagesExistAsync().ConfigureAwait(false))
         {
-            await UpdateAdvertisingManifestsAsync(false, ShouldUseWorkloadSetMode(_sdkFeatureBand, _userProfileDir));
+            await UpdateAdvertisingManifestsAsync(
+                false,
+                ShouldUseWorkloadSetMode(_sdkFeatureBand, _userProfileDir)).ConfigureAwait(false);
             var sentinelPath = GetAdvertisingManifestSentinelPath(_sdkFeatureBand);
             if (File.Exists(sentinelPath))
             {
@@ -108,10 +110,7 @@ internal class WorkloadAdvertisingManifestUpdater(
         var updatableWorkloads = GetUpdatableWorkloadsToAdvertise(installedWorkloads);
         var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
         var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
-        if (Directory.Exists(Path.GetDirectoryName(filePath)))
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
-        }
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
         File.WriteAllText(filePath, jsonContent);
     }
 

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/ReadOnlyWindowsWorkloadInstallationRecordRepository.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/ReadOnlyWindowsWorkloadInstallationRecordRepository.cs
@@ -40,30 +40,3 @@ internal sealed class ReadOnlyWindowsWorkloadInstallationRecordRepository : IWor
     public void DeleteWorkloadInstallationRecord(WorkloadId workloadId, SdkFeatureBand sdkFeatureBand)
         => throw new NotSupportedException();
 }
-
-#if NETCOREAPP
-[SupportedOSPlatform("windows")]
-#endif
-internal static class WindowsWorkloadInstallationRecordReader
-{
-    internal static IEnumerable<SdkFeatureBand> GetFeatureBandsWithInstallationRecords(RegistryKey baseKey, string basePath)
-    {
-        using RegistryKey? key = baseKey.OpenSubKey(basePath);
-
-        return key is null
-            ? Enumerable.Empty<SdkFeatureBand>()
-            : [.. (from string name in key.GetSubKeyNames()
-                   let subkey = key.OpenSubKey(name)
-                   where subkey is not null && subkey.GetSubKeyNames().Length > 0
-                   select new SdkFeatureBand(name))];
-    }
-
-    internal static IEnumerable<WorkloadId> GetInstalledWorkloads(
-        RegistryKey baseKey,
-        string basePath,
-        SdkFeatureBand sdkFeatureBand)
-    {
-        using RegistryKey? workloadKey = baseKey.OpenSubKey(Path.Combine(basePath, $"{sdkFeatureBand}"));
-        return workloadKey?.GetSubKeyNames().Select(id => new WorkloadId(id)).ToList() ?? Enumerable.Empty<WorkloadId>();
-    }
-}

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/ReadOnlyWindowsWorkloadInstallationRecordRepository.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/ReadOnlyWindowsWorkloadInstallationRecordRepository.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.Win32;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+
+#if NETCOREAPP
+[SupportedOSPlatform("windows")]
+#endif
+internal sealed class ReadOnlyWindowsWorkloadInstallationRecordRepository : IWorkloadInstallationRecordRepository
+{
+    private static readonly string s_hostArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+    private readonly RegistryKey _baseKey;
+    private readonly string _basePath;
+
+    internal ReadOnlyWindowsWorkloadInstallationRecordRepository()
+        : this(Registry.LocalMachine, @$"SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\{s_hostArchitecture}")
+    {
+    }
+
+    internal ReadOnlyWindowsWorkloadInstallationRecordRepository(RegistryKey baseKey, string basePath)
+    {
+        _baseKey = baseKey;
+        _basePath = basePath;
+    }
+
+    public IEnumerable<SdkFeatureBand> GetFeatureBandsWithInstallationRecords()
+        => WindowsWorkloadInstallationRecordReader.GetFeatureBandsWithInstallationRecords(_baseKey, _basePath);
+
+    public IEnumerable<WorkloadId> GetInstalledWorkloads(SdkFeatureBand sdkFeatureBand)
+        => WindowsWorkloadInstallationRecordReader.GetInstalledWorkloads(_baseKey, _basePath, sdkFeatureBand);
+
+    public void WriteWorkloadInstallationRecord(WorkloadId workloadId, SdkFeatureBand sdkFeatureBand)
+        => throw new NotSupportedException();
+
+    public void DeleteWorkloadInstallationRecord(WorkloadId workloadId, SdkFeatureBand sdkFeatureBand)
+        => throw new NotSupportedException();
+}
+
+#if NETCOREAPP
+[SupportedOSPlatform("windows")]
+#endif
+internal static class WindowsWorkloadInstallationRecordReader
+{
+    internal static IEnumerable<SdkFeatureBand> GetFeatureBandsWithInstallationRecords(RegistryKey baseKey, string basePath)
+    {
+        using RegistryKey? key = baseKey.OpenSubKey(basePath);
+
+        return key is null
+            ? Enumerable.Empty<SdkFeatureBand>()
+            : [.. (from string name in key.GetSubKeyNames()
+                   let subkey = key.OpenSubKey(name)
+                   where subkey is not null && subkey.GetSubKeyNames().Length > 0
+                   select new SdkFeatureBand(name))];
+    }
+
+    internal static IEnumerable<WorkloadId> GetInstalledWorkloads(
+        RegistryKey baseKey,
+        string basePath,
+        SdkFeatureBand sdkFeatureBand)
+    {
+        using RegistryKey? workloadKey = baseKey.OpenSubKey(Path.Combine(basePath, $"{sdkFeatureBand}"));
+        return workloadKey?.GetSubKeyNames().Select(id => new WorkloadId(id)).ToList() ?? Enumerable.Empty<WorkloadId>();
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/WindowsWorkloadInstallationRecordReader.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadInstallRecords/WindowsWorkloadInstallationRecordReader.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using Microsoft.Win32;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+
+#if NETCOREAPP
+[SupportedOSPlatform("windows")]
+#endif
+internal static class WindowsWorkloadInstallationRecordReader
+{
+    internal static IEnumerable<SdkFeatureBand> GetFeatureBandsWithInstallationRecords(RegistryKey baseKey, string basePath)
+    {
+        using RegistryKey? key = baseKey.OpenSubKey(basePath);
+        if (key is null)
+        {
+            return [];
+        }
+
+        List<SdkFeatureBand> featureBands = [];
+        foreach (string name in key.GetSubKeyNames())
+        {
+            using RegistryKey? subkey = key.OpenSubKey(name);
+            if (subkey is not null && subkey.GetSubKeyNames().Length > 0)
+            {
+                featureBands.Add(new SdkFeatureBand(name));
+            }
+        }
+
+        return featureBands;
+    }
+
+    internal static IEnumerable<WorkloadId> GetInstalledWorkloads(
+        RegistryKey baseKey,
+        string basePath,
+        SdkFeatureBand sdkFeatureBand)
+    {
+        using RegistryKey? workloadKey = baseKey.OpenSubKey(Path.Combine(basePath, $"{sdkFeatureBand}"));
+        return workloadKey?.GetSubKeyNames().Select(id => new WorkloadId(id)).ToList() ?? [];
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.Managed.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.Managed.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli.Utils.Extensions;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
+
+internal partial class WorkloadManifestUpdater : IWorkloadManifestUpdater
+{
+    private readonly IReporter _reporter;
+    private readonly IWorkloadResolver _workloadResolver;
+    private readonly INuGetPackageDownloader _nugetPackageDownloader;
+    private readonly SdkFeatureBand _sdkFeatureBand;
+    private readonly PackageSourceLocation? _packageSourceLocation;
+    private readonly IWorkloadManifestInstaller _workloadManifestInstaller;
+    private readonly WorkloadAdvertisingManifestUpdater _advertisingUpdater;
+
+    public WorkloadManifestUpdater(
+        IReporter reporter,
+        IWorkloadResolver workloadResolver,
+        INuGetPackageDownloader nugetPackageDownloader,
+        string userProfileDir,
+        IWorkloadInstallationRecordRepository workloadRecordRepo,
+        IWorkloadManifestInstaller workloadManifestInstaller,
+        PackageSourceLocation? packageSourceLocation = null,
+        Func<string, string?>? getEnvironmentVariable = null,
+        bool displayManifestUpdates = true,
+        SdkFeatureBand? sdkFeatureBand = null)
+    {
+        _reporter = reporter;
+        _workloadResolver = workloadResolver;
+        _nugetPackageDownloader = nugetPackageDownloader;
+        _sdkFeatureBand = sdkFeatureBand ?? new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
+        _packageSourceLocation = packageSourceLocation;
+        _workloadManifestInstaller = workloadManifestInstaller;
+        _advertisingUpdater = new WorkloadAdvertisingManifestUpdater(
+            reporter,
+            workloadResolver,
+            nugetPackageDownloader,
+            userProfileDir,
+            workloadRecordRepo,
+            workloadManifestInstaller,
+            packageSourceLocation,
+            getEnvironmentVariable,
+            displayManifestUpdates,
+            _sdkFeatureBand);
+    }
+
+    public Task UpdateAdvertisingManifestsAsync(
+        bool includePreviews,
+        bool useWorkloadSets = false,
+        DirectoryPath? offlineCache = null)
+        => _advertisingUpdater.UpdateAdvertisingManifestsAsync(includePreviews, useWorkloadSets, offlineCache);
+
+    public Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync()
+        => _advertisingUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
+
+    public void DeleteUpdatableWorkloadsFile()
+        => _advertisingUpdater.DeleteUpdatableWorkloadsFile();
+
+    public string? GetAdvertisedWorkloadSetVersion()
+        => _advertisingUpdater.GetAdvertisedWorkloadSetVersion();
+
+    public IEnumerable<ManifestUpdateWithWorkloads> CalculateManifestUpdates()
+        => _advertisingUpdater.CalculateManifestUpdates();
+
+    public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads)
+        => _advertisingUpdater.GetUpdatableWorkloadsToAdvertise(installedWorkloads);
+
+    public IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(
+        string rollbackDefinitionFilePath,
+        WorkloadHistoryRecorder? recorder = null)
+    {
+        var currentManifestIds = GetInstalledManifestIds();
+        var manifestRollbacks = ParseRollbackDefinitionFile(rollbackDefinitionFilePath, _sdkFeatureBand);
+
+        if (recorder is not null)
+        {
+            recorder.HistoryRecord.RollbackFileContents = manifestRollbacks.ToDictionary(
+                kvp => kvp.Id.ToString(),
+                kvp => kvp.ManifestWithBand.Version + "/" + kvp.ManifestWithBand.Band);
+        }
+
+        var unrecognizedManifestIds = manifestRollbacks.Where(rollbackManifest => !currentManifestIds.Contains(rollbackManifest.Id));
+        if (unrecognizedManifestIds.Any())
+        {
+            _reporter.WriteLine(string.Format(
+                CliCommandStrings.RollbackDefinitionContainsExtraneousManifestIds,
+                rollbackDefinitionFilePath,
+                string.Join(" ", unrecognizedManifestIds)).Yellow());
+            manifestRollbacks = manifestRollbacks.Where(rollbackManifest => currentManifestIds.Contains(rollbackManifest.Id));
+        }
+
+        return CalculateManifestRollbacks(manifestRollbacks);
+    }
+
+    private static IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(
+        IEnumerable<(ManifestId Id, ManifestVersionWithBand ManifestWithBand)> versionUpdates)
+    {
+        return versionUpdates.Select(manifest =>
+        {
+            var (id, (version, band)) = manifest;
+            return new ManifestVersionUpdate(id, version, band.ToString());
+        });
+    }
+
+    public async Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(
+        bool includePreviews,
+        SdkFeatureBand providedSdkFeatureBand,
+        SdkFeatureBand installedSdkFeatureBand)
+    {
+        var downloads = new List<WorkloadDownload>();
+        foreach (var manifest in _workloadResolver.GetInstalledManifests())
+        {
+            try
+            {
+                PackageId? providedPackageId = null;
+                var fallbackFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
+                SdkFeatureBand[] bands = [providedSdkFeatureBand, installedSdkFeatureBand, fallbackFeatureBand];
+                var success = false;
+
+                foreach (var band in bands.Distinct())
+                {
+                    var packageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), band);
+                    providedPackageId ??= packageId;
+
+                    try
+                    {
+                        var latestVersion = await _nugetPackageDownloader.GetLatestPackageVersion(
+                            packageId,
+                            _packageSourceLocation,
+                            includePreviews);
+                        success = true;
+                        downloads.Add(new WorkloadDownload(manifest.Id, packageId.ToString(), latestVersion.ToString()));
+                        break;
+                    }
+                    catch (NuGetPackageNotFoundException)
+                    {
+                    }
+                }
+
+                if (!success)
+                {
+                    _reporter.WriteLine(CliCommandStrings.ManifestPackageUrlNotResolved, providedPackageId);
+                }
+            }
+            catch
+            {
+                _reporter.WriteLine(CliCommandStrings.ManifestPackageUrlNotResolved, manifest.Id);
+            }
+        }
+
+        return downloads;
+    }
+
+    private IEnumerable<ManifestId> GetInstalledManifestIds()
+        => _workloadResolver.GetInstalledManifests().Select(manifest => new ManifestId(manifest.Id));
+
+    public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesFromHistory(WorkloadHistoryState state)
+    {
+        return state.ManifestVersions.Select(
+            m => new ManifestVersionUpdate(
+                new ManifestId(m.Key),
+                new ManifestVersion(m.Value.Split('/')[0]),
+                m.Value.Split('/')[1]));
+    }
+
+    public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet)
+    {
+        return CalculateManifestRollbacks(
+            workloadSet.ManifestVersions.Select(
+                kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand))));
+    }
+
+    private static IEnumerable<(ManifestId Id, ManifestVersionWithBand ManifestWithBand)> ParseRollbackDefinitionFile(
+        string rollbackDefinitionFilePath,
+        SdkFeatureBand featureBand)
+    {
+        string fileContent;
+
+        if (Uri.TryCreate(rollbackDefinitionFilePath, UriKind.Absolute, out var rollbackUri) && !rollbackUri.IsFile)
+        {
+            using HttpClient httpClient = new();
+            fileContent = httpClient.GetStringAsync(rollbackDefinitionFilePath).Result;
+        }
+        else if (File.Exists(rollbackDefinitionFilePath))
+        {
+            fileContent = File.ReadAllText(rollbackDefinitionFilePath);
+        }
+        else
+        {
+            throw new ArgumentException(string.Format(
+                CliCommandStrings.RollbackDefinitionFileDoesNotExist,
+                rollbackDefinitionFilePath));
+        }
+
+        var versions = WorkloadSet.FromJson(fileContent, featureBand).ManifestVersions;
+        return versions.Select(kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand)));
+    }
+}

--- a/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
+++ b/src/Cli/dotnet/Commands/Workload/Install/WorkloadManifestUpdater.cs
@@ -4,65 +4,37 @@
 #nullable disable
 
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
-using Microsoft.DotNet.Cli.Commands.Workload.List;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
-using NuGet.Packaging;
-using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.Commands.Workload.Install;
 
-internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
+/// <summary>
+///  Shared background advertising-manifest entry points used by both the managed and Native AOT CLI.
+///  The managed <see cref="IWorkloadManifestUpdater"/> implementation is in the managed-only partial.
+/// </summary>
+internal partial class WorkloadManifestUpdater
 {
     public static readonly string WorkloadSetManifestId = "Microsoft.NET.Workloads";
 
-    private readonly IReporter _reporter;
-    private readonly IWorkloadResolver _workloadResolver;
-    private readonly INuGetPackageDownloader _nugetPackageDownloader;
-    private readonly SdkFeatureBand _sdkFeatureBand;
-    private readonly string _userProfileDir;
-    private readonly PackageSourceLocation _packageSourceLocation;
-    private readonly Func<string, string> _getEnvironmentVariable;
-    private readonly IWorkloadInstallationRecordRepository _workloadRecordRepo;
-    private readonly IWorkloadManifestInstaller _workloadManifestInstaller;
-    private readonly bool _displayManifestUpdates;
-
-    public WorkloadManifestUpdater(IReporter reporter,
-        IWorkloadResolver workloadResolver,
-        INuGetPackageDownloader nugetPackageDownloader,
-        string userProfileDir,
-        IWorkloadInstallationRecordRepository workloadRecordRepo,
-        IWorkloadManifestInstaller workloadManifestInstaller,
-        PackageSourceLocation packageSourceLocation = null,
-        Func<string, string> getEnvironmentVariable = null,
-        bool displayManifestUpdates = true,
-        SdkFeatureBand? sdkFeatureBand = null)
-    {
-        _reporter = reporter;
-        _workloadResolver = workloadResolver;
-        _userProfileDir = userProfileDir;
-        _nugetPackageDownloader = nugetPackageDownloader;
-        _sdkFeatureBand = sdkFeatureBand ?? new SdkFeatureBand(_workloadResolver.GetSdkFeatureBand());
-        _packageSourceLocation = packageSourceLocation;
-        _getEnvironmentVariable = getEnvironmentVariable ?? Environment.GetEnvironmentVariable;
-        _workloadRecordRepo = workloadRecordRepo;
-        _workloadManifestInstaller = workloadManifestInstaller;
-        _displayManifestUpdates = displayManifestUpdates;
-    }
-
-    private static WorkloadManifestUpdater GetInstance(string userProfileDir)
+    /// <summary>
+    ///  Builds the narrow set of dependencies the background advertising-manifest update needs, without
+    ///  going through <see cref="WorkloadInstallerFactory"/> (i.e. without constructing the full
+    ///  <see cref="FileBasedInstaller"/>/<see cref="NetSdkMsiInstallerClient"/> installer or, on Windows,
+    ///  any elevated MSI IPC).
+    /// </summary>
+    private static WorkloadAdvertisingManifestUpdater GetAdvertisingUpdaterInstance(string userProfileDir)
     {
         var reporter = new NullReporter();
         var dotnetPath = Path.GetDirectoryName(Environment.ProcessPath);
         var sdkVersion = Product.Version;
+        var sdkFeatureBand = new SdkFeatureBand(sdkVersion);
         var workloadManifestProvider = new SdkDirectoryWorkloadManifestProvider(dotnetPath, sdkVersion, userProfileDir, SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(Environment.CurrentDirectory));
         var workloadResolver = WorkloadResolver.Create(workloadManifestProvider, dotnetPath, sdkVersion, userProfileDir);
         var tempPackagesDir = new DirectoryPath(TemporaryDirectory.CreateSubdirectory());
@@ -76,40 +48,37 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
             verifySignatures,
             reporter: reporter);
 
-        var installer = WorkloadInstallerFactory.GetWorkloadInstaller(
-            reporter,
-            new SdkFeatureBand(sdkVersion),
-            workloadResolver,
-            VerbosityOptions.normal,
-            userProfileDir,
-            verifyMsiSignature: false);
+        IWorkloadManifestInstaller manifestInstaller;
+        IWorkloadInstallationRecordRepository workloadRecordRepo;
 
-        var workloadRecordRepo = installer.GetWorkloadInstallationRecordRepository();
-
-        return new WorkloadManifestUpdater(reporter, workloadResolver, nugetPackageDownloader, userProfileDir, workloadRecordRepo, installer);
-    }
-
-    public async Task UpdateAdvertisingManifestsAsync(bool includePreviews, bool useWorkloadSets = false, DirectoryPath? offlineCache = null)
-    {
-        if (useWorkloadSets)
+        if (WorkloadInstallType.GetWorkloadInstallType(sdkFeatureBand, dotnetPath) == InstallType.Msi)
         {
-            await UpdateManifestWithVersionAsync("Microsoft.NET.Workloads", includePreviews, _sdkFeatureBand, null, offlineCache);
+#if !TARGET_WINDOWS
+            throw new InvalidOperationException(CliCommandStrings.OSDoesNotSupportMsi);
+#else
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new InvalidOperationException(CliCommandStrings.OSDoesNotSupportMsi);
+            }
+
+            manifestInstaller = WindowsMsiManifestInstaller.CreateForAdvertisingManifestUpdates(nugetPackageDownloader, out workloadRecordRepo);
+#endif
         }
         else
         {
-            // this updates all the manifests
-            var manifests = _workloadResolver.GetInstalledManifests();
-            await Task.WhenAll(manifests.Select(manifest => UpdateAdvertisingManifestAsync(manifest, includePreviews, offlineCache))).ConfigureAwait(false);
-            WriteUpdatableWorkloadsFile();
+            manifestInstaller = new FileBasedManifestInstaller(nugetPackageDownloader, tempPackagesDir);
+            workloadRecordRepo = FileBasedWorkloadInstallationRecordRepositoryFactory.Create(dotnetPath, sdkFeatureBand, userProfileDir);
         }
+
+        return new WorkloadAdvertisingManifestUpdater(reporter, workloadResolver, nugetPackageDownloader, userProfileDir, workloadRecordRepo, manifestInstaller, sdkFeatureBand: sdkFeatureBand);
     }
 
     public static async Task BackgroundUpdateAdvertisingManifestsAsync(string userProfileDir)
     {
         try
         {
-            var manifestUpdater = GetInstance(userProfileDir);
-            await manifestUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
+            var advertisingUpdater = GetAdvertisingUpdaterInstance(userProfileDir);
+            await advertisingUpdater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
         }
         catch (Exception)
         {
@@ -117,53 +86,8 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         }
     }
 
-    public async Task BackgroundUpdateAdvertisingManifestsWhenRequiredAsync()
-    {
-        if (!BackgroundUpdatesAreDisabled() &&
-            AdManifestSentinelIsDueForUpdate() &&
-            UpdatedAdManifestPackagesExistAsync().GetAwaiter().GetResult())
-        {
-            await UpdateAdvertisingManifestsAsync(false, ShouldUseWorkloadSetMode(_sdkFeatureBand, _userProfileDir));
-            var sentinelPath = GetAdvertisingManifestSentinelPath(_sdkFeatureBand);
-            if (File.Exists(sentinelPath))
-            {
-                File.SetLastAccessTime(sentinelPath, DateTime.Now);
-            }
-            else
-            {
-                File.Create(sentinelPath).Close();
-            }
-        }
-    }
-
     public static bool ShouldUseWorkloadSetMode(SdkFeatureBand sdkFeatureBand, string dotnetDir)
-    {
-        string path = Path.Combine(WorkloadInstallType.GetInstallStateFolder(sdkFeatureBand, dotnetDir), "default.json");
-        var installStateContents = File.Exists(path) ? InstallStateContents.FromString(File.ReadAllText(path)) : new InstallStateContents();
-        return installStateContents.ShouldUseWorkloadSets();
-    }
-
-    private void WriteUpdatableWorkloadsFile()
-    {
-        var installedWorkloads = _workloadRecordRepo.GetInstalledWorkloads(_sdkFeatureBand);
-        var updatableWorkloads = GetUpdatableWorkloadsToAdvertise(installedWorkloads);
-        var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
-        var jsonContent = JsonSerializer.Serialize(updatableWorkloads.Select(workload => workload.ToString()).ToArray(), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
-        if (Directory.Exists(Path.GetDirectoryName(filePath)))
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-        }
-        File.WriteAllText(filePath, jsonContent);
-    }
-
-    public void DeleteUpdatableWorkloadsFile()
-    {
-        var filePath = GetAdvertisingWorkloadsFilePath(_sdkFeatureBand);
-        if (File.Exists(filePath))
-        {
-            File.Delete(filePath);
-        }
-    }
+        => WorkloadAdvertisingManifestUpdater.ShouldUseWorkloadSetMode(sdkFeatureBand, dotnetDir);
 
     public static void AdvertiseWorkloadUpdates()
     {
@@ -171,7 +95,7 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         {
             var backgroundUpdatesDisabled = bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE), out var disableEnvVar) && disableEnvVar;
             SdkFeatureBand featureBand = new(Product.Version);
-            var adUpdatesFile = GetAdvertisingWorkloadsFilePath(CliFolderPathCalculator.DotnetUserProfileFolderPath, featureBand);
+            var adUpdatesFile = WorkloadAdvertisingManifestUpdater.GetAdvertisingWorkloadsFilePath(CliFolderPathCalculator.DotnetUserProfileFolderPath, featureBand);
             if (!backgroundUpdatesDisabled && File.Exists(adUpdatesFile))
             {
                 var updatableWorkloads = JsonSerializer.Deserialize(File.ReadAllText(adUpdatesFile), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray);
@@ -188,357 +112,4 @@ internal class WorkloadManifestUpdater : IWorkloadManifestUpdater
         }
     }
 
-    public string GetAdvertisedWorkloadSetVersion()
-    {
-        var advertisedPath = GetAdvertisingManifestPath(_sdkFeatureBand, new ManifestId(WorkloadSetManifestId));
-        var workloadSetVersionFilePath = Path.Combine(advertisedPath, Constants.workloadSetVersionFileName);
-        if (File.Exists(workloadSetVersionFilePath))
-        {
-            return File.ReadAllText(workloadSetVersionFilePath);
-        }
-        return null;
-    }
-
-    public IEnumerable<ManifestUpdateWithWorkloads> CalculateManifestUpdates()
-    {
-        var currentManifestIds = GetInstalledManifestIds();
-        foreach (var manifestId in currentManifestIds)
-        {
-            var advertisingInfo = GetAdvertisingManifestVersionAndWorkloads(manifestId);
-            if (advertisingInfo == null)
-            {
-                continue;
-            }
-
-            var (installedVersion, installedBand) = GetInstalledManifestVersion(manifestId);
-            var ((adVersion, adBand), adWorkloads) = advertisingInfo.Value;
-            if (adVersion.CompareTo(installedVersion) > 0 && adBand.Equals(installedBand) ||
-                adBand.CompareTo(installedBand) > 0)
-            {
-                var update = new ManifestVersionUpdate(manifestId, adVersion, adBand.ToString());
-                yield return new(update, adWorkloads);
-            }
-        }
-    }
-
-    public IEnumerable<WorkloadId> GetUpdatableWorkloadsToAdvertise(IEnumerable<WorkloadId> installedWorkloads)
-    {
-        try
-        {
-#if TARGET_WINDOWS
-            if (OperatingSystem.IsWindows())
-            {
-                //  Also advertise updates for workloads installed by Visual Studio
-                InstalledWorkloadsCollection installedVSWorkloads = new InstalledWorkloadsCollection();
-                VisualStudioWorkloads.GetInstalledWorkloads(_workloadResolver, installedVSWorkloads, _sdkFeatureBand);
-                installedWorkloads = [.. installedWorkloads.Concat(installedVSWorkloads.AsEnumerable().Select(kvp => new WorkloadId(kvp.Key))).Distinct()];
-            }
-#endif
-
-            var overlayProvider = new TempDirectoryWorkloadManifestProvider(Path.Combine(_userProfileDir, "sdk-advertising", _sdkFeatureBand.ToString()), _sdkFeatureBand.ToString());
-            var advertisingManifestResolver = _workloadResolver.CreateOverlayResolver(overlayProvider);
-            return _workloadResolver.GetUpdatedWorkloads(advertisingManifestResolver, installedWorkloads);
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    public IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(string rollbackDefinitionFilePath, WorkloadHistoryRecorder recorder = null)
-    {
-        var currentManifestIds = GetInstalledManifestIds();
-        var manifestRollbacks = ParseRollbackDefinitionFile(rollbackDefinitionFilePath, _sdkFeatureBand);
-
-        if (recorder is not null)
-        {
-            recorder.HistoryRecord.RollbackFileContents = manifestRollbacks.ToDictionary(kvp => kvp.Id.ToString(), kvp => kvp.ManifestWithBand.Version + "/" + kvp.ManifestWithBand.Band);
-        }
-
-        var unrecognizedManifestIds = manifestRollbacks.Where(rollbackManifest => !currentManifestIds.Contains(rollbackManifest.Id));
-        if (unrecognizedManifestIds.Any())
-        {
-            _reporter.WriteLine(string.Format(CliCommandStrings.RollbackDefinitionContainsExtraneousManifestIds, rollbackDefinitionFilePath, string.Join(" ", unrecognizedManifestIds)).Yellow());
-            manifestRollbacks = manifestRollbacks.Where(rollbackManifest => currentManifestIds.Contains(rollbackManifest.Id));
-        }
-
-        return CalculateManifestRollbacks(manifestRollbacks);
-    }
-
-    private static IEnumerable<ManifestVersionUpdate> CalculateManifestRollbacks(IEnumerable<(ManifestId Id, ManifestVersionWithBand ManifestWithBand)> versionUpdates)
-    {
-        return versionUpdates.Select(manifest =>
-        {
-            var (id, (version, band)) = manifest;
-            return new ManifestVersionUpdate(id, version, band.ToString());
-        });
-    }
-
-    public async Task<IEnumerable<WorkloadDownload>> GetManifestPackageDownloadsAsync(bool includePreviews, SdkFeatureBand providedSdkFeatureBand, SdkFeatureBand installedSdkFeatureBand)
-    {
-        var downloads = new List<WorkloadDownload>();
-        foreach (var manifest in _workloadResolver.GetInstalledManifests())
-        {
-            try
-            {
-                PackageId? providedPackageId = null;
-                var fallbackFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
-                // The bands should be checked in the order defined here.
-                SdkFeatureBand[] bands = [providedSdkFeatureBand, installedSdkFeatureBand, fallbackFeatureBand];
-                var success = false;
-                // Use Distinct to eliminate bands that are the same.
-                foreach (var band in bands.Distinct())
-                {
-                    var packageId = _workloadManifestInstaller.GetManifestPackageId(new ManifestId(manifest.Id), band);
-                    providedPackageId ??= packageId;
-
-                    try
-                    {
-                        var latestVersion = await _nugetPackageDownloader.GetLatestPackageVersion(packageId, _packageSourceLocation, includePreviews);
-                        success = true;
-                        downloads.Add(new WorkloadDownload(manifest.Id, packageId.ToString(), latestVersion.ToString()));
-                        break;
-                    }
-                    catch (NuGetPackageNotFoundException)
-                    {
-                    }
-                }
-
-                if (!success)
-                {
-                    _reporter.WriteLine(CliCommandStrings.ManifestPackageUrlNotResolved, providedPackageId);
-                }
-            }
-            catch
-            {
-                _reporter.WriteLine(CliCommandStrings.ManifestPackageUrlNotResolved, manifest.Id);
-            }
-        }
-
-        return downloads;
-    }
-
-    private IEnumerable<ManifestId> GetInstalledManifestIds() => _workloadResolver.GetInstalledManifests().Select(manifest => new ManifestId(manifest.Id));
-
-    private async Task<bool> UpdateManifestWithVersionAsync(string id, bool includePreviews, SdkFeatureBand band, NuGetVersion packageVersion = null, DirectoryPath? offlineCache = null)
-    {
-        var manifestId = new ManifestId(id);
-        string packagePath = null;
-        try
-        {
-            var manifestPackageId = _workloadManifestInstaller.GetManifestPackageId(manifestId, band);
-            try
-            {
-                // If an offline cache is present, use that. Otherwise, try to acquire the package online.
-                packagePath = offlineCache != null ?
-                    Directory.GetFiles(offlineCache.Value.Value)
-                        .Where(path =>
-                        path.EndsWith(".nupkg") &&
-                        Path.GetFileName(path).StartsWith(manifestPackageId.ToString(), StringComparison.OrdinalIgnoreCase) &&
-                        (packageVersion == null || path.Contains(packageVersion.ToString())))
-                        .Max() :
-                    await _nugetPackageDownloader.DownloadPackageAsync(manifestPackageId, packageVersion: packageVersion, packageSourceLocation: _packageSourceLocation, includePreview: includePreviews);
-            }
-            catch (NuGetPackageNotFoundException)
-            {
-            }
-
-            if (packagePath is null)
-            {
-                return false;
-            }
-
-            var adManifestPath = GetAdvertisingManifestPath(_sdkFeatureBand, manifestId);
-            await _workloadManifestInstaller.ExtractManifestAsync(packagePath, adManifestPath);
-
-            // add file that contains the advertised manifest feature band so GetAdvertisingManifestVersionAndWorkloads will use correct feature band, regardless of if rollback occurred or not
-            File.WriteAllText(Path.Combine(adManifestPath, "AdvertisedManifestFeatureBand.txt"), band.ToString());
-
-            if (id.Equals(WorkloadSetManifestId))
-            {
-                // Create version file later used as part of installing the workload set in the file-based installer and in the msi-based installer
-                using PackageArchiveReader packageReader = new(packagePath);
-                var downloadedPackageVersion = packageReader.NuspecReader.GetVersion();
-                if (packageVersion != null && !downloadedPackageVersion.Equals(packageVersion))
-                {
-                    throw new NuGetPackageNotFoundException($"Requested workload version {packageVersion} of {id} but found version {downloadedPackageVersion} instead.");
-                }
-
-                var workloadSetVersion = band.GetWorkloadSetPackageVersion(downloadedPackageVersion.ToString());
-                File.WriteAllText(Path.Combine(adManifestPath, Constants.workloadSetVersionFileName), workloadSetVersion);
-            }
-
-            if (_displayManifestUpdates)
-            {
-                _reporter.WriteLine(CliCommandStrings.AdManifestUpdated, manifestId);
-            }
-
-            return true;
-        }
-        catch (Exception e)
-        {
-            _reporter.WriteLine(CliCommandStrings.FailedAdManifestUpdate, manifestId, e.Message);
-            return false;
-        }
-        finally
-        {
-            if (!string.IsNullOrEmpty(packagePath) && File.Exists(packagePath) && (offlineCache == null || !offlineCache.HasValue))
-            {
-                File.Delete(packagePath);
-            }
-            if (!string.IsNullOrEmpty(packagePath) && (offlineCache == null || !offlineCache.HasValue))
-            {
-                var versionDir = Path.GetDirectoryName(packagePath);
-
-                if (Directory.Exists(versionDir) && !Directory.GetFileSystemEntries(versionDir).Any())
-                {
-                    Directory.Delete(versionDir);
-                    var idDir = Path.GetDirectoryName(versionDir);
-                    if (Directory.Exists(idDir) && !Directory.GetFileSystemEntries(idDir).Any())
-                    {
-                        Directory.Delete(idDir);
-                    }
-                }
-            }
-        }
-    }
-
-    private async Task UpdateAdvertisingManifestAsync(WorkloadManifestInfo manifest, bool includePreviews, DirectoryPath? offlineCache = null)
-    {
-        var fallbackFeatureBand = new SdkFeatureBand(manifest.ManifestFeatureBand);
-        // The bands should be checked in the order defined here.
-        SdkFeatureBand[] bands = [_sdkFeatureBand, fallbackFeatureBand];
-        foreach (var band in bands.Distinct())
-        {
-            if (await UpdateManifestWithVersionAsync(manifest.Id, includePreviews, band, null, offlineCache))
-            {
-                return;
-            }
-        }
-
-        _reporter.WriteLine(CliCommandStrings.AdManifestPackageDoesNotExist, manifest.Id);
-    }
-
-    private (ManifestVersionWithBand ManifestWithBand, WorkloadCollection Workloads)? GetAdvertisingManifestVersionAndWorkloads(ManifestId manifestId)
-    {
-        var manifestPath = Path.Combine(GetAdvertisingManifestPath(_sdkFeatureBand, manifestId), "WorkloadManifest.json");
-        if (!File.Exists(manifestPath))
-        {
-            return null;
-        }
-
-        using FileStream fsSource = new(manifestPath, FileMode.Open, FileAccess.Read);
-        var manifest = WorkloadManifestReader.ReadWorkloadManifest(manifestId.ToString(), fsSource, manifestPath);
-        // we need to know the feature band of the advertised manifest (read it from the AdvertisedManifestFeatureBand.txt file)
-        // if we don't find the file then use the current feature band
-        var adManifestFeatureBandPath = Path.Combine(GetAdvertisingManifestPath(_sdkFeatureBand, manifestId), "AdvertisedManifestFeatureBand.txt");
-
-        SdkFeatureBand adManifestFeatureBand = _sdkFeatureBand;
-        if (File.Exists(adManifestFeatureBandPath))
-        {
-            adManifestFeatureBand = new SdkFeatureBand(File.ReadAllText(adManifestFeatureBandPath));
-        }
-
-        ManifestVersionWithBand manifestWithBand = new(new ManifestVersion(manifest.Version), adManifestFeatureBand);
-        var workloads = manifest.Workloads.Values.OfType<WorkloadDefinition>().ToDictionary(w => w.Id);
-        return (manifestWithBand, workloads);
-    }
-
-    private ManifestVersionWithBand GetInstalledManifestVersion(ManifestId manifestId)
-    {
-        return new(new ManifestVersion(_workloadResolver.GetManifestVersion(manifestId.ToString())), new SdkFeatureBand(_workloadResolver.GetManifestFeatureBand(manifestId.ToString())));
-    }
-
-    private bool AdManifestSentinelIsDueForUpdate()
-    {
-        var sentinelPath = GetAdvertisingManifestSentinelPath(_sdkFeatureBand);
-        if (!int.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS), out int updateIntervalHours))
-        {
-            updateIntervalHours = 24;
-        }
-
-        if (File.Exists(sentinelPath))
-        {
-            var lastAccessTime = File.GetLastAccessTime(sentinelPath);
-            if (lastAccessTime.AddHours(updateIntervalHours) > DateTime.Now)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private async Task<bool> UpdatedAdManifestPackagesExistAsync()
-    {
-        var manifests = GetInstalledManifestIds();
-        //  TODO: This doesn't seem to account for differing feature bands
-        var availableUpdates = await Task.WhenAll(manifests.Select(manifest => NewerManifestPackageExists(manifest))).ConfigureAwait(false);
-        return availableUpdates.Any();
-    }
-
-    private async Task<bool> NewerManifestPackageExists(ManifestId manifest)
-    {
-        try
-        {
-            var currentVersion = NuGetVersion.Parse(_workloadResolver.GetManifestVersion(manifest.ToString()));
-            var latestVersion = await _nugetPackageDownloader.GetLatestPackageVersion(_workloadManifestInstaller.GetManifestPackageId(manifest, _sdkFeatureBand));
-            return latestVersion > currentVersion;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
-
-    public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesForWorkloadSet(WorkloadSet workloadSet)
-    {
-        return CalculateManifestRollbacks(workloadSet.ManifestVersions.Select(kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand))));
-    }
-
-    private static IEnumerable<(ManifestId Id, ManifestVersionWithBand ManifestWithBand)> ParseRollbackDefinitionFile(string rollbackDefinitionFilePath, SdkFeatureBand featureBand)
-    {
-        string fileContent;
-
-        if (Uri.TryCreate(rollbackDefinitionFilePath, UriKind.Absolute, out var rollbackUri) && !rollbackUri.IsFile)
-        {
-            using HttpClient httpClient = new();
-            fileContent = httpClient.GetStringAsync(rollbackDefinitionFilePath).Result;
-        }
-        else if (File.Exists(rollbackDefinitionFilePath))
-        {
-            fileContent = File.ReadAllText(rollbackDefinitionFilePath);
-        }
-        else
-        {
-            throw new ArgumentException(string.Format(CliCommandStrings.RollbackDefinitionFileDoesNotExist, rollbackDefinitionFilePath));
-        }
-
-        var versions = WorkloadSet.FromJson(fileContent, featureBand).ManifestVersions;
-        return versions.Select(kvp => (kvp.Key, new ManifestVersionWithBand(kvp.Value.Version, kvp.Value.FeatureBand)));
-    }
-
-    public IEnumerable<ManifestVersionUpdate> CalculateManifestUpdatesFromHistory(WorkloadHistoryState state)
-    {
-        return state.ManifestVersions.Select(
-            m => new ManifestVersionUpdate(
-                new ManifestId(m.Key),
-                new ManifestVersion(m.Value.Split('/')[0]),
-                m.Value.Split('/')[1]));
-    }
-
-    private bool BackgroundUpdatesAreDisabled() => bool.TryParse(_getEnvironmentVariable(EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE), out var disableEnvVar) && disableEnvVar;
-
-    private string GetAdvertisingManifestSentinelPath(SdkFeatureBand featureBand) => Path.Combine(_userProfileDir, $".workloadAdvertisingManifestSentinel{featureBand}");
-
-    private string GetAdvertisingWorkloadsFilePath(SdkFeatureBand featureBand) => GetAdvertisingWorkloadsFilePath(_userProfileDir, featureBand);
-
-    private static string GetAdvertisingWorkloadsFilePath(string userProfileDir, SdkFeatureBand featureBand) => Path.Combine(userProfileDir, $".workloadAdvertisingUpdates{featureBand}");
-
-    private string GetAdvertisingManifestPath(SdkFeatureBand featureBand, ManifestId manifestId) => Path.Combine(_userProfileDir, "sdk-advertising", featureBand.ToString(), manifestId.ToString());
-
-    private record ManifestVersionWithBand(ManifestVersion Version, SdkFeatureBand Band);
 }
-
-[JsonSerializable(typeof(string[]))]
-internal partial class WorkloadManifestUpdaterJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Commands/Workload/SIGNING-VERIFICATION.md
+++ b/src/Cli/dotnet/Commands/Workload/SIGNING-VERIFICATION.md
@@ -134,9 +134,12 @@ check, **not** a cryptographic signature check.
 - `ShouldVerifySignatures()` → `verifySignatures` (single value for both layers)
 - Reinstalls existing workloads to verify integrity
 
-### 4. `WorkloadManifestUpdater.GetInstance()` (background advertising)
+### 4. `WorkloadManifestUpdater.GetAdvertisingUpdaterInstance()` (background advertising)
 - NuGet: `ShouldVerifySignatures()` (respects policy, no user flags)
-- MSI: **disabled** (`false`) — only downloads advertising manifests, not MSIs
+- MSI: **disabled** (`false`) — only downloads advertising manifests, not MSIs. This path builds a
+  lightweight `WindowsMsiManifestInstaller`/`FileBasedManifestInstaller` directly (via
+  `WorkloadAdvertisingManifestUpdater`) instead of `WorkloadInstallerFactory`, so it never constructs
+  the full `NetSdkMsiInstallerClient`/`FileBasedInstaller` or elevated MSI IPC.
 
 ### 5. `NetSdkMsiInstallerClient.Create()` (fallback downloader)
 - `CreateForWorkloads(verifyNuGetSignatures: false)` — MSI Authenticode is the primary gate

--- a/src/Cli/dotnet/Commands/Workload/WorkloadInfoHelper.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadInfoHelper.cs
@@ -64,7 +64,7 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
         // read-only construction in WorkloadInstallDetector.
         WorkloadRecordRepo = workloadRecordRepo ?? CreateInstallationRecordRepository(DotnetPath, _currentSdkFeatureBand, userProfileDir);
 
-        UserLocalPath = dotnetDir ?? (IsUserLocal(DotnetPath, _currentSdkFeatureBand.ToString()) ? userProfileDir : DotnetPath);
+        UserLocalPath = dotnetDir ?? (FileBasedWorkloadInstallationRecordRepositoryFactory.IsUserLocal(DotnetPath, _currentSdkFeatureBand) ? userProfileDir : DotnetPath);
 #else
         var restoreConfig = new RestoreActionConfig(Interactive: isInteractive);
 
@@ -95,16 +95,9 @@ internal class WorkloadInfoHelper : IWorkloadInfoHelper
     private static IWorkloadInstallationRecordRepository CreateInstallationRecordRepository(string dotnetDir, SdkFeatureBand sdkFeatureBand, string userProfileDir)
         => WorkloadInstallType.GetWorkloadInstallType(sdkFeatureBand, dotnetDir) switch
         {
-            InstallType.Msi => new RegistryWorkloadInstallationRecordRepository(),
-            _ => new FileBasedInstallationRecordRepository(Path.Combine(
-                     IsUserLocal(dotnetDir, sdkFeatureBand.ToString()) ? userProfileDir : dotnetDir,
-                     "metadata", "workloads")),
+            InstallType.Msi => new ReadOnlyWindowsWorkloadInstallationRecordRepository(),
+            _ => FileBasedWorkloadInstallationRecordRepositoryFactory.Create(dotnetDir, sdkFeatureBand, userProfileDir),
         };
-
-    // Inlined equivalent of WorkloadFileBasedInstall.IsUserLocal, avoiding that type's workload-history
-    // (System.Text.Json) helpers compiled under '#if DotnetCsproj'.
-    private static bool IsUserLocal(string dotnetDir, string sdkFeatureBand)
-        => File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand, "userlocal"));
 #endif
 
 #if !CLI_AOT

--- a/src/Cli/dotnet/Commands/Workload/WorkloadInstallDetector.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadInstallDetector.cs
@@ -48,25 +48,16 @@ internal static class WorkloadInstallDetector
         // Records live under {workloadRoot}/metadata/workloads, where workloadRoot is the user profile
         // for user-local installs and the dotnet root otherwise. This mirrors the layout used by
         // FileBasedInstaller / FileBasedInstallationRecordRepository.
-        var workloadRootDir = IsUserLocal(dotnetDir, sdkFeatureBand)
-            ? CliFolderPathCalculator.DotnetUserProfileFolderPath
-            : dotnetDir;
-        if (workloadRootDir is null)
+        if (dotnetDir is null)
         {
             return false;
         }
 
-        var metadataDir = Path.Combine(workloadRootDir, "metadata", "workloads");
-        return new FileBasedInstallationRecordRepository(metadataDir)
+        return FileBasedWorkloadInstallationRecordRepositoryFactory
+            .Create(dotnetDir, sdkFeatureBand, CliFolderPathCalculator.DotnetUserProfileFolderPath)
             .GetInstalledWorkloads(sdkFeatureBand)
             .Any();
     }
-
-    // Equivalent to WorkloadFileBasedInstall.IsUserLocal, inlined here to avoid pulling that type's
-    // workload-history (System.Text.Json) helpers into the NativeAOT build.
-    private static bool IsUserLocal(string? dotnetDir, SdkFeatureBand sdkFeatureBand)
-        => dotnetDir is not null
-           && File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand.ToString(), "userlocal"));
 
     private static bool HasMsiWorkloadRecords(SdkFeatureBand sdkFeatureBand)
     {
@@ -75,15 +66,43 @@ internal static class WorkloadInstallDetector
             return false;
         }
 
-#if CLI_AOT
-        return new RegistryWorkloadInstallationRecordRepository()
+        return new ReadOnlyWindowsWorkloadInstallationRecordRepository()
             .GetInstalledWorkloads(sdkFeatureBand)
             .Any();
-#else
-        // This detector is only exercised on the NativeAOT first-run path; the managed build uses
-        // WorkloadIntegrityChecker instead. The read-only registry repository constructor used above
-        // only exists under CLI_AOT, so there is nothing to do here in the managed build.
-        return false;
-#endif
+    }
+}
+
+/// <summary>
+///  Builds a <see cref="FileBasedInstallationRecordRepository"/> for a given dotnet root without
+///  needing the full workload installer.
+///
+///  <para>
+///  Shared by <see cref="WorkloadInstallDetector"/> above and the CLI_AOT construction path of
+///  <see cref="WorkloadInfoHelper"/> (both already part of the NativeAOT closure via
+///  <c>AotSourceFiles.props</c>, so this factory lives in the same already-linked file rather than a
+///  new one), and reused by the managed-only lightweight background advertising-manifest-update
+///  construction path in <see cref="Install.WorkloadManifestUpdater"/>, so the file-based-vs-user-local
+///  layout logic is defined in exactly one place.
+///  </para>
+/// </summary>
+internal static class FileBasedWorkloadInstallationRecordRepositoryFactory
+{
+    /// <summary>
+    ///  Equivalent to <see cref="WorkloadFileBasedInstall.IsUserLocal(string, string)"/>, inlined here
+    ///  (like the call sites that used to duplicate this check) to avoid pulling in that type's
+    ///  workload-history (System.Text.Json) helpers, which are not needed for read-only record lookup.
+    /// </summary>
+    public static bool IsUserLocal(string dotnetDir, SdkFeatureBand sdkFeatureBand)
+        => dotnetDir is not null && File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand.ToString(), "userlocal"));
+
+    /// <summary>
+    ///  Constructs the file-based installation record repository for <paramref name="sdkFeatureBand"/>,
+    ///  choosing between the user-profile and dotnet-root metadata locations the same way
+    ///  <see cref="Install.FileBasedInstaller"/> does.
+    /// </summary>
+    public static FileBasedInstallationRecordRepository Create(string dotnetDir, SdkFeatureBand sdkFeatureBand, string userProfileDir)
+    {
+        var workloadRootDir = IsUserLocal(dotnetDir, sdkFeatureBand) ? userProfileDir : dotnetDir;
+        return new FileBasedInstallationRecordRepository(Path.Combine(workloadRootDir, "metadata", "workloads"));
     }
 }

--- a/src/Cli/dotnet/Commands/Workload/WorkloadInstallDetector.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadInstallDetector.cs
@@ -71,38 +71,3 @@ internal static class WorkloadInstallDetector
             .Any();
     }
 }
-
-/// <summary>
-///  Builds a <see cref="FileBasedInstallationRecordRepository"/> for a given dotnet root without
-///  needing the full workload installer.
-///
-///  <para>
-///  Shared by <see cref="WorkloadInstallDetector"/> above and the CLI_AOT construction path of
-///  <see cref="WorkloadInfoHelper"/> (both already part of the NativeAOT closure via
-///  <c>AotSourceFiles.props</c>, so this factory lives in the same already-linked file rather than a
-///  new one), and reused by the managed-only lightweight background advertising-manifest-update
-///  construction path in <see cref="Install.WorkloadManifestUpdater"/>, so the file-based-vs-user-local
-///  layout logic is defined in exactly one place.
-///  </para>
-/// </summary>
-internal static class FileBasedWorkloadInstallationRecordRepositoryFactory
-{
-    /// <summary>
-    ///  Equivalent to <see cref="WorkloadFileBasedInstall.IsUserLocal(string, string)"/>, inlined here
-    ///  (like the call sites that used to duplicate this check) to avoid pulling in that type's
-    ///  workload-history (System.Text.Json) helpers, which are not needed for read-only record lookup.
-    /// </summary>
-    public static bool IsUserLocal(string dotnetDir, SdkFeatureBand sdkFeatureBand)
-        => dotnetDir is not null && File.Exists(Path.Combine(dotnetDir, "metadata", "workloads", sdkFeatureBand.ToString(), "userlocal"));
-
-    /// <summary>
-    ///  Constructs the file-based installation record repository for <paramref name="sdkFeatureBand"/>,
-    ///  choosing between the user-profile and dotnet-root metadata locations the same way
-    ///  <see cref="Install.FileBasedInstaller"/> does.
-    /// </summary>
-    public static FileBasedInstallationRecordRepository Create(string dotnetDir, SdkFeatureBand sdkFeatureBand, string userProfileDir)
-    {
-        var workloadRootDir = IsUserLocal(dotnetDir, sdkFeatureBand) ? userProfileDir : dotnetDir;
-        return new FileBasedInstallationRecordRepository(Path.Combine(workloadRootDir, "metadata", "workloads"));
-    }
-}

--- a/src/Cli/dotnet/Installer/Windows/MsiManifestJsonSerializerContext.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiManifestJsonSerializerContext.cs
@@ -5,7 +5,6 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.Cli.Installer.Windows;
 
-[JsonSerializable(typeof(InstallRequestMessage))]
-[JsonSerializable(typeof(InstallResponseMessage))]
+[JsonSerializable(typeof(MsiManifest))]
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-internal partial class InstallerJsonSerializerContext : JsonSerializerContext;
+internal partial class MsiManifestJsonSerializerContext : JsonSerializerContext;

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageCache.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Installer.Windows.Security;
@@ -96,7 +95,7 @@ internal class MsiPackageCache(
 
             // We cannot assume that the MSI adjacent to the manifest is the one to cache. We'll trust
             // the manifest to provide the MSI filename.
-            MsiManifest? msiManifest = JsonSerializer.Deserialize(File.ReadAllText(fullManifestPath), InstallerJsonSerializerContext.Default.MsiManifest);
+            MsiManifest? msiManifest = JsonSerializer.Deserialize(File.ReadAllText(fullManifestPath), MsiManifestJsonSerializerContext.Default.MsiManifest);
             // Only use the filename+extension of the payload property in case the manifest has been altered.
             string msiPath = Path.Combine(Path.GetDirectoryName(fullManifestPath)!, Path.GetFileName(msiManifest?.Payload ?? string.Empty));
 
@@ -142,43 +141,15 @@ internal class MsiPackageCache(
         string packageCacheDirectory = GetPackageDirectory(packageId, packageVersion);
         payload = default;
 
-        if (!TryGetMsiPathFromPackageData(packageCacheDirectory, out string? msiPath, out string manifestPath))
+        if (!MsiPackageData.TryGetMsiPath(packageCacheDirectory, out string? msiPath, out string manifestPath, message => Log?.LogMessage(message)))
         {
             return false;
         }
 
-        VerifyPackageSignature(msiPath);
+        VerifyPackageSignature(msiPath!);
 
-        payload = new MsiPayload(manifestPath, msiPath);
+        payload = new MsiPayload(manifestPath, msiPath!);
 
-        return true;
-    }
-
-    public bool TryGetMsiPathFromPackageData(string packageDataPath, [NotNullWhen(true)] out string? msiPath, out string manifestPath)
-    {
-        msiPath = default;
-        manifestPath = Path.GetFullPath(Path.Combine(packageDataPath, "msi.json"));
-
-        // It's possible that the MSI is cached, but without the JSON manifest we cannot
-        // trust that the MSI in the cache directory is the correct file.
-        if (!File.Exists(manifestPath))
-        {
-            Log?.LogMessage($"MSI manifest file does not exist, '{manifestPath}'");
-            return false;
-        }
-
-        // The msi.json manifest contains the name of the actual MSI. The filename does not necessarily match the package
-        // ID as it may have been shortened to support VS caching.
-        MsiManifest? msiManifest = JsonSerializer.Deserialize(File.ReadAllText(manifestPath), InstallerJsonSerializerContext.Default.MsiManifest);
-        string possibleMsiPath = Path.Combine(Path.GetDirectoryName(manifestPath)!, msiManifest?.Payload ?? string.Empty);
-
-        if (!File.Exists(possibleMsiPath))
-        {
-            Log?.LogMessage($"MSI package not found, '{possibleMsiPath}'");
-            return false;
-        }
-
-        msiPath = possibleMsiPath;
         return true;
     }
 

--- a/src/Cli/dotnet/Installer/Windows/MsiPackageData.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPackageData.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Microsoft.DotNet.Cli.Installer.Windows;
+
+internal static class MsiPackageData
+{
+    public static bool TryGetMsiPath(
+        string packageDataPath,
+        [NotNullWhen(true)] out string? msiPath,
+        out string manifestPath,
+        Action<string>? logMessage = null)
+    {
+        msiPath = default;
+        manifestPath = Path.GetFullPath(Path.Combine(packageDataPath, "msi.json"));
+
+        if (!File.Exists(manifestPath))
+        {
+            logMessage?.Invoke($"MSI manifest file does not exist, '{manifestPath}'");
+            return false;
+        }
+
+        MsiManifest? msiManifest = JsonSerializer.Deserialize(
+            File.ReadAllText(manifestPath),
+            MsiManifestJsonSerializerContext.Default.MsiManifest);
+        string possibleMsiPath = Path.Combine(Path.GetDirectoryName(manifestPath)!, msiManifest?.Payload ?? string.Empty);
+
+        if (!File.Exists(possibleMsiPath))
+        {
+            logMessage?.Invoke($"MSI package not found, '{possibleMsiPath}'");
+            return false;
+        }
+
+        msiPath = possibleMsiPath;
+        return true;
+    }
+}

--- a/src/Cli/dotnet/Installer/Windows/MsiPayload.cs
+++ b/src/Cli/dotnet/Installer/Windows/MsiPayload.cs
@@ -69,7 +69,7 @@ internal class MsiPayload(string manifestPath, string msiPath)
     {
         get
         {
-            _manifest ??= JsonSerializer.Deserialize(File.ReadAllText(ManifestPath), InstallerJsonSerializerContext.Default.MsiManifest);
+            _manifest ??= JsonSerializer.Deserialize(File.ReadAllText(ManifestPath), MsiManifestJsonSerializerContext.Default.MsiManifest);
 
             return _manifest;
         }

--- a/src/Cli/dotnet/MsbuildProject.cs
+++ b/src/Cli/dotnet/MsbuildProject.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectTools;
 
-#if !CLI_AOT
 using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
@@ -18,7 +17,6 @@ using Microsoft.Build.Logging;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using NuGet.Frameworks;
-#endif
 
 namespace Microsoft.DotNet.Cli;
 
@@ -32,7 +30,6 @@ internal class MsbuildProject
     public static bool TryGetProjectFileFromDirectory(string projectDirectory, [NotNullWhen(true)] out string projectFilePath)
         => ProjectLocator.TryGetProjectFileFromDirectory(projectDirectory, out projectFilePath, out _);
 
-#if !CLI_AOT
     const string ProjectItemElementType = "ProjectReference";
 
     public ProjectRootElement ProjectRootElement { get; private set; }
@@ -153,7 +150,6 @@ internal class MsbuildProject
         _cachedTfms = [.. project.GetTargetFrameworks()];
         return _cachedTfms;
     }
-
     public IEnumerable<string> GetConfigurations()
     {
         return cachedConfigurations ??= GetEvaluatedProject().GetPropertyCommaSeparatedValues("Configurations");
@@ -184,7 +180,6 @@ internal class MsbuildProject
 
         return false;
     }
-
     private ProjectInstance GetEvaluatedProject()
     {
         // Reuse a single evaluation across the RID/TFM/Configuration getters. A ProjectInstance is a
@@ -195,6 +190,7 @@ internal class MsbuildProject
             return _cachedEvaluatedProject;
         }
 
+        string originalDotnetHostPath = null;
         try
         {
             // Only evaluated properties (RuntimeIdentifier(s), TargetFramework(s), Configurations) are read
@@ -208,6 +204,7 @@ internal class MsbuildProject
             if (_interactive)
             {
                 // NuGet need this environment variable to call plugin dll
+                originalDotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
                 Environment.SetEnvironmentVariable("DOTNET_HOST_PATH", new Muxer().MuxerPath);
                 // Even during evaluation time, the SDK resolver may need to output auth instructions, so set a logger.
                 _projects.RegisterLogger(new ConsoleLogger(LoggerVerbosity.Minimal));
@@ -225,7 +222,10 @@ internal class MsbuildProject
         }
         finally
         {
-            Environment.SetEnvironmentVariable("DOTNET_HOST_PATH", null);
+            if (_interactive)
+            {
+                Environment.SetEnvironmentVariable("DOTNET_HOST_PATH", originalDotnetHostPath);
+            }
         }
     }
 
@@ -294,5 +294,4 @@ internal class MsbuildProject
             return null;
         }
     }
-#endif
 }

--- a/src/Cli/dotnet/dotnet.csproj
+++ b/src/Cli/dotnet/dotnet.csproj
@@ -52,6 +52,7 @@
     <Compile Remove="Commands\Workload\Install\NetSdkMsiInstallerClient.InstallRecords.cs" />
     <Compile Remove="Commands\Workload\Install\NetSdkMsiInstallerClient.PackGroup.cs" />
     <Compile Remove="Commands\Workload\Install\NetSdkMsiInstallerServer.cs" />
+    <Compile Remove="Commands\Workload\Install\WindowsMsiManifestInstaller.cs" />
     <Compile Remove="Commands\Workload\Install\WorkloadInstallRecords\RegistryWorkloadInstallationRecordRepository.cs" />
     <Compile Remove="Commands\Workload\SignCheck_Windows.cs" />
   </ItemGroup>

--- a/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\Microsoft.DotNet.SdkResolver\**\*.cs" LinkBase="Microsoft.DotNet.SdkResolver" />
     <Compile Include="..\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\CachingWorkloadResolver.cs" LinkBase="Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver" />
     <Compile Include="..\Microsoft.NET.Sdk.WorkloadManifestReader\**\*.cs" LinkBase="Microsoft.NET.Sdk.WorkloadManifestReader" />
+    <Compile Include="..\..\Cli\Microsoft.DotNet.Cli.CoreUtils\SdkPaths.cs" LinkBase="Cli" />
     <Compile Include="..\..\Cli\dotnet\Commands\Workload\Install\WorkloadInstallRecords\**\*.cs"
              Exclude="..\..\Cli\dotnet\Commands\Workload\Install\WorkloadInstallRecords\RegistryWorkloadInstallationRecordRepository.cs"
              LinkBase="WorkloadInstallRecords" />

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -2,14 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.Collections.Immutable;
-
-#if NET
-using Microsoft.DotNet.Cli;
-#else
-using Microsoft.DotNet.DotNetSdkResolver;
-#endif
 
 namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
 {
@@ -69,7 +64,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
 
             if (_enabled)
             {
-                string sentinelPath = Path.Combine(Path.GetDirectoryName(typeof(CachingWorkloadResolver).Assembly.Location) ?? string.Empty, "DisableWorkloadResolver.sentinel");
+                string sentinelPath = Path.Combine(SdkPaths.SdkDirectory, "DisableWorkloadResolver.sentinel");
                 if (File.Exists(sentinelPath))
                 {
                     _enabled = false;

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="..\Microsoft.DotNet.SdkResolver\Microsoft.DotNet.SdkResolver.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <Compile Include="..\..\Cli\Microsoft.DotNet.Cli.CoreUtils\SdkPaths.cs" Link="SdkPaths.cs" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="$(SystemCollectionsImmutableToolsetPackageVersion)" />
   </ItemGroup>
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -75,8 +75,7 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
         private string? GetSdkDirectory(SdkResolverContext context)
         {
 #if NET
-            var sdkDirectory = Path.GetDirectoryName(typeof(DotnetFiles).Assembly.Location);
-            return sdkDirectory;
+            return SdkPaths.SdkDirectory;
 
 #else
             string dotnetExeDir = EnvironmentProvider.GetDotnetExeDirectory();
@@ -117,4 +116,3 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
         }
     }
 }
-

--- a/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
+++ b/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+using System.Xml;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Logging;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -26,6 +31,31 @@ public class MSBuildEvaluationTests
         }
     }
 
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void UsesNuGetAotFeatureSwitch()
+    {
+        Assert.IsTrue(AppContext.TryGetSwitch("NuGet.UseSystemTextJsonDeserialization", out bool useSystemTextJson));
+        Assert.IsTrue(useSystemTextJson);
+    }
+
+    [TestMethod]
+    public void NativeAotUsesProductionMSBuildFeatureSwitches()
+    {
+        if (RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return;
+        }
+
+        Assert.IsTrue(AppContext.TryGetSwitch("Microsoft.Build.EnableSdkResolverDynamicLoading", out bool dynamicResolverLoading));
+        Assert.IsFalse(dynamicResolverLoading);
+        Assert.IsTrue(AppContext.TryGetSwitch("Microsoft.Build.EnableAllPropertyFunctions", out bool allPropertyFunctions));
+        Assert.IsFalse(allPropertyFunctions);
+        Assert.IsTrue(AppContext.TryGetSwitch("Microsoft.Build.RestrictPropertyFunctionReceivers", out bool restrictedPropertyFunctions));
+        Assert.IsTrue(restrictedPropertyFunctions);
+    }
+
     [TestMethod]
     public void MSBuildForwardingUsesVersionedSdkDirectory()
     {
@@ -43,5 +73,76 @@ public class MSBuildEvaluationTests
         Assert.AreEqual(
             sdkDirectory,
             forwardingApp.GetProcessStartInfo().Environment["MSBuildExtensionsPath"]);
+    }
+
+    [TestMethod]
+    public void StockSdkProjectCanBeEvaluated()
+    {
+        string sdkDirectory = GetRequiredSdkDirectory();
+
+        string binlogPath = Path.Combine(
+            Path.GetTempPath(),
+            $"aot-eval-{TestContext.TestName}-{Guid.NewGuid():N}.binlog");
+        TestContext.WriteLine($"MSBuild evaluation binlog: {binlogPath}");
+
+        using var _ = new SdkDirectoryScope(sdkDirectory);
+        try
+        {
+            MSBuildSdkResolverRegistration.Register();
+
+            var projectContent = new StringReader(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net11.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var binlog = new BinaryLogger
+            {
+                Parameters = binlogPath
+            };
+            using var projectCollection = new ProjectCollection(
+                globalProperties: new Dictionary<string, string>
+                {
+                    // since this test is under the repo root, it wants to glob for repo-level Directory.Build.props/targets, which we don't want to do. Disable those imports.
+                    ["ImportDirectoryBuildProps"] = "false",
+                    ["ImportDirectoryBuildTargets"] = "false",
+                },
+                loggers: [binlog],
+                toolsetDefinitionLocations: ToolsetDefinitionLocations.Default
+            );
+            var project = Project.FromXmlReader(
+                XmlReader.Create(projectContent),
+                new()
+                {
+                    ProjectCollection = projectCollection,
+                    EvaluationStage = ProjectEvaluationStage.Properties,
+                });
+            Assert.AreEqual("net11.0", project.GetPropertyValue("TargetFramework"));
+            Assert.Contains(import =>
+                import.ImportedProject.FullPath.EndsWith(
+                    Path.Combine("Microsoft.NET.Sdk", "Sdk", "Sdk.targets"),
+                    StringComparison.OrdinalIgnoreCase),
+                project.Imports);
+        }
+        finally
+        {
+            if (File.Exists(binlogPath))
+            {
+                TestContext.AddResultFile(binlogPath);
+            }
+        }
+    }
+
+    private static string GetRequiredSdkDirectory()
+    {
+        string? sdkDirectory = Environment.GetEnvironmentVariable("DOTNET_AOT_TEST_SDK_DIRECTORY");
+        if (string.IsNullOrEmpty(sdkDirectory))
+        {
+            Assert.Inconclusive("DOTNET_AOT_TEST_SDK_DIRECTORY must identify the SDK used for Native AOT validation.");
+        }
+
+        return sdkDirectory;
     }
 }

--- a/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
+++ b/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.MSBuild;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+[TestClass]
+public class MSBuildEvaluationTests
+{
+    private readonly struct SdkDirectoryScope : IDisposable
+    {
+        private readonly object? _previousSdkRoot = AppContext.GetData(SdkPaths.DataName);
+
+        public SdkDirectoryScope(string sdkDirectory)
+        {
+            AppContext.SetData(SdkPaths.DataName, sdkDirectory);
+            SdkPaths.ClearSdkDirectoryCacheForTests();
+        }
+
+        public void Dispose()
+        {
+            AppContext.SetData(SdkPaths.DataName, _previousSdkRoot);
+            SdkPaths.ClearSdkDirectoryCacheForTests();
+        }
+    }
+
+    [TestMethod]
+    public void MSBuildForwardingUsesVersionedSdkDirectory()
+    {
+        string sdkDirectory = Path.Combine(Path.GetTempPath(), "dotnet", "sdk", "test-version");
+        using var _ = new SdkDirectoryScope(sdkDirectory + Path.DirectorySeparatorChar);
+
+        var forwardingApp = new MSBuildForwardingAppWithoutLogging(
+            MSBuildArgs.FromOtherArgs(),
+            forceOutOfProc: true);
+
+        Assert.AreEqual(Path.Combine(sdkDirectory, "MSBuild.dll"), forwardingApp.MSBuildPath);
+        Assert.AreEqual(
+            Path.Combine(sdkDirectory, "Sdks"),
+            forwardingApp.GetProcessStartInfo().Environment["MSBuildSDKsPath"]);
+        Assert.AreEqual(
+            sdkDirectory,
+            forwardingApp.GetProcessStartInfo().Environment["MSBuildExtensionsPath"]);
+    }
+}

--- a/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
+++ b/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using Microsoft.Build.Evaluation;

--- a/test/dotnet-aot.Tests/WorkloadInstallDetectorTests.cs
+++ b/test/dotnet-aot.Tests/WorkloadInstallDetectorTests.cs
@@ -98,7 +98,7 @@ public partial class WorkloadInstallDetectorTests
                 Assert.IsNotNull(recordKey);
             }
 
-            var repository = new RegistryWorkloadInstallationRecordRepository(Registry.CurrentUser, basePath);
+            var repository = new ReadOnlyWindowsWorkloadInstallationRecordRepository(Registry.CurrentUser, basePath);
 
             var installed = repository.GetInstalledWorkloads(featureBand).ToList();
             Assert.HasCount(1, installed);

--- a/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
+++ b/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
@@ -1,0 +1,280 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.DotNet.Cli.Commands.Workload.Install;
+using Microsoft.DotNet.Cli.Commands.Workload.Install.WorkloadInstallRecords;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.DotNet.Cli.SdkVulnerability;
+using Microsoft.DotNet.Cli.ToolPackage;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+using NuGet.Configuration;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+[TestClass]
+public class WorkloadUpdateTests
+{
+    private const string ManifestId = "microsoft.net.sdk.test";
+    private static readonly SdkFeatureBand s_featureBand = new("11.0.100");
+
+    [TestMethod]
+    public async Task DisabledBackgroundUpdateDoesNotQueryNuGet()
+    {
+        using var testDirectory = new TestDirectory();
+        var downloader = CreateUpdater(testDirectory.Path, out WorkloadAdvertisingManifestUpdater updater,
+            name => name == EnvironmentVariableNames.WORKLOAD_UPDATE_NOTIFY_DISABLE ? "true" : null);
+
+        await updater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
+
+        Assert.AreEqual(0, downloader.LatestVersionQueries);
+        Assert.AreEqual(0, downloader.Downloads);
+        Assert.IsFalse(File.Exists(GetSentinelPath(testDirectory.Path)));
+    }
+
+    [TestMethod]
+    public async Task DueBackgroundUpdateDownloadsManifestAndWritesState()
+    {
+        using var testDirectory = new TestDirectory();
+        var downloader = CreateUpdater(testDirectory.Path, out WorkloadAdvertisingManifestUpdater updater, _ => null);
+
+        await updater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
+
+        Assert.AreEqual(1, downloader.LatestVersionQueries);
+        Assert.AreEqual(1, downloader.Downloads);
+        Assert.AreEqual(1, downloader.Extractions);
+        Assert.AreEqual($"{ManifestId}.manifest-{s_featureBand}", downloader.LastPackageId?.ToString());
+        Assert.IsTrue(File.Exists(GetSentinelPath(testDirectory.Path)));
+
+        string updatesFile = WorkloadAdvertisingManifestUpdater.GetAdvertisingWorkloadsFilePath(testDirectory.Path, s_featureBand);
+        Assert.IsTrue(File.Exists(updatesFile));
+        Assert.AreSequenceEqual(
+            Array.Empty<string>(),
+            JsonSerializer.Deserialize(File.ReadAllText(updatesFile), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray)!);
+
+        string advertisingManifest = Path.Combine(
+            testDirectory.Path, "sdk-advertising", s_featureBand.ToString(), ManifestId, "WorkloadManifest.json");
+        Assert.IsTrue(File.Exists(advertisingManifest));
+    }
+
+#if TARGET_WINDOWS
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public async Task WindowsMsiAdvertisingInstallerExtractsPreExpandedManifest()
+    {
+        using var testDirectory = new TestDirectory();
+        Directory.CreateDirectory(testDirectory.Path);
+        string sourceManifestPath = WriteManifest(testDirectory.Path, "source", "2.0.0");
+        var downloader = new RecordingNuGetPackageDownloader(
+            testDirectory.Path,
+            sourceManifestPath,
+            useMsiLayout: true);
+        WindowsMsiManifestInstaller installer =
+            WindowsMsiManifestInstaller.CreateForAdvertisingManifestUpdates(downloader, out var records);
+        string targetPath = Path.Combine(testDirectory.Path, "target", ManifestId);
+
+        await installer.ExtractManifestAsync("manifest.nupkg", targetPath);
+
+        Assert.IsInstanceOfType<ReadOnlyWindowsWorkloadInstallationRecordRepository>(records);
+        Assert.AreEqual(
+            $"{ManifestId}.Manifest-{s_featureBand}.Msi.{RuntimeInformation.ProcessArchitecture}".ToLowerInvariant(),
+            installer.GetManifestPackageId(new ManifestId(ManifestId), s_featureBand).ToString());
+        Assert.IsTrue(File.Exists(Path.Combine(targetPath, "WorkloadManifest.json")));
+    }
+#endif
+
+    [TestMethod]
+    public void VulnerabilityCacheReadsSourceGeneratedJsonAndHonorsSentinel()
+    {
+        using var testDirectory = new TestDirectory();
+        Directory.CreateDirectory(testDirectory.Path);
+        var expected = new SdkVulnerabilityInfo
+        {
+            IsEol = true,
+            EolDate = new DateTime(2026, 1, 13, 0, 0, 0, DateTimeKind.Utc),
+            LatestSdkVersion = "11.0.102",
+            Cves = [new SdkCveInfo { Id = "CVE-2026-0001", Url = "https://example.test/CVE-2026-0001" }],
+        };
+        File.WriteAllText(
+            Path.Combine(testDirectory.Path, "sdk-status-11.0.100.json"),
+            JsonSerializer.Serialize(expected, SdkVulnerabilityJsonContext.Default.SdkVulnerabilityInfo));
+        File.WriteAllText(Path.Combine(testDirectory.Path, ".sentinel"), "");
+
+        var cache = new SdkReleaseMetadataCache(testDirectory.Path, _ => null);
+        SdkVulnerabilityInfo? actual = cache.ReadCachedSummary("11.0.100");
+
+        Assert.IsNotNull(actual);
+        Assert.IsTrue(actual.IsEol);
+        Assert.IsTrue(actual.HasVulnerabilities);
+        Assert.AreEqual("CVE-2026-0001", actual.Cves[0].Id);
+        Assert.AreEqual("11.0.102", actual.LatestSdkVersion);
+        Assert.IsFalse(cache.IsDueForUpdate());
+    }
+
+    private static RecordingNuGetPackageDownloader CreateUpdater(
+        string testRoot,
+        out WorkloadAdvertisingManifestUpdater updater,
+        Func<string, string?> getEnvironmentVariable)
+    {
+        Directory.CreateDirectory(testRoot);
+        string installStateDirectory = Path.Combine(
+            testRoot,
+            "metadata",
+            "workloads",
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            s_featureBand.ToString(),
+            "InstallState");
+        Directory.CreateDirectory(installStateDirectory);
+        File.WriteAllText(Path.Combine(installStateDirectory, "default.json"), """{"useWorkloadSets":false}""");
+        string installedManifestPath = WriteManifest(testRoot, "installed", "1.0.0");
+        string advertisingManifestPath = WriteManifest(testRoot, "advertising", "2.0.0");
+        var provider = new TestManifestProvider(installedManifestPath);
+        WorkloadResolver resolver = WorkloadResolver.CreateForTests(provider, testRoot);
+        var downloader = new RecordingNuGetPackageDownloader(testRoot, advertisingManifestPath);
+        var installer = new FileBasedManifestInstaller(downloader, new DirectoryPath(testRoot));
+        var records = new FileBasedInstallationRecordRepository(Path.Combine(testRoot, "metadata", "workloads"));
+        updater = new WorkloadAdvertisingManifestUpdater(
+            new NullReporter(),
+            resolver,
+            downloader,
+            testRoot,
+            records,
+            installer,
+            getEnvironmentVariable: getEnvironmentVariable,
+            displayManifestUpdates: false,
+            sdkFeatureBand: s_featureBand);
+        return downloader;
+    }
+
+    private static string WriteManifest(string testRoot, string directoryName, string version)
+    {
+        string directory = Path.Combine(testRoot, directoryName, ManifestId);
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "WorkloadManifest.json");
+        File.WriteAllText(path, $$"""
+            {
+              "version": "{{version}}",
+              "workloads": {},
+              "packs": {}
+            }
+            """);
+        return path;
+    }
+
+    private static string GetSentinelPath(string testRoot) =>
+        Path.Combine(testRoot, $".workloadAdvertisingManifestSentinel{s_featureBand}");
+
+    private sealed class TestDirectory : IDisposable
+    {
+        public string Path { get; } =
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aot-workload-update-" + Guid.NewGuid().ToString("N"));
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestManifestProvider(string manifestPath) : IWorkloadManifestProvider
+    {
+        public IEnumerable<ReadableWorkloadManifest> GetManifests()
+        {
+            yield return new(
+                ManifestId,
+                System.IO.Path.GetDirectoryName(manifestPath)!,
+                manifestPath,
+                s_featureBand.ToString(),
+                "1.0.0",
+                () => File.OpenRead(manifestPath),
+                () => null);
+        }
+
+        public string GetSdkFeatureBand() => s_featureBand.ToString();
+
+        public IWorkloadManifestProvider.WorkloadVersionInfo GetWorkloadVersion() =>
+            new(s_featureBand + ".1");
+
+        public Dictionary<string, WorkloadSet> GetAvailableWorkloadSets() => [];
+
+        public void RefreshWorkloadManifests()
+        {
+        }
+    }
+
+    private sealed class RecordingNuGetPackageDownloader(
+        string testRoot,
+        string advertisingManifestPath,
+        bool useMsiLayout = false)
+        : INuGetPackageDownloader
+    {
+        public int LatestVersionQueries { get; private set; }
+        public int Downloads { get; private set; }
+        public int Extractions { get; private set; }
+        public PackageId? LastPackageId { get; private set; }
+
+        public Task<string> DownloadPackageAsync(
+            PackageId packageId,
+            NuGetVersion? packageVersion = null,
+            PackageSourceLocation? packageSourceLocation = null,
+            bool includePreview = false,
+            bool? includeUnlisted = null,
+            DirectoryPath? downloadFolder = null,
+            PackageSourceMapping? packageSourceMapping = null)
+        {
+            Downloads++;
+            LastPackageId = packageId;
+            string path = System.IO.Path.Combine(testRoot, $"{packageId}.2.0.0.nupkg");
+            File.WriteAllText(path, "");
+            return Task.FromResult(path);
+        }
+
+        public Task<IEnumerable<string>> ExtractPackageAsync(string packagePath, DirectoryPath targetFolder)
+        {
+            Extractions++;
+            string dataDirectory = useMsiLayout
+                ? System.IO.Path.Combine(targetFolder.Value, "data", "extractedManifest")
+                : System.IO.Path.Combine(targetFolder.Value, "data");
+            Directory.CreateDirectory(dataDirectory);
+            string destination = System.IO.Path.Combine(dataDirectory, "WorkloadManifest.json");
+            File.Copy(advertisingManifestPath, destination);
+            return Task.FromResult<IEnumerable<string>>([destination]);
+        }
+
+        public Task<NuGetVersion> GetLatestPackageVersion(
+            PackageId packageId,
+            PackageSourceLocation? packageSourceLocation = null,
+            bool includePreview = false)
+        {
+            LatestVersionQueries++;
+            LastPackageId = packageId;
+            return Task.FromResult(NuGetVersion.Parse("2.0.0"));
+        }
+
+        public Task<string> GetPackageUrl(
+            PackageId packageId,
+            NuGetVersion? packageVersion = null,
+            PackageSourceLocation? packageSourceLocation = null,
+            bool includePreview = false) => throw new NotSupportedException();
+
+        public Task<IEnumerable<NuGetVersion>> GetLatestPackageVersions(
+            PackageId packageId,
+            int numberOfResults,
+            PackageSourceLocation? packageSourceLocation = null,
+            bool includePreview = false) => throw new NotSupportedException();
+
+        public Task<NuGetVersion> GetBestPackageVersionAsync(
+            PackageId packageId,
+            VersionRange versionRange,
+            PackageSourceLocation? packageSourceLocation = null) => throw new NotSupportedException();
+
+        public Task<(NuGetVersion version, PackageSource source)> GetBestPackageVersionAndSourceAsync(
+            PackageId packageId,
+            VersionRange versionRange,
+            PackageSourceLocation? packageSourceLocation = null) => throw new NotSupportedException();
+    }
+}

--- a/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
+++ b/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
@@ -38,7 +38,12 @@ public class WorkloadUpdateTests
     public async Task DueBackgroundUpdateDownloadsManifestAndWritesState()
     {
         using var testDirectory = new TestDirectory();
-        var downloader = CreateUpdater(testDirectory.Path, out WorkloadAdvertisingManifestUpdater updater, _ => null);
+        string userProfileDir = Path.Combine(testDirectory.Path, "new-user-profile");
+        var downloader = CreateUpdater(
+            testDirectory.Path,
+            out WorkloadAdvertisingManifestUpdater updater,
+            _ => null,
+            userProfileDir);
 
         await updater.BackgroundUpdateAdvertisingManifestsWhenRequiredAsync();
 
@@ -46,16 +51,16 @@ public class WorkloadUpdateTests
         Assert.AreEqual(1, downloader.Downloads);
         Assert.AreEqual(1, downloader.Extractions);
         Assert.AreEqual($"{ManifestId}.manifest-{s_featureBand}", downloader.LastPackageId?.ToString());
-        Assert.IsTrue(File.Exists(GetSentinelPath(testDirectory.Path)));
+        Assert.IsTrue(File.Exists(GetSentinelPath(userProfileDir)));
 
-        string updatesFile = WorkloadAdvertisingManifestUpdater.GetAdvertisingWorkloadsFilePath(testDirectory.Path, s_featureBand);
+        string updatesFile = WorkloadAdvertisingManifestUpdater.GetAdvertisingWorkloadsFilePath(userProfileDir, s_featureBand);
         Assert.IsTrue(File.Exists(updatesFile));
         Assert.AreSequenceEqual(
             Array.Empty<string>(),
             JsonSerializer.Deserialize(File.ReadAllText(updatesFile), WorkloadManifestUpdaterJsonSerializerContext.Default.StringArray)!);
 
         string advertisingManifest = Path.Combine(
-            testDirectory.Path, "sdk-advertising", s_featureBand.ToString(), ManifestId, "WorkloadManifest.json");
+            userProfileDir, "sdk-advertising", s_featureBand.ToString(), ManifestId, "WorkloadManifest.json");
         Assert.IsTrue(File.Exists(advertisingManifest));
     }
 
@@ -116,11 +121,12 @@ public class WorkloadUpdateTests
     private static RecordingNuGetPackageDownloader CreateUpdater(
         string testRoot,
         out WorkloadAdvertisingManifestUpdater updater,
-        Func<string, string?> getEnvironmentVariable)
+        Func<string, string?> getEnvironmentVariable,
+        string? userProfileDir = null)
     {
         Directory.CreateDirectory(testRoot);
         string installStateDirectory = Path.Combine(
-            testRoot,
+            userProfileDir ?? testRoot,
             "metadata",
             "workloads",
             RuntimeInformation.ProcessArchitecture.ToString(),

--- a/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
+++ b/test/dotnet-aot.Tests/WorkloadUpdateTests.cs
@@ -125,8 +125,9 @@ public class WorkloadUpdateTests
         string? userProfileDir = null)
     {
         Directory.CreateDirectory(testRoot);
+        string effectiveUserProfileDir = userProfileDir ?? testRoot;
         string installStateDirectory = Path.Combine(
-            userProfileDir ?? testRoot,
+            effectiveUserProfileDir,
             "metadata",
             "workloads",
             RuntimeInformation.ProcessArchitecture.ToString(),
@@ -145,7 +146,7 @@ public class WorkloadUpdateTests
             new NullReporter(),
             resolver,
             downloader,
-            testRoot,
+            effectiveUserProfileDir,
             records,
             installer,
             getEnvironmentVariable: getEnvironmentVariable,

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -35,6 +35,7 @@
   <!-- NativeEntryPoint for ExecuteCore tests (ManagedHost is stubbed in TestManagedHost.cs) -->
   <ItemGroup>
     <Compile Include="..\..\src\Cli\dotnet-aot\NativeEntryPoint.cs" Link="NativeEntryPoint.cs" />
+    <Compile Include="..\..\src\Cli\dotnet-aot\MSBuildSdkResolverRegistration.cs" Link="MSBuildSdkResolverRegistration.cs" />
     <Compile Include="..\..\src\Cli\dotnet-aot\SdkRootLocator.cs" Link="SdkRootLocator.cs" />
   </ItemGroup>
 
@@ -53,6 +54,7 @@
     <ProjectReference Include="..\..\src\Cli\Microsoft.DotNet.Cli.Telemetry\Microsoft.DotNet.Cli.Telemetry.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectTools\Microsoft.DotNet.ProjectTools.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\Microsoft.NET.Sdk.WorkloadManifestReader.csproj" />
+    <ProjectReference Include="..\..\src\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.csproj" />
     <ProjectReference Include="..\..\src\Resolvers\Microsoft.DotNet.NativeWrapper\Microsoft.DotNet.NativeWrapper.csproj">
       <Aliases>global,NativeWrapper,DotNetNativeWrapper</Aliases>
     </ProjectReference>

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -29,7 +29,8 @@
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
 
-  <!-- Shared AOT source files (Parser, option actions, EnvironmentVariableNames) -->
+  <!-- Shared AOT dependencies and source files. -->
+  <Import Project="..\..\src\Cli\dotnet-aot\AotDependencies.props" />
   <Import Project="..\..\src\Cli\dotnet-aot\AotSourceFiles.props" />
 
   <!-- NativeEntryPoint for ExecuteCore tests (ManagedHost is stubbed in TestManagedHost.cs) -->

--- a/test/dotnet-aot.Tests/run-aot-tests.ps1
+++ b/test/dotnet-aot.Tests/run-aot-tests.ps1
@@ -112,6 +112,22 @@ if (-not (Test-Path $exePath)) {
 Write-Host "Running AOT tests..." -ForegroundColor Yellow
 Write-Host ""
 
+$sdkDirectory = & $dotnet --info 2>$null | ForEach-Object {
+    if ($_ -match '^\s*Base Path:\s*(.+?)\s*$') {
+        $Matches[1]
+    }
+} | Select-Object -First 1
+
+if (-not $sdkDirectory) {
+    Write-Host "ERROR: Could not determine the bootstrap SDK directory." -ForegroundColor Red
+    exit 1
+}
+
+$previousTestSdkDirectory = $env:DOTNET_AOT_TEST_SDK_DIRECTORY
+$previousDotnetHostPath = $env:DOTNET_HOST_PATH
+$env:DOTNET_AOT_TEST_SDK_DIRECTORY = $sdkDirectory
+$env:DOTNET_HOST_PATH = $dotnet
+
 # When -Trx is set, emit a TRX report (the AOT test binary is a Microsoft.Testing.Platform
 # app, so it accepts the --report-trx options) so CI can publish the results.
 $runArgs = @()
@@ -123,8 +139,14 @@ if ($Trx) {
     $runArgs += @("--report-trx", "--report-trx-filename", "dotnet-aot.Tests.trx", "--results-directory", $ResultsDirectory)
 }
 
-& $exePath @runArgs
-$testExitCode = $LASTEXITCODE
+try {
+    & $exePath @runArgs
+    $testExitCode = $LASTEXITCODE
+}
+finally {
+    $env:DOTNET_AOT_TEST_SDK_DIRECTORY = $previousTestSdkDirectory
+    $env:DOTNET_HOST_PATH = $previousDotnetHostPath
+}
 
 Write-Host ""
 if ($testExitCode -eq 0) {

--- a/test/dotnet-aot.Tests/run-aot-tests.sh
+++ b/test/dotnet-aot.Tests/run-aot-tests.sh
@@ -91,6 +91,21 @@ fi
 echo "Running AOT tests..."
 echo ""
 
+SDK_DIRECTORY=$("$DOTNET" --info 2>/dev/null | awk '
+    /^[[:space:]]*Base Path:/ {
+        sub(/^[[:space:]]*Base Path:[[:space:]]*/, "")
+        print
+        exit
+    }')
+
+if [[ -z "$SDK_DIRECTORY" ]]; then
+    echo "ERROR: Could not determine the bootstrap SDK directory."
+    exit 1
+fi
+
+export DOTNET_AOT_TEST_SDK_DIRECTORY="$SDK_DIRECTORY"
+export DOTNET_HOST_PATH="$DOTNET"
+
 chmod +x "$EXE_PATH"
 
 # When --trx is set, emit a TRX report (the AOT test binary is a Microsoft.Testing.Platform

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenAFileBasedManifestInstaller.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenAFileBasedManifestInstaller.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Workload.Install;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Workload.Install.Tests
+{
+    /// <summary>
+    ///  Focused tests for <see cref="FileBasedManifestInstaller"/>, the narrow
+    ///  <see cref="IWorkloadManifestInstaller"/> extracted out of <see cref="FileBasedInstaller"/> so it
+    ///  can be shared by the full file-based installer and by lightweight consumers (e.g. the background
+    ///  advertising-manifest updater) without pulling in the rest of the installer.
+    /// </summary>
+    [TestClass]
+    public class GivenAFileBasedManifestInstaller : SdkTest
+    {
+        [TestMethod]
+        public void GetManifestPackageIdReturnsTheWorkloadSetPackageIdForTheWorkloadSetManifestId()
+        {
+            var installer = new FileBasedManifestInstaller(new MockNuGetPackageDownloader(), new DirectoryPath(TestAssetsManager.CreateTestDirectory().Path));
+            var featureBand = new SdkFeatureBand("6.0.100");
+
+            var packageId = installer.GetManifestPackageId(new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId), featureBand);
+
+            packageId.ToString().Should().Be($"{WorkloadManifestUpdater.WorkloadSetManifestId}.{featureBand}".ToLowerInvariant());
+        }
+
+        [TestMethod]
+        public void GetManifestPackageIdReturnsTheManifestPackageIdForOtherManifestIds()
+        {
+            var installer = new FileBasedManifestInstaller(new MockNuGetPackageDownloader(), new DirectoryPath(TestAssetsManager.CreateTestDirectory().Path));
+            var featureBand = new SdkFeatureBand("6.0.100");
+            var manifestId = new ManifestId("test.manifest");
+
+            var packageId = installer.GetManifestPackageId(manifestId, featureBand);
+
+            packageId.ToString().Should().Be($"{manifestId}.Manifest-{featureBand}".ToLowerInvariant());
+        }
+
+        [TestMethod]
+        public void GetManifestPackageIdMatchesTheFileBasedInstallerItWasExtractedFrom()
+        {
+            var testDirectory = TestAssetsManager.CreateTestDirectory().Path;
+            var dotnetRoot = Path.Combine(testDirectory, "dotnet");
+            var manifestInstaller = new FileBasedManifestInstaller(new MockNuGetPackageDownloader(), new DirectoryPath(testDirectory));
+            var fullInstaller = new FileBasedInstaller(
+                new BufferedReporter(),
+                new SdkFeatureBand("6.0.100"),
+                workloadResolver: null,
+                userProfileDir: testDirectory,
+                nugetPackageDownloader: new MockNuGetPackageDownloader(),
+                dotnetDir: dotnetRoot);
+
+            foreach (var (manifestId, featureBand) in new[]
+            {
+                (new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId), new SdkFeatureBand("6.0.100")),
+                (new ManifestId("test.manifest"), new SdkFeatureBand("6.0.300")),
+            })
+            {
+                fullInstaller.GetManifestPackageId(manifestId, featureBand)
+                    .Should().Be(manifestInstaller.GetManifestPackageId(manifestId, featureBand));
+            }
+        }
+
+        [TestMethod]
+        public async Task ExtractManifestAsyncMovesTheExtractedDataDirectoryToTheTargetPath()
+        {
+            var testDirectory = TestAssetsManager.CreateTestDirectory().Path;
+            var nugetDownloader = new MockNuGetPackageDownloader(testDirectory, manifestDownload: true);
+            var installer = new FileBasedManifestInstaller(nugetDownloader, new DirectoryPath(testDirectory));
+            var targetPath = Path.Combine(testDirectory, "target-manifest");
+
+            await installer.ExtractManifestAsync(Path.Combine(testDirectory, "fake.nupkg"), targetPath);
+
+            File.Exists(Path.Combine(targetPath, "WorkloadManifest.json")).Should().BeTrue();
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Workload/Install/GivenAWindowsMsiManifestInstaller.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Install/GivenAWindowsMsiManifestInstaller.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using Microsoft.DotNet.Cli.Commands.Workload.Install;
+using Microsoft.DotNet.Cli.NuGetPackageDownloader;
+using Microsoft.NET.Sdk.WorkloadManifestReader;
+
+namespace Microsoft.DotNet.Cli.Workload.Install.Tests;
+
+[TestClass]
+[SupportedOSPlatform("windows")]
+public class GivenAWindowsMsiManifestInstaller : SdkTest
+{
+    [TestMethod]
+    public void GetManifestPackageIdReturnsTheArchitectureQualifiedWorkloadSetPackageId()
+    {
+        var installer = new WindowsMsiManifestInstaller(new MockNuGetPackageDownloader());
+        var featureBand = new SdkFeatureBand("6.0.100");
+
+        var packageId = installer.GetManifestPackageId(
+            new ManifestId(WorkloadManifestUpdater.WorkloadSetManifestId),
+            featureBand);
+
+        packageId.ToString().Should().Be(
+            $"{WorkloadManifestUpdater.WorkloadSetManifestId}.{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture}"
+                .ToLowerInvariant());
+    }
+
+    [TestMethod]
+    public void GetManifestPackageIdReturnsTheArchitectureQualifiedManifestPackageId()
+    {
+        var installer = new WindowsMsiManifestInstaller(new MockNuGetPackageDownloader());
+        var featureBand = new SdkFeatureBand("6.0.300");
+        var manifestId = new ManifestId("test.manifest");
+
+        var packageId = installer.GetManifestPackageId(manifestId, featureBand);
+
+        packageId.ToString().Should().Be(
+            $"{manifestId}.Manifest-{featureBand}.Msi.{RuntimeInformation.ProcessArchitecture}".ToLowerInvariant());
+    }
+}

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -28,6 +28,7 @@
   <!-- Windows-only test files that reference Installer\Windows, VisualStudio, and MSI types -->
   <ItemGroup Condition="'$(TargetOS)' != 'windows'">
     <Compile Remove="WindowsInstallerTests.cs" />
+    <Compile Remove="CommandTests\Workload\Install\GivenAWindowsMsiManifestInstaller.cs" />
     <Compile Remove="CommandTests\Workload\List\GivenAnMsiInstallation.cs" />
     <Compile Remove="CommandTests\Workload\List\GivenDotnetWorkloadList.cs" />
     <Compile Remove="CommandTests\Workload\List\VisualStudioWorkloadsTests.cs" />


### PR DESCRIPTION
## Summary

- Centralize versioned SDK path resolution in `SdkPaths.SdkDirectory` so the managed and Native AOT CLIs, forwarding apps, and SDK resolvers use the same probing logic.
- Add reflection-friendly workload and NuGet SDK resolver registration infrastructure plus physical-project metadata evaluation support for Native AOT.
- Extract the workload advertising-manifest services and include the workload/vulnerability update source closure needed by shared restore-based command code.
- Keep `AotSourceFiles.props` limited to source/resource inputs, with shared dependencies and runtime configuration in `AotDependencies.props`.
- Document SDK-root resolution and the Native AOT MSBuild evaluation boundary.

This is the infrastructure layer of a two-PR stack. It deliberately does **not** call `MSBuildSdkResolverRegistration.Register()` during Native AOT startup and does not enable any additional MSBuild-backed commands. Unsupported commands continue to fall through to the managed CLI, so the resolver/evaluation closure is not activated in the shipping native image by this PR.

## Validation

- `dotnet-aot.csproj` builds with no warnings or errors.
- The managed `dotnet.csproj` builds with no warnings or errors.
- The infrastructure Native AOT publish emits zero diagnostics with `TrimmerSingleWarn=false`.
- Focused tests cover SDK-root forwarding, explicit resolver registration, project metadata evaluation, workload advertising updates, and SDK vulnerability cache behavior.