### PR TITLE
Document CI telemetry correlation requirements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,6 +172,21 @@ manually edit:
 - **Generated workflow lock files** (`.github/workflows/*.lock.yml`).
 - More broadly, any file marked `linguist-generated=true` in `.gitattributes`.
 
+### Preserve CI telemetry correlation
+
+Every CI workflow or pipeline entry point must set `DOTNET_CLI_TELEMETRY_SESSIONID` at
+the widest supported shared scope: workflow or pipeline scope when available, otherwise
+on every job. Use the repository's provider-specific value unchanged:
+
+- GitHub Actions:
+  `gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}`
+- Azure DevOps:
+  `azdo-$(System.CollectionId)-$(System.TeamProjectId)-$(Build.BuildId)`
+
+When adding or editing shared CI environment variables, preserve this setting. See
+the [developer guide](../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation)
+for the required YAML shapes and rationale.
+
 ## External Dependencies
 
 Adding or updating a dependency is a repo-wide compatibility and supply-chain change,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,18 +174,17 @@ manually edit:
 
 ### Preserve CI telemetry correlation
 
-Every CI workflow or pipeline entry point must set `DOTNET_CLI_TELEMETRY_SESSIONID` at
-the widest supported shared scope: workflow or pipeline scope when available, otherwise
-on every job. Use the repository's provider-specific value unchanged:
+Set `DOTNET_CLI_TELEMETRY_SESSIONID` in every CI workflow and pipeline entry point. Set
+the variable at the workflow or pipeline scope. Use the applicable value without changes:
 
 - GitHub Actions:
   `gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}`
 - Azure DevOps:
   `azdo-$(System.CollectionId)-$(System.TeamProjectId)-$(Build.BuildId)`
 
-When adding or editing shared CI environment variables, preserve this setting. See
+When you change shared CI environment variables, preserve this variable. See
 the [developer guide](../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation)
-for the required YAML shapes and rationale.
+for the required YAML and the reason for this variable.
 
 ## External Dependencies
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,7 +175,8 @@ manually edit:
 ### Preserve CI telemetry correlation
 
 Set `DOTNET_CLI_TELEMETRY_SESSIONID` in every CI workflow and pipeline entry point. Set
-the variable at the workflow or pipeline scope. Use the applicable value without changes:
+the variable at the workflow or pipeline scope. Job scope is valid for a single-job
+workflow. Use the applicable value without changes:
 
 - GitHub Actions:
   `gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}`

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -137,7 +137,7 @@ Then read the PR description, labels, and linked issues (in PR review mode) as *
 
 - Compare *behavior*, not just shape: how leniently each accepts input, how each orders or normalizes values, and which options or flags each honors. An input the SDK accepts elsewhere should not fail here, and vice versa — flag the divergence with both file:line references (the new code and the established sibling).
 - When the new code emits output that another component must later consume (a project-file edit, a generated directive, a manifest), verify the consumer's contract is satisfied — including ordering and implicit-default semantics, not just syntactic validity.
-- For each changed CI entry point, verify that `DOTNET_CLI_TELEMETRY_SESSIONID` remains at workflow or pipeline scope. Use the provider format from the [developer guide](../../../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation). Flag a missing, per-step, or changed value. These errors prevent reliable correlation between the run's `dotnet` processes.
+- For each changed CI entry point, verify the scope of `DOTNET_CLI_TELEMETRY_SESSIONID`. Require workflow or pipeline scope for multiple jobs. Permit job scope for a single-job workflow. Use the provider format from the [developer guide](../../../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation). Flag a missing, per-step, or changed value. These errors prevent reliable correlation between the run's `dotnet` processes.
 
 ### Impact Analysis for Tests and Regressions
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -137,7 +137,7 @@ Then read the PR description, labels, and linked issues (in PR review mode) as *
 
 - Compare *behavior*, not just shape: how leniently each accepts input, how each orders or normalizes values, and which options or flags each honors. An input the SDK accepts elsewhere should not fail here, and vice versa — flag the divergence with both file:line references (the new code and the established sibling).
 - When the new code emits output that another component must later consume (a project-file edit, a generated directive, a manifest), verify the consumer's contract is satisfied — including ordering and implicit-default semantics, not just syntactic validity.
