### PR TITLE
Report MSBuild errors from `dotnet test` device deploy and run-argument builds

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
@@ -556,6 +557,7 @@ internal static class SolutionAndProjectUtility
             runProperties = DeployAndGetRunProperties(
                 project,
                 logger,
+                AnalyzeStandardTestMSBuildArgs(buildOptions.MSBuildArgs),
                 buildOptions.EnvironmentVariables,
                 out runtimeEnvironmentVariables);
 
@@ -603,6 +605,7 @@ internal static class SolutionAndProjectUtility
         static RunProperties DeployAndGetRunProperties(
             ProjectInstance project,
             FacadeLogger? logger,
+            MSBuildArgs msbuildArgs,
             IReadOnlyDictionary<string, string> environmentVariables,
             out IReadOnlyDictionary<string, string> runtimeEnvironmentVariables)
         {
@@ -618,14 +621,13 @@ internal static class SolutionAndProjectUtility
             // NOTE: BuildManager is singleton.
             lock (s_buildLock)
             {
-                var loggers = logger is null ? null : new[] { logger };
                 if (project.Targets.ContainsKey(Constants.DeployToDevice) &&
-                    !project.Build([Constants.DeployToDevice], loggers))
+                    !project.Build([Constants.DeployToDevice], CreateBuildLoggers(msbuildArgs, logger)))
                 {
                     throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
                 }
 
-                if (!project.Build(s_computeRunArgumentsTarget, loggers))
+                if (!project.Build(s_computeRunArgumentsTarget, CreateBuildLoggers(msbuildArgs, logger)))
                 {
                     throw new GracefulException(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, s_computeRunArgumentsTarget[0]);
                 }
@@ -635,6 +637,34 @@ internal static class SolutionAndProjectUtility
                 ? EnvironmentVariablesToMSBuild.ReadFromItems(project)
                 : environmentVariables;
             return RunProperties.FromProject(project);
+        }
+    }
+
+    /// <summary>
+    /// Gets the loggers to attach to an in-process <see cref="ProjectInstance"/> build.
+    /// A console logger is attached (unless <c>-noConsoleLogger</c> was passed) so that MSBuild errors are
+    /// actually reported to the user: the binary logger only forwards events to binlogs, and it is only
+    /// created when <c>-bl</c> was passed, so without a console logger these builds fail silently and the user
+    /// is only told to "fix the errors and warnings" without any error being printed anywhere.
+    /// This mirrors what <c>dotnet run</c> does in <c>RunCommand.InvokeRunArgumentsTarget</c>.
+    /// </summary>
+    /// <remarks>
+    /// A fresh console logger is created for each build to avoid disposal issues when calling
+    /// <see cref="ProjectInstance.Build(string[], IEnumerable{ILogger})"/> multiple times.
+    /// </remarks>
+    private static IEnumerable<ILogger> CreateBuildLoggers(MSBuildArgs msbuildArgs, FacadeLogger? binaryLogger)
+    {
+        if (binaryLogger is not null)
+        {
+            yield return binaryLogger;
+        }
+
+        if (!LoggerUtility.HasNoConsoleLoggerArgument(msbuildArgs.OtherMSBuildArgs))
+        {
+            // These builds only compute run arguments and deploy, so keep them quiet - at this verbosity
+            // MSBuild still reports errors and warnings.
+            yield return CommonRunHelpers.GetConsoleLogger(
+                msbuildArgs.CloneWithExplicitArgs([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", .. msbuildArgs.OtherMSBuildArgs]));
         }
     }
 

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -50,6 +50,12 @@
       Overwrite="true" />
   </Target>
 
+  <Target Name="_FailComputeRunArguments"
+          BeforeTargets="ComputeRunArguments"
+          Condition="'$(FailComputeRunArguments)' == 'true'">
+    <Error Text="ComputeRunArguments failed as requested." />
+  </Target>
+
   <Target Name="_LogRuntimeEnvironmentVariableDuringBuild"
           BeforeTargets="_MTPBuild"
           Condition="'@(RuntimeEnvironmentVariable)' != ''">

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -608,7 +608,33 @@ public class GivenDotnetTestSelectsDevice : SdkTest
                 "-p:FailDeployToDevice=true");
 
         result.Should().Fail()
-            .And.HaveStdErrContaining(CliCommandStrings.RunCommandDeployFailed);
+            .And.HaveStdErrContaining(CliCommandStrings.RunCommandDeployFailed)
+            // The MSBuild error itself must be reported, otherwise the user is told to fix errors
+            // that were never printed anywhere.
+            .And.HaveStdOutContaining("DeployToDevice failed as requested.");
+    }
+
+    [TestMethod]
+    public void ItFailsWhenComputeRunArgumentsTargetFails()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", identifier: "ComputeRunArgumentsFailure")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute(
+                "--framework",
+                ToolsetInfo.CurrentTargetFramework,
+                "--device",
+                "test-device-1",
+                "-p:FailComputeRunArguments=true");
+
+        result.Should().Fail()
+            .And.HaveStdErrContaining(string.Format(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, "ComputeRunArguments"))
+            // The MSBuild error itself must be reported, otherwise the user is told to fix errors
+            // that were never printed anywhere.
+            .And.HaveStdOutContaining("ComputeRunArguments failed as requested.");
     }
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/sdk/pull/55502#discussion_r3672192063.

