### PR TITLE
[dotnet test][MTP] Don't replay live output in the exit-code summary

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -207,14 +207,7 @@ internal sealed class TestApplication(
             }
 
             var exitCode = process.ExitCode;
-            var capturedOutput = stdOutBuilder.GetCapturedOutput();
-            var capturedError = stdErrBuilder.GetCapturedOutput();
-            _handler.OnTestProcessExited(
-                exitCode,
-                capturedOutput.Output,
-                capturedError.Output,
-                capturedOutput.WasStreamedLive,
-                capturedError.WasStreamedLive);
+            _handler.OnTestProcessExited(exitCode, stdOutBuilder.GetOutputToReport(), stdErrBuilder.GetOutputToReport());
 
             // This condition is to prevent considering the test app as successful when we didn't receive test session end.
             // We don't produce the exception if the exit code is already non-zero to avoid surfacing this exception when there is already a known failure.
@@ -761,23 +754,22 @@ internal sealed class TestApplication(
         }
 
         /// <summary>
-        /// Returns the captured tail of the stream, together with whether that content already
-        /// reached the terminal as live output.
+        /// Returns the captured tail of the stream for the caller to report, or an empty string when
+        /// that content already reached the terminal as live output.
         /// </summary>
         /// <remarks>
-        /// Both values are read under the same lock so callers cannot pair output with a stale
-        /// streaming state. <c>WasStreamedLive</c> is <see langword="true"/> only once live
-        /// streaming actually engaged for this stream; when it does, everything buffered so far is
-        /// flushed in the same step, so the whole capture - including lines later evicted by
-        /// <see cref="TrimToBoundedTail"/> - has been shown. Callers must therefore not replay the
-        /// output on the terminal in that case, while diagnostics that only record it (trace
-        /// logging) still want the full text.
+        /// Live streaming engages only once for a stream, and everything buffered up to that point is
+        /// flushed in the same step, so from then on the whole capture - including lines later evicted
+        /// by <see cref="TrimToBoundedTail"/> - has been shown. Reporting it again would print it twice
+        /// (https://github.com/dotnet/sdk/issues/55549). Until streaming engages the capture is the only
+        /// copy there is, so it is returned in full: older Microsoft.Testing.Platform versions that
+        /// don't negotiate protocol 1.1.0, and processes that fail before the handshake, depend on it.
         /// </remarks>
