### PR TITLE
[release/10.0.1xx] Port template engine Helix consolidation (PR #53546)

### DIFF
--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -29,6 +29,7 @@ robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutio
 set DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%
 set DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\r
 set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets
+set DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=%TestExecutionDirectory%\TemplateFeed
 
 REM call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive

--- a/build/RunTestsOnHelix.cmd
+++ b/build/RunTestsOnHelix.cmd
@@ -29,7 +29,7 @@ robocopy %HELIX_CORRELATION_PAYLOAD%\t\TestExecutionDirectoryFiles %TestExecutio
 set DOTNET_SDK_TEST_EXECUTION_DIRECTORY=%TestExecutionDirectory%
 set DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=%HELIX_CORRELATION_PAYLOAD%\r
 set DOTNET_SDK_TEST_ASSETS_DIRECTORY=%TestExecutionDirectory%\TestAssets
-set DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=%TestExecutionDirectory%\TemplateFeed
+set DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=%TestExecutionDirectory%\template_feed
 
 REM call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -16,7 +16,7 @@ cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionD
 export DOTNET_SDK_TEST_EXECUTION_DIRECTORY=$TestExecutionDirectory
 export DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=$HELIX_CORRELATION_PAYLOAD/r
 export DOTNET_SDK_TEST_ASSETS_DIRECTORY=$TestExecutionDirectory/TestAssets
-export DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=$TestExecutionDirectory/TemplateFeed
+export DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=$TestExecutionDirectory/template_feed
 
 # call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive

--- a/build/RunTestsOnHelix.sh
+++ b/build/RunTestsOnHelix.sh
@@ -16,6 +16,7 @@ cp -a $HELIX_CORRELATION_PAYLOAD/t/TestExecutionDirectoryFiles/. $TestExecutionD
 export DOTNET_SDK_TEST_EXECUTION_DIRECTORY=$TestExecutionDirectory
 export DOTNET_SDK_TEST_MSBUILDSDKRESOLVER_FOLDER=$HELIX_CORRELATION_PAYLOAD/r
 export DOTNET_SDK_TEST_ASSETS_DIRECTORY=$TestExecutionDirectory/TestAssets
+export DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY=$TestExecutionDirectory/TemplateFeed
 
 # call dotnet new so the first run message doesn't interfere with the first test
 dotnet new --debug:ephemeral-hive

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -12,9 +12,6 @@ parameters:
     runTestsAsTool: true
     # This job uses the build step for testing, so the extra test step is not necessary.
     runTests: false
-  - categoryName: TemplateEngine
-    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-    publishXunitResults: true
   - categoryName: AoT
     runAoTTests: true
   ### LINUX ###
@@ -33,17 +30,9 @@ parameters:
     osProperties: /p:OSName=linux /p:BuildSdkDeb=true
     # Helix is hanging on this job using the container. See: https://github.com/dotnet/dnceng/issues/6000
     disableJob: true
-  - categoryName: TemplateEngine
-    osProperties: $(linuxOsglibcProperties)
-    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-    publishXunitResults: true
   ### MACOS ###
   macOSJobParameterSets:
   - categoryName: TestBuild
-    runtimeIdentifier: osx-x64
-  - categoryName: TemplateEngine
-    testProjects: $(Build.SourcesDirectory)/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj;$(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-    publishXunitResults: true
     runtimeIdentifier: osx-x64
   - categoryName: AoT
     runAoTTests: true

--- a/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
@@ -3,13 +3,26 @@
 
 namespace Microsoft.NET.TestFramework
 {
+    [Flags]
+    public enum TestArchitectures
+    {
+        None = 0,
+        X64 = 1,
+        ARM64 = 2,
+        All = ~0
+    }
+
     public class PlatformSpecificFact : FactAttribute
     {
-        public PlatformSpecificFact(TestPlatforms platforms)
+        public PlatformSpecificFact(TestPlatforms platforms, TestArchitectures architectures = TestArchitectures.All)
         {
             if (ShouldSkip(platforms))
             {
                 Skip = "This test is not supported on this platform.";
+            }
+            else if (ShouldSkipArchitecture(architectures))
+            {
+                Skip = "This test is not supported on this architecture.";
             }
         }
 
@@ -18,5 +31,10 @@ namespace Microsoft.NET.TestFramework
                 || (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !platforms.HasFlag(TestPlatforms.Linux))
                 || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !platforms.HasFlag(TestPlatforms.OSX))
                 || (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")) && !platforms.HasFlag(TestPlatforms.FreeBSD));
+
+        internal static bool ShouldSkipArchitecture(TestArchitectures architectures) =>
+            architectures != TestArchitectures.All &&
+            ((RuntimeInformation.ProcessArchitecture == Architecture.X64 && !architectures.HasFlag(TestArchitectures.X64))
+                || (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 && !architectures.HasFlag(TestArchitectures.ARM64)));
     }
 }

--- a/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificFact.cs
@@ -34,7 +34,11 @@ namespace Microsoft.NET.TestFramework
 
         internal static bool ShouldSkipArchitecture(TestArchitectures architectures) =>
             architectures != TestArchitectures.All &&
-            ((RuntimeInformation.ProcessArchitecture == Architecture.X64 && !architectures.HasFlag(TestArchitectures.X64))
-                || (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 && !architectures.HasFlag(TestArchitectures.ARM64)));
+            RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => !architectures.HasFlag(TestArchitectures.X64),
+                Architecture.Arm64 => !architectures.HasFlag(TestArchitectures.ARM64),
+                _ => true,
+            };
     }
 }

