### PR TITLE
Add targeted test workflow for agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,7 +140,7 @@ Canonical scenarios:
   - The built SDK is output to `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
   - The first build is slow; subsequent builds are incremental.
 - Run tests: prefer targeted runs — a single test project or test (see the
-  [Testing](#testing) section) and the `incremental-test` skill. `build.cmd -test` /
+  [Testing](#testing) section) and the `targeted-test` skill. `build.cmd -test` /
   `./build.sh --test` runs the **entire** suite, which is very large and takes a long time;
   avoid running the full suite for routine local or agent work.
 - Release build: `build.cmd -c Release`.
@@ -149,8 +149,10 @@ Canonical scenarios:
   See the [Testing](#testing) section for assembly filtering and more examples.
 - Validate changes locally using the SDK you built at
   `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
-- For fast inner-loop runs of `dotnet.Tests` without a full rebuild, use the
-  `incremental-test` skill.
+- Use the `targeted-test` skill to select projects from the shared
+  `test/ConditionalTests.props` scopes when available and retain detailed failure output,
+  a TRX, and a binlog. For fast inner-loop runs of `dotnet.Tests` without a full rebuild,
+  use `incremental-test`.
 
 ## Guardrails
 
@@ -227,12 +229,10 @@ property:
 
 - Large changes should always include test changes.
 - The Skip parameter of the Fact attribute to point to the specific issue link.
-- To run tests in this repo (after a full build, invoke the repo-local bootstrap SDK directly):
-  - For MSTest-style projects: `./.dotnet/dotnet test path/to/project.csproj --filter "FullyQualifiedName~TestName"`
-  - To run a built test assembly directly: `./.dotnet/dotnet exec artifacts/bin/redist/Debug/TestAssembly.dll --filter "TestMethodName"`
-  - Examples:
-    - `./.dotnet/dotnet test test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~ItShowsTheAppropriateMessageToTheUser"`
-    - `./.dotnet/dotnet exec artifacts/bin/redist/Debug/dotnet.Tests.dll --filter "ItShowsTheAppropriateMessageToTheUser"`
+- Use the `targeted-test` skill to choose projects from `test/ConditionalTests.props`
+  when the changed paths match a configured scope, or use its fallback mappings for
+  unscoped common areas. Run one project, class, or method with detailed live output and
+  retained TRX/binlog diagnostics.
 - For incremental test runs of `dotnet.Tests` (avoids slow full `build.cmd`), use the `incremental-test` skill.
 - This repo uses conditional test filtering to skip expensive test suites on PRs when
   relevant source files have not changed. When adding new test projects, consider

--- a/.github/skills/ValidateSkill.cs
+++ b/.github/skills/ValidateSkill.cs
@@ -1,4 +1,8 @@
 #!/usr/bin/env dotnet
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #:property ManagePackageVersionsCentrally=false
 #:property PublishAot=false
 #:package YamlDotNet@16.3.0

--- a/.github/skills/incremental-test/SKILL.md
+++ b/.github/skills/incremental-test/SKILL.md
@@ -80,14 +80,14 @@ The test project `test\dotnet.Tests\dotnet.Tests.csproj` outputs directly to `ar
 
 ### Step 5: Run the tests
 
-Run specific tests:
-```
-.\.dotnet\dotnet exec artifacts\bin\redist\Debug\dotnet.Tests.dll -method "*TestMethodName*"
-```
+Use the **targeted-test** runner so failures retain detailed output, a TRX, and a
+binlog:
 
-Or run filtered tests via `dotnet test`:
-```
-.\.dotnet\dotnet test test\dotnet.Tests\dotnet.Tests.csproj --no-build --filter "Name~TestMethodName"
+```powershell
+.\.dotnet\dotnet.exe .github\skills\targeted-test\scripts\RunTargetedTests.cs -- `
+  --project test\dotnet.Tests\dotnet.Tests.csproj `
+  --filter "Name~TestMethodName" `
+  --no-build
 ```
 
 ## Common project paths

--- a/.github/skills/incremental-test/SKILL.md
+++ b/.github/skills/incremental-test/SKILL.md
@@ -83,11 +83,8 @@ The test project `test\dotnet.Tests\dotnet.Tests.csproj` outputs directly to `ar
 Use the **targeted-test** runner so failures retain detailed output, a TRX, and a
 binlog:
 
-```powershell
-.\.dotnet\dotnet.exe .github\skills\targeted-test\scripts\RunTargetedTests.cs -- `
-  --project test\dotnet.Tests\dotnet.Tests.csproj `
-  --filter "Name~TestMethodName" `
-  --no-build
+```shell
+./.dotnet/dotnet .github/skills/targeted-test/scripts/RunTargetedTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~TestMethodName" --no-build
 ```
 
 ## Common project paths

--- a/.github/skills/targeted-test/SKILL.md
+++ b/.github/skills/targeted-test/SKILL.md
@@ -38,11 +38,12 @@ project separately with the runner below. If a changed file matches
 `GlobalTriggerPaths`, the conditional system cannot safely narrow the suite; use broader
 validation instead.
 
-## Fall back for unscoped areas
+## Fall back for common unscoped areas
 
 When no `ConditionalTestScope` covers the changed paths, start with the project that
 owns the changed behavior. If a change crosses areas, run each relevant project
-separately so a failure identifies the affected area.
+separately so a failure identifies the affected area. This table is intentionally
+limited to common areas rather than being an exhaustive test-project catalog.
 
 | Change area | Primary test project |
 | --- | --- |
@@ -63,8 +64,10 @@ separately so a failure identifies the affected area.
 | Blazor WebAssembly SDK | `test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj` |
 
 Keep this fallback table limited to areas not represented in
-`test/ConditionalTests.props`. Add or change configured mappings there so local agent
-selection and PR filtering stay aligned.
+`test/ConditionalTests.props`. Whenever that file changes, reconcile this table: remove
+entries for areas that are now configured, and update entries when test-project ownership
+changes. Do not duplicate configured mappings here; add or change them in the props file
+so local agent selection and PR filtering stay aligned.
 
 ## Make the product output current
 

