### PR TITLE
Fix Queue Tests restore regression and skip redundant restore work

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -165,7 +165,7 @@ jobs:
       # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
       - ${{ if eq(parameters.pool.os, 'windows') }}:
         - powershell: eng/common/build.ps1
-            -restore -test -ci -prepareMachine -nativeToolsOnMachine
+            -test -ci -prepareMachine -nativeToolsOnMachine
             -configuration $(buildConfiguration)
             -binaryLogName ${{ parameters.categoryName }}Tests.binlog
             /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
@@ -175,7 +175,6 @@ jobs:
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
             /p:EnableHelixJobMonitor=true
             /p:SkippedTestScopes="$(SkippedTestScopes)"
-            /p:Restore=false
           displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.
@@ -189,7 +188,7 @@ jobs:
         # The /p:CustomHelixTargetQueue syntax is: <queue-name>@<container-url>
         # For the Helix containers, see the 'simpleTags' arrays here: https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
         - script: eng/common/build.sh
-            -restore -test -ci -prepareMachine
+            -test -ci -prepareMachine
             -configuration $(buildConfiguration)
             --binaryLogName ${{ parameters.categoryName }}Tests.binlog
             '/p:Projects="${{ parameters.testProjects }}"'
@@ -201,7 +200,6 @@ jobs:
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
             /p:EnableHelixJobMonitor=true
             /p:SkippedTestScopes="$(SkippedTestScopes)"
-            /p:Restore=false
           displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -165,7 +165,7 @@ jobs:
       # For the /p:Projects syntax for PowerShell, see: https://github.com/dotnet/msbuild/issues/471#issuecomment-1146466335
       - ${{ if eq(parameters.pool.os, 'windows') }}:
         - powershell: eng/common/build.ps1
-            -restore -test -ci -prepareMachine -nativeToolsOnMachine
+            -test -ci -prepareMachine -nativeToolsOnMachine
             -configuration $(buildConfiguration)
             -binaryLogName ${{ parameters.categoryName }}Tests.binlog
             /p:Projects=\`"${{ replace(parameters.testProjects, ';', '`;') }}\`"
@@ -188,7 +188,7 @@ jobs:
         # The /p:CustomHelixTargetQueue syntax is: <queue-name>@<container-url>
         # For the Helix containers, see the 'simpleTags' arrays here: https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
         - script: eng/common/build.sh
-            -restore -test -ci -prepareMachine
+            -test -ci -prepareMachine
             -configuration $(buildConfiguration)
             --binaryLogName ${{ parameters.categoryName }}Tests.binlog
             '/p:Projects="${{ parameters.testProjects }}"'

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -8,10 +8,6 @@ function InitializeCustomSDKToolset {
         Write-Host "INFO: Tests will run against full MSBuild in $env:DOTNET_SDK_TEST_MSBUILD_PATH"
     }
 
-    if (-not $restore) {
-        return
-    }
-
     # The following frameworks and tools are used only for testing.
     # Do not attempt to install them when building in the VMR.
     if ($fromVmr) {
@@ -321,6 +317,7 @@ function CleanOutStage0ToolsetsAndRuntimes {
     }
 }
 
-InitializeCustomSDKToolset
-
-CleanOutStage0ToolsetsAndRuntimes
+if ($restore) {
+    InitializeCustomSDKToolset
+    CleanOutStage0ToolsetsAndRuntimes
+}

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -4,10 +4,6 @@
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dotnetup-shared.sh"
 
 function InitializeCustomSDKToolset {
-  if [[ "$restore" != true ]]; then
-    return
-  fi
-
   # The following frameworks and tools are used only for testing.
   # Do not attempt to install them when building in the VMR.
   if [[ $from_vmr == true ]]; then
@@ -290,6 +286,7 @@ function CleanOutStage0ToolsetsAndRuntimes {
   fi
 }
 
-InitializeCustomSDKToolset
-
-CleanOutStage0ToolsetsAndRuntimes
+if [[ "$restore" == true ]]; then
+  InitializeCustomSDKToolset
+  CleanOutStage0ToolsetsAndRuntimes
+fi


### PR DESCRIPTION
Fixes #55504

## Problem

`Queue Tests` was spending significant time in restore even though the preceding Build step had already restored and built the repo.

A naive attempt to remove `-restore` from Queue Tests exposed a bash-specific failure in CI:

- `eng/common/build.sh` still sources `eng/restore-toolset.sh`
- with `restore=false`, `InitializeNativeTools` does not run, so `DOTNET_INSTALL_DIR` is unset
- `restore-toolset.sh` previously called `CleanOutStage0ToolsetsAndRuntimes` unconditionally
- that function dereferenced `DOTNET_INSTALL_DIR` under `set -u`
- Linux/macOS test legs failed with `DOTNET_INSTALL_DIR: unbound variable`

## Why `/p:Restore=false` was not used

Another attempt kept `-restore` and appended `/p:Restore=false`. In CI, restore still occurred in Queue Tests (visible `Determining projects to restore...` / `Restored ...` output), so this did not reliably remove the expensive restore work.

## Fix

1. **Remove `-restore` from Queue Tests** (Windows and non-Windows) in:
   - `eng/pipelines/templates/jobs/sdk-build.yml`

2. **Make restore-toolset execution restore-gated in one place** in both scripts:
   - `eng/restore-toolset.sh`
   - `eng/restore-toolset.ps1`

   Specifically, wrap both calls with `if restore`:
   - `InitializeCustomSDKToolset`
   - `CleanOutStage0ToolsetsAndRuntimes`

This keeps restore behavior intact when restore is requested, and prevents cleanup/toolset paths from running during test-only invocations where restore initialization is intentionally skipped.