--- a/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
+++ b/test/Microsoft.NET.TestFramework/Attributes/PlatformSpecificTheory.cs
@@ -5,11 +5,15 @@ namespace Microsoft.NET.TestFramework
 {
     public class PlatformSpecificTheory : TheoryAttribute
     {
-        public PlatformSpecificTheory(TestPlatforms platforms)
+        public PlatformSpecificTheory(TestPlatforms platforms, TestArchitectures architectures = TestArchitectures.All)
         {
             if (PlatformSpecificFact.ShouldSkip(platforms))
             {
                 Skip = "This test is not supported on this platform.";
+            }
+            else if (PlatformSpecificFact.ShouldSkipArchitecture(architectures))
+            {
+                Skip = "This test is not supported on this architecture.";
             }
         }
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         /// <summary>
         /// Gets a path to the template packages maintained in the repo (/template_feed).
         /// </summary>
-        public static string RepoTemplatePackages { get; } = VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
+        public static string RepoTemplatePackages { get; } = GetTemplatePackagesDirectory();
 
         /// <summary>
         /// Gets a path to the test template with a <paramref name="templateName"/> name.
@@ -51,6 +51,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Assert.Fail($"The folder '{folder}' does not exist.");
             }
             return folder;
+        }
+
+        private static string GetTemplatePackagesDirectory()
+        {
+            string? envDir = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY");
+            if (!string.IsNullOrEmpty(envDir))
+            {
+                return VerifyExists(envDir);
+            }
+            return VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
         }
 
         private static string GetAndVerifyRepoRoot()

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/BaseTest.cs
@@ -21,9 +21,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         public static string DotnetNewTestTemplatesBasePath { get; } = VerifyExists(Path.Combine(DotnetNewTestAssets, "test_templates"));
 
         /// <summary>
-        /// Gets a path to the repo root folder.
+        /// Gets a path to the repo root folder (may be null when running in Helix).
         /// </summary>
-        public static string CodeBaseRoot { get; } = GetAndVerifyRepoRoot();
+        public static string? CodeBaseRoot { get; } = GetRepoRoot();
 
         /// <summary>
         /// Gets a path to the template packages maintained in the repo (/template_feed).
@@ -60,19 +60,20 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             {
                 return VerifyExists(envDir);
             }
