### PR TITLE
Remove IdentityModel source-build workaround

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -19,7 +19,6 @@
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <BuildArgs>$(BuildArgs) /p:PortableBuild=$(PortableBuild)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:TargetRuntimeIdentifier=$(TargetRid)</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:IdentityModelVersion=8.19.2</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)no-build-repo-tasks</BuildArgs>
   </PropertyGroup>
 


### PR DESCRIPTION
The aspnetcore fix that made the IdentityModel version override unnecessary has flowed into this branch. Remove the temporary source-only `IdentityModelVersion` pin so aspnetcore uses its repository-defined version again.

Fixes dotnet/source-build#5617