--- a/.github/skills/targeted-test/SKILL.md
+++ b/.github/skills/targeted-test/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: targeted-test
+description: >-
+  Select and run the smallest relevant .NET SDK tests with live output and retained
+  TRX/binlog diagnostics. REQUIRED: invoke before answering any dotnet/sdk request
+  containing an explicit deliverable to select, run, or rerun narrow local tests. Use
+  the owning workflow for the change, then this skill for test selection and execution.
+  Also use to test a completed change, choose tests from changed files, run targeted,
+  focused, or smallest relevant tests, or run one project, class, or method, including
+  plans and dry runs. NEVER invoke when the user says not to run tests yet. DO NOT USE
+  for full suites, end-to-end validation, repo investigations, or review.
+license: MIT
+---
+
+# Targeted tests
+
+Run the smallest project and filter that cover the changed behavior. This workflow
+streams detailed test output and writes a TRX plus an MSBuild binlog under
+`artifacts/log/targeted-tests/`.
+
+## Select configured test scopes first
+
+Read `test/ConditionalTests.props` before choosing tests. Its `TriggerPaths` and
+`TestProjects` metadata are the repository's source of truth for configured areas; do
+not duplicate those mappings in this skill.
+
+For each scope whose `TriggerPaths` match the changed files, expand its project globs
+with the same evaluator used by PR validation:
+
+```powershell
+.\.dotnet\dotnet.exe run scripts\EvaluateConditionalTestScopes.cs -- `
+  --repo-root . `
+  --list-test-projects ApiCompat
+```
+
+The command writes one `Targeted test project:` line per concrete project. Run each
+project separately with the runner below. If a changed file matches
+`GlobalTriggerPaths`, the conditional system cannot safely narrow the suite; use broader
+validation instead.
+
+## Fall back for unscoped areas
+
+When no `ConditionalTestScope` covers the changed paths, start with the project that
+owns the changed behavior. If a change crosses areas, run each relevant project
+separately so a failure identifies the affected area.
+
+| Change area | Primary test project |
+| --- | --- |
+| Managed CLI commands, parsing, help, and workloads | `test/dotnet.Tests/dotnet.Tests.csproj` |
+| CLI utilities | `test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj` |
+| SDK build targets and NETSDK diagnostics | `test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj` |
+| Build task unit behavior | `test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj` |
+| Publish | `test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj` |
+| Pack | `test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj` |
+| Restore | `test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj` |
+| MSBuild SDK resolution | `test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj` |
+| Containers | `test/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj` |
+| Containers with registry/runtime behavior | `test/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj` |
+| `dotnet watch` | `test/dotnet-watch.Tests/dotnet-watch.Tests.csproj` |
+| Static Web Assets | `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj` |
+| Web SDK | `test/Microsoft.NET.Sdk.Web.Tests/Microsoft.NET.Sdk.Web.Tests.csproj` |
+| Razor SDK | `test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj` |
+| Blazor WebAssembly SDK | `test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj` |
+
+Keep this fallback table limited to areas not represented in
+`test/ConditionalTests.props`. Add or change configured mappings there so local agent
+selection and PR filtering stay aligned.
+
+## Make the product output current
+
+Tests exercise the SDK under `artifacts/bin/redist/<Configuration>/dotnet`, not only
+assemblies built beside the test project.
+
+1. If the redist layout does not exist, run `build.cmd` on Windows or `./build.sh` on
+   macOS/Linux.
+2. If production code changed, ensure the redist layout contains that change before
+   trusting the result:
+   - For managed CLI changes covered by `dotnet.Tests`, use **incremental-test** to build
+     and deploy the changed assemblies without a full rebuild.
+   - For Static Web Assets implementation changes, use
+     **validate-static-web-asset-change**.
+   - Otherwise rebuild the repository. Building only a test project can leave the SDK
+     under test stale even when the test assembly itself is current.
+3. If only test code changed, the runner can build the selected test project directly.
+
+## Run
+
+Start with a build-producing run. The runner builds the selected project by default,
+which keeps the test assembly current and produces the binlog needed to diagnose build
+failures. Add `--no-build` only after this session built that exact project after the
+latest test-code change and confirmed its expected output exists. Do not infer readiness
+from another project or an older artifact; when uncertain, omit `--no-build`.
+
+From the repository root on Windows:
+
+```powershell
+.\.dotnet\dotnet.exe .github\skills\targeted-test\scripts\RunTargetedTests.cs -- `
+  --project test\Microsoft.NET.Build.Tests\Microsoft.NET.Build.Tests.csproj `
+  --filter "FullyQualifiedName~GivenThatWeWantToBuildALibrary"
+```
+
+On macOS/Linux:
+
+```bash
+./.dotnet/dotnet .github/skills/targeted-test/scripts/RunTargetedTests.cs -- \
+  --project test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj \
+  --filter "FullyQualifiedName~GivenThatWeWantToBuildALibrary"
+```
+
+Omit `--filter` to run the whole project. Use `--configuration Release` when validating
+a Release redist layout. A `--no-build` run does not produce a new build binlog.
+
+The runner evaluates the project to select its test platform. It executes MSTest.Sdk
+projects through their built Microsoft.Testing.Platform executable and keeps
+`dotnet test` for other projects. It prints the exact command before execution. On
+failure it also prints failed test names when a TRX is available, the retained
+TRX/binlog paths, and the rerun command. Do not replace it with a command that
+suppresses console output or discards those artifacts.

--- a/.github/skills/targeted-test/SKILL.md
+++ b/.github/skills/targeted-test/SKILL.md
@@ -69,6 +69,10 @@ entries for areas that are now configured, and update entries when test-project 
 changes. Do not duplicate configured mappings here; add or change them in the props file
 so local agent selection and PR filtering stay aligned.
 
+Also revisit this table when adding a test project for a substantive new area. Prefer a
+`ConditionalTestScope` when reliable trigger paths can be defined. When the area is too
+broad for practical conditional filtering, add its primary test project to this table.
+
 ## Make the product output current
 
 Tests exercise the SDK under `artifacts/bin/redist/<Configuration>/dotnet`, not only

