### PR TITLE
Add copilot-app LLM environment telemetry detection [10.0.4xx]

### DIFF
--- a/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+++ b/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
@@ -14,6 +14,8 @@ internal class LLMEnvironmentDetectorForTelemetry : ILLMEnvironmentDetector
         new EnvironmentDetectionRuleWithResult<string>("gemini", new BooleanEnvironmentRule("GEMINI_CLI")),
         // GitHub Copilot
         new EnvironmentDetectionRuleWithResult<string>("copilot", new BooleanEnvironmentRule("GITHUB_COPILOT_CLI_MODE", "COPILOT_CLI")),
+        // GitHub Copilot desktop application running as an AI agent
+        new EnvironmentDetectionRuleWithResult<string>("copilot-app", new EnvironmentVariableValueRule("AI_AGENT", "github_copilot_app_agent")),
         // Codex CLI
         new EnvironmentDetectionRuleWithResult<string>("codex", new AnyPresentEnvironmentRule("CODEX_CLI", "CODEX_SANDBOX")),
         // Aider

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -8,6 +8,29 @@ namespace Microsoft.DotNet.Tests
 {
     public class TelemetryCommonPropertiesTests : SdkTest
     {
+        // All environment variables checked by LLMEnvironmentDetectorForTelemetry.
+        // Used to save/restore ambient state so tests are isolated from the host environment.
+        private static readonly string[] _allLLMEnvVars = [
+            "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+            "CURSOR_EDITOR", "CURSOR_AI",
+            "GEMINI_CLI",
+            "GITHUB_COPILOT_CLI_MODE", "COPILOT_CLI",
+            "AI_AGENT",
+            "CODEX_CLI", "CODEX_SANDBOX",
+            "OR_APP_NAME",
+            "AMP_HOME",
+            "QWEN_CODE",
+            "DROID_CLI",
+            "OPENCODE_AI",
+            "ZED_ENVIRONMENT", "ZED_TERM",
+            "KIMI_CLI",
+            "GOOSE_TERMINAL",
+            "CLINE_TASK_ID",
+            "ROO_CODE_TASK_ID",
+            "WINDSURF_SESSION",
+            "AGENT_CLI",
+        ];
+
         public TelemetryCommonPropertiesTests(ITestOutputHelper log) : base(log)
         {
         }
@@ -165,7 +188,13 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldReturnIsLLMDetection()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["llm"].Should().BeOneOf("claude", null);
+            var llmValue = unitUnderTest.GetTelemetryCommonProperties("dummySessionId")["llm"];
+            // The value may be non-null when tests run inside an LLM agent environment.
+            // Just verify the property exists and is either null or a non-empty detection result.
+            if (llmValue != null)
+            {
+                llmValue.Should().NotBeEmpty();
+            }
         }
 
         [Theory]
@@ -193,6 +222,17 @@ namespace Microsoft.DotNet.Tests
         [MemberData(nameof(LLMTelemetryTestCases))]
         public void CanDetectLLMStatusForEnvVars(Dictionary<string, string>? envVars, string? expected)
         {
+            // Save and clear all ambient LLM env vars so the test is isolated
+            // from the host environment (e.g., when running inside a Copilot CLI agent).
+            var savedEnvVars = _allLLMEnvVars
+                .Select(v => (v, Environment.GetEnvironmentVariable(v)))
+                .Where(t => t.Item2 != null)
+                .ToArray();
+            foreach (var (key, _) in savedEnvVars)
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+
             try
             {
                 if (envVars is not null){
@@ -211,6 +251,11 @@ namespace Microsoft.DotNet.Tests
                     {
                         Environment.SetEnvironmentVariable(key, null);
                     }
+                }
+                // Restore saved ambient env vars
+                foreach (var (key, value) in savedEnvVars)
+                {
+                    Environment.SetEnvironmentVariable(key, value);
                 }
             }
         }
@@ -237,6 +282,7 @@ namespace Microsoft.DotNet.Tests
             { new Dictionary<string, string> { { "GEMINI_CLI", "true" } }, "gemini" },
             { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
             { new Dictionary<string, string> { { "COPILOT_CLI", "1" } }, "copilot" },
+            { new Dictionary<string, string> { { "AI_AGENT", "github_copilot_app_agent" } }, "copilot-app" },
             { new Dictionary<string, string> { { "CODEX_CLI", "1" } }, "codex" },
             { new Dictionary<string, string> { { "CODEX_SANDBOX", "1" } }, "codex" },
             { new Dictionary<string, string> { { "OR_APP_NAME", "Aider" } }, "aider" },
@@ -264,6 +310,7 @@ namespace Microsoft.DotNet.Tests
             { new Dictionary<string, string> { { "OR_APP_NAME", "Aider" }, { "CLINE_TASK_ID", "task123" } }, "aider, cline" },
             { new Dictionary<string, string> { { "CODEX_CLI", "1" }, { "WINDSURF_SESSION", "session789" } }, "codex, windsurf" },
             { new Dictionary<string, string> { { "GOOSE_TERMINAL", "1" }, { "ROO_CODE_TASK_ID", "task456" } }, "goose, roo" },
+            { new Dictionary<string, string> { { "COPILOT_CLI", "1" }, { "AI_AGENT", "github_copilot_app_agent" } }, "copilot, copilot-app" },
             { new Dictionary<string, string> { { "GEMINI_CLI", "false" } }, null },
             { new Dictionary<string, string> { { "GITHUB_COPILOT_CLI_MODE", "false" } }, null },
             { new Dictionary<string, string> { { "AGENT_CLI", "false" } }, null },


### PR DESCRIPTION
Backport of #55440 to release/10.0.4xx.

Adds a new `copilot-app` detection rule to the LLM environment telemetry detector for the GitHub Copilot desktop application, which sets `AI_AGENT=github_copilot_app_agent`. This is separate from the existing `copilot` rule (CLI presence via `COPILOT_CLI`).

Also fixes the LLM environment tests to save/restore ambient environment variables so they pass correctly when the test process itself runs inside an LLM agent environment.