-        public (string Output, bool WasStreamedLive) GetCapturedOutput()
+        public string GetOutputToReport()
         {
             lock (_lock)
             {
-                return (string.Join(Environment.NewLine, _lines), _liveStreamingEnabled);
+                return _liveStreamingEnabled ? string.Empty : string.Join(Environment.NewLine, _lines);
             }
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -703,18 +703,24 @@ internal sealed class TestApplication(
             lock (_lock)
             {
                 _lines.Enqueue(line);
-                if (liveOutputStreamingState != true)
-                {
-                    return;
-                }
 
                 string outputToWrite;
                 if (_liveStreamingEnabled)
                 {
+                    // The caller sampled the streaming state before taking this lock, so it can be
+                    // stale: negotiation may have enabled streaming in between. Once streaming is on
+                    // it never turns back off, and the capture is reported as already shown, so this
+                    // line has to be written even when the stale sample says otherwise - skipping it
+                    // would drop it from the terminal entirely.
                     outputToWrite = line + Environment.NewLine;
                 }
                 else
                 {
+                    if (liveOutputStreamingState != true)
+                    {
+                        return;
+                    }
+
                     _liveStreamingEnabled = true;
                     outputToWrite = JoinLinesWithTrailingNewLine(_lines);
                 }

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -207,7 +207,14 @@ internal sealed class TestApplication(
             }
 
             var exitCode = process.ExitCode;
-            _handler.OnTestProcessExited(exitCode, stdOutBuilder.GetOutput(), stdErrBuilder.GetOutput());
+            var capturedOutput = stdOutBuilder.GetCapturedOutput();
+            var capturedError = stdErrBuilder.GetCapturedOutput();
+            _handler.OnTestProcessExited(
+                exitCode,
+                capturedOutput.Output,
+                capturedError.Output,
+                capturedOutput.WasStreamedLive,
+                capturedError.WasStreamedLive);
 
             // This condition is to prevent considering the test app as successful when we didn't receive test session end.
             // We don't produce the exception if the exit code is already non-zero to avoid surfacing this exception when there is already a known failure.
@@ -680,7 +687,7 @@ internal sealed class TestApplication(
     private void OnDisplayMessage(DisplayMessage displayMessage)
         => _handler.OnDisplayMessageReceived(displayMessage);
 
-    private sealed class ProcessOutputCollector(int liveOutputTailLineCount, Action<string> writeOutput)
+    internal sealed class ProcessOutputCollector(int liveOutputTailLineCount, Action<string> writeOutput)
     {
         private readonly object _lock = new();
         private readonly Queue<string> _lines = [];
@@ -688,56 +695,73 @@ internal sealed class TestApplication(
 
         public void AddLine(string line, bool? liveOutputStreamingState)
         {
-            string? outputToWrite = null;
+            // The write happens while the lock is held on purpose. Releasing it first lets this
+            // reader thread and the protocol-negotiation flush race, which can put a later line on
+            // the terminal ahead of the buffered lines that precede it. Live output is the only
+            // copy the user gets, so its order has to match the order the test process produced it
+            // in. Nothing reached from writeOutput takes this lock back, so holding it is safe.
             lock (_lock)
             {
                 _lines.Enqueue(line);
-                if (liveOutputStreamingState == true)
+                if (liveOutputStreamingState != true)
                 {
-                    if (_liveStreamingEnabled)
-                    {
-                        outputToWrite = line + Environment.NewLine;
-                    }
-                    else
-                    {
-                        _liveStreamingEnabled = true;
-                        outputToWrite = JoinLinesWithTrailingNewLine(_lines);
-                    }
-
-                    TrimToBoundedTail();
+                    return;
                 }
-            }
 
-            if (outputToWrite is not null)
-            {
+                string outputToWrite;
+                if (_liveStreamingEnabled)
+                {
+                    outputToWrite = line + Environment.NewLine;
+                }
+                else
+                {
+                    _liveStreamingEnabled = true;
+                    outputToWrite = JoinLinesWithTrailingNewLine(_lines);
+                }
+
+                TrimToBoundedTail();
                 writeOutput(outputToWrite);
             }
         }
 
         public void FlushBufferedOutputIfLiveStreamingEnabled(bool? liveOutputStreamingState)
         {
-            string? outputToWrite = null;
             lock (_lock)
             {
-                if (liveOutputStreamingState == true && !_liveStreamingEnabled)
+                if (liveOutputStreamingState != true || _liveStreamingEnabled)
                 {
-                    _liveStreamingEnabled = true;
-                    outputToWrite = JoinLinesWithTrailingNewLine(_lines);
-                    TrimToBoundedTail();
+                    return;
                 }
-            }
 
-            if (!string.IsNullOrEmpty(outputToWrite))
-            {
-                writeOutput(outputToWrite);
+                _liveStreamingEnabled = true;
+                string outputToWrite = JoinLinesWithTrailingNewLine(_lines);
+                TrimToBoundedTail();
+
+                if (outputToWrite.Length > 0)
+                {
+                    writeOutput(outputToWrite);
+                }
             }
         }
 
-        public string GetOutput()
+        /// <summary>
+        /// Returns the captured tail of the stream, together with whether that content already
+        /// reached the terminal as live output.
+        /// </summary>
+        /// <remarks>
+        /// Both values are read under the same lock so callers cannot pair output with a stale
+        /// streaming state. <see cref="WasStreamedLive"/> is <see langword="true"/> only once live
+        /// streaming actually engaged for this stream; when it does, everything buffered so far is
+        /// flushed in the same step, so the whole capture - including lines later evicted by
+        /// <see cref="TrimToBoundedTail"/> - has been shown. Callers must therefore not replay the
+        /// output on the terminal in that case, while diagnostics that only record it (trace
+        /// logging) still want the full text.
+        /// </remarks>
+        public (string Output, bool WasStreamedLive) GetCapturedOutput()
         {
             lock (_lock)
             {
-                return string.Join(Environment.NewLine, _lines);
+                return (string.Join(Environment.NewLine, _lines), _liveStreamingEnabled);
             }
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -689,59 +689,69 @@ internal sealed class TestApplication(
 
     internal sealed class ProcessOutputCollector(int liveOutputTailLineCount, Action<string> writeOutput)
     {
+        // Serializes "decide what to write, then write it" so live output reaches the terminal in the
+        // order the test process produced it. Without it the protocol-negotiation flush and a reader
+        // thread can interleave and put a later line ahead of the buffered lines that precede it, and
+        // live output is the only copy the user gets. This is deliberately separate from _lock so a
+        // capture read never waits on terminal IO - RunAsync reads the capture on a timeout path that
+        // exists precisely because a reader may be stuck. Always taken before _lock, never after.
+        private readonly object _writeLock = new();
         private readonly object _lock = new();
         private readonly Queue<string> _lines = [];
         private bool _liveStreamingEnabled;
 
         public void AddLine(string line, bool? liveOutputStreamingState)
         {
-            // The write happens while the lock is held on purpose. Releasing it first lets this
-            // reader thread and the protocol-negotiation flush race, which can put a later line on
-            // the terminal ahead of the buffered lines that precede it. Live output is the only
-            // copy the user gets, so its order has to match the order the test process produced it
-            // in. Nothing reached from writeOutput takes this lock back, so holding it is safe.
-            lock (_lock)
+            lock (_writeLock)
             {
-                _lines.Enqueue(line);
-
                 string outputToWrite;
-                if (_liveStreamingEnabled)
+                lock (_lock)
                 {
-                    // The caller sampled the streaming state before taking this lock, so it can be
-                    // stale: negotiation may have enabled streaming in between. Once streaming is on
-                    // it never turns back off, and the capture is reported as already shown, so this
-                    // line has to be written even when the stale sample says otherwise - skipping it
-                    // would drop it from the terminal entirely.
-                    outputToWrite = line + Environment.NewLine;
-                }
-                else
-                {
-                    if (liveOutputStreamingState != true)
+                    _lines.Enqueue(line);
+
+                    if (_liveStreamingEnabled)
                     {
-                        return;
+                        // The caller sampled the streaming state before taking this lock, so it can be
+                        // stale: negotiation may have enabled streaming in between. Once streaming is on
+                        // it never turns back off, and the capture is reported as already shown, so this
+                        // line has to be written even when the stale sample says otherwise - skipping it
+                        // would drop it from the terminal entirely.
+                        outputToWrite = line + Environment.NewLine;
+                    }
+                    else
+                    {
+                        if (liveOutputStreamingState != true)
+                        {
+                            return;
+                        }
+
+                        _liveStreamingEnabled = true;
+                        outputToWrite = JoinLinesWithTrailingNewLine(_lines);
                     }
 
-                    _liveStreamingEnabled = true;
-                    outputToWrite = JoinLinesWithTrailingNewLine(_lines);
+                    TrimToBoundedTail();
                 }
 
-                TrimToBoundedTail();
                 writeOutput(outputToWrite);
             }
         }
 
         public void FlushBufferedOutputIfLiveStreamingEnabled(bool? liveOutputStreamingState)
         {
-            lock (_lock)
+            lock (_writeLock)
             {
-                if (liveOutputStreamingState != true || _liveStreamingEnabled)
+                string outputToWrite;
+                lock (_lock)
                 {
-                    return;
-                }
+                    if (liveOutputStreamingState != true || _liveStreamingEnabled)
+                    {
+                        return;
+                    }
 
-                _liveStreamingEnabled = true;
-                string outputToWrite = JoinLinesWithTrailingNewLine(_lines);
-                TrimToBoundedTail();
+                    _liveStreamingEnabled = true;
+                    outputToWrite = JoinLinesWithTrailingNewLine(_lines);
+                    TrimToBoundedTail();
+                }
 
                 if (outputToWrite.Length > 0)
                 {
@@ -756,7 +766,7 @@ internal sealed class TestApplication(
         /// </summary>
         /// <remarks>
         /// Both values are read under the same lock so callers cannot pair output with a stale
-        /// streaming state. <see cref="WasStreamedLive"/> is <see langword="true"/> only once live
+        /// streaming state. <c>WasStreamedLive</c> is <see langword="true"/> only once live
         /// streaming actually engaged for this stream; when it does, everything buffered so far is
         /// flushed in the same step, so the whole capture - including lines later evicted by
         /// <see cref="TrimToBoundedTail"/> - has been shown. Callers must therefore not replay the

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -207,7 +207,22 @@ internal sealed class TestApplication(
             }
 
             var exitCode = process.ExitCode;
-            _handler.OnTestProcessExited(exitCode, stdOutBuilder.GetOutputToReport(), stdErrBuilder.GetOutputToReport());
+            string outputToReport = stdOutBuilder.GetOutputToReport();
+            string errorToReport = stdErrBuilder.GetOutputToReport();
+
+            // Output that was streamed live is not reported again - it is already on the terminal, and
+            // replaying it printed everything twice (https://github.com/dotnet/sdk/issues/55549). The trace
+            // file has no console sink and is collected on its own, though, so it would silently lose that
+            // output. Record it here, where the full capture is still available, for the streams the
+            // handler is not going to log. Guarded so nothing is materialized unless tracing is enabled,
+            // which it is not by default.
+            if (Logger.TraceEnabled)
+            {
+                LogStreamedProcessOutput("Output Data", outputToReport, stdOutBuilder);
+                LogStreamedProcessOutput("Error Data", errorToReport, stdErrBuilder);
+            }
+
+            _handler.OnTestProcessExited(exitCode, outputToReport, errorToReport);
 
             // This condition is to prevent considering the test app as successful when we didn't receive test session end.
             // We don't produce the exception if the exit code is already non-zero to avoid surfacing this exception when there is already a known failure.
@@ -639,6 +654,25 @@ internal sealed class TestApplication(
     private bool? GetLiveOutputStreamingState() =>
         Volatile.Read(ref _protocolNegotiated) == 0 ? null : IsProtocol_1_1_OrHigher;
 
+    /// <summary>
+    /// Records process output that is not being reported to the user because it already reached the
+    /// terminal as live output, so that an enabled trace file still contains it.
+    /// </summary>
+    private static void LogStreamedProcessOutput(string label, string reportedOutput, ProcessOutputCollector collector)
+    {
+        if (reportedOutput.Length > 0)
+        {
+            // The output is being reported, so the handler traces it as usual.
+            return;
+        }
+
+        string capturedOutput = collector.GetCapturedOutput();
+        if (capturedOutput.Length > 0)
+        {
+            Logger.LogTrace($"{label} (already streamed live): {capturedOutput}");
+        }
+    }
+
     private void FlushBufferedOutputIfLiveStreamingEnabled()
     {
         bool? liveOutputStreamingState = GetLiveOutputStreamingState();
@@ -770,6 +804,19 @@ internal sealed class TestApplication(
             lock (_lock)
             {
                 return _liveStreamingEnabled ? string.Empty : string.Join(Environment.NewLine, _lines);
+            }
+        }
+
+        /// <summary>
+        /// Returns the captured tail of the stream whether or not it was already streamed live. Only for
+        /// diagnostics that record the output without showing it to the user - anything rendered on the
+        /// terminal must go through <see cref="GetOutputToReport"/> instead, or it will be printed twice.
+        /// </summary>
+        public string GetCapturedOutput()
+        {
+            lock (_lock)
+            {
+                return string.Join(Environment.NewLine, _lines);
             }
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -613,12 +613,22 @@ internal sealed class TestApplicationHandler
         }
     }
 
-    internal void OnTestProcessExited(int exitCode, string outputData, string errorData)
+    internal void OnTestProcessExited(int exitCode, string outputData, string errorData, bool outputAlreadyStreamedLive = false, bool errorAlreadyStreamedLive = false)
     {
+        // Output that was streamed to the terminal as the test process produced it is already on
+        // screen, so the summaries below must not replay it - doing so printed every captured line
+        // twice for any run that ended with a non-zero exit code (https://github.com/dotnet/sdk/issues/55549).
+        // When live streaming never engaged (older Microsoft.Testing.Platform versions that don't
+        // negotiate protocol 1.1.0, or a process that failed before the handshake) these summaries
+        // remain the only place the output is shown, so it is still passed through. Trace logging
+        // always receives the full captured text regardless.
+        string summaryOutputData = outputAlreadyStreamedLive ? string.Empty : outputData;
+        string summaryErrorData = errorAlreadyStreamedLive ? string.Empty : errorData;
+
         if (_options.IsArtifactPostProcessing)
         {
-            WriteMessage(outputData);
-            WriteMessage(errorData);
+            WriteMessage(summaryOutputData);
+            WriteMessage(summaryErrorData);
             LogTestProcessExit(exitCode, outputData, errorData);
             return;
         }
@@ -627,11 +637,11 @@ internal sealed class TestApplicationHandler
         {
             // If we received a handshake from TestHostController but not from TestHost,
             // call HandshakeFailure instead of AssemblyRunCompleted
-            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
+            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, summaryOutputData, summaryErrorData);
         }
         else
         {
-            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
+            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, summaryOutputData, summaryErrorData);
         }
 
         LogTestProcessExit(exitCode, outputData, errorData);

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -613,22 +613,12 @@ internal sealed class TestApplicationHandler
         }
     }
 
-    internal void OnTestProcessExited(int exitCode, string outputData, string errorData, bool outputAlreadyStreamedLive = false, bool errorAlreadyStreamedLive = false)
+    internal void OnTestProcessExited(int exitCode, string outputData, string errorData)
     {
-        // Output that was streamed to the terminal as the test process produced it is already on
-        // screen, so the summaries below must not replay it - doing so printed every captured line
-        // twice for any run that ended with a non-zero exit code (https://github.com/dotnet/sdk/issues/55549).
-        // When live streaming never engaged (older Microsoft.Testing.Platform versions that don't
-        // negotiate protocol 1.1.0, or a process that failed before the handshake) these summaries
-        // remain the only place the output is shown, so it is still passed through. Trace logging
-        // always receives the full captured text regardless.
-        string summaryOutputData = outputAlreadyStreamedLive ? string.Empty : outputData;
-        string summaryErrorData = errorAlreadyStreamedLive ? string.Empty : errorData;
-
         if (_options.IsArtifactPostProcessing)
         {
-            WriteMessage(summaryOutputData);
-            WriteMessage(summaryErrorData);
+            WriteMessage(outputData);
+            WriteMessage(errorData);
             LogTestProcessExit(exitCode, outputData, errorData);
             return;
         }
@@ -637,11 +627,11 @@ internal sealed class TestApplicationHandler
         {
             // If we received a handshake from TestHostController but not from TestHost,
             // call HandshakeFailure instead of AssemblyRunCompleted
-            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, summaryOutputData, summaryErrorData);
+            _output.AssemblyRunCompleted(_handshakeInfo.Value.ExecutionId, exitCode, outputData, errorData);
         }
         else
         {
-            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, summaryOutputData, summaryErrorData);
+            _output.HandshakeFailure(_module.TargetPath ?? _module.ProjectFullPath ?? string.Empty, _module.TargetFramework, exitCode, outputData, errorData);
         }
 
         LogTestProcessExit(exitCode, outputData, errorData);

--- a/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/Program.cs
+++ b/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/Program.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());
+
+using var testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+	public string Uid => nameof(DummyTestAdapter);
+
+	public string Version => "2.0.0";
+
+	public string DisplayName => nameof(DummyTestAdapter);
+
+	public string Description => nameof(DummyTestAdapter);
+
+	public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+	public Type[] DataTypesProduced => new[] {
+		typeof(TestNodeUpdateMessage)
+	};
+
+	public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+		=> Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+	public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+		=> Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+	public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+	{
+		// The failing test below makes this app exit with a non-zero exit code, which is what makes
+		// 'dotnet test' render its exit code summary. That summary used to replay the console output
+		// captured below even though it had already been forwarded live, printing every line twice.
+		Console.WriteLine("FAILING_RUN_STANDARD_OUTPUT");
+		Console.Error.WriteLine("FAILING_RUN_STANDARD_ERROR");
+
+		await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+		{
+			Uid = "Test0",
+			DisplayName = "Test0",
+			Properties = new PropertyBag(new FailedTestNodeStateProperty("Intentional failure")),
+		}));
+
+		context.Complete();
+	}
+}

--- a/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/TestProjectWithFailingTestAndConsoleOutput.csproj
+++ b/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/TestProjectWithFailingTestAndConsoleOutput.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+	<PropertyGroup>
+		<TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+		<OutputType>Exe</OutputType>
+
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+		<IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+	</ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/global.json
+++ b/test/TestAssets/TestProjects/TestProjectWithFailingTestAndConsoleOutput/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -21,6 +21,8 @@ public class GivenDotnetTestForwardsTestHostOutput : SdkTest
     private const string OutputDeviceWarningMarker = "LIVE_OUTPUT_WARNING_MESSAGE";
     private const string OutputDeviceErrorMarker = "LIVE_OUTPUT_ERROR_MESSAGE";
     private const string OutputBeforeHandshakeMarker = "OUTPUT_BEFORE_HANDSHAKE";
+    private const string FailingRunStandardOutputMarker = "FAILING_RUN_STANDARD_OUTPUT";
+    private const string FailingRunStandardErrorMarker = "FAILING_RUN_STANDARD_ERROR";
 
     [DataRow(TestingConstants.Debug)]
     [DataRow(TestingConstants.Release)]
@@ -131,5 +133,49 @@ public class GivenDotnetTestForwardsTestHostOutput : SdkTest
         }
 
         result.ExitCode.Should().Be(ExitCodes.Success);
+    }
+
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/55549. A non-zero exit code makes
+    /// 'dotnet test' render its exit code summary, which used to replay the whole captured standard
+    /// output and error even though live output had already shown them, so every line appeared twice.
+    /// </summary>
+    [DataRow(TestingConstants.Debug)]
+    [DataRow(TestingConstants.Release)]
+    [TestMethod]
+    public void RunFailingTestProjectWritingToConsole_ShouldNotAlsoReplayTheOutputInTheExitCodeSummary(string configuration)
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithFailingTestAndConsoleOutput", Guid.NewGuid().ToString())
+            .WithSource();
+
+        CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                                .WithWorkingDirectory(testInstance.Path)
+                                .Execute("-c", configuration);
+
+        // Exactly once: the live stream is the complete copy and the only one the user needs. The
+        // summary's copy is additionally lossy (it is truncated for long output), so it is the one
+        // that has to go.
+        CountOccurrences(result.StdOut, FailingRunStandardOutputMarker).Should().Be(1);
+        CountOccurrences(result.StdOut, FailingRunStandardErrorMarker).Should().Be(1);
+
+        result.ExitCode.Should().NotBe(ExitCodes.Success);
+    }
+
+    private static int CountOccurrences(string? text, string value)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        int count = 0;
+        int index = text.IndexOf(value, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(value, index + value.Length, StringComparison.Ordinal);
+        }
+
+        return count;
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestForwardsTestHostOutput.cs
@@ -158,6 +158,16 @@ public class GivenDotnetTestForwardsTestHostOutput : SdkTest
         CountOccurrences(result.StdOut, FailingRunStandardOutputMarker).Should().Be(1);
         CountOccurrences(result.StdOut, FailingRunStandardErrorMarker).Should().Be(1);
 
+        // ...and that single copy has to be the live one. Live output is written verbatim, so the marker
+        // sits alone on its line, whereas the summary folds it into an indented "<label>: <output>" line.
+        // Without this the assertion above would also pass against a host that never streams at all, which
+        // would silently stop exercising the regression. Comparing trimmed lines keeps it locale-agnostic.
+        string[] trimmedLines = [.. (result.StdOut ?? string.Empty).Split('\n').Select(line => line.Trim())];
+        trimmedLines.Should().Contain(FailingRunStandardOutputMarker,
+            "the marker must be the live copy, not folded into the exit code summary");
+        trimmedLines.Should().Contain(FailingRunStandardErrorMarker,
+            "the marker must be the live copy, not folded into the exit code summary");
+
         result.ExitCode.Should().NotBe(ExitCodes.Success);
     }
 

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -32,10 +32,7 @@ public class ProcessOutputCollectorTests
         collector.AddLine("second", liveOutputStreamingState: null);
 
         written.Should().BeEmpty();
-
-        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
-        wasStreamedLive.Should().BeFalse();
-        output.Should().Be($"first{Environment.NewLine}second");
+        collector.GetOutputToReport().Should().Be($"first{Environment.NewLine}second");
     }
 
     /// <summary>
