### PR TITLE
Unify internal CI matrix and refactor CG mode to SDL mode

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -138,7 +138,7 @@ extends:
             additionalWindowsJobParameterSets:
             # Note: This job is only used to allow the test templates to be built locally on the agent as opposed to Helix.
             # The tests acquire the templates' PackageReferences from NuGet, which allows them to be scanned by CG (component governance).
-            # CG is only ran internally, so this job runs only in CG mode.
+            # CG is only run internally, so this job runs only in CG mode.
             - categoryName: TestTemplatesCG
               runTests: true
               testExecutionMode: local

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -165,9 +165,9 @@ extends:
             # The tests acquire the templates' PackageReferences from NuGet, which allows them to be scanned by CG (component governance).
             # CG is only ran internally, so this job makes sense to only run alongside of the official jobs.
             - categoryName: TestTemplatesCG
+              testExecutionMode: local
               testProjects: $(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-              testRunnerAdditionalArguments: -class Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
-              publishXunitResults: true
+              testFilter: FullyQualifiedName~Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
 
       ############### LINUX ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,6 +30,11 @@ parameters:
   displayName: Run A Test Build
   type: boolean
   default: false
+# When true, forces a complete CG scan including test template acquisition for non-scheduled runs.
+- name: forceCompleteCg
+  displayName: Force complete CG scan
+  type: boolean
+  default: false
 
 variables:
 - template: /eng/pipelines/templates/variables/sdk-defaults.yml
@@ -39,6 +44,9 @@ variables:
 # Variables used: HelixApiAccessToken
 - group: DotNet-HelixApi-Access
 - group: AzureDevOps-Artifact-Feeds-Pats
+- ${{ if or(eq(parameters.forceCompleteCg, true), eq(variables['Build.Reason'], 'Schedule')) }}:
+  - name: runInCompleteCgMode
+    value: true
 # Allows Arcade to run a signed build by disabling post-build signing for release-branch builds or manual builds that are not running tests.
 - ${{ if and(eq(parameters.runTestBuild, false), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
   - name: PostBuildSign
@@ -127,7 +135,7 @@ extends:
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
             displayName: Create artifacts/bin directory
-          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'BatchedCI')) }}:
+          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
             timeoutInMinutes: 180
             windowsJobParameterSets:
             ### OFFICIAL ###
@@ -182,7 +190,7 @@ extends:
             publishTaskPrefix: 1ES.
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'BatchedCI')) }}:
+          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
             timeoutInMinutes: 90
             linuxJobParameterSets:
             ### OFFICIAL ###
@@ -265,7 +273,7 @@ extends:
             publishTaskPrefix: 1ES.
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.Reason'], 'BatchedCI')) }}:
+          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
             macOSJobParameterSets:
             ### OFFICIAL ###
             - categoryName: Official

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -57,16 +57,6 @@ variables:
 # Provides TSA variables for automatic bug reporting.
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - group: DotNet-CLI-SDLValidation-Params
-### LOCAL ONLY ###
-- name: _publishArgument
-  value: -publish
-- name: _signArgument
-  value: -sign
-- name: _officialBuildProperties
-  # The OfficialBuilder property is set to Microsoft for the official build only.
-  # This property is checked in Directory.Build.props and adds the MICROSOFT_ENABLE_TELEMETRY constant.
-  # This constant is used in CompileOptions.cs to set both TelemetryOptOutDefault and TelemetryOptOutDefaultString.
-  value: /p:DotNetPublishUsingPipelines=true /p:OfficialBuilder=Microsoft /p:OfficialBuildId=$(Build.BuildNumber)
 
 resources:
   repositories:
@@ -104,10 +94,9 @@ extends:
         enabled: true
       binskim:
         enabled: true
-      ${{ if or(eq(parameters.forceTestBuild, true), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['runInCgMode'], 'true')) }}:
-        componentgovernance:
-          # Refdoc: https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
-          ignoreDirectories: artifacts, .packages
+      componentgovernance:
+        # Refdoc: https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
+        ignoreDirectories: artifacts, .packages
 
     stages:
     ############### BUILD STAGE ###############

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,4 +1,10 @@
-# Pipeline: https://dev.azure.com/dnceng/internal/_build?definitionId=286
+# This yml is used by these pipelines:
+# - dotnet-sdk-official-ci
+#   https://dev.azure.com/dnceng/internal/_build?definitionId=286
+#   Triggers: CI batch and weekly schedule (complete CG scan)
+# - dotnet-sdk-unofficial-ci
+#   https://dev.azure.com/dnceng/internal/_build?definitionId=1472
+#   Triggers: PR
 
 trigger:
   batch: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -180,6 +180,7 @@ extends:
       - stage: publish
         displayName: Publish
         dependsOn: []
