### PR TITLE
Fix duplicate runtime pack crash in `dotnet test` device deployment

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -619,10 +619,14 @@ internal static class SolutionAndProjectUtility
             lock (s_buildLock)
             {
                 var loggers = logger is null ? null : new[] { logger };
-                if (project.Targets.ContainsKey(Constants.DeployToDevice) &&
-                    !project.Build([Constants.DeployToDevice], loggers))
+                if (project.Targets.ContainsKey(Constants.DeployToDevice))
                 {
-                    throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
+                    // Create a fresh ProjectInstance for each build operation
+                    // to avoid accumulating state (existing item groups) from previous builds
+                    if (!project.DeepCopy().Build([Constants.DeployToDevice], loggers))
+                    {
+                        throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
+                    }
                 }
 
                 if (!project.Build(s_computeRunArgumentsTarget, loggers))

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -621,8 +621,10 @@ internal static class SolutionAndProjectUtility
                 var loggers = logger is null ? null : new[] { logger };
                 if (project.Targets.ContainsKey(Constants.DeployToDevice))
                 {
-                    // Create a fresh ProjectInstance for each build operation
-                    // to avoid accumulating state (existing item groups) from previous builds
+                    // Deploy on a fresh ProjectInstance to avoid accumulating state (existing item
+                    // groups) that would leak into the ComputeRunArguments build below, which has to
+                    // build the original instance since the run properties are read back from it.
+                    // Same reason as dotnet run, see RunCommandSelector.OpenProjectIfNeeded.
                     if (!project.DeepCopy().Build([Constants.DeployToDevice], loggers))
                     {
                         throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -40,7 +40,8 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DeployToDevice">
+  <!-- ResolveFrameworkReferences mimics Android -->
+  <Target Name="DeployToDevice" DependsOnTargets="ResolveFrameworkReferences">
     <Message Text="DeployToDevice: Deployed $(TargetFramework) to device $(Device) with RuntimeIdentifier $(RuntimeIdentifier)" />
     <Message Text="DeployToDevice: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
     <Error Condition="'$(FailDeployToDevice)' == 'true'" Text="DeployToDevice failed as requested." />
@@ -72,5 +73,10 @@
           Condition="'@(RuntimeEnvironmentVariable)' != ''">
     <Message Text="ComputeRunArguments: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
   </Target>
+  <!-- Unlike dotnet run, dotnet test builds DeployToDevice first and ComputeRunArguments second,
+       so ResolveFrameworkReferences has to run in the second build too to mimic Android. -->
+  <Target Name="_ComputeRunArgumentsDependsOnResolveFrameworkReferences"
+          BeforeTargets="ComputeRunArguments"
+          DependsOnTargets="ResolveFrameworkReferences" />
 
 </Project>


### PR DESCRIPTION
Fixes the `dotnet test` crash reported in dotnet/android#12254.

## The bug

`dotnet test` against a device project (e.g. Android) failed with only a generic message:

```
Running the ComputeRunArguments target to discover run commands failed for this project. Fix the errors and warnings and run again.
```

The real error was visible only in a binlog:

```
Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(411,5): error MSB4018:
The "ResolveFrameworkReferences" task failed unexpectedly.
System.ArgumentException: An item with the same key has already been added. Key: Microsoft.NETCore.App
   at Microsoft.NET.Build.Tasks.ResolveFrameworkReferences.ExecuteCore()
```

## Root cause

`SolutionAndProjectUtility.DeployAndGetRunProperties` built `DeployToDevice` and then `ComputeRunArguments` against the **same** `ProjectInstance`.

MSBuild `<Output ItemName="..."/>` **appends**, and `ProjectInstance.Build()` is a self-contained `BuildManager` session that does not reset instance state between calls. So every target shared by both builds contributed its items a second time:

1. `ProcessFrameworkReferences` appended 4 more `@(TargetingPack)` items (4 → 8).
2. `ResolveFrameworkReferences`'s `GetPackageDirectory Items="@(TargetingPack)"` appended its 8 outputs onto the 4 `@(ResolvedTargetingPack)` items already present → 12, containing `Microsoft.NETCore.App` three times.
3. `ResolveFrameworkReferences.ExecuteCore()`'s `ResolvedTargetingPacks.ToDictionary(tp => tp.ItemSpec, ...)` threw.

Confirmed from the CI binlog — three MSBuild submissions on the same project, the third reusing the second's instance:

| # | Entry point | `ResolvedTargetingPack` seen / added |
| - | ----------- | ----------------------------------- |
| 1 | `ComputeAvailableDevices` (own instance, via `RunCommandSelector`) | 4 / 4 |
| 2 | `DeployToDevice` | 4 / 4 |
| 3 | `ComputeRunArguments` — **same instance as #2** | **12** 💥 |

`dotnet run` does not hit this because it never shares an instance across builds — #52046 fixed exactly this class of bug in `RunCommandSelector.OpenProjectIfNeeded`, and `ComputeRunArguments` is built on a separately loaded instance in `RunCommand`.

## The fix

Deploy against a fresh `ProjectInstance` so its item state cannot leak into the `ComputeRunArguments` build, matching `dotnet run`:

```csharp
// Create a fresh ProjectInstance for each build operation
// to avoid accumulating state (existing item groups) from previous builds
if (!project.DeepCopy().Build([Constants.DeployToDevice], loggers))
```

`ComputeRunArguments` still builds the original instance, which is what `RunProperties.FromProject` and `EnvironmentVariablesToMSBuild.ReadFromItems` read from afterwards. `ProjectInstance.DeepCopy()` is the `ProjectInstance`-level analogue of `Project.CreateProjectInstance()` used by `dotnet run` (both are snapshots of an already-evaluated project, not re-evaluations); it also preserves the `@(RuntimeEnvironmentVariable)` items that `EnvironmentVariablesToMSBuild.AddAsItems` adds before the deploy build. `dotnet watch` uses `DeepCopy()` for the same reason.

## Test coverage

Following the same approach as #52046, there is no bespoke regression test — instead `DotnetTestDevices.csproj` now runs the real `ResolveFrameworkReferences` task, which makes the **existing** device tests catch the bug.

Two asset changes are needed. The first mirrors `DotnetRunDevices.csproj` exactly:

```xml
<!-- ResolveFrameworkReferences mimics Android -->
<Target Name="DeployToDevice" DependsOnTargets="ResolveFrameworkReferences">
```

The second has no counterpart in #52046, and is required. `dotnet run`'s accumulating pair was `ComputeAvailableDevices` + `DeployToDevice` (both through `RunCommandSelector`), whereas `dotnet test`'s pair is `DeployToDevice` + `ComputeRunArguments`. The SDK's `ComputeRunArguments` target is **empty with no `DependsOnTargets`**, so without a hook the second build runs nothing and nothing accumulates:

```xml
<!-- Unlike dotnet run, dotnet test builds DeployToDevice first and ComputeRunArguments second,
     so ResolveFrameworkReferences has to run in the second build too to mimic Android. -->
<Target Name="_ComputeRunArgumentsDependsOnResolveFrameworkReferences"
        BeforeTargets="ComputeRunArguments"
        DependsOnTargets="ResolveFrameworkReferences" />
```

This is faithful to Android: the CI binlog shows the real `ComputeRunArguments` submission running the full framework-reference chain.

### Verified red → green

All three combinations were measured against `GivenDotnetTestSelectsDevice`:

| Test asset | CLI | Result |
| ---------- | --- | ------ |
| `DeployToDevice DependsOnTargets` only, no `ComputeRunArguments` hook | unfixed | 29 passed — bug **not** caught |
| Both asset changes | unfixed | **13 failed**, 16 passed |
| Both asset changes | fixed | **29 passed** |

The 13 tests that the `DotnetTestDevices.csproj` change causes to fail without the CLI fix, and which the `SolutionAndProjectUtility.cs` change fixes:

- `ItRunsTestsWithSpecifiedDevice("test-device-1")`
- `ItRunsTestsWithSpecifiedDevice("test-device-2")`
- `ItAutoSelectsSingleDevice`
- `ItAutoSelectsSingleDevicePerTfm`
- `ItRunsWithDeviceAndFramework`
- `ItRunsDeviceProjectsInSolution`
- `ItAcceptsDeviceViaMSBuildProperty`
- `ItPassesEnvironmentVariablesToBuildDeployAndRunArgumentsTargets`
- `ItCallsDeployToDeviceTargetWhenDeviceIsSpecified`
- `ItCallsDeployToDeviceTargetWhenDeviceIsAutoSelected`
- `ItCallsDeployToDeviceTargetEvenWithNoBuild`
- `ItDeploysBeforeComputingRunArguments`
- `ItDeploysEveryTargetFramework`

`GivenDotnetRunSelectsDevice` also passes 23/23.

## End-to-end validation

Validated on a real Android device (`dotnet new androidtest` against SDK `11.0.100-preview.7.26376.106` with the released `Microsoft.Android.Sdk.Windows 37.0.0-preview.6.59`, physical device attached):

| | Before | After |
| - | ------ | ----- |
| `dotnet test` | fails in ~10s with the `ComputeRunArguments` message | gets past `ComputeRunArguments`, deploys the APK, and runs `am instrument` on device |

logcat confirms MSTest actually starts on device. Note there is a **separate, unrelated** downstream failure once the test host is running (`NotSupportedException: Running tests in any of the provided sources is not supported for the selected platform`) which reproduces against the released Android workload and is being tracked on the dotnet/android side — this PR fixes the item-accumulation crash, it does not claim `dotnet test` fully succeeds end-to-end on Android yet.

## Notes

- `ResolveFrameworkReferences` is deliberately **not** hardened to tolerate duplicates. De-duplicating there would mask doubled item state that every downstream `@(ResolvedRuntimePack)` / `@(ResolvedTargetingPack)` consumer would still see, so a recurrence should keep failing loudly.