### PR TITLE
Add telemetry for --help, --version, and --info options

### DIFF
--- a/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryFilter.cs
@@ -48,10 +48,27 @@ internal class TelemetryFilter(Func<string, string>? hash) : ITelemetryFilter
             yield break;
         }
 
+        // When a top-level terminating option (--help, --version, --info) is invoked without a
+        // subcommand, RootSubCommandResult() returns empty string.  Use the option name as the
+        // verb so these invocations are visible in telemetry.
+        if (string.IsNullOrEmpty(topLevelCommandName)
+            && parseResult.Action is InvocableOptionAction { Terminating: true } topLevelOptionAction)
+        {
+            topLevelCommandName = topLevelOptionAction.Option.Name;
+        }
+
         Dictionary<string, string?> properties = new() { ["verb"] = topLevelCommandName };
         if (!string.IsNullOrEmpty(globalJsonState))
         {
             properties["globalJson"] = globalJsonState;
+        }
+
+        // When --help is the active action on any command (e.g. "dotnet build --help"),
+        // record that the invocation was a help request so it can be distinguished from
+        // an actual command execution.
+        if (parseResult.Action is PrintHelpAction)
+        {
+            properties["help"] = "true";
         }
 
         yield return new TelemetryEntryFormat("toplevelparser/command", properties);

--- a/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryFilterTest.cs
@@ -137,4 +137,59 @@ public class TelemetryFilterTests : SdkTest
                                                         e.Properties["subcommand"] ==
                                                         Sha256Hasher.Hash("INSTALL"));
     }
+
+    [TestMethod]
+    public void DotnetHelpShouldSendHelpVerbToTelemetry()
+    {
+        var parseResult = Parser.Parse(["--help"]);
+        TelemetryEventEntry.SendFiltered(parseResult);
+        _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                e.Properties.ContainsKey("verb") &&
+                e.Properties["verb"] == Sha256Hasher.Hash("--HELP") &&
+                e.Properties.ContainsKey("help") &&
+                e.Properties["help"] == Sha256Hasher.Hash("TRUE"));
+    }
+
+    [TestMethod]
+    public void DotnetVersionShouldSendVersionVerbToTelemetry()
+    {
+        var parseResult = Parser.Parse(["--version"]);
+        TelemetryEventEntry.SendFiltered(parseResult);
+        _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                e.Properties.ContainsKey("verb") &&
+                e.Properties["verb"] == Sha256Hasher.Hash("--VERSION"));
+    }
+
+    [TestMethod]
+    public void DotnetInfoShouldSendInfoVerbToTelemetry()
+    {
+        var parseResult = Parser.Parse(["--info"]);
+        TelemetryEventEntry.SendFiltered(parseResult);
+        _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                e.Properties.ContainsKey("verb") &&
+                e.Properties["verb"] == Sha256Hasher.Hash("--INFO"));
+    }
+
+    [TestMethod]
+    public void SubcommandHelpShouldSendVerbWithHelpProperty()
+    {
+        var parseResult = Parser.Parse(["build", "--help"]);
+        TelemetryEventEntry.SendFiltered(parseResult);
+        _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                e.Properties.ContainsKey("verb") &&
+                e.Properties["verb"] == Sha256Hasher.Hash("BUILD") &&
+                e.Properties.ContainsKey("help") &&
+                e.Properties["help"] == Sha256Hasher.Hash("TRUE"));
+    }
+
+    [TestMethod]
+    public void RegularBuildCommandShouldNotHaveHelpProperty()
+    {
+        var parseResult = Parser.Parse(["build"]);
+        TelemetryEventEntry.SendFiltered(parseResult);
+        _fakeTelemetry.LogEntries.Should().Contain(e => e.EventName == "toplevelparser/command" &&
+                e.Properties.ContainsKey("verb") &&
+                e.Properties["verb"] == Sha256Hasher.Hash("BUILD") &&
+                !e.Properties.ContainsKey("help"));
+    }
 }


### PR DESCRIPTION
## Motivation

The CLI collects telemetry for command invocations, but `--help`, `--version`, and `--info` have a gap: root-level invocations like `dotnet --help` produce an empty verb, making them invisible in telemetry. Subcommand help like `dotnet build --help` emits telemetry with `verb=build` but is indistinguishable from an actual `dotnet build` execution. This PR closes both gaps.

## Changes

Modifies `TelemetryFilter.FilterImpl` with two small additions:

1. **Meaningful verb for root-level options** -- When `RootSubCommandResult()` returns an empty string and the active action is a terminating option (`--help`, `--version`, `--info`), the option's name is used as the verb instead of empty string.

2. **`help=true` property for help requests** -- When `parseResult.Action` is a `PrintHelpAction` (covers both managed and AOT paths), a `help=true` property is added to the telemetry event. This distinguishes `dotnet build --help` from `dotnet build`.

### Resulting telemetry

| Command | verb (hashed) | help property |
|---------|--------------|---------------|
| `dotnet --help` | `--help` | `true` |
| `dotnet --version` | `--version` | -- |
| `dotnet --info` | `--info` | -- |
| `dotnet build --help` | `build` | `true` |
| `dotnet build` | `build` | -- |

## Performance

Benchmarked with 10-15 iterations per command. The telemetry infrastructure cost (~300ms for OpenTelemetry/TelemetryClient init) is pre-existing and unchanged. Our filter additions are just two type checks and one dictionary insert -- nanosecond-scale operations. `TrackEvent` dispatches via `Task.Run()` (fire-and-forget), so event emission does not block command execution.

| Command | Built SDK (avg) | System SDK (avg) | Delta |
|---------|----------------|-----------------|-------|
| `--version` | 576ms | 645ms | -70ms |
| `--help` | 597ms | 654ms | -58ms |
| `build --help` | 615ms | 584ms | +32ms (noise) |

No measurable regression.

## Testing

Added 5 new tests in `TelemetryFilterTest.cs` covering all new scenarios. All 12 telemetry filter tests pass.