+            if (CodeBaseRoot is null)
+            {
+                Assert.Fail("The repo root could not be determined and DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY is not set.");
+            }
             return VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
         }
 
-        private static string GetAndVerifyRepoRoot()
+        private static string? GetRepoRoot()
         {
             string repoRoot = Path.GetFullPath(Path.Combine(TestContext.Current.TestAssetsDirectory, "..", ".."));
-            if (!Directory.Exists(repoRoot))
+            if (!Directory.Exists(repoRoot) || !File.Exists(Path.Combine(repoRoot, "sdk.slnx")))
             {
-                Assert.Fail($"The repo root cannot be evaluated.");
-            }
-            if (!File.Exists(Path.Combine(repoRoot, "sdk.slnx")))
-            {
-                Assert.Fail($"The repo root doesn't contain 'sdk.slnx'.");
+                // Running in Helix or another environment where the full repo isn't available.
+                return null;
             }
             return repoRoot;
         }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <None Include="TemplateInstallTests/TestTemplates/**/*" CopyToOutputDirectory="Always" />
+    <None Include="ParserTests/Approvals/**/*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ModuleInitializer.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ModuleInitializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             DerivePathInfo(
                    (_, _, type, method) => new(
-                       directory: "Approvals",
+                       directory: Path.Combine(AppContext.BaseDirectory, "Approvals"),
                        typeName: type.Name,
                        methodName: method.Name));
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ModuleInitializer.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ModuleInitializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             DerivePathInfo(
                    (_, _, type, method) => new(
-                       directory: Path.Combine(AppContext.BaseDirectory, "Approvals"),
+                       directory: Path.Combine(AppContext.BaseDirectory, "ParserTests", "Approvals"),
                        typeName: type.Name,
                        methodName: method.Name));
 

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -31,6 +31,12 @@
     <!-- Don't run MSI installation tests in Helix / CI -->
     <SdkCustomXUnitProject Remove="dotnet-MsiInstallation.Tests\**\*" />
 
+    <!-- dotnet-format unit tests are run under the DOTNET_FORMAT pipeline section. -->
+    <SDKCustomXUnitProject Remove="dotnet-format.UnitTests\dotnet-format.UnitTests.csproj" />
+
+    <!-- ApiCompat integration tests are only run with TestFullMSBuild=true (see below). -->
+    <SDKCustomXUnitProject Remove="Microsoft.DotNet.ApiCompat.IntegrationTests\Microsoft.DotNet.ApiCompat.IntegrationTests.csproj" />
+
     <!-- .NET Framework only test projects are added manually below. -->
     <SDKCustomXUnitProject Remove="Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj" />
   </ItemGroup>

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -17,24 +17,21 @@
 
   <ItemGroup>
     <SDKCustomXUnitProject Include="**\*.Tests.csproj" Exclude="**\*.AoT.Tests.csproj;TestAssets\**\*.Tests.csproj;**\*.AnalyzerRedirecting.Tests.csproj" />
+    <SDKCustomXUnitProject Include="**\*UnitTests.csproj" Exclude="TestAssets\**\*UnitTests.csproj" />
+    <SDKCustomXUnitProject Include="**\*IntegrationTests.csproj" Exclude="TestAssets\**\*IntegrationTests.csproj" />
     <SDKCustomXUnitProject Include="$(RepoRoot)src\Microsoft.CodeAnalysis.NetAnalyzers\tests\**\*.*Tests.csproj" />
     <SDKCustomXUnitProject Condition="$(_AGENTOSNAME) == 'Windows_NT_FullFramework'" Include="**\*.AnalyzerRedirecting.Tests.csproj">
       <TargetFramework>net472</TargetFramework>
       <RuntimeTargetFramework>net472</RuntimeTargetFramework>
     </SDKCustomXUnitProject>
 