-- For added or changed CI workflow and pipeline entry points, verify that `DOTNET_CLI_TELEMETRY_SESSIONID` remains defined at the widest supported shared scope with the provider-specific format from the [developer guide](../../../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation). Flag a missing, per-step-only, or reformatted value because it prevents reliable correlation across the run's `dotnet` processes.
+- For each changed CI entry point, verify that `DOTNET_CLI_TELEMETRY_SESSIONID` remains at workflow or pipeline scope. Use the provider format from the [developer guide](../../../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation). Flag a missing, per-step, or changed value. These errors prevent reliable correlation between the run's `dotnet` processes.
 
 ### Impact Analysis for Tests and Regressions
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -110,7 +110,7 @@ Group files by area to guide how deeply to review each. The first five areas are
 | Compatibility tooling | `src/Compatibility/**` (ApiCompat/GenAPI) | Compiler/language semantic fidelity, diagnostics, generated reference output, framework variation |
 | Watch / Containers | `src/Dotnet.Watch/**`, `src/Containers/**` | Process lifetime, cancellation, file-system races, cleanup |
 | Analyzers | `src/Microsoft.CodeAnalysis.NetAnalyzers/**` | Roslyn diagnostic correctness across supported frameworks |
-| Build/Infra | `eng/**`, `Directory.Build.props`, `Directory.Build.targets`, `*.slnx` | Unintended side effects, breaking conditional logic |
+| Build/Infra | `eng/**`, `.github/workflows/**`, `.vsts*.yml`, `Directory.Build.props`, `Directory.Build.targets`, `*.slnx` | Unintended side effects, breaking conditional logic, CI telemetry correlation |
 | Tests | `test/**` | Scenario-accurate regression coverage, target/platform gating, tests that would fail without the fix |
 
 ## Step 4: Review the Code
@@ -137,6 +137,7 @@ Then read the PR description, labels, and linked issues (in PR review mode) as *
 
 - Compare *behavior*, not just shape: how leniently each accepts input, how each orders or normalizes values, and which options or flags each honors. An input the SDK accepts elsewhere should not fail here, and vice versa — flag the divergence with both file:line references (the new code and the established sibling).
 - When the new code emits output that another component must later consume (a project-file edit, a generated directive, a manifest), verify the consumer's contract is satisfied — including ordering and implicit-default semantics, not just syntactic validity.