--- a/.github/skills/targeted-test/scripts/RunTargetedTests.cs
+++ b/.github/skills/targeted-test/scripts/RunTargetedTests.cs
@@ -152,7 +152,12 @@ static async Task<int> RunAsync(
     // The repository contains both MSTest.Sdk/Microsoft.Testing.Platform projects and projects
     // that still run through `dotnet test`. Query evaluated MSBuild properties instead of
     // guessing from package references or project text, which may be supplied by imports.
-    var projectProperties = await GetProjectProperties(dotnetPath, projectPath, configuration, repoRoot);
+    var projectProperties = await GetProjectProperties(
+        dotnetPath,
+        projectPath,
+        configuration,
+        repoRoot,
+        cancellationToken);
     if (projectProperties is null)
     {
         return 2;
@@ -174,7 +179,7 @@ static async Task<int> RunAsync(
         };
         Console.WriteLine($"Build command: {FormatCommand(dotnetPath, buildArguments, repoRoot)}");
         Console.WriteLine();
-        var buildExitCode = await RunProcess(dotnetPath, buildArguments, repoRoot);
+        var buildExitCode = await RunProcess(dotnetPath, buildArguments, repoRoot, cancellationToken);
         if (buildExitCode != 0)
         {
             Console.Error.WriteLine($"Targeted test project build failed with exit code {buildExitCode}.");
@@ -243,7 +248,7 @@ static async Task<int> RunAsync(
             + "Build the project or omit --no-build.");
     }
 
-    var testExitCode = await RunProcess(dotnetPath, testArguments, repoRoot);
+    var testExitCode = await RunProcess(dotnetPath, testArguments, repoRoot, cancellationToken);
 
     Console.WriteLine();
     if (testExitCode == 0)
@@ -301,7 +306,8 @@ static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties
     string dotnetPath,
     string projectPath,
     string configuration,
-    string repoRoot)
+    string repoRoot,
+    CancellationToken cancellationToken)
 {
     // -getProperty asks MSBuild for the fully evaluated values and emits a small JSON document.
     // Running the repo-local MSBuild process guarantees evaluation with this checkout's pinned
@@ -322,28 +328,17 @@ static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties
 
     // Property evaluation output must be captured for JSON parsing. The actual build and test
     // processes intentionally inherit the console instead so their detailed output streams live.
-    using var process = Process.Start(startInfo);
-    if (process is null)
+    var processOutput = await Process.RunAndCaptureTextAsync(startInfo, cancellationToken);
+
+    if (processOutput.ExitStatus.ExitCode != 0)
     {
-        Console.Error.WriteLine($"Error: Failed to start {dotnetPath}.");
+        Console.Error.WriteLine(
+            $"Error: Could not evaluate test project properties (exit code {processOutput.ExitStatus.ExitCode}).");
+        Console.Error.WriteLine(processOutput.StandardError);
         return null;
     }
 
-    var standardOutput = process.StandardOutput.ReadToEndAsync();
-    var standardError = process.StandardError.ReadToEndAsync();
-
-    // Drain both redirected streams concurrently. Reading one stream only after the process exits
-    // can deadlock when the other stream fills its operating-system pipe buffer.
-    await process.WaitForExitAsync();
-    var output = await standardOutput;
-    var error = await standardError;
-
-    if (process.ExitCode != 0)
-    {
-        Console.Error.WriteLine($"Error: Could not evaluate test project properties (exit code {process.ExitCode}).");
-        Console.Error.WriteLine(error);
-        return null;
-    }
+    var output = processOutput.StandardOutput;
 
     // MSBuild may write SDK or workload messages around the JSON payload. Extract the outer JSON
     // object rather than requiring stdout to contain JSON and nothing else.
@@ -393,19 +388,15 @@ static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties
 static async Task<int> RunProcess(
     string executable,
     IEnumerable<string> arguments,
-    string workingDirectory)
+    string workingDirectory,
+    CancellationToken cancellationToken)
 {
     // Do not redirect output here. The runner promises detailed live diagnostics, and inheriting
     // stdout/stderr preserves test-host formatting and avoids buffering large build logs in memory.
-    using var process = Process.Start(CreateProcessStartInfo(executable, arguments, workingDirectory));
-    if (process is null)
-    {
-        Console.Error.WriteLine($"Error: Failed to start {executable}.");
-        return 2;
-    }
-
-    await process.WaitForExitAsync();
-    return process.ExitCode;
+    var exitStatus = await Process.RunAsync(
+        CreateProcessStartInfo(executable, arguments, workingDirectory),
+        cancellationToken);
+    return exitStatus.ExitCode;
 }
 
 static ProcessStartInfo CreateProcessStartInfo(

--- a/.github/skills/targeted-test/scripts/RunTargetedTests.cs
+++ b/.github/skills/targeted-test/scripts/RunTargetedTests.cs
@@ -24,7 +24,7 @@ Option<string?> filterOption = new("--filter")
     Arity = ArgumentArity.ExactlyOne,
     Description = "VSTest filter, for example FullyQualifiedName~TestClass."
 };
