### PR TITLE
Add affected test selection to dotnet test

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/CommandDefinitionStrings.resx
@@ -454,6 +454,24 @@ This is equivalent to deleting project.assets.json.</value>
   <data name="CmdListTestsDescription" xml:space="preserve">
     <value>List the discovered tests instead of running the tests. Optionally accepts a format: 'text' (default) for human-readable output or 'json' for machine-readable output.</value>
   </data>
+  <data name="CmdAffectedTestsFeatureDisabled" xml:space="preserve">
+    <value>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</value>
+  </data>
+  <data name="CmdAffectedTestsOptionsMutuallyExclusive" xml:space="preserve">
+    <value>The options '--collect-test-map' and '--affected-tests' cannot be used together.</value>
+  </data>
+  <data name="CmdCollectTestMapDescription" xml:space="preserve">
+    <value>Run tests and write the source-to-test map used by affected-test selection.</value>
+  </data>
+  <data name="CmdCollectTestMapCannotRunModulesInParallel" xml:space="preserve">
+    <value>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</value>
+  </data>
+  <data name="CmdCollectTestMapCannotRequireMinimumTests" xml:space="preserve">
+    <value>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</value>
+  </data>
+  <data name="CmdAffectedTestsDescription" xml:space="preserve">
+    <value>Run only tests linked in the test map to sources changed in Git.</value>
+  </data>
   <data name="CmdLockedModeOptionDescription" xml:space="preserve">
     <value>Don't allow updating project lock file.</value>
   </data>

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Test/TestCommandDefinition.MicrosoftTestingPlatform.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Help;
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
@@ -181,6 +182,18 @@ internal abstract partial class TestCommandDefinition
             Arity = ArgumentArity.Zero
         };
 
+        public const string EnableAffectedTestsEnvironmentVariable = "DOTNET_CLI_ENABLE_AFFECTED_TESTS";
+
+        public const string CollectTestMapOptionName = "--collect-test-map";
+
+        public readonly Option<bool> CollectTestMapOption;
+
+        public const string AffectedTestsOptionName = "--affected-tests";
+
+        public readonly Option<bool> AffectedTestsOption;
+
+        public bool AffectedTestsEnabled { get; }
+
         public readonly Option<string> ArtifactsPathOption = CommonOptions.CreateArtifactsPathOption();
 
         public const string BuildTargetName = "_MTPBuild";
@@ -194,6 +207,24 @@ internal abstract partial class TestCommandDefinition
         {
             MinimumExpectedTestsOption.Validators.Add(ValidatePositiveInteger);
             MaximumFailedTestsOption.Validators.Add(ValidatePositiveInteger);
+
+            AffectedTestsEnabled = EnvironmentVariableParser.ParseBool(
+                Environment.GetEnvironmentVariable(EnableAffectedTestsEnvironmentVariable),
+                defaultValue: false);
+
+            CollectTestMapOption = new(CollectTestMapOptionName)
+            {
+                Description = CommandDefinitionStrings.CmdCollectTestMapDescription,
+                Arity = ArgumentArity.Zero,
+                Hidden = !AffectedTestsEnabled,
+            };
+
+            AffectedTestsOption = new(AffectedTestsOptionName)
+            {
+                Description = CommandDefinitionStrings.CmdAffectedTestsDescription,
+                Arity = ArgumentArity.Zero,
+                Hidden = !AffectedTestsEnabled,
+            };
 
             Options.Add(ProjectOrSolutionOption);
             Options.Add(SolutionOption);
@@ -228,7 +259,33 @@ internal abstract partial class TestCommandDefinition
             Options.Add(NoLaunchProfileArgumentsOption);
             Options.Add(DeviceOption);
             Options.Add(ListDevicesOption);
+            Options.Add(CollectTestMapOption);
+            Options.Add(AffectedTestsOption);
             Options.Add(MTPTargetOption);
+
+            Validators.Add(commandResult =>
+            {
+                bool collectTestMap = commandResult.HasOption(CollectTestMapOption);
+                bool affectedTests = commandResult.HasOption(AffectedTestsOption);
+                if (!AffectedTestsEnabled && (collectTestMap || affectedTests))
+                {
+                    commandResult.AddError(string.Format(
+                        CommandDefinitionStrings.CmdAffectedTestsFeatureDisabled,
+                        EnableAffectedTestsEnvironmentVariable));
+                }
+                else if (collectTestMap && affectedTests)
+                {
+                    commandResult.AddError(CommandDefinitionStrings.CmdAffectedTestsOptionsMutuallyExclusive);
+                }
+                else if (collectTestMap && commandResult.HasOption(MaxParallelTestModulesOption))
+                {
+                    commandResult.AddError(CommandDefinitionStrings.CmdCollectTestMapCannotRunModulesInParallel);
+                }
+                else if (collectTestMap && commandResult.HasOption(MinimumExpectedTestsOption))
+                {
+                    commandResult.AddError(CommandDefinitionStrings.CmdCollectTestMapCannotRequireMinimumTests);
+                }
+            });
         }
 
         public IEnumerable<Action<HelpContext>> CustomHelpLayout()

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.cs.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Cílový modul runtime pro vyčištění.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Umožní shromažďovat výpisy stavu systému při očekávaných i neočekávaných ukončeních hostitele testů.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Hodnota časového limitu je zadána v následujícím formátu: 1,5 h / 90m / 5400 s / 5400000 ms. Pokud se nepoužije žádná jednotka (např. 5400000), předpokládá se, že hodnota je v milisekundách.
 Při použití společně s testy řízenými daty závisí chování časového limitu na použitém testovacím adaptéru. Pro xUnit, NUnit a MSTest 2.2.4+ se časový limit prodlouží po každém testovacím případu
 Pro MSTest před 2.2.4 se časový limit použije pro všechny testovací případy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.de.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Die Zielruntime für die Bereinigung.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Aktiviert die Erfassung von Absturzabbildern bei einer erwarteten und einer unerwarteten Beendigung des Testhosts.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Der Timeoutwert wird im folgenden Format angegeben: 1.5h. / 90m / 5400s / 5400000ms. Wenn keine Einheit verwendet wird (z. B. 5400000), wird davon ausgegangen, dass der Wert in Millisekunden angegeben ist.
 Wenn dies zusammen mit datengesteuerten Tests verwendet wird, hängt das Timeoutverhalten vom verwendeten Testadapter ab. Für xUnit, NUnit und MSTest 2.2.4+ wird das Timeout nach jedem Testfall erneuert,
 Für MSTest vor 2.2.4 wird das Timeout für alle Testfälle verwendet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.es.xlf
@@ -157,6 +157,21 @@
         <target state="translated">El entorno de tiempo de ejecución para el que se limpia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Habilita la recopilación del volcado de memoria en la salida del host de prueba esperada e inesperada.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 El valor de tiempo de espera se especifica en el siguiente formato: 1,5 h / 90 m / 5400 s / 5 400 000 ms. Cuando no se usa ninguna unidad (por ejemplo, 5400000), se supone que el valor está en milisegundos.
 Cuando se usa junto con pruebas basadas en datos, el comportamiento del tiempo de espera depende del adaptador de pruebas utilizado. Para xUnit, NUnit y MSTest 2.2.4+ el tiempo de espera se renueva después de cada caso de prueba,
 Para MSTest antes de 2.2.4, el tiempo de espera se usa para todos los casos de prueba.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.fr.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Runtime cible pour lequel le nettoyage est effectué.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Active la collecte des données de vidage sur plantage en cas de sortie attendue et inattendue de testhost.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 La valeur du délai d’attente est spécifiée au format suivant : 1,5 h/ 90 m / 5 400 / 54 000 000 ms. Si aucune unité n'est utilisée (par exemple 5 400 000), la valeur est supposée être en millisecondes.
 Lorsqu’elle est utilisée avec des tests pilotés par les données, le comportement du délai d’attente dépend de l’adaptateur de test utilisé. Pour xUnit, NUnit et MSTest 2.2.4+ le délai d’expiration est renouvelé après chaque cas de test,
 Pour MSTest avant la version 2.2.4, le délai d’expiration est utilisé pour tous les cas de test.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.it.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Runtime di destinazione per cui eseguire la pulizia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Abilita la raccolta del dump di arresto anomalo in caso di chiusura prevista e imprevista dell'host di test.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Il valore di timeout viene specificato nel formato seguente: 1,5 ore / 90 m / 5400 s / 5400000 ms. Quando non viene usata alcuna unità (ad es. 5400000), si presuppone che il valore sia in millisecondi.
 Se viene usato insieme a test basati sui dati, il comportamento del timeout dipende dall'adattatore di test usato. Per xUnit e NUnit e MSTest 2.2.4+, il timeout viene rinnovato dopo ogni test case,
 Per MSTest anteriore a 2.2.4, il timeout viene usato per tutti i test case.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ja.xlf
