### PR TITLE
Move cross-AOT legs into shared SDK job matrix

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -169,35 +169,6 @@ extends:
               testRunnerAdditionalArguments: -class Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
               publishXunitResults: true
 
-      ### AOT (win-arm64 cross-build) ###
-      # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC
-      # arm64 linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is
-      # required). This leg therefore BUILDS on the existing win-x64 pool with /p:CrossBuild=true and
-      # produces the dotnet-aot .dll plus its mstat/dgml size-analysis artifacts (that step is gated
-      # on the AOT category). It is build-only (runTests: false): there is no wired windows arm64 Helix
-      # queue yet, so running the *.AoT.Tests on arm64 hardware is a follow-up pending a
-      # windows.11.arm64 queue. The VS 2026 build image is required for the arm64 linker used by this
-      # cross-build. Runs for internal PRs and test builds.
-      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-          parameters:
-            pool:
-              name: $(DncEngInternalBuildPool)
-              image: windows.vs2026.amd64
-              os: windows
-            helixTargetQueue: windows.amd64.vs2026.pre.scout
-            oneESCompat:
-              templateFolderName: templates-official
-              publishTaskPrefix: 1ES.
-            populateInternalRuntimeVariables: true
-            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-            windowsJobParameterSets:
-            - categoryName: AOT
-              targetArchitecture: arm64
-              runtimeIdentifier: win-arm64
-              osProperties: /p:CrossBuild=true
-              runTests: false
-
       ############### LINUX ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:
@@ -281,36 +252,6 @@ extends:
               osProperties: /p:OSName=linux-musl
               runTests: false
 
-      ### AOT (linux-arm64 cross-build) ###
-      # dotnet-aot is built with NativeAOT, which can cross-compile for linux-arm64 from an x64 host
-      # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
-      # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
-      # /crossrootfs/arm64 sysroot and sets ROOTFS_DIR) and passes /p:CrossBuild=true. Consistent
-      # with the other linux-arm64 legs, this only performs the build (the x64 AOT leg provides the
-      # running test coverage). Runs for internal PRs and test builds; official builds publish via
-      # the Official legs above and don't need it.
-      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-          parameters:
-            pool:
-              name: $(DncEngInternalBuildPool)
-              image: build.azurelinux.3.amd64
-              os: linux
-            helixTargetQueue: ubuntu.2204.amd64
-            oneESCompat:
-              templateFolderName: templates-official
-              publishTaskPrefix: 1ES.
-            populateInternalRuntimeVariables: true
-            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-            timeoutInMinutes: 90
-            linuxJobParameterSets:
-            - categoryName: AOT
-              container: azureLinuxCrossArm64
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true
-              runTests: false
-
       ############### MACOS ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:
@@ -338,34 +279,6 @@ extends:
               publishArgument: $(_publishArgument)
               officialBuildProperties: $(_officialBuildProperties)
               runTests: false
-      ### AOT (osx-arm64 cross-build) ###
-      # dotnet-aot is built with NativeAOT, which can cross-compile osx-x64 -> osx-arm64 (clang/link
-      # on macOS are multi-target and need no extra sysroot). This leg therefore BUILDS on the x64
-      # macOS pool (the Official osx-arm64 leg already cross-builds on macOS-latest/x64) with
-      # /p:CrossBuild=true. Because AOT tests are dispatched to Helix (runTests passes
-      # -test /p:CustomHelixTargetQueue=...), the *.AoT.Tests still execute on the osx.15.arm64
-      # Helix queue, so there is no macOS AOT test-coverage loss. Runs for internal PRs and test
-      # builds; official builds publish via the Official legs above and don't need it.
-      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-          parameters:
-            pool:
-              name: Azure Pipelines
-              vmImage: macOS-latest
-              os: macOS
-            helixTargetQueue: osx.15.arm64
-            oneESCompat:
-              templateFolderName: templates-official
-              publishTaskPrefix: 1ES.
-            populateInternalRuntimeVariables: true
-            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-            macOSJobParameterSets:
-            - categoryName: AOT
-              runAoTTests: true
-              targetArchitecture: arm64
-              runtimeIdentifier: osx-arm64
-              osProperties: /p:CrossBuild=true
-
       ############### DOTNET-FORMAT ###############
       - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/dotnet-format/dotnet-format-integration.yml@self

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -65,28 +65,6 @@ stages:
         os: windows
       helixTargetQueue: windows.amd64.vs2026.pre.scout.open
 
