### PR TITLE
Add E2E coverage for dotnet test (MTP) live test-host output

### DIFF
--- a/test/TestAssets/TestProjects/TestProjectWithLiveOutput/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithLiveOutput/Program.cs
@@ -1,21 +1,28 @@
 ﻿using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
-
-// Written before the test application is built, i.e. before the pipe handshake with the SDK
-// completes. It exercises the "buffer until the protocol version is negotiated, then flush" path.
-Console.WriteLine("LIVE_OUTPUT_BEFORE_HANDSHAKE");
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
 
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
-testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, serviceProvider) => new DummyTestAdapter(serviceProvider.GetOutputDevice()));
 
 using var testApplication = await testApplicationBuilder.BuildAsync();
 return await testApplication.RunAsync();
 
-public class DummyTestAdapter : ITestFramework, IDataProducer
+public class DummyTestAdapter(IOutputDevice outputDevice) : ITestFramework, IDataProducer, IOutputDeviceDataProducer
 {
+	// Set by the test to a path that does not exist yet. The test creates the file as soon as it
+	// observes LIVE_OUTPUT_STANDARD_OUTPUT on the standard output of 'dotnet test' while the
+	// command is still running, so this app can only see the file appear if its own console output
+	// really was forwarded live rather than buffered until it exits.
+	private const string SentinelPathEnvironmentVariable = "LIVE_OUTPUT_SENTINEL_PATH";
+
+	private static readonly TimeSpan SentinelTimeout = TimeSpan.FromSeconds(60);
+
 	public string Uid => nameof(DummyTestAdapter);
 
 	public string Version => "2.0.0";
@@ -38,18 +45,50 @@ public class DummyTestAdapter : ITestFramework, IDataProducer
 
 	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
 	{
-		// Written while the test session is running, so it must be streamed to the SDK terminal
-		// as it is produced instead of being buffered and only shown when something fails.
 		Console.WriteLine("LIVE_OUTPUT_STANDARD_OUTPUT");
 		Console.Error.WriteLine("LIVE_OUTPUT_STANDARD_ERROR");
+
+		// Text written through the platform's output device does not reach the console directly:
+		// it is forwarded to 'dotnet test' over the pipe protocol and rendered by its reporter.
+		// Only durable session messages, warnings and errors cross the wire - plain informational
+		// text is deliberately discarded by the host under the pipe protocol.
+		await outputDevice.DisplayAsync(this, new SessionMessageOutputDeviceData("LIVE_OUTPUT_SESSION_MESSAGE"), context.CancellationToken);
+		await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData("LIVE_OUTPUT_WARNING_MESSAGE"), context.CancellationToken);
+		await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData("LIVE_OUTPUT_ERROR_MESSAGE"), context.CancellationToken);
+
+		string? failureReason = await WaitForOutputToBeObservedAsync();
 
 		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
 		{
 			Uid = "Test0",
 			DisplayName = "Test0",
-			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+			Properties = new PropertyBag(failureReason is null
+				? new PassedTestNodeStateProperty("OK")
+				: new FailedTestNodeStateProperty(failureReason)),
 		}));
 
 		context.Complete();
+	}
+
+	private static async Task<string?> WaitForOutputToBeObservedAsync()
+	{
+		string? sentinelPath = Environment.GetEnvironmentVariable(SentinelPathEnvironmentVariable);
+		if (string.IsNullOrEmpty(sentinelPath))
+		{
+			return $"{SentinelPathEnvironmentVariable} is not set.";
+		}
+
+		DateTime deadline = DateTime.UtcNow + SentinelTimeout;
+		while (DateTime.UtcNow < deadline)
+		{
+			if (File.Exists(sentinelPath))
+			{
+				return null;
+			}
+
+			await Task.Delay(50);
+		}
+
+		return $"The standard output of this test app was not observed within {SentinelTimeout.TotalSeconds} seconds while it was still running, so it was not forwarded live.";
 	}
 }