@@ -157,6 +157,21 @@
         <target state="translated">クリーンする対象のターゲット ランタイム。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">TestHost の予期されるおよび予期されない終了時にクラッシュ ダンプを収集することを有効にします。</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 タイムアウト値は次の形式で指定します: 1.5h / 90m / 5400s / 5400000ms。単位が使用されていない場合 (例: 5400000)、値は ms (ミリ秒) 単位と見なされます。
 データ ドリブン テストと共に使用すると、タイムアウトの動作は使用するテスト アダプターによって異なります。xUnit、NUnit、MSTest 2.2.4 以降の場合、タイムアウトはテスト ケースの後に毎回更新されます、
 2.2.4 より前の MSTest の場合、タイムアウトはすべてのテストケースで使用されます。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ko.xlf
@@ -157,6 +157,21 @@
         <target state="translated">정리할 대상 런타임입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">예상된 테스트 호스트 종료와 예기치 않은 테스트 호스트 종료 시 크래시 덤프 수집을 사용하도록 설정합니다.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 이 시간 제한 값은 1.5h/90m/5400s/5400000ms 형식으로 지정됩니다. 단위가 사용되지 않는 경우(예: 5400000) 값은 밀리초 단위로 간주됩니다.
 데이터 기반 테스트와 함께 사용하는 경우 시간제한 동작은 사용되는 테스트 어댑터에 따라 달라집니다. xUnit, NUnit, MSTest 2.2.4 이상의 경우 테스트 사례마다 시간 제한이 갱신됩니다.
 MSTest 2.2.4 이전의 경우 시간 제한은 모든 테스트케이스에 사용됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pl.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Docelowe środowisko uruchomieniowe czyszczenia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Włącza zbieranie zrzutów awaryjnych po oczekiwanym i nieoczekiwanym zakończenia działania przez host testowy.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Wartość limitu czasu jest określana w następującym formacie: 1,5 godz. / 90 min / 5400 s / 5 400 000 ms. Jeśli nie jest używana żadna jednostka (np. 5 400 000), przyjmuje się, że wartość jest wyrażona w milisekundach.
 W przypadku użycia razem z testami opartymi na danych zachowanie limitu czasu zależy od użytego adaptera testowego. W przypadku struktur xUnit, NUnit i MSTest w wersji 2.2.4+ limit czasu jest odnawiany po każdym przypadku testowym,
 W przypadku platformy MSTest w wersji wcześniejszej niż 2.2.4 limit czasu jest używany dla wszystkich przypadków testowych.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.pt-BR.xlf
@@ -157,6 +157,21 @@
         <target state="translated">O runtime de destino para o qual a limpeza ocorrerá.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Habilita a coleta de despejo de memória nas saídas esperada e inesperada do host de teste.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 O valor do tempo limite é especificado no seguinte formato: 1.5h / 90m / 5400s / 5400000ms. Quando nenhuma unidade é usada (por exemplo, 5400000), supõe-se que o valor esteja em milissegundos.
 Quando usado junto com testes controlados por dados, o comportamento do tempo limite depende do adaptador de teste usado. Para xUnit, NUnit e MSTest 2.2.4+, o tempo limite é renovado após cada caso de teste,
 Para MSTest antes de 2.2.4, o tempo limite é usado para todos os casos de teste.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.ru.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Целевая среда выполнения для очистки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Включает сбор аварийного дампа при ожидаемом и неожиданном завершении работы узла тестирования.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Значение времени ожидания указывается в следующем формате: 1.5h / 90m / 5400s / 5400000ms. Если единица измерения не указана (например, 5400000), предполагается, что время задано в миллисекундах.
 При использовании вместе с тестами под управлением данных время ожидания зависит от используемого адаптера теста. Для xUnit, NUnit и MSTest начиная с версии 2.2.4 отсчет времени ожидания начинается заново для каждого тестового случая,
 В MSTest версии ниже 2.2.4 время ожидания подсчитывается суммарно для всех тестовых случаев.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.tr.xlf
@@ -157,6 +157,21 @@
         <target state="translated">Temizlenecek hedef çalışma zamanı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">Hem beklenen hem de beklenmeyen test ana bilgisayarı çıkışında kilitlenme bilgi dökümünün toplanmasını sağlar.</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 Zaman aşımı değeri aşağıdaki biçimlerde belirtilir: 1,5 sa / 90 dk / 5400 s / 5400000 ms. Hiçbir birim kullanılmazsa (örn. 5400000), değerin milisaniye cinsinden olduğu varsayılır.
 Veri odaklı testlerle birlikte kullanıldığında, zaman aşımı davranışı kullanılan test bağdaştırıcısına bağlıdır. xUnit, NUnit ve MSTest 2.2.4+ için zaman aşımı her test durumundan sonra yenilenir,
 MSTest için 2.2.4'ten önce, zaman aşımı tüm test durumları için kullanılır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hans.xlf
@@ -157,6 +157,21 @@
         <target state="translated">要清理的目标运行时。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">允许在预期和意外的 testhost 退出时收集故障转储。</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 超时值采用以下格式指定: 1.5h / 90m / 5400s / 5400000ms。如果未使用任何单位(例如 5400000)，则假定该值以毫秒为单位。
 在与数据驱动测试一起使用时，超时行为取决于所使用的测试适配器。对于 xUnit、NUnit 和 MSTest 2.2.4+，将在每个测试用例后续订超时，
 对于 2.2.4 之前的 MSTest，超时用于所有测试用例。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/xlf/CommandDefinitionStrings.zh-Hant.xlf
@@ -157,6 +157,21 @@
         <target state="translated">要為其進行清理的目標執行階段。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsDescription">
+        <source>Run only tests linked in the test map to sources changed in Git.</source>
+        <target state="new">Run only tests linked in the test map to sources changed in Git.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdBlameCrashCollectAlwaysDescription">
         <source>Enables collecting crash dump on expected as well as unexpected testhost exit.</source>
         <target state="translated">允許在測試主機如預期或未預期地結束時收集損毀傾印。</target>
@@ -242,6 +257,21 @@ For MSTest before 2.2.4, the timeout is used for all testcases.</source>
 以下列格式指定逾時值: 1.5 小時 / 90 分鐘 / 5400 秒 / 5400000 毫秒。如果未使用單位 (例如 5400000)，則假設值為毫秒。
 與資料驅動測試搭配使用時，逾時行為取決於所使用的測試配接器。針對 xUnit、NUnit 和 MSTest 2.2.4+ ，每次測試案例之後都會更新逾時，
 針對 2.2.4 之前的 MSTest，系統會針對所有測試案例使用逾時。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapDescription">
+        <source>Run tests and write the source-to-test map used by affected-test selection.</source>
+        <target state="new">Run tests and write the source-to-test map used by affected-test selection.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfig">

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -456,6 +456,9 @@ This is equivalent to deleting project.assets.json.</value>
   <data name="CmdListDevicesAndListTestsMutuallyExclusive" xml:space="preserve">
     <value>The '--list-devices' and '--list-tests' options cannot be used together.</value>
   </data>
+  <data name="CmdListDevicesAndAffectedTestsMutuallyExclusive" xml:space="preserve">
+    <value>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</value>
+  </data>
   <data name="CmdDeviceOptionsRequireProject" xml:space="preserve">
     <value>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</value>
   </data>
@@ -2752,5 +2755,20 @@ Proceed?</value>
   <data name="WorkloadSetVersionSpecifiedInGlobalJson" xml:space="preserve">
     <value> (Specified in '{0}')</value>
     <comment>{0} is the path to the global.json file.</comment>
+  </data>
+  <data name="CmdAffectedTestsFeatureDisabled" xml:space="preserve">
+    <value>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</value>
+  </data>
+  <data name="CmdAffectedTestsOptionsMutuallyExclusive" xml:space="preserve">
+    <value>The options '--collect-test-map' and '--affected-tests' cannot be used together.</value>
+  </data>
+  <data name="CmdCollectTestMapCannotRunModulesInParallel" xml:space="preserve">
+    <value>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</value>
+  </data>
+  <data name="CmdCollectTestMapCannotRequireMinimumTests" xml:space="preserve">
+    <value>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</value>
+  </data>
+  <data name="CmdAffectedTestsResponseFilesMustBeConsistent" xml:space="preserve">
+    <value>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</value>
   </data>
 </root>

