### PR TITLE
Skip test-runtime install on cross-architecture builds

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -27,21 +27,29 @@ function InitializeCustomSDKToolset {
     # The following shared frameworks are only needed for testing.
     # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
     if ($env:DOTNET_INSTALL_TEST_RUNTIMES -ne 'false') {
-        $installTestRuntimes = $true
-        if (-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) {
-            $nativeArch = Get-NativeMachineArchitecture
-            if ($env:TARGET_ARCHITECTURE -ne $nativeArch) {
-                $installTestRuntimes = $false
-                Write-Host "Skipping test-runtime install: host architecture '$nativeArch' cannot run target architecture '$env:TARGET_ARCHITECTURE' runtimes on this cross-build leg."
-            }
-        }
+        $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
+        # Also install the exact runtime versions that arcade's toolset requires
+        # (from Version.Details.props) so tests can target those specific versions.
+        $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
 
-        if ($installTestRuntimes) {
-            $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
-            # Also install the exact runtime versions that arcade's toolset requires
-            # (from Version.Details.props) so tests can target those specific versions.
-            $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
-            InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs
+        $nativeArch = Get-NativeMachineArchitecture
+        if ((-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) -and ($env:TARGET_ARCHITECTURE -ne $nativeArch)) {
+            # Cross-build (e.g. an x64 host producing an arm64 test payload). The host cannot execute
+            # target-architecture runtimes, so installing them into the host .dotnet would break host
+            # tools that must load a shared framework there (e.g. the NuGet credential provider, whose
+            # libhostpolicy load fails on an architecture mismatch). Instead, download the
+            # target-architecture test runtimes into a sidecar folder under artifacts. The matching
+            # OverlayCrossArchTestRuntimes target in src/Layout/redist/targets/OverlaySdkOnLKG.targets
+            # copies these into the test host that ships to Helix, where they run on
+            # target-architecture hardware. The host .dotnet keeps only host-architecture runtimes;
+            # host tools roll forward to the host SDK runtime.
+            $sidecarDir = Join-Path (Join-Path $ArtifactsDir "test-runtimes") $env:TARGET_ARCHITECTURE
+            Write-Host "Cross-build detected (host '$nativeArch', target '$env:TARGET_ARCHITECTURE'). Installing target-architecture test runtimes into sidecar '$sidecarDir' for the Helix test payload."
+            New-Item -ItemType Directory -Force -Path $sidecarDir | Out-Null
+            InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -DotNetRoot $sidecarDir -Architecture $env:TARGET_ARCHITECTURE
+        }
+        else {
+            InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -DotNetRoot $env:DOTNET_INSTALL_DIR
         }
     }
 
@@ -204,9 +212,7 @@ function Test-SharedFrameworkInstalled([string]$dotNetRoot, [string]$component, 
     return [bool](Test-Path -PathType Container (Join-Path $fxRoot $version))
 }
 
-function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$architecture = "") {
-    $dotnetRoot = $env:DOTNET_INSTALL_DIR
-
+function InstallDotNetSharedFrameworks([string[]]$runtimeSpecs, [string]$dotNetRoot, [string]$architecture = "") {
     # Skip if every requested framework is already on disk. Accept either a
     # dotnet runtime version/channel or a component@version spec such as
     # aspnetcore@11.0.0-preview.6. Treat major.minor channels as present if any

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -1,16 +1,6 @@
 # Shared dotnetup acquisition helpers (architecture detection, cache freshness, download).
 . (Join-Path $PSScriptRoot 'dotnetup-shared.ps1')
 
-function Get-DotNetInstallFallbackArchitecture {
-    if (-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) {
-        $nativeArch = Get-NativeMachineArchitecture
-        if ($env:TARGET_ARCHITECTURE -ne $nativeArch) {
-            return $env:TARGET_ARCHITECTURE
-        }
-    }
-
-    return ""
-}
 
 function InitializeCustomSDKToolset {
     if ($env:TestFullMSBuild -eq "true") {
@@ -37,14 +27,22 @@ function InitializeCustomSDKToolset {
     # The following shared frameworks are only needed for testing.
     # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
     if ($env:DOTNET_INSTALL_TEST_RUNTIMES -ne 'false') {
-        $fallbackArchitecture = Get-DotNetInstallFallbackArchitecture
-        $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
-        if ([string]::IsNullOrEmpty($fallbackArchitecture)) {
+        $installTestRuntimes = $true
+        if (-not [string]::IsNullOrEmpty($env:TARGET_ARCHITECTURE)) {
+            $nativeArch = Get-NativeMachineArchitecture
+            if ($env:TARGET_ARCHITECTURE -ne $nativeArch) {
+                $installTestRuntimes = $false
+                Write-Host "Skipping test-runtime install: host architecture '$nativeArch' cannot run target architecture '$env:TARGET_ARCHITECTURE' runtimes on this cross-build leg."
+            }
+        }
+
+        if ($installTestRuntimes) {
+            $runtimeSpecs = @("6.0", "7.0", "8.0", "9.0", "10.0")
             # Also install the exact runtime versions that arcade's toolset requires
             # (from Version.Details.props) so tests can target those specific versions.
             $runtimeSpecs += Get-CurrentRuntimeToolsetSpecs
+            InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs
         }
-        InstallDotNetSharedFrameworks -RuntimeSpecs $runtimeSpecs -Architecture $fallbackArchitecture
     }
 
     CreateBuildEnvScripts

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -35,13 +35,8 @@ function InitializeCustomSDKToolset {
     local native_arch
     native_arch=$(GetNativeMachineArchitecture)
     if [[ -n "${TARGET_ARCHITECTURE:-}" && "$TARGET_ARCHITECTURE" != "$native_arch" ]]; then
-      # On macOS arm64, x64 binaries can run via Rosetta 2, so we still install.
-      if [[ "$(uname)" == "Darwin" && "$native_arch" == "arm64" && "$TARGET_ARCHITECTURE" == "x64" ]]; then
-        : # Allow — Rosetta 2 can run x64 on arm64
-      else
-        install_test_runtimes=false
-        echo "Skipping test-runtime install: host architecture '$native_arch' cannot run target architecture '$TARGET_ARCHITECTURE' runtimes on this cross-build leg."
-      fi
+      install_test_runtimes=false
+      echo "Skipping test-runtime install: host architecture '$native_arch' cannot run target architecture '$TARGET_ARCHITECTURE' runtimes on this cross-build leg."
     fi
 
     if [[ "$install_test_runtimes" == true ]]; then

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -31,15 +31,21 @@ function InitializeCustomSDKToolset {
   # The following shared frameworks are only needed for testing.
   # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
   if [[ "${DOTNET_INSTALL_TEST_RUNTIMES:-true}" != "false" ]]; then
-    local install_script_arch=""
+    local install_test_runtimes=true
     local native_arch
     native_arch=$(GetNativeMachineArchitecture)
     if [[ -n "${TARGET_ARCHITECTURE:-}" && "$TARGET_ARCHITECTURE" != "$native_arch" ]]; then
-      install_script_arch="$TARGET_ARCHITECTURE"
+      # On macOS arm64, x64 binaries can run via Rosetta 2, so we still install.
+      if [[ "$(uname)" == "Darwin" && "$native_arch" == "arm64" && "$TARGET_ARCHITECTURE" == "x64" ]]; then
+        : # Allow — Rosetta 2 can run x64 on arm64
+      else
+        install_test_runtimes=false
+        echo "Skipping test-runtime install: host architecture '$native_arch' cannot run target architecture '$TARGET_ARCHITECTURE' runtimes on this cross-build leg."
+      fi
     fi
 
-    local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
-    if [[ -z "$install_script_arch" ]]; then
+    if [[ "$install_test_runtimes" == true ]]; then
+      local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
       # Also install the exact runtime versions that arcade's toolset requires
       # (from Version.Details.props) so tests can target those specific versions.
       local runtime_version
@@ -52,9 +58,9 @@ function InitializeCustomSDKToolset {
       if [[ -n "$aspnetcore_version" ]]; then
         runtime_specs+=("aspnetcore@$aspnetcore_version")
       fi
-    fi
 
-    InstallDotNetSharedFrameworks "$install_script_arch" "${runtime_specs[@]}"
+      InstallDotNetSharedFrameworks "" "${runtime_specs[@]}"
+    fi
   fi
 
   CreateBuildEnvScript

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -31,30 +31,38 @@ function InitializeCustomSDKToolset {
   # The following shared frameworks are only needed for testing.
   # Set DOTNET_INSTALL_TEST_RUNTIMES=false to skip (e.g. cross-build containers with limited disk).
   if [[ "${DOTNET_INSTALL_TEST_RUNTIMES:-true}" != "false" ]]; then
-    local install_test_runtimes=true
+    local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
+    # Also install the exact runtime versions that arcade's toolset requires
+    # (from Version.Details.props) so tests can target those specific versions.
+    local runtime_version
+    runtime_version=$(ReadVersionDetailsProperty "MicrosoftNETCoreAppRefPackageVersion")
+    local aspnetcore_version
+    aspnetcore_version=$(ReadVersionDetailsProperty "MicrosoftAspNetCoreAppRefPackageVersion")
+    if [[ -n "$runtime_version" ]]; then
+      runtime_specs+=("$runtime_version")
+    fi
+    if [[ -n "$aspnetcore_version" ]]; then
+      runtime_specs+=("aspnetcore@$aspnetcore_version")
+    fi
+
     local native_arch
     native_arch=$(GetNativeMachineArchitecture)
     if [[ -n "${TARGET_ARCHITECTURE:-}" && "$TARGET_ARCHITECTURE" != "$native_arch" ]]; then
-      install_test_runtimes=false
-      echo "Skipping test-runtime install: host architecture '$native_arch' cannot run target architecture '$TARGET_ARCHITECTURE' runtimes on this cross-build leg."
-    fi
-
-    if [[ "$install_test_runtimes" == true ]]; then
-      local runtime_specs=("6.0" "7.0" "8.0" "9.0" "10.0")
-      # Also install the exact runtime versions that arcade's toolset requires
-      # (from Version.Details.props) so tests can target those specific versions.
-      local runtime_version
-      runtime_version=$(ReadVersionDetailsProperty "MicrosoftNETCoreAppRefPackageVersion")
-      local aspnetcore_version
-      aspnetcore_version=$(ReadVersionDetailsProperty "MicrosoftAspNetCoreAppRefPackageVersion")
-      if [[ -n "$runtime_version" ]]; then
-        runtime_specs+=("$runtime_version")
-      fi
-      if [[ -n "$aspnetcore_version" ]]; then
-        runtime_specs+=("aspnetcore@$aspnetcore_version")
-      fi
-
-      InstallDotNetSharedFrameworks "" "${runtime_specs[@]}"
+      # Cross-build (e.g. an x64 host producing an arm64 test payload). The host cannot execute
+      # target-architecture runtimes, so installing them into the host .dotnet would break host
+      # tools that must load a shared framework there (e.g. the NuGet credential provider, whose
+      # libhostpolicy load fails on an architecture mismatch). Instead, download the
+      # target-architecture test runtimes into a sidecar folder under artifacts. The matching
+      # OverlayCrossArchTestRuntimes target in src/Layout/redist/targets/OverlaySdkOnLKG.targets
+      # copies these into the test host that ships to Helix, where they run on target-architecture
+      # hardware. The host .dotnet keeps only host-architecture runtimes; host tools roll forward
+      # to the host SDK runtime.
+      local sidecar_dir="$artifacts_dir/test-runtimes/$TARGET_ARCHITECTURE"
+      echo "Cross-build detected (host '$native_arch', target '$TARGET_ARCHITECTURE'). Installing target-architecture test runtimes into sidecar '$sidecar_dir' for the Helix test payload."
+      mkdir -p "$sidecar_dir"
+      InstallDotNetSharedFrameworks "$sidecar_dir" "$TARGET_ARCHITECTURE" "${runtime_specs[@]}"
+    else
+      InstallDotNetSharedFrameworks "$DOTNET_INSTALL_DIR" "" "${runtime_specs[@]}"
     fi
   fi
 
@@ -106,9 +114,9 @@ function IsSharedFrameworkInstalled {
 
 # Installs additional shared frameworks for testing purposes.
 function InstallDotNetSharedFrameworks {
-  local arch=$1
-  shift
-  local dotnet_root=$DOTNET_INSTALL_DIR
+  local dotnet_root=$1
+  local arch=$2
+  shift 2
   local specs_to_install=()
 
   for spec in "$@"; do

--- a/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -155,4 +155,29 @@
           DestinationFiles="@(WorkloadPackContent->'$(TestHostDotNetRoot)packs\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
+  <!-- On a cross-build, restore-toolset.{sh,ps1} downloads the target-architecture test shared
+       frameworks (6.0-9.0, plus the exact toolset versions) into a sidecar folder under artifacts,
+       rather than into the host .dotnet (whose runtimes must stay host-architecture so host tools
+       such as the NuGet credential provider keep working). Copy those target-architecture shared
+       frameworks into the test host so the Helix test payload runs them on target-architecture
+       hardware. The current major.minor band is handled by OverwriteStage0SharedFxForCrossCompilation
+       above using the locally built target-architecture files; this target covers the older bands,
+       which have no locally built binaries.
+       The sidecar path must match the one restore-toolset.{sh,ps1} write to. -->
+  <Target Name="OverlayCrossArchTestRuntimes"
+          AfterTargets="OverlaySdkOnLKG"
+          Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)'">
+    <PropertyGroup>
+      <_CrossArchTestRuntimeSidecar>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'test-runtimes', '$(TargetArchitecture)'))</_CrossArchTestRuntimeSidecar>
+    </PropertyGroup>
+    <ItemGroup Condition="Exists('$(_CrossArchTestRuntimeSidecar)')">
+      <_CrossArchTestRuntimeFile Include="$(_CrossArchTestRuntimeSidecar)shared\**\*" />
+    </ItemGroup>
+    <Copy Condition="'@(_CrossArchTestRuntimeFile)' != ''"
+          SourceFiles="@(_CrossArchTestRuntimeFile)"
+          DestinationFiles="@(_CrossArchTestRuntimeFile->'$(TestHostDotNetRoot)shared\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          UseHardLinksIfPossible="false" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary

On cross-build CI legs (e.g. x64 host building for arm64), the restore scripts install target-architecture runtimes into the host `.dotnet` folder. This causes `libhostpolicy` load failures when the NuGet credential provider resolves a shared framework built for the wrong CPU architecture, breaking `dotnet tool restore`.

## Fix

Skip installing test runtimes entirely when `TARGET_ARCHITECTURE` differs from the host architecture (since the built product won't run on the build machine anyway). Preserves the macOS Rosetta 2 exception where x64 binaries can run on arm64.

Port of the fix from `release/dnup` (PR #55435 by @dsplaisted) to `main`.

Fixes #55457