### PR TITLE
Harden MTP artifact post-processing and add an opt-out

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -494,6 +494,9 @@ This is equivalent to deleting project.assets.json.</value>
   <data name="CmdNoHttpCacheOptionDescription" xml:space="preserve">
     <value>Disable Http Caching for packages.</value>
   </data>
+  <data name="CmdNoArtifactPostProcessingDescription" xml:space="preserve">
+    <value>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</value>
+  </data>
   <data name="CmdNoProgressDescription" xml:space="preserve">
     <value>Disable progress reporting.</value>
   </data>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -113,6 +113,12 @@ internal abstract partial class TestCommandDefinition
             Arity = ArgumentArity.Zero
         };
 
+        public readonly Option<bool> NoArtifactPostProcessingOption = new("--no-artifact-post-processing")
+        {
+            Description = CommandDefinitionStrings.CmdNoArtifactPostProcessingDescription,
+            Arity = ArgumentArity.Zero
+        };
+
         public readonly Option<OutputOptions> OutputOption = new("--output")
         {
             Description = CommandDefinitionStrings.CmdTestOutputDescription,
@@ -190,6 +196,7 @@ internal abstract partial class TestCommandDefinition
             Options.Add(UseCurrentRuntimeOption);
             Options.Add(NoAnsiOption);
             Options.Add(NoProgressOption);
+            Options.Add(NoArtifactPostProcessingOption);
             Options.Add(OutputOption);
             Options.Add(ListTestsOption);
             Options.Add(NoLaunchProfileOption);

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -429,6 +429,11 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">Zakáže výstup ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Nesestavujte projekt, dokud ho neotestujete. Implikuje možnost --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -429,6 +429,11 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">Deaktivieren Sie die ANSI-Ausgabe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Erstellt das Projekt nicht vor dem Testen. Impliziert "--no-restore".</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -429,6 +429,11 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">Deshabilite la salida ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">No compile el proyecto antes de probarlo. Implica --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -429,6 +429,11 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">Désactivez la sortie ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Ne pas générer le projet avant les tests. Implique --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -429,6 +429,11 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">Disabilita l'output ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Non compila il progetto prima del test. Implica --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -429,6 +429,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">ANSI 出力を無効にします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">テストする前にプロジェクトをビルドしないでください。--no-restore を意味します。</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -429,6 +429,11 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">ANSI 출력을 비활성화합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">테스트하기 전에 프로젝트를 빌드하지 않습니다. 복원 없음을 의미합니다.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -429,6 +429,11 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">Wyłącz dane wyjściowe ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Nie kompiluj tego projektu przed testowaniem. Powoduje przyjęcie, że podano parametr --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -429,6 +429,11 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">Desabilite a saída ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Não compile o projeto antes de testar. Implica em --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -429,6 +429,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">Отключить вывод ANSI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Сборка проекта перед тестированием не выполняется. Подразумевает --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -429,6 +429,11 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">ANSI çıkışını devre dışı bırakın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">Test etmeden önce projeyi derlemeyin. --no-restore anlamına gelir.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -429,6 +429,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">禁用 ANSI 输出。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">测试之前不要生成项目。Implies --no-restore.</target>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -429,6 +429,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">停用 ANSI 輸出。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoArtifactPostProcessingDescription">
+        <source>Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</source>
+        <target state="new">Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
         <source>Do not build the project before testing. Implies --no-restore.</source>
         <target state="translated">請勿在測試之前建置專案。提示：-no-restore。</target>

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
@@ -112,7 +111,7 @@ internal sealed class ArtifactPostProcessingManager
 
                 if (invocation.FailureMessage is { } failureMessage)
                 {
-                    output.WriteWarningMessage(string.Format(
+                    ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                         CultureInfo.CurrentCulture,
                         CliCommandStrings.ArtifactPostProcessingFailed,
                         job.Application.Module.TargetPath,
@@ -120,21 +119,21 @@ internal sealed class ArtifactPostProcessingManager
                 }
                 else if (exitCode != ExitCode.Success)
                 {
-                    output.WriteWarningMessage(string.Format(
+                    ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                         CultureInfo.CurrentCulture,
                         CliCommandStrings.ArtifactPostProcessingProcessFailed,
                         job.Application.Module.TargetPath,
                         exitCode));
                 }
             }
-            catch (Exception ex) when (ex is IOException
-                or UnauthorizedAccessException
-                or InvalidOperationException
-                or Win32Exception
-                or NotSupportedException
-                or TimeoutException)
+            catch (Exception ex)
             {
-                output.WriteWarningMessage(string.Format(
+                // Post-processing is a best-effort convenience on top of a completed test run: the
+                // original artifacts are always still on disk and still reported, so no failure here
+                // may escape and turn a finished run into a CLI crash with a different exit code.
+                Logger.LogTrace($"Artifact post-processing with '{job.Application.Module.TargetPath}' failed: {ex}");
+
+                ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                     CultureInfo.CurrentCulture,
                     CliCommandStrings.ArtifactPostProcessingFailed,
                     job.Application.Module.TargetPath,
@@ -155,6 +154,24 @@ internal sealed class ArtifactPostProcessingManager
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Reports a post-processing failure, unless the user cancelled the run. Cancellation kills the
+    /// post-processing process the same way it kills a test application, so the resulting failure is
+    /// the cancellation the user asked for rather than a post-processing problem worth reporting.
+    /// </summary>
+    internal static void ReportFailureUnlessCancelled(
+        TerminalTestReporter output,
+        CtrlCCancellationManager ctrlC,
+        string message)
+    {
+        if (ctrlC.Token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        output.WriteWarningMessage(message);
     }
 
     internal IReadOnlyList<ArtifactPostProcessingApplication> SnapshotApplications()

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -95,7 +95,10 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 artifactPostProcessingManager);
             exitCode = testHandler.RunTestApplications(actionQueue);
 
-            if (!testOptions.IsHelp && !testOptions.IsDiscovery && !ctrlC.Token.IsCancellationRequested)
+            if (!testOptions.IsHelp
+                && !testOptions.IsDiscovery
+                && !parseResult.GetValue(definition.NoArtifactPostProcessingOption)
+                && !ctrlC.Token.IsCancellationRequested)
             {
                 artifactPostProcessingManager.ExecuteAsync(buildOptions, output, ctrlC).GetAwaiter().GetResult();
             }

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 using Microsoft.DotNet.Cli.Commands.Test.Terminal;
 using TestExitCode = Microsoft.DotNet.Cli.Commands.Test.ExitCode;
 
@@ -129,6 +131,135 @@ public class ArtifactPostProcessingManagerTests
         arguments.Should().BeEmpty();
     }
 
+    [TestMethod]
+    public async Task ExecuteAsync_WhenJobFailsUnexpectedly_ReportsWarningWithoutThrowing()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        // A NUL character makes Path.GetFullPath throw ArgumentException while planning the job.
+        // ArgumentException is outside the exception set this code used to catch, so before the
+        // catch-all it escaped ExecuteAsync and crashed a 'dotnet test' run that had already
+        // completed, replacing its exit code.
+        ArtifactPostProcessingManager manager = CreateManagerWithMergeableArtifacts("first\0.trx", "second\0.trx");
+        using var ctrlC = CreateCancellationManager();
+
+        await manager.ExecuteAsync(CreateBuildOptions(), reporter, ctrlC);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, TestExitCode.Success);
+
+        console.GetOutput().Should().Contain(
+            FormatPrefix(CliCommandStrings.ArtifactPostProcessingFailed, "A.dll"),
+            "the failure must degrade to a warning instead of escaping");
+    }
+
+    /// <summary>
+    /// Formats a two-placeholder message up to its second placeholder, so an assertion can match the
+    /// reported message without depending on the exception text that fills the placeholder.
+    /// </summary>
+    private static string FormatPrefix(string format, string firstArgument)
+        => string.Format(format, firstArgument, "\u0001").Split('\u0001')[0];
+
+    [TestMethod]
+    public async Task ExecuteAsync_WhenCancelledBeforeStarting_RunsNoJobs()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        ArtifactPostProcessingManager manager = CreateManagerWithMergeableArtifacts("first.trx", "second.trx");
+        using var ctrlC = CreateCancellationManager();
+        ctrlC.SimulateCtrlC();
+        // Running a job creates its results directory before anything else is attempted, so the
+        // directory staying absent is the observable proof that no job ran. Asserting on the absence
+        // of a warning would not be: a job that ran and failed is silent too, because the failure of
+        // a cancelled run is deliberately not reported.
+        string resultsDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-test-postproc-tests-{Guid.NewGuid():N}");
+
+        try
+        {
+            await manager.ExecuteAsync(CreateBuildOptions(resultsDirectory), reporter, ctrlC);
+
+            Directory.Exists(resultsDirectory).Should().BeFalse(
+                "a cancelled run must not start the jobs it planned");
+        }
+        finally
+        {
+            if (Directory.Exists(resultsDirectory))
+            {
+                Directory.Delete(resultsDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ReportFailureUnlessCancelled_WhenNotCancelled_WritesWarning()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        using var ctrlC = CreateCancellationManager();
+
+        ArtifactPostProcessingManager.ReportFailureUnlessCancelled(reporter, ctrlC, "post-processing warning");
+
+        console.GetOutput().Should().Contain("post-processing warning");
+    }
+
+    [TestMethod]
+    public void ReportFailureUnlessCancelled_WhenCancelled_WritesNothing()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        using var ctrlC = CreateCancellationManager();
+        // Cancellation kills the post-processing process, so its failure is the cancellation the
+        // user asked for rather than a post-processing problem worth reporting.
+        ctrlC.SimulateCtrlC();
+
+        ArtifactPostProcessingManager.ReportFailureUnlessCancelled(reporter, ctrlC, "post-processing warning");
+
+        console.GetOutput().Should().NotContain("post-processing warning");
+    }
+
+    private static ArtifactPostProcessingManager CreateManagerWithMergeableArtifacts(params string[] artifactPaths)
+    {
+        var manager = new ArtifactPostProcessingManager();
+        TestModule module = CreateModule();
+        manager.RecordCapabilities(
+            module,
+            "net10.0",
+            "x64",
+            new HandshakeMessage(new Dictionary<byte, string>
+            {
+                [HandshakeMessagePropertyNames.SupportedPostProcessorKinds] = "microsoft.testing.trx",
+            }));
+
+        foreach (string artifactPath in artifactPaths)
+        {
+            manager.RecordArtifact(
+                module,
+                "net10.0",
+                "x64",
+                "execution-1",
+                new FileArtifactMessage(artifactPath, "TRX", null, null, null, null, "microsoft.testing.trx"));
+        }
+
+        return manager;
+    }
+
+    private static CtrlCCancellationManager CreateCancellationManager()
+        => new(onFirstCtrlC: () => { }, exitAction: _ => { }, subscribeToConsole: false);
+
+    private static BuildOptions CreateBuildOptions(string? resultsDirectory = null)
+        => new(
+            new PathOptions(null, null, null, ResultsDirectoryPath: resultsDirectory, null, null),
+            HasNoRestore: false,
+            HasNoBuild: false,
+            Verbosity: null,
+            NoLaunchProfile: false,
+            NoLaunchProfileArguments: false,
+            TestApplicationArguments: [],
+            MSBuildArgs: [],
+            Device: null,
+            ListDevices: false,
+            EnvironmentVariables: new Dictionary<string, string>());
+
     private static TerminalTestReporter CreateReporter(CapturingConsole console)
     {
         var reporter = new TerminalTestReporter(console, new TerminalTestReporterOptions
@@ -147,7 +278,16 @@ public class ArtifactPostProcessingManagerTests
 
     private static ArtifactPostProcessingApplication CreateApplication()
     {
-        var module = new TestModule(
+        return new ArtifactPostProcessingApplication(
+            CreateModule(),
+            "net10.0",
+            "x64",
+            new HashSet<string>(StringComparer.Ordinal) { "microsoft.testing.trx", "microsoft.codecoverage" },
+            new HashSet<string>(StringComparer.Ordinal));
+    }
+
+    private static TestModule CreateModule()
+        => new(
             new RunProperties("dotnet", "A.dll", null),
             ProjectFullPath: null,
             TargetFramework: "net10.0",
@@ -156,13 +296,6 @@ public class ArtifactPostProcessingManagerTests
             TargetPath: "A.dll",
             DotnetRootArchVariableName: null,
             EnvironmentVariables: new Dictionary<string, string>());
-        return new ArtifactPostProcessingApplication(
-            module,
-            "net10.0",
-            "x64",
-            new HashSet<string>(StringComparer.Ordinal) { "microsoft.testing.trx", "microsoft.codecoverage" },
-            new HashSet<string>(StringComparer.Ordinal));
-    }
 
     private static ArtifactPostProcessingArtifact CreateArtifact(string path, string? kind)
         => new(path, kind, "A.dll", "net10.0", "x64", Guid.NewGuid().ToString("N"));

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
@@ -44,13 +44,40 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
         mergedTrx.Descendants(ns + "Counters").Single().Attribute("total")!.Value.Should().Be("5");
     }
 
-    private CommandResult Run(string workingDirectory, string resultsDirectory)
-        => new DotnetTestCommand(Log, disableNewOutput: false)
+    [TestMethod]
+    public void MultiProjectRun_WithNoArtifactPostProcessing_KeepsOneReportPerTestApplication()
+    {
+        TestAsset testInstance = TestAssetsManager
+            .CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())
+            .WithSource();
+        EnableTrxReport(testInstance.Path);
+        string resultsDirectory = Path.Combine(testInstance.Path, "TestResults");
+
+        CommandResult result = Run(testInstance.Path, resultsDirectory, "--no-artifact-post-processing");
+
+        result.ExitCode.Should().Be(
+            ExitCodes.AtLeastOneTestFailed,
+            $"the test output was:{Environment.NewLine}{result.StdOut}{Environment.NewLine}{result.StdErr}");
+
+        string[] trxReports = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.AllDirectories);
+        trxReports.Should().HaveCount(2, "no test application is relaunched to merge the reports");
+        trxReports.Should().NotContain(path => Path.GetFileName(path).StartsWith("merged-", StringComparison.Ordinal));
+    }
+
+    private CommandResult Run(string workingDirectory, string resultsDirectory, params string[] additionalArguments)
+    {
+        string[] arguments =
+        [
+            "--report-trx",
+            "--results-directory", resultsDirectory,
+            "--configuration", TestingConstants.Debug,
+            .. additionalArguments
+        ];
+
+        return new DotnetTestCommand(Log, disableNewOutput: false)
             .WithWorkingDirectory(workingDirectory)
-            .Execute(
-                "--report-trx",
-                "--results-directory", resultsDirectory,
-                "--configuration", TestingConstants.Debug);
+            .Execute(arguments);
+    }
 
     private static string GetMergedTrxPath(CommandResult result)
     {

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -39,6 +39,7 @@ Options:
   --ucr, --use-current-runtime                    Use current runtime as the target runtime. [default: False]
   --no-ansi                                       Disable ANSI output. [default: False]
   --no-progress                                   Disable progress reporting. [default: False]
+  --no-artifact-post-processing                   Do not merge compatible artifacts, such as TRX reports or code coverage files, produced by different test applications. [default: False]
   --output <Detailed|Normal>                      Verbosity of test output.
   --list-tests <text|json>                        List the discovered tests instead of running the tests. Optionally accepts a format: 'text' (default) for human-readable output or 'json' for machine-readable output.
   --no-launch-profile                             Do not attempt to use launchSettings.json or [app].run.json to configure the application. [default: False]


### PR DESCRIPTION
Follow-up to #55419, which added MTP artifact post-processing to `dotnet test`.

Post-processing runs *after* a test run has completed and reported its results, and it works by relaunching test applications with a hidden merge tool. That makes it a best-effort convenience layered on top of a finished run — it must never be able to change that run's outcome. Two ways it currently can are fixed here, and an opt-out is added.

### Post-processing could crash a completed run

`ArtifactPostProcessingManager.ExecuteAsync` caught only a hand-picked set of exceptions (`IOException`, `UnauthorizedAccessException`, `InvalidOperationException`, `Win32Exception`, `NotSupportedException`, `TimeoutException`). Anything outside that set escaped `ExecuteAsync`; the caller in `MicrosoftTestingPlatformTestCommand.Run` does not catch it, so it reached the top-level handler in `Program.cs` and turned an already-finished test run into a CLI crash with a different exit code and a raw stack trace.

It is now a catch-all that logs the full exception to trace and downgrades to the existing `ArtifactPostProcessingFailed` warning. The original artifacts are still on disk and still reported, which is exactly what that warning already promises.

### Ctrl+C was reported as a post-processing failure

Cancelling the run kills the post-processing child process along with everything else. Its non-zero exit code was then surfaced as an `ArtifactPostProcessingProcessFailed` warning, blaming post-processing for something the user asked for. Both warning sites now route through `ReportFailureUnlessCancelled`, which suppresses the warning when the cancellation token is signalled. Loop termination is unchanged — the existing top-of-loop guard still stops the remaining jobs.

### New `--no-artifact-post-processing`

Every MTP run currently relaunches test applications to merge artifacts, with no way to turn it off. The new flag skips post-processing entirely, so each test application keeps its own artifacts:

```
dotnet test --report-trx --results-directory ./TestResults --no-artifact-post-processing
```

### Notes

While preparing this I also tried excluding superseded retry attempts from the merge inputs, on the theory that a merged TRX could double-count retried tests. That turned out to be wrong and is deliberately **not** included: `Microsoft.Testing.Extensions.Retry` re-runs only the previously failed tests, so a later attempt's report contains just that subset — the SDK's own `TestProgressState.ReportGenericTestResult` models this by subtracting per-test-uid only when a uid reappears. Dropping earlier attempts would have silently lost every test that passed first time and was never retried, which is worse than the duplicate it was meant to prevent. Correctly de-duplicating requires per-test knowledge that lives inside the artifacts, i.e. inside the merge tool, so it belongs upstream in TestFX rather than here.

### Testing

- `ExecuteAsync_WhenJobFailsUnexpectedly_ReportsWarningWithoutThrowing` — mutation-tested: narrowing the catch back to `catch (IOException ex)` makes the `ArgumentException` escape and the test fail.
- `ExecuteAsync_WhenCancelledBeforeStarting_RunsNoJobs` — asserts the results directory is never created, which is the first observable side effect of running a job. Mutation-tested: deleting the top-of-loop cancellation guard makes it fail. (Asserting on the *absence* of a warning would have been vacuous here, since a job that runs and fails under cancellation is silent by design.)
- `ReportFailureUnlessCancelled_When{Cancelled,NotCancelled}` — cover the new suppression directly.
- `MultiProjectRun_WithNoArtifactPostProcessing_KeepsOneReportPerTestApplication` — end-to-end, asserts exactly two unmerged TRX reports and no `merged-` file.

Full `build.cmd`, then against the built redist SDK: the `ArtifactPostProcessing*`, `TestApplicationHandlerTests`, `TerminalTestReporterTests` and `TestProgressStateTests` unit sets (67 tests), plus `MTPHelpSnapshotTests`, both artifact post-processing E2E tests and `RunTestProjectWithWithRetryFeature`. The help snapshot is updated for the new option; all 15 `.xlf` files were regenerated by the build rather than hand-edited.

Relates to #47613.