### PR TITLE
Stop running build jobs on official check-in CI runs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -36,6 +36,11 @@ parameters:
   displayName: Force test build
   type: boolean
   default: false
+# When true, forces publish-stage routing on non-check-in runs.
+- name: forcePublish
+  displayName: Force publish stage
+  type: boolean
+  default: false
 # When true, forces a complete CG scan including test template acquisition for non-scheduled runs.
 - name: forceCompleteCg
   displayName: Force complete CG scan
@@ -106,77 +111,79 @@ extends:
 
     stages:
     ############### BUILD STAGE ###############
-    - stage: build
-      displayName: Build
-      jobs:
-      ############### HELIX JOB MONITOR ###############
-      - ${{ if eq(variables['runInTestMode'], 'true') }}:
-        - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
+    # Run build jobs for non-check-in runs.
+    - ${{ if and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'BatchedCI')) }}:
+      - stage: build
+        displayName: Build
+        jobs:
+        ############### HELIX JOB MONITOR ###############
+        - ${{ if eq(variables['runInTestMode'], 'true') }}:
+          - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
+            parameters:
+              helixAccessToken: $(HelixApiAccessToken)
+
+        ############### WINDOWS ###############
+        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
           parameters:
-            helixAccessToken: $(HelixApiAccessToken)
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: windows.vs2026.amd64
+              os: windows
+            helixTargetQueue: windows.amd64.vs2026.pre.scout
+            oneESCompat:
+              templateFolderName: templates-official
+              publishTaskPrefix: 1ES.
+            runTests: ${{ eq(variables['runInTestMode'], 'true') }}
+            populateInternalRuntimeVariables: true
+            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+            locBranch: release/10.0.3xx
+            # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+            preSteps:
+            - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
+              displayName: Create artifacts/bin directory
+            ${{ if and(eq(parameters.forceTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
+              additionalWindowsJobParameterSets:
+              # Note: This job is only used to allow the test templates to be built locally on the agent as opposed to Helix.
+              # The tests acquire the templates' PackageReferences from NuGet, which allows them to be scanned by CG (component governance).
+              # CG is only run internally, so this job runs only in CG mode.
+              - categoryName: TestTemplatesCG
+                runTests: true
+                testExecutionMode: local
+                testProjects: $(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+                testFilter: FullyQualifiedName~Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
 
-      ############### WINDOWS ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-        parameters:
-          pool:
-            name: $(DncEngInternalBuildPool)
-            image: windows.vs2026.amd64
-            os: windows
-          helixTargetQueue: windows.amd64.vs2026.pre.scout
-          oneESCompat:
-            templateFolderName: templates-official
-            publishTaskPrefix: 1ES.
-          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
-          populateInternalRuntimeVariables: true
-          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-          locBranch: release/10.0.3xx
-          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
-          preSteps:
-          - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
-            displayName: Create artifacts/bin directory
-          ${{ if and(eq(parameters.forceTestBuild, false), eq(variables['runInCompleteCgMode'], 'true')) }}:
-            additionalWindowsJobParameterSets:
-            # Note: This job is only used to allow the test templates to be built locally on the agent as opposed to Helix.
-            # The tests acquire the templates' PackageReferences from NuGet, which allows them to be scanned by CG (component governance).
-            # CG is only run internally, so this job runs only in CG mode.
-            - categoryName: TestTemplatesCG
-              runTests: true
-              testExecutionMode: local
-              testProjects: $(Build.SourcesDirectory)/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
-              testFilter: FullyQualifiedName~Microsoft.DotNet.Cli.New.IntegrationTests.DotnetNewTestTemplatesTests
+        ############### LINUX ###############
+        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+          parameters:
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: build.azurelinux.3.amd64
+              os: linux
+            helixTargetQueue: ubuntu.2204.amd64
+            oneESCompat:
+              templateFolderName: templates-official
+              publishTaskPrefix: 1ES.
+            runTests: ${{ eq(variables['runInTestMode'], 'true') }}
+            populateInternalRuntimeVariables: true
+            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
 
-      ############### LINUX ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-        parameters:
-          pool:
-            name: $(DncEngInternalBuildPool)
-            image: build.azurelinux.3.amd64
-            os: linux
-          helixTargetQueue: ubuntu.2204.amd64
-          oneESCompat:
-            templateFolderName: templates-official
-            publishTaskPrefix: 1ES.
-          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
-          populateInternalRuntimeVariables: true
-          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
-      ############### MACOS ###############
-      - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
-        parameters:
-          pool:
-            name: Azure Pipelines
-            image: macOS-latest
-            os: macOS
-          helixTargetQueue: osx.15.arm64
-          oneESCompat:
-            templateFolderName: templates-official
-            publishTaskPrefix: 1ES.
-          runTests: ${{ eq(variables['runInTestMode'], 'true') }}
-          populateInternalRuntimeVariables: true
-          runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+        ############### MACOS ###############
+        - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
+          parameters:
+            pool:
+              name: Azure Pipelines
+              image: macOS-latest
+              os: macOS
+            helixTargetQueue: osx.15.arm64
+            oneESCompat:
+              templateFolderName: templates-official
+              publishTaskPrefix: 1ES.
+            runTests: ${{ eq(variables['runInTestMode'], 'true') }}
+            populateInternalRuntimeVariables: true
+            runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
 
     ############### PUBLISH STAGE ###############
-    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'), eq(parameters.forcePublish, true)) }}:
       - stage: publish
         displayName: Publish
         dependsOn: []


### PR DESCRIPTION
## Summary

Stops running build jobs on official check-in CI runs, while preserving publish behavior needed for source-flow.

This updates `.vsts-ci.yml` so that:

- **Build stage** runs only for non-check-in reasons (not `IndividualCI` / `BatchedCI`)
- **Publish stage** runs for:
  - `IndividualCI`
  - `BatchedCI`
  - manual runs with `forcePublish: true`

Also adds a new pipeline parameter:

- `forcePublish` (default `false`) to allow testing publish logic without editing pipeline conditions.

## Why

Official check-in runs primarily need to publish assets for flow, and running full build legs there is unnecessary compute.
This change reduces redundant build execution while still allowing explicit publish validation paths.

## Issue

Fixes dotnet/sdk#55544