### PR TITLE
Update VersionFeature properties for July 2026 releases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,9 +34,9 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>28</VersionFeature80>
-    <VersionFeature90>17</VersionFeature90>
-    <VersionFeature100>9</VersionFeature100>
+    <VersionFeature80>29</VersionFeature80>
+    <VersionFeature90>18</VersionFeature90>
+    <VersionFeature100>10</VersionFeature100>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
Update VersionFeature80 (28→29), VersionFeature90 (17→18), and VersionFeature100 (9→10) to match the latest publicly released runtime versions from releases.json.

| Version | Released Runtime | Previous VersionFeature | Updated VersionFeature |
|---------|-----------------|------------------------|----------------------|
| 8.0 | 8.0.29 | 28 | 29 |
| 9.0 | 9.0.18 | 17 | 18 |
| 10.0 | 10.0.10 | 9 | 10 |

Sources:
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/releases.json
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/10.0/releases.json