@@ -51,18 +48,15 @@ public class ProcessOutputCollectorTests
         collector.AddLine("first", liveOutputStreamingState: false);
 
         written.Should().BeEmpty();
-
-        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
-        wasStreamedLive.Should().BeFalse();
-        output.Should().Be("first");
+        collector.GetOutputToReport().Should().Be("first");
     }
 
     /// <summary>
     /// Once streaming engages the whole buffer is flushed, so every line the process produced has been
-    /// shown and the capture must be reported as already streamed.
+    /// shown and nothing is left for the caller to report.
     /// </summary>
     [TestMethod]
-    public void AddLine_WhenStreamingEngages_FlushesTheBufferOnceAndReportsCaptureAsStreamed()
+    public void AddLine_WhenStreamingEngages_FlushesTheBufferOnceAndReportsNothing()
     {
         var written = new List<string>();
         var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
@@ -74,7 +68,7 @@ public class ProcessOutputCollectorTests
         string.Concat(written).Should().Be(
             $"buffered-before-handshake{Environment.NewLine}first-streamed{Environment.NewLine}second-streamed{Environment.NewLine}");
 
-        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+        collector.GetOutputToReport().Should().BeEmpty();
     }
 
     /// <summary>
@@ -94,7 +88,7 @@ public class ProcessOutputCollectorTests
         collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
 
         written.Should().ContainSingle().Which.Should().Be($"buffered-before-handshake{Environment.NewLine}");
