### PR TITLE
Close SDK-side gaps in MTP artifact post-processing

### DIFF
--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -134,7 +134,85 @@ Today only **TRX** consolidates: the only shipping post-processor is the one in 
 `Microsoft.Testing.Extensions.TrxReport` package. Code coverage and other formats will only be
 merged once a post-processor ships in the extension that produces them; until then those
 artifacts are listed individually, exactly as before. This is a capability question, not a
-configuration one — the SDK merges whatever the installed extensions advertise.
+configuration one — the SDK merges whatever the installed extensions advertise. The contract for
+adding a format is public; see [Extending it to another artifact format](#extending-it-to-another-artifact-format).
+
+## Extending it to another artifact format
+
+The post-processing contract is **public API on `Microsoft.Testing.Platform`**, so a third-party
+extension can consolidate its own format without any change to the SDK. It is gated behind the
+`TPEXP` experimental diagnostic, so it can still change; suppressing that diagnostic is how you
+opt in.
+
+The relevant public types live in `Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing`:
+
+| Type | Role |
+|---|---|
+| `IArtifactPostProcessor` | The contract: `SupportedKinds`, `SupportedFileExtensionsFallback`, and `ProcessAsync(inputs, outputDirectory, cancellationToken)`. |
+| `IArtifactPostProcessingManager` | Registration, via `AddArtifactPostProcessor(Func<IServiceProvider, IArtifactPostProcessor>)`. |
+| `InputArtifact` | One input: path, kind, producing test module, target framework, architecture, execution id. |
+| `ProcessedArtifact` | The merged result: path, kind, display name, description. |
+
+The dispatcher that runs post-processors, the manifest, and the handshake plumbing are all
+internal — an extension never interacts with them.
+
+A minimal processor:
+
+```csharp
+#pragma warning disable TPEXP // Artifact post-processing is experimental.
+internal sealed class MyArtifactPostProcessor : IArtifactPostProcessor
+{
+    public string Uid => "Contoso.MyReport.PostProcessor";
+    public string Version => "1.0.0";
+    public string DisplayName => "Contoso report merger";
+    public string Description => "Merges Contoso reports.";
+
+    public IReadOnlyList<string> SupportedKinds { get; } = ["contoso.myreport"];
+    public IReadOnlyList<string> SupportedFileExtensionsFallback { get; } = [".myreport"];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public async Task<ProcessedArtifact?> ProcessAsync(
+        IReadOnlyList<InputArtifact> inputs, string outputDirectory, CancellationToken cancellationToken)
+    {
+        if (inputs.Count < 2)
+        {
+            return null; // Nothing worth merging; the originals stay listed.
+        }
+
+        string output = Path.Combine(outputDirectory, "merged.myreport");
+        await MergeAsync(inputs.Select(i => i.Path), output, cancellationToken);
+        return new ProcessedArtifact(output, "contoso.myreport", "Contoso report (merged)", null);
+    }
+}
+#pragma warning restore TPEXP
+```
+
+What `dotnet test` expects of a processor:
+
+- **Tag the artifacts you produce with the same `Kind` you advertise.** Grouping is by kind first;
+  the file-extension list is only a fallback for producers that have not adopted kinds.
+- **Do not claim an overly generic fallback extension.** Claiming something like `.xml`, which
+  several unrelated formats use, opts your extension into groups of artifacts that are not yours.
+  Prefer kind-only routing for formats whose file extension is not distinctive.
+- **Return `null` rather than throwing** when there is nothing to do. The SDK only ever asks you to
+  merge a group of two or more inputs, but your own policy may still decline (for example, inputs
+  a binary format cannot safely combine).
+- **Treat inputs as read-only** and write under the supplied `outputDirectory`. Never return one of
+  the inputs as your output, and never delete a source file.
+- **Set `Kind` on the artifact you return.** That is what the SDK uses to decide which originals the
+  merged artifact replaced in the run summary.
+- **Be deterministic**: the same set of inputs should produce the same output path.
+
+Two SDK behaviors are worth knowing about. The SDK relaunches the *fewest* test applications that
+cover all mergeable groups, so a processor may be asked to merge artifacts produced by a different
+test application than the one hosting it. And architecture compatibility is enforced only for code
+coverage (kind `microsoft.codecoverage` / extension `.coverage`), because that format is a binary
+blob; every other kind may be elected regardless of architecture.
+
+The design behind all of this, including the election algorithm and the reasoning for kinds over
+file extensions, is
+[microsoft/testfx RFC 018](https://github.com/microsoft/testfx/blob/main/docs/RFCs/018-Artifact-Post-Processing.md).
 
 ## Failure behavior
 

--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -1,0 +1,185 @@
+# `dotnet test` artifact post-processing (Microsoft.Testing.Platform)
+
+## Overview
+
+When `dotnet test` runs a solution (or several projects) on
+[Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)
+(MTP), every test application produces its own artifacts — one TRX report per module, one
+code-coverage file per module, and so on. Left as-is, the run summary lists each of those
+files individually, and downstream consumers (Azure DevOps `PublishTestResults`,
+`ReportGenerator`, CI dashboards) have to glob dozens of paths or merge them out of band.
+
+**Artifact post-processing** consolidates compatible artifacts produced by different test
+applications into a single merged artifact, so a multi-project run surfaces one report per
+format instead of one per module. It is on by default and runs automatically; nothing in the
+project or the command line is required to opt in.
+
+This document describes what the .NET SDK actually does. The upstream concept is defined by
+microsoft/testfx
+[RFC 018](https://github.com/microsoft/testfx/blob/main/docs/RFCs/018-Artifact-Post-Processing.md);
+where the two differ, this document reflects the SDK's behavior.
+
+> This feature applies only to the Microsoft.Testing.Platform runner for `dotnet test`. It is
+> unrelated to the VSTest artifact post-processing described under [Caveats](#caveats).
+
+## When it runs
+
+Post-processing happens after every test application has exited and before the run summary is
+rendered. To keep the merged report trustworthy, the SDK
+[skips it entirely](../../src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs)
+when any of the following is true:
+
+- `--help` was requested (`dotnet test --help`).
+- `--list-tests` was requested (test discovery, not execution).
+- `--no-artifact-post-processing` was passed.
+- The run was cancelled with <kbd>Ctrl</kbd>+<kbd>C</kbd>.
+- The run was cut short by `--maximum-failed-tests` or `--timeout`. A truncated run produced
+  the artifacts of a truncated run — modules that never started contributed nothing, and
+  modules killed mid-flight wrote whatever they had — so merging them into one
+  authoritative-looking report would hide the truncation. The per-module artifacts are left
+  as they are.
+
+Post-processing can never change the run's exit code; it only affects which artifacts are
+listed. See [Failure behavior](#failure-behavior).
+
+## How the SDK decides what to merge
+
+The SDK never inspects artifact contents to decide what is mergeable. It works entirely from
+data it already has: the capabilities each test application advertised during the MTP
+handshake, and the artifacts that streamed live over the `dotnet-test` pipe during the run.
+The grouping and election logic lives in
+[`ArtifactPostProcessingPlanner`](../../src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingPlanner.cs).
+
+### Capability comes from the handshake
+
+During its handshake, each MTP test application reports the post-processors registered inside
+it through two properties: `SupportedPostProcessorKinds` (reverse-DNS artifact *kinds*, e.g.
+`microsoft.testing.trx`) and `SupportedPostProcessorExtensionsLegacy` (lowercase file
+extensions, for producers that do not tag a kind). Both are semicolon-separated. An
+application that advertises neither simply never participates — it is neither a candidate to
+perform a merge nor a source of mergeable groups. The handshake property ids are defined in
+[`CliConstants`](../../src/Cli/dotnet/Commands/Test/CliConstants.cs).
+
+### Grouping
+
+Artifacts are de-duplicated by path and then grouped:
+
+1. **Kind first.** Artifacts that carry a reverse-DNS `Kind` are grouped by that kind.
+2. **Extension fallback.** Artifacts with no kind are grouped by lowercase file extension.
+
+A group is a merge candidate only if a compatible application advertised the matching kind or
+extension, and only if it has **at least two inputs** — merging a single file is pointless. (A
+kind group and a matching extension group that individually have one input each can still be
+merged together when a shared application supports both and the combined count reaches two.)
+
+For binary code-coverage artifacts (kind `microsoft.codecoverage` / extension `.coverage`),
+an application is a candidate only when its architecture matches the inputs. Coverage blobs
+are architecture-specific, so an `x64` application is not asked to merge `arm64` coverage.
+This constraint applies only to coverage; TRX and other text formats are
+architecture-agnostic.
+
+### Election
+
+Multiple applications may be able to merge the same group. The planner runs a greedy minimal
+[set-cover](https://en.wikipedia.org/wiki/Set_cover_problem): it repeatedly elects the
+application that covers the most still-uncovered groups, so the **fewest** test applications
+are relaunched. Ties are broken deterministically — preferring an application that produced
+more of the inputs, then the higher target-framework version, then path order — so a given
+input set always produces the same plan.
+
+## How the merge is performed
+
+Each elected application is relaunched **once** — not to run tests, but as an MTP tool. The tool
+name is passed as the first argument, followed by the manifest
+(`<test application> internal-merge-artifacts --manifest <manifest.json>`), and the process is
+connected to a fresh `dotnet-test` pipe. The launch, timeout, and argument construction live in
+[`TestApplication`](../../src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs); the tool name
+and manifest option are defined in
+[`CliConstants`](../../src/Cli/dotnet/Commands/Test/CliConstants.cs).
+
+The SDK writes a JSON manifest listing the input artifacts (path, kind, producing module,
+target framework, architecture, execution id) and the output directory, then hands it to the
+relaunched tool. The merged artifacts flow **back over the same pipe** as ordinary
+file-artifact messages, so they re-enter the normal reporter path. In the summary, the SDK
+[removes the inputs it consumed and adds the merged output](../../src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs)
+in their place.
+
+The original per-module artifacts are **never deleted from disk** — only the run summary
+changes. If you need the individual files (for example a per-module TRX), they are still where
+each module wrote them.
+
+## Where the merged artifact lands
+
+The output directory is chosen by
+[`ArtifactPostProcessingManager`](../../src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs):
+
+- **With `--results-directory <dir>`**, the merged artifact is written under that directory.
+- **Without `--results-directory`**, each application writes beside its own binaries and no
+  single directory belongs to the run, so the SDK picks the directory of an input produced by
+  the elected application (falling back to the first input directory in path order). The
+  merged artifact then lands next to the reports it summarizes instead of inside an unrelated
+  project's output.
+
+The merging extension — not the SDK — decides the final file name and may nest its output. The TRX
+post-processor names its output `merged-<runId>.trx`, where `runId` is derived from the inputs, and
+with the currently referenced `Microsoft.Testing.Extensions.TrxReport` it writes that file directly
+into the supplied directory, as a sibling of the reports it merged. A non-recursive `*.trx` glob
+over the results directory therefore picks up both the merged report and its own inputs, which
+would double-count every test. Configure CI to publish the merged file specifically, rather than
+globbing the whole directory.
+
+## What currently merges
+
+Today only **TRX** consolidates: the only shipping post-processor is the one in the
+`Microsoft.Testing.Extensions.TrxReport` package. Code coverage and other formats will only be
+merged once a post-processor ships in the extension that produces them; until then those
+artifacts are listed individually, exactly as before. This is a capability question, not a
+configuration one — the SDK merges whatever the installed extensions advertise.
+
+## Failure behavior
+
+Post-processing is a best-effort convenience layered on top of an already-completed run, so it
+**cannot change the run's exit code**. A merge failure, a non-zero exit from the merge host, or
+a timeout is degraded to a warning, and the original per-module artifacts stay listed. A run
+whose tests all passed still reports success even if merging failed.
+
+## Configuration
+
+| Knob | Effect |
+|---|---|
+| `--no-artifact-post-processing` | Skip post-processing entirely. Each test application's artifacts are listed individually, one per module. |
+| `DOTNET_CLI_TEST_ARTIFACT_POST_PROCESSING_TIMEOUT_SECONDS` | Override the default 15-minute bound on a single merge host. `0` removes the bound (useful for attaching a debugger to a merge host). An absent, non-numeric, or negative value keeps the default. |
+| `--results-directory` | Determines the output directory recorded in the manifest (see [Where the merged artifact lands](#where-the-merged-artifact-lands)). It is not passed to the merge host on the command line — the merged output location travels in the manifest so the SDK keeps control of it even when it has to be derived. |
+| `--config-file` | Forwarded to the merge host, so it resolves and enables the same extensions as the test run. |
+| `--diagnostic-output-directory` | Forwarded to the merge host, so its diagnostic logs land beside the run's. |
+
+## Caveats
+
+- **`--no-build` uses whatever binary is on disk.** If that binary no longer advertises the
+  kind (for example it was rebuilt without the TRX extension), post-processing silently does
+  nothing — there is no candidate to elect.
+- **Merging is scoped to a single `dotnet test` invocation.** There is deliberately no
+  cross-invocation correlation. Artifacts produced by separate `dotnet test` runs are never
+  merged together.
+- **This is not VSTest artifact post-processing.** The VSTest runner has its own, unrelated
+  two-phase flow (`--artifactsProcessingMode-collect` / `--artifactsProcessingMode-postprocess`
+  with a `--testSessionCorrelationId`) and its own opt-out environment variable,
+  `VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING`. That variable has **no effect on MTP runs**, and
+  `--no-artifact-post-processing` has **no effect on VSTest runs**. The two mechanisms are
+  independent.
+- **Retried tests.** `Microsoft.Testing.Extensions.Retry` re-runs only previously failed
+  tests, so each attempt's report holds a different subset of results. De-duplicating across
+  attempts is the responsibility of the merging extension, not the SDK.
+
+## Troubleshooting
+
+- **Did post-processing run?** When it starts, the SDK prints
+  `Merging compatible artifacts produced by different test applications...`. If merging
+  succeeded, the artifacts list shows a single merged path in place of the per-module inputs.
+  If the line never appears, no group met the [criteria for merging](#how-the-sdk-decides-what-to-merge)
+  (for example, only one artifact of a kind, or no installed extension advertised a
+  post-processor for it).
+- **Merge host command line and failures.** Setting `DOTNET_CLI_TEST_TRACEFILE` to a file path
+  enables SDK trace logging, which records the merge host command line and any failure details.
+  This is the fastest way to see exactly which application was relaunched and why a merge did
+  not happen.

--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -148,7 +148,7 @@ whose tests all passed still reports success even if merging failed.
 | Knob | Effect |
 |---|---|
 | `--no-artifact-post-processing` | Skip post-processing entirely. Each test application's artifacts are listed individually, one per module. |
-| `DOTNET_CLI_TEST_ARTIFACT_POST_PROCESSING_TIMEOUT_SECONDS` | Override the default 15-minute bound on a single merge host. `0` removes the bound (useful for attaching a debugger to a merge host). An absent, non-numeric, or negative value keeps the default. |
+| `DOTNET_CLI_TEST_ARTIFACT_POST_PROCESSING_TIMEOUT_SECONDS` | Override the default 15-minute bound on a single merge host. `0` removes the bound (useful for attaching a debugger to a merge host), as does any value large enough that the runtime could not wait on it (above roughly 49.7 days). An absent, non-numeric, or negative value keeps the default. |
 | `--results-directory` | Determines the output directory recorded in the manifest (see [Where the merged artifact lands](#where-the-merged-artifact-lands)). It is not passed to the merge host on the command line — the merged output location travels in the manifest so the SDK keeps control of it even when it has to be derived. |
 | `--config-file` | Forwarded to the merge host, so it resolves and enables the same extensions as the test run. |
 | `--diagnostic-output-directory` | Forwarded to the merge host, so its diagnostic logs land beside the run's. |

--- a/documentation/project-docs/telemetry.md
+++ b/documentation/project-docs/telemetry.md
@@ -8,6 +8,7 @@
   - [Common Properties Collected](#common-properties-collected)
   - [Telemetry Events](#telemetry-events)
     - [Core CLI Events](#core-cli-events)
+    - [Test Events](#test-events)
     - [Template Engine Events](#template-engine-events)
     - [SDK-Collected Build Events](#sdk-collected-build-events)
     - [MSBuild Engine Telemetry](#msbuild-engine-telemetry)
@@ -214,6 +215,24 @@ Every telemetry event automatically includes these common properties:
 - `detail`: Exception details (sensitive message removed)
 
 **Description**: Tracks unhandled exceptions for diagnostics
+
+### Test Events
+
+#### `test/artifact-post-processing`
+
+**When fired**: Once per `dotnet test` Microsoft.Testing.Platform run that planned at least one artifact post-processing job. Runs that plan nothing (no mergeable artifacts) emit nothing.
+
+**Properties**:
+
+- `jobs_planned`: Number of elected test-application relaunches planned
+- `jobs_executed`: Number of jobs actually attempted (differs from `jobs_planned` only when the run was cancelled mid-way)
+- `jobs_failed`: Number of jobs that reported a failure
+- `artifact_count`: Total number of input artifacts across all planned groups
+- `kinds`: Semicolon-separated, sorted, distinct artifact kinds that were merged; any kind outside a fixed well-known list is reported as `other`
+- `extensions`: Semicolon-separated, sorted, distinct file extensions from file-extension fallback groups; any extension outside a fixed well-known list is reported as `other`
+- `duration_ms`: Total wall-clock time spent post-processing, in milliseconds
+
+**Description**: Tracks how often artifact post-processing runs and on which shipped formats. No file paths, artifact contents, project names, or user-defined identifiers are collected — that is why unknown kinds and extensions are bucketed as `other`.
 
 ### Template Engine Events
 

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2681,6 +2681,9 @@ Proceed?</value>
     <value>Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</value>
     <comment>{0} is the test application path. {1} is the process exit code.</comment>
   </data>
+  <data name="ArtifactPostProcessingStarted" xml:space="preserve">
+    <value>Merging compatible artifacts produced by different test applications...</value>
+  </data>
   <data name="UnexpectedMessageInHelpMode" xml:space="preserve">
     <value>A message of type '{0}' was received in help mode, which is not expected.</value>
   </data>

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -27,6 +27,12 @@ internal static class CliConstants
     public const string DLLExtension = ".dll";
 
     public const string TestTraceLoggingEnvVar = "DOTNET_CLI_TEST_TRACEFILE";
+
+    /// <summary>
+    /// Overrides how long a relaunched artifact post-processing host may run, in seconds.
+    /// '0' removes the bound entirely. Absent, non-numeric or negative values keep the default.
+    /// </summary>
+    public const string TestArtifactPostProcessingTimeoutEnvVar = "DOTNET_CLI_TEST_ARTIFACT_POST_PROCESSING_TIMEOUT_SECONDS";
 }
 
 internal static class TestStates

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
@@ -67,9 +68,42 @@ internal sealed class ArtifactPostProcessingManager
         TerminalTestReporter output,
         CtrlCCancellationManager ctrlC)
     {
+        try
+        {
+            await ExecuteCoreAsync(buildOptions, output, ctrlC);
+        }
+        catch (Exception ex)
+        {
+            // Individual jobs already degrade their own failures to warnings. This guard covers
+            // everything around them — planning, the progress line, telemetry — so that no part of a
+            // best-effort convenience layered on a finished run can escape and turn that run into a
+            // CLI crash with a different exit code.
+            Logger.LogTrace($"Artifact post-processing failed: {ex}");
+        }
+    }
+
+    private async Task ExecuteCoreAsync(
+        BuildOptions buildOptions,
+        TerminalTestReporter output,
+        CtrlCCancellationManager ctrlC)
+    {
         ArtifactPostProcessingPlan plan = ArtifactPostProcessingPlanner.Plan(
             SnapshotApplications(),
             SnapshotArtifacts());
+
+        if (plan.Jobs.Count == 0)
+        {
+            return;
+        }
+
+        // Post-processing runs after the last test application has exited and before the run summary
+        // is rendered, so without this line a merge that takes a while is indistinguishable from a
+        // hung CLI: the progress area is empty and no assembly is still running.
+        output.WriteInformationMessage(CliCommandStrings.ArtifactPostProcessingStarted);
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+        int executedJobs = 0;
+        int failedJobs = 0;
 
         foreach (ArtifactPostProcessingJob job in plan.Jobs)
         {
@@ -81,6 +115,8 @@ internal sealed class ArtifactPostProcessingManager
             string tempDirectory = Path.Combine(
                 Path.GetTempPath(),
                 $"dotnet-test-postproc-{Guid.NewGuid():N}");
+
+            executedJobs++;
 
             try
             {
@@ -111,19 +147,19 @@ internal sealed class ArtifactPostProcessingManager
 
                 if (invocation.FailureMessage is { } failureMessage)
                 {
-                    ReportFailureUnlessCancelled(output, ctrlC, string.Format(
+                    failedJobs += ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                         CultureInfo.CurrentCulture,
                         CliCommandStrings.ArtifactPostProcessingFailed,
                         job.Application.Module.TargetPath,
-                        failureMessage));
+                        failureMessage)) ? 1 : 0;
                 }
                 else if (exitCode != ExitCode.Success)
                 {
-                    ReportFailureUnlessCancelled(output, ctrlC, string.Format(
+                    failedJobs += ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                         CultureInfo.CurrentCulture,
                         CliCommandStrings.ArtifactPostProcessingProcessFailed,
                         job.Application.Module.TargetPath,
-                        exitCode));
+                        exitCode)) ? 1 : 0;
                 }
             }
             catch (Exception ex)
@@ -133,11 +169,11 @@ internal sealed class ArtifactPostProcessingManager
                 // may escape and turn a finished run into a CLI crash with a different exit code.
                 Logger.LogTrace($"Artifact post-processing with '{job.Application.Module.TargetPath}' failed: {ex}");
 
-                ReportFailureUnlessCancelled(output, ctrlC, string.Format(
+                failedJobs += ReportFailureUnlessCancelled(output, ctrlC, string.Format(
                     CultureInfo.CurrentCulture,
                     CliCommandStrings.ArtifactPostProcessingFailed,
                     job.Application.Module.TargetPath,
-                    ex.Message));
+                    ex.Message)) ? 1 : 0;
             }
             finally
             {
@@ -154,24 +190,32 @@ internal sealed class ArtifactPostProcessingManager
                 }
             }
         }
+
+        ArtifactPostProcessingTelemetry.TrackPostProcessing(
+            plan,
+            executedJobs,
+            failedJobs,
+            Stopwatch.GetElapsedTime(startTimestamp));
     }
 
     /// <summary>
-    /// Reports a post-processing failure, unless the user cancelled the run. Cancellation kills the
-    /// post-processing process the same way it kills a test application, so the resulting failure is
-    /// the cancellation the user asked for rather than a post-processing problem worth reporting.
+    /// Reports a post-processing failure, unless the user cancelled the run, and returns whether it
+    /// was reported. Cancellation kills the post-processing process the same way it kills a test
+    /// application, so the resulting failure is the cancellation the user asked for rather than a
+    /// post-processing problem worth reporting — or counting as a failure in telemetry.
     /// </summary>
-    internal static void ReportFailureUnlessCancelled(
+    internal static bool ReportFailureUnlessCancelled(
         TerminalTestReporter output,
         CtrlCCancellationManager ctrlC,
         string message)
     {
         if (ctrlC.Token.IsCancellationRequested)
         {
-            return;
+            return false;
         }
 
         output.WriteWarningMessage(message);
+        return true;
     }
 
     internal IReadOnlyList<ArtifactPostProcessingApplication> SnapshotApplications()
@@ -207,20 +251,31 @@ internal sealed class ArtifactPostProcessingManager
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
 
-    private static string GetOutputDirectory(BuildOptions buildOptions, ArtifactPostProcessingJob job)
+    internal static string GetOutputDirectory(BuildOptions buildOptions, ArtifactPostProcessingJob job)
     {
         if (buildOptions.PathOptions.ResultsDirectoryPath is { } resultsDirectory)
         {
             return Path.GetFullPath(resultsDirectory);
         }
 
-        string firstInputPath = job.Groups
-            .SelectMany(group => group.Artifacts)
-            .Select(artifact => artifact.Path)
-            .OrderBy(path => path, FileUtilities.PathComparer)
-            .First();
+        ArtifactPostProcessingArtifact[] inputs =
+        [
+            .. job.Groups
+                .SelectMany(group => group.Artifacts)
+                .OrderBy(artifact => artifact.Path, FileUtilities.PathComparer)
+        ];
 
-        return Path.GetDirectoryName(Path.GetFullPath(firstInputPath))!;
+        // Without --results-directory every test application writes its artifacts next to its own
+        // binaries, so no directory belongs to the run as a whole. Prefer one the elected application
+        // already writes to: the merged artifact then lands beside the reports it summarizes instead
+        // of inside an unrelated project's output. An application can be elected purely for the kinds
+        // it advertises without having produced any of the inputs, so fall back to the first input
+        // directory in path order.
+        ArtifactPostProcessingArtifact preferredInput = inputs.FirstOrDefault(artifact =>
+            FileUtilities.PathComparer.Equals(artifact.ProducingTestModule, job.Application.Module.TargetPath))
+            ?? inputs[0];
+
+        return Path.GetDirectoryName(Path.GetFullPath(preferredInput.Path))!;
     }
 
     private static void WriteManifest(

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingTelemetry.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingTelemetry.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Commands.Test;
+
+/// <summary>
+/// Reports one event per <c>dotnet test</c> run that planned at least one artifact post-processing
+/// job. Runs that plan nothing are silent, because the interesting population is the runs where
+/// post-processing actually had work to do.
+/// </summary>
+internal static class ArtifactPostProcessingTelemetry
+{
+    private const string EventName = "test/artifact-post-processing";
+
+    /// <summary>
+    /// Replaces any kind or extension outside the well-known sets below. Artifact kinds and file
+    /// extensions are chosen by whoever wrote the producing extension, so an in-house post-processor
+    /// can carry a product or team name. Bucketing everything unrecognized still answers what the
+    /// event exists to answer — how often post-processing runs, and on which shipped formats.
+    /// </summary>
+    private const string OtherValue = "other";
+
+    private static readonly HashSet<string> WellKnownKinds = new(StringComparer.Ordinal)
+    {
+        "microsoft.testing.trx",
+        "microsoft.codecoverage",
+        "coverlet.cobertura",
+        "junit.report",
+        "nunit.report",
+    };
+
+    private static readonly HashSet<string> WellKnownExtensions = new(StringComparer.Ordinal)
+    {
+        ".trx",
+        ".coverage",
+        ".cobertura",
+        ".xml",
+        ".json",
+    };
+
+    public static void TrackPostProcessing(
+        ArtifactPostProcessingPlan plan,
+        int executedJobs,
+        int failedJobs,
+        TimeSpan duration)
+        => TelemetryEventEntry.TrackEvent(
+            EventName,
+            CreateProperties(plan, executedJobs, failedJobs, duration));
+
+    internal static Dictionary<string, string?> CreateProperties(
+        ArtifactPostProcessingPlan plan,
+        int executedJobs,
+        int failedJobs,
+        TimeSpan duration)
+    {
+        ArtifactPostProcessingGroup[] groups = [.. plan.Jobs.SelectMany(job => job.Groups)];
+
+        return new Dictionary<string, string?>
+        {
+            ["jobs_planned"] = plan.Jobs.Count.ToString(CultureInfo.InvariantCulture),
+            ["jobs_executed"] = executedJobs.ToString(CultureInfo.InvariantCulture),
+            ["jobs_failed"] = failedJobs.ToString(CultureInfo.InvariantCulture),
+            ["artifact_count"] = groups.Sum(group => group.Artifacts.Count).ToString(CultureInfo.InvariantCulture),
+            ["kinds"] = Join(groups.Where(group => group.IsKind).Select(group => group.Key), WellKnownKinds),
+            ["extensions"] = Join(groups.Where(group => !group.IsKind).Select(group => group.Key), WellKnownExtensions),
+            ["duration_ms"] = ((long)duration.TotalMilliseconds).ToString(CultureInfo.InvariantCulture),
+        };
+    }
+
+    private static string Join(IEnumerable<string> values, HashSet<string> wellKnownValues)
+        => string.Join(
+            ';',
+            values
+                .Select(value => wellKnownValues.Contains(value) ? value : OtherValue)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal));
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -116,10 +116,11 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 exitCode = ExitCode.TestSessionAborted;
             }
 
-            if (!testOptions.IsHelp
-                && !testOptions.IsDiscovery
-                && !parseResult.GetValue(definition.NoArtifactPostProcessingOption)
-                && !ctrlC.Token.IsCancellationRequested)
+            if (ShouldPostProcessArtifacts(
+                testOptions,
+                parseResult.GetValue(definition.NoArtifactPostProcessingOption),
+                ctrlC.Token.IsCancellationRequested,
+                cancellationReason))
             {
                 artifactPostProcessingManager.ExecuteAsync(buildOptions, output, ctrlC).GetAwaiter().GetResult();
             }
@@ -158,6 +159,28 @@ internal partial class MicrosoftTestingPlatformTestCommand
             output.TestExecutionCompleted(DateTimeOffset.Now, exitCode);
         }
     }
+
+    /// <summary>
+    /// Decides whether the artifacts of a finished run should be consolidated.
+    /// </summary>
+    /// <remarks>
+    /// Help and discovery produce no artifacts to merge, and <c>--no-artifact-post-processing</c> is
+    /// the explicit opt-out. The two cancellation cases are the interesting ones: a run stopped by
+    /// Ctrl+C, <c>--maximum-failed-tests</c> or <c>--timeout</c> produced the artifacts of a
+    /// truncated run — modules that never started contributed nothing, and modules killed mid-flight
+    /// wrote whatever they had. Merging those into a single report would hide the truncation behind
+    /// one authoritative-looking artifact, so the per-module artifacts are left as they are.
+    /// </remarks>
+    internal static bool ShouldPostProcessArtifacts(
+        TestOptions testOptions,
+        bool noArtifactPostProcessingRequested,
+        bool cancellationRequested,
+        TestRunCancellationReason cancellationReason)
+        => !testOptions.IsHelp
+            && !testOptions.IsDiscovery
+            && !noArtifactPostProcessingRequested
+            && !cancellationRequested
+            && cancellationReason == TestRunCancellationReason.None;
 
     private static TestListFormat GetListTestsFormat(ParseResult parseResult, TestCommandDefinition.MicrosoftTestingPlatform definition)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -1068,6 +1068,12 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.Append(text);
         });
 
+    internal void WriteInformationMessage(string text) =>
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.AppendLine(text);
+        });
+
     internal void WriteWarningMessage(string text) =>
         _terminalWithProgress.WriteToTerminal(terminal =>
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -26,7 +26,15 @@ internal sealed class TestApplication(
     TestRunPolicy? testRunPolicy = null) : IDisposable
 {
     private static readonly Version ProtocolVersion_1_1 = new(1, 1, 0);
-    private static readonly TimeSpan ArtifactPostProcessingTimeout = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan DefaultArtifactPostProcessingTimeout = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Largest timeout <see cref="Task.WaitAsync(TimeSpan)"/> accepts, in seconds. Anything above
+    /// <c>Timer.MaxSupportedTimeout</c> (0xFFFFFFFE milliseconds) throws instead of waiting.
+    /// </summary>
+    private const int MaximumArtifactPostProcessingTimeoutSeconds = (int)(0xFFFFFFFE / 1000);
+
+    private static readonly TimeSpan ArtifactPostProcessingTimeout = GetArtifactPostProcessingTimeout();
     private const int LiveOutputTailLineCount = 200;
 
     private readonly Lock _requestLock = new();
@@ -309,16 +317,11 @@ internal sealed class TestApplication(
 
         if (_artifactPostProcessingInvocation is not null)
         {
-            builder.Append($" {CliConstants.ArtifactPostProcessingToolName}");
-            builder.Append($" {CliConstants.ArtifactPostProcessingManifestOptionKey} {ArgumentEscaper.EscapeSingleArg(_artifactPostProcessingInvocation.ManifestPath)}");
-
-            if (_buildOptions.PathOptions.DiagnosticOutputDirectoryPath is { } toolDiagnosticOutputDirectoryPath)
-            {
-                builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.DiagnosticOutputDirectoryOptionName} {ArgumentEscaper.EscapeSingleArg(toolDiagnosticOutputDirectoryPath)}");
-            }
-
-            builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
-            return builder.ToString();
+            return BuildArtifactPostProcessingArguments(
+                builder,
+                _buildOptions.PathOptions,
+                _artifactPostProcessingInvocation.ManifestPath,
+                _pipeName);
         }
 
         if (TestOptions.IsHelp)
@@ -363,6 +366,68 @@ internal sealed class TestApplication(
             StringComparison.OrdinalIgnoreCase)
             ? $"exec {ArgumentEscaper.EscapeSingleArg(module.TargetPath)}"
             : string.Empty;
+
+    /// <summary>
+    /// Appends the arguments that put a relaunched test application into merge-host mode. None of the
+    /// options describing the test run itself are forwarded — the host discovers nothing and runs no
+    /// tests — but the options deciding which extensions load, and where they write diagnostics, must
+    /// match the run that produced the artifacts.
+    /// </summary>
+    internal static string BuildArtifactPostProcessingArguments(
+        StringBuilder builder,
+        PathOptions pathOptions,
+        string manifestPath,
+        string pipeName)
+    {
+        builder.Append($" {CliConstants.ArtifactPostProcessingToolName}");
+        builder.Append($" {CliConstants.ArtifactPostProcessingManifestOptionKey} {ArgumentEscaper.EscapeSingleArg(manifestPath)}");
+
+        // A merge host resolves and enables its extensions exactly like a test host does, so a
+        // configuration file that governs which extensions load has to reach it too. Without this
+        // the merge runs with a different extension set than the run that produced the artifacts,
+        // and a post-processor disabled by configuration silently comes back for the merge.
+        if (pathOptions.ConfigFilePath is { } configFilePath)
+        {
+            builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ConfigFileOptionName} {ArgumentEscaper.EscapeSingleArg(configFilePath)}");
+        }
+
+        if (pathOptions.DiagnosticOutputDirectoryPath is { } diagnosticOutputDirectoryPath)
+        {
+            builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.DiagnosticOutputDirectoryOptionName} {ArgumentEscaper.EscapeSingleArg(diagnosticOutputDirectoryPath)}");
+        }
+
+        // The results directory is deliberately not forwarded: the merged output location travels in
+        // the manifest instead, so the SDK keeps control of it even when it has to be derived.
+        builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}");
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Resolves how long a relaunched merge host may run before it is killed. The bound exists so a
+    /// hung merge host cannot hold an already-finished test run open indefinitely, but no single
+    /// value fits every repository — merging the coverage of a large solution legitimately takes far
+    /// longer than merging two TRX reports. The override also accepts '0' to remove the bound, which
+    /// is what makes it possible to attach a debugger to a merge host.
+    /// </summary>
+    private static TimeSpan GetArtifactPostProcessingTimeout()
+        => ParseArtifactPostProcessingTimeout(
+            Environment.GetEnvironmentVariable(CliConstants.TestArtifactPostProcessingTimeoutEnvVar));
+
+    internal static TimeSpan ParseArtifactPostProcessingTimeout(string? configuredTimeout)
+    {
+        if (!int.TryParse(configuredTimeout, NumberStyles.Integer, CultureInfo.InvariantCulture, out int seconds) || seconds < 0)
+        {
+            return DefaultArtifactPostProcessingTimeout;
+        }
+
+        // Task.WaitAsync rejects a timeout above Timer.MaxSupportedTimeout (~49.7 days) with an
+        // ArgumentOutOfRangeException, which would escape the TimeoutException-only catch around the
+        // wait and fail every merge. A caller asking for a timeout that long means "effectively
+        // never", so give them that instead of a broken run.
+        return seconds == 0 || seconds > MaximumArtifactPostProcessingTimeoutSeconds
+            ? Timeout.InfiniteTimeSpan
+            : TimeSpan.FromSeconds(seconds);
+    }
 
     private async Task WaitConnectionAsync(CancellationToken token)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -415,7 +415,11 @@ internal sealed class TestApplication(
 
     internal static TimeSpan ParseArtifactPostProcessingTimeout(string? configuredTimeout)
     {
-        if (!int.TryParse(configuredTimeout, NumberStyles.Integer, CultureInfo.InvariantCulture, out int seconds) || seconds < 0)
+        // Parsed as long rather than int so that a value chosen to mean 'a very long time' lands in
+        // the 'effectively never' branch below instead of overflowing the parse and silently falling
+        // back to the default. Anything above long.MaxValue seconds is not a duration anyone means,
+        // so it keeps the default along with the other unusable values.
+        if (!long.TryParse(configuredTimeout, NumberStyles.Integer, CultureInfo.InvariantCulture, out long seconds) || seconds < 0)
         {
             return DefaultArtifactPostProcessingTimeout;
         }

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Úloha Aspire je zastaralá a už není potřeba. Aspire je nyní k dispozici v podobě balíčků NuGet, které můžete přidat přímo do svých projektů. Další informace najdete na https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Die Workload „Aspire“ ist veraltet und nicht mehr erforderlich. Aspire ist jetzt als NuGet-Pakete verfügbar, die Sie direkt Ihren Projekten hinzufügen können. Weitere Informationen finden Sie unter https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">La carga de trabajo Aspire está en desuso y ya no es necesaria. Ahora Aspire está disponible como paquetes NuGet que puedes añadir directamente a tus proyectos. Para obtener más información, consulta https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">La charge de travail Aspire est dépréciée et n’est plus nécessaire. Aspire est désormais disponible sous forme de packages NuGet que vous pouvez ajouter directement à vos projets. Pour plus d’informations, consultez https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Il carico di lavoro Aspire è deprecato e non è più necessario. Aspire ora è disponibile come pacchetti NuGet che puoi aggiungere direttamente ai tuoi progetti. Per altre informazioni, visita https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Aspire ワークロードは非推奨となり、不要になりました。Aspire は現在、プロジェクトに直接追加できる NuGet パッケージとして利用可能です。詳細情報については、https://aka.ms/aspire/support-policy をご覧ください</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Aspire 워크로드는 더 이상 사용되지 않으며 필요하지 않습니다. Aspire는 이제 NuGet 패키지로 제공되어 프로젝트에 직접 추가할 수 있습니다. 자세한 내용은 https://aka.ms/aspire/support-policy를 참조하세요.</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Obciążenie Aspire jest przestarzałe i nie jest już konieczne. Usługa Aspire jest teraz dostępna jako pakiety NuGet, które można dodawać bezpośrednio do projektów. Więcej informacji znajdziesz na stronie https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">A carga de trabalho Aspire está obsoleta e não é mais necessária. O Aspire agora está disponível como pacotes NuGet que você pode adicionar diretamente aos seus projetos. Para mais informações, consulte https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Рабочая нагрузка Aspire является нерекомендуемой и больше не требуется. Теперь нагрузка Aspire доступна в виде пакетов NuGet, которые можно добавлять непосредственно в проекты. Дополнительные сведения см. на странице https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Aspire iş yükü kullanım dışı bırakıldı ve artık gerekli değil. Aspire, projelerinize doğrudan ekleyebileceğiniz NuGet paketleri olarak kullanılabilir. Daha fazla bilgi için bkz. https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Aspire 工作负载已弃用，并且不再是必需项。Aspire 现在以 NuGet 包的形式提供，可以直接将其添加到项目中。有关详细信息，请参阅 https://aka.ms/aspire/support-policy</target>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="new">Artifact post-processing with '{0}' exited with code {1}. Any artifacts that were not merged will be reported individually.</target>
         <note>{0} is the test application path. {1} is the process exit code.</note>
       </trans-unit>
+      <trans-unit id="ArtifactPostProcessingStarted">
+        <source>Merging compatible artifacts produced by different test applications...</source>
+        <target state="new">Merging compatible artifacts produced by different test applications...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireWorkloadDeprecated">
         <source>The Aspire workload is deprecated and no longer necessary. Aspire is now available as NuGet packages that you can add directly to your projects. For more information, see https://aka.ms/aspire/support-policy</source>
         <target state="translated">Aspire 工作負載已棄用，不再需要。Aspire 現已作為 NuGet 套件提供，您可以將它直接新增至專案。如需詳細資訊，請參閱 https://aka.ms/aspire/support-policy</target>

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Commands.Test;
@@ -129,6 +130,222 @@ public class ArtifactPostProcessingManagerTests
         string arguments = TestApplication.GetArtifactPostProcessingLaunchArguments(appHostModule);
 
         arguments.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void BuildArtifactPostProcessingArguments_ForwardsOptionsThatGovernExtensionLoading()
+    {
+        var pathOptions = new PathOptions(
+            ProjectOrSolutionPath: null,
+            SolutionPath: null,
+            TestModules: null,
+            ResultsDirectoryPath: "/results",
+            ConfigFilePath: "/config/testconfig.json",
+            DiagnosticOutputDirectoryPath: "/diagnostics");
+
+        string arguments = TestApplication.BuildArtifactPostProcessingArguments(
+            new StringBuilder("exec A.dll"),
+            pathOptions,
+            "/tmp/manifest.json",
+            "pipe-name");
+
+        arguments.Should().Contain($"{CliConstants.ArtifactPostProcessingToolName}");
+        arguments.Should().Contain($"{CliConstants.ArtifactPostProcessingManifestOptionKey} ");
+        arguments.Should().Contain(
+            TestCommandDefinition.MicrosoftTestingPlatform.ConfigFileOptionName,
+            "a merge host resolves its extensions from the same configuration file as the test run");
+        arguments.Should().Contain(TestCommandDefinition.MicrosoftTestingPlatform.DiagnosticOutputDirectoryOptionName);
+        arguments.Should().Contain($"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue}");
+    }
+
+    [TestMethod]
+    public void BuildArtifactPostProcessingArguments_DoesNotForwardResultsDirectory()
+    {
+        var pathOptions = new PathOptions(
+            ProjectOrSolutionPath: null,
+            SolutionPath: null,
+            TestModules: null,
+            ResultsDirectoryPath: "/results",
+            ConfigFilePath: null,
+            DiagnosticOutputDirectoryPath: null);
+
+        string arguments = TestApplication.BuildArtifactPostProcessingArguments(
+            new StringBuilder("exec A.dll"),
+            pathOptions,
+            "/tmp/manifest.json",
+            "pipe-name");
+
+        arguments.Should().NotContain(
+            TestCommandDefinition.MicrosoftTestingPlatform.ResultsDirectoryOptionName,
+            "the merged output location travels in the manifest, so the SDK keeps control of it");
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("not-a-number")]
+    [DataRow("-1")]
+    public void ParseArtifactPostProcessingTimeout_UnusableValue_KeepsDefault(string? configuredTimeout)
+        => TestApplication.ParseArtifactPostProcessingTimeout(configuredTimeout)
+            .Should().Be(TimeSpan.FromMinutes(15));
+
+    [TestMethod]
+    public void ParseArtifactPostProcessingTimeout_PositiveValue_IsInterpretedAsSeconds()
+        => TestApplication.ParseArtifactPostProcessingTimeout("30").Should().Be(TimeSpan.FromSeconds(30));
+
+    [TestMethod]
+    public void ParseArtifactPostProcessingTimeout_Zero_RemovesTheBound()
+        => TestApplication.ParseArtifactPostProcessingTimeout("0").Should().Be(Timeout.InfiniteTimeSpan);
+
+    [TestMethod]
+    [DataRow("4294968")]
+    [DataRow("2147483647")]
+    public void ParseArtifactPostProcessingTimeout_ValueTooLargeToWaitOn_RemovesTheBound(string configuredTimeout)
+    {
+        // Task.WaitAsync throws for a timeout above ~49.7 days instead of waiting, which would fail
+        // every merge. Asking for a timeout that long means 'effectively never'.
+        TimeSpan timeout = TestApplication.ParseArtifactPostProcessingTimeout(configuredTimeout);
+
+        timeout.Should().Be(Timeout.InfiniteTimeSpan);
+        Action wait = () => Task.CompletedTask.WaitAsync(timeout, CancellationToken.None);
+        wait.Should().NotThrow("a timeout the framework rejects would fail every merge instead of bounding it");
+    }
+
+    [TestMethod]
+    public void ShouldPostProcessArtifacts_CompletedRun_MergesArtifacts()
+        => MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: false,
+            TestRunCancellationReason.None).Should().BeTrue();
+
+    [TestMethod]
+    public void ShouldPostProcessArtifacts_HelpOrDiscovery_MergesNothing()
+    {
+        MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(isHelp: true),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: false,
+            TestRunCancellationReason.None).Should().BeFalse("help prints usage and produces no artifacts");
+
+        MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(isDiscovery: true),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: false,
+            TestRunCancellationReason.None).Should().BeFalse("discovery runs no tests and produces no artifacts");
+    }
+
+    [TestMethod]
+    public void ShouldPostProcessArtifacts_OptedOut_MergesNothing()
+        => MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(),
+            noArtifactPostProcessingRequested: true,
+            cancellationRequested: false,
+            TestRunCancellationReason.None).Should().BeFalse();
+
+    [TestMethod]
+    public void ShouldPostProcessArtifacts_TruncatedRun_MergesNothing()
+    {
+        // Merging the artifacts of a run that was cut short would hide the truncation behind one
+        // authoritative-looking report, so every way of cutting a run short has to skip the merge.
+        MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: true,
+            TestRunCancellationReason.None).Should().BeFalse("Ctrl+C leaves a truncated run");
+
+        MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: false,
+            TestRunCancellationReason.MaximumFailedTests).Should().BeFalse("--maximum-failed-tests leaves a truncated run");
+
+        MicrosoftTestingPlatformTestCommand.ShouldPostProcessArtifacts(
+            CreateTestOptions(),
+            noArtifactPostProcessingRequested: false,
+            cancellationRequested: false,
+            TestRunCancellationReason.Timeout).Should().BeFalse("--timeout leaves a truncated run");
+    }
+
+    private static TestOptions CreateTestOptions(bool isHelp = false, bool isDiscovery = false)
+        => new(isHelp, isDiscovery, TestListFormat.Text);
+
+    [TestMethod]
+    public void GetOutputDirectory_WithResultsDirectory_UsesThatDirectory()
+    {
+        string resultsDirectory = Path.Combine(Path.GetTempPath(), "results");
+        ArtifactPostProcessingJob job = CreateJob(
+            CreateArtifact(Path.Combine(Path.GetTempPath(), "a", "first.trx"), "microsoft.testing.trx"));
+
+        string outputDirectory = ArtifactPostProcessingManager.GetOutputDirectory(
+            CreateBuildOptions(resultsDirectory),
+            job);
+
+        outputDirectory.Should().Be(Path.GetFullPath(resultsDirectory));
+    }
+
+    [TestMethod]
+    public void GetOutputDirectory_WithoutResultsDirectory_PrefersDirectoryOfElectedApplicationInput()
+    {
+        // 'aaa' sorts before 'zzz', so an implementation that just takes the first input in path
+        // order would drop the merged artifact into the output of a project that merely contributed
+        // an input, instead of beside the reports of the application performing the merge.
+        ArtifactPostProcessingArtifact produced = new(
+            Path.Combine(Path.GetTempPath(), "zzz", "elected.trx"),
+            "microsoft.testing.trx",
+            ProducingTestModule: "A.dll",
+            "net10.0",
+            "x64",
+            "execution-1");
+        ArtifactPostProcessingArtifact other = new(
+            Path.Combine(Path.GetTempPath(), "aaa", "other.trx"),
+            "microsoft.testing.trx",
+            ProducingTestModule: "B.dll",
+            "net10.0",
+            "x64",
+            "execution-2");
+
+        string outputDirectory = ArtifactPostProcessingManager.GetOutputDirectory(
+            CreateBuildOptions(),
+            CreateJob(other, produced));
+
+        outputDirectory.Should().Be(Path.GetFullPath(Path.Combine(Path.GetTempPath(), "zzz")));
+    }
+
+    [TestMethod]
+    public void GetOutputDirectory_WhenElectedApplicationProducedNoInput_UsesFirstInputDirectoryInPathOrder()
+    {
+        // An application can be elected purely for the kinds it advertises, without having produced
+        // any of the inputs. Path order then keeps the choice deterministic.
+        ArtifactPostProcessingArtifact last = new(
+            Path.Combine(Path.GetTempPath(), "zzz", "last.trx"),
+            "microsoft.testing.trx",
+            ProducingTestModule: "B.dll",
+            "net10.0",
+            "x64",
+            "execution-1");
+        ArtifactPostProcessingArtifact first = new(
+            Path.Combine(Path.GetTempPath(), "aaa", "first.trx"),
+            "microsoft.testing.trx",
+            ProducingTestModule: "C.dll",
+            "net10.0",
+            "x64",
+            "execution-2");
+
+        string outputDirectory = ArtifactPostProcessingManager.GetOutputDirectory(
+            CreateBuildOptions(),
+            CreateJob(last, first));
+
+        outputDirectory.Should().Be(Path.GetFullPath(Path.Combine(Path.GetTempPath(), "aaa")));
+    }
+
+    private static ArtifactPostProcessingJob CreateJob(params ArtifactPostProcessingArtifact[] artifacts)
+    {
+        ArtifactPostProcessingApplication application = CreateApplication();
+        return new ArtifactPostProcessingJob(
+            application,
+            [new ArtifactPostProcessingGroup("microsoft.testing.trx", IsKind: true, artifacts, [application])]);
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
@@ -201,6 +201,7 @@ public class ArtifactPostProcessingManagerTests
     [TestMethod]
     [DataRow("4294968")]
     [DataRow("2147483647")]
+    [DataRow("9999999999")]
     public void ParseArtifactPostProcessingTimeout_ValueTooLargeToWaitOn_RemovesTheBound(string configuredTimeout)
     {
         // Task.WaitAsync throws for a timeout above ~49.7 days instead of waiting, which would fail

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingPlannerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingPlannerTests.cs
@@ -207,6 +207,61 @@ public class ArtifactPostProcessingPlannerTests
         plan.Jobs[0].Application.Should().BeSameAs(arm64);
     }
 
+    [TestMethod]
+    public void Plan_DifferentKindsSharingAnExtension_AreNotMerged()
+    {
+        // JUnit and NUnit3 both write '.xml'. Extension-only matching would collapse them into one
+        // group and hand a JUnit merger a set of NUnit3 reports; the kind is what keeps them apart.
+        ArtifactPostProcessingApplication application = CreateApplication(
+            "A.dll",
+            "net10.0",
+            "x64",
+            ["example.junit", "example.nunit3"],
+            [".xml"]);
+        ArtifactPostProcessingArtifact[] artifacts =
+        [
+            CreateArtifact("A-junit.xml", "example.junit", "A.dll", "x64"),
+            CreateArtifact("B-junit.xml", "example.junit", "B.dll", "x64"),
+            CreateArtifact("A-nunit.xml", "example.nunit3", "A.dll", "x64"),
+            CreateArtifact("B-nunit.xml", "example.nunit3", "B.dll", "x64"),
+        ];
+
+        ArtifactPostProcessingPlan plan = ArtifactPostProcessingPlanner.Plan([application], artifacts);
+
+        plan.Jobs.Should().ContainSingle();
+        ArtifactPostProcessingGroup[] groups = [.. plan.Jobs[0].Groups];
+        groups.Select(group => group.Key).Should().BeEquivalentTo("example.junit", "example.nunit3");
+        groups.Should().OnlyContain(
+            group => group.Artifacts.Count == 2,
+            "each kind keeps its own inputs even though both write the same file extension");
+    }
+
+    [TestMethod]
+    public void Plan_TaggedArtifact_IsNotAlsoRoutedThroughTheExtensionFallback()
+    {
+        // A tagged artifact must never appear in both its kind group and the fallback group for its
+        // extension: the merge tool would then receive it twice and double-count its tests.
+        ArtifactPostProcessingApplication application = CreateApplication(
+            "A.dll",
+            "net10.0",
+            "x64",
+            ["microsoft.testing.trx"],
+            [".trx"]);
+        ArtifactPostProcessingArtifact[] artifacts =
+        [
+            CreateArtifact("A.trx", "microsoft.testing.trx", "A.dll", "x64"),
+            CreateArtifact("B.trx", "microsoft.testing.trx", "B.dll", "x64"),
+            CreateArtifact("C.trx", kind: null, "C.dll", "x64"),
+        ];
+
+        ArtifactPostProcessingPlan plan = ArtifactPostProcessingPlanner.Plan([application], artifacts);
+
+        string[] plannedPaths =
+            [.. plan.Jobs.SelectMany(job => job.Groups).SelectMany(group => group.Artifacts).Select(artifact => artifact.Path)];
+        plannedPaths.Should().OnlyHaveUniqueItems();
+        plannedPaths.Should().BeEquivalentTo("A.trx", "B.trx", "C.trx");
+    }
+
     private static ArtifactPostProcessingApplication CreateApplication(
         string targetPath,
         string targetFramework,

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingTelemetryTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingTelemetryTests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public class ArtifactPostProcessingTelemetryTests
+{
+    [TestMethod]
+    public void CreateProperties_ReportsPlanShapeAndDuration()
+    {
+        ArtifactPostProcessingApplication application = CreateApplication();
+        var plan = new ArtifactPostProcessingPlan(
+        [
+            new ArtifactPostProcessingJob(
+                application,
+                [
+                    CreateGroup("microsoft.testing.trx", isKind: true, artifactCount: 3),
+                    CreateGroup(".coverage", isKind: false, artifactCount: 2),
+                ]),
+        ]);
+
+        Dictionary<string, string?> properties = ArtifactPostProcessingTelemetry.CreateProperties(
+            plan,
+            executedJobs: 1,
+            failedJobs: 0,
+            TimeSpan.FromMilliseconds(1234));
+
+        properties["jobs_planned"].Should().Be("1");
+        properties["jobs_executed"].Should().Be("1");
+        properties["jobs_failed"].Should().Be("0");
+        properties["artifact_count"].Should().Be("5");
+        properties["kinds"].Should().Be("microsoft.testing.trx");
+        properties["extensions"].Should().Be(".coverage");
+        properties["duration_ms"].Should().Be("1234");
+    }
+
+    [TestMethod]
+    public void CreateProperties_UnknownKindsAndExtensions_AreBucketed()
+    {
+        // Kinds and file extensions are chosen by whoever wrote the producing extension, so an
+        // in-house post-processor can carry a product or team name. Only shipped formats are
+        // reported verbatim; everything else has to collapse into a single opaque bucket.
+        ArtifactPostProcessingApplication application = CreateApplication();
+        var plan = new ArtifactPostProcessingPlan(
+        [
+            new ArtifactPostProcessingJob(
+                application,
+                [
+                    CreateGroup("contoso.internal.telemetry", isKind: true, artifactCount: 2),
+                    CreateGroup("fabrikam.audit", isKind: true, artifactCount: 2),
+                    CreateGroup("microsoft.testing.trx", isKind: true, artifactCount: 2),
+                    CreateGroup(".contoso", isKind: false, artifactCount: 2),
+                ]),
+        ]);
+
+        Dictionary<string, string?> properties = ArtifactPostProcessingTelemetry.CreateProperties(
+            plan,
+            executedJobs: 1,
+            failedJobs: 1,
+            TimeSpan.Zero);
+
+        properties["kinds"].Should().Be(
+            "microsoft.testing.trx;other",
+            "the two private kinds must collapse into one bucket rather than being uploaded");
+        properties["extensions"].Should().Be("other");
+    }
+
+    [TestMethod]
+    public void CreateProperties_NeverReportsArtifactPaths()
+    {
+        ArtifactPostProcessingApplication application = CreateApplication();
+        var artifact = new ArtifactPostProcessingArtifact(
+            "/repo/src/Contoso.Secret.Tests/bin/Debug/TestResults/report.trx",
+            "microsoft.testing.trx",
+            "Contoso.Secret.Tests.dll",
+            "net10.0",
+            "x64",
+            "execution-1");
+        var plan = new ArtifactPostProcessingPlan(
+        [
+            new ArtifactPostProcessingJob(
+                application,
+                [new ArtifactPostProcessingGroup("microsoft.testing.trx", IsKind: true, [artifact, artifact], [application])]),
+        ]);
+
+        Dictionary<string, string?> properties = ArtifactPostProcessingTelemetry.CreateProperties(
+            plan,
+            executedJobs: 1,
+            failedJobs: 0,
+            TimeSpan.Zero);
+
+        properties.Values.Should().NotContain(value => value != null && value.Contains("Contoso"));
+    }
+
+    private static ArtifactPostProcessingGroup CreateGroup(string key, bool isKind, int artifactCount)
+    {
+        ArtifactPostProcessingApplication application = CreateApplication();
+        ArtifactPostProcessingArtifact[] artifacts =
+        [
+            .. Enumerable.Range(0, artifactCount).Select(index => new ArtifactPostProcessingArtifact(
+                $"artifact-{index}{(isKind ? ".trx" : key)}",
+                isKind ? key : null,
+                "A.dll",
+                "net10.0",
+                "x64",
+                $"execution-{index}"))
+        ];
+
+        return new ArtifactPostProcessingGroup(key, isKind, artifacts, [application]);
+    }
+
+    private static ArtifactPostProcessingApplication CreateApplication()
+        => new(
+            new TestModule(
+                new RunProperties("dotnet", "A.dll", null),
+                ProjectFullPath: null,
+                TargetFramework: "net10.0",
+                IsTestingPlatformApplication: true,
+                LaunchSettings: null,
+                TargetPath: "A.dll",
+                DotnetRootArchVariableName: null,
+                EnvironmentVariables: new Dictionary<string, string>()),
+            "net10.0",
+            "x64",
+            new HashSet<string>(StringComparer.Ordinal) { "microsoft.testing.trx" },
+            new HashSet<string>(StringComparer.Ordinal));
+}

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Utils;
 using ExitCodes = Microsoft.NET.TestFramework.ExitCode;
@@ -64,6 +65,104 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
         trxReports.Should().NotContain(path => Path.GetFileName(path).StartsWith("merged-", StringComparison.Ordinal));
     }
 
+    [TestMethod]
+    public void SingleTestApplication_ProducesOneReport_WithNoMergedReport()
+    {
+        TestAsset testInstance = TestAssetsManager
+            .CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())
+            .WithSource();
+        EnableTrxReport(testInstance.Path);
+        string resultsDirectory = Path.Combine(testInstance.Path, "TestResults");
+
+        // Scoping the multi-project solution to a single project yields exactly one test application,
+        // so the planner never sees the >= 2 inputs it requires to plan a merge.
+        CommandResult result = Run(
+            testInstance.Path,
+            resultsDirectory,
+            "--project",
+            $"TestProject{Path.DirectorySeparatorChar}TestProject.csproj");
+
+        result.ExitCode.Should().Be(
+            ExitCodes.AtLeastOneTestFailed,
+            $"the test output was:{Environment.NewLine}{result.StdOut}{Environment.NewLine}{result.StdErr}");
+
+        string[] trxReports = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.AllDirectories);
+        trxReports.Should().ContainSingle("a single test application produces exactly one TRX report");
+        trxReports.Should().NotContain(
+            path => Path.GetFileName(path).StartsWith("merged-", StringComparison.Ordinal),
+            "a single input never satisfies the planner's >= 2 inputs rule, so no test application is relaunched to merge");
+    }
+
+    [TestMethod]
+    public void RunCutShortByMaximumFailedTests_KeepsOneReportPerTestApplication()
+    {
+        TestAsset testInstance = TestAssetsManager
+            .CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())
+            .WithSource();
+        EnableTrxReport(testInstance.Path);
+        string resultsDirectory = Path.Combine(testInstance.Path, "TestResults");
+
+        CommandResult result = Run(testInstance.Path, resultsDirectory, "--maximum-failed-tests", "1");
+
+        result.ExitCode.Should().Be(
+            ExitCodes.TestExecutionStoppedForMaxFailedTests,
+            $"the test output was:{Environment.NewLine}{result.StdOut}{Environment.NewLine}{result.StdErr}");
+
+        // The run is parallel, so how many modules survived to write a TRX before the policy tripped is
+        // timing dependent; only the absence of a merged report is deterministic.
+        string[] trxReports = Directory.Exists(resultsDirectory)
+            ? Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.AllDirectories)
+            : [];
+        trxReports.Should().NotContain(
+            path => Path.GetFileName(path).StartsWith("merged-", StringComparison.Ordinal),
+            "a run truncated by --maximum-failed-tests skips post-processing so the truncation is not hidden behind one merged report");
+
+        // The progress line is printed as soon as post-processing has anything planned, so its absence
+        // shows the merge was skipped rather than merely finding nothing to do. (For the same
+        // timing reason as above this cannot prove a plan would have existed, so it is a guard against
+        // the skip regressing, not a proof that a merge was averted.)
+        result.StdOut.Should().NotContain(
+            CliCommandStrings.ArtifactPostProcessingStarted,
+            "a truncated run must not even start post-processing");
+    }
+
+    [TestMethod]
+    public void TestModulesRun_MergesTrxArtifacts()
+    {
+        TestAsset testInstance = TestAssetsManager
+            .CopyTestAsset("MultiTestProjectSolutionWithTests", Guid.NewGuid().ToString())
+            .WithSource();
+        EnableTrxReport(testInstance.Path);
+
+        new BuildCommand(testInstance, "TestProject").Execute().Should().Pass();
+        new BuildCommand(testInstance, "OtherTestProject").Execute().Should().Pass();
+
+        string resultsDirectory = Path.Combine(testInstance.Path, "TestResults");
+        string modulesFilter = $"**/bin/**/Debug/{ToolsetInfo.CurrentTargetFramework}/*TestProject.dll"
+            .Replace('/', Path.DirectorySeparatorChar);
+
+        CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--test-modules", modulesFilter, "--report-trx", "--results-directory", resultsDirectory);
+
+        string mergedTrxPath = GetMergedTrxPath(result);
+        File.Exists(mergedTrxPath).Should().BeTrue();
+        Path.GetFileName(mergedTrxPath).Should().MatchRegex("^merged-[0-9a-f]{32}\\.trx$");
+        Directory.GetFiles(resultsDirectory, "merged-*.trx", SearchOption.AllDirectories)
+            .Should().ContainSingle("post-processing is orchestrated independently of --test-modules discovery");
+
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        int TotalCount(string trxPath) => int.Parse(
+            XDocument.Load(trxPath).Descendants(ns + "Counters").Single().Attribute("total")!.Value);
+
+        int individualTotal = Directory.GetFiles(resultsDirectory, "*.trx", SearchOption.AllDirectories)
+            .Where(path => !Path.GetFileName(path).StartsWith("merged-", StringComparison.Ordinal))
+            .Sum(TotalCount);
+        TotalCount(mergedTrxPath).Should().Be(
+            individualTotal,
+            "the merged report accounts for every test from each per-module report");
+    }
+
     private CommandResult Run(string workingDirectory, string resultsDirectory, params string[] additionalArguments)
     {
         string[] arguments =
@@ -76,6 +175,12 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
 
         return new DotnetTestCommand(Log, disableNewOutput: false)
             .WithWorkingDirectory(workingDirectory)
+            // This test suite itself runs under Microsoft.Testing.Platform, so its process already
+            // carries an execution id. A test application only generates its own when the variable is
+            // unset, so without this the applications launched by the inner 'dotnet test' would adopt
+            // this harness's id and every invocation would look like the same execution. Clearing it
+            // restores what a normal 'dotnet test' sees: one fresh execution id per invocation.
+            .WithEnvironmentVariable("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID", string.Empty)
             .Execute(arguments);
     }
 

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
@@ -173,15 +173,18 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
             .. additionalArguments
         ];
 