-    <!--containers tests end with UnitTests and IntegrationTests, therefore included manually -->
-    <SDKCustomXUnitProject Include="containerize.UnitTests\containerize.UnitTests.csproj" />
-    <SDKCustomXUnitProject Include="Microsoft.NET.Build.Containers.IntegrationTests\Microsoft.NET.Build.Containers.IntegrationTests.csproj" />
-
-    <SDKCustomXUnitProject Include="Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj" />
     <SDKCustomXUnitProject Include="..\src\Tasks\Microsoft.NET.Build.Extensions.Tasks.UnitTests\Microsoft.NET.Build.Extensions.Tasks.UnitTests.csproj" ExcludeAdditionalParameters="true" />
     <SDKCustomXUnitProject Include="..\src\Tasks\Microsoft.NET.Build.Tasks.UnitTests\Microsoft.NET.Build.Tasks.UnitTests.csproj" ExcludeAdditionalParameters="true" />
 
     <!-- Don't run MSI installation tests in Helix / CI -->
     <SdkCustomXUnitProject Remove="dotnet-MsiInstallation.Tests\**\*" />
 
-    <!-- Filter out .NET Framework only test projects and add them manually. -->
+    <!-- .NET Framework only test projects are added manually below. -->
     <SDKCustomXUnitProject Remove="Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj" />
   </ItemGroup>
 
@@ -94,6 +91,9 @@
 
       <AssetFiles Include="TestAssets\**\*.*" />
 
+      <!-- Include the template_feed directory from the repo root so tests that reference RepoTemplatePackages work in Helix. -->
+      <TemplateFeedFiles Include="$(RepoRoot)template_feed\**\*.*" />
+
       <!-- Files in testExecutionDirectory to prevent environment interference -->
       <TestExecutionDirectoryFiles Include="$(TestLayoutDir)NuGet.config" />
       <TestExecutionDirectoryFiles Include="$(TestLayoutDir)Directory.Build.props" />
@@ -130,6 +130,7 @@
     <Copy SourceFiles="@(ContainerFiles)" DestinationFiles="@(ContainerFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\Container\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(LockFiles)" DestinationFiles="@(LockFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\LockFiles\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(AssetFiles)" DestinationFiles="@(AssetFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\TestAssets\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(TemplateFeedFiles)" DestinationFiles="@(TemplateFeedFiles->'$(HelixPayloadOnHost)\TestExecutionDirectoryFiles\template_feed\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="AppendHelixPreCommand" BeforeTargets="CoreTest" DependsOnTargets="CopyHelixFiles">

--- a/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
+++ b/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
@@ -32,9 +32,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         public static string DotnetNewTestTemplatePackageProjectPath { get; } = VerifyFileExists(Path.Combine(DotnetNewTestAssets, "Microsoft.TemplateEngine.TestTemplates.csproj"));
 
         /// <summary>
-        /// Gets a path to the repo root folder.
+        /// Gets a path to the repo root folder (may be null when running in Helix).
         /// </summary>
-        public static string CodeBaseRoot { get; } = GetAndVerifyRepoRoot();
+        public static string? CodeBaseRoot { get; } = GetRepoRoot();
 
         /// <summary>
         /// Gets a path to the template packages maintained in the repo (/template_feed).
@@ -183,19 +183,20 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             {
                 return VerifyExists(envDir);
             }
+            if (CodeBaseRoot is null)
+            {
+                Assert.Fail("The repo root could not be determined and DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY is not set.");
+            }
             return VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
         }
 
-        private static string GetAndVerifyRepoRoot()
+        private static string? GetRepoRoot()
         {
             string repoRoot = Path.GetFullPath(Path.Combine(TestContext.Current.TestAssetsDirectory, "..", ".."));
-            if (!Directory.Exists(repoRoot))
+            if (!Directory.Exists(repoRoot) || !File.Exists(Path.Combine(repoRoot, "sdk.slnx")))
             {
-                Assert.Fail($"The repo root cannot be evaluated.");
-            }
-            if (!File.Exists(Path.Combine(repoRoot, "sdk.slnx")))
-            {
-                Assert.Fail($"The repo root doesn't contain 'sdk.slnx'.");
+                // Running in Helix or another environment where the full repo isn't available.
+                return null;
             }
             return repoRoot;
         }