--- a/src/Cli/dotnet/Commands/Test/MTP/ITestHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ITestHandler.cs
@@ -7,5 +7,7 @@ internal interface ITestHandler
 {
     bool Initialize();
 
+    IEnumerable<string?> GetTestApplicationWorkingDirectories();
+
     int RunTestApplications(TestApplicationActionQueue actionQueue);
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
@@ -80,6 +80,10 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, MSBuildSession b
         return actionQueue.CompleteEnqueueAndWait();
     }
 
+    public IEnumerable<string?> GetTestApplicationWorkingDirectories()
+        => _testApplications.SelectMany(static group => group)
+            .Select(static module => module.RunProperties.WorkingDirectory);
+
     private static void LogProjectProperties(IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> moduleGroups)
     {
         if (!Logger.TraceEnabled)

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Definition;
@@ -17,11 +18,29 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal partial class MicrosoftTestingPlatformTestCommand
 {
+    private const string MinimumExpectedTestsOptionName = "--minimum-expected-tests";
+
     public int Run(ParseResult parseResult, bool isHelp)
     {
         var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
+        string invocationWorkingDirectory = Directory.GetCurrentDirectory();
 
         BuildOptions buildOptions = MSBuildUtility.GetBuildOptions(parseResult);
+        (buildOptions, bool forwardedCollectTestMap, bool forwardedAffectedTests) =
+            NormalizeForwardedAffectedTestsOptions(buildOptions);
+        bool forwardedMinimumExpectedTests = HasForwardedOption(
+            buildOptions.TestApplicationArguments,
+            MinimumExpectedTestsOptionName);
+
+        bool collectTestMap = parseResult.HasOption(definition.CollectTestMapOption) || forwardedCollectTestMap;
+        bool affectedTests = parseResult.HasOption(definition.AffectedTestsOption) || forwardedAffectedTests;
+        ValidateAffectedTestsOptions(
+            definition,
+            parseResult,
+            collectTestMap,
+            affectedTests,
+            forwardedMinimumExpectedTests);
+
         ValidationUtility.ValidateMutuallyExclusiveOptions(parseResult, buildOptions.PathOptions);
 
         // --list-devices and --list-tests describe incompatible behaviors: the former lists
@@ -29,6 +48,11 @@ internal partial class MicrosoftTestingPlatformTestCommand
         if (buildOptions.ListDevices && parseResult.HasOption(definition.ListTestsOption))
         {
             throw new GracefulException(CliCommandStrings.CmdListDevicesAndListTestsMutuallyExclusive);
+        }
+
+        if (buildOptions.ListDevices && (collectTestMap || affectedTests))
+        {
+            throw new GracefulException(CliCommandStrings.CmdListDevicesAndAffectedTestsMutuallyExclusive);
         }
 
         // --list-devices and --device require a project to evaluate; --test-modules bypasses
@@ -80,6 +104,17 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 return ExitCode.GenericFailure;
             }
 
+            (bool responseFileCollectTestMap, bool responseFileAffectedTests, bool responseFileMinimumExpectedTests) =
+                DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    buildOptions.TestApplicationArguments,
+                    testHandler.GetTestApplicationWorkingDirectories(),
+                    invocationWorkingDirectory);
+            collectTestMap |= responseFileCollectTestMap;
+            affectedTests |= responseFileAffectedTests;
+            forwardedCollectTestMap |= responseFileCollectTestMap;
+            forwardedAffectedTests |= responseFileAffectedTests;
+            forwardedMinimumExpectedTests |= responseFileMinimumExpectedTests;
+
             // Ends the session on the success path, so a failure MSBuild only reports from EndBuild -
             // a binary logger failing to write, for example - is surfaced rather than swallowed.
             buildSession.Complete();
@@ -92,12 +127,25 @@ internal partial class MicrosoftTestingPlatformTestCommand
             logger?.ReallyShutdown();
         }
 