-        return new DotnetTestCommand(Log, disableNewOutput: false)
-            .WithWorkingDirectory(workingDirectory)
-            // This test suite itself runs under Microsoft.Testing.Platform, so its process already
-            // carries an execution id. A test application only generates its own when the variable is
-            // unset, so without this the applications launched by the inner 'dotnet test' would adopt
-            // this harness's id and every invocation would look like the same execution. Clearing it
-            // restores what a normal 'dotnet test' sees: one fresh execution id per invocation.
-            .WithEnvironmentVariable("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID", string.Empty)
-            .Execute(arguments);
+        Microsoft.NET.TestFramework.Commands.TestCommand command = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(workingDirectory);
+
+        // This test suite itself runs under Microsoft.Testing.Platform, so its process already
+        // carries an execution id. A test application only generates its own when the variable is
+        // unset, so without this the applications launched by the inner 'dotnet test' would adopt
+        // this harness's id and every invocation would look like the same execution. Removing it
+        // from the child environment restores what a normal 'dotnet test' sees: one fresh execution
+        // id per invocation.
+        command.EnvironmentToRemove.Add("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID");
+
+        return command.Execute(arguments);
     }
 
     private static string GetMergedTrxPath(CommandResult result)


### PR DESCRIPTION
Follow-up to #55419 (the feature) and #55480 (hardening). Artifact post-processing shipped as SDK orchestration plus a TRX post-processor, but a handful of SDK-owned gaps against [microsoft/testfx RFC 018](https://github.com/microsoft/testfx/blob/main/docs/RFCs/018-Artifact-Post-Processing.md) were left open. This closes them.