-        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+        collector.GetOutputToReport().Should().BeEmpty();
     }
 
     /// <summary>
@@ -110,12 +104,15 @@ public class ProcessOutputCollectorTests
         collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
 
         written.Should().BeEmpty();
-        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+
+        collector.AddLine("produced-after-the-flush", liveOutputStreamingState: true);
+        string.Concat(written).Should().Be($"produced-after-the-flush{Environment.NewLine}");
+        collector.GetOutputToReport().Should().BeEmpty();
     }
 
     /// <summary>
     /// The capture is trimmed to a bounded tail once streaming engages, so it is a strict subset of what
-    /// was already shown. That is exactly why the summary must not replay it.
+    /// was already shown. That is exactly why there is nothing left to report.
     /// </summary>
     [TestMethod]
     public void AddLine_WhenStreaming_KeepsOnlyTheBoundedTailButStreamsEveryLine()
@@ -133,9 +130,7 @@ public class ProcessOutputCollectorTests
             string.Concat(written).Should().Contain($"line{i}");
         }
 
-        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
-        wasStreamedLive.Should().BeTrue();
-        output.Should().Be($"line3{Environment.NewLine}line4{Environment.NewLine}line5");
+        collector.GetOutputToReport().Should().BeEmpty();
     }
 
     /// <summary>
@@ -158,7 +153,7 @@ public class ProcessOutputCollectorTests
         string.Concat(written).Should().Be(
             $"sampled-before-negotiation{Environment.NewLine}sampled-as-non-streaming{Environment.NewLine}");
 
-        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+        collector.GetOutputToReport().Should().BeEmpty();
     }
 
     /// <summary>
@@ -232,7 +227,7 @@ public class ProcessOutputCollectorTests
     /// then block behind an in-flight write.
     /// </summary>
     [TestMethod]
-    public void GetCapturedOutput_WhileALineIsBeingWritten_DoesNotWaitForTheWriteToComplete()
+    public void GetOutputToReport_WhileALineIsBeingWritten_DoesNotWaitForTheWriteToComplete()
     {
         TestApplication.ProcessOutputCollector? collector = null;
 
@@ -262,8 +257,7 @@ public class ProcessOutputCollectorTests
             // up as a failed join here. Reading on this thread instead would deadlock until the callback's
             // own timeout released it, and the test would then still pass - just far more slowly.
             string? output = null;
-            bool wasStreamedLive = false;
-            var captureThread = new Thread(() => (output, wasStreamedLive) = collector.GetCapturedOutput())
+            var captureThread = new Thread(() => output = collector.GetOutputToReport())
             {
                 // Background so a thread left blocked by a regression cannot keep the test host alive.
                 IsBackground = true,
@@ -273,8 +267,7 @@ public class ProcessOutputCollectorTests
             captureThread.Join(TimeSpan.FromSeconds(15))
                 .Should().BeTrue("reading the capture must not wait for an in-flight terminal write");
 
-            output.Should().Be("blocked-line");
-            wasStreamedLive.Should().BeTrue();
+            output.Should().BeEmpty("the line being written is already reaching the terminal");
         }
         finally
         {

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -191,7 +191,11 @@ public class ProcessOutputCollectorTests
                     readerEnteredAddLine.Set();
                     collector!.AddLine("produced-second", liveOutputStreamingState: true);
                     readerCompletedAddLine.Set();
-                });
+                })
+                {
+                    // Background so a thread left blocked by a regression cannot keep the test host alive.
+                    IsBackground = true,
+                };
                 readerThread.Start();
 
                 // Wait for the reader to be running and about to call AddLine, so the probe below is not
