### PR TITLE
[release/11.0.1xx-preview7] Implement global command-line options for dotnet test (MTP): --timeout and --maximum-failed-tests (#55458)

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -1344,7 +1344,22 @@ To display a value, specify the corresponding command-line option without provid
     <value>VERSION</value>
   </data>
   <data name="CmdMinimumExpectedTestsDescription" xml:space="preserve">
-    <value>Specifies the minimum number of tests that are expected to run.</value>
+    <value>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</value>
+  </data>
+  <data name="CmdMaximumFailedTestsDescription" xml:space="preserve">
+    <value>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</value>
+  </data>
+  <data name="CmdTimeoutDescription" xml:space="preserve">
+    <value>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</value>
+  </data>
+  <data name="CmdDurationName" xml:space="preserve">
+    <value>DURATION</value>
+  </data>
+  <data name="CmdTestPositiveIntegerRequired" xml:space="preserve">
+    <value>The value must be a positive integer.</value>
+  </data>
+  <data name="CmdTestInvalidTimeout" xml:space="preserve">
+    <value>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</value>
   </data>
   <data name="Option_Output" xml:space="preserve">
     <value>Location to place the generated output.</value>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -3,6 +3,9 @@
 
 using System.Collections.ObjectModel;
 using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Help;
 
@@ -10,8 +13,10 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal abstract partial class TestCommandDefinition
 {
-    public sealed class MicrosoftTestingPlatform : TestCommandDefinition, ICustomHelp
+    public sealed partial class MicrosoftTestingPlatform : TestCommandDefinition, ICustomHelp
     {
+        private const long MaxSupportedTimeoutMilliseconds = 0xfffffffe;
+
         public readonly Option<string> ProjectOrSolutionOption = new("--project")
         {
             Description = CommandDefinitionStrings.CmdProjectOrSolutionDescriptionFormat,
@@ -75,6 +80,21 @@ internal abstract partial class TestCommandDefinition
         {
             Description = CommandDefinitionStrings.CmdMinimumExpectedTestsDescription,
             HelpName = CommandDefinitionStrings.CmdNumberName
+        };
+
+        public readonly Option<int?> MaximumFailedTestsOption = new("--maximum-failed-tests")
+        {
+            Description = CommandDefinitionStrings.CmdMaximumFailedTestsDescription,
+            HelpName = CommandDefinitionStrings.CmdNumberName,
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        public readonly Option<TimeSpan?> TimeoutOption = new("--timeout")
+        {
+            Description = CommandDefinitionStrings.CmdTimeoutDescription,
+            HelpName = CommandDefinitionStrings.CmdDurationName,
+            Arity = ArgumentArity.ExactlyOne,
+            CustomParser = ParseTimeout
         };
 
         public readonly Option<IReadOnlyDictionary<string, string>> EnvOption = CommonOptions.CreateEnvOption();
@@ -166,6 +186,9 @@ internal abstract partial class TestCommandDefinition
         public MicrosoftTestingPlatform()
             : base(CommandDefinitionStrings.DotnetTestCommandMTPDescription)
         {
+            MinimumExpectedTestsOption.Validators.Add(ValidatePositiveInteger);
+            MaximumFailedTestsOption.Validators.Add(ValidatePositiveInteger);
+
             Options.Add(ProjectOrSolutionOption);
             Options.Add(SolutionOption);
             Options.Add(TestModulesFilterOption);
@@ -175,6 +198,8 @@ internal abstract partial class TestCommandDefinition
             Options.Add(DiagnosticOutputDirectoryOption);
             Options.Add(MaxParallelTestModulesOption);
             Options.Add(MinimumExpectedTestsOption);
+            Options.Add(MaximumFailedTestsOption);
+            Options.Add(TimeoutOption);
             Options.Add(EnvOption);
             Options.Add(PropertiesOption);
             Options.Add(ConfigurationOption);
@@ -201,5 +226,66 @@ internal abstract partial class TestCommandDefinition
 
         public IEnumerable<Action<HelpContext>> CustomHelpLayout()
             => CustomHelpLayoutProvider?.CustomHelpLayout() ?? [];
+
+        private static void ValidatePositiveInteger(OptionResult optionResult)
+        {
+            if (optionResult.Tokens.Count == 1 &&
+                int.TryParse(optionResult.Tokens[0].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) &&
+                value <= 0)
+            {
+                optionResult.AddError(CommandDefinitionStrings.CmdTestPositiveIntegerRequired);
+            }
+        }
+
+        private static TimeSpan? ParseTimeout(ArgumentResult argumentResult)
+        {
+            if (argumentResult.Tokens.Count != 1)
+            {
+                return null;
+            }
+
+            string value = argumentResult.Tokens[0].Value;
+            Match match = TimeoutPattern().Match(value);
+            if (!match.Success ||
+                !double.TryParse(match.Groups["value"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out double number))
+            {
+                argumentResult.AddError(CommandDefinitionStrings.CmdTestInvalidTimeout);
+                return null;
+            }
+
+            string suffix = match.Groups["suffix"].Value;
+            TimeSpan timeout;
+            try
+            {
+                timeout = suffix.StartsWith("ms", StringComparison.OrdinalIgnoreCase) ||
+                          suffix.StartsWith("mil", StringComparison.OrdinalIgnoreCase)
+                    ? TimeSpan.FromMilliseconds(number)
+                    : suffix.StartsWith("s", StringComparison.OrdinalIgnoreCase)
+                        ? TimeSpan.FromSeconds(number)
+                        : suffix.StartsWith("m", StringComparison.OrdinalIgnoreCase)
+                            ? TimeSpan.FromMinutes(number)
+                            : suffix.StartsWith("h", StringComparison.OrdinalIgnoreCase)
+                                ? TimeSpan.FromHours(number)
+                                : TimeSpan.FromDays(number);
+            }
+            catch (Exception ex) when (ex is OverflowException or ArgumentException)
+            {
+                argumentResult.AddError(CommandDefinitionStrings.CmdTestInvalidTimeout);
+                return null;
+            }
+
+            if (timeout <= TimeSpan.Zero || timeout.TotalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                argumentResult.AddError(CommandDefinitionStrings.CmdTestInvalidTimeout);
+                return null;
+            }
+
+            return timeout;
+        }
+
+        [GeneratedRegex(
+            @"^(?<value>\d+(?:\.\d+)?)(?:\s*(?<suffix>ms|mils?|milliseconds?|s|secs?|seconds?|m|mins?|minutes?|h|hours?|d|days?))$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        private static partial Regex TimeoutPattern();
     }
 }

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -301,6 +301,11 @@ Pokud není zadaný, soubor se vygeneruje ve výchozím adresáři TestResults.<
         <target state="translated">Zabrání souběžnému obnovení několika projektů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">Maximální počet testovacích modulů, které je možné spustit paralelně.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Určuje minimální počet testů, jejichž spuštění se očekává.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Určuje minimální počet testů, jejichž spuštění se očekává.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Příklady:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Spusťte testy pro zadané testovací moduly.</target>
@@ -681,6 +696,16 @@ Příklady:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Podrobnosti výstupu testu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -301,6 +301,11 @@ Sofern nicht angegeben, wird die Datei im Standardverzeichnis „TestResults“ 
         <target state="translated">Hiermit wird die parallele Wiederherstellung mehrerer Projekte verhindert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">Die maximale Anzahl von Testmodulen, die parallel ausgeführt werden können.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Gibt die Mindestanzahl von Tests an, die ausgeführt werden sollen.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Gibt die Mindestanzahl von Tests an, die ausgeführt werden sollen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Beispiele:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Führen Sie Tests für die angegebenen Testmodule aus.</target>
@@ -681,6 +696,16 @@ Beispiele:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Ausführlichkeit der Testausgabe.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -301,6 +301,11 @@ Si no se especifica, el archivo se generará dentro del directorio predeterminad
         <target state="translated">Evite la restauración de varios proyectos en paralelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">Número máximo de módulos de prueba que se pueden ejecutar en paralelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Especifica el número mínimo de pruebas que se espera que se ejecuten.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Especifica el número mínimo de pruebas que se espera que se ejecuten.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Ejemplos:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Ejecute pruebas para los módulos de prueba especificados.</target>
@@ -681,6 +696,16 @@ Ejemplos:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Nivel de detalle de la salida de la prueba.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -301,6 +301,11 @@ S’il n’est pas spécifié, le fichier est généré dans le répertoire « 
         <target state="translated">Empêche la restauration de plusieurs projets en parallèle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">Nombre maximal de modules de test qui peuvent s’exécuter en parallèle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Spécifie le nombre minimal de tests censés s’exécuter.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Spécifie le nombre minimal de tests censés s’exécuter.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Exemples :
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Exécutez les tests pour les modules de test spécifiés.</target>
@@ -681,6 +696,16 @@ Exemples :
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Verbosité de la sortie de test.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -301,6 +301,11 @@ Se non specificato, il file verrà generato all'interno della directory 'TestRes
         <target state="translated">Impedisce il ripristino di più progetti in parallelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">Numero massimo di moduli di test che possono essere eseguiti in parallelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Specifica il numero minimo dei test che si prevede saranno eseguiti.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Specifica il numero minimo dei test che si prevede saranno eseguiti.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Esempi:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Esegui i test per i moduli di test specificati.</target>
@@ -681,6 +696,16 @@ Esempi:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Dettaglio dell'output di test.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -301,6 +301,11 @@ If not specified the file will be generated inside the default 'TestResults' dir
         <target state="translated">複数のプロジェクトを並行して復元できないようにします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">並列で実行できるテスト モジュールの最大数。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">実行する必要があるテストの最小数を指定します。</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">実行する必要があるテストの最小数を指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Examples:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">指定されたテスト モジュールのテストを実行します。</target>
@@ -681,6 +696,16 @@ Examples:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">テスト出力の詳細。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -301,6 +301,11 @@ If not specified the file will be generated inside the default 'TestResults' dir
         <target state="translated">여러 프로젝트를 병렬로 복원하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">병렬로 실행할 수 있는 최대 테스트 모듈 수입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">실행될 것으로 예상되는 최소 테스트 수를 지정합니다.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">실행될 것으로 예상되는 최소 테스트 수를 지정합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Examples:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">지정된 테스트 모듈에 대한 테스트를 실행합니다.</target>
@@ -681,6 +696,16 @@ Examples:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">테스트 출력의 세부 정보 표시입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -301,6 +301,11 @@ W katalogu domyślnym „TestResults” zostanie wygenerowany plik, jeśli nie z
         <target state="translated">Nie zezwalaj na równoległe przywracanie wielu projektów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">Maksymalna liczba modułów testowych, które mogą być uruchamiane równolegle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Określa minimalną liczbę testów, które mają zostać uruchomione.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Określa minimalną liczbę testów, które mają zostać uruchomione.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Przykłady:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Uruchom testy dla określonych modułów testowych.</target>
@@ -681,6 +696,16 @@ Przykłady:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Szczegółowość danych wyjściowych testu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -301,6 +301,11 @@ Se não for especificado, o arquivo será gerado dentro do diretório padrão "T
         <target state="translated">Evite restaurar vários projetos em paralelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">O número máximo de módulos de teste que podem ser executados em paralelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Especifica o número mínimo de testes que devem ser executados.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Especifica o número mínimo de testes que devem ser executados.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Exemplos:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Execute testes para os módulos de teste especificados.</target>
@@ -681,6 +696,16 @@ Exemplos:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Detalhamento da saída do teste.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -301,6 +301,11 @@ If not specified the file will be generated inside the default 'TestResults' dir
         <target state="translated">Блокировка параллельного восстановления множества проектов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">Максимальное число тестовых модулей, которые могут выполняться параллельно.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Указывает минимальное число тестов, которые должны быть запущены.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Указывает минимальное число тестов, которые должны быть запущены.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Examples:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Запускает тесты для указанных модулей.</target>
@@ -681,6 +696,16 @@ Examples:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Уровень детализации вывода тестов.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -301,6 +301,11 @@ Belirtilmezse dosya varsayılan 'TestResults' dizini içinde oluşturulur.</targ
         <target state="translated">Birden fazla projenin paralel olarak geri yüklenmesini önler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">Paralel olarak çalıştırılabilecek test modüllerinin maksimum sayısı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">Çalıştırılması beklenen en düşük test sayısını belirtir.</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">Çalıştırılması beklenen en düşük test sayısını belirtir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Bu bağımsız değişken, birden çok değişken sağlamak için birden çok ke
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">Belirtilen test modülleri için testleri çalıştırın.</target>
@@ -681,6 +696,16 @@ Bu bağımsız değişken, birden çok değişken sağlamak için birden çok ke
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">Test çıkışının ayrıntı düzeyi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -301,6 +301,11 @@ If not specified the file will be generated inside the default 'TestResults' dir
         <target state="translated">防止并行还原多个项目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">可并行运行的测试模块的最大数目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">指定预期运行的最小测试数。</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">指定预期运行的最小测试数。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Examples:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">对指定的测试模块运行测试。</target>
@@ -681,6 +696,16 @@ Examples:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">测试输出的详细程度。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -301,6 +301,11 @@ If not specified the file will be generated inside the default 'TestResults' dir
         <target state="translated">避免平行還原多個專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDurationName">
+        <source>DURATION</source>
+        <target state="new">DURATION</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdEnvironmentVariableDescription">
         <source>Sets the value of an environment variable. 
 Creates the variable if it does not exist, overrides if it does. 
@@ -419,9 +424,14 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">可平行執行的測試模組數目上限。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdMaximumFailedTestsDescription">
+        <source>Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</source>
+        <target state="new">Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdMinimumExpectedTestsDescription">
-        <source>Specifies the minimum number of tests that are expected to run.</source>
-        <target state="translated">指定預期執行的測試數目下限。</target>
+        <source>Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="needs-review-translation">指定預期執行的測試數目下限。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdNoAnsiDescription">
@@ -668,6 +678,11 @@ Examples:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdTestInvalidTimeout">
+        <source>The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</source>
+        <target state="new">The timeout must be a positive duration with an explicit unit suffix such as ms, s, m, h, or d (longer forms like 'seconds', 'minutes', 'hours', and 'days' are also accepted).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdTestModulesDescription">
         <source>Run tests for the specified test modules.</source>
         <target state="translated">為指定的測試模組執行測試。</target>
@@ -681,6 +696,16 @@ Examples:
       <trans-unit id="CmdTestOutputDescription">
         <source>Verbosity of test output.</source>
         <target state="translated">測試輸出的詳細程度。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTestPositiveIntegerRequired">
+        <source>The value must be a positive integer.</source>
+        <target state="new">The value must be a positive integer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdTimeoutDescription">
+        <source>Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</source>
+        <target state="new">Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTransitiveDescription">

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -75,6 +75,10 @@ internal static class HandshakeMessagePropertyNames
     // it, in which case the SDK falls back to its previous (no-validation) behavior.
     internal const byte ExecutionMode = 10;
 
+    // Reply-only capability that tells Microsoft.Testing.Platform where to open
+    // the reverse channel used for server-initiated session cancellation.
+    internal const byte ServerControlPipeName = 12;
+
     // Optional 1-based retry attempt number. Multiple test host instances, such as shards,
     // can belong to the same attempt. Older hosts omit it, so the SDK retains instance-based
     // retry inference as a compatibility fallback.
@@ -116,6 +120,11 @@ internal static class ProtocolConstants
     // NOTE: 1.4.0 (the reverse server-control pipe / server-initiated cancellation) is intentionally NOT advertised yet:
     // it is a separate, larger feature that is out of scope here.
     internal const string SupportedVersions = "1.0.0;1.1.0;1.2.0;1.3.0";
+}
+
+internal static class ServerControlKinds
+{
+    internal const byte CancelSession = 1;
 }
 
 internal static class ProjectProperties

--- a/src/Cli/dotnet/Commands/Test/MTP/ExitCode.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ExitCode.cs
@@ -14,4 +14,5 @@ internal static class ExitCode
     public const int TestSessionAborted = 3;
     public const int ZeroTests = 8;
     public const int MinimumExpectedTestsPolicyViolation = 9;
+    public const int TestExecutionStoppedForMaxFailedTests = 13;
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/ServerControlMessage.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/ServerControlMessage.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+internal sealed record ServerControlMessage(byte Kind) : IResponse;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/WaitForServerControlRequest.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/WaitForServerControlRequest.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+internal sealed class WaitForServerControlRequest : IRequest
+{
+    public static readonly WaitForServerControlRequest CachedInstance = new();
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -190,6 +190,14 @@ internal static class DisplayMessageFieldsId
     public const ushort Text = 4;
 }
 
-// NOTE: Serializer ids 13 (WaitForServerControlRequest) and 14 (ServerControlMessage) exist upstream
-// in testfx but are intentionally not vendored here yet: they belong to the reverse server-control pipe
-// / server-initiated cancellation feature (protocol 1.4.0), which is out of scope for this contract.
+internal static class WaitForServerControlRequestFieldsId
+{
+    public const int MessagesSerializerId = 13;
+}
+
+internal static class ServerControlMessageFieldsId
+{
+    public const int MessagesSerializerId = 14;
+
+    public const ushort Kind = 1;
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/RegisterSerializers.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
  * TestInProgressMessagesSerializer: 10
  * AzureDevOpsLogMessageSerializer: 11
  * DisplayMessageSerializer: 12
+ * WaitForServerControlRequestSerializer: 13
+ * ServerControlMessageSerializer: 14
  */
 
 internal static class RegisterSerializers
@@ -37,5 +39,7 @@ internal static class RegisterSerializers
         namedPipeBase.RegisterSerializer(new TestInProgressMessagesSerializer(), typeof(TestInProgressMessages));
         namedPipeBase.RegisterSerializer(new AzureDevOpsLogMessageSerializer(), typeof(AzureDevOpsLogMessage));
         namedPipeBase.RegisterSerializer(new DisplayMessageSerializer(), typeof(DisplayMessage));
+        namedPipeBase.RegisterSerializer(new WaitForServerControlRequestSerializer(), typeof(WaitForServerControlRequest));
+        namedPipeBase.RegisterSerializer(new ServerControlMessageSerializer(), typeof(ServerControlMessage));
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/ServerControlMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/ServerControlMessageSerializer.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+internal sealed class ServerControlMessageSerializer : BaseSerializer, INamedPipeSerializer
+{
+    public int Id => ServerControlMessageFieldsId.MessagesSerializerId;
+
+    public object Deserialize(Stream stream)
+    {
+        byte kind = 0;
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            if (fieldId == ServerControlMessageFieldsId.Kind)
+            {
+                kind = ReadByte(stream);
+                if (fieldSize > 1)
+                {
+                    SetPosition(stream, stream.Position + fieldSize - 1);
+                }
+            }
+            else
+            {
+                SetPosition(stream, stream.Position + fieldSize);
+            }
+        }
+
+        return new ServerControlMessage(kind);
+    }
+
+    public void Serialize(object objectToSerialize, Stream stream)
+    {
+        var message = (ServerControlMessage)objectToSerialize;
+        WriteUShort(stream, 1);
+        WriteField(stream, ServerControlMessageFieldsId.Kind, message.Kind);
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/WaitForServerControlRequestSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/WaitForServerControlRequestSerializer.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+internal sealed class WaitForServerControlRequestSerializer : INamedPipeSerializer
+{
+    public int Id => WaitForServerControlRequestFieldsId.MessagesSerializerId;
+
+    public object Deserialize(Stream _)
+        => WaitForServerControlRequest.CachedInstance;
+
+    public void Serialize(object _, Stream __)
+    {
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -80,7 +80,16 @@ internal partial class MicrosoftTestingPlatformTestCommand
             ListTestsFormat: GetListTestsFormat(parseResult, definition));
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);
+        using var testRunPolicy = new TestRunPolicy(
+            testOptions.IsDiscovery || testOptions.IsHelp
+                ? null
+                : parseResult.GetValue(definition.MaximumFailedTestsOption),
+            testOptions.IsDiscovery || testOptions.IsHelp
+                ? null
+                : parseResult.GetValue(definition.TimeoutOption),
+            onCancellation: _ => output.MarkCancelled());
         using var ctrlC = new CtrlCCancellationManager(output.StartCancelling);
+        using var queueCancellation = CancellationTokenSource.CreateLinkedTokenSource(ctrlC.Token, testRunPolicy.Token);
         var artifactPostProcessingManager = new ArtifactPostProcessingManager();
         int? exitCode = null;
         try
@@ -92,8 +101,20 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 output,
                 OnHelpRequested,
                 ctrlC,
-                artifactPostProcessingManager);
+                artifactPostProcessingManager,
+                testRunPolicy,
+                queueCancellation.Token);
             exitCode = testHandler.RunTestApplications(actionQueue);
+            TestRunCancellationReason cancellationReason = testRunPolicy.Complete();
+
+            if (cancellationReason == TestRunCancellationReason.MaximumFailedTests)
+            {
+                exitCode = ExitCode.TestExecutionStoppedForMaxFailedTests;
+            }
+            else if (cancellationReason == TestRunCancellationReason.Timeout)
+            {
+                exitCode = ExitCode.TestSessionAborted;
+            }
 
             if (!testOptions.IsHelp && !testOptions.IsDiscovery && !ctrlC.Token.IsCancellationRequested)
             {

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -68,7 +68,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private int _buildErrorsCount;
 
-    private bool _wasCancelled;
+    private volatile bool _wasCancelled;
 
     public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
     public int TotalTests => _assemblies.Values.Sum(a => a.TotalTests);
@@ -1102,6 +1102,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.AppendLine(CliCommandStrings.PressCtrlCAgainToForceExit);
             terminal.AppendLine();
         });
+    }
+
+    public void MarkCancelled()
+    {
+        _wasCancelled = true;
     }
 
     internal void TestDiscovered(

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -22,13 +22,16 @@ internal sealed class TestApplication(
     TerminalTestReporter output,
     Action<CommandLineOptionMessages> onHelpRequested,
     ArtifactPostProcessingManager? artifactPostProcessingManager = null,
-    ArtifactPostProcessingInvocation? artifactPostProcessingInvocation = null) : IDisposable
+    ArtifactPostProcessingInvocation? artifactPostProcessingInvocation = null,
+    TestRunPolicy? testRunPolicy = null) : IDisposable
 {
     private static readonly Version ProtocolVersion_1_1 = new(1, 1, 0);
     private static readonly TimeSpan ArtifactPostProcessingTimeout = TimeSpan.FromMinutes(15);
     private const int LiveOutputTailLineCount = 200;
 
     private readonly Lock _requestLock = new();
+    private readonly Lock _controlRequestLock = new();
+    private readonly Lock _pipeConnectionsLock = new();
     private readonly BuildOptions _buildOptions = buildOptions;
     private readonly Action<CommandLineOptionMessages> _onHelpRequested = onHelpRequested;
     private readonly TestApplicationHandler _handler = new(
@@ -36,16 +39,22 @@ internal sealed class TestApplication(
         module,
         testOptions,
         artifactPostProcessingManager,
-        artifactPostProcessingInvocation);
+        artifactPostProcessingInvocation,
+        testRunPolicy);
     private readonly ArtifactPostProcessingInvocation? _artifactPostProcessingInvocation = artifactPostProcessingInvocation;
+    private readonly TestRunPolicy? _testRunPolicy = testRunPolicy;
+    private readonly CancellationTokenSource _pipeCancellationTokenSource = new();
 
     private readonly string _pipeName = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
+    private readonly string _controlPipeName = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
 
     private readonly List<NamedPipeServer> _testAppPipeConnections = [];
     private readonly Dictionary<NamedPipeServer, HandshakeMessage> _handshakes = new();
+    private readonly List<TaskCompletionSource<IResponse>> _pendingControlRequests = [];
 
     private int _hasRun;
     private int _protocolNegotiated;
+    private int _sessionCancellationRequested;
     private Version? _negotiatedProtocolVersion;
     private ProcessOutputCollector? _standardOutputCollector;
     private ProcessOutputCollector? _standardErrorCollector;
@@ -68,16 +77,19 @@ internal sealed class TestApplication(
 
         var processStartInfo = CreateProcessStartInfo();
 
-        var cancellationTokenSource = new CancellationTokenSource();
-        var cancellationToken = cancellationTokenSource.Token;
+        var cancellationToken = _pipeCancellationTokenSource.Token;
         var testAppPipeConnectionLoop = Task.Run(async () => await WaitConnectionAsync(cancellationToken));
+        var controlPipeConnectionLoop = Task.Run(async () => await WaitControlConnectionAsync(cancellationToken));
 
         Process? process = null;
+        bool testApplicationStarted = false;
         try
         {
             Logger.LogTrace($"Starting test process with command '{processStartInfo.FileName}' and arguments '{processStartInfo.Arguments}'.");
 
             process = Process.Start(processStartInfo)!;
+            _testRunPolicy?.OnTestApplicationStarted();
+            testApplicationStarted = true;
 
             // Register with the Ctrl+C manager so a force-exit (second Ctrl+C) kills this process
             // tree even if the child's own cooperative cancellation hangs.
@@ -119,7 +131,44 @@ internal sealed class TestApplication(
             bool artifactPostProcessingTimedOut = false;
             if (_artifactPostProcessingInvocation is null)
             {
-                await process.WaitForExitAsync();
+                Task processExitTask = process.WaitForExitAsync();
+                if (_testRunPolicy is { } testRunPolicy)
+                {
+                    Task firstCompletedTask = await Task.WhenAny(processExitTask, testRunPolicy.Cancellation);
+                    if (firstCompletedTask != processExitTask)
+                    {
+                        RequestSessionCancellation();
+                        try
+                        {
+                            await processExitTask.WaitAsync(testRunPolicy.CancellationGracePeriod);
+                        }
+                        catch (TimeoutException)
+                        {
+                            try
+                            {
+                                if (!process.HasExited)
+                                {
+                                    process.Kill(entireProcessTree: true);
+                                }
+                            }
+                            catch (InvalidOperationException ex)
+                            {
+                                // The process exited between the HasExited check and Kill.
+                                Logger.LogTrace($"Test process exited before it could be killed after cancellation:\n{ex}");
+                            }
+
+                            await processExitTask;
+                        }
+                    }
+                    else
+                    {
+                        await processExitTask;
+                    }
+                }
+                else
+                {
+                    await processExitTask;
+                }
             }
             else
             {
@@ -138,6 +187,9 @@ internal sealed class TestApplication(
                     artifactPostProcessingTimedOut = true;
                 }
             }
+
+            _testRunPolicy?.OnTestApplicationExited();
+            testApplicationStarted = false;
 
             // At this point, process already exited. Allow for 5 seconds to consume stdout/stderr.
             // We might not be able to consume all the output if the test app has exited but left a child process alive.
@@ -171,6 +223,11 @@ internal sealed class TestApplication(
         }
         finally
         {
+            if (testApplicationStarted)
+            {
+                _testRunPolicy?.OnTestApplicationExited();
+            }
+
             if (process is not null)
             {
                 ctrlC.Unregister(process);
@@ -180,8 +237,8 @@ internal sealed class TestApplication(
             Volatile.Write(ref _standardOutputCollector, null);
             Volatile.Write(ref _standardErrorCollector, null);
 
-            cancellationTokenSource.Cancel();
-            await testAppPipeConnectionLoop;
+            _pipeCancellationTokenSource.Cancel();
+            await Task.WhenAll(testAppPipeConnectionLoop, controlPipeConnectionLoop);
         }
     }
 
@@ -317,7 +374,7 @@ internal sealed class TestApplication(
                 pipeConnection.RegisterAllSerializers();
 
                 await pipeConnection.WaitConnectionAsync(token);
-                _testAppPipeConnections.Add(pipeConnection);
+                AddPipeConnection(pipeConnection);
             }
         }
         catch (OperationCanceledException ex)
@@ -330,6 +387,91 @@ internal sealed class TestApplication(
             var exAsString = ex.ToString();
             Logger.LogTrace(exAsString);
             Environment.FailFast(exAsString);
+        }
+    }
+
+    private async Task WaitControlConnectionAsync(CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                NamedPipeServer? pipeConnection = new(
+                    _controlPipeName,
+                    OnControlRequest,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    token,
+                    skipUnknownMessages: false);
+                try
+                {
+                    pipeConnection.RegisterAllSerializers();
+
+                    await pipeConnection.WaitConnectionAsync(token);
+                    AddPipeConnection(pipeConnection);
+                    pipeConnection = null;
+                }
+                finally
+                {
+                    pipeConnection?.Dispose();
+                }
+            }
+        }
+        catch (OperationCanceledException ex) when (ex.CancellationToken == token)
+        {
+            Logger.LogTrace("WaitControlConnectionAsync() was cancelled.");
+        }
+        catch (Exception ex)
+        {
+            // The reverse channel is an optional capability. A failure here must not replace
+            // the test application's result; policy cancellation can still use the kill fallback.
+            Logger.LogTrace($"The server-control pipe stopped accepting connections:\n{ex}");
+        }
+    }
+
+    private Task<IResponse> OnControlRequest(NamedPipeServer _, IRequest request)
+    {
+        if (request is not WaitForServerControlRequest)
+        {
+            throw new NotSupportedException(string.Format(CliCommandStrings.CmdUnsupportedMessageRequestTypeException, request.GetType()));
+        }
+
+        lock (_controlRequestLock)
+        {
+            if (Volatile.Read(ref _sessionCancellationRequested) != 0)
+            {
+                return Task.FromResult<IResponse>(new ServerControlMessage(ServerControlKinds.CancelSession));
+            }
+
+            var completion = new TaskCompletionSource<IResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pendingControlRequests.Add(completion);
+            _pipeCancellationTokenSource.Token.Register(
+                () => completion.TrySetCanceled(_pipeCancellationTokenSource.Token));
+            return completion.Task;
+        }
+    }
+
+    private void AddPipeConnection(NamedPipeServer pipeConnection)
+    {
+        lock (_pipeConnectionsLock)
+        {
+            _testAppPipeConnections.Add(pipeConnection);
+        }
+    }
+
+    private void RequestSessionCancellation()
+    {
+        if (Interlocked.Exchange(ref _sessionCancellationRequested, 1) != 0)
+        {
+            return;
+        }
+
+        lock (_controlRequestLock)
+        {
+            var message = new ServerControlMessage(ServerControlKinds.CancelSession);
+            foreach (TaskCompletionSource<IResponse> request in _pendingControlRequests)
+            {
+                request.TrySetResult(message);
+            }
         }
     }
 
@@ -463,15 +605,24 @@ internal sealed class TestApplication(
         return highestCommonVersionText;
     }
 
-    private static HandshakeMessage CreateHandshakeMessage(string version) =>
-        new HandshakeMessage(new Dictionary<byte, string>(capacity: 5)
+    private HandshakeMessage CreateHandshakeMessage(string version)
+    {
+        var properties = new Dictionary<byte, string>(capacity: 6)
         {
             { HandshakeMessagePropertyNames.PID, Environment.ProcessId.ToString(CultureInfo.InvariantCulture) },
             { HandshakeMessagePropertyNames.Architecture, RuntimeInformation.ProcessArchitecture.ToString() },
             { HandshakeMessagePropertyNames.Framework, RuntimeInformation.FrameworkDescription },
             { HandshakeMessagePropertyNames.OS, RuntimeInformation.OSDescription },
             { HandshakeMessagePropertyNames.SupportedProtocolVersions, version }
-        });
+        };
+
+        if (version.Length > 0)
+        {
+            properties.Add(HandshakeMessagePropertyNames.ServerControlPipeName, _controlPipeName);
+        }
+
+        return new HandshakeMessage(properties);
+    }
 
     private void SetNegotiatedProtocolVersion(string negotiatedVersion)
     {
@@ -676,5 +827,7 @@ internal sealed class TestApplication(
                 Reporter.Error.WriteLine(messageBuilder.ToString());
             }
         }
+
+        _pipeCancellationTokenSource.Dispose();
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationActionQueue.cs
@@ -12,6 +12,7 @@ internal class TestApplicationActionQueue
 {
     private readonly Channel<ParallelizableTestModuleGroupWithSequentialInnerModules> _channel;
     private readonly Task[] _readers;
+    private readonly CancellationToken _cancellationToken;
 
     private int? _aggregateExitCode;
 
@@ -24,10 +25,13 @@ internal class TestApplicationActionQueue
         TerminalTestReporter output,
         Action<CommandLineOptionMessages> onHelpRequested,
         CtrlCCancellationManager ctrlC,
-        ArtifactPostProcessingManager artifactPostProcessingManager)
+        ArtifactPostProcessingManager artifactPostProcessingManager,
+        TestRunPolicy testRunPolicy,
+        CancellationToken cancellationToken)
     {
         _channel = Channel.CreateUnbounded<ParallelizableTestModuleGroupWithSequentialInnerModules>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
         _readers = new Task[degreeOfParallelism];
+        _cancellationToken = cancellationToken;
 
         for (int i = 0; i < degreeOfParallelism; i++)
         {
@@ -37,12 +41,18 @@ internal class TestApplicationActionQueue
                 output,
                 onHelpRequested,
                 ctrlC,
-                artifactPostProcessingManager));
+                artifactPostProcessingManager,
+                testRunPolicy));
         }
     }
 
     public void Enqueue(ParallelizableTestModuleGroupWithSequentialInnerModules testApplication)
     {
+        if (_cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         if (!_channel.Writer.TryWrite(testApplication))
         {
             throw new InvalidOperationException($"Failed to write to channel for test application: {testApplication}");
@@ -67,15 +77,16 @@ internal class TestApplicationActionQueue
         TerminalTestReporter output,
         Action<CommandLineOptionMessages> onHelpRequested,
         CtrlCCancellationManager ctrlC,
-        ArtifactPostProcessingManager artifactPostProcessingManager)
+        ArtifactPostProcessingManager artifactPostProcessingManager,
+        TestRunPolicy testRunPolicy)
     {
         try
         {
-            await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync(ctrlC.Token))
+            await foreach (var nonParallelizedGroup in _channel.Reader.ReadAllAsync(_cancellationToken))
             {
                 foreach (var module in nonParallelizedGroup)
                 {
-                    ctrlC.Token.ThrowIfCancellationRequested();
+                    _cancellationToken.ThrowIfCancellationRequested();
 
                     int result = ExitCode.GenericFailure;
                     var testApp = new TestApplication(
@@ -84,7 +95,8 @@ internal class TestApplicationActionQueue
                         testOptions,
                         output,
                         onHelpRequested,
-                        artifactPostProcessingManager);
+                        artifactPostProcessingManager,
+                        testRunPolicy: testRunPolicy);
                     try
                     {
                         using (testApp)
@@ -141,12 +153,11 @@ internal class TestApplicationActionQueue
             }
 
         }
-        catch (OperationCanceledException) when (ctrlC.Token.IsCancellationRequested)
+        catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
         {
-            // Stop scheduling new test apps once the user has pressed Ctrl+C the first time.
+            // Stop scheduling new test apps once cancellation is requested.
             // Already-running test apps are left alone so they can gracefully cancel themselves
-            // (and report final session state via IPC); a second Ctrl+C is what force-kills them
-            // via the CtrlCCancellationManager.
+            // and report final session state via IPC.
         }
     }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -13,6 +13,7 @@ internal sealed class TestApplicationHandler
     private readonly TestOptions _options;
     private readonly ArtifactPostProcessingManager? _artifactPostProcessingManager;
     private readonly ArtifactPostProcessingInvocation? _artifactPostProcessingInvocation;
+    private readonly TestRunPolicy? _testRunPolicy;
     private readonly Lock _lock = new();
     private readonly Dictionary<string, (int TestSessionStartCount, int TestSessionEndCount)> _testSessionEventCountPerSessionUid = new();
 
@@ -24,13 +25,15 @@ internal sealed class TestApplicationHandler
         TestModule module,
         TestOptions options,
         ArtifactPostProcessingManager? artifactPostProcessingManager = null,
-        ArtifactPostProcessingInvocation? artifactPostProcessingInvocation = null)
+        ArtifactPostProcessingInvocation? artifactPostProcessingInvocation = null,
+        TestRunPolicy? testRunPolicy = null)
     {
         _output = output;
         _module = module;
         _options = options;
         _artifactPostProcessingManager = artifactPostProcessingManager;
         _artifactPostProcessingInvocation = artifactPostProcessingInvocation;
+        _testRunPolicy = testRunPolicy;
     }
 
     /// <summary>