--- a/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
+++ b/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
@@ -41,6 +41,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         /// </summary>
         public static string RepoTemplatePackages { get; } = GetTemplatePackagesDirectory();
 
+        /// <summary>
+        /// Gets the path to the approval snapshots copied beside the test assembly.
+        /// </summary>
+        public static string ApprovalsDirectory { get; } = Path.Combine(AppContext.BaseDirectory, "Approvals");
+
 #if DEBUG
         /// <summary>
         /// Gets configuration name.

--- a/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
+++ b/test/dotnet-new.IntegrationTests/BaseIntegrationTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         /// <summary>
         /// Gets a path to the template packages maintained in the repo (/template_feed).
         /// </summary>
-        public static string RepoTemplatePackages { get; } = VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
+        public static string RepoTemplatePackages { get; } = GetTemplatePackagesDirectory();
 
 #if DEBUG
         /// <summary>
@@ -174,6 +174,16 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 Assert.Fail($"The file '{file}' does not exist.");
             }
             return file;
+        }
+
+        private static string GetTemplatePackagesDirectory()
+        {
+            string? envDir = Environment.GetEnvironmentVariable("DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY");
+            if (!string.IsNullOrEmpty(envDir))
+            {
+                return VerifyExists(envDir);
+            }
+            return VerifyExists(Path.Combine(CodeBaseRoot, "template_feed"));
         }
 
         private static string GetAndVerifyRepoRoot()

--- a/test/dotnet-new.IntegrationTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/CommonTemplatesTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             {
                 // squashing snapshots by creating output unique for template (but not alias) and preventing item to have name by alias
                 TemplateSpecificArgs = new[] { "-o", itemName, "-n", "item" }.Concat(args ?? Enumerable.Empty<string>()),
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 VerifyCommandOutput = true,
                 VerificationExcludePatterns = new[] { "*/stderr.txt", "*\\stderr.txt" },
                 SettingsDirectory = _fixture.HomeDirectory,
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         //{
         //    TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: "editorconfig")
         //    {
-        //        SnapshotsDirectory = "Approvals",
+        //        SnapshotsDirectory = ApprovalsDirectory,
         //        SettingsDirectory = _fixture.HomeDirectory,
         //    }
         //    .WithCustomDirectoryVerifier(async (content, contentFetcher) =>
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: name)
             {
                 TemplateSpecificArgs = args,
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 OutputDirectory = workingDir,
                 SettingsDirectory = _fixture.HomeDirectory,
                 VerifyCommandOutput = true,
@@ -401,7 +401,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: name)
             {
                 TemplateSpecificArgs = args,
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 OutputDirectory = workingDir,
                 SettingsDirectory = _fixture.HomeDirectory,
                 VerifyCommandOutput = true,

--- a/test/dotnet-new.IntegrationTests/DotnetClassTemplateTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetClassTemplateTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: templateShortName)
             {
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 VerifyCommandOutput = true,
                 TemplateSpecificArgs = new[] { "--name", "TestItem1" },
                 VerificationExcludePatterns = new[]
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: templateShortName)
             {
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 VerifyCommandOutput = true,
                 TemplateSpecificArgs = new[] { "--name", string.IsNullOrWhiteSpace(fileName) ? "TestItem1" : fileName, "--language", "VB" },
                 VerificationExcludePatterns = new[]

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             ("nunit-playwright", new[] { Languages.CSharp }, false, false),
         ];
 
-        private static readonly string PackagesJsonPath = Path.Combine(CodeBaseRoot, "test", "TestPackages", "cgmanifest.json");
+        private static readonly string? PackagesJsonPath = CodeBaseRoot is not null ? Path.Combine(CodeBaseRoot, "test", "TestPackages", "cgmanifest.json") : null;
 
         public DotnetNewTestTemplatesTests(ITestOutputHelper log) : base(log)
         {

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -30,8 +30,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             ("nunit-playwright", new[] { Languages.CSharp }, false, false),
         ];
 