-Option<string> configurationOption = new("--configuration")
+Option<string> configurationOption = new("--configuration", "-c")
 {
     Arity = ArgumentArity.ExactlyOne,
     DefaultValueFactory = _ => "Debug",

--- a/.github/skills/targeted-test/scripts/RunTargetedTests.cs
+++ b/.github/skills/targeted-test/scripts/RunTargetedTests.cs
@@ -1,0 +1,530 @@
+#!/usr/bin/env dotnet
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#:package System.CommandLine
+
+using System.CommandLine;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Linq;
+
+RootCommand rootCommand = new("Run one dotnet/sdk test project with detailed output and retained diagnostics.");
+
+Option<string> projectOption = new("--project")
+{
+    Arity = ArgumentArity.ExactlyOne,
+    Description = "Test .csproj path relative to the repository root.",
+    Required = true
+};
+Option<string?> filterOption = new("--filter")
+{
+    Arity = ArgumentArity.ExactlyOne,
+    Description = "VSTest filter, for example FullyQualifiedName~TestClass."
+};
+Option<string> configurationOption = new("--configuration")
+{
+    Arity = ArgumentArity.ExactlyOne,
+    DefaultValueFactory = _ => "Debug",
+    Description = "Debug (default) or Release."
+};
+configurationOption.Validators.Add(optionResult =>
+{
+    string? configuration = optionResult.GetValueOrDefault<string>();
+    if (!string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(configuration, "Release", StringComparison.OrdinalIgnoreCase))
+    {
+        optionResult.AddError($"Unsupported configuration '{configuration}'. Use Debug or Release.");
+    }
+});
+Option<bool> noBuildOption = new("--no-build")
+{
+    Description = "Do not build the test project before running it."
+};
+Option<string?> repoRootOption = new("--repo-root")
+{
+    Arity = ArgumentArity.ExactlyOne,
+    Description = "Repository root; inferred from the current directory by default."
+};
+
+rootCommand.Options.Add(projectOption);
+rootCommand.Options.Add(filterOption);
+rootCommand.Options.Add(configurationOption);
+rootCommand.Options.Add(noBuildOption);
+rootCommand.Options.Add(repoRootOption);
+
+rootCommand.SetAction((parseResult, cancellationToken) => RunAsync(
+    parseResult.GetValue(projectOption)!,
+    parseResult.GetValue(filterOption),
+    parseResult.GetValue(configurationOption)!,
+    parseResult.GetValue(noBuildOption),
+    parseResult.GetValue(repoRootOption),
+    cancellationToken));
+
+return await rootCommand
+    .Parse(args)
+    .InvokeAsync();
+
+static async Task<int> RunAsync(
+    string project,
+    string? filter,
+    string configuration,
+    bool noBuild,
+    string? repoRootArgument,
+    CancellationToken cancellationToken)
+{
+    cancellationToken.ThrowIfCancellationRequested();
+
+    // Resolve every path from the repository root. Agents may launch this script from a
+    // subdirectory, and allowing the current directory to influence individual paths would
+    // make the same command target different projects or artifact locations.
+    var repoRoot = repoRootArgument is null
+        ? FindRepoRoot(Environment.CurrentDirectory)
+        : Path.GetFullPath(repoRootArgument);
+    if (repoRoot is null || !IsRepoRoot(repoRoot))
+    {
+        return Fail(
+            "Could not find the dotnet/sdk repository root. Run from inside the checkout or pass --repo-root <path>.");
+    }
+
+    var projectPath = Path.GetFullPath(project, repoRoot);
+    if (!File.Exists(projectPath))
+    {
+        return Fail($"Test project does not exist: {projectPath}");
+    }
+
+    if (!projectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+    {
+        return Fail($"Expected a .csproj test project, but got: {projectPath}");
+    }
+
+    // Besides catching accidental typos, this boundary prevents a caller from using the
+    // runner as a generic way to execute and write artifacts for projects outside dotnet/sdk.
+    var relativeProjectPath = Path.GetRelativePath(repoRoot, projectPath);
+    if (relativeProjectPath.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        || Path.IsPathRooted(relativeProjectPath))
+    {
+        return Fail($"Test project must be inside the repository: {projectPath}");
+    }
+
+    // Use the bootstrap SDK pinned by this checkout rather than an arbitrary dotnet on PATH.
+    // This keeps MSBuild evaluation and test execution aligned with global.json.
+    var dotnetPath = Path.Combine(
+        repoRoot,
+        ".dotnet",
+        OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+    if (!File.Exists(dotnetPath))
+    {
+        return Fail(
+            $"Repo-local SDK not found at {dotnetPath}.{Environment.NewLine}"
+            + $"Run {(OperatingSystem.IsWindows() ? @".\restore.cmd" : "./restore.sh")} to install it.");
+    }
+
+    // SDK tests exercise the assembled redist layout. A test project can build successfully
+    // while still testing stale or missing product bits, so fail early when that layout does
+    // not exist instead of producing a misleading test result.
+    var redistRoot = Path.Combine(repoRoot, "artifacts", "bin", "redist", configuration, "dotnet");
+    if (!Directory.Exists(redistRoot))
+    {
+        return Fail(
+            $"The {configuration} redist SDK does not exist at {redistRoot}.{Environment.NewLine}"
+            + $"Run {(OperatingSystem.IsWindows() ? @".\build.cmd" : "./build.sh")} "
+            + $"{(configuration.Equals("Release", StringComparison.OrdinalIgnoreCase) ? "-c Release" : "")} first.");
+    }
+
+    // Give each invocation its own directory. The timestamp makes runs easy to inspect while
+    // the process ID prevents collisions when agents start the same project in parallel.
+    var projectName = Path.GetFileNameWithoutExtension(projectPath);
+    var runDirectory = Path.Combine(
+        repoRoot,
+        "artifacts",
+        "log",
+        "targeted-tests",
+        projectName,
+        $"{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Environment.ProcessId}");
+    Directory.CreateDirectory(runDirectory);
+
+    var trxPath = Path.Combine(runDirectory, "test-results.trx");
+    var binlogPath = Path.Combine(runDirectory, "build.binlog");
+
+    // The repository contains both MSTest.Sdk/Microsoft.Testing.Platform projects and projects
+    // that still run through `dotnet test`. Query evaluated MSBuild properties instead of
+    // guessing from package references or project text, which may be supplied by imports.
+    var projectProperties = await GetProjectProperties(dotnetPath, projectPath, configuration, repoRoot);
+    if (projectProperties is null)
+    {
+        return 2;
+    }
+
+    // MSTest.Sdk projects are executable test applications. Build them explicitly so the
+    // build failure has its own exit code and binlog, then execute TargetPath below. Running
+    // `dotnet test` for these projects can succeed while discovering zero tests.
+    if (projectProperties.Value.UsesMSTestSdk && !noBuild)
+    {
+        var buildArguments = new List<string>
+        {
+            "build",
+            projectPath,
+            "--configuration",
+            configuration,
+            "--nologo",
+            $"-bl:{binlogPath}"
+        };
+        Console.WriteLine($"Build command: {FormatCommand(dotnetPath, buildArguments, repoRoot)}");
+        Console.WriteLine();
+        var buildExitCode = await RunProcess(dotnetPath, buildArguments, repoRoot);
+        if (buildExitCode != 0)
+        {
+            Console.Error.WriteLine($"Targeted test project build failed with exit code {buildExitCode}.");
+            PrintArtifacts(repoRoot, trxPath, binlogPath);
+            return buildExitCode;
+        }
+    }
+
+    // Microsoft.Testing.Platform accepts test options after the assembly path, while the
+    // traditional path accepts them through `dotnet test`. Construct the appropriate command
+    // once so logging, filtering, display, and rerun guidance all describe the exact process.
+    var testArguments = projectProperties.Value.UsesMSTestSdk
+        ? new List<string>
+        {
+            "exec",
+            projectProperties.Value.TargetPath,
+            "--report-trx",
+            "--report-trx-filename",
+            "test-results.trx",
+            "--results-directory",
+            runDirectory
+        }
+        : new List<string>
+        {
+            "test",
+            projectPath,
+            "--configuration",
+            configuration,
+            "--logger",
+            "console;verbosity=detailed",
+            "--logger",
+            "trx;LogFileName=test-results.trx",
+            "--results-directory",
+            runDirectory,
+            $"-bl:{binlogPath}"
+        };
+
+    // The explicit MSTest.Sdk build above is already skipped when --no-build is set. Only the
+    // `dotnet test` command needs the switch forwarded.
+    if (noBuild && !projectProperties.Value.UsesMSTestSdk)
+    {
+        testArguments.Add("--no-build");
+    }
+
+    if (!string.IsNullOrWhiteSpace(filter))
+    {
+        testArguments.Add("--filter");
+        testArguments.Add(filter);
+    }
+
+    // Print the command before execution so live logs remain useful if the process hangs or is
+    // cancelled before it can produce a TRX.
+    var displayCommand = FormatCommand(dotnetPath, testArguments, repoRoot);
+    Console.WriteLine($"Project: {relativeProjectPath}");
+    Console.WriteLine($"Artifacts: {Path.GetRelativePath(repoRoot, runDirectory)}");
+    Console.WriteLine($"Command: {displayCommand}");
+    Console.WriteLine();
+
+    // In --no-build mode, TargetPath may describe where output would be written even when the
+    // file is absent. Detect that case here and explain how to recover instead of forwarding a
+    // less actionable dotnet exec "file not found" error.
+    if (projectProperties.Value.UsesMSTestSdk && !File.Exists(projectProperties.Value.TargetPath))
+    {
+        return Fail(
+            $"Built MSTest test assembly not found at {projectProperties.Value.TargetPath}. "
+            + "Build the project or omit --no-build.");
+    }
+
+    var testExitCode = await RunProcess(dotnetPath, testArguments, repoRoot);
+
+    Console.WriteLine();
+    if (testExitCode == 0)
+    {
+        Console.WriteLine("Targeted tests passed.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        return 0;
+    }
+
+    Console.Error.WriteLine($"Targeted tests failed with exit code {testExitCode}.");
+    if (File.Exists(trxPath))
+    {
+        // Surface names in the console for immediate triage while retaining the complete TRX
+        // for stack traces, output, timings, and larger failure sets.
+        PrintFailedTests(trxPath);
+    }
+    else
+    {
+        Console.Error.WriteLine("No TRX was produced; the failure occurred before test results were written.");
+    }
+
+    // Always show whatever diagnostics exist. Build failures may produce only a binlog, while
+    // early test-host failures may produce neither; stating that explicitly is more actionable
+    // than making the caller search the artifact tree.
+    PrintArtifacts(repoRoot, trxPath, binlogPath);
+    Console.Error.WriteLine($"Rerun: {displayCommand}");
+    return testExitCode;
+}
+
+static string? FindRepoRoot(string startDirectory)
+{
+    // Walking upward supports invocation from anywhere in the checkout without relying on git,
+    // which also keeps this file-based app usable in source archives and constrained agents.
+    for (var directory = new DirectoryInfo(Path.GetFullPath(startDirectory));
+         directory is not null;
+         directory = directory.Parent)
+    {
+        if (IsRepoRoot(directory.FullName))
+        {
+            return directory.FullName;
+        }
+    }
+
+    return null;
+}
+
+// Use SDK-specific sentinels rather than accepting any directory containing a .git entry.
+// Worktrees store .git as a file, while ordinary checkouts use a directory.
+static bool IsRepoRoot(string path) =>
+    File.Exists(Path.Combine(path, "global.json"))
+    && File.Exists(Path.Combine(path, "sdk.slnx"))
+    && (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")));
+
+static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties(
+    string dotnetPath,
+    string projectPath,
+    string configuration,
+    string repoRoot)
+{
+    // -getProperty asks MSBuild for the fully evaluated values and emits a small JSON document.
+    // Running the repo-local MSBuild process guarantees evaluation with this checkout's pinned
+    // SDK, imports, workload resolvers, and MSBuild version. Using the MSBuild APIs in-process
+    // would require package dependencies, toolset registration, assembly-load management, and
+    // isolation from MSBuild's global state for the sake of reading only these two properties.
+    var arguments = new[]
+    {
+        "msbuild",
+        projectPath,
+        "-getProperty:UsingMSTestSdk,TargetPath",
+        $"-p:Configuration={configuration}",
+        "--nologo"
+    };
+    var startInfo = CreateProcessStartInfo(dotnetPath, arguments, repoRoot);
+    startInfo.RedirectStandardOutput = true;
+    startInfo.RedirectStandardError = true;
+
+    // Property evaluation output must be captured for JSON parsing. The actual build and test
+    // processes intentionally inherit the console instead so their detailed output streams live.
+    using var process = Process.Start(startInfo);
+    if (process is null)
+    {
+        Console.Error.WriteLine($"Error: Failed to start {dotnetPath}.");
+        return null;
+    }
+
+    var standardOutput = process.StandardOutput.ReadToEndAsync();
+    var standardError = process.StandardError.ReadToEndAsync();
+
+    // Drain both redirected streams concurrently. Reading one stream only after the process exits
+    // can deadlock when the other stream fills its operating-system pipe buffer.
+    await process.WaitForExitAsync();
+    var output = await standardOutput;
+    var error = await standardError;
+
+    if (process.ExitCode != 0)
+    {
+        Console.Error.WriteLine($"Error: Could not evaluate test project properties (exit code {process.ExitCode}).");
+        Console.Error.WriteLine(error);
+        return null;
+    }
+
+    // MSBuild may write SDK or workload messages around the JSON payload. Extract the outer JSON
+    // object rather than requiring stdout to contain JSON and nothing else.
+    var jsonStart = output.IndexOf('{');
+    var jsonEnd = output.LastIndexOf('}');
+    if (jsonStart < 0 || jsonEnd < jsonStart)
+    {
+        Console.Error.WriteLine("Error: MSBuild did not return the requested test project properties.");
+        Console.Error.WriteLine(output);
+        return null;
+    }
+
+    JsonDocument document;
+    try
+    {
+        document = JsonDocument.Parse(output[jsonStart..(jsonEnd + 1)]);
+    }
+    catch (JsonException exception)
+    {
+        Console.Error.WriteLine($"Error: Could not parse MSBuild test project properties: {exception.Message}");
+        return null;
+    }
+
+    using (document)
+    {
+        var properties = document.RootElement.GetProperty("Properties");
+
+        // UsingMSTestSdk is a string-valued MSBuild property, so compare it using MSBuild's
+        // case-insensitive boolean convention instead of relying on JSON boolean parsing.
+        var usesMSTestSdk = string.Equals(
+            properties.GetProperty("UsingMSTestSdk").GetString(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        var targetPath = properties.GetProperty("TargetPath").GetString();
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            Console.Error.WriteLine("Error: MSBuild returned an empty TargetPath for the test project.");
+            return null;
+        }
+
+        // TargetPath may be relative depending on project configuration. Normalize it now so the
+        // later existence check and dotnet exec invocation are independent of process cwd.
+        return (usesMSTestSdk, Path.GetFullPath(targetPath, repoRoot));
+    }
+}
+
+static async Task<int> RunProcess(
+    string executable,
+    IEnumerable<string> arguments,
+    string workingDirectory)
+{
+    // Do not redirect output here. The runner promises detailed live diagnostics, and inheriting
+    // stdout/stderr preserves test-host formatting and avoids buffering large build logs in memory.
+    using var process = Process.Start(CreateProcessStartInfo(executable, arguments, workingDirectory));
+    if (process is null)
+    {
+        Console.Error.WriteLine($"Error: Failed to start {executable}.");
+        return 2;
+    }
+
+    await process.WaitForExitAsync();
+    return process.ExitCode;
+}
+
+static ProcessStartInfo CreateProcessStartInfo(
+    string executable,
+    IEnumerable<string> arguments,
+    string workingDirectory)
+{
+    var startInfo = new ProcessStartInfo(executable)
+    {
+        WorkingDirectory = workingDirectory,
+        UseShellExecute = false
+    };
+
+    // ArgumentList delegates platform-specific escaping to ProcessStartInfo. Building one command
+    // string would be fragile for filters, spaces, quotes, and Windows paths.
+    foreach (var argument in arguments)
+    {
+        startInfo.ArgumentList.Add(argument);
+    }
+
+    return startInfo;
+}
+
+static void PrintFailedTests(string trxPath)
+{
+    const int MaximumDisplayedFailures = 20;
+
+    try
+    {
+        var document = XDocument.Load(trxPath);
+
+        // TRX elements are namespace-qualified, and the namespace version can vary with the test
+        // platform. LocalName keeps this summary compatible without hardcoding a schema URI.
+        var failures = document
+            .Descendants()
+            .Where(element => element.Name.LocalName == "UnitTestResult"
+                && string.Equals((string?)element.Attribute("outcome"), "Failed", StringComparison.OrdinalIgnoreCase))
+            .Select(element => (string?)element.Attribute("testName"))
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToList();
+
+        if (failures.Count == 0)
+        {
+            return;
+        }
+
+        Console.Error.WriteLine($"Failed tests ({failures.Count}):");
+
+        // Keep terminal output actionable but bounded. The TRX remains the source of truth when a
+        // broad filter fails hundreds of tests.
+        foreach (var failure in failures.Take(MaximumDisplayedFailures))
+        {
+            Console.Error.WriteLine($"  {failure}");
+        }
+        if (failures.Count > MaximumDisplayedFailures)
+        {
+            Console.Error.WriteLine(
+                $"  ... and {failures.Count - MaximumDisplayedFailures} more; see the TRX for the complete list.");
+        }
+    }
+    catch (IOException exception)
+    {
+        Console.Error.WriteLine($"Could not read the TRX failure summary: {exception.Message}");
+    }
+    catch (XmlException exception)
+    {
+        Console.Error.WriteLine($"Could not parse the TRX failure summary: {exception.Message}");
+    }
+}
+
+static void PrintArtifacts(string repoRoot, string trxPath, string binlogPath)
+{
+    // Relative paths are easier to copy into a follow-up command and do not leak machine-specific
+    // checkout locations into logs or agent responses.
+    Console.WriteLine("Diagnostic artifacts:");
+    Console.WriteLine(
+        File.Exists(trxPath)
+            ? $"  TRX: {Path.GetRelativePath(repoRoot, trxPath)}"
+            : "  TRX: not produced");
+    Console.WriteLine(
+        File.Exists(binlogPath)
+            ? $"  Binlog: {Path.GetRelativePath(repoRoot, binlogPath)}"
+            : "  Binlog: not produced");
+}
+
+static string FormatCommand(string executable, IEnumerable<string> arguments, string repoRoot)
+{
+    // Display the repo-local executable as a relative path so the rerun command is portable to
+    // another checkout and visibly cannot resolve to a global dotnet installation.
+    var relativeExecutable = Path.GetRelativePath(repoRoot, executable);
+    if (!relativeExecutable.StartsWith($".{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        && !relativeExecutable.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+    {
+        relativeExecutable = $".{Path.DirectorySeparatorChar}{relativeExecutable}";
+    }
+
+    return string.Join(" ", new[] { relativeExecutable }.Concat(arguments).Select(QuoteArgument));
+}
+
+static string QuoteArgument(string argument)
+{
+    // This formatter is for human-readable rerun guidance only; ProcessStartInfo.ArgumentList
+    // performs the real process escaping. Leave simple arguments readable and quote the rest.
+    if (argument.Length > 0 && argument.All(IsShellSafe))
+    {
+        return argument;
+    }
+
+    return $"\"{argument.Replace("\"", "\\\"")}\"";
+}
+
+static bool IsShellSafe(char value) =>
+    // These characters are common in paths, properties, and test filters and do not require
+    // quoting in the supported shells. Everything else takes the conservative quoted path.
+    char.IsLetterOrDigit(value)
+    || value is '_' or '-' or '.' or ':' or '\\' or '/' or '~' or '=' or '+';
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"Error: {message}");
+    return 2;
+}

--- a/.github/skills/targeted-test/scripts/RunTargetedTests.cs
+++ b/.github/skills/targeted-test/scripts/RunTargetedTests.cs
@@ -160,7 +160,7 @@ static async Task<int> RunAsync(
         cancellationToken);
     if (projectProperties is null)
     {
-        return 2;
+        return 1;
     }
 
     // MSTest.Sdk projects are executable test applications. Build them explicitly so the
@@ -517,5 +517,5 @@ static bool IsShellSafe(char value) =>
 static int Fail(string message)
 {
     Console.Error.WriteLine($"Error: {message}");
-    return 2;
+    return 1;
 }

--- a/documentation/project-docs/pr-test-filtering.md
+++ b/documentation/project-docs/pr-test-filtering.md
@@ -156,9 +156,9 @@ scope into concrete project paths with:
 
 The command writes one repo-relative `Targeted test project:` line for each project
 matched by the scope's `TestProjects` globs. Run those projects individually so a
-failure identifies the affected project. The `targeted-test` agent skill provides the
-runner and fallback mappings for change areas that do not yet have a
-`ConditionalTestScope`.
+failure identifies the affected project. The
+[`targeted-test`](../../.github/skills/targeted-test/SKILL.md) agent skill provides the
+runner and fallback mappings for change areas that do not yet have a `ConditionalTestScope`.
 
 If a changed file matches `GlobalTriggerPaths`, do not use an individual conditional
 scope to claim complete coverage: PR validation deliberately runs all tests for those
@@ -167,9 +167,10 @@ shared changes.
 ## Adding a new scope
 
 1. Add a `<ConditionalTestScope>` item in `test/ConditionalTests.props`.
-2. Reconcile the fallback table in the `targeted-test` agent skill. Remove an entry when
-   the new scope now covers that area, or update it if test-project ownership changed.
-   Do not copy configured mappings into the fallback table.
+2. Reconcile the fallback table in the
+   [`targeted-test`](../../.github/skills/targeted-test/SKILL.md) agent skill. Remove an
+   entry when the new scope now covers that area, or update it if test-project ownership
+   changed. Do not copy configured mappings into the fallback table.
 3. The evaluation script and `UnitTests.proj` are generic and require no per-scope
    changes.
 
@@ -232,9 +233,10 @@ too coarse, it can be tuned later — see [Future enhancements](#future-enhancem
 ## Design principles
 
 - **Single source of truth**: `test/ConditionalTests.props` defines everything about a
-  scope — trigger paths, projects, and conditions. The `targeted-test` skill reads these
-  mappings directly; its separate fallback table contains only common unscoped areas and
-  must be reconciled when scopes or test-project ownership change.
+  scope — trigger paths, projects, and conditions. The
+  [`targeted-test`](../../.github/skills/targeted-test/SKILL.md) skill reads these mappings
+  directly; its separate fallback table contains only common unscoped areas and must be
+  reconciled when scopes or test-project ownership change.
 - **Safe by default**: when in doubt, tests run. The system only skips tests when it has
   positive evidence that no relevant files changed.
 - **No extra build legs**: filtering happens within the existing build/test pipeline.

--- a/documentation/project-docs/pr-test-filtering.md
+++ b/documentation/project-docs/pr-test-filtering.md
@@ -142,6 +142,28 @@ Is this a PR build?
 - **Non-PR builds**: `RunAlways=CI` ensures no scopes are skipped on `main` / release
   branches.
 
+### Use a scope for targeted local tests
+
+Agents and contributors should use the same `TestProjects` mappings for local targeted
+validation rather than maintaining a second area-to-project list. Expand a configured
+scope into concrete project paths with:
+
+```shell
+./.dotnet/dotnet run scripts/EvaluateConditionalTestScopes.cs -- \
+  --repo-root . \
+  --list-test-projects TemplateEngine
+```
+
+The command writes one repo-relative `Targeted test project:` line for each project
+matched by the scope's `TestProjects` globs. Run those projects individually so a
+failure identifies the affected project. The `targeted-test` agent skill provides the
+runner and fallback mappings for change areas that do not yet have a
+`ConditionalTestScope`.
+
+If a changed file matches `GlobalTriggerPaths`, do not use an individual conditional
+scope to claim complete coverage: PR validation deliberately runs all tests for those
+shared changes.
+
 ## Adding a new scope
 
 1. Add a `<ConditionalTestScope>` item in `test/ConditionalTests.props`.

--- a/documentation/project-docs/pr-test-filtering.md
+++ b/documentation/project-docs/pr-test-filtering.md
@@ -167,8 +167,11 @@ shared changes.
 ## Adding a new scope
 
 1. Add a `<ConditionalTestScope>` item in `test/ConditionalTests.props`.
-2. That's it — the evaluation script and `UnitTests.proj` are generic and require no
-   per-scope changes.
+2. Reconcile the fallback table in the `targeted-test` agent skill. Remove an entry when
+   the new scope now covers that area, or update it if test-project ownership changed.
+   Do not copy configured mappings into the fallback table.
+3. The evaluation script and `UnitTests.proj` are generic and require no per-scope
+   changes.
 
 Example:
 
@@ -229,8 +232,9 @@ too coarse, it can be tuned later — see [Future enhancements](#future-enhancem
 ## Design principles
 
 - **Single source of truth**: `test/ConditionalTests.props` defines everything about a
-  scope — trigger paths, projects, and conditions. Adding or removing a scope is a
-  one-file change.
+  scope — trigger paths, projects, and conditions. The `targeted-test` skill reads these
+  mappings directly; its separate fallback table contains only common unscoped areas and
+  must be reconciled when scopes or test-project ownership change.
 - **Safe by default**: when in doubt, tests run. The system only skips tests when it has
   positive evidence that no relevant files changed.
 - **No extra build legs**: filtering happens within the existing build/test pipeline.

--- a/scripts/EvaluateConditionalTestScopes.cs
+++ b/scripts/EvaluateConditionalTestScopes.cs
@@ -286,6 +286,7 @@ static string? GetArg(string name)
 static bool ValidateConfiguration(string repoRoot, List<XElement> scopes, string[] globalTriggerPaths)
 {
     var errors = new List<string>();
+    var scopeNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     foreach (var scope in scopes)
     {
@@ -294,6 +295,11 @@ static bool ValidateConfiguration(string repoRoot, List<XElement> scopes, string
         {
             errors.Add("ConditionalTestScope is missing a name (Include attribute).");
             continue;
+        }
+
+        if (!scopeNames.Add(scopeName))
+        {
+            errors.Add($"Conditional test scope name '{scopeName}' is duplicated. Scope names must be unique (case-insensitive).");
         }
 
         var triggerPaths = (scope.Element("TriggerPaths")?.Value ?? "")

--- a/scripts/EvaluateConditionalTestScopes.cs
+++ b/scripts/EvaluateConditionalTestScopes.cs
@@ -3,14 +3,18 @@
 
 #:property RollForward=LatestMajor
 
-// Evaluates which conditional test scopes should be skipped based on changed files and build context.
-// Reads test/ConditionalTests.props and outputs a semicolon-separated list of skipped scope names.
+// Evaluates conditional test scopes from test/ConditionalTests.props.
+// It can output either the scopes to skip based on changed files and build context or the concrete
+// test projects in one configured scope for targeted local validation.
 //
 // Usage:
 //   dotnet run EvaluateConditionalTestScopes.cs -- --repo-root <path> [--target-branch <branch>] [--build-reason <reason>] [--output-variable <name>]
+//   dotnet run EvaluateConditionalTestScopes.cs -- --repo-root <path> --list-test-projects <scope>
 //
 // When --target-branch is not provided, no scopes are skipped (safe default for local dev).
 // Changed files are determined via `git diff --name-only --no-renames origin/<target-branch>...HEAD`.
+// --list-test-projects expands the configured TestProjects globs and writes one repo-relative
+// "Targeted test project:" line per concrete project without evaluating the git diff.
 //
 // Output variable format (set via ##vso when running in Azure Pipelines):
 //   - Empty string: no scopes skipped, all tests run.
@@ -29,6 +33,7 @@ var targetBranch = GetArg("--target-branch");
 var buildReason = GetArg("--build-reason") ?? "";
 var repoRoot = GetArg("--repo-root");
 var outputVariable = GetArg("--output-variable");
+var listTestProjects = GetArg("--list-test-projects");
 
 if (string.IsNullOrEmpty(repoRoot) || !Directory.Exists(repoRoot))
 {
@@ -56,6 +61,43 @@ var globalTriggerPaths = (doc.Descendants("GlobalTriggerPaths").FirstOrDefault()
 if (!ValidateConfiguration(repoRoot, scopes, globalTriggerPaths))
 {
     return 1;
+}
+
+if (!string.IsNullOrEmpty(listTestProjects))
+{
+    var scope = scopes.SingleOrDefault(
+        scope => string.Equals(
+            scope.Attribute("Include")?.Value,
+            listTestProjects,
+            StringComparison.OrdinalIgnoreCase));
+    if (scope is null)
+    {
+        Console.Error.WriteLine($"Error: Conditional test scope '{listTestProjects}' was not found.");
+        return 1;
+    }
+
+    var testProjectPatterns = (scope.Element("TestProjects")?.Value ?? "")
+        .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    var testProjects = Directory
+        .EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
+        .Select(path => Path.GetRelativePath(repoRoot, path).Replace('\\', '/'))
+        .Where(path => testProjectPatterns.Any(pattern => GlobMatches(path, pattern.Replace('\\', '/'))))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Order(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    if (testProjects.Count == 0)
+    {
+        Console.Error.WriteLine($"Error: Conditional test scope '{listTestProjects}' did not match any test projects.");
+        return 1;
+    }
+
+    foreach (var testProject in testProjects)
+    {
+        Console.WriteLine($"Targeted test project: {testProject}");
+    }
+
+    return 0;
 }
 
 bool isCI = buildReason is not "" and not "PullRequest";

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -37,6 +37,10 @@ Guidance for changes under `test/`.
   `TestContext` output is both captured in the result and shown while the test runs.
 - **Run focused tests through `targeted-test`.** It runs the smallest relevant tests and
   preserves actionable output and diagnostics when a local run fails.
+- **Map new substantive test areas for targeted testing.** Prefer adding a
+  `ConditionalTestScope` when reliable trigger paths can be defined. When the area is too
+  broad for practical conditional filtering, add its primary project to the fallback
+  table in the `targeted-test` skill.
 - **Skips must point to a tracking issue URL** — `[Ignore("https://github.com/dotnet/sdk/issues/N")]`.
 - **Verify (approval) snapshots**: `*.verified.*` is checked in; the runner writes a
   `*.received.*` on mismatch — promote received → verified when you change output

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -35,6 +35,8 @@ Guidance for changes under `test/`.
 - **MSTest output is live.** `test/testconfig.json` is copied beside each MSTest
   test executable as `<AssemblyName>.testconfig.json`, so console, trace, and
   `TestContext` output is both captured in the result and shown while the test runs.
+- **Run focused tests through `targeted-test`.** It runs the smallest relevant tests and
+  preserves actionable output and diagnostics when a local run fails.
 - **Skips must point to a tracking issue URL** — `[Ignore("https://github.com/dotnet/sdk/issues/N")]`.
 - **Verify (approval) snapshots**: `*.verified.*` is checked in; the runner writes a
   `*.received.*` on mismatch — promote received → verified when you change output

--- a/test/ConditionalTests.props
+++ b/test/ConditionalTests.props
@@ -5,6 +5,10 @@
 
     This file defines which tests can be skipped on PRs that don't touch relevant source.
     See documentation/project-docs/pr-test-filtering.md for design details and usage guide.
+
+    The targeted-test agent skill reads these scopes directly. When changing them, also
+    reconcile its fallback table for common unscoped areas: remove entries now covered by
+    a scope, and update entries when test-project ownership changes.
   -->
 
   <!-- ======== Global trigger paths ========

--- a/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
@@ -284,6 +284,42 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     }
 
     [TestMethod]
+    public async Task ListTestProjects_DuplicateScopeNames_ReturnsClearError()
+    {
+        var props = """
+            <Project>
+              <ItemGroup>
+                <ConditionalTestScope Include="TestScope">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/*.csproj</TestProjects>
+                  <TriggerPaths>src/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+                <ConditionalTestScope Include="testscope">
+                  <Mechanism>project</Mechanism>
+                  <TestProjects>test/*.csproj</TestProjects>
+                  <TriggerPaths>src/**</TriggerPaths>
+                  <RunAlways>CI</RunAlways>
+                </ConditionalTestScope>
+              </ItemGroup>
+            </Project>
+            """;
+
+        using var repo = new TestRepo(props, "src", "test");
+
+        var result = await RunScript(
+            repo.Root,
+            targetBranch: null,
+            buildReason: "PullRequest",
+            listTestProjects: "TestScope");
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.Contains(
+            "Conditional test scope name 'testscope' is duplicated. Scope names must be unique (case-insensitive).",
+            result.StdOut);
+    }
+
+    [TestMethod]
     public async Task Validation_MissingMechanism_ReturnsError()
     {
         var props = """

--- a/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/EvaluateConditionalTestScopesTests.cs
@@ -247,6 +247,43 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     }
 
     [TestMethod]
+    public async Task ListTestProjects_ExpandsConfiguredScopeGlobs()
+    {
+        using var repo = new TestRepo(
+            CreateBasicProps("test/MyFeature.Tests/**/*.csproj"),
+            BasicPropsDirs);
+        CreateFile(repo.Root, "test/MyFeature.Tests/First.Tests.csproj");
+        CreateFile(repo.Root, "test/MyFeature.Tests/Nested/Second.Tests.csproj");
+        CreateFile(repo.Root, "test/Other.Tests/Other.Tests.csproj");
+
+        var result = await RunScript(
+            repo.Root,
+            targetBranch: null,
+            buildReason: "PullRequest",
+            listTestProjects: "TestScope");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdErr);
+        Assert.Contains("Targeted test project: test/MyFeature.Tests/First.Tests.csproj", result.StdOut);
+        Assert.Contains("Targeted test project: test/MyFeature.Tests/Nested/Second.Tests.csproj", result.StdOut);
+        Assert.DoesNotContain("Other.Tests.csproj", result.StdOut);
+    }
+
+    [TestMethod]
+    public async Task ListTestProjects_UnknownScope_ReturnsError()
+    {
+        using var repo = new TestRepo(CreateBasicProps(), BasicPropsDirs);
+
+        var result = await RunScript(
+            repo.Root,
+            targetBranch: null,
+            buildReason: "PullRequest",
+            listTestProjects: "MissingScope");
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.Contains("Conditional test scope 'MissingScope' was not found", result.StdErr);
+    }
+
+    [TestMethod]
     public async Task Validation_MissingMechanism_ReturnsError()
     {
         var props = """
@@ -445,7 +482,7 @@ public class EvaluateConditionalTestScopesTests : SdkTest
 
     // --- Helpers ---
 
-    private static string CreateBasicProps() => """
+    private static string CreateBasicProps(string testProjects = "test/MyFeature.Tests/*.csproj") => $$"""
         <Project>
           <PropertyGroup>
             <GlobalTriggerPaths>
@@ -455,7 +492,7 @@ public class EvaluateConditionalTestScopesTests : SdkTest
           <ItemGroup>
             <ConditionalTestScope Include="TestScope">
               <Mechanism>project</Mechanism>
-              <TestProjects>test/MyFeature.Tests/*.csproj</TestProjects>
+              <TestProjects>{{testProjects}}</TestProjects>
               <TriggerPaths>src/MyFeature/**;test/MyFeature.Tests/**</TriggerPaths>
               <RunAlways>CI</RunAlways>
             </ConditionalTestScope>
@@ -467,7 +504,12 @@ public class EvaluateConditionalTestScopesTests : SdkTest
     private static readonly string[] BasicPropsDirs =
         ["test/Microsoft.NET.TestFramework", "src/MyFeature", "test/MyFeature.Tests"];
 
-    private async Task<ScriptResult> RunScript(string repoRoot, string? targetBranch, string buildReason, string? outputVariable = null)
+    private async Task<ScriptResult> RunScript(
+        string repoRoot,
+        string? targetBranch,
+        string buildReason,
+        string? outputVariable = null,
+        string? listTestProjects = null)
     {
         var args = $"run \"{_scriptPath}\" -- --repo-root \"{repoRoot}\" --build-reason \"{buildReason}\"";
         if (targetBranch != null)
@@ -477,6 +519,10 @@ public class EvaluateConditionalTestScopesTests : SdkTest
         if (outputVariable != null)
         {
             args += $" --output-variable \"{outputVariable}\"";
+        }
+        if (listTestProjects != null)
+        {
+            args += $" --list-test-projects \"{listTestProjects}\"";
         }
 
         var psi = new ProcessStartInfo(_dotnetPath, args)
@@ -522,6 +568,13 @@ public class EvaluateConditionalTestScopesTests : SdkTest
         }
 
         return new ScriptResult(output.ExitStatus.ExitCode, output.StandardOutput, output.StandardError);
+    }
+
+    private static void CreateFile(string repoRoot, string relativePath)
+    {
+        var fullPath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, "<Project />");
     }
 
     private record ScriptResult(int ExitCode, string StdOut, string StdErr);


### PR DESCRIPTION
## Summary

Adds a `targeted-test` agent skill that selects and runs the smallest relevant tests for a product change while retaining actionable diagnostics.

The workflow:

- Reuses `test/ConditionalTests.props` for configured change areas.
- Adds `--list-test-projects` to `EvaluateConditionalTestScopes.cs` to expand a scope into concrete test projects.
- Provides owning-project fallbacks for common areas not covered by conditional test scopes.
- Handles both traditional `dotnet test` projects and MSTest.Sdk/Microsoft.Testing.Platform test applications.
- Streams test output and retains a TRX and MSBuild binlog under `artifacts\log\targeted-tests\`.
- Reports failed test names, diagnostic paths, and the exact rerun command.
- Integrates focused execution with the existing `incremental-test` workflow.

## Evaluation

I ran eight matched agent tasks covering four product-change scenarios:

1. C# file covered by `ConditionalTests.props`.
2. Supporting file covered by `ConditionalTests.props`.
3. C# file outside configured scopes.
4. Supporting file outside configured scopes.

Each scenario ran once with the skill and once without it. All runs used the same commit, model, reasoning setting, and isolated worktrees.

| Measure | With skill | Without skill | Difference |
| --- | ---: | ---: | ---: |
| Input tokens | 4,644,327 | 9,818,861 | 52.7% lower |
| Output tokens | 39,738 | 92,216 | 56.9% lower |
| Total tokens | 4,684,065 | 9,911,077 | 52.7% lower |
| Model rounds | 78 | 149 | 47.7% lower |
| Aggregate active time | 1,485.5 seconds | 2,159.7 seconds | 31.2% lower |

The agents without the skill still found the intended owning test projects in all four scenarios. The main difference was execution reliability and efficiency: three control runs first tried `dotnet test` commands that executed zero MSTest.Sdk tests and then had to discover direct Microsoft.Testing.Platform execution. The fourth selected the correct project but stopped after a zero-test run and a product build.

The skill also consistently identified whether the changed path was covered by a configured conditional scope and produced diagnostics in a predictable location.

---

Builds on the conditional test filtering system introduced by #55166.

Fixes #55185.