@@ -357,6 +360,8 @@ internal sealed class TestApplicationHandler
                 standardOutput: testResult.StandardOutput,
                 errorOutput: testResult.ErrorOutput);
         }
+
+        _testRunPolicy?.ReportFailedTests(testResultMessage.FailedTestMessages.Length);
     }
 
     internal void OnTestInProgressReceived(TestInProgressMessages testInProgressMessages)

--- a/src/Cli/dotnet/Commands/Test/MTP/TestRunPolicy.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestRunPolicy.cs
@@ -1,0 +1,209 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Cli.Commands.Test;
+
+internal enum TestRunCancellationReason
+{
+    None,
+    MaximumFailedTests,
+    Timeout,
+}
+
+internal sealed class TestRunPolicy : IDisposable
+{
+    private const int CompletedState = -1;
+
+    internal static readonly TimeSpan DefaultCancellationGracePeriod = TimeSpan.FromSeconds(30);
+
+    private readonly int? _maximumFailedTests;
+    private readonly TimeSpan? _timeout;
+    private readonly Action<TestRunCancellationReason>? _onCancellation;
+    private readonly TaskCompletionSource<TestRunCancellationReason> _cancellation =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly Lock _timerLock = new();
+
+    private Timer? _timer;
+    private TimeSpan? _remainingTimeout;
+    private long _timerStartedTimestamp;
+    private int _activeTestApplications;
+    private int _failedTests;
+    private int _reason;
+    private bool _disposed;
+
+    public TestRunPolicy(
+        int? maximumFailedTests,
+        TimeSpan? timeout,
+        TimeSpan? cancellationGracePeriod = null,
+        Action<TestRunCancellationReason>? onCancellation = null)
+    {
+        if (maximumFailedTests is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumFailedTests));
+        }
+
+        if (timeout.HasValue && timeout.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        _maximumFailedTests = maximumFailedTests;
+        _timeout = timeout;
+        _remainingTimeout = timeout;
+        _onCancellation = onCancellation;
+        CancellationGracePeriod = cancellationGracePeriod ?? DefaultCancellationGracePeriod;
+    }
+
+    public CancellationToken Token => _cancellationTokenSource.Token;
+
+    public Task<TestRunCancellationReason> Cancellation => _cancellation.Task;
+
+    public TestRunCancellationReason Reason
+    {
+        get
+        {
+            int reason = Volatile.Read(ref _reason);
+            return reason == CompletedState
+                ? TestRunCancellationReason.None
+                : (TestRunCancellationReason)reason;
+        }
+    }
+
+    public int FailedTests => Volatile.Read(ref _failedTests);
+
+    public TimeSpan CancellationGracePeriod { get; }
+
+    public void OnTestApplicationStarted()
+    {
+        if (_timeout is null)
+        {
+            return;
+        }
+
+        lock (_timerLock)
+        {
+            _activeTestApplications++;
+            if (_activeTestApplications == 1 &&
+                !_disposed &&
+                Reason == TestRunCancellationReason.None &&
+                _remainingTimeout is { } remainingTimeout)
+            {
+                _timerStartedTimestamp = Stopwatch.GetTimestamp();
+
+                // A concurrent OnTestApplicationExited can drive _remainingTimeout non-positive a
+                // moment before it flips Reason to Timeout, so clamp to avoid passing a negative due
+                // time to Timer (which throws ArgumentOutOfRangeException). A zero due time fires
+                // immediately and OnTimeout performs the cancellation.
+                TimeSpan dueTime = remainingTimeout > TimeSpan.Zero ? remainingTimeout : TimeSpan.Zero;
+                _timer = new Timer(
+                    static state => ((TestRunPolicy)state!).OnTimeout(),
+                    this,
+                    dueTime,
+                    Timeout.InfiniteTimeSpan);
+            }
+        }
+    }
+
+    public void OnTestApplicationExited()
+    {
+        bool timeoutReached = false;
+        lock (_timerLock)
+        {
+            if (_timeout is null)
+            {
+                return;
+            }
+
+            if (_activeTestApplications <= 0)
+            {
+                throw new InvalidOperationException("A test application exited without a matching start.");
+            }
+
+            _activeTestApplications--;
+            if (_activeTestApplications == 0 && _timer is not null)
+            {
+                _timer.Dispose();
+                _timer = null;
+
+                TimeSpan elapsed = Stopwatch.GetElapsedTime(_timerStartedTimestamp);
+                _remainingTimeout -= elapsed;
+                timeoutReached = _remainingTimeout <= TimeSpan.Zero;
+            }
+        }
+
+        if (timeoutReached)
+        {
+            TryCancel(TestRunCancellationReason.Timeout);
+        }
+    }
+
+    public void ReportFailedTests(int count)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        int failedTests = Interlocked.Add(ref _failedTests, count);
+        if (_maximumFailedTests is { } maximumFailedTests && failedTests >= maximumFailedTests)
+        {
+            TryCancel(TestRunCancellationReason.MaximumFailedTests);
+        }
+    }
+
+    public TestRunCancellationReason Complete()
+    {
+        int state = Interlocked.CompareExchange(
+            ref _reason,
+            CompletedState,
+            (int)TestRunCancellationReason.None);
+
+        lock (_timerLock)
+        {
+            _timer?.Dispose();
+            _timer = null;
+        }
+
+        return state is (int)TestRunCancellationReason.None or CompletedState
+            ? TestRunCancellationReason.None
+            : (TestRunCancellationReason)state;
+    }
+
+    private void TryCancel(TestRunCancellationReason reason)
+    {
+        if (Interlocked.CompareExchange(ref _reason, (int)reason, (int)TestRunCancellationReason.None) !=
+            (int)TestRunCancellationReason.None)
+        {
+            return;
+        }
+
+        _onCancellation?.Invoke(reason);
+        _cancellation.TrySetResult(reason);
+        _cancellationTokenSource.Cancel();
+    }
+
+    private void OnTimeout()
+    {
+        lock (_timerLock)
+        {
+            if (_activeTestApplications > 0 && !_disposed)
+            {
+                TryCancel(TestRunCancellationReason.Timeout);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        Complete();
+        lock (_timerLock)
+        {
+            _disposed = true;
+        }
+
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/test/Microsoft.NET.TestFramework/Constants.cs
+++ b/test/Microsoft.NET.TestFramework/Constants.cs
@@ -18,7 +18,9 @@ namespace Microsoft.NET.TestFramework
         public const int Success = 0;
         public const int GenericFailure = 1;
         public const int AtLeastOneTestFailed = 2;
+        public const int TestSessionAborted = 3;
         public const int ZeroTests = 8;
         public const int MinimumExpectedTestsPolicyViolation = 9;
+        public const int TestExecutionStoppedForMaxFailedTests = 13;
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -615,6 +615,32 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        public void RunMTPSolutionWithMaximumFailedTestsReturnsPolicyExitCode()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("MultiTestProjectSolutionWithDifferentFailures", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("--maximum-failed-tests", "1");
+
+            result.ExitCode.Should().Be(ExitCodes.TestExecutionStoppedForMaxFailedTests);
+        }
+
+        [TestMethod]
+        public void RunMTPProjectWithGlobalTimeoutReturnsTestSessionAborted()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectMTPCrash", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("--timeout", "100ms");
+
+            result.ExitCode.Should().Be(ExitCodes.TestSessionAborted);
+        }
+
+        [TestMethod]
         public void RunMTPProjectThatCrashesWithExitCodeZero_ShouldFail()
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectMTPCrash", Guid.NewGuid().ToString())

--- a/test/dotnet.Tests/CommandTests/Test/ServerControlMessageSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ServerControlMessageSerializerTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class ServerControlMessageSerializerTests
+{
+    [TestMethod]
+    public void ServerControlMessageRoundTrips()
+    {
+        var serializer = new ServerControlMessageSerializer();
+        var message = new ServerControlMessage(ServerControlKinds.CancelSession);
+        using var stream = new MemoryStream();
+
+        serializer.Serialize(message, stream);
+        stream.Position = 0;
+
+        serializer.Deserialize(stream).Should().Be(message);
+    }
+
+    [TestMethod]
+    public void SerializerIdsMatchTestFxContract()
+    {
+        new WaitForServerControlRequestSerializer().Id.Should().Be(13);
+        new ServerControlMessageSerializer().Id.Should().Be(14);
+    }
+
+    [TestMethod]
+    public void WaitForServerControlRequestHasNoPayload()
+    {
+        var serializer = new WaitForServerControlRequestSerializer();
+        using var stream = new MemoryStream();
+
+        serializer.Serialize(WaitForServerControlRequest.CachedInstance, stream);
+
+        stream.Length.Should().Be(0);
+        serializer.Deserialize(stream).Should().BeSameAs(WaitForServerControlRequest.CachedInstance);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -160,6 +160,99 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        public void MTPCommandParsesGlobalMaximumFailedTests()
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--maximum-failed-tests", "5"]);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(command.MaximumFailedTestsOption).Should().Be(5);
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        [DataRow("--maximum-failed-tests=5")]
+        [DataRow("--maximum-failed-tests:5")]
+        public void MTPCommandParsesInlineGlobalMaximumFailedTests(string argument)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse([argument]);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(command.MaximumFailedTestsOption).Should().Be(5);
+        }
+
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("-1")]
+        public void MTPCommandRejectsNonPositiveGlobalMaximumFailedTests(string value)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--maximum-failed-tests", value]);
+
+            parseResult.Errors.Should().NotBeEmpty();
+        }
+
+        [TestMethod]
+        [DataRow("500ms", 500.0)]
+        [DataRow("2s", 2_000.0)]
+        [DataRow("1.5m", 90_000.0)]
+        public void MTPCommandParsesGlobalTimeout(string value, double expectedMilliseconds)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--timeout", value]);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(command.TimeoutOption)!.Value.TotalMilliseconds.Should().Be(expectedMilliseconds);
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        [DataRow("--timeout=2s")]
+        [DataRow("--timeout:2s")]
+        public void MTPCommandParsesInlineGlobalTimeout(string argument)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse([argument]);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(command.TimeoutOption).Should().Be(TimeSpan.FromSeconds(2));
+        }
+
+        [TestMethod]
+        [DataRow("200")]
+        [DataRow("0s")]
+        [DataRow("-1s")]
+        [DataRow("50d")]
+        [DataRow("invalid")]
+        public void MTPCommandRejectsInvalidGlobalTimeout(string value)
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse(["--timeout", value]);
+
+            parseResult.Errors.Should().NotBeEmpty();
+        }
+
+        [TestMethod]
+        public void MTPCommandForwardsPolicyOptionsAfterSeparator()
+        {
+            var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+            var parseResult = command.Parse([
+                "--maximum-failed-tests", "5",
+                "--timeout", "1m",
+                "--",
+                "--maximum-failed-tests", "2",
+                "--timeout", "10s"]);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.GetValue(command.MaximumFailedTestsOption).Should().Be(5);
+            parseResult.GetValue(command.TimeoutOption).Should().Be(TimeSpan.FromMinutes(1));
+            parseResult.UnmatchedTokens.Should().Equal(
+                "--maximum-failed-tests", "2",
+                "--timeout", "10s");
+        }
+
+        [TestMethod]
         [DataRow("text")]
         [DataRow("json")]
         public void MTPCommandAcceptsListTestsFormatValue(string format)