+- For added or changed CI workflow and pipeline entry points, verify that `DOTNET_CLI_TELEMETRY_SESSIONID` remains defined at the widest supported shared scope with the provider-specific format from the [developer guide](../../../documentation/project-docs/developer-guide.md#ci-workflow-telemetry-correlation). Flag a missing, per-step-only, or reformatted value because it prevents reliable correlation across the run's `dotnet` processes.
 
 ### Impact Analysis for Tests and Regressions
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,13 +14,12 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
-
 jobs:
 
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    env:
+      DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,12 +14,13 @@ on:
 permissions:
   contents: read
 
+env:
+  DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
 
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    env:
-      DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -176,6 +176,38 @@ taskkill /F /IM VSTest.Console.exe /T ||
 taskkill /F /IM msbuild.exe /T
 ```
 
+## CI workflow telemetry correlation
+
+Every CI workflow or pipeline entry point in this repository must define
+`DOTNET_CLI_TELEMETRY_SESSIONID` at the widest supported shared scope. The CLI uses this
+value to correlate telemetry from separate `dotnet` processes that belong to the same
+run. Defining it centrally also ensures that later steps inherit the correlation ID
+without needing per-step updates.
+
+GitHub Actions workflows under [`.github/workflows`](../../.github/workflows) should use:
+
+```yaml
+env:
+  DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+```
+
+Use workflow-level `env` when the workflow schema supports it. For special workflows
+that do not support workflow-level `env`, such as `copilot-setup-steps.yml`, define the
+same value on every job instead.
+
+Azure DevOps pipeline entry points should use:
+
+```yaml
+variables:
+- name: DOTNET_CLI_TELEMETRY_SESSIONID
+  value: azdo-$(System.CollectionId)-$(System.TeamProjectId)-$(Build.BuildId)
+```
+
+When adding a workflow or pipeline, or changing its shared environment or variables,
+preserve this setting and the provider-specific format. See the
+[telemetry documentation](telemetry.md#related-environment-variables) for the CLI
+behavior.
+
 ## Automated PR Maintenance Commands
 
 The SDK repository includes GitHub Actions workflows that automate common maintenance tasks directly from pull requests.

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -179,9 +179,9 @@ taskkill /F /IM msbuild.exe /T
 ## CI workflow telemetry correlation
 
 Set `DOTNET_CLI_TELEMETRY_SESSIONID` in every CI workflow and pipeline entry point.
-Set the variable at the workflow or pipeline scope. The CLI uses this value to correlate
-telemetry from separate `dotnet` processes in one run. All steps inherit the value from
-the shared scope.
+Set the variable at the workflow or pipeline scope. You can use job scope in a
+single-job workflow. The CLI uses this value to correlate telemetry from separate
+`dotnet` processes in one run.
 
 Use this value in GitHub Actions workflows under
 [`.github/workflows`](../../.github/workflows):

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -178,24 +178,20 @@ taskkill /F /IM msbuild.exe /T
 
 ## CI workflow telemetry correlation
 
-Every CI workflow or pipeline entry point in this repository must define
-`DOTNET_CLI_TELEMETRY_SESSIONID` at the widest supported shared scope. The CLI uses this
-value to correlate telemetry from separate `dotnet` processes that belong to the same
-run. Defining it centrally also ensures that later steps inherit the correlation ID
-without needing per-step updates.
+Set `DOTNET_CLI_TELEMETRY_SESSIONID` in every CI workflow and pipeline entry point.
+Set the variable at the workflow or pipeline scope. The CLI uses this value to correlate
+telemetry from separate `dotnet` processes in one run. All steps inherit the value from
+the shared scope.
 
-GitHub Actions workflows under [`.github/workflows`](../../.github/workflows) should use:
+Use this value in GitHub Actions workflows under
+[`.github/workflows`](../../.github/workflows):
 
 ```yaml
 env:
   DOTNET_CLI_TELEMETRY_SESSIONID: gha-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
 ```
 
-Use workflow-level `env` when the workflow schema supports it. For special workflows
-that do not support workflow-level `env`, such as `copilot-setup-steps.yml`, define the
-same value on every job instead.
-
-Azure DevOps pipeline entry points should use:
+Use this value in Azure DevOps pipeline entry points:
 
 ```yaml
 variables:
@@ -203,10 +199,9 @@ variables:
   value: azdo-$(System.CollectionId)-$(System.TeamProjectId)-$(Build.BuildId)
 ```
 
-When adding a workflow or pipeline, or changing its shared environment or variables,
-preserve this setting and the provider-specific format. See the
-[telemetry documentation](telemetry.md#related-environment-variables) for the CLI
-behavior.
+When you add or change a CI entry point, preserve this variable and its provider-specific
+format. For CLI behavior, see the
+[telemetry documentation](telemetry.md#related-environment-variables).
 
 ## Automated PR Maintenance Commands
 


### PR DESCRIPTION
## Summary

- Document the required `DOTNET_CLI_TELEMETRY_SESSIONID` values for GitHub Actions and Azure DevOps.
- Add the requirement to the repository Copilot instructions.
- Add a CI telemetry correlation check to the code-review skill.
- Require shared scope for workflows and pipelines with multiple jobs.
- Permit job scope for a single-job workflow.

This change follows #54447, which added CI-seeded CLI telemetry session IDs.

See dotnet/arcade#17232 for the proposal to set this variable through Arcade.