### PR TITLE
Fix repeatable attribute matching in ApiCompat

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -100,44 +100,53 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             {
                 if (rightAttributeSet.TryGetValue(leftGroup.Representative, out AttributeGroup? rightGroup))
                 {
-                    // If attribute exists on left and the right, compare their arguments.
+                    // Match equal attribute instances first so repeated attributes are compared as a multiset.
+                    List<AttributeData> unmatchedLeft = new();
                     foreach (AttributeData leftAttribute in leftGroup.Attributes)
                     {
-                        bool seen = false;
+                        bool matched = false;
                         for (int j = 0; j < rightGroup.Attributes.Count; j++)
                         {
                             AttributeData rightAttribute = rightGroup.Attributes[j];
-                            if (_settings.AttributeDataEqualityComparer.Equals(leftAttribute, rightAttribute))
+                            if (!rightGroup.Seen[j] && _settings.AttributeDataEqualityComparer.Equals(leftAttribute, rightAttribute))
                             {
                                 rightGroup.Seen[j] = true;
-                                seen = true;
+                                matched = true;
                                 break;
                             }
                         }
 
-                        if (!seen)
+                        if (!matched)
                         {
-                            // Attribute arguments exist on left but not right.
-                            // Issue "changed" diagnostic.
-                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, leftAttribute);
+                            unmatchedLeft.Add(leftAttribute);
                         }
                     }
 
+                    List<AttributeData> unmatchedRight = new();
                     for (int i = 0; i < rightGroup.Attributes.Count; i++)
                     {
-                        if (!rightGroup.Seen[i] && _settings.StrictMode)
+                        if (!rightGroup.Seen[i])
                         {
-                            // Attribute arguments exist on right but not left.
-                            // Left
-                            //   [Foo("a")]
-                            //   void F()
-                            // Right
-                            //   [Foo("a")]
-                            //   [Foo("b")]
-                            //   void F()
-                            // Issue "changed" diagnostic when in strict mode.
-                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, rightGroup.Attributes[i]);
+                            unmatchedRight.Add(rightGroup.Attributes[i]);
                         }
+                    }
+
+                    // Pair remaining instances as argument changes. Any unpaired instances were
+                    // genuinely removed or added.
+                    int changedCount = Math.Min(unmatchedLeft.Count, unmatchedRight.Count);
+                    for (int i = 0; i < changedCount; i++)
+                    {
+                        AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, unmatchedLeft[i]);
+                    }
+
+                    for (int i = changedCount; i < unmatchedLeft.Count; i++)
+                    {
+                        AddDifference(differences, DifferenceType.Removed, leftMetadata, rightMetadata, containing, itemRef, unmatchedLeft[i]);
+                    }
+
+                    for (int i = changedCount; i < unmatchedRight.Count; i++)
+                    {
+                        AddDifference(differences, DifferenceType.Added, leftMetadata, rightMetadata, containing, itemRef, unmatchedRight[i]);
                     }
                 }
                 else

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AttributesMustMatchTests.cs
@@ -187,6 +187,112 @@ namespace CompatTests
 ",
 new CompatDifference[] {}
             },
+            // Repeated attribute removed
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  [Foo(""T"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
+}
+            },
+            // Identical repeated attribute removed
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  [Foo(""S"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
+}
+            },
+            // Repeated attribute changed and removed
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  [Foo(""T"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""U"")]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]"),
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotRemoveAttribute, "", DifferenceType.Removed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
+}
+            },
 
             // Attribute added to type
             {
@@ -845,7 +951,42 @@ namespace CompatTests
 }
 ",
 new CompatDifference[] {
-    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotChangeAttribute, "", DifferenceType.Changed, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
+}
+            },
+            // Identical attribute repeated
+            {
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  public class First {}
+}
+",
+                @"
+namespace CompatTests
+{
+  using System;
+
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+  public class FooAttribute : Attribute {
+    public FooAttribute(String s) {}
+  }
+
+  [Foo(""S"")]
+  [Foo(""S"")]
+  public class First {}
+}
+",
+new CompatDifference[] {
+    CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.CannotAddAttribute, "", DifferenceType.Added, "T:CompatTests.First:[T:CompatTests.FooAttribute]")
 }
             },
             // Attributes on method


### PR DESCRIPTION
## Summary

Match repeated attributes as multisets in `AttributesMustMatch`.

- match identical attribute instances one-to-one
- report unmatched pairs as changed arguments
- report remaining left instances as removed
- report remaining right instances as added (and suppress them outside strict mode as before)

This prevents an added repeatable attribute instance from being reported as a change to an existing instance, and prevents duplicate left instances from reusing the same right-side match.

Fixes part of #35542.

## Tests

- `Microsoft.DotNet.ApiCompatibility.Tests` (250 passed)