@@ -243,14 +247,32 @@ public class ProcessOutputCollectorTests
             releaseWrite.Wait(TimeSpan.FromSeconds(30), cancellationToken);
         });
 
-        var writerThread = new Thread(() => collector.AddLine("blocked-line", liveOutputStreamingState: true));
+        var writerThread = new Thread(() => collector.AddLine("blocked-line", liveOutputStreamingState: true))
+        {
+            // Background so a thread left blocked by a regression cannot keep the test host alive.
+            IsBackground = true,
+        };
         writerThread.Start();
 
         try
         {
             writeStarted.Wait(TimeSpan.FromSeconds(30), cancellationToken).Should().BeTrue();
 
-            (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
+            // The read runs on its own thread so a regression that puts it behind the blocked write shows
+            // up as a failed join here. Reading on this thread instead would deadlock until the callback's
+            // own timeout released it, and the test would then still pass - just far more slowly.
+            string? output = null;
+            bool wasStreamedLive = false;
+            var captureThread = new Thread(() => (output, wasStreamedLive) = collector.GetCapturedOutput())
+            {
+                // Background so a thread left blocked by a regression cannot keep the test host alive.
+                IsBackground = true,
+            };
+            captureThread.Start();
+
+            captureThread.Join(TimeSpan.FromSeconds(15))
+                .Should().BeTrue("reading the capture must not wait for an in-flight terminal write");
+
             output.Should().Be("blocked-line");
             wasStreamedLive.Should().BeTrue();
         }

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -137,6 +137,29 @@ public class ProcessOutputCollectorTests
     }
 
     /// <summary>
+    /// The reader thread samples the streaming state before it takes the collector's lock, so the value
+    /// it passes can be stale: the protocol-negotiation flush may have enabled streaming in between. The
+    /// line still has to be written, because the capture is now reported as already shown and the summary
+    /// suppresses it - skipping it would drop it from the terminal entirely.
+    /// </summary>
+    [TestMethod]
+    public void AddLine_WithAStaleStreamingStateAfterStreamingEngaged_StillWritesTheLine()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
+
+        collector.AddLine("sampled-before-negotiation", liveOutputStreamingState: null);
+        collector.AddLine("sampled-as-non-streaming", liveOutputStreamingState: false);
+
+        string.Concat(written).Should().Be(
+            $"sampled-before-negotiation{Environment.NewLine}sampled-as-non-streaming{Environment.NewLine}");
+
+        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+    }
+
+    /// <summary>
     /// The buffered lines have to reach the terminal in the order the process produced them. The flush
     /// (driven by protocol negotiation on the pipe thread) and the stdout reader run concurrently, so the
     /// write cannot happen after the collector's lock is released: a line added in that window would be

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -157,6 +157,23 @@ public class ProcessOutputCollectorTests
     }
 
     /// <summary>