--- a/test/dotnet.Tests/CommandTests/Test/TestRunPolicyTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestRunPolicyTests.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class TestRunPolicyTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task MaximumFailedTestsCancelsWhenThresholdIsReached()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        TestRunCancellationReason? callbackReason = null;
+        using var policy = new TestRunPolicy(
+            maximumFailedTests: 3,
+            timeout: null,
+            onCancellation: reason => callbackReason = reason);
+
+        policy.ReportFailedTests(2);
+
+        policy.Token.IsCancellationRequested.Should().BeFalse();
+        policy.Reason.Should().Be(TestRunCancellationReason.None);
+
+        policy.ReportFailedTests(1);
+
+        TestRunCancellationReason reason = await policy.Cancellation.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        reason.Should().Be(TestRunCancellationReason.MaximumFailedTests);
+        policy.Token.IsCancellationRequested.Should().BeTrue();
+        policy.FailedTests.Should().Be(3);
+        callbackReason.Should().Be(TestRunCancellationReason.MaximumFailedTests);
+    }
+
+    [TestMethod]
+    public async Task FailureCountingIsIndependentOfRetryBookkeeping()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        using var policy = new TestRunPolicy(maximumFailedTests: 2, timeout: null);
+
+        policy.ReportFailedTests(1);
+        policy.ReportFailedTests(1);
+
+        TestRunCancellationReason reason = await policy.Cancellation.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        reason.Should().Be(TestRunCancellationReason.MaximumFailedTests);
+        policy.FailedTests.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task TimeoutStartsWithFirstTestApplication()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        using var policy = new TestRunPolicy(maximumFailedTests: null, timeout: TimeSpan.FromMilliseconds(100));
+
+        await Task.Delay(200, cancellationToken);
+        policy.Reason.Should().Be(TestRunCancellationReason.None);
+
+        policy.OnTestApplicationStarted();
+
+        TestRunCancellationReason reason = await policy.Cancellation.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        reason.Should().Be(TestRunCancellationReason.Timeout);
+    }
+
+    [TestMethod]
+    public void StartingAdditionalTestApplicationsDoesNotRestartTimeout()
+    {
+        using var policy = new TestRunPolicy(maximumFailedTests: null, timeout: TimeSpan.FromMinutes(1));
+
+        policy.OnTestApplicationStarted();
+        policy.OnTestApplicationStarted();
+
+        policy.Reason.Should().Be(TestRunCancellationReason.None);
+    }
+
+    [TestMethod]
+    public async Task TimeoutOnlyCountsTimeWithActiveTestApplications()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        using var policy = new TestRunPolicy(maximumFailedTests: null, timeout: TimeSpan.FromMilliseconds(300));
+
+        policy.OnTestApplicationStarted();
+        await Task.Delay(100, cancellationToken);
+        policy.OnTestApplicationExited();
+
+        await Task.Delay(300, cancellationToken);
+        policy.Reason.Should().Be(TestRunCancellationReason.None);
+
+        policy.OnTestApplicationStarted();
+        TestRunCancellationReason reason = await policy.Cancellation.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+
+        reason.Should().Be(TestRunCancellationReason.Timeout);
+    }
+
+    [TestMethod]
+    public async Task CompletingPolicyPreventsLateTimeout()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        using var policy = new TestRunPolicy(maximumFailedTests: null, timeout: TimeSpan.FromMilliseconds(100));
+
+        policy.OnTestApplicationStarted();
+        TestRunCancellationReason reason = policy.Complete();
+        await Task.Delay(200, cancellationToken);
+
+        reason.Should().Be(TestRunCancellationReason.None);
+        policy.Reason.Should().Be(TestRunCancellationReason.None);
+        policy.Token.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void CompletingPolicyPreservesCancellationReason()
+    {
+        using var policy = new TestRunPolicy(maximumFailedTests: 1, timeout: null);
+
+        policy.ReportFailedTests(1);
+
+        policy.Complete().Should().Be(TestRunCancellationReason.MaximumFailedTests);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentStartAndExitAtTimeoutBoundaryDoesNotThrow()
+    {
+        // Regression: OnTestApplicationExited can drive the remaining timeout non-positive a moment
+        // before it flips Reason to Timeout. A test application starting in that window must not
+        // construct a Timer with a negative due time (which previously threw and corrupted the
+        // active-application accounting).
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+        using var policy = new TestRunPolicy(maximumFailedTests: null, timeout: TimeSpan.FromMilliseconds(30));
+
+        var workers = new Task[3];
+        for (int w = 0; w < workers.Length; w++)
+        {
+            workers[w] = Task.Run(async () =>
+            {
+                while (policy.Reason == TestRunCancellationReason.None)
+                {
+                    policy.OnTestApplicationStarted();
+                    await Task.Delay(1, cancellationToken);
+                    policy.OnTestApplicationExited();
+                }
+            }, cancellationToken);
+        }
+
+        await Task.WhenAll(workers).WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+        policy.Reason.Should().Be(TestRunCancellationReason.Timeout);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -15,7 +15,9 @@ Options:
   --diagnostic-output-directory <DIAGNOSTIC_DIR>  Output directory of the diagnostic logging.
                                                   If not specified the file will be generated inside the default 'TestResults' directory.
   --max-parallel-test-modules <NUMBER>            The max number of test modules that can run in parallel.
-  --minimum-expected-tests <NUMBER>               Specifies the minimum number of tests that are expected to run.
+  --minimum-expected-tests <NUMBER>               Specifies the minimum number of tests that are expected to run across all test applications. Pass after '--' to apply per test application.
+  --maximum-failed-tests <NUMBER>                 Stops test execution when the specified number of failures is reached across all test applications. Pass after '--' to apply per test application when supported.
+  --timeout <DURATION>                            Stops test execution when the specified test execution time is reached across all test applications. Pass after '--' to apply per test application.
   -e, --environment <NAME="VALUE">                Sets the value of an environment variable. 
                                                   Creates the variable if it does not exist, overrides if it does. 
                                                   This argument can be specified multiple times to provide multiple variables.
@@ -77,8 +79,6 @@ Platform Options:
                                   Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an LLM/AI agent environment is detected).
   --show-stdout                   Determines when to show captured standard output of a test.
                                   Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an LLM/AI agent environment is detected).