-  ### AOT (win-arm64 cross-build) ###
-  # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC arm64
-  # linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is required).
-  # This leg BUILDS on the win-x64 pool with /p:CrossBuild=true and produces the dotnet-aot .dll plus
-  # its mstat/dgml size-analysis artifacts (that step is gated on the AOT category). It is build-only
-  # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
-  # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
-  # The VS 2026 build image is required for the arm64 linker used by this cross-build.
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-    parameters:
-      pool:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2026.amd64.open
-        os: windows
-      helixTargetQueue: windows.amd64.vs2026.pre.scout.open
-      windowsJobParameterSets:
-      - categoryName: AOT
-        targetArchitecture: arm64
-        runtimeIdentifier: win-arm64
-        osProperties: /p:CrossBuild=true
-        runTests: false
-
   ############### LINUX ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
@@ -96,29 +74,6 @@ stages:
         os: linux
       helixTargetQueue: ubuntu.2204.amd64.open
 
-  ### AOT (linux-arm64 cross-build) ###
-  # dotnet-aot is built with NativeAOT, which can cross-compile for linux-arm64 from an x64 host
-  # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
-  # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
-  # /crossrootfs/arm64 sysroot and sets ROOTFS_DIR) and passes /p:CrossBuild=true. Consistent with
-  # the other linux-arm64 legs, this only performs the build (the x64 AOT leg provides the running
-  # test coverage).
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
-    parameters:
-      pool:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals build.azurelinux.3.amd64.open
-        os: linux
-      helixTargetQueue: ubuntu.2204.amd64.open
-      timeoutInMinutes: 90
-      linuxJobParameterSets:
-      - categoryName: AOT
-        container: azureLinuxCrossArm64
-        targetArchitecture: arm64
-        runtimeIdentifier: linux-arm64
-        osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true
-        runTests: false
-
   ############### MACOS ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
     parameters:
@@ -127,24 +82,6 @@ stages:
         vmImage: macOS-latest
         os: macOS
       helixTargetQueue: osx.15.arm64.open
-  ### AOT (osx-arm64 cross-build) ###
-  # dotnet-aot is built with NativeAOT, which can cross-compile osx-x64 -> osx-arm64 (clang/link on
-  # macOS are multi-target and need no extra sysroot). This leg BUILDS on the x64 macOS pool with
-  # /p:CrossBuild=true; because AOT tests are dispatched to Helix, the *.AoT.Tests still run on the
-  # osx.15.arm64 Helix queue, so there is no macOS AOT test-coverage loss.
-  - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml
-    parameters:
-      pool:
-        name: Azure Pipelines
-        vmImage: macOS-latest
-        os: macOS
-      helixTargetQueue: osx.15.arm64.open
-      macOSJobParameterSets:
-      - categoryName: AOT
-        runAoTTests: true
-        targetArchitecture: arm64
-        runtimeIdentifier: osx-arm64
-        osProperties: /p:CrossBuild=true
   ### x64 (CI only) ###
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -8,6 +8,18 @@ parameters:
     runNativeAotCliTests: true
   - categoryName: AOT
     runAoTTests: true
+  # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC arm64
+  # linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is required).
+  # This leg BUILDS on the win-x64 pool with /p:CrossBuild=true and produces the dotnet-aot .dll plus
+  # its mstat/dgml size-analysis artifacts (that step is gated on the AOT category). It is build-only
+  # (runTests: false): there is no wired windows arm64 Helix queue yet, so running the *.AoT.Tests on
+  # arm64 hardware is a follow-up pending a windows.11.arm64 queue.
+  # The VS 2026 build image is required for the arm64 linker used by this cross-build.
+  - categoryName: AOT
+    targetArchitecture: arm64
+    runtimeIdentifier: win-arm64
+    osProperties: /p:CrossBuild=true
+    runTests: false
   - categoryName: FullFramework
     testFullMSBuild: true
   ### LINUX ###
@@ -21,11 +33,22 @@ parameters:
     runTests: false
   # The x64 AOT leg runs on native x64 hardware (HostRid == TargetRid == linux-x64) so it can both
   # build dotnet-aot via NativeAOT (producing the .so and its mstat/dgml size-analysis output) and
-  # run the *.AoT.Tests.csproj test projects. linux-arm64 AOT is covered by a separate cross-build
-  # leg (see .vsts-pr.yml / .vsts-ci.yml).
+  # run the *.AoT.Tests.csproj test projects.
   - categoryName: AOT
     runAoTTests: true
     osProperties: $(linuxOsglibcProperties)
+  # dotnet-aot is built with NativeAOT, which can cross-compile for linux-arm64 from an x64 host
+  # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
+  # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
+  # /crossrootfs/arm64 sysroot and sets ROOTFS_DIR) and passes /p:CrossBuild=true. Consistent with
+  # the other linux-arm64 legs, this only performs the build (the x64 AOT leg provides the running
+  # test coverage).
+  - categoryName: AOT
+    container: azureLinuxCrossArm64
+    targetArchitecture: arm64
+    runtimeIdentifier: linux-arm64
+    osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true
+    runTests: false
   - categoryName: ContainerBased
     container: azureLinux30Amd64
     helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