### A truncated run could be merged into one authoritative-looking report

Only Ctrl+C skipped post-processing. A run stopped by `--maximum-failed-tests` or `--timeout` still merged whatever artifacts existed: modules that never started contributed nothing, and modules killed mid-flight wrote whatever they had. The merged report then looked like a complete run. Both cases now skip, exactly as Ctrl+C already did.

The decision moved out of the inline condition into `ShouldPostProcessArtifacts`, so all five reasons to skip (help, discovery, opt-out, cancellation, policy truncation) are covered by deterministic unit tests instead of only by a timing-dependent end-to-end test.

### The merge host did not see `--config-file`

A merge host resolves and enables its extensions exactly like a test host does, so a configuration file that governs which extensions load has to reach it. Without it the merge ran with a different extension set than the run that produced the artifacts, and a post-processor disabled by configuration silently came back for the merge. `--config-file` is now forwarded alongside `--diagnostic-output-directory`.

`--results-directory` is deliberately still not forwarded: the merged output location travels in the manifest so the SDK keeps control of it even when it has to be derived. That is now stated in a comment rather than being implicit.

### Merged output landed in an arbitrary project's bin folder

Without `--results-directory` the output directory was the directory of whichever input sorted first. It is now the directory of an input produced by the elected application when there is one, so the merged artifact lands beside the reports it summarizes rather than inside an unrelated project's output. Path order remains the fallback, because an application can be elected purely for the kinds it advertises without having produced any input.