-        private static readonly string? PackagesJsonPath = CodeBaseRoot is not null ? Path.Combine(CodeBaseRoot, "test", "TestPackages", "cgmanifest.json") : null;
-
         public DotnetNewTestTemplatesTests(ITestOutputHelper log) : base(log)
         {
             _log = log;
@@ -233,10 +231,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         private void RecordPackages(string projectDirectory)
         {
-            if (PackagesJsonPath is null)
-            {
-                return;
-            }
+            string packagesJsonPath = Path.Combine(
+                TestContext.Current.TestPackages ?? throw new InvalidOperationException("TestPackages should never be null."),
+                "cgmanifest.json");
 
             // Get all project files with a single directory search, then filter to specific types
             var projectFiles = Directory.GetFiles(projectDirectory, "*.*proj")
@@ -247,11 +244,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             // Load existing component detection manifest or create new one
             ComponentDetectionManifest manifest;
 
-            if (File.Exists(PackagesJsonPath))
+            if (File.Exists(packagesJsonPath))
             {
                 try
                 {
-                    string jsonContent = File.ReadAllText(PackagesJsonPath);
+                    string jsonContent = File.ReadAllText(packagesJsonPath);
                     manifest = JsonSerializer.Deserialize<ComponentDetectionManifest>(jsonContent) ??
                         CreateNewManifest();
                 }
@@ -329,19 +326,19 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             if (updatedManifest)
             {
                 // Ensure directory exists
-                if (Path.GetDirectoryName(PackagesJsonPath) is string directoryPath)
+                if (Path.GetDirectoryName(packagesJsonPath) is string directoryPath)
                 {
                     Directory.CreateDirectory(directoryPath);
                 }
                 else
                 {
-                    _log.WriteLine($"Warning: Could not determine directory path for '{PackagesJsonPath}'.");
+                    _log.WriteLine($"Warning: Could not determine directory path for '{packagesJsonPath}'.");
                     return;
                 }
 
                 // Write updated manifest
                 File.WriteAllText(
-                    PackagesJsonPath,
+                    packagesJsonPath,
                     JsonSerializer.Serialize(manifest, new JsonSerializerOptions
                     {
                         WriteIndented = true,

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -233,6 +233,11 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         private void RecordPackages(string projectDirectory)
         {
+            if (PackagesJsonPath is null)
+            {
+                return;
+            }
+
             // Get all project files with a single directory search, then filter to specific types
             var projectFiles = Directory.GetFiles(projectDirectory, "*.*proj")
                 .Where(file => file.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
@@ -336,7 +341,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
                 // Write updated manifest
                 File.WriteAllText(
-                    PackagesJsonPath!,
+                    PackagesJsonPath,
                     JsonSerializer.Serialize(manifest, new JsonSerializerOptions
                     {
                         WriteIndented = true,

--- a/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewTestTemplatesTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
                 // Write updated manifest
                 File.WriteAllText(
-                    PackagesJsonPath,
+                    PackagesJsonPath!,
                     JsonSerializer.Serialize(manifest, new JsonSerializerOptions
                     {
                         WriteIndented = true,

--- a/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
+++ b/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             DerivePathInfo(
                    (_, _, type, method) => new(
-                       directory: "Approvals",
+                       directory: Path.Combine(AppContext.BaseDirectory, "Approvals"),
                        typeName: type.Name,
                        methodName: method.Name));
 

--- a/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
+++ b/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             DerivePathInfo(
                    (_, _, type, method) => new(
-                       directory: Path.Combine(AppContext.BaseDirectory, "Approvals"),
+                       directory: BaseIntegrationTest.ApprovalsDirectory,
                        typeName: type.Name,
                        methodName: method.Name));
 

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             _templateDiscoveryTool = templateDiscoveryTool;
         }
 
+        // https://github.com/dotnet/sdk/issues/53569
         [PlatformSpecificFact(TestPlatforms.Any, TestArchitectures.X64)]
         public async Task CanRunDiscoveryTool()
         {

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.NET.TestFramework;
 using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
@@ -16,7 +17,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             _templateDiscoveryTool = templateDiscoveryTool;
         }
 
-        [Fact]
+        [PlatformSpecificFact(TestPlatforms.All, TestArchitectures.X64)]
         public async Task CanRunDiscoveryTool()
         {
             string testDir = CreateTemporaryFolder();

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.NET.TestFramework;
 using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
@@ -17,7 +16,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             _templateDiscoveryTool = templateDiscoveryTool;
         }
 
-        [PlatformSpecificFact(TestPlatforms.All, TestArchitectures.X64)]
+        [PlatformSpecificFact(TestPlatforms.Any, TestArchitectures.X64)]
         public async Task CanRunDiscoveryTool()
         {
             string testDir = CreateTemporaryFolder();

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
@@ -32,7 +32,9 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                 "install",
                 "Microsoft.TemplateSearch.TemplateDiscovery",
                 "--version",
-                TemplatePackageVersion.MicrosoftTemplateSearchTemplateDiscoveryPackageVersion)
+                TemplatePackageVersion.MicrosoftTemplateSearchTemplateDiscoveryPackageVersion,
+                "--add-source",
+                AppContext.BaseDirectory)
                 .WithWorkingDirectory(dotnetNewTestExecutionDir)
                 .Execute()
                 .Should()

--- a/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             {
                 TemplateSpecificArgs = arguments ?? Enumerable.Empty<string>(),
                 VerifyCommandOutput = true,
-                SnapshotsDirectory = "Approvals",
+                SnapshotsDirectory = ApprovalsDirectory,
                 SettingsDirectory = _sharedHome.HomeDirectory,
                 DoNotAppendTemplateArgsToScenarioName = true,
                 DotnetExecutablePath = TestContext.Current.ToolsetUnderTest?.DotNetHostPath,

--- a/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+++ b/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageDownload Include="Microsoft.TemplateSearch.TemplateDiscovery" Version="[$(MicrosoftTemplateSearchTemplateDiscoveryPackageVersion)]" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" VersionOverride="6.0.*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.7.0" VersionOverride="7.0.*-*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.8.0" VersionOverride="8.0.*-*" GeneratePathProperty="true" />
@@ -74,6 +75,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
     <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_7_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_8_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_9_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(NuGetPackageRoot)microsoft.templatesearch.templatediscovery\$(MicrosoftTemplateSearchTemplateDiscoveryPackageVersion)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.cs">

--- a/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+++ b/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -38,14 +38,22 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
   internal class TemplatePackagesPaths
   {
-      public const string MicrosoftDotNetCommonProjectTemplates60Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_6_0)"%3B
-      public const string MicrosoftDotNetCommonProjectTemplates70Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_7_0)"%3B
-      public const string MicrosoftDotNetCommonProjectTemplates80Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_8_0)"%3B
-      public const string MicrosoftDotNetCommonProjectTemplates90Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_9_0)"%3B
-      public const string MicrosoftDotNetWebProjectTemplates60Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_6_0)"%3B
-      public const string MicrosoftDotNetWebProjectTemplates70Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_7_0)"%3B
-      public const string MicrosoftDotNetWebProjectTemplates80Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_8_0)"%3B
-      public const string MicrosoftDotNetWebProjectTemplates90Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_9_0)"%3B
+      private static string FindNupkg(string namePrefix)
+      {
+          string[] files = System.IO.Directory.GetFiles(System.AppContext.BaseDirectory, namePrefix + "*.nupkg")%3B
+          if (files.Length == 0)
+              throw new System.IO.FileNotFoundException($"No nupkg matching '{namePrefix}*.nupkg' in '{System.AppContext.BaseDirectory}'")%3B
+          return files[0]%3B
+      }
+
+      public static string MicrosoftDotNetCommonProjectTemplates60Path => FindNupkg("microsoft.dotnet.common.projecttemplates.6.0.")%3B
+      public static string MicrosoftDotNetCommonProjectTemplates70Path => FindNupkg("microsoft.dotnet.common.projecttemplates.7.0.")%3B
+      public static string MicrosoftDotNetCommonProjectTemplates80Path => FindNupkg("microsoft.dotnet.common.projecttemplates.8.0.")%3B
+      public static string MicrosoftDotNetCommonProjectTemplates90Path => FindNupkg("microsoft.dotnet.common.projecttemplates.9.0.")%3B
+      public static string MicrosoftDotNetWebProjectTemplates60Path => FindNupkg("microsoft.dotnet.web.projecttemplates.6.0.")%3B
+      public static string MicrosoftDotNetWebProjectTemplates70Path => FindNupkg("microsoft.dotnet.web.projecttemplates.7.0.")%3B
+      public static string MicrosoftDotNetWebProjectTemplates80Path => FindNupkg("microsoft.dotnet.web.projecttemplates.8.0.")%3B
+      public static string MicrosoftDotNetWebProjectTemplates90Path => FindNupkg("microsoft.dotnet.web.projecttemplates.9.0.")%3B
   }
 
   internal class TemplatePackageVersion
@@ -56,6 +64,17 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
       ]]>
     </GeneratedText>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(PkgMicrosoft_DotNet_Common_ProjectTemplates_6_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Common_ProjectTemplates_7_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Common_ProjectTemplates_8_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Common_ProjectTemplates_9_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_6_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_7_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_8_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_DotNet_Web_ProjectTemplates_9_0)\*.nupkg" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
   <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.cs">
     <PropertyGroup>

--- a/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+++ b/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
   <ItemGroup>
     <Compile Remove="Approvals\**\*" />
-    <None Include="Approvals\**\*" CopyToOutputDirectory="Never" />
+    <None Include="Approvals\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Ports the template engine Helix consolidation from PR #53546 (merged to `main`) into `release/10.0.1xx`. This removes dedicated TemplateEngine CI pipeline legs and consolidates those tests to run in Helix instead.

## Changes

- **Remove TemplateEngine CI legs** (Windows, Linux, macOS) from `sdk-job-matrix.yml`
- **Expand `UnitTests.proj` globs** to include `*UnitTests.csproj` and `*IntegrationTests.csproj`
- **Add `template_feed` payload** to Helix via `UnitTests.proj` Copy task
- **Add `DOTNET_SDK_TEST_TEMPLATE_PACKAGES_DIRECTORY` env var** to `RunTestsOnHelix.cmd/.sh`
- **Add `TestArchitectures` enum** to `PlatformSpecificFact`/`PlatformSpecificTheory` for architecture filtering
- **Update `ModuleInitializer.cs` files** to use `AppContext.BaseDirectory` for Approvals paths
- **Update `BaseIntegrationTest.cs` and `BaseTest.cs`** with env var fallback for template packages
- **Skip `TemplateDiscoveryTests` on non-x64** (macOS ARM64)
- **Update csproj files** to copy Approvals to output directory

## Adaptations for release/10.0.1xx

The release branch has structural differences from `main` that required adaptation:

| Difference | Adaptation |
|---|---|
| Uses `RunTestsOnHelix` scripts (not `SetupHelixEnvironment`) | Added env var to `RunTestsOnHelix.cmd/.sh` |
| No `SdkTestContext.cs` | Put env var fallback directly in `BaseIntegrationTest.cs` and `BaseTest.cs` |
| `template_feed` contains source dirs (not `.nupkg` files) | Uses `**/*.*` glob instead of `*.nupkg` |
| `documentation/TemplateEngine/Samples/` doesn't exist | Skipped `TemplateSampleFiles` item |

## Testing

The `Microsoft.NET.TestFramework` project (containing core `PlatformSpecificFact`/`TestArchitectures` changes) compiles successfully. Full validation requires CI pipeline execution.