+        condition: ne(variables['runInCompleteCgMode'], 'true')
         jobs:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -25,9 +25,9 @@ pr:
     - internal/release/*
 
 parameters:
-# When true, runs the pipeline in the same way as the PR pipeline.
-- name: runTestBuild
-  displayName: Run A Test Build
+# When true, forces test mode on non-PR runs.
+- name: forceTestBuild
+  displayName: Force test build
   type: boolean
   default: false
 # When true, forces a complete CG scan including test template acquisition for non-scheduled runs.
@@ -44,11 +44,14 @@ variables:
 # Variables used: HelixApiAccessToken
 - group: DotNet-HelixApi-Access
 - group: AzureDevOps-Artifact-Feeds-Pats
+- ${{ if or(eq(parameters.forceTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: runInTestMode
+    value: true
 - ${{ if or(eq(parameters.forceCompleteCg, true), eq(variables['Build.Reason'], 'Schedule')) }}:
   - name: runInCompleteCgMode
     value: true
 # Allows Arcade to run a signed build by disabling post-build signing for release-branch builds or manual builds that are not running tests.
-- ${{ if and(eq(parameters.runTestBuild, false), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
+- ${{ if and(eq(parameters.forceTestBuild, false), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual'))) }}:
   - name: PostBuildSign
     value: false
 # Provides TSA variables for automatic bug reporting.
@@ -101,7 +104,7 @@ extends:
         enabled: true
       binskim:
         enabled: true
-      ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if or(eq(parameters.forceTestBuild, true), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['runInCgMode'], 'true')) }}:
         componentgovernance:
           # Refdoc: https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
           ignoreDirectories: artifacts, .packages
@@ -112,7 +115,7 @@ extends:
       displayName: Build
       jobs:
       ############### HELIX JOB MONITOR ###############
-      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if eq(variables['runInTestMode'], 'true') }}:
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
             helixAccessToken: $(HelixApiAccessToken)
@@ -128,6 +131,7 @@ extends:
           oneESCompat:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
+          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
           locBranch: release/10.0.3xx
@@ -135,44 +139,13 @@ extends:
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
             displayName: Create artifacts/bin directory
-          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
-            timeoutInMinutes: 180
-            windowsJobParameterSets:
-            ### OFFICIAL ###
-            - categoryName: Official
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties) /p:BuildWorkloads=true
-              enableDefaultArtifacts: true
-              runTests: false
-              publishRetryConfig: true
-              variables:
-                _SignType: real
-            - categoryName: Official
-              targetArchitecture: x86
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-              dependsOn: Windows_x64_Official
-              downloadManifestMsiPackages: true
-            - categoryName: Official
-              targetArchitecture: arm64
-              publishArgument: $(_publishArgument)
-              signArgument: $(_signArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-              variables:
-                _SignType: real
-              dependsOn: Windows_x64_Official
-              downloadManifestMsiPackages: true
-            ### TestTemplatesCG ###
+          ${{ if and(eq(parameters.forceTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
+            additionalWindowsJobParameterSets:
             # Note: This job is only used to allow the test templates to be built locally on the agent as opposed to Helix.
             # The tests acquire the templates' PackageReferences from NuGet, which allows them to be scanned by CG (component governance).
-            # CG is only ran internally, so this job makes sense to only run alongside of the official jobs.
+            # CG is only ran internally, so this job runs only in CG mode.
             - categoryName: TestTemplatesCG
+              runTests: true
               testExecutionMode: local
               testProjects: $(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
               testFilter: FullyQualifiedName~Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
@@ -188,77 +161,9 @@ extends:
           oneESCompat:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
+          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
-            timeoutInMinutes: 90
-            linuxJobParameterSets:
-            ### OFFICIAL ###
-            # Note: These builds are also glibc like the glibc category, but that category uses containers, and doesn't publish zips and tarballs.
-            - categoryName: Official
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm
-              runtimeIdentifier: linux-arm
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties)
-              runTests: false
-            ### glibc ###
-            - categoryName: glibc
-              # Do not publish zips and tarballs. The linux-x64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true /p:BuildSdkRpm=true
-              runTests: false
-            - categoryName: glibc
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-arm64
-              # Do not publish zips and tarballs. The linux-arm64 binaries are already published by Official.
-              publishArgument: $(_publishArgument) /p:PublishBinariesAndBadge=false
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: $(linuxOsglibcProperties) /p:BuildSdkDeb=true /p:BuildSdkRpm=true
-              runTests: false
-            ### musl ###
-            - categoryName: musl
-              container: azureLinux30Amd64
-              runtimeIdentifier: linux-musl-x64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              # Use HostOS when running on alpine.
-              osProperties: /p:HostOS=linux-musl
-              # SBOM generation is not supported for alpine.
-              enableSbom: false
-              runTests: false
-              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-              disableJob: true
-            - categoryName: musl
-              container: azureLinux30Amd64
-              targetArchitecture: arm
-              runtimeIdentifier: linux-musl-arm
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: /p:OSName=linux-musl
-              runTests: false
-              # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
-              disableJob: true
-            - categoryName: musl
-              targetArchitecture: arm64
-              runtimeIdentifier: linux-musl-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              osProperties: /p:OSName=linux-musl
-              runTests: false
 
       ############### MACOS ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
@@ -271,22 +176,9 @@ extends:
           oneESCompat:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
+          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          ${{ if and(eq(parameters.runTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
-            macOSJobParameterSets:
-            ### OFFICIAL ###
-            - categoryName: Official
-              runtimeIdentifier: osx-x64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
-            - categoryName: Official
-              targetArchitecture: arm64
-              runtimeIdentifier: osx-arm64
-              publishArgument: $(_publishArgument)
-              officialBuildProperties: $(_officialBuildProperties)
-              runTests: false
 
     ############### PUBLISH STAGE ###############
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -1,4 +1,7 @@
-# Pipeline: https://dev.azure.com/dnceng-public/public/_build?definitionId=101
+# This yml is used by these pipelines:
+# - dotnet-sdk-public-ci
+#   https://dev.azure.com/dnceng-public/public/_build?definitionId=101
+#   Triggers: CI batch and PR
 
 trigger:
   batch: true

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -96,9 +96,11 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: $(DncEngPublicBuildPool)
+      os: linux
       demands: ImageOverride -equals build.azurelinux.3.amd64.open
     ${{ else }}:
       name: $(DncEngInternalBuildPool)
+      os: linux
       demands: ImageOverride -equals build.azurelinux.3.amd64
   steps:
   - checkout: self

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -10,9 +10,10 @@ parameters:
   categoryName: ''
   platformName: ''
   runTests: true
+  testExecutionMode: helix
   testProjects: $(Build.SourcesDirectory)/test/UnitTests.proj
+  testFilter: ''
   publishRetryConfig: false
-  publishXunitResults: false
   testRunnerAdditionalArguments: ''
   enableSbom: true
   populateInternalRuntimeVariables: false
@@ -152,61 +153,94 @@ jobs:
     ############### TESTING ###############
     - ${{ if eq(parameters.runTests, true) }}:
 
-      # Determine which test groups to skip based on changed files and build context.
-      - script: $(Build.SourcesDirectory)/.dotnet/dotnet run $(Build.SourcesDirectory)/scripts/EvaluateConditionalTestScopes.cs --
-            --repo-root "$(Build.SourcesDirectory)"
-            --target-branch "$(System.PullRequest.TargetBranch)"
-            --build-reason "$(Build.Reason)"
-            --output-variable "SkippedTestScopes"
-        displayName: 🟣 Evaluate Conditional Test Scopes
-        # If evaluation fails, the variable remains empty and all tests run.
-        continueOnError: true
+      - ${{ if eq(parameters.testExecutionMode, 'helix') }}:
+        # Determine which test groups to skip based on changed files and build context.
+        - script: $(Build.SourcesDirectory)/.dotnet/dotnet run $(Build.SourcesDirectory)/scripts/EvaluateConditionalTestScopes.cs --
+              --repo-root "$(Build.SourcesDirectory)"
+              --target-branch "$(System.PullRequest.TargetBranch)"
+              --build-reason "$(Build.Reason)"
+              --output-variable "SkippedTestScopes"
+          displayName: 🟣 Evaluate Conditional Test Scopes
+          # If evaluation fails, the variable remains empty and all tests run.
+          continueOnError: true
 
-      # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
-      - ${{ if eq(parameters.pool.os, 'windows') }}:
-        - powershell: eng/common/build.ps1
-            -restore -test -ci -prepareMachine -nativeToolsOnMachine
-            -configuration $(buildConfiguration)
-            -binaryLogName ${{ parameters.categoryName }}Tests.binlog
-            /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
-            /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
-            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-            ${{ parameters.runtimeSourceProperties }}
-            /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
-            /p:EnableHelixJobMonitor=true
-            /p:SkippedTestScopes="$(SkippedTestScopes)"
-          displayName: 🟣 Queue Tests
-          env:
-            # Required by Arcade for running in Helix.
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-            HelixAccessToken: $(HelixApiAccessToken)
-            RunAoTTests: ${{ parameters.runAoTTests }}
-            TestFullMSBuild: ${{ parameters.testFullMSBuild }}
+        # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
+        - ${{ if eq(parameters.pool.os, 'windows') }}:
+          - powershell: eng/common/build.ps1
+              -restore -test -ci -prepareMachine -nativeToolsOnMachine
+              -configuration $(buildConfiguration)
+              -binaryLogName ${{ parameters.categoryName }}Tests.binlog
+              /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
+              /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
+              /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+              ${{ parameters.runtimeSourceProperties }}
+              /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
+              /p:EnableHelixJobMonitor=true
+              /p:SkippedTestScopes="$(SkippedTestScopes)"
+            displayName: 🟣 Queue Tests
+            env:
+              # Required by Arcade for running in Helix.
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: $(HelixApiAccessToken)
+              RunAoTTests: ${{ parameters.runAoTTests }}
+              TestFullMSBuild: ${{ parameters.testFullMSBuild }}
 
-      - ${{ else }}:
-        # For the /p:Projects syntax for Bash, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1690189034
-        # The /p:CustomHelixTargetQueue syntax is: <queue-name>@<container-url>
-        # For the Helix containers, see the 'simpleTags' arrays here: https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
-        - script: eng/common/build.sh
-            -restore -test -ci -prepareMachine
-            -configuration $(buildConfiguration)
-            --binaryLogName ${{ parameters.categoryName }}Tests.binlog
-            '/p:Projects="${{ parameters.testProjects }}"'
-            /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
-            /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-            /p:TargetRid=${{ parameters.runtimeIdentifier }}
-            ${{ parameters.osProperties }}
-            ${{ parameters.runtimeSourceProperties }}
-            /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
-            /p:EnableHelixJobMonitor=true
-            /p:SkippedTestScopes="$(SkippedTestScopes)"
-          displayName: 🟣 Queue Tests
-          env:
-            # Required by Arcade for running in Helix.
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-            HelixAccessToken: $(HelixApiAccessToken)
-            RunAoTTests: ${{ parameters.runAoTTests }}
-            TARGET_ARCHITECTURE: ${{ parameters.targetArchitecture }}
+        - ${{ else }}:
+          # For the /p:Projects syntax for Bash, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1690189034
+          # The /p:CustomHelixTargetQueue syntax is: <queue-name>@<container-url>
+          # For the Helix containers, see the 'simpleTags' arrays here: https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
+          - script: eng/common/build.sh
+              -restore -test -ci -prepareMachine
+              -configuration $(buildConfiguration)
+              --binaryLogName ${{ parameters.categoryName }}Tests.binlog
+              '/p:Projects="${{ parameters.testProjects }}"'
+              /p:TestRunnerAdditionalArguments="${{ parameters.testRunnerAdditionalArguments }}"
+              /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+              /p:TargetRid=${{ parameters.runtimeIdentifier }}
+              ${{ parameters.osProperties }}
+              ${{ parameters.runtimeSourceProperties }}
+              /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
+              /p:EnableHelixJobMonitor=true
+              /p:SkippedTestScopes="$(SkippedTestScopes)"
+            displayName: 🟣 Queue Tests
+            env:
+              # Required by Arcade for running in Helix.
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: $(HelixApiAccessToken)
+              RunAoTTests: ${{ parameters.runAoTTests }}
+              TARGET_ARCHITECTURE: ${{ parameters.targetArchitecture }}
+
+      - ${{ if eq(parameters.testExecutionMode, 'local') }}:
+        - ${{ if eq(parameters.pool.os, 'windows') }}:
+          - powershell: |
+              $args = @(
+                "test",
+                "${{ parameters.testProjects }}",
+                "--configuration", "$(buildConfiguration)",
+                "--no-build")
+              if (-not [string]::IsNullOrWhiteSpace("${{ parameters.testFilter }}"))
+              {
+                  $args += @("--filter", "${{ parameters.testFilter }}")
+              }
+              $args += @(
+                "--",
+                "--report-trx",
+                "--report-trx-filename", "${{ parameters.categoryName }}.trx",
+                "--results-directory", "$(Build.SourcesDirectory)/artifacts/TestResults/$(buildConfiguration)")
+
+              & "$(Build.SourcesDirectory)/.dotnet/dotnet.exe" @args
+            displayName: 🟣 Run Tests Locally
+
+          - task: PublishTestResults@2
+            displayName: 🟣 Publish Local Test Results
+            inputs:
+              testResultsFormat: VSTest
+              testResultsFiles: artifacts/TestResults/$(buildConfiguration)/*.trx
+              testRunTitle: $(System.PhaseName)
+              buildPlatform: ${{ parameters.targetArchitecture }}
+              buildConfiguration: $(buildConfiguration)
+            continueOnError: true
+            condition: always()
 
     ############### NATIVE AOT CLI TESTS ###############
     # Publishes test/dotnet-aot.Tests as a NativeAOT binary and runs it on the build agent.
@@ -248,19 +282,6 @@ jobs:
         condition: always()
 
     ############### POST ###############
-    - ${{ if eq(parameters.publishXunitResults, true) }}:
-      # This is only necessary for non-Helix tests.
-      - task: PublishTestResults@2
-        displayName: 🟣 Publish xUnit Test Results
-        inputs:
-          testResultsFormat: xUnit
-          testResultsFiles: artifacts/TestResults/$(buildConfiguration)/*.xml
-          testRunTitle: $(System.PhaseName)
-          buildPlatform: ${{ parameters.targetArchitecture }}
-          buildConfiguration: $(buildConfiguration)
-        continueOnError: true
-        condition: always()
-
     - task: CopyFiles@2
       displayName: 🟣 Copy Logs
       inputs:

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -242,44 +242,44 @@ jobs:
             continueOnError: true
             condition: always()
 
-    ############### NATIVE AOT CLI TESTS ###############
-    # Publishes test/dotnet-aot.Tests as a NativeAOT binary and runs it on the build agent.
-    # NativeAOT binaries must run on the same architecture they are built for, so the scripts
-    # auto-detect the agent's host RID (via .dotnet/dotnet --info) rather than using the build's
-    # target RID. On cross-architecture legs (e.g. the macOS leg cross-builds osx-arm64 on an
-    # x64 host) this runs the tests for the host architecture. Runs after the Helix queue step
-    # so it never prevents the broader Helix test submission.
-    - ${{ if eq(parameters.runNativeAotCliTests, true) }}:
-      - ${{ if eq(parameters.pool.os, 'windows') }}:
-        - powershell: |
-            test/dotnet-aot.Tests/run-aot-tests.ps1 `
-              -Configuration $(buildConfiguration) `
-              -Trx `
-              -ResultsDirectory $(Build.SourcesDirectory)/artifacts/TestResults/$(buildConfiguration)
-          displayName: 🟣 Run NativeAOT CLI Tests
-      - ${{ else }}:
-        - script: |
-            chmod +x test/dotnet-aot.Tests/run-aot-tests.sh
-            test/dotnet-aot.Tests/run-aot-tests.sh \
-              --configuration $(buildConfiguration) \
-              --trx \
-              --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(buildConfiguration)
-          displayName: 🟣 Run NativeAOT CLI Tests
-          # The CLI's --cli-schema rendering evaluates a shell-completion default that requires
-          # SHELL to be set; the bare AzDO script task does not export it, so set it explicitly.
-          env:
-            SHELL: /bin/bash
+      ############### NATIVE AOT CLI TESTS ###############
+      # Publishes test/dotnet-aot.Tests as a NativeAOT binary and runs it on the build agent.
+      # NativeAOT binaries must run on the same architecture they are built for, so the scripts
+      # auto-detect the agent's host RID (via .dotnet/dotnet --info) rather than using the build's
+      # target RID. On cross-architecture legs (e.g. the macOS leg cross-builds osx-arm64 on an
+      # x64 host) this runs the tests for the host architecture. Runs after the Helix queue step
+      # so it never prevents the broader Helix test submission.
+      - ${{ if eq(parameters.runNativeAotCliTests, true) }}:
+        - ${{ if eq(parameters.pool.os, 'windows') }}:
+          - powershell: |
+              test/dotnet-aot.Tests/run-aot-tests.ps1 `
+                -Configuration $(buildConfiguration) `
+                -Trx `
+                -ResultsDirectory $(Build.SourcesDirectory)/artifacts/TestResults/$(buildConfiguration)
+            displayName: 🟣 Run NativeAOT CLI Tests
+        - ${{ else }}:
+          - script: |
+              chmod +x test/dotnet-aot.Tests/run-aot-tests.sh
+              test/dotnet-aot.Tests/run-aot-tests.sh \
+                --configuration $(buildConfiguration) \
+                --trx \
+                --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(buildConfiguration)
+            displayName: 🟣 Run NativeAOT CLI Tests
+            # The CLI's --cli-schema rendering evaluates a shell-completion default that requires
+            # SHELL to be set; the bare AzDO script task does not export it, so set it explicitly.
+            env:
+              SHELL: /bin/bash
 
-      - task: PublishTestResults@2
-        displayName: 🟣 Publish NativeAOT CLI Test Results
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: artifacts/TestResults/$(buildConfiguration)/dotnet-aot.Tests.trx
-          testRunTitle: NativeAOT CLI ($(System.PhaseName))
-          buildPlatform: ${{ parameters.targetArchitecture }}
-          buildConfiguration: $(buildConfiguration)
-        continueOnError: true
-        condition: always()
+        - task: PublishTestResults@2
+          displayName: 🟣 Publish NativeAOT CLI Test Results
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: artifacts/TestResults/$(buildConfiguration)/dotnet-aot.Tests.trx
+            testRunTitle: NativeAOT CLI ($(System.PhaseName))
+            buildPlatform: ${{ parameters.targetArchitecture }}
+            buildConfiguration: $(buildConfiguration)
+          continueOnError: true
+          condition: always()
 
     ############### POST ###############
     - task: CopyFiles@2

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -2,6 +2,7 @@ parameters:
   oneESCompat:
     templateFolderName: templates
   locBranch: ''
+  additionalWindowsJobParameterSets: []
   ### WINDOWS ###
   windowsJobParameterSets:
   - publishRetryConfig: true
@@ -85,6 +86,13 @@ jobs:
 # The parameters sent to this template are also passed to the job, which does include the os-specific jobParameterSets array, but that array itself isn't used in the job.
 - ${{ if eq(parameters.pool.os, 'windows') }}:
   - ${{ each jobParameters in parameters.windowsJobParameterSets }}:
+    - ${{ if not(jobParameters.disableJob) }}:
+      - template: /eng/pipelines/templates/jobs/sdk-build.yml
+        parameters:
+          ${{ insert }}: ${{ parameters }}
+          ${{ insert }}: ${{ jobParameters }}
+          platformName: Windows
+  - ${{ each jobParameters in parameters.additionalWindowsJobParameterSets }}:
     - ${{ if not(jobParameters.disableJob) }}:
       - template: /eng/pipelines/templates/jobs/sdk-build.yml
         parameters:

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -2,6 +2,7 @@ parameters:
   oneESCompat:
     templateFolderName: templates
   locBranch: ''
+  runTests: true
   additionalWindowsJobParameterSets: []
   ### WINDOWS ###
   windowsJobParameterSets:
@@ -83,20 +84,25 @@ jobs:
       MirrorRepo: sdk
 ### BUILD JOBS ###
 # Each job parameter set creates a new job and the parameter set is unwrapped into the parameters for that job.
-# The parameters sent to this template are also passed to the job, which does include the os-specific jobParameterSets array, but that array itself isn't used in the job.
+# jobParameters takes priority: iterate top-level parameters and skip any key that jobParameters already
+# defines, then insert jobParameters. This avoids duplicate-key conflicts for any override (e.g. runTests).
 - ${{ if eq(parameters.pool.os, 'windows') }}:
   - ${{ each jobParameters in parameters.windowsJobParameterSets }}:
     - ${{ if not(jobParameters.disableJob) }}:
       - template: /eng/pipelines/templates/jobs/sdk-build.yml
         parameters:
-          ${{ insert }}: ${{ parameters }}
+          ${{ each param in parameters }}:
+            ${{ if eq(jobParameters[param.key], '') }}:
+              ${{ param.key }}: ${{ param.value }}
           ${{ insert }}: ${{ jobParameters }}
           platformName: Windows
   - ${{ each jobParameters in parameters.additionalWindowsJobParameterSets }}:
     - ${{ if not(jobParameters.disableJob) }}:
       - template: /eng/pipelines/templates/jobs/sdk-build.yml
         parameters:
-          ${{ insert }}: ${{ parameters }}
+          ${{ each param in parameters }}:
+            ${{ if eq(jobParameters[param.key], '') }}:
+              ${{ param.key }}: ${{ param.value }}
           ${{ insert }}: ${{ jobParameters }}
           platformName: Windows
 - ${{ if eq(parameters.pool.os, 'linux') }}:
@@ -104,7 +110,9 @@ jobs:
     - ${{ if not(jobParameters.disableJob) }}:
       - template: /eng/pipelines/templates/jobs/sdk-build.yml
         parameters:
-          ${{ insert }}: ${{ parameters }}
+          ${{ each param in parameters }}:
+            ${{ if eq(jobParameters[param.key], '') }}:
+              ${{ param.key }}: ${{ param.value }}
           ${{ insert }}: ${{ jobParameters }}
           platformName: Linux
 - ${{ if eq(parameters.pool.os, 'macOS') }}:
@@ -112,6 +120,8 @@ jobs:
     - ${{ if not(jobParameters.disableJob) }}:
       - template: /eng/pipelines/templates/jobs/sdk-build.yml
         parameters:
-          ${{ insert }}: ${{ parameters }}
+          ${{ each param in parameters }}:
+            ${{ if eq(jobParameters[param.key], '') }}:
+              ${{ param.key }}: ${{ param.value }}
           ${{ insert }}: ${{ jobParameters }}
           platformName: Mac


### PR DESCRIPTION
## Summary

This PR simplifies and unifies internal CI behavior across PR, official, and complete CG configurations by standardizing on a shared matrix model.

## What changed

1. Fixed `TestTemplatesCG` after the MSTest conversion by adding explicit local test-execution support in the shared SDK job template and wiring this leg to use that path. This preserves the intended local execution model for template CG validation while aligning with the current test infrastructure.
   - Fixes #55496
2. Added `forceCompleteCg` queue-time parameter and derived `runInCompleteCgMode`:
   - Enables triggering a complete CG scan on demand (scheduled builds use this mode automatically).
   - Complete CG mode adds the `TestTemplatesCG` Windows job to the standard matrix.
   - The base SDL block (policheck, TSA, binskim, componentgovernance) runs unconditionally on all official builds; complete CG mode is only needed for the full template acquisition scan.
   - Publish is skipped in complete CG mode (scheduled and `forceCompleteCg=true` runs) since these are scan-only builds, not releases.
3. Unified matrix behavior across pipeline configurations:
   - PR, official, and complete CG now all run the same base matrix.
   - Complete CG mode no longer uses the old "official-only" leg set; it uses the standard matrix and adds one extra Windows job: `TestTemplatesCG`.
   - Test execution is PR-only by default (`runInTestMode`), preventing unmonitored Helix test queueing in official non-PR runs.
   - NativeAOT CLI tests are now gated on `runTests`, consistent with all other test steps.
   
 ## Test Builds
 
- Official Build - https://dev.azure.com/dnceng/internal/_build/results?buildId=3033690
- Complete CG Build (mimics the scheduled build) - https://dev.azure.com/dnceng/internal/_build/results?buildId=3033692