### Other gaps

- **Configurable timeout.** The 15 minute bound on a merge host is now overridable through `DOTNET_CLI_TEST_ARTIFACT_POST_PROCESSING_TIMEOUT_SECONDS`, with `0` removing it entirely (which is what makes attaching a debugger to a merge host possible). Values the framework would reject, above roughly 49.7 days, collapse to "no bound" instead of throwing out of the wait and failing every merge.
- **Progress feedback.** Post-processing runs after the last module exits and before the summary, so a slow merge was indistinguishable from a hung CLI. A single line is printed once a plan exists.
- **Telemetry** (RFC section 7.11). New `test/artifact-post-processing` event with jobs planned/executed/failed, artifact count, kinds, extensions and wall time. Kinds and extensions are producer-chosen strings, so anything outside a fixed well-known list is reported as `other` and a private post-processor's identifier is never uploaded. Runs that plan nothing emit nothing.
- **Documentation.** The feature had none. Adds `documentation/general/dotnet-test-artifact-post-processing.md` covering when it runs and when it is skipped, how groups and elections are computed, where merged output lands, the `--no-build` caveat, why this is unrelated to VSTest's `VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING`, and troubleshooting. Plus the telemetry event entry.

### Hardening found in review

`ExecuteAsync` guarded each job but not the code around them. Planning, the progress line and the telemetry call sat outside any `catch`, and `ExecuteAsync` is invoked with `.GetAwaiter().GetResult()` under a `try`/`finally` with no `catch`, so a throw from any of them could still turn a finished run into a CLI crash with a different exit code. The whole body is now guarded. Separately, a merge killed by Ctrl+C reported `jobs_failed` in telemetry even though the user-facing warning was deliberately suppressed for that case; `ReportFailureUnlessCancelled` now returns whether it reported, and the counter follows it.

