### PR TITLE
[release/10.0.3xx] Fix DownloadBlobAsync_RetriesOnFailure digest validation

### DIFF
--- a/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -553,7 +553,7 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_RetriesOnFailure));
 
         var repoName = "testRepo";
-        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81", 1234);
         var cancellationToken = CancellationToken.None;
 
         var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);

--- a/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -553,6 +553,9 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_RetriesOnFailure));
 
         var repoName = "testRepo";
+        // The digest must be the actual SHA-256 of the response bytes so that the internal
+        // branch's CopyToAndVerifyAsync digest validation passes after the download succeeds.
+        var responseBytes = new byte[] { 1, 2, 3 };
         var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81", 1234);
         var cancellationToken = CancellationToken.None;
 
@@ -561,7 +564,7 @@ public class RegistryTests : IDisposable
             .SetupSequence(api => api.Blob.GetStreamAsync(repoName, descriptor.Digest, cancellationToken))
             .ThrowsAsync(new Exception("Simulated failure 1")) // First attempt fails
             .ThrowsAsync(new Exception("Simulated failure 2")) // Second attempt fails
-            .ReturnsAsync(new MemoryStream(new byte[] { 1, 2, 3 })); // Third attempt succeeds
+            .ReturnsAsync(new MemoryStream(responseBytes)); // Third attempt succeeds
 
         Registry registry = new(repoName, logger, mockRegistryAPI.Object, null, () => TimeSpan.Zero);
 
@@ -593,7 +596,7 @@ public class RegistryTests : IDisposable
         var logger = _loggerFactory.CreateLogger(nameof(DownloadBlobAsync_ThrowsAfterMaxRetries));
 
         var repoName = "testRepo";
-        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:testdigest1234", 1234);
+        var descriptor = new Descriptor(SchemaTypes.OciLayerGzipV1, "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2", 1234);
         var cancellationToken = CancellationToken.None;
 
         var mockRegistryAPI = new Mock<IRegistryAPI>(MockBehavior.Strict);


### PR DESCRIPTION
## Problem
The blob digest-validation feature (`Registry.DownloadBlobAsync` -> `StreamExtensions.CopyToAndVerifyAsync` -> `DigestUtils.GetEncodedValue`) is flowing into `release/10.0.3xx` from the VMR, but `RegistryTests.DownloadBlobAsync_RetriesOnFailure` still uses the placeholder digest `sha256:testdigest1234`.

Once verification runs, the retried download "succeeds" returning bytes `{ 1, 2, 3 }` and the code strips `sha256:` then calls `Convert.FromHexString("testdigest1234")`, which throws `FormatException: The input is not a valid hex string` (`t`/`s` aren't hex). The next retry NREs (mock exhausted) and the method throws `UnableToDownloadFromRepositoryException`, failing the test on **every** leg (Linux/macOS/Windows/FullFramework).

This blocks the codeflow PR #55455 and every codeflow into `release/10.0.3xx`.

## Fix
Use the real SHA-256 of the mock content `{ 1, 2, 3 }` (`039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81`) so digest verification passes. This matches the fix already on `main` (commit `b525d46`, "Add digest validation for downloaded and cached registry blobs").

Landing this on `release/10.0.3xx` forward-flows the correction to the VMR so codeflow PRs stop reintroducing the broken test.

## Validation
`SHA256({ 1, 2, 3 })` == `039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81` (verified), so `CopyToAndVerifyAsync` computes a matching hash and the retry test passes.