+    /// The diagnostics accessor keeps returning the capture after it was streamed. The trace file has no
+    /// console sink and is collected on its own, so it would otherwise silently lose output that only ever
+    /// went to the terminal.
+    /// </summary>
+    [TestMethod]
+    public void GetCapturedOutput_AfterStreamingEngaged_StillReturnsTheCapture()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.AddLine("streamed-line", liveOutputStreamingState: true);
+
+        collector.GetOutputToReport().Should().BeEmpty("it is already on the terminal");
+        collector.GetCapturedOutput().Should().Be("streamed-line", "diagnostics still need the text");
+    }
+
+    /// <summary>
     /// The buffered lines have to reach the terminal in the order the process produced them. The flush
     /// (driven by protocol negotiation on the pipe thread) and the stdout reader run concurrently, so the
     /// write cannot happen once the ordering lock is released: a line added in that window would be

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -1,0 +1,184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+/// <summary>
+/// Regression coverage for https://github.com/dotnet/sdk/issues/55549. The collector both streams
+/// the test application's output to the terminal as it is produced and keeps a bounded tail for the
+/// failure summaries. It has to tell those two consumers apart, otherwise everything it streamed is
+/// printed a second time by the summary.
+/// </summary>
+[TestClass]
+public class ProcessOutputCollectorTests
+{
+    private const int TailLineCount = 3;
+
+    /// <summary>
+    /// Before the protocol version is known the streaming state is <see langword="null"/>: nothing may
+    /// reach the terminal yet, and the capture has to stay available so a failure summary can show it.
+    /// </summary>
+    [TestMethod]
+    public void AddLine_BeforeProtocolIsNegotiated_BuffersWithoutWriting()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.AddLine("first", liveOutputStreamingState: null);
+        collector.AddLine("second", liveOutputStreamingState: null);
+
+        written.Should().BeEmpty();
+
+        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
+        wasStreamedLive.Should().BeFalse();
+        output.Should().Be($"first{Environment.NewLine}second");
+    }
+
+    /// <summary>
+    /// Protocol 1.0.0 hosts never stream, so the summary stays the only place their output is shown.
+    /// Suppression must key off whether streaming actually happened, not off "a protocol was negotiated".
+    /// </summary>
+    [TestMethod]
+    public void AddLine_WhenNegotiatedProtocolDoesNotSupportStreaming_BuffersWithoutWriting()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.AddLine("first", liveOutputStreamingState: false);
+
+        written.Should().BeEmpty();
+
+        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
+        wasStreamedLive.Should().BeFalse();
+        output.Should().Be("first");
+    }
+
+    /// <summary>
+    /// Once streaming engages the whole buffer is flushed, so every line the process produced has been
+    /// shown and the capture must be reported as already streamed.
+    /// </summary>
+    [TestMethod]
+    public void AddLine_WhenStreamingEngages_FlushesTheBufferOnceAndReportsCaptureAsStreamed()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.AddLine("buffered-before-handshake", liveOutputStreamingState: null);
+        collector.AddLine("first-streamed", liveOutputStreamingState: true);
+        collector.AddLine("second-streamed", liveOutputStreamingState: true);
+
+        string.Concat(written).Should().Be(
+            $"buffered-before-handshake{Environment.NewLine}first-streamed{Environment.NewLine}second-streamed{Environment.NewLine}");
+
+        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The flush triggered by protocol negotiation covers output produced before the handshake even when
+    /// the process writes nothing afterwards — the reader thread would otherwise never observe the
+    /// transition.
+    /// </summary>
+    [TestMethod]
+    public void FlushBufferedOutputIfLiveStreamingEnabled_WhenStreamingEngages_WritesTheBufferOnce()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.AddLine("buffered-before-handshake", liveOutputStreamingState: null);
+
+        collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
+        collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
+
+        written.Should().ContainSingle().Which.Should().Be($"buffered-before-handshake{Environment.NewLine}");
+        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Nothing is written for a process that produced no output, but the stream still counts as streamed
+    /// so a later line is not mistaken for never-shown content.
+    /// </summary>
+    [TestMethod]
+    public void FlushBufferedOutputIfLiveStreamingEnabled_WithEmptyBuffer_WritesNothingButEnablesStreaming()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
+
+        written.Should().BeEmpty();
+        collector.GetCapturedOutput().WasStreamedLive.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The capture is trimmed to a bounded tail once streaming engages, so it is a strict subset of what
+    /// was already shown. That is exactly why the summary must not replay it.
+    /// </summary>
+    [TestMethod]
+    public void AddLine_WhenStreaming_KeepsOnlyTheBoundedTailButStreamsEveryLine()
+    {
+        var written = new List<string>();
+        var collector = new TestApplication.ProcessOutputCollector(TailLineCount, written.Add);
+
+        for (int i = 1; i <= TailLineCount + 2; i++)
+        {
+            collector.AddLine($"line{i}", liveOutputStreamingState: true);
+        }
+
+        for (int i = 1; i <= TailLineCount + 2; i++)
+        {
+            string.Concat(written).Should().Contain($"line{i}");
+        }
+
+        (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
+        wasStreamedLive.Should().BeTrue();
+        output.Should().Be($"line3{Environment.NewLine}line4{Environment.NewLine}line5");
+    }
+
+    /// <summary>
+    /// The buffered lines have to reach the terminal in the order the process produced them. The flush
+    /// (driven by protocol negotiation on the pipe thread) and the stdout reader run concurrently, so the
+    /// write cannot happen after the collector's lock is released: a line added in that window would be
+    /// printed ahead of the buffered lines that precede it. Live output is now the only copy the user
+    /// sees, so nothing corrects a swap after the fact.
+    /// </summary>
+    [TestMethod]
+    public void AddLine_WhileTheNegotiationFlushIsWriting_CannotOvertakeTheBufferedLines()
+    {
+        var written = new List<string>();
+        TestApplication.ProcessOutputCollector? collector = null;
+        Thread? readerThread = null;
+        int firstWrite = 0;
+
+        collector = new TestApplication.ProcessOutputCollector(liveOutputTailLineCount: 1000, line =>
+        {
+            // Reproduce the reader thread arriving exactly while the flush is writing. If the write is
+            // not covered by the collector's lock, this AddLine runs to completion here and its line
+            // lands before the flush records its own.
+            if (Interlocked.Exchange(ref firstWrite, 1) == 0)
+            {
+                readerThread = new Thread(() => collector!.AddLine("produced-second", liveOutputStreamingState: true));
+                readerThread.Start();
+                readerThread.Join(TimeSpan.FromMilliseconds(250));
+            }
+
+            lock (written)
+            {
+                written.Add(line);
+            }
+        });
+
+        collector.AddLine("produced-first", liveOutputStreamingState: null);
+        collector.FlushBufferedOutputIfLiveStreamingEnabled(liveOutputStreamingState: true);
+
+        readerThread.Should().NotBeNull();
+        readerThread!.Join(TimeSpan.FromSeconds(30)).Should().BeTrue();
+
+        string rendered = string.Concat(written);
+        rendered.IndexOf("produced-first", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                rendered.IndexOf("produced-second", StringComparison.Ordinal),
+                "live output must keep the order the test process produced it in");
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ProcessOutputCollectorTests.cs
@@ -16,6 +16,8 @@ public class ProcessOutputCollectorTests
 {
     private const int TailLineCount = 3;
 
+    public TestContext TestContext { get; set; } = null!;
+
     /// <summary>
     /// Before the protocol version is known the streaming state is <see langword="null"/>: nothing may
     /// reach the terminal yet, and the capture has to stay available so a failure summary can show it.
@@ -162,7 +164,7 @@ public class ProcessOutputCollectorTests
     /// <summary>
     /// The buffered lines have to reach the terminal in the order the process produced them. The flush
     /// (driven by protocol negotiation on the pipe thread) and the stdout reader run concurrently, so the
-    /// write cannot happen after the collector's lock is released: a line added in that window would be
+    /// write cannot happen once the ordering lock is released: a line added in that window would be
     /// printed ahead of the buffered lines that precede it. Live output is now the only copy the user
     /// sees, so nothing corrects a swap after the fact.
     /// </summary>
@@ -174,16 +176,30 @@ public class ProcessOutputCollectorTests
         Thread? readerThread = null;
         int firstWrite = 0;
 
+        using var readerEnteredAddLine = new ManualResetEventSlim(false);
+        using var readerCompletedAddLine = new ManualResetEventSlim(false);
+
         collector = new TestApplication.ProcessOutputCollector(liveOutputTailLineCount: 1000, line =>
         {
             // Reproduce the reader thread arriving exactly while the flush is writing. If the write is
-            // not covered by the collector's lock, this AddLine runs to completion here and its line
-            // lands before the flush records its own.
+            // not covered by the ordering lock, that AddLine runs to completion here and its line lands
+            // before the flush records its own.
             if (Interlocked.Exchange(ref firstWrite, 1) == 0)
             {
-                readerThread = new Thread(() => collector!.AddLine("produced-second", liveOutputStreamingState: true));
+                readerThread = new Thread(() =>
+                {
+                    readerEnteredAddLine.Set();
+                    collector!.AddLine("produced-second", liveOutputStreamingState: true);
+                    readerCompletedAddLine.Set();
+                });
                 readerThread.Start();
-                readerThread.Join(TimeSpan.FromMilliseconds(250));
+
+                // Wait for the reader to be running and about to call AddLine, so the probe below is not
+                // measuring thread start-up. Then give it a window to get through AddLine: it must not,
+                // because this callback still holds the ordering lock.
+                readerEnteredAddLine.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken).Should().BeTrue();
+                readerCompletedAddLine.Wait(TimeSpan.FromSeconds(2), TestContext.CancellationToken)
+                    .Should().BeFalse("a line produced while the flush is writing must wait for it");
             }
 
             lock (written)
@@ -203,5 +219,45 @@ public class ProcessOutputCollectorTests
             .Should().BeLessThan(
                 rendered.IndexOf("produced-second", StringComparison.Ordinal),
                 "live output must keep the order the test process produced it in");
+    }
+
+    /// <summary>
+    /// Reading the capture must not wait on terminal IO. <c>TestApplication.RunAsync</c> gives the reader
+    /// threads a bounded grace period after the test process exits and then reads the capture anyway,
+    /// precisely because a reader can still be stuck; that timeout would be pointless if the read could
+    /// then block behind an in-flight write.
+    /// </summary>
+    [TestMethod]
+    public void GetCapturedOutput_WhileALineIsBeingWritten_DoesNotWaitForTheWriteToComplete()
+    {
+        TestApplication.ProcessOutputCollector? collector = null;
+
+        using var writeStarted = new ManualResetEventSlim(false);
+        using var releaseWrite = new ManualResetEventSlim(false);
+
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+
+        collector = new TestApplication.ProcessOutputCollector(TailLineCount, _ =>
+        {
+            writeStarted.Set();
+            releaseWrite.Wait(TimeSpan.FromSeconds(30), cancellationToken);
+        });
+
+        var writerThread = new Thread(() => collector.AddLine("blocked-line", liveOutputStreamingState: true));
+        writerThread.Start();
+
+        try
+        {
+            writeStarted.Wait(TimeSpan.FromSeconds(30), cancellationToken).Should().BeTrue();
+
+            (string output, bool wasStreamedLive) = collector.GetCapturedOutput();
+            output.Should().Be("blocked-line");
+            wasStreamedLive.Should().BeTrue();
+        }
+        finally
+        {
+            releaseWrite.Set();
+            writerThread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue();
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -383,6 +383,104 @@ public class TestApplicationHandlerTests : IDisposable
         reporter.HasHandshakeFailure.Should().BeFalse();
     }
 
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/55549. Output that was streamed to the
+    /// terminal while the test process was running must not be replayed by the non-zero exit code
+    /// summary — doing so printed every captured line twice for any failing run.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenOutputWasStreamedLive_DoesNotReplayItInTheExitCodeSummary()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        handler.OnHandshakeReceived(BuildHandshake(executionMode: HandshakeMessageExecutionModes.Run), gotSupportedVersion: true)
+            .Should().BeTrue();
+
+        handler.OnTestProcessExited(
+            exitCode: 1,
+            outputData: "streamed-stdout-line",
+            errorData: "streamed-stderr-line",
+            outputAlreadyStreamedLive: true,
+            errorAlreadyStreamedLive: true);
+
+        // The run went through the normal completion summary (not the handshake-failure path), and that
+        // summary reported the exit code without repeating the output that is already on screen.
+        reporter.HasHandshakeFailure.Should().BeFalse();
+
+        string rendered = console.GetOutput();
+        rendered.Should().NotContain("streamed-stdout-line");
+        rendered.Should().NotContain("streamed-stderr-line");
+    }
+
+    /// <summary>
+    /// The other side of <see cref="OnTestProcessExited_WhenOutputWasStreamedLive_DoesNotReplayItInTheExitCodeSummary"/>:
+    /// hosts that never stream (Microsoft.Testing.Platform versions below protocol 1.1.0) rely on the
+    /// summary as the only place their output is shown, so it must still be printed there.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenOutputWasNotStreamedLive_StillReportsItInTheExitCodeSummary()
+    {
+        (TestApplicationHandler handler, _, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        handler.OnHandshakeReceived(BuildHandshake(executionMode: HandshakeMessageExecutionModes.Run), gotSupportedVersion: true)
+            .Should().BeTrue();
+
+        handler.OnTestProcessExited(
+            exitCode: 1,
+            outputData: "buffered-stdout-line",
+            errorData: "buffered-stderr-line");
+
+        string rendered = console.GetOutput();
+        rendered.Should().Contain("buffered-stdout-line");
+        rendered.Should().Contain("buffered-stderr-line");
+    }
+
+    /// <summary>
+    /// The handshake-failure path shares the same replay problem: a controller-only handshake that
+    /// negotiated protocol 1.1.0 has already streamed the process output.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenOutputWasStreamedLiveAndHandshakeFailed_DoesNotReplayItButStillReportsTheAssembly()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
+
+        handler.OnTestProcessExited(
+            exitCode: 1,
+            outputData: "streamed-stdout-line",
+            errorData: "streamed-stderr-line",
+            outputAlreadyStreamedLive: true,
+            errorAlreadyStreamedLive: true);
+
+        reporter.HasHandshakeFailure.Should().BeTrue();
+
+        string rendered = console.GetOutput();
+        rendered.Should().NotContain("streamed-stdout-line");
+        rendered.Should().NotContain("streamed-stderr-line");
+        rendered.Should().Contain(TargetPath, "the failing assembly still has to be identified");
+    }
+
+    /// <summary>
+    /// Artifact post-processing writes the captured output straight back to the terminal instead of going
+    /// through a summary, so it needs the same guard.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WhenArtifactPostProcessingAndOutputWasStreamedLive_DoesNotReplayIt()
+    {
+        (TestApplicationHandler handler, _, CapturingConsole console) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            artifactPostProcessingInvocation: new ArtifactPostProcessingInvocation("manifest.json"));
+
+        handler.OnTestProcessExited(
+            exitCode: 0,
+            outputData: "streamed-stdout-line",
+            errorData: "streamed-stderr-line",
+            outputAlreadyStreamedLive: true,
+            errorAlreadyStreamedLive: true);
+
+        console.GetOutput().Should().NotContain("streamed-stdout-line").And.NotContain("streamed-stderr-line");
+    }
+
     private const string TargetPath = "/repo/bin/Debug/net9.0/MyTest.dll";
     private const string ProjectPath = "/repo/MyTest.csproj";
     private const string TargetFramework = "net9.0";

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
@@ -384,41 +385,35 @@ public class TestApplicationHandlerTests : IDisposable
     }
 
     /// <summary>
-    /// Regression test for https://github.com/dotnet/sdk/issues/55549. Output that was streamed to the
-    /// terminal while the test process was running must not be replayed by the non-zero exit code
-    /// summary — doing so printed every captured line twice for any failing run.
+    /// Related to https://github.com/dotnet/sdk/issues/55549. Output already streamed to the terminal is
+    /// reported as nothing left to show (<c>ProcessOutputCollector.GetOutputToReport</c> returns empty),
+    /// and the handler must then render no output block at all rather than an empty heading.
     /// </summary>
     [TestMethod]
-    public void OnTestProcessExited_WhenOutputWasStreamedLive_DoesNotReplayItInTheExitCodeSummary()
+    public void OnTestProcessExited_WithNoOutputToReport_RendersNoOutputBlockInTheExitCodeSummary()
     {
         (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
 
         handler.OnHandshakeReceived(BuildHandshake(executionMode: HandshakeMessageExecutionModes.Run), gotSupportedVersion: true)
             .Should().BeTrue();
 
-        handler.OnTestProcessExited(
-            exitCode: 1,
-            outputData: "streamed-stdout-line",
-            errorData: "streamed-stderr-line",
-            outputAlreadyStreamedLive: true,
-            errorAlreadyStreamedLive: true);
+        handler.OnTestProcessExited(exitCode: 1, outputData: string.Empty, errorData: string.Empty);
 
-        // The run went through the normal completion summary (not the handshake-failure path), and that
-        // summary reported the exit code without repeating the output that is already on screen.
+        // The run went through the normal completion summary rather than the handshake-failure path.
         reporter.HasHandshakeFailure.Should().BeFalse();
 
         string rendered = console.GetOutput();
-        rendered.Should().NotContain("streamed-stdout-line");
-        rendered.Should().NotContain("streamed-stderr-line");
+        rendered.Should().NotContain(CliCommandStrings.StandardOutput);
+        rendered.Should().NotContain(CliCommandStrings.StandardError);
     }
 
     /// <summary>
-    /// The other side of <see cref="OnTestProcessExited_WhenOutputWasStreamedLive_DoesNotReplayItInTheExitCodeSummary"/>:
+    /// The other side of <see cref="OnTestProcessExited_WithNoOutputToReport_RendersNoOutputBlockInTheExitCodeSummary"/>:
     /// hosts that never stream (Microsoft.Testing.Platform versions below protocol 1.1.0) rely on the
     /// summary as the only place their output is shown, so it must still be printed there.
     /// </summary>
     [TestMethod]
-    public void OnTestProcessExited_WhenOutputWasNotStreamedLive_StillReportsItInTheExitCodeSummary()
+    public void OnTestProcessExited_WithOutputToReport_StillReportsItInTheExitCodeSummary()
     {
         (TestApplicationHandler handler, _, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
 
@@ -436,35 +431,46 @@ public class TestApplicationHandlerTests : IDisposable
     }
 
     /// <summary>
-    /// The handshake-failure path shares the same replay problem: a controller-only handshake that
-    /// negotiated protocol 1.1.0 has already streamed the process output.
+    /// Suppressing already-streamed output must not cost the failing assembly's identity: the
+    /// handshake-failure report is what tells the user which module produced the failure.
     /// </summary>
     [TestMethod]
-    public void OnTestProcessExited_WhenOutputWasStreamedLiveAndHandshakeFailed_DoesNotReplayItButStillReportsTheAssembly()
+    public void OnTestProcessExited_WithNoOutputToReportAndHandshakeFailed_StillReportsTheAssembly()
     {
         (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(isHelp: false, isDiscovery: false);
 
-        handler.OnTestProcessExited(
-            exitCode: 1,
-            outputData: "streamed-stdout-line",
-            errorData: "streamed-stderr-line",
-            outputAlreadyStreamedLive: true,
-            errorAlreadyStreamedLive: true);
+        handler.OnTestProcessExited(exitCode: 1, outputData: string.Empty, errorData: string.Empty);
 
         reporter.HasHandshakeFailure.Should().BeTrue();
 
         string rendered = console.GetOutput();
-        rendered.Should().NotContain("streamed-stdout-line");
-        rendered.Should().NotContain("streamed-stderr-line");
         rendered.Should().Contain(TargetPath, "the failing assembly still has to be identified");
+        rendered.Should().Contain(TargetFramework);
     }
 
     /// <summary>
-    /// Artifact post-processing writes the captured output straight back to the terminal instead of going
-    /// through a summary, so it needs the same guard.
+    /// Artifact post-processing writes the reported output straight back to the terminal instead of going
+    /// through a summary. It is not gated on the exit code, so it has to honour "nothing to report" too.
     /// </summary>
     [TestMethod]
-    public void OnTestProcessExited_WhenArtifactPostProcessingAndOutputWasStreamedLive_DoesNotReplayIt()
+    public void OnTestProcessExited_WithNoOutputToReportDuringArtifactPostProcessing_WritesNothing()
+    {
+        (TestApplicationHandler handler, _, CapturingConsole console) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            artifactPostProcessingInvocation: new ArtifactPostProcessingInvocation("manifest.json"));
+
+        handler.OnTestProcessExited(exitCode: 0, outputData: string.Empty, errorData: string.Empty);
+
+        console.GetOutput().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The other side of the artifact post-processing path: output that was never streamed still has to
+    /// reach the terminal there.
+    /// </summary>
+    [TestMethod]
+    public void OnTestProcessExited_WithOutputToReportDuringArtifactPostProcessing_WritesIt()
     {
         (TestApplicationHandler handler, _, CapturingConsole console) = CreateHandler(
             isHelp: false,
@@ -473,12 +479,10 @@ public class TestApplicationHandlerTests : IDisposable
 
         handler.OnTestProcessExited(
             exitCode: 0,
-            outputData: "streamed-stdout-line",
-            errorData: "streamed-stderr-line",
-            outputAlreadyStreamedLive: true,
-            errorAlreadyStreamedLive: true);
+            outputData: "buffered-stdout-line",
+            errorData: "buffered-stderr-line");
 
-        console.GetOutput().Should().NotContain("streamed-stdout-line").And.NotContain("streamed-stderr-line");
+        console.GetOutput().Should().Contain("buffered-stdout-line").And.Contain("buffered-stderr-line");
     }
 
     private const string TargetPath = "/repo/bin/Debug/net9.0/MyTest.dll";


### PR DESCRIPTION
Fixes #55549

## Problem

On the MTP `dotnet test` path, the live output feature added by #51615 streams the test application's standard output/error to the terminal as they are produced. When the run ends with a non-zero exit code, the pre-existing exit-code summary still replayed the same captured buffer indented under `Standard output` / `Standard error`, so every captured line was printed twice.

Any failing test yields exit code 2, so this affected essentially every failing run of a test app that writes to the console. It was reported against [dotnet/aspnet-api-versioning](https://github.com/dotnet/aspnet-api-versioning).

Reproduced with a minimal xUnit v3 (`xunit.v3.mtp-v2`) project on `11.0.100-rc.1.26380.103`:

```
Running tests from ...\Repro.dll (net11.0|x64)
CONSOLE-PASS-LINE            <-- live output
CONSOLE-FAIL-LINE            <-- live output
failed Tests.FailingWithOutput (167ms)
  ...
...\Repro.dll (net11.0|x64) failed with 1 error(s) [+1/x1/?0] (1s 172ms)
Exit code: 2
  Standard output: CONSOLE-PASS-LINE     <-- same lines a second time
  CONSOLE-FAIL-LINE
```

The same project on `10.0.302` prints only the trailing block, so this is a regression.

## Fix

`ProcessOutputCollector` now reports whether a stream actually engaged live streaming alongside its captured tail (`GetCapturedOutput()` returning `(string Output, bool WasStreamedLive)`, read atomically), and `TestApplicationHandler.OnTestProcessExited` suppresses the terminal replay for streams that were already shown.

The summary is still printed when live streaming never engaged — older Microsoft.Testing.Platform versions that don't negotiate protocol 1.1.0, and processes that fail before the handshake, rely on it as the only place their output is surfaced. `Exit code: N` and the assembly identification are unchanged, and trace logging still receives the full captured text. Suppressing the summary rather than the live stream is the right way round: the summary copy is additionally lossy (truncated to 30 head + 10 tail lines by `TruncateOutputForSummary`, on top of the 200-line tail bound).

Two concurrency issues surfaced while making the live stream the only copy the user sees, both fixed here:

- **A line racing with protocol negotiation could be dropped entirely.** The reader threads sample the streaming state *before* taking the collector lock, so negotiation could enable streaming in between; `AddLine` then queued the line without writing it while the capture was already reported as streamed, so the summary suppressed it too. `AddLine` now decides from the collector's own state rather than the caller's sample.
- **Live output could be reordered at the negotiation boundary.** The flush and a reader thread could interleave so a later line was printed ahead of the buffered lines preceding it. A dedicated ordering lock now spans "decide what to write, then write it". It is deliberately separate from the state lock so that reading the capture never waits on terminal I/O — `RunAsync` reads the capture after a bounded 5-second wait for the reader tasks, a timeout that exists precisely because a reader can be stuck.

## Verification

Original xUnit v3 repro against the locally built SDK now prints each console line exactly once.

New tests:
- `ProcessOutputCollectorTests` — buffering vs. streaming, flush-on-negotiation, the bounded tail being a subset of what was streamed, the stale-sample case, ordering at the negotiation boundary, and that reading the capture does not wait on an in-flight write.
- `TestApplicationHandlerTests` — no replay when already streamed (completion, handshake-failure, and artifact post-processing paths), and still reported when not streamed.
- `GivenDotnetTestForwardsTestHostOutput.RunFailingTestProjectWritingToConsole_ShouldNotAlsoReplayTheOutputInTheExitCodeSummary` — end-to-end, asserts each marker appears exactly once, with a new `TestProjectWithFailingTestAndConsoleOutput` asset.

Each new regression test was empirically confirmed to fail against the corresponding pre-fix behavior, not just to pass against the fix. `ProcessOutputCollectorTests`, `TestApplicationHandlerTests`, `TerminalTestReporterTests` and `GivenDotnetTestForwardsTestHostOutput` pass locally; leaving the full suite to CI.