-        int degreeOfParallelism = GetDegreeOfParallelism(parseResult);
+        ValidateAffectedTestsOptions(
+            definition,
+            parseResult,
+            collectTestMap,
+            affectedTests,
+            forwardedMinimumExpectedTests);
+
+        int degreeOfParallelism = GetDegreeOfParallelism(parseResult, collectTestMap);
 
         var testOptions = new TestOptions(
             IsHelp: isHelp,
             IsDiscovery: parseResult.HasOption(definition.ListTestsOption),
-            ListTestsFormat: GetListTestsFormat(parseResult, definition));
+            ListTestsFormat: GetListTestsFormat(parseResult, definition))
+        {
+            CollectTestMap = collectTestMap,
+            AffectedTests = affectedTests,
+            CollectTestMapForwarded = forwardedCollectTestMap,
+            AffectedTestsForwarded = forwardedAffectedTests,
+        };
 
         var output = InitializeOutput(degreeOfParallelism, parseResult, testOptions);
         using var testRunPolicy = new TestRunPolicy(
@@ -161,7 +209,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
             else if (exitCode == ExitCode.Success &&
                 !isHelp &&
                 !parseResult.HasOption(definition.MinimumExpectedTestsOption) &&
-                output.TotalTests == 0)
+                ShouldFailForNoExecutedTests(testOptions.IsAffectedTestsMode, output.TotalTests, output.SkippedTests))
             {
                 // Whole-run "zero tests ran" verdict. Individual modules that matched no tests return exit
                 // code 8, but TestApplicationActionQueue normalizes that to success so a single empty module
@@ -201,6 +249,316 @@ internal partial class MicrosoftTestingPlatformTestCommand
             && !noArtifactPostProcessingRequested
             && !cancellationRequested
             && cancellationReason == TestRunCancellationReason.None;
+
+    internal static (BuildOptions BuildOptions, bool CollectTestMap, bool AffectedTests) NormalizeForwardedAffectedTestsOptions(
+        BuildOptions buildOptions)
+    {
+        bool collectTestMap = false;
+        bool affectedTests = false;
+        ImmutableArray<string>.Builder remainingArguments = ImmutableArray.CreateBuilder<string>();
+        foreach (string argument in buildOptions.TestApplicationArguments)
+        {
+            if (IsAffectedTestsOption(argument, TestCommandDefinition.MicrosoftTestingPlatform.CollectTestMapOptionName))
+            {
+                collectTestMap = true;
+                remainingArguments.Add(argument);
+            }
+            else if (IsAffectedTestsOption(argument, TestCommandDefinition.MicrosoftTestingPlatform.AffectedTestsOptionName))
+            {
+                affectedTests = true;
+                remainingArguments.Add(argument);
+            }
+            else
+            {
+                remainingArguments.Add(argument);
+            }
+        }
+
+        return (
+            buildOptions with { TestApplicationArguments = remainingArguments.ToImmutable() },
+            collectTestMap,
+            affectedTests);
+    }
+
+    private static void ValidateAffectedTestsOptions(
+        TestCommandDefinition.MicrosoftTestingPlatform definition,
+        ParseResult parseResult,
+        bool collectTestMap,
+        bool affectedTests,
+        bool forwardedMinimumExpectedTests)
+    {
+        if (!definition.AffectedTestsEnabled && (collectTestMap || affectedTests))
+        {
+            throw new GracefulException(
+                string.Format(
+                    CliCommandStrings.CmdAffectedTestsFeatureDisabled,
+                    TestCommandDefinition.MicrosoftTestingPlatform.EnableAffectedTestsEnvironmentVariable));
+        }
+
+        if (collectTestMap && affectedTests)
+        {
+            throw new GracefulException(CliCommandStrings.CmdAffectedTestsOptionsMutuallyExclusive);
+        }
+
+        if (collectTestMap && parseResult.HasOption(definition.MaxParallelTestModulesOption))
+        {
+            throw new GracefulException(CliCommandStrings.CmdCollectTestMapCannotRunModulesInParallel);
+        }
+
+        if (collectTestMap &&
+            (parseResult.HasOption(definition.MinimumExpectedTestsOption) || forwardedMinimumExpectedTests))
+        {
+            throw new GracefulException(CliCommandStrings.CmdCollectTestMapCannotRequireMinimumTests);
+        }
+    }
+
+    internal static (bool CollectTestMap, bool AffectedTests, bool MinimumExpectedTests) DetectAffectedTestsOptionsInForwardedResponseFiles(
+        ImmutableArray<string> testApplicationArguments,
+        IEnumerable<string?> testApplicationWorkingDirectories,
+        string invocationWorkingDirectory)
+    {
+        var workingDirectories = testApplicationWorkingDirectories
+            .Select(directory => string.IsNullOrEmpty(directory)
+                ? invocationWorkingDirectory
+                : Path.GetFullPath(directory, invocationWorkingDirectory))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        ForwardedOptionState? commonState = null;
+        bool foundInvalidResponseFile = false;
+        foreach (string workingDirectory in workingDirectories)
+        {
+            ForwardedOptionState workingDirectoryState = default;
+            foreach (string argument in testApplicationArguments)
+            {
+                if (argument.Length > 1 && argument[0] == '@')
+                {
+                    if (!TryDetectAffectedTestsOptionsInResponseFile(
+                        argument[1..],
+                        workingDirectory,
+                        new HashSet<string>(StringComparer.Ordinal),
+                        out ForwardedOptionState responseFileState))
+                    {
+                        foundInvalidResponseFile = true;
+                        continue;
+                    }
+
+                    workingDirectoryState = workingDirectoryState.Merge(responseFileState);
+                }
+            }
+
+            if (commonState is { } previousState &&
+                (previousState.CollectTestMap != workingDirectoryState.CollectTestMap ||
+                 previousState.AffectedTests != workingDirectoryState.AffectedTests))
+            {
+                throw new GracefulException(CliCommandStrings.CmdAffectedTestsResponseFilesMustBeConsistent);
+            }
+
+            commonState = workingDirectoryState with
+            {
+                MinimumExpectedTests =
+                    (commonState?.MinimumExpectedTests ?? false) || workingDirectoryState.MinimumExpectedTests,
+            };
+        }
+
+        ForwardedOptionState state = commonState ?? default;
+        if (foundInvalidResponseFile && (state.CollectTestMap || state.AffectedTests))
+        {
+            throw new GracefulException(CliCommandStrings.CmdAffectedTestsResponseFilesMustBeConsistent);
+        }
+
+        if (foundInvalidResponseFile)
+        {
+            // MTP will report the response-file error. Do not partially activate a mode
+            // or replace its diagnostic with an SDK validation error.
+            return default;
+        }
+
+        return (state.CollectTestMap, state.AffectedTests, state.MinimumExpectedTests);
+    }
+
+    private static bool TryDetectAffectedTestsOptionsInResponseFile(
+        string responseFilePath,
+        string workingDirectory,
+        HashSet<string> recursionStack,
+        out ForwardedOptionState state)
+    {
+        state = default;
+        string fullPath = Path.GetFullPath(responseFilePath, workingDirectory);
+        if (!recursionStack.Add(fullPath) || !File.Exists(fullPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            string[] tokens = [..
+                File.ReadAllLines(fullPath)
+                    .Select(static line => line.Trim())
+                    .Where(static line => line.Length > 0 && line[0] != '#')
+                    .SelectMany(SplitResponseFileLine)];
+
+            ForwardedOptionState detectedState = default;
+            foreach (string token in tokens)
+            {
+                if (token.Length > 1 && token[0] == '@')
+                {
+                    if (!TryDetectAffectedTestsOptionsInResponseFile(
+                        token[1..],
+                        workingDirectory,
+                        recursionStack,
+                        out ForwardedOptionState nestedState))
+                    {
+                        return false;
+                    }
+
+                    detectedState = detectedState.Merge(nestedState);
+                }
+                else
+                {
+                    if (IsAffectedTestsOption(token, TestCommandDefinition.MicrosoftTestingPlatform.CollectTestMapOptionName))
+                    {
+                        detectedState = detectedState with { CollectTestMap = true };
+                    }
+                    else if (IsAffectedTestsOption(token, TestCommandDefinition.MicrosoftTestingPlatform.AffectedTestsOptionName))
+                    {
+                        detectedState = detectedState with { AffectedTests = true };
+                    }
+                    else if (IsOption(token, MinimumExpectedTestsOptionName, allowValue: true))
+                    {
+                        detectedState = detectedState with { MinimumExpectedTests = true };
+                    }
+                }
+            }
+
+            state = detectedState;
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or FormatException)
+        {
+            // MTP reports response-file read and format errors. Do not replace its diagnostic here.
+            return false;
+        }
+        finally
+        {
+            recursionStack.Remove(fullPath);
+        }
+    }
+
+    private static bool HasForwardedOption(ImmutableArray<string> arguments, string canonicalOption)
+        => arguments.Any(argument => IsOption(argument, canonicalOption, allowValue: true));
+
+    private static bool IsAffectedTestsOption(string argument, string canonicalOption)
+        => IsOption(argument, canonicalOption, allowValue: false);
+
+    private static bool IsOption(string argument, string canonicalOption, bool allowValue)
+    {
+        if (argument.Length < 2 ||
+            argument[0] != '-' ||
+            (argument[1] == '-' && (argument.Length < 3 || argument[2] == '-')))
+        {
+            return false;
+        }
+
+        string option = argument[1] == '-' ? argument[2..] : argument[1..];
+        int separatorIndex = option.IndexOfAny('=', ':');
+        if (separatorIndex >= 0 && !allowValue)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> optionName = separatorIndex >= 0 ? option.AsSpan(0, separatorIndex) : option;
+        return optionName.Equals(canonicalOption.AsSpan().TrimStart('-'), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> SplitResponseFileLine(string line)
+    {
+        int tokenStart = 0;
+        int position = 0;
+        bool seekingTokenStart = true;
+        bool insideQuotes = false;
+
+        while (position < line.Length)
+        {
+            char character = line[position];
+
+            if (char.IsWhiteSpace(character))
+            {
+                if (!insideQuotes)
+                {
+                    if (!seekingTokenStart)
+                    {
+                        yield return CurrentToken();
+                        tokenStart = position;
+                        seekingTokenStart = true;
+                    }
+                    else
+                    {
+                        tokenStart = position;
+                    }
+                }
+            }
+            if (character == '"')
+            {
+                if (seekingTokenStart)
+                {
+                    if (insideQuotes)
+                    {
+                        yield return CurrentToken();
+                        tokenStart = position;
+                        insideQuotes = false;
+                    }
+                    else
+                    {
+                        tokenStart = position + 1;
+                        insideQuotes = true;
+                    }
+                }
+                else
+                {
+                    insideQuotes = !insideQuotes;
+                }
+            }
+            else if (seekingTokenStart && !insideQuotes && !char.IsWhiteSpace(character))
+            {
+                seekingTokenStart = false;
+                tokenStart = position;
+            }
+
+            position++;
+
+            if (position == line.Length)
+            {
+                if (insideQuotes)
+                {
+                    throw new FormatException();
+                }
+
+                if (!seekingTokenStart)
+                {
+                    yield return CurrentToken();
+                }
+            }
+        }
+
+        string CurrentToken() => line.Substring(tokenStart, position - tokenStart).Replace("\"", string.Empty);
+    }
+
+    private readonly record struct ForwardedOptionState(
+        bool CollectTestMap,
+        bool AffectedTests,
+        bool MinimumExpectedTests)
+    {
+        public ForwardedOptionState Merge(ForwardedOptionState other)
+            => new(
+                CollectTestMap || other.CollectTestMap,
+                AffectedTests || other.AffectedTests,
+                MinimumExpectedTests || other.MinimumExpectedTests);
+    }
+
+    internal static bool ShouldFailForNoExecutedTests(bool isAffectedTestsMode, int totalTests, int skippedTests)
+        => (!isAffectedTestsMode && totalTests == 0) ||
+            (totalTests > 0 && totalTests == skippedTests);
 
     private static TestListFormat GetListTestsFormat(ParseResult parseResult, TestCommandDefinition.MicrosoftTestingPlatform definition)
     {
@@ -257,6 +615,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
             ShowAssembly = !isJsonDiscovery,
             ShowAssemblyStartAndComplete = !isJsonDiscovery,
             MinimumExpectedTests = parseResult.GetValue(definition.MinimumExpectedTestsOption),
+            AllowZeroTests = testOptions.IsAffectedTestsMode,
             ListTestsFormat = testOptions.ListTestsFormat,
         });
 
@@ -271,8 +630,13 @@ internal partial class MicrosoftTestingPlatformTestCommand
         return output;
     }
 
-    private static int GetDegreeOfParallelism(ParseResult parseResult)
+    private static int GetDegreeOfParallelism(ParseResult parseResult, bool collectTestMap)
     {
+        if (collectTestMap)
+        {
+            return 1;
+        }
+
         var definition = (TestCommandDefinition.MicrosoftTestingPlatform)parseResult.CommandResult.Command;
 
         var degreeOfParallelism = parseResult.GetValue(definition.MaxParallelTestModulesOption);

--- a/src/Cli/dotnet/Commands/Test/MTP/Options.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Options.cs
@@ -18,7 +18,22 @@ internal enum TestListFormat
     Json,
 }
 
-internal record TestOptions(bool IsHelp, bool IsDiscovery, TestListFormat ListTestsFormat, bool IsArtifactPostProcessing = false);
+internal record TestOptions(
+    bool IsHelp,
+    bool IsDiscovery,
+    TestListFormat ListTestsFormat,
+    bool IsArtifactPostProcessing = false)
+{
+    internal const string AffectedTestsModeEnvironmentVariable = "DOTNET_CLI_TEST_AFFECTED_TESTS_MODE";
+    internal const string CollectTestMapMode = "collect";
+    internal const string RunAffectedTestsMode = "run";
+
+    public bool CollectTestMap { get; init; }
+    public bool AffectedTests { get; init; }
+    public bool CollectTestMapForwarded { get; init; }
+    public bool AffectedTestsForwarded { get; init; }
+    public bool IsAffectedTestsMode => CollectTestMap || AffectedTests;
+}
 
 internal record PathOptions(string? ProjectOrSolutionPath, string? SolutionPath, string? TestModules, string? ResultsDirectoryPath, string? ConfigFilePath, string? DiagnosticOutputDirectoryPath);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -72,6 +72,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
     public int TotalTests => _assemblies.Values.Sum(a => a.TotalTests);
+    public int SkippedTests => _assemblies.Values.Sum(a => a.SkippedTests);
 
     // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
     // thread suspends, so the regex gets blamed incorrectly.
@@ -267,10 +268,15 @@ internal sealed partial class TerminalTestReporter : IDisposable
         int totalSkippedTests = _assemblies.Values.Sum(a => a.SkippedTests);
 
         bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
-        bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
+        bool allTestsWereSkipped = (totalTests == 0 && !_options.AllowZeroTests)
+            || (totalTests > 0 && totalTests == totalSkippedTests);
         bool anyTestFailed = totalFailedTests > 0;
         bool anyAssemblyFailed = _assemblies.Values.Any(a => !a.Success) || HasHandshakeFailure;
-        bool runFailed = anyAssemblyFailed || anyTestFailed || notEnoughTests || allTestsWereSkipped || _wasCancelled;
+        bool unexpectedNonZeroExitCode = exitCode is not null
+            && exitCode != ExitCode.Success
+            && exitCode != ExitCode.ZeroTests
+            && exitCode != ExitCode.MinimumExpectedTestsPolicyViolation;
+        bool runFailed = anyAssemblyFailed || anyTestFailed || notEnoughTests || allTestsWereSkipped || unexpectedNonZeroExitCode || _wasCancelled;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 
         terminal.Append(CliCommandStrings.TestRunSummary);
@@ -284,7 +290,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.MinimumExpectedTestsPolicyViolation, totalTests, _options.MinimumExpectedTests));
         }