### Pre-existing test failure fixed

`MultiProjectRun_MergesTrxArtifacts` was failing on `main`. I confirmed this by stashing everything and rebuilding before touching it.

This suite runs under Microsoft.Testing.Platform, so its process already carries a `TESTINGPLATFORM_DOTNETTEST_EXECUTIONID`. A test application only generates its own when that variable is unset, so the applications launched by the inner `dotnet test` adopted the harness's id and both invocations looked like the same execution. The merged report name is derived from the inputs and their execution ids, so the second run collided with the first. The test now clears the variable per invocation.

Worth flagging as a possible follow-up, deliberately not changed here: this means `dotnet test` propagates an inherited execution id to every test application it starts, contrary to the platform's documented "each test application gets its own" model. It is niche and upstream-adjacent, so I did not change that hot path.

### Still out of scope

Coverage merging needs a post-processor in the extension that produces `.coverage` (RFC Phase 3, microsoft/codecoverage); coverlet is Phase 4; de-duplicating retried tests belongs to the merge engine. Until Phase 3 ships, TRX remains the only format that consolidates, which is why #47613 stays open.

### Validation

`build.cmd -c Debug` is clean. 52/52 `ArtifactPostProcessing*` tests pass, plus 89 neighbouring tests (`TerminalTestReporter`, `TestApplicationHandler`, `TestProgressState`, `MTPHelpSnapshot`, `TestCommandParser`, and the max-failed-tests, timeout and retry end-to-end tests). All 15 `.xlf` files were regenerated by the build rather than hand-edited.

New coverage: 2 planner tests (kinds sharing an extension are not conflated; a tagged artifact is never routed through both its kind group and the extension fallback), 11 manager tests (output directory selection, timeout parsing, merge-host argument construction, the skip decision), 3 telemetry tests including one asserting no path or project name reaches any property, and 3 end-to-end tests from the RFC behavior matrix (single application produces no merged report, a run truncated by `--maximum-failed-tests` is not merged, `--test-modules` merges and the merged counters equal the sum of the per-module ones).

Relates to #47613.