### PR TITLE
Fix stale TRX merged-report location in artifact post-processing doc

### DIFF
--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -125,8 +125,9 @@ version of `Microsoft.Testing.Extensions.TrxReport` currently referenced by the 
 `merged-<runId>.trx`, where `runId` is derived from the inputs, and writes it into a `merged/`
 subdirectory of the supplied output directory. Because the merged report is nested, a non-recursive
 `*.trx` glob over the results directory picks up the per-module inputs but not the merged report, so
-it does not double-count tests. CI that wants the merged report must target it explicitly or use a
-recursive glob.
+it does not double-count tests. CI that wants the merged report must target the `merged/` subdirectory
+explicitly, for example with `merged/merged-*.trx`; a broad recursive glob would also pick up the
+per-module inputs and double-count tests.
 
 ## What currently merges
 

--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -120,13 +120,13 @@ The output directory is chosen by
   merged artifact then lands next to the reports it summarizes instead of inside an unrelated
   project's output.
 
-The merging extension — not the SDK — decides the final file name and may nest its output. The TRX
-post-processor names its output `merged-<runId>.trx`, where `runId` is derived from the inputs, and
-with the currently referenced `Microsoft.Testing.Extensions.TrxReport` it writes that file directly
-into the supplied directory, as a sibling of the reports it merged. A non-recursive `*.trx` glob
-over the results directory therefore picks up both the merged report and its own inputs, which
-would double-count every test. Configure CI to publish the merged file specifically, rather than
-globbing the whole directory.
+The merging extension — not the SDK — decides the final file name and may nest its output. The
+version of `Microsoft.Testing.Extensions.TrxReport` currently referenced by the SDK names its output
+`merged-<runId>.trx`, where `runId` is derived from the inputs, and writes it into a `merged/`
+subdirectory of the supplied output directory. Because the merged report is nested, a non-recursive
+`*.trx` glob over the results directory picks up the per-module inputs but not the merged report, so
+it does not double-count tests. CI that wants the merged report must target it explicitly or use a
+recursive glob.
 
 ## What currently merges
 


### PR DESCRIPTION
## Summary

- Correct the documented location of merged TRX reports for the current `Microsoft.Testing.Extensions.TrxReport`.
- Explain that the report is written under the `merged/` subdirectory, so a non-recursive `*.trx` glob finds the per-module inputs but not the merged report.

This behavior changed in [microsoft/testfx#10277](https://github.com/microsoft/testfx/pull/10277), which nested merged TRX reports to avoid double-counting with non-recursive result globs.

## Verification

Verified with a two-project MSTest solution containing three tests, using .NET SDK `11.0.100-preview.7.26376.106` and locally built testfx packages from current `main`:

- Inputs: `TR\P1_net10.0_x64.trx`, `TR\P2_net10.0_x64.trx`
- Merged report: `TR\merged\merged-24aef8ed8acb9fa1ef8fb889eb0ee2b1.trx`

The merged report contained all three test results.