-        else if (anyTestFailed || HasHandshakeFailure)
+        else if (anyTestFailed || HasHandshakeFailure || unexpectedNonZeroExitCode)
         {
             // Handshake failures take precedence over "Zero tests ran": when an assembly failed to
             // hand-shake we want the headline to reflect that the run failed, not that no tests ran
@@ -464,12 +470,12 @@ internal sealed partial class TerminalTestReporter : IDisposable
     /// <summary>
     /// Print a build result summary to the output.
     /// </summary>
-    private static void AppendAssemblyResult(ITerminal terminal, TestProgressState state)
+    private void AppendAssemblyResult(ITerminal terminal, TestProgressState state)
     {
         if (state.ExitCode == ExitCode.ZeroTests)
         {
-            terminal.SetColor(TerminalColor.DarkRed);
-            terminal.Append(CliCommandStrings.ZeroTestsRan);
+            terminal.SetColor(_options.AllowZeroTests ? TerminalColor.DarkGreen : TerminalColor.DarkRed);
+            terminal.Append(_options.AllowZeroTests ? CliCommandStrings.PassedLowercase : CliCommandStrings.ZeroTestsRan);
             terminal.ResetColor();
         }
         else if (!state.Success)
@@ -858,7 +864,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             _terminalWithProgress.WriteToTerminal(terminal => AppendAssemblySummary(assemblyRun, terminal));
         }
 
-        if (exitCode == 0)
+        if (exitCode == 0 || (_options.AllowZeroTests && exitCode == ExitCode.ZeroTests))
         {
             // Report nothing, we don't want to report on success, because then we will also report on test-discovery etc.
             return;
@@ -969,7 +975,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             // escape char
             .Replace('\x001b', '\x241b');
 
-    private static void AppendAssemblySummary(TestProgressState assemblyRun, ITerminal terminal)
+    private void AppendAssemblySummary(TestProgressState assemblyRun, ITerminal terminal)
     {
         terminal.ResetColor();
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
@@ -31,6 +31,11 @@ internal sealed class TerminalTestReporterOptions
     public int MinimumExpectedTests { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether a run with no selected tests is successful.
+    /// </summary>
+    public bool AllowZeroTests { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether we should write the progress periodically to screen. When ANSI is allowed we update the progress as often as we can.
     /// When ANSI is not allowed we never have progress.
     /// </summary>

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -265,7 +265,7 @@ internal sealed class TestApplication(
         }
     }
 
-    private ProcessStartInfo CreateProcessStartInfo()
+    internal ProcessStartInfo CreateProcessStartInfo()
     {
         var processStartInfo = new ProcessStartInfo
         {
@@ -312,6 +312,19 @@ internal sealed class TestApplication(
             processStartInfo.Environment[Module.DotnetRootArchVariableName] = Path.GetDirectoryName(new Muxer().MuxerPath);
         }
 
+        if (TestOptions.CollectTestMap)
+        {
+            processStartInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable] = TestOptions.CollectTestMapMode;
+        }
+        else if (TestOptions.AffectedTests)
+        {
+            processStartInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable] = TestOptions.RunAffectedTestsMode;
+        }
+        else
+        {
+            processStartInfo.Environment.Remove(TestOptions.AffectedTestsModeEnvironmentVariable);
+        }
+
         processStartInfo.Environment["DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY"] = Directory.GetCurrentDirectory();
         return processStartInfo;
     }
@@ -347,6 +360,16 @@ internal sealed class TestApplication(
         if (TestOptions.IsDiscovery)
         {
             builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.ListTestsOptionName}");
+        }
+
+        if (TestOptions.CollectTestMap && !TestOptions.CollectTestMapForwarded)
+        {
+            builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.CollectTestMapOptionName}");
+        }
+
+        if (TestOptions.AffectedTests && !TestOptions.AffectedTestsForwarded)
+        {
+            builder.Append($" {TestCommandDefinition.MicrosoftTestingPlatform.AffectedTestsOptionName}");
         }
 
         if (_buildOptions.PathOptions.ResultsDirectoryPath is { } resultsDirectoryPath)

--- a/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestModulesFilterHandler.cs
@@ -86,6 +86,11 @@ internal sealed class TestModulesFilterHandler : ITestHandler
         return actionQueue.CompleteEnqueueAndWait();
     }
 
+    public IEnumerable<string?> GetTestApplicationWorkingDirectories()
+    {
+        yield return null;
+    }
+
     internal static List<string> GetMatchedModulePaths(string testModules, string? rootDirectory)
     {
         if (string.IsNullOrEmpty(rootDirectory))

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET Builder</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET-Generator</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Generador para .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Générateur .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Generatore .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET ビルダー</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET 작성기</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Konstruktor platformy .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Construtor do .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -107,9 +107,39 @@
         <target state="translated">Построитель .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET Oluşturucusu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET 生成器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -107,9 +107,39 @@
         <target state="translated">.NET 產生器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdAffectedTestsFeatureDisabled">
+        <source>Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</source>
+        <target state="new">Affected-test selection is experimental. Set the '{0}' environment variable to '1' to enable it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsOptionsMutuallyExclusive">
+        <source>The options '--collect-test-map' and '--affected-tests' cannot be used together.</source>
+        <target state="new">The options '--collect-test-map' and '--affected-tests' cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdAffectedTestsResponseFilesMustBeConsistent">
+        <source>Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</source>
+        <target state="new">Forwarded response files must select the same affected-test operation for every test application. Specify '--collect-test-map' or '--affected-tests' directly on 'dotnet test' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRequireMinimumTests">
+        <source>The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--minimum-expected-tests'. Collection batches do not report test totals to the parent process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdCollectTestMapCannotRunModulesInParallel">
+        <source>The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</source>
+        <target state="new">The option '--collect-test-map' cannot be combined with '--max-parallel-test-modules'. Test maps are collected one module at a time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdDeviceOptionsRequireProject">
         <source>The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</source>
         <target state="new">The '--device' and '--list-devices' options require a project and cannot be used with '--test-modules'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdListDevicesAndAffectedTestsMutuallyExclusive">
+        <source>The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</source>
+        <target state="new">The '--list-devices' option cannot be combined with '--collect-test-map' or '--affected-tests'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdListDevicesAndListTestsMutuallyExclusive">

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -698,9 +698,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
                 result.StdErr.Should().Contain("System.InvalidOperationException: A test session start event was received without a corresponding test session end.");
 
-                // TODO: It's much better to introduce a new kind of "summary" indicating
-                // that the test app exited with zero exit code before sending test session end event
-                result.StdOut.Should().Contain("Test run summary: Passed!")
+                result.StdOut.Should().Contain("Test run summary: Failed!")
                     .And.Contain("total: 1")
                     .And.Contain("succeeded: 1")
                     .And.Contain("failed: 0")

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -442,6 +442,24 @@ public class GivenDotnetTestSelectsDevice : SdkTest
     }
 
     [TestMethod]
+    [DataRow("--collect-test-map")]
+    [DataRow("--affected-tests")]
+    public void ItErrorsWhenListDevicesAndAffectedTestOperationAreCombined(string affectedTestOption)
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", $"ListDevicesWith{affectedTestOption.TrimStart('-')}")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .WithEnvironmentVariable("DOTNET_CLI_ENABLE_AFFECTED_TESTS", "1")
+            .Execute("--list-devices", affectedTestOption, "-f", "net11.0-android");
+
+        result.Should().Fail()
+            .And.HaveStdErrContaining(CliCommandStrings.CmdListDevicesAndAffectedTestsMutuallyExclusive);
+    }
+
+    [TestMethod]
     public void ItListsDevicesForExplicitFrameworkOnMultiTargetedProject()
     {
         // DotnetTestDevices targets both net9.0 and $(CurrentTargetFramework) with different

--- a/test/dotnet.Tests/CommandTests/Test/MTPHelpSnapshotTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/MTPHelpSnapshotTests.cs
@@ -26,6 +26,7 @@ public partial class MTPHelpSnapshotTests : SdkTest
 
         CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
             .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable(TestCommandDefinition.MicrosoftTestingPlatform.EnableAffectedTestsEnvironmentVariable, "0")
             .Execute(CliConstants.HelpOptionKey);
 
         result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -199,6 +199,87 @@ public class TerminalTestReporterTests
         output.Should().NotContain("error:");
     }
 
