### PR TITLE
Make ResolvePackageAssets cache hash location-independent under DeterministicSourcePaths

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolvePackageAssets.cs
@@ -48,6 +48,15 @@ namespace Microsoft.NET.Build.Tasks
         public string ProjectPath { get; set; }
 
         /// <summary>
+        /// Optional path map, in the same "from=to,from2=to2" form the compiler accepts for /pathmap.
+        /// When set, it is applied (as a path-prefix replacement) to the project-owned paths that feed the
+        /// cache-invalidation hash, so an otherwise-identical restore under a different repo root produces the
+        /// same hash and the assets cache stays valid across checkout locations. Empty by default, so the hash
+        /// is unchanged for normal builds - the normalization is opt-in.
+        /// </summary>
+        public string PathMap { get; set; }
+
+        /// <summary>
         /// TargetFramework to use for compile-time assets.
         /// </summary>
         [Required]
@@ -437,6 +446,10 @@ namespace Microsoft.NET.Build.Tasks
 
         internal byte[] HashSettings()
         {
+            // Applied to the project-owned paths below so the invalidation hash is independent of the
+            // checkout location when the compiler is already producing location-independent output.
+            List<KeyValuePair<string, string>> pathMap = ParsePathMap(PathMap);
+
             using (var stream = new MemoryStream())
             {
                 using (var writer = new BinaryWriter(stream, TextEncoding, leaveOpen: true))
@@ -467,8 +480,8 @@ namespace Microsoft.NET.Build.Tasks
                             writer.Write(implicitPackage.GetMetadata(MetadataKeys.Version) ?? "");
                         }
                     }
-                    writer.Write(ProjectAssetsCacheFile);
-                    writer.Write(ProjectAssetsFile ?? "");
+                    writer.Write(NormalizePathPrefix(ProjectAssetsCacheFile, pathMap));
+                    writer.Write(NormalizePathPrefix(ProjectAssetsFile ?? "", pathMap));
                     writer.Write(PlatformLibraryName ?? "");
                     if (RuntimeFrameworks != null)
                     {
@@ -487,7 +500,7 @@ namespace Microsoft.NET.Build.Tasks
                     }
                     writer.Write(ProjectLanguage ?? "");
                     writer.Write(CompilerApiVersion ?? "");
-                    writer.Write(ProjectPath);
+                    writer.Write(NormalizePathPrefix(ProjectPath, pathMap));
                     // we want to ensure uniqueness of results, so even though `any` is No RID for purposes of Task logic,
                     // we continue to treat it distinctly for hashing
                     writer.Write(RuntimeIdentifier ?? "");
@@ -510,6 +523,153 @@ namespace Microsoft.NET.Build.Tasks
                     return hash.ComputeHash(stream);
                 }
             }
