### PR TITLE
Track the four new TerminalTestReporter partials in the vendored-files manifest

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -34,7 +34,7 @@
     {
       "id": "dotnet-test-terminal-reporter",
       "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs",
-      "notes": "The Microsoft.Testing.Platform terminal UI reporter, hard-forked into 'dotnet test'. testfx has since split TerminalTestReporter into partial files; the SDK keeps a single TerminalTestReporter.cs. Each upstream partial is tracked so any upstream reporter change pings the SDK to reconcile. This is a hard fork: local content intentionally diverges; the signal is 'upstream changed', not 'files differ'.",
+      "notes": "The Microsoft.Testing.Platform terminal UI reporter, hard-forked into 'dotnet test'. testfx has since split TerminalTestReporter into partial files; the SDK keeps a single TerminalTestReporter.cs. Each upstream partial is tracked so any upstream reporter change pings the SDK to reconcile. This is a hard fork: local content intentionally diverges; the signal is 'upstream changed', not 'files differ'. NOT YET PORTED: the coverage summary (TerminalTestReporter.Coverage.cs), the flaky-test listing (.FlakyTests.cs), the slowest-test listing (.SlowestTests.cs) and the flaky/retried counter lines. Those were added upstream after the .Summary.cs baseline and then moved into their own partials, so a net .Summary.cs diff no longer shows them - the drift issue for .Summary.cs cannot surface this backlog. See microsoft/testfx#10390.",
       "sources": [
         {
           "repo": "microsoft/testfx",
@@ -106,6 +106,38 @@
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs",
           "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
           "baseline_blob_sha": "b8aee10a39ad8b5a7a64d6b9d5b2e1571de1f698",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Coverage.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "897e98cd2503a44f6d92ac0f7008edc77741c017",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.FlakyTests.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "b61b9512cd73c34ecbd86c45abccaeaa5cc9765c",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.SlowestTests.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "0463662d971dc911a7f8aacaaca68b9d4d3d6f7a",
+          "scope": "reporter partial"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestDiscovery.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "55fb099b665181200701f0153282093b511ce499",
           "scope": "reporter partial"
         }
       ]

--- a/eng/vendored-files.md
+++ b/eng/vendored-files.md
@@ -91,6 +91,12 @@ Idempotency uses a hidden marker `<!-- vendored-sync:id={id}:{source-index} -->`
 in the issue body, not the title. Existing matching issues are updated in place
 when the rendered body changes; otherwise they are left alone.
 
+Because that marker embeds the *positional* index of the source, **`sources` is
+append-only**. Inserting or reordering entries shifts every later index, which
+orphans the open issues keyed to the old positions and files duplicates at the
+new ones. Always add a new source at the end of the array, even when that breaks
+an otherwise alphabetical list.
+
 The workflow never auto-closes issues. A reviewer closes the issue after the
 reconciliation PR is merged.
 
@@ -107,6 +113,10 @@ reconciliation PR is merged.
      (`gh api "repos/{repo}/contents/{path}?ref={ref}" --jq .sha`).
 3. Run `python .github/scripts/check_vendored_files.py validate` locally to
    confirm the structure is correct.
+
+To add another *source* to an existing entry, append it to the end of that
+entry's `sources` array — see the append-only note under
+[How drift is detected](#how-drift-is-detected).
 
 ## Reconciling drift
 


### PR DESCRIPTION
Adds the four `TerminalTestReporter` partials that testfx introduced in [microsoft/testfx#10387](https://github.com/microsoft/testfx/pull/10387) to the `dotnet-test-terminal-reporter` entry, so upstream edits to them are visible to the drift detector. Tracked upstream as [microsoft/testfx#10390](https://github.com/microsoft/testfx/issues/10390).

## Background

testfx split `TerminalTestReporter.Summary.cs` (715 lines) into focused partial files. The manifest enumerates each upstream partial individually rather than globbing the folder, so the four new paths were silently untracked:

| New upstream path | Renders |
| --- | --- |
| `TerminalTestReporter.Coverage.cs` | code-coverage summary + threshold results |
| `TerminalTestReporter.FlakyTests.cs` | the "Flaky tests" section |
| `TerminalTestReporter.SlowestTests.cs` | the "Slowest tests" section |
| `TerminalTestReporter.TestDiscovery.cs` | discovery-mode output |

Nothing changed on the testfx side: its `TerminalReporterContract.props` includes the reporter via a `*.cs` glob, so the split needed no manifest edit there. Ours is the manifest that enumerates.

## What this PR does

Adds the four sources with `"scope": "reporter partial"`, baselined at testfx `main` `f935d2d3f9ce1ab831a361041b0ceaf92ff73363` with blob SHAs read from the contents API. **No existing baseline is touched** — this PR is about the missing paths, not about reconciling the outstanding drift.

### Why they're appended instead of sorted alphabetically

I originally inserted them in alphabetical order, then caught this with a local `check --dry-run`: the bot's idempotency marker is `<!-- vendored-sync:id={id}:{source-index} -->`, i.e. issue identity is the **positional index**. Inserting `.Coverage.cs` and `.FlakyTests.cs` ahead of `.Summary.cs` shifted it from index 7 to 10, which would have orphaned the open #55472 (`(#7)`) and #55473 (`(#8)`) and filed duplicates at the new positions.

So the four are appended, and `eng/vendored-files.md` now documents that `sources` is append-only. That felt worth writing down — the trap is invisible unless you happen to run the checker before and after.

## One thing worth flagging

While checking what our fork already has, I found that `src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs` contains **no** `AppendCoverageSummary`, `AppendFlakyTests`, `AppendSlowestTests` or `AppendRetrySummaryLines`. That upstream work is not ported.

More importantly, **the `.Summary.cs` drift issue can never surface it.** That code was added to `Summary.cs` upstream *after* our baseline (`dba319b2`) and then moved out into the new partials. A unified diff only compares two endpoints, so:

- at our baseline, `Summary.cs` had no coverage/flaky/slowest code (not written yet),
- at current `main`, `Summary.cs` has no coverage/flaky/slowest code (moved out),

and the rendered diff therefore shows none of it. Added-then-moved content is invisible to endpoint diffing.

I did **not** try to encode that backlog in the baseline SHAs — the schema has no way to say "never synced", and faking one would produce a misleading diff. Instead I recorded it in the entry's `notes`, which the bot already renders into every drift issue for this entry, so it will be in front of whoever picks up #55472. Happy to take a different approach if you'd rather express it structurally.

## Validation

`validate` is clean:

```
$ python .github/scripts/check_vendored_files.py validate
Manifest OK: 30 entries, 42 sources.
```

And `check --dry-run` against live upstream confirms the four new sources resolve, and that every pre-existing index is unchanged:

```
[drift  ] dotnet-test-terminal-reporter#0
[ok]      dotnet-test-terminal-reporter#1  (TerminalTestReporter.ErroredAssemblies.cs)
[ok]      dotnet-test-terminal-reporter#2  (TerminalTestReporter.Formatting.ControlCharacters.cs)
[ok]      dotnet-test-terminal-reporter#3  (TerminalTestReporter.Formatting.cs)
[ok]      dotnet-test-terminal-reporter#4  (TerminalTestReporter.Handshake.cs)
[ok]      dotnet-test-terminal-reporter#5  (TerminalTestReporter.Lifecycle.cs)
[ok]      dotnet-test-terminal-reporter#6  (TerminalTestReporter.Messaging.cs)
[drift  ] dotnet-test-terminal-reporter#7   <- .Summary.cs, still matches #55472
[drift  ] dotnet-test-terminal-reporter#8   <- .TestCompletion.cs, still matches #55473
[ok]      dotnet-test-terminal-reporter#9  (TerminalTestReporter.Coverage.cs)
[ok]      dotnet-test-terminal-reporter#10 (TerminalTestReporter.FlakyTests.cs)
[ok]      dotnet-test-terminal-reporter#11 (TerminalTestReporter.SlowestTests.cs)
[ok]      dotnet-test-terminal-reporter#12 (TerminalTestReporter.TestDiscovery.cs)
```

Unrelated, noticed while running the above: `check` crashes locally on Windows with `UnicodeEncodeError: 'charmap' codec can't encode character '\ufeff'` when it prints a dry-run body, because testfx's C# files are UTF-8 **with BOM**. Harmless in CI (UTF-8 default) and I left it alone, but `PYTHONIOENCODING=utf-8` is needed to run it locally on Windows.