+    [TestMethod]
+    public void TestExecutionCompleted_WithAllowedZeroTests_PrintsPassingAssemblyAndRunSummary()
+    {
+        var capturingConsole = new CapturingConsole();
+        var options = new TerminalTestReporterOptions
+        {
+            AllowZeroTests = true,
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = true,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Affected.Tests.dll";
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId: "exec-empty", instanceId: "inst-empty");
+        reporter.AssemblyRunCompleted(
+            executionId: "exec-empty",
+            exitCode: Microsoft.DotNet.Cli.Commands.Test.ExitCode.ZeroTests,
+            outputData: null,
+            errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: Microsoft.DotNet.Cli.Commands.Test.ExitCode.Success);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+        output.Should().Contain("Test run summary: Passed!");
+        GetAssemblySummaryLine(output, assembly).Should().Contain("passed");
+        output.Should().NotContain("Zero tests ran");
+        output.Should().NotContain("Test run returned non-zero exit code");
+    }
+
+    [TestMethod]
+    public void TestExecutionCompleted_WithAllowedZeroTestsAndAllSelectedTestsSkipped_RemainsZeroTests()
+    {
+        var capturingConsole = new CapturingConsole();
+        var options = new TerminalTestReporterOptions
+        {
+            AllowZeroTests = true,
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Affected.Tests.dll";
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId: "exec-skipped", instanceId: "inst-skipped");
+        ReportTest(reporter, assembly, executionId: "exec-skipped", instanceId: "inst-skipped", testUid: "skipped-1", TestOutcome.Skipped);
+        reporter.AssemblyRunCompleted(
+            executionId: "exec-skipped",
+            exitCode: Microsoft.DotNet.Cli.Commands.Test.ExitCode.Success,
+            outputData: null,
+            errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: Microsoft.DotNet.Cli.Commands.Test.ExitCode.Success);
+
+        StripAnsi(capturingConsole.GetOutput()).Should().Contain("Zero tests ran");
+    }
+
+    [TestMethod]
+    public void TestExecutionCompleted_WithAllowedZeroTestsAndUnexpectedNonZeroExit_PrintsFailedSummary()
+    {
+        var capturingConsole = new CapturingConsole();
+        var options = new TerminalTestReporterOptions
+        {
+            AllowZeroTests = true,
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+        };
+
+        using var reporter = new TerminalTestReporter(capturingConsole, options);
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+        reporter.TestExecutionCompleted(
+            DateTimeOffset.UtcNow,
+            exitCode: Microsoft.DotNet.Cli.Commands.Test.ExitCode.GenericFailure);
+
+        StripAnsi(capturingConsole.GetOutput()).Should().Contain("Test run summary: Failed!");
+    }
+
     /// <summary>
     /// When an assembly's tests were retried, the per-assembly summary should append a
     /// "/r{N}" segment to the compact counts block so users can tell the final counts came from retries.

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationLaunchTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationLaunchTests.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.Terminal;
+using Microsoft.DotNet.ProjectTools;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public sealed class TestApplicationLaunchTests
+{
+    [TestMethod]
+    public void CreateProcessStartInfo_TopLevelAffectedTests_AddsOptionAndRunMarker()
+    {
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text) { AffectedTests = true });
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        startInfo.Arguments.Should().Contain("--affected-tests");
+        startInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable]
+            .Should().Be(TestOptions.RunAffectedTestsMode);
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_TopLevelCollectTestMap_AddsOptionAndCollectMarker()
+    {
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text) { CollectTestMap = true });
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        startInfo.Arguments.Should().Contain("--collect-test-map");
+        startInfo.Arguments.LastIndexOf("--collect-test-map", StringComparison.Ordinal)
+            .Should().Be(startInfo.Arguments.IndexOf("--collect-test-map", StringComparison.Ordinal));
+        startInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable]
+            .Should().Be(TestOptions.CollectTestMapMode);
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_ForwardedAffectedTests_PreservesOriginalArgumentPosition()
+    {
+        string[] forwardedArguments = ["--minimum-expected-tests", "--affected-tests", "1"];
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text)
+            {
+                AffectedTests = true,
+                AffectedTestsForwarded = true,
+            },
+            forwardedArguments);
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        int minimumIndex = startInfo.Arguments.IndexOf("--minimum-expected-tests", StringComparison.Ordinal);
+        int affectedIndex = startInfo.Arguments.IndexOf("--affected-tests", StringComparison.Ordinal);
+        int valueIndex = startInfo.Arguments.IndexOf(" 1", affectedIndex, StringComparison.Ordinal);
+        minimumIndex.Should().BeGreaterThanOrEqualTo(0);
+        affectedIndex.Should().BeGreaterThan(minimumIndex);
+        valueIndex.Should().BeGreaterThan(affectedIndex);
+        startInfo.Arguments.LastIndexOf("--affected-tests", StringComparison.Ordinal).Should().Be(affectedIndex);
+        startInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable]
+            .Should().Be(TestOptions.RunAffectedTestsMode);
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_ForwardedCollectTestMap_PreservesOriginalArgumentPosition()
+    {
+        string[] forwardedArguments = ["--filter", "TestClass", "--collect-test-map"];
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text)
+            {
+                CollectTestMap = true,
+                CollectTestMapForwarded = true,
+            },
+            forwardedArguments);
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        int filterIndex = startInfo.Arguments.IndexOf("--filter", StringComparison.Ordinal);
+        int collectIndex = startInfo.Arguments.IndexOf("--collect-test-map", StringComparison.Ordinal);
+        filterIndex.Should().BeGreaterThanOrEqualTo(0);
+        collectIndex.Should().BeGreaterThan(filterIndex);
+        startInfo.Arguments.LastIndexOf("--collect-test-map", StringComparison.Ordinal).Should().Be(collectIndex);
+        startInfo.Environment[TestOptions.AffectedTestsModeEnvironmentVariable]
+            .Should().Be(TestOptions.CollectTestMapMode);
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_OrdinaryRun_RemovesInheritedModuleMarker()
+    {
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text),
+            environmentVariables: new Dictionary<string, string>
+            {
+                [TestOptions.AffectedTestsModeEnvironmentVariable] = TestOptions.CollectTestMapMode,
+            });
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        startInfo.Environment.ContainsKey(TestOptions.AffectedTestsModeEnvironmentVariable).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_LaunchProfileAffectedOption_DoesNotCreateSdkMarker()
+    {
+        var launchProfile = new ProjectLaunchProfile
+        {
+            CommandLineArgs = "--affected-tests",
+            EnvironmentVariables = ImmutableDictionary<string, string>.Empty
+                .Add(TestOptions.AffectedTestsModeEnvironmentVariable, TestOptions.RunAffectedTestsMode),
+        };
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text),
+            launchProfile: launchProfile);
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        startInfo.Arguments.Should().Contain("--affected-tests");
+        startInfo.Environment.ContainsKey(TestOptions.AffectedTestsModeEnvironmentVariable).Should().BeFalse();
+    }
+
+    private static TestApplication CreateApplication(
+        TestOptions testOptions,
+        IEnumerable<string>? forwardedArguments = null,
+        IReadOnlyDictionary<string, string>? environmentVariables = null,
+        ProjectLaunchProfile? launchProfile = null)
+    {
+        var module = new TestModule(
+            new RunProperties("dotnet", "test.dll", null),
+            ProjectFullPath: "test.csproj",
+            TargetFramework: "net11.0",
+            IsTestingPlatformApplication: true,
+            LaunchSettings: launchProfile,
+            TargetPath: "test.dll",
+            DotnetRootArchVariableName: null,
+            EnvironmentVariables: environmentVariables ?? ImmutableDictionary<string, string>.Empty);
+        var buildOptions = new BuildOptions(
+            new PathOptions(null, null, null, null, null, null),
+            HasNoRestore: false,
+            HasNoBuild: false,
+            Verbosity: null,
+            NoLaunchProfile: false,
+            NoLaunchProfileArguments: false,
+            TestApplicationArguments: forwardedArguments?.ToImmutableArray() ?? [],
+            MSBuildArgs: [],
+            Device: null,
+            ListDevices: false,
+            EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+        var reporter = new TerminalTestReporter(
+            new CapturingConsole(),
+            new TerminalTestReporterOptions
+            {
+                AnsiMode = AnsiMode.SimpleAnsi,
+                ShowProgress = false,
+            });
+
+        return new TestApplication(module, buildOptions, testOptions, reporter, _ => { });
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Extensions;
+using Microsoft.DotNet.Cli.Utils;
 using TestCommand = Microsoft.DotNet.Cli.Commands.Test.TestCommand;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
@@ -278,6 +280,345 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [DataRow("--collect-test-map")]
+        [DataRow("--affected-tests")]
+        public void MTPCommandAcceptsAffectedTestOptions(string option)
+        {
+            WithAffectedTestsFeature(enabled: true, () =>
+            {
+                var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var parseResult = command.Parse([option]);
+
+                parseResult.Errors.Should().BeEmpty();
+                parseResult.HasOption(
+                    option == "--collect-test-map"
+                        ? command.CollectTestMapOption
+                        : command.AffectedTestsOption).Should().BeTrue();
+            });
+        }
+
+        [TestMethod]
+        public void MTPCommandRejectsAffectedTestOptionsTogether()
+        {
+            WithAffectedTestsFeature(enabled: true, () =>
+            {
+                var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var parseResult = command.Parse(["--collect-test-map", "--affected-tests"]);
+
+                parseResult.Errors.Should().ContainSingle()
+                    .Which.Message.Should().Contain("cannot be used together");
+            });
+        }
+
+        [TestMethod]
+        [DataRow("--collect-test-map")]
+        [DataRow("--affected-tests")]
+        public void MTPCommandRejectsAffectedTestOptionsWhenFeatureIsDisabled(string option)
+        {
+            WithAffectedTestsFeature(enabled: false, () =>
+            {
+                var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var parseResult = command.Parse([option]);
+
+                parseResult.Errors.Should().ContainSingle()
+                    .Which.Message.Should().Contain(TestCommandDefinition.MicrosoftTestingPlatform.EnableAffectedTestsEnvironmentVariable);
+                command.CollectTestMapOption.Hidden.Should().BeTrue();
+                command.AffectedTestsOption.Hidden.Should().BeTrue();
+            });
+        }
+
+        [TestMethod]
+        public void MTPCommandRejectsCollectTestMapWithParallelModules()
+        {
+            WithAffectedTestsFeature(enabled: true, () =>
+            {
+                var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var parseResult = command.Parse(["--collect-test-map", "--max-parallel-test-modules", "2"]);
+
+                parseResult.Errors.Should().ContainSingle()
+                    .Which.Message.Should().Contain("--max-parallel-test-modules");
+            });
+        }
+
+        [TestMethod]
+        public void MTPCommandNormalizesAffectedOptionsForwardedAfterDoubleDash()
+        {
+            var buildOptions = new BuildOptions(
+                new PathOptions(null, null, null, null, null, null),
+                HasNoRestore: false,
+                HasNoBuild: false,
+                Verbosity: null,
+                NoLaunchProfile: false,
+                NoLaunchProfileArguments: false,
+                TestApplicationArguments: ImmutableArray.Create("--collect-test-map", "--other", "--affected-tests"),
+                MSBuildArgs: [],
+                Device: null,
+                ListDevices: false,
+                EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+
+            (BuildOptions normalized, bool collectTestMap, bool affectedTests) =
+                MicrosoftTestingPlatformTestCommand.NormalizeForwardedAffectedTestsOptions(buildOptions);
+
+            collectTestMap.Should().BeTrue();
+            affectedTests.Should().BeTrue();
+            normalized.TestApplicationArguments.Should().Equal("--collect-test-map", "--other", "--affected-tests");
+        }
+
+        [DataRow("-affected-tests", true)]
+        [DataRow("--Affected-Tests", true)]
+        [DataRow("-AFFECTED-TESTS=true", false)]
+        [DataRow("---affected-tests", false)]
+        [DataRow("----affected-tests", false)]
+        [TestMethod]
+        public void MTPCommandNormalizesForwardedAffectedOptionSpellings(string option, bool expectedAffectedTests)
+        {
+            var buildOptions = new BuildOptions(
+                new PathOptions(null, null, null, null, null, null),
+                HasNoRestore: false,
+                HasNoBuild: false,
+                Verbosity: null,
+                NoLaunchProfile: false,
+                NoLaunchProfileArguments: false,
+                TestApplicationArguments: ImmutableArray.Create(option),
+                MSBuildArgs: [],
+                Device: null,
+                ListDevices: false,
+                EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+
+            (BuildOptions normalized, _, bool affectedTests) =
+                MicrosoftTestingPlatformTestCommand.NormalizeForwardedAffectedTestsOptions(buildOptions);
+
+            affectedTests.Should().Be(expectedAffectedTests);
+            normalized.TestApplicationArguments.Should().Equal(option);
+        }
+
+        [TestMethod]
+        public void MTPCommandDetectsAffectedOptionInForwardedResponseFile()
+        {
+            using var temp = new TempDirectory();
+            string responseFile = Path.Combine(temp.Path, "affected.rsp");
+            File.WriteAllText(responseFile, "--affected-tests");
+            var buildOptions = new BuildOptions(
+                new PathOptions(null, null, null, null, null, null),
+                HasNoRestore: false,
+                HasNoBuild: false,
+                Verbosity: null,
+                NoLaunchProfile: false,
+                NoLaunchProfileArguments: false,
+                TestApplicationArguments: ImmutableArray.Create($"@{responseFile}"),
+                MSBuildArgs: [],
+                Device: null,
+                ListDevices: false,
+                EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+
+            (BuildOptions normalized, _, bool affectedTests) =
+                MicrosoftTestingPlatformTestCommand.NormalizeForwardedAffectedTestsOptions(buildOptions);
+
+            affectedTests.Should().BeFalse();
+            normalized.TestApplicationArguments.Should().Equal($"@{responseFile}");
+
+            (_, affectedTests, _) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    normalized.TestApplicationArguments,
+                    [null],
+                    Directory.GetCurrentDirectory());
+
+            affectedTests.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void MTPCommandDoesNotEnableAffectedTestsForValuedResponseFileOption()
+        {
+            using var temp = new TempDirectory();
+            string responseFile = Path.Combine(temp.Path, "affected.rsp");
+            File.WriteAllText(responseFile, "--affected-tests=false");
+            var buildOptions = new BuildOptions(
+                new PathOptions(null, null, null, null, null, null),
+                HasNoRestore: false,
+                HasNoBuild: false,
+                Verbosity: null,
+                NoLaunchProfile: false,
+                NoLaunchProfileArguments: false,
+                TestApplicationArguments: ImmutableArray.Create($"@{responseFile}"),
+                MSBuildArgs: [],
+                Device: null,
+                ListDevices: false,
+                EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+
+            (_, _, bool affectedTests) =
+                MicrosoftTestingPlatformTestCommand.NormalizeForwardedAffectedTestsOptions(buildOptions);
+
+            affectedTests.Should().BeFalse();
+
+            (_, affectedTests, _) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    buildOptions.TestApplicationArguments,
+                    [null],
+                    Directory.GetCurrentDirectory());
+
+            affectedTests.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void MTPCommandDetectsAffectedOptionInQuotedNestedResponseFile()
+        {
+            using var temp = new TempDirectory();
+            string inner = Path.Combine(temp.Path, "inner.rsp");
+            string outer = Path.Combine(temp.Path, "outer.rsp");
+            File.WriteAllText(inner, "\"--affected-tests\"");
+            File.WriteAllText(outer, $"\"@{inner}\"");
+            var buildOptions = new BuildOptions(
+                new PathOptions(null, null, null, null, null, null),
+                HasNoRestore: false,
+                HasNoBuild: false,
+                Verbosity: null,
+                NoLaunchProfile: false,
+                NoLaunchProfileArguments: false,
+                TestApplicationArguments: ImmutableArray.Create($"@{outer}"),
+                MSBuildArgs: [],
+                Device: null,
+                ListDevices: false,
+                EnvironmentVariables: ImmutableDictionary<string, string>.Empty);
+
+            (_, _, bool affectedTests) =
+                MicrosoftTestingPlatformTestCommand.NormalizeForwardedAffectedTestsOptions(buildOptions);
+
+            affectedTests.Should().BeFalse();
+
+            (_, affectedTests, _) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    buildOptions.TestApplicationArguments,
+                    [null],
+                    Directory.GetCurrentDirectory());
+
+            affectedTests.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void MTPCommandRejectsDifferentAffectedOperationsAcrossWorkingDirectories()
+        {
+            using var temp = new TempDirectory();
+            string affectedDirectory = Path.Combine(temp.Path, "affected");
+            string ordinaryDirectory = Path.Combine(temp.Path, "ordinary");
+            Directory.CreateDirectory(affectedDirectory);
+            Directory.CreateDirectory(ordinaryDirectory);
+            File.WriteAllText(Path.Combine(affectedDirectory, "options.rsp"), "--affected-tests");
+            File.WriteAllText(Path.Combine(ordinaryDirectory, "options.rsp"), "--filter TestClass");
+
+            Action action = () =>
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    ImmutableArray.Create("@options.rsp"),
+                    [ordinaryDirectory, affectedDirectory],
+                    temp.Path);
+
+            action.Should().Throw<GracefulException>()
+                .WithMessage("*same affected-test operation*");
+        }
+
+        [TestMethod]
+        public void MTPCommandMatchesMTPResponseFileQuoteBoundaries()
+        {
+            using var temp = new TempDirectory();
+            string responseFile = Path.Combine(temp.Path, "affected.rsp");
+            File.WriteAllText(responseFile, "\"--affected-tests\"\"--filter\"");
+
+            (_, bool affectedTests, _) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    ImmutableArray.Create("@affected.rsp"),
+                    [null],
+                    temp.Path);
+
+            affectedTests.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void MTPCommandDoesNotPartiallyActivateMalformedResponseFile()
+        {
+            using var temp = new TempDirectory();
+            string responseFile = Path.Combine(temp.Path, "affected.rsp");
+            File.WriteAllLines(responseFile, ["--affected-tests", "--filter \"unclosed"]);
+
+            (bool collectTestMap, bool affectedTests, bool minimumExpectedTests) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    ImmutableArray.Create("@affected.rsp"),
+                    [null],
+                    temp.Path);
+
+            collectTestMap.Should().BeFalse();
+            affectedTests.Should().BeFalse();
+            minimumExpectedTests.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void MTPCommandRejectsFeatureActivationWhenAnotherWorkingDirectoryCannotReadResponseFile()
+        {
+            using var temp = new TempDirectory();
+            string affectedDirectory = Path.Combine(temp.Path, "affected");
+            string missingDirectory = Path.Combine(temp.Path, "missing");
+            Directory.CreateDirectory(affectedDirectory);
+            Directory.CreateDirectory(missingDirectory);
+            File.WriteAllText(Path.Combine(affectedDirectory, "options.rsp"), "--affected-tests");
+
+            Action action = () =>
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    ImmutableArray.Create("@options.rsp"),
+                    [missingDirectory, affectedDirectory],
+                    temp.Path);
+
+            action.Should().Throw<GracefulException>()
+                .WithMessage("*same affected-test operation*");
+        }
+
+        [TestMethod]
+        public void MTPCommandDetectsMinimumExpectedTestsInResponseFile()
+        {
+            using var temp = new TempDirectory();
+            File.WriteAllText(
+                Path.Combine(temp.Path, "options.rsp"),
+                "--collect-test-map --minimum-expected-tests=1");
+
+            (bool collectTestMap, _, bool minimumExpectedTests) =
+                MicrosoftTestingPlatformTestCommand.DetectAffectedTestsOptionsInForwardedResponseFiles(
+                    ImmutableArray.Create("@options.rsp"),
+                    [null],
+                    temp.Path);
+
+            collectTestMap.Should().BeTrue();
+            minimumExpectedTests.Should().BeTrue();
+        }
+
+        [TestMethod]
+        [DataRow(false, 0, 0, true)]
+        [DataRow(true, 0, 0, false)]
+        [DataRow(false, 2, 2, true)]
+        [DataRow(true, 2, 2, true)]
+        [DataRow(true, 2, 1, false)]
+        public void MTPCommandFailsOnlyForDisallowedEmptyOrAllSkippedRuns(
+            bool isAffectedTestsMode,
+            int totalTests,
+            int skippedTests,
+            bool expectedFailure)
+        {
+            MicrosoftTestingPlatformTestCommand.ShouldFailForNoExecutedTests(
+                isAffectedTestsMode,
+                totalTests,
+                skippedTests).Should().Be(expectedFailure);
+        }
+
+        [TestMethod]
+        public void MTPCommandRejectsCollectTestMapWithMinimumExpectedTests()
+        {
+            WithAffectedTestsFeature(enabled: true, () =>
+            {
+                var command = new TestCommandDefinition.MicrosoftTestingPlatform();
+                var parseResult = command.Parse(["--collect-test-map", "--minimum-expected-tests", "1"]);
+
+                parseResult.Errors.Should().ContainSingle()
+                    .Which.Message.Should().Contain("--minimum-expected-tests");
+            });
+        }
+
+        [TestMethod]
         [DataRow("foo")]
         [DataRow("JSON")]
         [DataRow("TEXT")]
@@ -366,6 +707,21 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             command.Should().BeOfType<TestCommandDefinition.VSTest>(
                 "an empty global.json must not crash the CLI parser (regression for https://github.com/dotnet/sdk/issues/52384)");
+        }
+
+        private static void WithAffectedTestsFeature(bool enabled, Action action)
+        {
+            const string variable = TestCommandDefinition.MicrosoftTestingPlatform.EnableAffectedTestsEnvironmentVariable;
+            string? previousValue = Environment.GetEnvironmentVariable(variable);
+            try
+            {
+                Environment.SetEnvironmentVariable(variable, enabled ? "1" : null);
+                action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(variable, previousValue);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Adds an experimental, Microsoft.Testing.Platform-only affected-test workflow to `dotnet test`:

```console
set DOTNET_CLI_ENABLE_AFFECTED_TESTS=1
dotnet test --collect-test-map
dotnet test --affected-tests
```

The SDK owns only the command-line and multi-module orchestration boundary. Repository analysis, test-map collection/storage, and affected-test filtering remain in a separately distributed MTP extension.

Relates to #55405. The composable MTP execution-filter API used by the extension was added by microsoft/testfx#10235.

## Behavior

- Adds gated, localized `--collect-test-map` and `--affected-tests` options for the MTP runner.
- Keeps the operations mutually exclusive and rejects incompatible device, parallel-module, and minimum-test policies.
- Runs test-map collection one module at a time.
- Preserves forwarded argument ordering and validates recursive response files using each test application's effective working directory.
- Requires response-file activation to resolve consistently across all test applications.
- Marks SDK-launched children with `DOTNET_CLI_TEST_AFFECTED_TESTS_MODE` so the companion extension can reject activation injected through launch profiles, project run arguments, or test configuration.
- Treats a valid empty affected selection as success while preserving failure for all-skipped runs and unexpected process failures.
- Leaves ordinary `dotnet test` behavior unchanged when neither operation is requested.

## Validation

- `src/Cli/dotnet/dotnet.csproj` builds with 0 warnings and 0 errors.
- `test/dotnet.Tests/dotnet.Tests.csproj` builds with 0 warnings and 0 errors.
- 123 targeted parser, launch-contract, terminal-reporting, and related command tests pass.
- Localization files regenerated with `UpdateXlf`.
- `git diff --check` passes.
- Six independent bug-focused review rounds were completed and all actionable findings were fixed.