+        }
+
+        /// <summary>
+        /// Parses a "from=to,from2=to2" path map (the same value the compiler receives via /pathmap) into
+        /// prefix-replacement pairs, ordered longest key first so the most specific prefix wins. Returns an
+        /// empty list when there is nothing to apply. Kept in sync with the compiler's path-map parsing
+        /// (Microsoft.CodeAnalysis.CommandLineParser.ParsePathMap / SortPathMap).
+        /// </summary>
+        private static List<KeyValuePair<string, string>> ParsePathMap(string pathMap)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+            if (string.IsNullOrEmpty(pathMap))
+            {
+                return result;
+            }
+
+            foreach (var kEqualsV in SplitWithDoubledSeparatorEscaping(pathMap, ','))
+            {
+                if (kEqualsV.Length == 0)
+                {
+                    continue;
+                }
+
+                var kv = SplitWithDoubledSeparatorEscaping(kEqualsV, '=');
+                if (kv.Length != 2)
+                {
+                    continue;
+                }
+
+                var from = kv[0];
+                var to = kv[1];
+                if (from.Length == 0 || to.Length == 0)
+                {
+                    continue;
+                }
+
+                result.Add(new KeyValuePair<string, string>(EnsureTrailingSeparator(from), EnsureTrailingSeparator(to)));
+            }
+
+            result.Sort((x, y) => -x.Key.Length.CompareTo(y.Key.Length));
+            return result;
+        }
+
+        /// <summary>
+        /// Kept in sync with Microsoft.CodeAnalysis.CommandLineParser.SplitWithDoubledSeparatorEscaping.
+        /// </summary>
+        private static string[] SplitWithDoubledSeparatorEscaping(string str, char separator)
+        {
+            if (str.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            var result = new List<string>();
+            var part = new StringBuilder();
+
+            int i = 0;
+            while (i < str.Length)
+            {
+                char c = str[i++];
+                if (c == separator)
+                {
+                    if (i < str.Length && str[i] == separator)
+                    {
+                        i++;
+                    }
+                    else
+                    {
+                        result.Add(part.ToString());
+                        part.Clear();
+                        continue;
+                    }
+                }
+
+                part.Append(c);
+            }
+
+            result.Add(part.ToString());
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Kept in sync with Roslyn.Utilities.PathUtilities.EnsureTrailingSeparator.
+        /// </summary>
+        private static string EnsureTrailingSeparator(string s)
+        {
+            if (s.Length == 0 || s[s.Length - 1] == '/' || s[s.Length - 1] == '\\')
+            {
+                return s;
+            }
+
+            // Use the existing slashes in the path, if they're consistent.
+            bool hasSlash = s.IndexOf('/') >= 0;
+            bool hasBackslash = s.IndexOf('\\') >= 0;
+            if (hasSlash && !hasBackslash)
+            {
+                return s + '/';
+            }
+            else if (!hasSlash && hasBackslash)
+            {
+                return s + '\\';
+            }
+            else
+            {
+                // If there are no slashes or they are inconsistent, use the current platform's slash.
+                return s + System.IO.Path.DirectorySeparatorChar;
+            }
+        }
+
+        /// <summary>
+        /// Applies the first matching path-prefix mapping to <paramref name="filePath"/>. Kept in sync with
+        /// Roslyn.Utilities.PathUtilities.NormalizePathPrefix. Comparison is ordinal because the compiler
+        /// expects consistent capitalization for path-map keys.
+        /// </summary>
+        private static string NormalizePathPrefix(string filePath, List<KeyValuePair<string, string>> pathMap)
+        {
+            if (pathMap.Count == 0 || string.IsNullOrEmpty(filePath))
+            {
+                return filePath;
+            }
+
+            foreach (var kv in pathMap)
+            {
+                var oldPrefix = kv.Key;
+                if (!(oldPrefix?.Length > 0))
+                {
+                    continue;
+                }
+
+                // oldPrefix always ends with a path separator, so a prefix match cannot be a partial segment
+                // (e.g. map /goo=/bar does not match /goooo).
+                if (filePath.StartsWith(oldPrefix, StringComparison.Ordinal))
+                {
+                    var replacementPrefix = kv.Value;
+                    var replacement = replacementPrefix + filePath.Substring(oldPrefix.Length);
+
+                    // Normalize the path separators if they are used uniformly in the replacement prefix.
+                    bool hasSlash = replacementPrefix.IndexOf('/') >= 0;
+                    bool hasBackslash = replacementPrefix.IndexOf('\\') >= 0;
+                    return
+                        (hasSlash && !hasBackslash) ? replacement.Replace('\\', '/') :
+                        (hasBackslash && !hasSlash) ? replacement.Replace('/', '\\') :
+                        replacement;
+                }
+            }
+
+            return filePath;
         }
 
         private sealed class CacheReader : IDisposable

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.PackageDependencyResolution.targets
@@ -263,10 +263,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ExpectedPlatformPackages Include="@(PackageReference)" Condition="'%(Identity)' == 'Microsoft.AspNetCore.All'" />
     </ItemGroup>
 
+    <!--
+      When the compiler already produces location-independent output (DeterministicSourcePaths), pass the same
+      PathMap so ResolvePackageAssets normalizes the project-owned paths in its cache-invalidation hash. The
+      assets cache then stays valid when identical sources are restored under a different repo root (for example
+      a cache seeded from another machine/agent). Empty otherwise, so the hash is unchanged for normal builds.
+    -->
+    <PropertyGroup>
+      <_ResolvePackageAssetsPathMap Condition="'$(DeterministicSourcePaths)' == 'true'">$(PathMap)</_ResolvePackageAssetsPathMap>
+    </PropertyGroup>
+
     <ResolvePackageAssets
       ProjectAssetsFile="$(ProjectAssetsFile)"
       ProjectAssetsCacheFile="$(ProjectAssetsCacheFile)"
       ProjectPath="$(MSBuildProjectFullPath)"
+      PathMap="$(_ResolvePackageAssetsPathMap)"
       ProjectLanguage="$(Language)"
       CompilerApiVersion="$(CompilerApiVersion)"
       EmitAssetsLogMessages="$(EmitAssetsLogMessages)"

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsTask.cs
@@ -77,6 +77,57 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
         }
 
         [TestMethod]
+        public void PathMapMakesTheSettingsHashLocationIndependent()
+        {
+            var task = InitializeTask(out _);
+
+            void SetProjectPaths(string root)
+            {
+                task.ProjectPath = root + @"\src\proj.csproj";
+                task.ProjectAssetsFile = root + @"\obj\project.assets.json";
+                task.ProjectAssetsCacheFile = root + @"\obj\project.assets.cache";
+            }
+
+            // Identical restores under two different roots hash differently without a path map...
+            SetProjectPaths(@"C:\rootA");
+            task.PathMap = null;
+            byte[] rootAUnmapped = task.HashSettings();
+
+            SetProjectPaths(@"C:\rootB");
+            byte[] rootBUnmapped = task.HashSettings();
+
+            rootBUnmapped.Should().NotBeEquivalentTo(rootAUnmapped,
+                because: "identical restores under different roots hash differently without a path map.");
+
+            // ...but converge once each root is mapped to the same deterministic prefix.
+            SetProjectPaths(@"C:\rootA");
+            task.PathMap = @"C:\rootA\=/_/";
+            byte[] rootAMapped = task.HashSettings();
+
+            SetProjectPaths(@"C:\rootB");
+            task.PathMap = @"C:\rootB\=/_/";
+            byte[] rootBMapped = task.HashSettings();
+
+            rootBMapped.Should().BeEquivalentTo(rootAMapped,
+                because: "mapping each root to the same prefix makes the settings hash location-independent.");
+        }
+
+        [TestMethod]
+        public void EmptyPathMapDoesNotChangeTheSettingsHash()
+        {
+            var task = InitializeTask(out _);
+
+            task.PathMap = null;
+            byte[] withoutPathMap = task.HashSettings();
+
+            task.PathMap = "";
+            byte[] withEmptyPathMap = task.HashSettings();
+
+            withEmptyPathMap.Should().BeEquivalentTo(withoutPathMap,
+                because: "an empty path map keeps the legacy hash, so the normalization is opt-in.");
+        }
+
+        [TestMethod]
         public void It_does_not_error_on_duplicate_package_names()
         {
             string projectAssetsJsonPath = Path.GetTempFileName();
@@ -205,6 +256,9 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public)
                 .Where(p => !p.IsDefined(typeof(OutputAttribute)) &&
                             p.Name != nameof(ResolvePackageAssets.DesignTimeBuild) &&
+                            // PathMap is not hashed directly; it transforms other hashed paths, so it is
+                            // covered by PathMapMakesTheSettingsHashLocationIndependent instead.
+                            p.Name != nameof(ResolvePackageAssets.PathMap) &&
                             p.Name != nameof(ResolvePackageAssets.TaskEnvironment))
                 .OrderBy(p => p.Name, StringComparer.Ordinal);
 


### PR DESCRIPTION
> [!NOTE]
> **Prototype / RFC — not requesting merge yet.** This is part of the 1ES build-speedup effort and is opened as a draft to gather expert feedback on the approach. See the "Open questions" below.

## Motivation

We are prototyping a content-addressed, cross-machine build cache (part of the 1ES build-speedup effort). For a cache to hit across different agents/checkout locations, an otherwise-identical restore under a *different repository root* must produce identical incremental state.

`ResolvePackageAssets.HashSettings()` hashes three absolute, root-dependent paths — `ProjectAssetsCacheFile`, `ProjectAssetsFile`, and `ProjectPath` — so an otherwise-identical restore under a different root produces a different settings hash. That invalidates the assets cache (and its consumers) even though the resolved assets are equivalent, defeating a build seeded from another machine or agent.

## Change

Add an optional `PathMap` task input that applies the compiler's own path mapping (prefix replacement) to those three project-owned paths before hashing, and pass `$(PathMap)` from the `ResolvePackageAssets` target **only when `$(DeterministicSourcePaths)` is true**.

- The parameter is **empty by default**, so the hash and behavior are **unchanged** for normal builds — opt-in, not a breaking change.
- `PathMap` is a transform rather than a directly-hashed setting, so it is excluded from `ItHashesAllParameters` and covered by dedicated tests.
- The path-map parsing/normalization mirrors the compiler's own logic (`CommandLineParser.ParsePathMap` / `PathUtilities.NormalizePathPrefix`).

## Validation

- New unit tests: identical restores under two roots hash differently without a map and converge once each root maps to the same deterministic prefix; an empty map reproduces the legacy hash.
- Verified end-to-end in a composed SDK (this change + the sibling dotnet/msbuild change): a cold-seeded cross-root build skips `CoreCompile`.

## Open questions for reviewers

1. Is applying the map inside `HashSettings()` (to the three project-owned paths) the right approach and the right set of paths?
2. This adds a copy of the compiler's path-map parsing helpers. There are sibling copies in dotnet/msbuild and dotnet/roslyn. **Suggestions for a shared, non-duplicated home welcome.**
3. Any concerns with gating on `$(DeterministicSourcePaths)` as the opt-in signal?
