### PR TITLE
Fix 'dotnet publish -o .' excluding all source files (CS5001)

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.targets
@@ -38,8 +38,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Exclude PublishDir to prevent published artifacts from being included in subsequent builds/publishes. 
          While in most cases PublishDir is contained within BaseOutputPath or BaseIntermediateOutputPath,
          this is by no means required, so we should protect against this happening here.
-         Guard against PublishDir being the project directory (e.g. 'dotnet publish -o .') which would exclude all source files. -->
-    <DefaultItemExcludes Condition="'$(PublishDir)' != '' And '$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(PublishDir)))' != '$([MSBuild]::NormalizePath($(MSBuildProjectDirectory)))'">$(DefaultItemExcludes);$(PublishDir)/**</DefaultItemExcludes>
+         Guard against PublishDir being the project directory (e.g. 'dotnet publish -o .') which would exclude all source files.
+         Use NormalizeDirectory (not NormalizePath) on both operands so the comparison is trailing-slash insensitive: the CLI
+         forwards PublishDir as an absolute path with a trailing separator, and NormalizePath preserves the input's trailing
+         slash, so NormalizePath would treat 'C:\proj\' and 'C:\proj' as different and re-introduce the exclusion. -->
+    <DefaultItemExcludes Condition="'$(PublishDir)' != '' And '$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory), $(PublishDir)))' != '$([MSBuild]::NormalizeDirectory($(MSBuildProjectDirectory)))'">$(DefaultItemExcludes);$(PublishDir)/**</DefaultItemExcludes>
 
     <!-- Various files that should generally always be ignored -->
     <DefaultItemExcludes>$(DefaultItemExcludes);**/*.user</DefaultItemExcludes>

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -897,11 +897,12 @@ public class Class1
 
                 var propertyGroup = new XElement(ns + "PropertyGroup");
                 project.Root.Add(propertyGroup);
-                // PublishDir set to the absolute project directory with a trailing separator.
+                // PublishDir set to the absolute project directory with an OS-appropriate trailing separator.
                 // This is exactly what the CLI forwards for 'dotnet publish -o .' (see
                 // OptionExtensions.ForwardAsOutputPath, which calls GetFullPath and appends a
                 // directory separator), and is the value that regressed in dotnet/sdk#55295.
-                propertyGroup.Add(new XElement(ns + "PublishDir", "$(MSBuildProjectDirectory)\\"));
+                // EnsureTrailingSlash yields the platform-correct separator so the test matches CLI behavior on all platforms.
+                propertyGroup.Add(new XElement(ns + "PublishDir", "$([MSBuild]::EnsureTrailingSlash($(MSBuildProjectDirectory)))"));
             };
 
             var compileItems = GivenThatWeWantToBuildALibrary.GetValuesFromTestLibrary(Log, TestAssetsManager, "Compile", setup, projectChanges: projectChanges);

--- a/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThereAreDefaultItems.cs
@@ -897,8 +897,11 @@ public class Class1
 
                 var propertyGroup = new XElement(ns + "PropertyGroup");
                 project.Root.Add(propertyGroup);
-                // PublishDir set to the project directory itself (simulates 'dotnet publish -o .')
-                propertyGroup.Add(new XElement(ns + "PublishDir", ".\\"));
+                // PublishDir set to the absolute project directory with a trailing separator.
+                // This is exactly what the CLI forwards for 'dotnet publish -o .' (see
+                // OptionExtensions.ForwardAsOutputPath, which calls GetFullPath and appends a
+                // directory separator), and is the value that regressed in dotnet/sdk#55295.
+                propertyGroup.Add(new XElement(ns + "PublishDir", "$(MSBuildProjectDirectory)\\"));
             };
 
             var compileItems = GivenThatWeWantToBuildALibrary.GetValuesFromTestLibrary(Log, TestAssetsManager, "Compile", setup, projectChanges: projectChanges);


### PR DESCRIPTION
Fixes #55295

## Problem

`dotnet publish -o .` (also `-o ./` and `-o ../<projname>`) fails with `CSC error CS5001: Program does not contain a static 'Main' method` for projects with top-level statements (and silently produces an empty assembly otherwise). This is a regression of #53626 whose fix (#53923, merged April) is present in `main` but ineffective for the value the CLI actually forwards — so the customer is correct that it still repros in 11.0 preview 6 / `main`.

## Root cause

The `$(PublishDir)/**` exclusion added to `DefaultItemExcludes` excludes every source file when the publish directory equals the project directory. #53923 added a guard to skip the exclusion in that case, but it used `[MSBuild]::NormalizePath`, which **preserves the input's trailing slash**:

| Expression | Result |
| --- | --- |
| `NormalizePath(projDir)` | `...\proj` (no slash) |
| `NormalizePath(projDir, '<absProjDir>\')` | `...\proj\` (trailing slash) → **not equal → guard fails** |

The CLI **always** forwards `PublishDir` as an absolute path **with** a trailing separator (`OptionExtensions.ForwardAsOutputPath` → `GetFullPath` + append `Path.DirectorySeparatorChar`). So the guard compared `C:\proj\` against `C:\proj`, found them unequal, and re-applied the exclusion → all source excluded → CS5001.

The #53923 regression test only set `PublishDir=.\` (relative), which never simulated the absolute-trailing-slash value the CLI emits, so it gave false confidence.

## Fix

Use `[MSBuild]::NormalizeDirectory` on **both** operands. It always emits a consistent trailing slash, so equal directories compare equal regardless of the input's trailing slash, while real publish subdirectories still differ and remain correctly excluded:

| Expression | Result | Behavior |
| --- | --- | --- |
| `NormalizeDirectory(projDir, '<absProjDir>\')` | `...\proj\` → equal | correctly **not** excluded |
| `NormalizeDirectory(projDir, './out/')` | `...\proj\out\` → differs | correctly excluded |

`NormalizeDirectory` is already widely used in SDK targets, so no new dependency/risk. A comment was added explaining why `NormalizeDirectory` (not `NormalizePath`) is required, to prevent a future regression.

## Test

Strengthened `It_does_not_exclude_source_files_when_publish_dir_is_project_root` to set `PublishDir` to `$(MSBuildProjectDirectory)\` — the absolute trailing-slash value the CLI actually forwards — which is the case that regressed. The existing `It_excludes_items_in_publish_directory` test continues to guard the real-subdirectory case.

## Validation

- Full `build.cmd -c Debug` succeeds.
- All 22 tests in `GivenThereAreDefaultItems` pass against the built SDK, including both the root-dir (not excluded) and subdir (excluded) cases.