@@ -37,6 +60,15 @@ parameters:
   - targetArchitecture: arm64
     runtimeIdentifier: osx-arm64
     runNativeAotCliTests: true
+  # dotnet-aot is built with NativeAOT, which can cross-compile osx-x64 -> osx-arm64 (clang/link on
+  # macOS are multi-target and need no extra sysroot). This leg BUILDS on the x64 macOS pool with
+  # /p:CrossBuild=true; because AOT tests are dispatched to Helix, the *.AoT.Tests still run on the
+  # osx.15.arm64 Helix queue, so there is no macOS AOT test-coverage loss.
+  - categoryName: AOT
+    runAoTTests: true
+    targetArchitecture: arm64
+    runtimeIdentifier: osx-arm64
+    osProperties: /p:CrossBuild=true
 
 jobs:
 ### ONELOCBUILD ###

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -8,6 +8,8 @@ parameters:
     runNativeAotCliTests: true
   - categoryName: AOT
     runAoTTests: true
+  - categoryName: FullFramework
+    testFullMSBuild: true
   # dotnet-aot is built with NativeAOT, which can cross-compile win-x64 -> win-arm64 (the MSVC arm64
   # linker and the RID-specific ILCompiler package handle the cross-link; no sysroot is required).
   # This leg BUILDS on the win-x64 pool with /p:CrossBuild=true and produces the dotnet-aot .dll plus
@@ -20,23 +22,27 @@ parameters:
     runtimeIdentifier: win-arm64
     osProperties: /p:CrossBuild=true
     runTests: false
-  - categoryName: FullFramework
-    testFullMSBuild: true
   ### LINUX ###
   linuxJobParameterSets:
   - osProperties: $(linuxOsglibcProperties)
     runNativeAotCliTests: true
-  - targetArchitecture: arm64
-    runtimeIdentifier: linux-arm64
-    osProperties: $(linuxOsglibcProperties)
-    # Don't run the tests on arm64. Only perform the build itself.
-    runTests: false
   # The x64 AOT leg runs on native x64 hardware (HostRid == TargetRid == linux-x64) so it can both
   # build dotnet-aot via NativeAOT (producing the .so and its mstat/dgml size-analysis output) and
   # run the *.AoT.Tests.csproj test projects.
   - categoryName: AOT
     runAoTTests: true
     osProperties: $(linuxOsglibcProperties)
+  - categoryName: ContainerBased
+    container: azureLinux30Amd64
+    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
+    osProperties: /p:OSName=linux /p:BuildSdkDeb=true /p:BuildSdkRpm=true
+    # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
+    disableJob: true
+  - targetArchitecture: arm64
+    runtimeIdentifier: linux-arm64
+    osProperties: $(linuxOsglibcProperties)
+    # Don't run the tests on arm64. Only perform the build itself.
+    runTests: false
   # dotnet-aot is built with NativeAOT, which can cross-compile for linux-arm64 from an x64 host
   # given a cross toolchain and target sysroot. This leg therefore runs on the regular x64 Linux
   # pool inside the azurelinux cross-arm64 prereq container (which provides clang + the
@@ -49,12 +55,6 @@ parameters:
     runtimeIdentifier: linux-arm64
     osProperties: $(linuxOsglibcProperties) /p:CrossBuild=true
     runTests: false
-  - categoryName: ContainerBased
-    container: azureLinux30Amd64
-    helixTargetContainer: $(helixTargetContainerPrefix)ubuntu-24.04-helix-amd64
-    osProperties: /p:OSName=linux /p:BuildSdkDeb=true /p:BuildSdkRpm=true
-    # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-    disableJob: true
   ### MACOS ###
   macOSJobParameterSets:
   - targetArchitecture: arm64


### PR DESCRIPTION
## Summary
This change encapsulates the cross-architecture AOT legs in the shared `sdk-job-matrix` instead of defining those legs directly in the top-level CI/PR pipelines.

## Why
The AOT legs run on the same OS pools as the rest of the matrix jobs. Keeping those legs inside the shared matrix improves maintainability by removing duplicated leg definitions from `.vsts-ci.yml` and `.vsts-pr.yml`.

This also helps ensure CI and PR continue to run the same job legs because those legs now come from one shared definition.

## What changed
- Added cross-AOT job parameter sets directly to `eng/pipelines/templates/jobs/sdk-job-matrix.yml`:
  - Windows AOT cross-build (`win-arm64`, build-only)
  - Linux AOT cross-build (`linux-arm64` via `azureLinuxCrossArm64`, build-only)
  - macOS AOT cross-build (`osx-arm64` with cross-build)
- Removed the duplicated standalone AOT matrix-template invocations from:
  - `.vsts-pr.yml`
  - `.vsts-ci.yml`
- Linux AOT cross-build uses the default job timeout; this leg is currently taking roughly the same amount of time as other legs so there is no reason for an extended timeout.