--- a/test/TestAssets/TestProjects/TestProjectWithLiveOutput/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithLiveOutput/Program.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+// Written before the test application is built, i.e. before the pipe handshake with the SDK
+// completes. It exercises the "buffer until the protocol version is negotiated, then flush" path.
+Console.WriteLine("LIVE_OUTPUT_BEFORE_HANDSHAKE");
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		// Written while the test session is running, so it must be streamed to the SDK terminal
+		// as it is produced instead of being buffered and only shown when something fails.
+		Console.WriteLine("LIVE_OUTPUT_STANDARD_OUTPUT");
+		Console.Error.WriteLine("LIVE_OUTPUT_STANDARD_ERROR");
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithLiveOutput/TestProjectWithLiveOutput.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithLiveOutput/TestProjectWithLiveOutput.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithLiveOutput/global.json
+++ b/test/TestAssets/TestProjects/TestProjectWithLiveOutput/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/Program.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+// This is the only console output the app produces, and it is written before the pipe handshake
+// with 'dotnet test' can have completed. The SDK has to buffer it until it knows the negotiated
+// protocol version and then flush it. Producing no further output afterwards is what makes this
+// asset a guard: the flush cannot be masked by a later line flushing the whole buffer, and since
+// the run succeeds the output is never replayed as part of a failure summary either.
+Console.WriteLine("OUTPUT_BEFORE_HANDSHAKE");
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new PassedTestNodeStateProperty("OK")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/TestProjectWithOutputBeforeHandshake.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/TestProjectWithOutputBeforeHandshake.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/global.json
+++ b/test/TestAssets/TestProjects/TestProjectWithOutputBeforeHandshake/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
+using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
+
+namespace Microsoft.DotNet.Cli.Test.Tests
+{
+    /// <summary>
+    /// End-to-end coverage for https://github.com/dotnet/sdk/issues/51615: the console output of a
+    /// test application must reach the user while the run is in progress, not only when a test fails.
+    /// </summary>
+    [TestClass]
+    public class GivenDotnetTestForwardsTestHostOutput : SdkTest
+    {
+        private const string OutputBeforeHandshake = "LIVE_OUTPUT_BEFORE_HANDSHAKE";
+        private const string StandardOutputDuringRun = "LIVE_OUTPUT_STANDARD_OUTPUT";
+        private const string StandardErrorDuringRun = "LIVE_OUTPUT_STANDARD_ERROR";
+
+        [DataRow(TestingConstants.Debug)]
+        [DataRow(TestingConstants.Release)]
+        [TestMethod]
+        public void RunTestProjectWritingToConsole_ShouldForwardOutputEvenWhenAllTestsPass(string configuration)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithLiveOutput", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("-c", configuration);
+
+            // The test app writes to the console before the handshake and while the test session runs.
+            // Both must show up even though the run succeeds and no output-related option was passed.
+            result.StdOut
+                .Should().Contain(OutputBeforeHandshake)
+                .And.Contain(StandardOutputDuringRun)
+                .And.Contain(StandardErrorDuringRun);
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("total: 1")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 0");
+
+                // The output is streamed as it is produced, so it precedes the end-of-run summary
+                // instead of being replayed as part of a failure report.
+                result.StdOut!.IndexOf(StandardOutputDuringRun, StringComparison.Ordinal)
+                    .Should().BeLessThan(result.StdOut!.IndexOf("Test run summary:", StringComparison.Ordinal));
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -4,133 +4,132 @@
 using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 
-namespace Microsoft.DotNet.Cli.Test.Tests
+namespace Microsoft.DotNet.Cli.Test.Tests;
+
+/// <summary>
+/// End-to-end coverage for https://github.com/dotnet/sdk/issues/51615: what a test application
+/// writes to the console must reach the user while the run is in progress, and not only be
+/// replayed when a test fails.
+/// </summary>
+[TestClass]
+public class GivenDotnetTestForwardsTestHostOutput : SdkTest
 {
-    /// <summary>
-    /// End-to-end coverage for https://github.com/dotnet/sdk/issues/51615: what a test application
-    /// writes to the console must reach the user while the run is in progress, and not only be
-    /// replayed when a test fails.
-    /// </summary>
-    [TestClass]
-    public class GivenDotnetTestForwardsTestHostOutput : SdkTest
+    private const string SentinelPathEnvironmentVariable = "LIVE_OUTPUT_SENTINEL_PATH";
+    private const string StandardOutputMarker = "LIVE_OUTPUT_STANDARD_OUTPUT";
+    private const string StandardErrorMarker = "LIVE_OUTPUT_STANDARD_ERROR";
+    private const string OutputDeviceSessionMessageMarker = "LIVE_OUTPUT_SESSION_MESSAGE";
+    private const string OutputDeviceWarningMarker = "LIVE_OUTPUT_WARNING_MESSAGE";
+    private const string OutputDeviceErrorMarker = "LIVE_OUTPUT_ERROR_MESSAGE";
+    private const string OutputBeforeHandshakeMarker = "OUTPUT_BEFORE_HANDSHAKE";
+
+    [DataRow(TestingConstants.Debug)]
+    [DataRow(TestingConstants.Release)]
+    [TestMethod]
+    public void RunTestProjectWritingToConsole_ShouldForwardOutputWhileTheRunIsInProgress(string configuration)
     {
-        private const string SentinelPathEnvironmentVariable = "LIVE_OUTPUT_SENTINEL_PATH";
-        private const string StandardOutputMarker = "LIVE_OUTPUT_STANDARD_OUTPUT";
-        private const string StandardErrorMarker = "LIVE_OUTPUT_STANDARD_ERROR";
-        private const string OutputDeviceSessionMessageMarker = "LIVE_OUTPUT_SESSION_MESSAGE";
-        private const string OutputDeviceWarningMarker = "LIVE_OUTPUT_WARNING_MESSAGE";
-        private const string OutputDeviceErrorMarker = "LIVE_OUTPUT_ERROR_MESSAGE";
-        private const string OutputBeforeHandshakeMarker = "OUTPUT_BEFORE_HANDSHAKE";
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithLiveOutput", Guid.NewGuid().ToString())
+            .WithSource();
 
-        [DataRow(TestingConstants.Debug)]
-        [DataRow(TestingConstants.Release)]
-        [TestMethod]
-        public void RunTestProjectWritingToConsole_ShouldForwardOutputWhileTheRunIsInProgress(string configuration)
+        // The test app blocks until this file exists, and the file is only created once the
+        // marker it wrote has been observed on the live standard output of 'dotnet test'.
+        // An implementation that buffers the test app's output until it exits therefore
+        // deadlocks the app until its own timeout expires, which fails the run.
+        string sentinelPath = Path.Combine(testInstance.Path, "live-output-observed.sentinel");
+
+        Exception? sentinelFailure = null;
+        var command = new DotnetTestCommand(Log, disableNewOutput: false)
+                                .WithWorkingDirectory(testInstance.Path)
+                                .WithEnvironmentVariable(SentinelPathEnvironmentVariable, sentinelPath);
+
+        // Execute retries the command on transient failures without re-copying the asset, so
+        // clear the sentinel on every attempt: a file left behind by an earlier attempt would
+        // let the app proceed immediately and quietly void what this test is proving.
+        // This runs after the command's process has started but before it is registered with
+        // the process reaper, so an exception escaping here would leave that process orphaned.
+        command.ProcessStartedHandler = _ =>
         {
-            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithLiveOutput", Guid.NewGuid().ToString())
-                .WithSource();
-
-            // The test app blocks until this file exists, and the file is only created once the
-            // marker it wrote has been observed on the live standard output of 'dotnet test'.
-            // An implementation that buffers the test app's output until it exits therefore
-            // deadlocks the app until its own timeout expires, which fails the run.
-            string sentinelPath = Path.Combine(testInstance.Path, "live-output-observed.sentinel");
-
-            Exception? sentinelFailure = null;
-            var command = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .WithEnvironmentVariable(SentinelPathEnvironmentVariable, sentinelPath);
-
-            // Execute retries the command on transient failures without re-copying the asset, so
-            // clear the sentinel on every attempt: a file left behind by an earlier attempt would
-            // let the app proceed immediately and quietly void what this test is proving.
-            // This runs after the command's process has started but before it is registered with
-            // the process reaper, so an exception escaping here would leave that process orphaned.
-            command.ProcessStartedHandler = _ =>
+            try
+            {
+                File.Delete(sentinelPath);
+            }
+            catch (Exception ex)
+            {
+                sentinelFailure ??= ex;
+            }
+        };
+        command.CommandOutputHandler = line =>
+        {
+            if (line.Contains(StandardOutputMarker, StringComparison.Ordinal) && !File.Exists(sentinelPath))
             {
                 try
                 {
-                    File.Delete(sentinelPath);
+                    File.WriteAllText(sentinelPath, string.Empty);
                 }
                 catch (Exception ex)
                 {
+                    // This runs on the only thread draining the command's standard output.
+                    // Letting the exception escape would stop that drain and hang the run, so
+                    // record it and let the assertion below report it.
                     sentinelFailure ??= ex;
                 }
-            };
-            command.CommandOutputHandler = line =>
-            {
-                if (line.Contains(StandardOutputMarker, StringComparison.Ordinal) && !File.Exists(sentinelPath))
-                {
-                    try
-                    {
-                        File.WriteAllText(sentinelPath, string.Empty);
-                    }
-                    catch (Exception ex)
-                    {
-                        // This runs on the only thread draining the command's standard output.
-                        // Letting the exception escape would stop that drain and hang the run, so
-                        // record it and let the assertion below report it.
-                        sentinelFailure ??= ex;
-                    }
-                }
-            };
-
-            CommandResult result = command.Execute("-c", configuration);
-
-            sentinelFailure.Should().BeNull("the sentinel file should be writable and deletable");
-
-            // The run succeeds, so nothing replays the test app's output as part of a failure
-            // report: the markers can only be present because they were forwarded as produced.
-            // The output device markers additionally cover the text the test app routes through
-            // the platform's IOutputDevice, which reaches the SDK as protocol 1.3.0 display
-            // messages and is rendered at its informational, warning and error levels.
-            result.StdOut
-                .Should().Contain(StandardOutputMarker)
-                .And.Contain(StandardErrorMarker)
-                .And.Contain(OutputDeviceSessionMessageMarker)
-                .And.Contain(OutputDeviceWarningMarker)
-                .And.Contain(OutputDeviceErrorMarker);
-
-            if (!SdkTestContext.IsLocalized())
-            {
-                result.StdOut
-                    .Should().Contain("Test run summary: Passed!")
-                    .And.Contain("total: 1")
-                    .And.Contain("succeeded: 1")
-                    .And.Contain("failed: 0")
-                    .And.Contain("skipped: 0");
             }
+        };
 
-            result.ExitCode.Should().Be(ExitCodes.Success);
-        }
+        CommandResult result = command.Execute("-c", configuration);
 
-        [DataRow(TestingConstants.Debug)]
-        [DataRow(TestingConstants.Release)]
-        [TestMethod]
-        public void RunTestProjectWritingToConsoleBeforeHandshake_ShouldForwardOutputOnceProtocolIsNegotiated(string configuration)
+        sentinelFailure.Should().BeNull("the sentinel file should be writable and deletable");
+
+        // The run succeeds, so nothing replays the test app's output as part of a failure
+        // report: the markers can only be present because they were forwarded as produced.
+        // The output device markers additionally cover the text the test app routes through
+        // the platform's IOutputDevice, which reaches the SDK as protocol 1.3.0 display
+        // messages and is rendered at its informational, warning and error levels.
+        result.StdOut
+            .Should().Contain(StandardOutputMarker)
+            .And.Contain(StandardErrorMarker)
+            .And.Contain(OutputDeviceSessionMessageMarker)
+            .And.Contain(OutputDeviceWarningMarker)
+            .And.Contain(OutputDeviceErrorMarker);
+
+        if (!SdkTestContext.IsLocalized())
         {
-            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithOutputBeforeHandshake", Guid.NewGuid().ToString())
-                .WithSource();
-
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .Execute("-c", configuration);
-
-            // The test app only writes before the handshake completes, so this output has to be
-            // buffered until the protocol version is known and then flushed.
-            result.StdOut.Should().Contain(OutputBeforeHandshakeMarker);
-
-            if (!SdkTestContext.IsLocalized())
-            {
-                result.StdOut
-                    .Should().Contain("Test run summary: Passed!")
-                    .And.Contain("total: 1")
-                    .And.Contain("succeeded: 1")
-                    .And.Contain("failed: 0")
-                    .And.Contain("skipped: 0");
-            }
-
-            result.ExitCode.Should().Be(ExitCodes.Success);
+            result.StdOut
+                .Should().Contain("Test run summary: Passed!")
+                .And.Contain("total: 1")
+                .And.Contain("succeeded: 1")
+                .And.Contain("failed: 0")
+                .And.Contain("skipped: 0");
         }
+
+        result.ExitCode.Should().Be(ExitCodes.Success);
+    }
+
+    [DataRow(TestingConstants.Debug)]
+    [DataRow(TestingConstants.Release)]
+    [TestMethod]
+    public void RunTestProjectWritingToConsoleBeforeHandshake_ShouldForwardOutputOnceProtocolIsNegotiated(string configuration)
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithOutputBeforeHandshake", Guid.NewGuid().ToString())
+            .WithSource();
+
+        CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                .WithWorkingDirectory(testInstance.Path)
+                                .Execute("-c", configuration);
+
+        // The test app only writes before the handshake completes, so this output has to be
+        // buffered until the protocol version is known and then flushed.
+        result.StdOut.Should().Contain(OutputBeforeHandshakeMarker);
+
+        if (!SdkTestContext.IsLocalized())
+        {
+            result.StdOut
+                .Should().Contain("Test run summary: Passed!")
+                .And.Contain("total: 1")
+                .And.Contain("succeeded: 1")
+                .And.Contain("failed: 0")
+                .And.Contain("skipped: 0");
+        }
+
+        result.ExitCode.Should().Be(ExitCodes.Success);
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -7,34 +7,59 @@ using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
     /// <summary>
-    /// End-to-end coverage for https://github.com/dotnet/sdk/issues/51615: the console output of a
-    /// test application must reach the user while the run is in progress, not only when a test fails.
+    /// End-to-end coverage for https://github.com/dotnet/sdk/issues/51615: what a test application
+    /// writes to the console must reach the user while the run is in progress, and not only be
+    /// replayed when a test fails.
     /// </summary>
     [TestClass]
     public class GivenDotnetTestForwardsTestHostOutput : SdkTest
     {
-        private const string OutputBeforeHandshake = "LIVE_OUTPUT_BEFORE_HANDSHAKE";
-        private const string StandardOutputDuringRun = "LIVE_OUTPUT_STANDARD_OUTPUT";
-        private const string StandardErrorDuringRun = "LIVE_OUTPUT_STANDARD_ERROR";
+        private const string SentinelPathEnvironmentVariable = "LIVE_OUTPUT_SENTINEL_PATH";
+        private const string StandardOutputMarker = "LIVE_OUTPUT_STANDARD_OUTPUT";
+        private const string StandardErrorMarker = "LIVE_OUTPUT_STANDARD_ERROR";
+        private const string OutputDeviceSessionMessageMarker = "LIVE_OUTPUT_SESSION_MESSAGE";
+        private const string OutputDeviceWarningMarker = "LIVE_OUTPUT_WARNING_MESSAGE";
+        private const string OutputDeviceErrorMarker = "LIVE_OUTPUT_ERROR_MESSAGE";
+        private const string OutputBeforeHandshakeMarker = "OUTPUT_BEFORE_HANDSHAKE";
 
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]
-        public void RunTestProjectWritingToConsole_ShouldForwardOutputEvenWhenAllTestsPass(string configuration)
+        public void RunTestProjectWritingToConsole_ShouldForwardOutputWhileTheRunIsInProgress(string configuration)
         {
             TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithLiveOutput", Guid.NewGuid().ToString())
                 .WithSource();
 
-            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
-                                    .WithWorkingDirectory(testInstance.Path)
-                                    .Execute("-c", configuration);
+            // The test app blocks until this file exists, and the file is only created once the
+            // marker it wrote has been observed on the live standard output of 'dotnet test'.
+            // An implementation that buffers the test app's output until it exits therefore
+            // deadlocks the app until its own timeout expires, which fails the run.
+            string sentinelPath = Path.Combine(testInstance.Path, "live-output-observed.sentinel");
 
-            // The test app writes to the console before the handshake and while the test session runs.
-            // Both must show up even though the run succeeds and no output-related option was passed.
+            var command = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .WithEnvironmentVariable(SentinelPathEnvironmentVariable, sentinelPath);
+            command.CommandOutputHandler = line =>
+            {
+                if (line.Contains(StandardOutputMarker, StringComparison.Ordinal) && !File.Exists(sentinelPath))
+                {
+                    File.WriteAllText(sentinelPath, string.Empty);
+                }
+            };
+
+            CommandResult result = command.Execute("-c", configuration);
+
+            // The run succeeds, so nothing replays the test app's output as part of a failure
+            // report: the markers can only be present because they were forwarded as produced.
+            // The output device markers additionally cover the text the test app routes through
+            // the platform's IOutputDevice, which reaches the SDK as protocol 1.3.0 display
+            // messages and is rendered at its informational, warning and error levels.
             result.StdOut
-                .Should().Contain(OutputBeforeHandshake)
-                .And.Contain(StandardOutputDuringRun)
-                .And.Contain(StandardErrorDuringRun);
+                .Should().Contain(StandardOutputMarker)
+                .And.Contain(StandardErrorMarker)
+                .And.Contain(OutputDeviceSessionMessageMarker)
+                .And.Contain(OutputDeviceWarningMarker)
+                .And.Contain(OutputDeviceErrorMarker);
 
             if (!SdkTestContext.IsLocalized())
             {
@@ -44,11 +69,35 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .And.Contain("succeeded: 1")
                     .And.Contain("failed: 0")
                     .And.Contain("skipped: 0");
+            }
 
-                // The output is streamed as it is produced, so it precedes the end-of-run summary
-                // instead of being replayed as part of a failure report.
-                result.StdOut!.IndexOf(StandardOutputDuringRun, StringComparison.Ordinal)
-                    .Should().BeLessThan(result.StdOut!.IndexOf("Test run summary:", StringComparison.Ordinal));
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
+        [DataRow(TestingConstants.Debug)]
+        [DataRow(TestingConstants.Release)]
+        [TestMethod]
+        public void RunTestProjectWritingToConsoleBeforeHandshake_ShouldForwardOutputOnceProtocolIsNegotiated(string configuration)
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithOutputBeforeHandshake", Guid.NewGuid().ToString())
+                .WithSource();
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                    .WithWorkingDirectory(testInstance.Path)
+                                    .Execute("-c", configuration);
+
+            // The test app only writes before the handshake completes, so this output has to be
+            // buffered until the protocol version is known and then flushed.
+            result.StdOut.Should().Contain(OutputBeforeHandshakeMarker);
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                result.StdOut
+                    .Should().Contain("Test run summary: Passed!")
+                    .And.Contain("total: 1")
+                    .And.Contain("succeeded: 1")
+                    .And.Contain("failed: 0")
+                    .And.Contain("skipped: 0");
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -36,18 +36,36 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // deadlocks the app until its own timeout expires, which fails the run.
             string sentinelPath = Path.Combine(testInstance.Path, "live-output-observed.sentinel");
 
+            Exception? sentinelWriteFailure = null;
             var command = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnvironmentVariable(SentinelPathEnvironmentVariable, sentinelPath);
+
+            // Execute retries the command on transient failures without re-copying the asset, so
+            // clear the sentinel on every attempt: a file left behind by an earlier attempt would
+            // let the app proceed immediately and quietly void what this test is proving.
+            command.ProcessStartedHandler = _ => File.Delete(sentinelPath);
             command.CommandOutputHandler = line =>
             {
                 if (line.Contains(StandardOutputMarker, StringComparison.Ordinal) && !File.Exists(sentinelPath))
                 {
-                    File.WriteAllText(sentinelPath, string.Empty);
+                    try
+                    {
+                        File.WriteAllText(sentinelPath, string.Empty);
+                    }
+                    catch (Exception ex)
+                    {
+                        // This runs on the only thread draining the command's standard output.
+                        // Letting the exception escape would stop that drain and hang the run, so
+                        // record it and let the assertion below report it.
+                        sentinelWriteFailure ??= ex;
+                    }
                 }
             };
 
             CommandResult result = command.Execute("-c", configuration);
+
+            sentinelWriteFailure.Should().BeNull("the sentinel file should be writable");
 
             // The run succeeds, so nothing replays the test app's output as part of a failure
             // report: the markers can only be present because they were forwarded as produced.

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // deadlocks the app until its own timeout expires, which fails the run.
             string sentinelPath = Path.Combine(testInstance.Path, "live-output-observed.sentinel");
 
-            Exception? sentinelWriteFailure = null;
+            Exception? sentinelFailure = null;
             var command = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
                                     .WithEnvironmentVariable(SentinelPathEnvironmentVariable, sentinelPath);
@@ -44,7 +44,19 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Execute retries the command on transient failures without re-copying the asset, so
             // clear the sentinel on every attempt: a file left behind by an earlier attempt would
             // let the app proceed immediately and quietly void what this test is proving.
-            command.ProcessStartedHandler = _ => File.Delete(sentinelPath);
+            // This runs after the command's process has started but before it is registered with
+            // the process reaper, so an exception escaping here would leave that process orphaned.
+            command.ProcessStartedHandler = _ =>
+            {
+                try
+                {
+                    File.Delete(sentinelPath);
+                }
+                catch (Exception ex)
+                {
+                    sentinelFailure ??= ex;
+                }
+            };
             command.CommandOutputHandler = line =>
             {
                 if (line.Contains(StandardOutputMarker, StringComparison.Ordinal) && !File.Exists(sentinelPath))
@@ -58,14 +70,14 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                         // This runs on the only thread draining the command's standard output.
                         // Letting the exception escape would stop that drain and hang the run, so
                         // record it and let the assertion below report it.
-                        sentinelWriteFailure ??= ex;
+                        sentinelFailure ??= ex;
                     }
                 }
             };
 
             CommandResult result = command.Execute("-c", configuration);
 
-            sentinelWriteFailure.Should().BeNull("the sentinel file should be writable");
+            sentinelFailure.Should().BeNull("the sentinel file should be writable and deletable");
 
             // The run succeeds, so nothing replays the test app's output as part of a failure
             // report: the markers can only be present because they were forwarded as produced.


### PR DESCRIPTION
Closes #51615.

The behavior change itself shipped earlier (#54825 plus follow-ups: highest-common protocol negotiation, live stdout/stderr streaming gated on ≥ 1.1.0, and forwarding of `AzureDevOpsLogMessage` (1.2.0) and `DisplayMessage` (1.3.0)). What was missing was end-to-end coverage: the existing tests were unit-level only (protocol negotiation + serializer round-trips), so nothing guarded the actual user-visible behavior through `dotnet test`.

## What this adds

`test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs` with two scenarios, each run for `Debug` and `Release`:

**1. Output is forwarded *while the run is in progress*** — `TestProjectWithLiveOutput`

Asserting on captured text after the process exits cannot distinguish "streamed live" from "buffered until exit", so this uses a sentinel handshake instead:

- the test app writes its marker to stdout, then blocks waiting for a sentinel file (60s timeout);
- the test's `CommandOutputHandler` creates that sentinel only when it sees the marker on the live output of the still-running `dotnet test`;
- if the app times out it publishes a **failed** test node, failing the run.

An implementation that buffers host output until process exit therefore deadlocks the app and fails, rather than passing by replaying everything just before the summary.

The same asset also exercises `IOutputDevice` (`SessionMessageOutputDeviceData`, `WarningMessageOutputDeviceData`, `ErrorMessageOutputDeviceData`), covering the 1.3.0 `DisplayMessage` path end to end rather than only at the serializer level. Because the run *succeeds*, none of these markers can come from a failure summary replay — they can only be present because they were forwarded as produced.

**2. Output written before the handshake completes is still surfaced** — `TestProjectWithOutputBeforeHandshake`

The app writes exactly one line before `TestApplication.CreateBuilderAsync`, and nothing afterwards. The SDK has to buffer it until the negotiated protocol version is known and then flush it. Producing no further output is what makes this a real guard: the flush cannot be masked by a later line draining the buffer, and the passing run rules out failure-summary replay.

## Validation

- All 4 rows pass against a local `build.cmd -c Debug` redist.
- **Negative control**: capping `ProtocolConstants.SupportedVersions` to `"1.0.0"` makes all 4 rows fail (the live-output rows fail with `The standard output of this test app was not observed within 60 seconds while it was still running, so it was not forwarded live.`), confirming both scenarios are load-bearing rather than vacuously passing.

No product code changes.