## The problem

`SolutionAndProjectUtility.DeployAndGetRunProperties` builds `DeployToDevice` and `ComputeRunArguments` on a `ProjectInstance`, passing only the `FacadeLogger` returned by `LoggerUtility.DetermineBinlogger(...)`. That logger is `null` unless the user passed `/bl`, so in the common case the build runs with **no loggers at all**: `ProjectInstance.Build` creates a fresh `BuildParameters()` and only populates `Loggers` when the argument is non-null — it does not fall back to the `ProjectCollection`'s loggers. And even with `-bl`, `FacadeLogger` only forwards to `BinaryLogger`s, never to the console.

The result is that any MSBuild error in these targets is invisible and the user only sees:

```
Running the ComputeRunArguments target to discover run commands failed for this project. Fix the errors and warnings and run again.
```

with no errors or warnings printed anywhere. That is exactly what made #55502 (`MSB4018` / duplicate `Microsoft.NETCore.App`) a binlog-only investigation.

`dotnet run` does not have this problem: `RunCommand.InvokeRunArgumentsTarget` always attaches a quiet console logger unless `-noConsoleLogger` was passed, and `RunCommandSelector.GetLoggers` does the same for the device-selection builds.

## The fix

Add `SolutionAndProjectUtility.CreateBuildLoggers`, which yields the binlog facade logger (when present) plus a fresh console logger at quiet verbosity unless `-noConsoleLogger` was passed, and use it for both the `DeployToDevice` and `ComputeRunArguments` builds. Quiet verbosity keeps successful runs silent while still reporting errors and warnings. A fresh console logger is created per build, matching `RunCommandSelector`'s comment about disposal across multiple `Build()` calls.

After the change, the failure looks like:

```
DotnetTestDevices.csproj(45,5): error : ComputeRunArguments failed as requested.
Running the ComputeRunArguments target to discover run commands failed for this project. Fix the errors and warnings and run again.
```

## Tests

- `ItFailsWhenDeployToDeviceTargetFails` now also asserts the underlying MSBuild error text is printed.
- New `ItFailsWhenComputeRunArgumentsTargetFails`, with a `FailComputeRunArguments` hook added to the `DotnetTestDevices` test asset, covering the `ComputeRunArguments` path from the linked discussion.

Verified locally against a Debug redist build:

| Filter | Result |
| ------ | ------ |
| `GivenDotnetTestSelectsDevice` | 30/30 passed |
| `Microsoft.DotNet.Cli.Test.Tests` | 415 total, 389 passed, 26 skipped, 0 failed |