### PR TITLE
[release/10.0.4xx] Fix NuGet subcommand help forwarding

### DIFF
--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -313,7 +313,7 @@ public static class Parser
                 option.EnsureHelpName();
             }
 
-            if (command.GetRootCommand() is NuGetCommandDefinition)
+            if (IsInNuGetCommandTree(command))
             {
                 NuGetCommand.Run(context.ParseResult);
             }
@@ -378,6 +378,20 @@ public static class Parser
 
                 base.Write(context);
             }
+        }
+
+        private static bool IsInNuGetCommandTree(Command command)
+        {
+            Command current = command;
+            while (current is not null)
+            {
+                if (current is NuGetCommandDefinition)
+                {
+                    return true;
+                }
+                current = current.Parents.FirstOrDefault(p => p is Command) as Command;
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
Backport of #53723 to release/10.0.4xx.

The NuGet help override checked `GetRootCommand()`, which returns the dotnet root rather than the NuGet ancestor. Walk the parent command chain instead so commands such as `dotnet nuget add source --help` forward to the NuGet CLI.


## Tactics

### Summary

The `DotnetHelpBuilder.Write()` method used `command.GetRootCommand() is NuGetCommandDefinition` to detect when a command is part of the NuGet subtree. Because `GetRootCommand()` always traverses all the way to the CLI root (`DotNetCommandDefinition`), this check always evaluates to `false`, causing all NuGet subcommand help (e.g., `dotnet nuget add source --help`) to display the generic System.CommandLine help instead of forwarding to the NuGet CLI. The fix replaces this broken check with a recursive ancestor walk (`IsInNuGetCommandTree`) in `src/Cli/dotnet/Parser.cs`, which correctly handles the root `NuGetCommandDefinition`, direct subcommands, and deeply nested subcommands. This is a minimal, targeted fix with no behavioral changes outside the NuGet help path.

### Customer Impact

Users running `dotnet nuget <subcommand> --help` (e.g., `dotnet nuget add source --help`, `dotnet nuget trust author --help`) in affected SDK versions receive generic, unhelpful System.CommandLine output instead of the NuGet-specific help text. This affects all users of NuGet subcommands on the impacted SDK. The regression was introduced in the 11.0 SDK (per the original PR #53723) and is now being backported to `release/10.0.4xx`. There is no known simple workaround; users must run `dotnet nuget --help` and navigate manually, or consult online documentation.

### Regression?

Yes — worked in 10.0.300 and below.

### Testing

The fix is validated by the original PR #53723, which included the root-cause analysis and fix. CI pipelines have been triggered for this backport PR (Azure Pipelines run confirmed in PR comments). No additional manual repro steps or new unit tests are described in the backport PR itself beyond what was covered upstream.

### Risk

Low. The change modifies a single file (`src/Cli/dotnet/Parser.cs`), adding 15 lines and removing 1. It is scoped entirely to the NuGet help-forwarding path and does not affect build, restore, publish, or any other SDK functionality. The fix was already validated in the main branch via #53723.

<!-- gh-aw-workflow-id: add-tactics-template-on-comment -->