-  --timeout                       A global test execution timeout.
-                                  Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.
   --zero-tests-policy             Specifies how a run that executed no tests is treated.
                                   Valid values are 'allow-skipped' (the default) which counts skipped tests as run, so only a run where no test was found at all fails with exit code 8, and 'strict' which treats skipped tests as not run, so a run where every test was skipped (or no test was found) fails with exit code 8.
 


### PR DESCRIPTION
Backport of #55458 to `release/11.0.1xx-preview7`.

/cc @Evangelink

## Customer Impact
Brings the new global `dotnet test` (Microsoft.Testing.Platform) command-line options to the preview7 release:
- `--timeout <DURATION>` — global test-execution timeout (measured across all test applications; returns `TestSessionAborted` / exit code 3 on timeout).
- `--maximum-failed-tests <NUMBER>` — stops the run once the given number of failures is reached across all test applications (independent of retry bookkeeping).

Both apply globally when placed before `--`, and can be passed after `--` to apply per test application. Implemented via an SDK server-side reverse control pipe that advertises `ServerControlPipeName` and sends `CancelSession` to TestFx.

## Notes on this manual backport
The automated `/backport` bot failed because its per-commit `git am` tried to re-apply the branch's `DangerousFileDetector` race fix, which already exists on `release/11.0.1xx-preview7` (both branches fixed the same race). Re-created manually via `git cherry-pick -m 1` of the merge commit (net-diff 3-way merge), which resolved that overlap cleanly — no code conflicts. The result is the same 35-file feature change, with `DangerousFileDetector.cs` producing no net change on this branch (already present).

Resolves the backport request on #55458. Original issue: #49709.
