### PR TITLE
Fix MSBuild telemetry when the server is enabled

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,10 +68,20 @@ runtime-library generators or `dotnet/sdk` for SDK analyzers.
 
 ### Architecture and major components
 
-The managed CLI dispatches commands registered in
-[`Parser.cs`](../src/Cli/dotnet/Parser.cs). Unmatched input goes through external command
-resolution and then file-based app fallback, as implemented by
-[`Program.cs`](../src/Cli/dotnet/Program.cs).
+SDK-owned CLI code has three conceptually equal process entry points:
+
+- The managed CLI dispatches commands registered in
+  [`Parser.cs`](../src/Cli/dotnet/Parser.cs). Unmatched input goes through external command
+  resolution and then file-based app fallback, as implemented by
+  [`Program.cs`](../src/Cli/dotnet/Program.cs).
+- The Native AOT CLI begins at
+  [`NativeEntryPoint.cs`](../src/Cli/dotnet-aot/NativeEntryPoint.cs), handles supported
+  commands directly, and falls through to the managed CLI for unsupported operations.
+- [`MSBuildLogger.cs`](../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) is a separate
+  SDK entry point loaded by MSBuild as an `INodeLogger`. It may execute in the CLI process,
+  a child MSBuild process, or a persistent MSBuild server, so code reached through it must
+  not assume either CLI bootstrap already initialized process-wide state. Treat
+  `BuildStarted`/`BuildFinished` as request boundaries and `Shutdown` as host teardown.
 
 Major source areas under [`src/`](../src/):
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,8 @@ SDK-owned CLI code has three conceptually equal process entry points:
   SDK entry point loaded by MSBuild as an `INodeLogger`. It may execute in the CLI process,
   a child MSBuild process, or a persistent MSBuild server, so code reached through it must
   not assume either CLI bootstrap already initialized process-wide state. Treat
-  `BuildStarted`/`BuildFinished` as request boundaries and `Shutdown` as host teardown.
+  `BuildStarted`/`BuildFinished` as request boundaries and `Shutdown` as logger-instance
+  completion, which does not necessarily mean process exit.
 
 Major source areas under [`src/`](../src/):
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,21 +68,21 @@ runtime-library generators or `dotnet/sdk` for SDK analyzers.
 
 ### Architecture and major components
 
-SDK-owned CLI code has three conceptually equal process entry points:
+SDK-owned CLI code has three process entry points of equal importance:
 
-- The managed CLI dispatches commands registered in
-  [`Parser.cs`](../src/Cli/dotnet/Parser.cs). Unmatched input goes through external command
-  resolution and then file-based app fallback, as implemented by
-  [`Program.cs`](../src/Cli/dotnet/Program.cs).
-- The Native AOT CLI begins at
-  [`NativeEntryPoint.cs`](../src/Cli/dotnet-aot/NativeEntryPoint.cs), handles supported
-  commands directly, and falls through to the managed CLI for unsupported operations.
-- [`MSBuildLogger.cs`](../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) is a separate
-  SDK entry point loaded by MSBuild as an `INodeLogger`. It may execute in the CLI process,
-  a child MSBuild process, or a persistent MSBuild server, so code reached through it must
-  not assume either CLI bootstrap already initialized process-wide state. Treat
-  `BuildStarted`/`BuildFinished` as request boundaries and `Shutdown` as logger-instance
-  completion, which does not necessarily mean process exit.
+- The managed CLI dispatches commands that
+  [`Parser.cs`](../src/Cli/dotnet/Parser.cs) registers.
+  [`Program.cs`](../src/Cli/dotnet/Program.cs) handles unmatched input through external
+  command resolution and file-based app fallback.
+- The Native AOT CLI starts in
+  [`NativeEntryPoint.cs`](../src/Cli/dotnet-aot/NativeEntryPoint.cs). It handles supported
+  commands directly. Unsupported operations continue in the managed CLI.
+- MSBuild loads [`MSBuildLogger`](../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) from
+  `dotnet.dll` as an `INodeLogger`. The logger can run in the CLI process, a child MSBuild
+  process, or a persistent MSBuild server. Code called through the logger must not assume
+  that a CLI bootstrap initialized process-wide state. Use `BuildStarted` and
+  `BuildFinished` as request boundaries. `Shutdown` completes one logger instance. It does
+  not necessarily end the process.
 
 Major source areas under [`src/`](../src/):
 

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -59,24 +59,22 @@ The build script will output a .NET Core installation to `artifacts\bin\redist\D
 
 ## SDK process entry points
 
-Contributor changes under `src/Cli` must account for three conceptually equal ways that
-SDK-owned code can begin executing:
+Changes under `src/Cli` must support three process entry points of equal importance:
 
 | Entry point | Source | Host |
 | --- | --- | --- |
 | Managed CLI | [`src/Cli/dotnet/Program.cs`](../../src/Cli/dotnet/Program.cs) | CoreCLR runs the full command implementation. |
-| Native AOT CLI | [`src/Cli/dotnet-aot/NativeEntryPoint.cs`](../../src/Cli/dotnet-aot/NativeEntryPoint.cs) | The native `dotnet` host calls the exported `dotnet_execute` fast path, which can fall through to the managed CLI. See the [NativeAOT design](../../src/Cli/dotnet-aot/DESIGN.md). |
-| MSBuild logger | [`src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) | MSBuild loads `dotnet.dll` as an `INodeLogger` using the `-distributedlogger` argument assembled by [`MSBuildForwardingApp`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs). |
+| Native AOT CLI | [`src/Cli/dotnet-aot/NativeEntryPoint.cs`](../../src/Cli/dotnet-aot/NativeEntryPoint.cs) | The native `dotnet` host calls the exported `dotnet_execute`. Unsupported operations can continue in the managed CLI. See the [NativeAOT design](../../src/Cli/dotnet-aot/DESIGN.md). |
+| MSBuild logger | [`src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) | MSBuild loads the logger type from `dotnet.dll` as an `INodeLogger`. [`MSBuildForwardingApp`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs) adds the `-distributedlogger` argument. |
 
-The MSBuild logger is a separate process entry point even though it is not a standalone
-executable. It may run in the managed CLI process, a child MSBuild process, or a persistent
-MSBuild server. Code reached through the logger must not assume that managed
-`Program.Main` or the Native AOT bootstrap already initialized process-wide state.
-Per-build state belongs to the MSBuild `BuildStarted`/`BuildFinished` lifecycle, while
-logger `Shutdown` represents completion of that logger instance, not necessarily process
-exit. Persistent servers can run multiple builds in one process, so request-specific
-environment and trace context must be refreshed for each build rather than retained
-globally.
+The MSBuild logger is a separate process entry point. It is not a standalone executable.
+The logger can run in the managed CLI process, a child MSBuild process, or a persistent
+MSBuild server. Code called through the logger must not assume that a CLI bootstrap
+initialized process-wide state.
+
+Use `BuildStarted` and `BuildFinished` to manage state for one build. `Shutdown` completes
+one logger instance. It does not necessarily end the process. A persistent server can run
+multiple builds in one process. Refresh the environment and trace context for each build.
 
 ## Running tests
 

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -73,9 +73,10 @@ executable. It may run in the managed CLI process, a child MSBuild process, or a
 MSBuild server. Code reached through the logger must not assume that managed
 `Program.Main` or the Native AOT bootstrap already initialized process-wide state.
 Per-build state belongs to the MSBuild `BuildStarted`/`BuildFinished` lifecycle, while
-logger `Shutdown` represents host teardown. Persistent servers can run multiple builds in
-one process, so request-specific environment and trace context must be refreshed for each
-build rather than retained globally.
+logger `Shutdown` represents completion of that logger instance, not necessarily process
+exit. Persistent servers can run multiple builds in one process, so request-specific
+environment and trace context must be refreshed for each build rather than retained
+globally.
 
 ## Running tests
 

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -67,6 +67,8 @@ Changes under `src/Cli` must support three process entry points of equal importa
 | Native AOT CLI | [`src/Cli/dotnet-aot/NativeEntryPoint.cs`](../../src/Cli/dotnet-aot/NativeEntryPoint.cs) | The native `dotnet` host calls the exported `dotnet_execute`. Unsupported operations can continue in the managed CLI. See the [NativeAOT design](../../src/Cli/dotnet-aot/DESIGN.md). |
 | MSBuild logger | [`src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) | MSBuild loads the logger type from `dotnet.dll` as an `INodeLogger`. [`MSBuildForwardingApp`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs) adds the `-distributedlogger` argument. |
 
+### MSBuild logger lifecycle
+
 The MSBuild logger is a separate process entry point. It is not a standalone executable.
 The logger can run in the managed CLI process, a child MSBuild process, or a persistent
 MSBuild server. Code called through the logger must not assume that a CLI bootstrap

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -57,6 +57,26 @@ Run the following command from the root of the repository:
 
 The build script will output a .NET Core installation to `artifacts\bin\redist\Debug\dotnet` that will include any local changes to the .NET Core CLI.
 
+## SDK process entry points
+
+Contributor changes under `src/Cli` must account for three conceptually equal ways that
+SDK-owned code can begin executing:
+
+| Entry point | Source | Host |
+| --- | --- | --- |
+| Managed CLI | [`src/Cli/dotnet/Program.cs`](../../src/Cli/dotnet/Program.cs) | CoreCLR runs the full command implementation. |
+| Native AOT CLI | [`src/Cli/dotnet-aot/NativeEntryPoint.cs`](../../src/Cli/dotnet-aot/NativeEntryPoint.cs) | The native `dotnet` host calls the exported `dotnet_execute` fast path, which can fall through to the managed CLI. See the [NativeAOT design](../../src/Cli/dotnet-aot/DESIGN.md). |
+| MSBuild logger | [`src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) | MSBuild loads `dotnet.dll` as an `INodeLogger` using the `-distributedlogger` argument assembled by [`MSBuildForwardingApp`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs). |
+
+The MSBuild logger is a separate process entry point even though it is not a standalone
+executable. It may run in the managed CLI process, a child MSBuild process, or a persistent
+MSBuild server. Code reached through the logger must not assume that managed
+`Program.Main` or the Native AOT bootstrap already initialized process-wide state.
+Per-build state belongs to the MSBuild `BuildStarted`/`BuildFinished` lifecycle, while
+logger `Shutdown` represents host teardown. Persistent servers can run multiple builds in
+one process, so request-specific environment and trace context must be refreshed for each
+build rather than retained globally.
+
 ## Running tests
 
 ### Windows

--- a/documentation/project-docs/telemetry.md
+++ b/documentation/project-docs/telemetry.md
@@ -274,6 +274,14 @@ Every telemetry event automatically includes these common properties:
 
 ### SDK-Collected Build Events
 
+These existing events are collected by
+[`MSBuildLogger`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs), which MSBuild
+loads from the SDK as a distributed logger. The logger can run inside the CLI process, in
+a child MSBuild process, or in a persistent MSBuild server. Each build gets its own
+internal activity, parented to the invoking CLI trace when context is available, so server
+reuse changes only telemetry delivery and correlation, not the data points or properties
+listed below.
+
 #### `msbuild/targetframeworkeval`
 
 **When fired**: When target framework is evaluated

--- a/documentation/project-docs/telemetry.md
+++ b/documentation/project-docs/telemetry.md
@@ -274,13 +274,13 @@ Every telemetry event automatically includes these common properties:
 
 ### SDK-Collected Build Events
 
-These existing events are collected by
-[`MSBuildLogger`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs), which MSBuild
-loads from the SDK as a distributed logger. The logger can run inside the CLI process, in
-a child MSBuild process, or in a persistent MSBuild server. Each build gets its own
-internal activity, parented to the invoking CLI trace when context is available, so server
-reuse changes only telemetry delivery and correlation, not the data points or properties
-listed below.
+[`MSBuildLogger`](../../src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs) collects the
+existing events below. MSBuild loads the logger from the SDK. The logger can run in the
+CLI process, a child MSBuild process, or a persistent MSBuild server.
+
+The logger creates an internal activity for each build. When trace context is available,
+the activity is a child of the invoking CLI trace. Server reuse changes telemetry delivery
+and correlation only. It does not change the listed data points or properties.
 
 #### `msbuild/targetframeworkeval`
 

--- a/src/Cli/AGENTS.md
+++ b/src/Cli/AGENTS.md
@@ -16,8 +16,9 @@ Treat the logger as an independent entry point, not as code that necessarily run
 managed `Program.Main` or the Native AOT bootstrap in the same process. Any process-wide
 state it uses, including telemetry and tracing, must initialize correctly when MSBuild
 loads it directly. Use `BuildStarted`/`BuildFinished` for request-scoped state and
-`Shutdown` for host teardown; a persistent server can execute multiple builds in the same
-process, with different environment and trace context for each request.
+`Shutdown` for logger-instance completion; it does not imply process exit. A persistent
+server can execute multiple builds in the same process, with different environment and
+trace context for each request.
 
 ## Three-project command split
 

--- a/src/Cli/AGENTS.md
+++ b/src/Cli/AGENTS.md
@@ -4,21 +4,20 @@ Guidance for changes under `src/Cli`.
 
 ## SDK process entry points
 
-SDK-owned CLI code can begin executing through three conceptually equal entry points:
+SDK-owned CLI code has three process entry points of equal importance:
 
 | Entry point | Source | Host and lifecycle |
 |-------------|--------|--------------------|
-| Managed CLI | `dotnet/Program.cs` | CoreCLR process; normal `Program.Main` startup and process shutdown. |
-| Native AOT CLI | `dotnet-aot/NativeEntryPoint.cs` | Native host calls the exported `dotnet_execute`; unsupported operations can fall through to the managed CLI. |
-| MSBuild logger | `dotnet/Commands/MSBuild/MSBuildLogger.cs` | MSBuild loads the SDK assembly as an `INodeLogger` through the `-distributedlogger` argument added by `MSBuildForwardingApp`. It can run inside the CLI process, a child MSBuild process, or a persistent MSBuild server. |
+| Managed CLI | `dotnet/Program.cs` | CoreCLR calls `Program.Main`. The process ends after the command completes. |
+| Native AOT CLI | `dotnet-aot/NativeEntryPoint.cs` | The native host calls the exported `dotnet_execute`. Unsupported operations can continue in the managed CLI. |
+| MSBuild logger | `dotnet/Commands/MSBuild/MSBuildLogger.cs` | MSBuild loads the SDK assembly as an `INodeLogger`. `MSBuildForwardingApp` adds the `-distributedlogger` argument. The logger can run in the CLI process, a child process, or a persistent server. |
 
-Treat the logger as an independent entry point, not as code that necessarily runs beneath
-managed `Program.Main` or the Native AOT bootstrap in the same process. Any process-wide
-state it uses, including telemetry and tracing, must initialize correctly when MSBuild
-loads it directly. Use `BuildStarted`/`BuildFinished` for request-scoped state and
-`Shutdown` for logger-instance completion; it does not imply process exit. A persistent
-server can execute multiple builds in the same process, with different environment and
-trace context for each request.
+Treat the logger as an independent entry point. Do not assume that it runs after managed
+`Program.Main` or the Native AOT bootstrap. Initialize process-wide telemetry and tracing
+when MSBuild loads the logger directly. Use `BuildStarted` and `BuildFinished` for
+request-specific state. `Shutdown` completes one logger instance. It does not necessarily
+end the process. Refresh the environment and trace context for each persistent-server
+request.
 
 ## Three-project command split
 

--- a/src/Cli/AGENTS.md
+++ b/src/Cli/AGENTS.md
@@ -2,7 +2,24 @@
 
 Guidance for changes under `src/Cli`.
 
-## Three-project split
+## SDK process entry points
+
+SDK-owned CLI code can begin executing through three conceptually equal entry points:
+
+| Entry point | Source | Host and lifecycle |
+|-------------|--------|--------------------|
+| Managed CLI | `dotnet/Program.cs` | CoreCLR process; normal `Program.Main` startup and process shutdown. |
+| Native AOT CLI | `dotnet-aot/NativeEntryPoint.cs` | Native host calls the exported `dotnet_execute`; unsupported operations can fall through to the managed CLI. |
+| MSBuild logger | `dotnet/Commands/MSBuild/MSBuildLogger.cs` | MSBuild loads the SDK assembly as an `INodeLogger` through the `-distributedlogger` argument added by `MSBuildForwardingApp`. It can run inside the CLI process, a child MSBuild process, or a persistent MSBuild server. |
+
+Treat the logger as an independent entry point, not as code that necessarily runs beneath
+managed `Program.Main` or the Native AOT bootstrap in the same process. Any process-wide
+state it uses, including telemetry and tracing, must initialize correctly when MSBuild
+loads it directly. Use `BuildStarted`/`BuildFinished` for request-scoped state and
+`Shutdown` for host teardown; a persistent server can execute multiple builds in the same
+process, with different environment and trace context for each request.
+
+## Three-project command split
 
 A `dotnet` command or option spans three cooperating projects:
 

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ActivityContextFactory.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ActivityContextFactory.cs
@@ -3,6 +3,10 @@
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
+#if TARGET_WINDOWS
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+#endif
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
@@ -21,16 +25,31 @@ public static class ActivityContextFactory
             return null;
         }
 
-        var environment = new Dictionary<string, string>(capacity: 2)
-        {
-            [Activities.TRACEPARENT] = $"00-{activityContext.TraceId}-{activityContext.SpanId}-{(activityContext.TraceFlags == ActivityTraceFlags.Recorded ? "01" : "00")}"
-        };
-
+        var environment = new Dictionary<string, string>(capacity: 2);
+#if TARGET_WINDOWS
+        var propagationContext = new PropagationContext(activityContext, Baggage.Current);
+        Propagators.DefaultTextMapPropagator.Inject(propagationContext, environment, WriteTraceStateIntoEnvironment);
+#else
+        environment[Activities.TRACEPARENT] = $"00-{activityContext.TraceId}-{activityContext.SpanId}-{(byte)activityContext.TraceFlags:x2}";
         if (!string.IsNullOrEmpty(activityContext.TraceState))
         {
             environment[Activities.TRACESTATE] = activityContext.TraceState;
         }
+#endif
 
         return environment;
+    }
+
+    private static void WriteTraceStateIntoEnvironment(Dictionary<string, string> environment, string key, string value)
+    {
+        switch (key)
+        {
+            case "traceparent":
+                environment[Activities.TRACEPARENT] = value;
+                break;
+            case "tracestate":
+                environment[Activities.TRACESTATE] = value;
+                break;
+        }
     }
 }

--- a/src/Cli/dotnet/CommandFactory/CommandResolution/ActivityContextFactory.cs
+++ b/src/Cli/dotnet/CommandFactory/CommandResolution/ActivityContextFactory.cs
@@ -3,10 +3,6 @@
 
 using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
-#if TARGET_WINDOWS
-using OpenTelemetry;
-using OpenTelemetry.Context.Propagation;
-#endif
 
 namespace Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 
@@ -25,24 +21,16 @@ public static class ActivityContextFactory
             return null;
         }
 
-        var environment = new Dictionary<string, string>(capacity: 2);
-#if TARGET_WINDOWS
-        var propagationContext = new PropagationContext(activityContext, Baggage.Current);
-        Propagators.DefaultTextMapPropagator.Inject(propagationContext, environment, WriteTraceStateIntoEnvironment);
-#endif
-        return environment;
-    }
-
-    private static void WriteTraceStateIntoEnvironment(Dictionary<string, string> environment, string key, string value)
-    {
-        switch (key)
+        var environment = new Dictionary<string, string>(capacity: 2)
         {
-            case "traceparent":
-                environment[Activities.TRACEPARENT] = value;
-                break;
-            case "tracestate":
-                environment[Activities.TRACESTATE] = value;
-                break;
+            [Activities.TRACEPARENT] = $"00-{activityContext.TraceId}-{activityContext.SpanId}-{(activityContext.TraceFlags == ActivityTraceFlags.Recorded ? "01" : "00")}"
+        };
+
+        if (!string.IsNullOrEmpty(activityContext.TraceState))
+        {
+            environment[Activities.TRACESTATE] = activityContext.TraceState;
         }
+
+        return environment;
     }
 }

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildForwardingApp.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Reflection;
 #endif
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
@@ -112,6 +113,14 @@ public class MSBuildForwardingApp : CommandBase
     private void InitializeRequiredEnvironmentVariables()
     {
         EnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_SESSIONID, TelemetryClient.CurrentSessionId);
+
+        if (ActivityContextFactory.MakeActivityContextEnvironment() is { } activityContextEnvironment)
+        {
+            foreach ((string name, string value) in activityContextEnvironment)
+            {
+                EnvironmentVariable(name, value);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -125,7 +125,10 @@ public sealed class MSBuildLogger : INodeLogger
 
     private void OnBuildStarted(object sender, BuildStartedEventArgs e)
     {
-        ActivityContext parentContext = Activity.Current?.Context ?? TelemetryClient.ParentActivityContext;
+        ActivityContext parentContext =
+            Activity.Current?.Context
+            ?? TelemetryClient.GetParentActivityContext()
+            ?? TelemetryClient.ParentActivityContext;
         _activity = Activities.Source.StartActivity(
             "msbuild",
             ActivityKind.Internal,

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -27,20 +27,19 @@ public sealed class MSBuildLogger : INodeLogger
     /// The process-wide telemetry client used by this logger instance.
     /// </summary>
     /// <remarks>
-    /// The managed CLI initializes this client for in-process builds. Other hosts use the
-    /// parameterless constructor to initialize the same process-wide client.
+    /// The managed CLI initializes this client before it runs MSBuild in the same process.
+    /// Other processes use the parameterless constructor to initialize their own client.
     /// </remarks>
     private readonly ITelemetryClient? _telemetry;
 
     /// <summary>
-    /// Whether this logger must shut down the telemetry providers that it created.
+    /// Whether this logger initialized the process-wide telemetry client.
     /// </summary>
     /// <remarks>
-    /// A one-shot child MSBuild process owns its telemetry configuration. The logger shuts
-    /// down those providers before the process exits. The managed CLI owns providers for an
-    /// in-process build. A persistent server must retain its providers for later builds.
+    /// The initializer controls provider shutdown. If this logger did not initialize the
+    /// client, the managed CLI controls its lifetime.
     /// </remarks>
-    private readonly bool _shutdownTelemetryProviders;
+    private readonly bool _initializedTelemetryClient;
 
     /// <summary>
     /// The activity owned by the current build.
@@ -104,27 +103,23 @@ public sealed class MSBuildLogger : INodeLogger
     /// </summary>
     /// <remarks>
     /// MSBuild uses the parameterless constructor to create loggers. The managed CLI can
-    /// initialize telemetry before an in-process build. A child process or persistent
-    /// server cannot depend on that initialization. The constructor reuses an existing
-    /// client to preserve CLI state. If no client exists, it creates one with the same
-    /// enablement and session behavior. Telemetry failures must not fail the build.
+    /// initialize telemetry before it runs MSBuild in the same process. When another process
+    /// loads the logger without an existing client, the constructor initializes one. It
+    /// reuses an existing client to preserve CLI state. Telemetry failures must not fail the
+    /// build.
     /// </remarks>
     public MSBuildLogger()
     {
         try
         {
             string? sessionId = Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_SESSIONID);
-            bool initializeTelemetry = !TelemetryClient.IsInitialized;
-
-            if (initializeTelemetry)
+            if (!TelemetryClient.IsInitialized)
             {
                 _ = new TelemetryClient(sessionId);
+                _initializedTelemetryClient = true;
             }
 
             _telemetry = TelemetryClient.Instance;
-            _shutdownTelemetryProviders = ShouldShutdownTelemetryProviders(
-                initializeTelemetry,
-                Environment.GetEnvironmentVariable("MSBUILDUSESERVER"));
         }
         catch (Exception)
         {
@@ -139,16 +134,6 @@ public sealed class MSBuildLogger : INodeLogger
     {
         _telemetry = telemetry;
     }
-
-    /// <summary>
-    /// Determines whether this logger owns the telemetry provider lifetime.
-    /// </summary>
-    /// <remarks>
-    /// Only the value <c>1</c> enables the MSBuild server. A reusable server keeps its
-    /// providers active after logger shutdown because a later build can reuse the process.
-    /// </remarks>
-    internal static bool ShouldShutdownTelemetryProviders(bool initializedTelemetry, string? useMSBuildServer) =>
-        initializedTelemetry && useMSBuildServer != "1";
 
     /// <summary>
     /// Connects this node logger to MSBuild's event lifecycle.
@@ -206,9 +191,10 @@ public sealed class MSBuildLogger : INodeLogger
     /// <remarks>
     /// A persistent server can receive different environment and trace context for each
     /// request. This method resolves the parent at <c>BuildStarted</c>, not in the
-    /// constructor. It uses the ambient activity for an in-process build. Otherwise, it
-    /// reads the context that the invoking CLI forwarded. The activity is internal because
-    /// it represents SDK work in the invoking command, not a remote client call.
+    /// constructor. It uses the ambient activity when the managed CLI runs MSBuild in the
+    /// same process. Otherwise, it reads the context that the invoking CLI forwarded. The
+    /// activity is internal because it represents SDK work in the invoking command, not a
+    /// remote client call.
     /// </remarks>
     private void OnBuildStarted(object sender, BuildStartedEventArgs e)
     {
@@ -406,10 +392,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// <c>BuildFinished</c> normally stops the build activity. <see cref="Shutdown"/> also
     /// stops the activity if an aborted build did not deliver <c>BuildFinished</c>. MSBuild
     /// calls this method when the logger instance ends. The method waits for queued events
-    /// before it writes the diagnostic log. In a persistent server, logger shutdown does not
-    /// end the process. A later logger instance can reuse the process-wide telemetry client.
-    /// A one-shot child process shuts down providers that this logger created. An in-process
-    /// build leaves provider shutdown to the managed CLI.
+    /// before it writes the diagnostic log. If this logger initialized the telemetry client,
+    /// it owns provider shutdown. When the managed CLI runs MSBuild in the same process,
+    /// provider shutdown remains with the CLI that initialized the client.
     /// </remarks>
     public void Shutdown()
     {
@@ -417,7 +402,7 @@ public sealed class MSBuildLogger : INodeLogger
 
         if (_telemetry is TelemetryClient telemetryClient)
         {
-            if (_shutdownTelemetryProviders)
+            if (_initializedTelemetryClient)
             {
                 TelemetryClient.FlushProviders();
             }

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -33,6 +33,16 @@ public sealed class MSBuildLogger : INodeLogger
     private readonly ITelemetryClient? _telemetry;
 
     /// <summary>
+    /// Whether this logger must shut down the telemetry providers that it created.
+    /// </summary>
+    /// <remarks>
+    /// A one-shot child MSBuild process owns its telemetry configuration. The logger shuts
+    /// down those providers before the process exits. The managed CLI owns providers for an
+    /// in-process build. A persistent server must retain its providers for later builds.
+    /// </remarks>
+    private readonly bool _shutdownTelemetryProviders;
+
+    /// <summary>
     /// The activity owned by the current build.
     /// </summary>
     /// <remarks>
@@ -104,13 +114,17 @@ public sealed class MSBuildLogger : INodeLogger
         try
         {
             string? sessionId = Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_SESSIONID);
+            bool initializeTelemetry = !TelemetryClient.IsInitialized;
 
-            if (!TelemetryClient.IsInitialized)
+            if (initializeTelemetry)
             {
                 _ = new TelemetryClient(sessionId);
             }
 
             _telemetry = TelemetryClient.Instance;
+            _shutdownTelemetryProviders = ShouldShutdownTelemetryProviders(
+                initializeTelemetry,
+                Environment.GetEnvironmentVariable("MSBUILDUSESERVER"));
         }
         catch (Exception)
         {
@@ -125,6 +139,16 @@ public sealed class MSBuildLogger : INodeLogger
     {
         _telemetry = telemetry;
     }
+
+    /// <summary>
+    /// Determines whether this logger owns the telemetry provider lifetime.
+    /// </summary>
+    /// <remarks>
+    /// Only the value <c>1</c> enables the MSBuild server. A reusable server keeps its
+    /// providers active after logger shutdown because a later build can reuse the process.
+    /// </remarks>
+    internal static bool ShouldShutdownTelemetryProviders(bool initializedTelemetry, string? useMSBuildServer) =>
+        initializedTelemetry && useMSBuildServer != "1";
 
     /// <summary>
     /// Connects this node logger to MSBuild's event lifecycle.
@@ -384,6 +408,8 @@ public sealed class MSBuildLogger : INodeLogger
     /// calls this method when the logger instance ends. The method waits for queued events
     /// before it writes the diagnostic log. In a persistent server, logger shutdown does not
     /// end the process. A later logger instance can reuse the process-wide telemetry client.
+    /// A one-shot child process shuts down providers that this logger created. An in-process
+    /// build leaves provider shutdown to the managed CLI.
     /// </remarks>
     public void Shutdown()
     {
@@ -391,7 +417,14 @@ public sealed class MSBuildLogger : INodeLogger
 
         if (_telemetry is TelemetryClient telemetryClient)
         {
-            telemetryClient.WaitForPendingEvents();
+            if (_shutdownTelemetryProviders)
+            {
+                TelemetryClient.FlushProviders();
+            }
+            else
+            {
+                telemetryClient.WaitForPendingEvents();
+            }
         }
 
         TelemetryClient.WriteLogIfNecessary();

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -1,9 +1,11 @@
 ﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Telemetry;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.Commands.MSBuild;
@@ -11,6 +13,7 @@ namespace Microsoft.DotNet.Cli.Commands.MSBuild;
 public sealed class MSBuildLogger : INodeLogger
 {
     private readonly ITelemetryClient? _telemetry;
+    private Activity? _activity;
 
     internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
     internal const string BuildTelemetryEventName = "build";
@@ -65,10 +68,12 @@ public sealed class MSBuildLogger : INodeLogger
         {
             string? sessionId = Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_TELEMETRY_SESSIONID);
 
-            if (sessionId != null)
+            if (!TelemetryClient.IsInitialized)
             {
-                _telemetry = new TelemetryClient(sessionId);
+                _ = new TelemetryClient(sessionId);
             }
+
+            _telemetry = TelemetryClient.Instance;
         }
         catch (Exception)
         {
@@ -106,6 +111,8 @@ public sealed class MSBuildLogger : INodeLogger
                 {
                     eventSource2.TelemetryLogged += OnTelemetryLogged;
                 }
+
+                eventSource.BuildStarted += OnBuildStarted;
             }
 
             eventSource.BuildFinished += OnBuildFinished;
@@ -116,9 +123,20 @@ public sealed class MSBuildLogger : INodeLogger
         }
     }
 
+    private void OnBuildStarted(object sender, BuildStartedEventArgs e)
+    {
+        ActivityContext parentContext = Activity.Current?.Context ?? TelemetryClient.ParentActivityContext;
+        _activity = Activities.Source.StartActivity(
+            "msbuild",
+            ActivityKind.Internal,
+            parentContext);
+    }
+
     private void OnBuildFinished(object sender, BuildFinishedEventArgs e)
     {
         SendAggregatedEventsOnBuildFinished(_telemetry);
+        _activity?.SetStatus(e.Succeeded ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+        StopActivity();
     }
 
     internal void SendAggregatedEventsOnBuildFinished(ITelemetryClient? telemetry)
@@ -267,6 +285,20 @@ public sealed class MSBuildLogger : INodeLogger
 
     public void Shutdown()
     {
+        StopActivity();
+
+        if (_telemetry is TelemetryClient telemetryClient)
+        {
+            telemetryClient.WaitForPendingEvents();
+        }
+
+        TelemetryClient.WriteLogIfNecessary();
+    }
+
+    private void StopActivity()
+    {
+        _activity?.Stop();
+        _activity = null;
     }
 
     public LoggerVerbosity Verbosity { get; set; }

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -10,9 +10,37 @@ using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.Cli.Commands.MSBuild;
 
+/// <summary>
+/// Receives telemetry emitted by MSBuild and SDK build logic and forwards it through the
+/// .NET SDK telemetry pipeline.
+/// </summary>
+/// <remarks>
+/// MSBuild loads this type from <c>dotnet.dll</c> as a distributed logger. This makes the
+/// logger a separate SDK entry point: it can run inside the managed CLI process, in a child
+/// MSBuild process, or in a persistent MSBuild server where neither CLI bootstrap runs.
+/// Consequently, process-wide telemetry is initialized here when necessary, while
+/// request-specific activity state is created and cleared at MSBuild's per-build event
+/// boundaries.
+/// </remarks>
 public sealed class MSBuildLogger : INodeLogger
 {
+    /// <summary>
+    /// The process-wide telemetry client used by this logger instance.
+    /// </summary>
+    /// <remarks>
+    /// In-process builds reuse the client initialized by the managed CLI. An out-of-process
+    /// host, including the persistent MSBuild server, initializes the same process-wide
+    /// client through the parameterless constructor.
+    /// </remarks>
     private readonly ITelemetryClient? _telemetry;
+
+    /// <summary>
+    /// The activity owned by the current build.
+    /// </summary>
+    /// <remarks>
+    /// This must never outlive <c>BuildFinished</c>: a persistent MSBuild server can handle
+    /// later builds with unrelated parent trace contexts in the same process.
+    /// </remarks>
     private Activity? _activity;
 
     internal const string TargetFrameworkTelemetryEventName = "targetframeworkeval";
@@ -62,6 +90,17 @@ public sealed class MSBuildLogger : INodeLogger
     /// </remarks>
     private Dictionary<string, Dictionary<string, int>> _aggregatedEvents = new();
 
+    /// <summary>
+    /// Initializes telemetry for the process hosting the logger.
+    /// </summary>
+    /// <remarks>
+    /// MSBuild constructs loggers through their parameterless constructor. The managed CLI
+    /// may already have initialized telemetry for an in-process build, but a child process
+    /// or persistent server enters the SDK through this logger and has no such guarantee.
+    /// Reusing an initialized client preserves CLI-owned state; initializing only when
+    /// necessary gives standalone MSBuild hosts the same enablement and session behavior.
+    /// Telemetry failures are isolated because diagnostics must never fail the build.
+    /// </remarks>
     public MSBuildLogger()
     {
         try
@@ -89,11 +128,29 @@ public sealed class MSBuildLogger : INodeLogger
         _telemetry = telemetry;
     }
 
+    /// <summary>
+    /// Connects this node logger to MSBuild's event lifecycle.
+    /// </summary>
+    /// <remarks>
+    /// The node-count overload exists for <see cref="INodeLogger"/> and intentionally shares
+    /// the same subscriptions as the standard logger overload. Activity ownership follows
+    /// build events rather than logger construction because a server process can execute
+    /// multiple builds and supply different request context to each one.
+    /// </remarks>
     public void Initialize(IEventSource eventSource, int nodeCount)
     {
         Initialize(eventSource);
     }
 
+    /// <summary>
+    /// Connects this logger to the events needed to collect telemetry and delimit a build.
+    /// </summary>
+    /// <remarks>
+    /// Telemetry events and <c>BuildStarted</c> are observed only when telemetry is enabled,
+    /// avoiding collection and activity work for opted-out builds. <c>BuildFinished</c> is
+    /// always observed as a defensive cleanup boundary so any activity owned by this logger
+    /// cannot leak into a later request.
+    /// </remarks>
     public void Initialize(IEventSource eventSource)
     {
         // Declare lack of dependency on having properties/items in ProjectStarted events
@@ -123,6 +180,16 @@ public sealed class MSBuildLogger : INodeLogger
         }
     }
 
+    /// <summary>
+    /// Starts the activity that contains telemetry for one MSBuild request.
+    /// </summary>
+    /// <remarks>
+    /// The parent is resolved here, not in the constructor, because a persistent server's
+    /// environment and trace context can change for every request. An ambient activity is
+    /// preferred for in-process builds; otherwise the context forwarded by the invoking CLI
+    /// is re-read from the current request environment. The activity is internal because it
+    /// represents SDK work within the invoking command rather than a remote client call.
+    /// </remarks>
     private void OnBuildStarted(object sender, BuildStartedEventArgs e)
     {
         ActivityContext parentContext =
@@ -135,6 +202,15 @@ public sealed class MSBuildLogger : INodeLogger
             parentContext);
     }
 
+    /// <summary>
+    /// Completes telemetry and activity state for one MSBuild request.
+    /// </summary>
+    /// <remarks>
+    /// Aggregated events are emitted before the activity is stopped so they remain attached
+    /// to the build span. The overall MSBuild result supplies the span status. Stopping and
+    /// clearing the activity here prevents a persistent server from parenting a later build
+    /// to the completed request.
+    /// </remarks>
     private void OnBuildFinished(object sender, BuildFinishedEventArgs e)
     {
         SendAggregatedEventsOnBuildFinished(_telemetry);
@@ -142,6 +218,13 @@ public sealed class MSBuildLogger : INodeLogger
         StopActivity();
     }
 
+    /// <summary>
+    /// Emits telemetry that is intentionally accumulated across nodes during a build.
+    /// </summary>
+    /// <remarks>
+    /// Removing each emitted aggregate is essential for persistent servers: process state
+    /// can survive into another build, but counts from the completed request must not.
+    /// </remarks>
     internal void SendAggregatedEventsOnBuildFinished(ITelemetryClient? telemetry)
     {
         if (telemetry is null) return;
@@ -286,6 +369,17 @@ public sealed class MSBuildLogger : INodeLogger
         }
     }
 
+    /// <summary>
+    /// Completes this MSBuild logger instance and drains its telemetry.
+    /// </summary>
+    /// <remarks>
+    /// <c>BuildFinished</c> is the normal activity boundary. The additional stop is an
+    /// idempotent fallback for aborted builds whose finish event was not delivered.
+    /// Exporter draining and diagnostic-log writing belong here rather than in
+    /// <c>BuildFinished</c> because MSBuild defines <see cref="Shutdown"/> as the logger
+    /// completion hook. In a persistent server this does not imply process shutdown; the
+    /// process-wide telemetry client remains reusable by a later logger instance.
+    /// </remarks>
     public void Shutdown()
     {
         StopActivity();
@@ -298,6 +392,14 @@ public sealed class MSBuildLogger : INodeLogger
         TelemetryClient.WriteLogIfNecessary();
     }
 
+    /// <summary>
+    /// Stops only the activity owned by this logger and clears the reference.
+    /// </summary>
+    /// <remarks>
+    /// The ambient parent belongs to the invoking host and must not be stopped here.
+    /// Clearing the field also makes cleanup safe when both <c>BuildFinished</c> and
+    /// <see cref="Shutdown"/> run.
+    /// </remarks>
     private void StopActivity()
     {
         _activity?.Stop();

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -206,10 +206,10 @@ public sealed class MSBuildLogger : INodeLogger
     /// Completes telemetry and activity state for one MSBuild request.
     /// </summary>
     /// <remarks>
-    /// Aggregated events are emitted before the activity is stopped so they remain attached
-    /// to the build span. The overall MSBuild result supplies the span status. Stopping and
-    /// clearing the activity here prevents a persistent server from parenting a later build
-    /// to the completed request.
+    /// MSBuild events are attached synchronously, so all events are present before the
+    /// activity is stopped and exporters snapshot it. The overall MSBuild result supplies
+    /// the span status. Stopping and clearing the activity here prevents a persistent server
+    /// from parenting a later build to the completed request.
     /// </remarks>
     private void OnBuildFinished(object sender, BuildFinishedEventArgs e)
     {
@@ -354,7 +354,16 @@ public sealed class MSBuildLogger : INodeLogger
             }
         }
 
-        telemetry?.TrackEvent(eventName, properties ?? eventProperties);
+        if (telemetry is TelemetryClient telemetryClient)
+        {
+            // This activity ends at BuildFinished, so production events must be attached before
+            // an exporter observes Activity.Stop. Test clients retain the ITelemetryClient seam.
+            telemetryClient.ThreadBlockingTrackEvent(eventName, properties ?? eventProperties);
+        }
+        else
+        {
+            telemetry?.TrackEvent(eventName, properties ?? eventProperties);
+        }
     }
 
     private void OnTelemetryLogged(object sender, TelemetryEventArgs args)

--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -11,16 +11,15 @@ using Microsoft.DotNet.Utilities;
 namespace Microsoft.DotNet.Cli.Commands.MSBuild;
 
 /// <summary>
-/// Receives telemetry emitted by MSBuild and SDK build logic and forwards it through the
-/// .NET SDK telemetry pipeline.
+/// Receives telemetry from MSBuild and SDK build logic. The logger sends the telemetry
+/// through the .NET SDK telemetry pipeline.
 /// </summary>
 /// <remarks>
-/// MSBuild loads this type from <c>dotnet.dll</c> as a distributed logger. This makes the
-/// logger a separate SDK entry point: it can run inside the managed CLI process, in a child
-/// MSBuild process, or in a persistent MSBuild server where neither CLI bootstrap runs.
-/// Consequently, process-wide telemetry is initialized here when necessary, while
-/// request-specific activity state is created and cleared at MSBuild's per-build event
-/// boundaries.
+/// MSBuild loads this type from <c>dotnet.dll</c> as a distributed logger. The logger is a
+/// separate SDK entry point. It can run in the managed CLI process, a child MSBuild
+/// process, or a persistent MSBuild server. Some hosts do not run either CLI bootstrap.
+/// The logger initializes process-wide telemetry when necessary. It creates and clears
+/// request-specific activity state at <c>BuildStarted</c> and <c>BuildFinished</c>.
 /// </remarks>
 public sealed class MSBuildLogger : INodeLogger
 {
@@ -28,9 +27,8 @@ public sealed class MSBuildLogger : INodeLogger
     /// The process-wide telemetry client used by this logger instance.
     /// </summary>
     /// <remarks>
-    /// In-process builds reuse the client initialized by the managed CLI. An out-of-process
-    /// host, including the persistent MSBuild server, initializes the same process-wide
-    /// client through the parameterless constructor.
+    /// The managed CLI initializes this client for in-process builds. Other hosts use the
+    /// parameterless constructor to initialize the same process-wide client.
     /// </remarks>
     private readonly ITelemetryClient? _telemetry;
 
@@ -38,8 +36,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// The activity owned by the current build.
     /// </summary>
     /// <remarks>
-    /// This must never outlive <c>BuildFinished</c>: a persistent MSBuild server can handle
-    /// later builds with unrelated parent trace contexts in the same process.
+    /// This activity belongs to one build. It must not remain active after
+    /// <c>BuildFinished</c>. A persistent server can run later builds with unrelated parent
+    /// trace contexts in the same process.
     /// </remarks>
     private Activity? _activity;
 
@@ -94,12 +93,11 @@ public sealed class MSBuildLogger : INodeLogger
     /// Initializes telemetry for the process hosting the logger.
     /// </summary>
     /// <remarks>
-    /// MSBuild constructs loggers through their parameterless constructor. The managed CLI
-    /// may already have initialized telemetry for an in-process build, but a child process
-    /// or persistent server enters the SDK through this logger and has no such guarantee.
-    /// Reusing an initialized client preserves CLI-owned state; initializing only when
-    /// necessary gives standalone MSBuild hosts the same enablement and session behavior.
-    /// Telemetry failures are isolated because diagnostics must never fail the build.
+    /// MSBuild uses the parameterless constructor to create loggers. The managed CLI can
+    /// initialize telemetry before an in-process build. A child process or persistent
+    /// server cannot depend on that initialization. The constructor reuses an existing
+    /// client to preserve CLI state. If no client exists, it creates one with the same
+    /// enablement and session behavior. Telemetry failures must not fail the build.
     /// </remarks>
     public MSBuildLogger()
     {
@@ -132,10 +130,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// Connects this node logger to MSBuild's event lifecycle.
     /// </summary>
     /// <remarks>
-    /// The node-count overload exists for <see cref="INodeLogger"/> and intentionally shares
-    /// the same subscriptions as the standard logger overload. Activity ownership follows
-    /// build events rather than logger construction because a server process can execute
-    /// multiple builds and supply different request context to each one.
+    /// <see cref="INodeLogger"/> requires this node-count overload. Both overloads use the
+    /// same event subscriptions. Build events control the activity lifetime because a
+    /// server can run multiple builds. Each build can have different request context.
     /// </remarks>
     public void Initialize(IEventSource eventSource, int nodeCount)
     {
@@ -146,10 +143,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// Connects this logger to the events needed to collect telemetry and delimit a build.
     /// </summary>
     /// <remarks>
-    /// Telemetry events and <c>BuildStarted</c> are observed only when telemetry is enabled,
-    /// avoiding collection and activity work for opted-out builds. <c>BuildFinished</c> is
-    /// always observed as a defensive cleanup boundary so any activity owned by this logger
-    /// cannot leak into a later request.
+    /// The logger subscribes to telemetry events and <c>BuildStarted</c> only when telemetry
+    /// is enabled. This avoids work for opted-out builds. The logger always subscribes to
+    /// <c>BuildFinished</c>. This lets the logger clear its activity before a later request.
     /// </remarks>
     public void Initialize(IEventSource eventSource)
     {
@@ -184,11 +180,11 @@ public sealed class MSBuildLogger : INodeLogger
     /// Starts the activity that contains telemetry for one MSBuild request.
     /// </summary>
     /// <remarks>
-    /// The parent is resolved here, not in the constructor, because a persistent server's
-    /// environment and trace context can change for every request. An ambient activity is
-    /// preferred for in-process builds; otherwise the context forwarded by the invoking CLI
-    /// is re-read from the current request environment. The activity is internal because it
-    /// represents SDK work within the invoking command rather than a remote client call.
+    /// A persistent server can receive different environment and trace context for each
+    /// request. This method resolves the parent at <c>BuildStarted</c>, not in the
+    /// constructor. It uses the ambient activity for an in-process build. Otherwise, it
+    /// reads the context that the invoking CLI forwarded. The activity is internal because
+    /// it represents SDK work in the invoking command, not a remote client call.
     /// </remarks>
     private void OnBuildStarted(object sender, BuildStartedEventArgs e)
     {
@@ -206,10 +202,10 @@ public sealed class MSBuildLogger : INodeLogger
     /// Completes telemetry and activity state for one MSBuild request.
     /// </summary>
     /// <remarks>
-    /// MSBuild events are attached synchronously, so all events are present before the
-    /// activity is stopped and exporters snapshot it. The overall MSBuild result supplies
-    /// the span status. Stopping and clearing the activity here prevents a persistent server
-    /// from parenting a later build to the completed request.
+    /// The logger attaches MSBuild events before it stops the activity. This order ensures
+    /// that exporters include the events when they capture the stopped activity. The method
+    /// sets the span status from the overall build result. It then clears the activity so a
+    /// later server build cannot use the completed activity as its parent.
     /// </remarks>
     private void OnBuildFinished(object sender, BuildFinishedEventArgs e)
     {
@@ -222,8 +218,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// Emits telemetry that is intentionally accumulated across nodes during a build.
     /// </summary>
     /// <remarks>
-    /// Removing each emitted aggregate is essential for persistent servers: process state
-    /// can survive into another build, but counts from the completed request must not.
+    /// A persistent server retains process state for the next build. This method removes
+    /// each aggregate after it sends the aggregate. The next build cannot reuse counts from
+    /// the completed request.
     /// </remarks>
     internal void SendAggregatedEventsOnBuildFinished(ITelemetryClient? telemetry)
     {
@@ -356,8 +353,8 @@ public sealed class MSBuildLogger : INodeLogger
 
         if (telemetry is TelemetryClient telemetryClient)
         {
-            // This activity ends at BuildFinished, so production events must be attached before
-            // an exporter observes Activity.Stop. Test clients retain the ITelemetryClient seam.
+            // Add production events before BuildFinished stops the activity.
+            // Test clients use ITelemetryClient without a real telemetry client.
             telemetryClient.ThreadBlockingTrackEvent(eventName, properties ?? eventProperties);
         }
         else
@@ -379,15 +376,14 @@ public sealed class MSBuildLogger : INodeLogger
     }
 
     /// <summary>
-    /// Completes this MSBuild logger instance and drains its telemetry.
+    /// Completes this MSBuild logger instance and writes its diagnostic telemetry log.
     /// </summary>
     /// <remarks>
-    /// <c>BuildFinished</c> is the normal activity boundary. The additional stop is an
-    /// idempotent fallback for aborted builds whose finish event was not delivered.
-    /// Exporter draining and diagnostic-log writing belong here rather than in
-    /// <c>BuildFinished</c> because MSBuild defines <see cref="Shutdown"/> as the logger
-    /// completion hook. In a persistent server this does not imply process shutdown; the
-    /// process-wide telemetry client remains reusable by a later logger instance.
+    /// <c>BuildFinished</c> normally stops the build activity. <see cref="Shutdown"/> also
+    /// stops the activity if an aborted build did not deliver <c>BuildFinished</c>. MSBuild
+    /// calls this method when the logger instance ends. The method waits for queued events
+    /// before it writes the diagnostic log. In a persistent server, logger shutdown does not
+    /// end the process. A later logger instance can reuse the process-wide telemetry client.
     /// </remarks>
     public void Shutdown()
     {
@@ -405,9 +401,9 @@ public sealed class MSBuildLogger : INodeLogger
     /// Stops only the activity owned by this logger and clears the reference.
     /// </summary>
     /// <remarks>
-    /// The ambient parent belongs to the invoking host and must not be stopped here.
-    /// Clearing the field also makes cleanup safe when both <c>BuildFinished</c> and
-    /// <see cref="Shutdown"/> run.
+    /// The invoking host owns the ambient parent activity. This method does not stop the
+    /// parent. Because this method clears the field, both <c>BuildFinished</c> and
+    /// <see cref="Shutdown"/> can call it safely.
     /// </remarks>
     private void StopActivity()
     {

--- a/src/Cli/dotnet/Telemetry/TelemetryClient.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryClient.cs
@@ -82,6 +82,8 @@ public class TelemetryClient : ITelemetryClient
     }
 
     public static string? CurrentSessionId { get; private set; } = null;
+    internal static bool IsInitialized { get; private set; }
+    internal static TelemetryClient? Instance { get; private set; }
     public static bool DisabledForTests
     {
         get => field;
@@ -92,6 +94,8 @@ public class TelemetryClient : ITelemetryClient
             if (field)
             {
                 CurrentSessionId = null;
+                IsInitialized = false;
+                Instance = null;
             }
         }
     } = false;
@@ -167,6 +171,9 @@ public class TelemetryClient : ITelemetryClient
 
     public TelemetryClient(string? sessionId, IEnvironmentProvider? environmentProvider = null)
     {
+        Instance = this;
+        IsInitialized = true;
+
         // This is some kind of special condition for MSBuild-related tests.
         if (DisabledForTests)
         {
@@ -271,9 +278,18 @@ public class TelemetryClient : ITelemetryClient
 
     public static void WriteLogIfNecessary()
     {
-        if (!string.IsNullOrWhiteSpace(s_diskLogPath) && s_activities.Any())
+        if (string.IsNullOrWhiteSpace(s_diskLogPath))
         {
-            TelemetryDiskLogger.WriteLog(s_diskLogPath, s_activities);
+            return;
+        }
+
+        Activity[] activities = [.. s_activities];
+        if (activities.Length > 0 && TelemetryDiskLogger.WriteLog(s_diskLogPath, activities))
+        {
+            foreach (Activity activity in activities)
+            {
+                s_activities.Remove(activity);
+            }
         }
     }
 
@@ -298,6 +314,11 @@ public class TelemetryClient : ITelemetryClient
         }
 
         TrackEventTask(eventName, properties);
+    }
+
+    internal void WaitForPendingEvents()
+    {
+        _trackEventTask?.GetAwaiter().GetResult();
     }
 
     private static void TrackEventTask(string eventName, IDictionary<string, string?>? properties)

--- a/src/Cli/dotnet/Telemetry/TelemetryClient.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryClient.cs
@@ -171,14 +171,14 @@ public class TelemetryClient : ITelemetryClient
 
     public TelemetryClient(string? sessionId, IEnvironmentProvider? environmentProvider = null)
     {
-        Instance = this;
-        IsInitialized = true;
-
         // This is some kind of special condition for MSBuild-related tests.
         if (DisabledForTests)
         {
             return;
         }
+
+        Instance = this;
+        IsInitialized = true;
 
         environmentProvider ??= new EnvironmentProvider();
         Enabled = !environmentProvider.GetEnvironmentVariableAsBool(EnvironmentVariableNames.TELEMETRY_OPTOUT,

--- a/src/Cli/dotnet/Telemetry/TelemetryClient.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryClient.cs
@@ -211,7 +211,7 @@ public class TelemetryClient : ITelemetryClient
     /// bridge via <c>hostfxr_set_runtime_property_value</c>), then falls back to the
     /// <c>TRACEPARENT</c> / <c>TRACESTATE</c> environment variables.
     /// </summary>
-    private static ActivityContext? GetParentActivityContext()
+    internal static ActivityContext? GetParentActivityContext()
     {
         // Runtime properties take precedence — they are set by the AOT bridge when it
         // falls back to the managed CLI so that the managed spans become children of the

--- a/src/Cli/dotnet/Telemetry/TelemetryDiskLogger.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryDiskLogger.cs
@@ -47,7 +47,7 @@ internal static class TelemetryDiskLogger
         s_jsonContext = new(s_jsonOptions);
     }
 
-    public static bool WriteLog(string logPath, IEnumerable<Activity> activies)
+    public static bool WriteLog(string logPath, IEnumerable<Activity> activities)
     {
         try
         {
@@ -55,7 +55,7 @@ internal static class TelemetryDiskLogger
             var root = JsonNode.Parse(jsonText)!;
             var activitiesArray = root["activities"]!.AsArray();
 
-            foreach (var activity in activies)
+            foreach (var activity in activities)
             {
                 activitiesArray.Add(JsonNode.Parse(JsonSerializer.Serialize(CreateActivityJsonModel(activity), s_jsonContext.ActivityModel)));
             }

--- a/src/Cli/dotnet/Telemetry/TelemetryDiskLogger.cs
+++ b/src/Cli/dotnet/Telemetry/TelemetryDiskLogger.cs
@@ -47,23 +47,26 @@ internal static class TelemetryDiskLogger
         s_jsonContext = new(s_jsonOptions);
     }
 
-    public static void WriteLog(string logPath, IEnumerable<Activity> activies)
+    public static bool WriteLog(string logPath, IEnumerable<Activity> activies)
     {
         try
         {
             var jsonText = !File.Exists(logPath) ? """{"activities":[]}""" : File.ReadAllText(logPath);
             var root = JsonNode.Parse(jsonText)!;
             var activitiesArray = root["activities"]!.AsArray();
+
             foreach (var activity in activies)
             {
                 activitiesArray.Add(JsonNode.Parse(JsonSerializer.Serialize(CreateActivityJsonModel(activity), s_jsonContext.ActivityModel)));
             }
             root["activities"] = activitiesArray;
             File.WriteAllText(logPath, root.ToJsonString(s_jsonOptions));
+            return true;
         }
         catch
         {
             // Swallow any exceptions to avoid interfering with telemetry shutdown.
+            return false;
         }
     }
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -331,5 +331,21 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 return activity;
             }
         }
+
+        [TestMethod]
+        [DataRow(false, null, false)]
+        [DataRow(false, "0", false)]
+        [DataRow(false, "1", false)]
+        [DataRow(true, null, true)]
+        [DataRow(true, "0", true)]
+        [DataRow(true, "1", false)]
+        public void ItShutsDownOnlyProvidersOwnedByAOneShotProcess(
+            bool initializedTelemetry,
+            string useMSBuildServer,
+            bool expected)
+        {
+            MSBuildLogger.ShouldShutdownTelemetryProviders(initializedTelemetry, useMSBuildServer)
+                .Should().Be(expected);
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -272,5 +272,64 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             stoppedActivity.Should().NotBeNull();
             stoppedActivity.Status.Should().Be(ActivityStatusCode.Ok);
         }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public void ItUsesTheCurrentParentContextForEachServerBuild()
+        {
+            string originalTraceParent = Environment.GetEnvironmentVariable(Activities.TRACEPARENT);
+            Activity ambientActivity = Activity.Current;
+            Activity.Current = null;
+
+            try
+            {
+                ActivitySource activitySource = Activities.Source;
+                using var listener = new ActivityListener
+                {
+                    ShouldListenTo = source => source == activitySource,
+                    Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                };
+                ActivitySource.AddActivityListener(listener);
+
+                var firstParent = new ActivityContext(
+                    ActivityTraceId.CreateRandom(),
+                    ActivitySpanId.CreateRandom(),
+                    ActivityTraceFlags.Recorded,
+                    isRemote: true);
+                var firstActivity = RunBuildWithParent(firstParent);
+
+                var secondParent = new ActivityContext(
+                    ActivityTraceId.CreateRandom(),
+                    ActivitySpanId.CreateRandom(),
+                    ActivityTraceFlags.Recorded,
+                    isRemote: true);
+                var secondActivity = RunBuildWithParent(secondParent);
+
+                firstActivity.TraceId.Should().Be(firstParent.TraceId);
+                firstActivity.ParentSpanId.Should().Be(firstParent.SpanId);
+                secondActivity.TraceId.Should().Be(secondParent.TraceId);
+                secondActivity.ParentSpanId.Should().Be(secondParent.SpanId);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Activities.TRACEPARENT, originalTraceParent);
+                Activity.Current = ambientActivity;
+            }
+
+            static Activity RunBuildWithParent(ActivityContext parentContext)
+            {
+                Environment.SetEnvironmentVariable(
+                    Activities.TRACEPARENT,
+                    $"00-{parentContext.TraceId}-{parentContext.SpanId}-01");
+
+                var eventSource = new PersistentDispatcher([]);
+                var logger = new MSBuildLogger(new FakeTelemetry());
+                logger.Initialize(eventSource);
+                eventSource.Dispatch(new BuildStartedEventArgs("Build started.", helpKeyword: null));
+                Activity activity = Activity.Current;
+                eventSource.Dispatch(new BuildFinishedEventArgs("Build finished.", helpKeyword: null, succeeded: true));
+                return activity;
+            }
+        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -331,21 +331,5 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 return activity;
             }
         }
-
-        [TestMethod]
-        [DataRow(false, null, false)]
-        [DataRow(false, "0", false)]
-        [DataRow(false, "1", false)]
-        [DataRow(true, null, true)]
-        [DataRow(true, "0", true)]
-        [DataRow(true, "1", false)]
-        public void ItShutsDownOnlyProvidersOwnedByAOneShotProcess(
-            bool initializedTelemetry,
-            string useMSBuildServer,
-            bool expected)
-        {
-            MSBuildLogger.ShouldShutdownTelemetryProviders(initializedTelemetry, useMSBuildServer)
-                .Should().Be(expected);
-        }
     }
 }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Utils;
@@ -239,6 +240,37 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             fakeTelemetry.LogEntry.Properties["Tasks"].Should().Be("[{\"Name\":\"Copy\",\"ExecutionsCount\":10}]");
             fakeTelemetry.LogEntry.Properties["TaskCount"].Should().Be("1");
             fakeTelemetry.LogEntry.Properties["TotalTaskCount"].Should().Be("1");
+        }
+
+        [TestMethod]
+        public void ItCreatesAnInternalActivityForEachBuild()
+        {
+            ActivitySource activitySource = Activities.Source;
+            Activity stoppedActivity = null;
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source == activitySource,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => stoppedActivity = activity,
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using Activity parentActivity = new Activity("parent").Start();
+            var eventSource = new PersistentDispatcher([]);
+            var logger = new MSBuildLogger(new FakeTelemetry());
+            logger.Initialize(eventSource);
+
+            eventSource.Dispatch(new BuildStartedEventArgs("Build started.", helpKeyword: null));
+
+            Activity.Current.Should().NotBeSameAs(parentActivity);
+            Activity.Current.Kind.Should().Be(ActivityKind.Internal);
+            Activity.Current.ParentSpanId.Should().Be(parentActivity.SpanId);
+
+            eventSource.Dispatch(new BuildFinishedEventArgs("Build finished.", helpKeyword: null, succeeded: true));
+
+            Activity.Current.Should().BeSameAs(parentActivity);
+            stoppedActivity.Should().NotBeNull();
+            stoppedActivity.Status.Should().Be(ActivityStatusCode.Ok);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var startInfo = new MSBuildForwardingApp(Array.Empty<string>(), "<msbuildpath>").GetProcessStartInfo();
 
             startInfo.Environment[Activities.TRACEPARENT]
-                .Should().Be($"00-{activity.TraceId}-{activity.SpanId}-{(activity.ActivityTraceFlags == ActivityTraceFlags.Recorded ? "01" : "00")}");
+                .Should().Be($"00-{activity.TraceId}-{activity.SpanId}-{(byte)activity.Context.TraceFlags:x2}");
             startInfo.Environment[Activities.TRACESTATE].Should().Be(activity.TraceStateString);
         }
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Diagnostics;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Telemetry;
@@ -45,6 +46,21 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var msbuildPath = "<msbuildpath>";
             var startInfo = new MSBuildForwardingApp(Array.Empty<string>(), msbuildPath).GetProcessStartInfo();
             startInfo.Environment.ContainsKey(envVarName).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ItPropagatesTheCurrentActivityContext()
+        {
+            using var activity = new Activity("invocation")
+                .SetIdFormat(ActivityIdFormat.W3C)
+                .Start();
+            activity.TraceStateString = "vendor=value";
+
+            var startInfo = new MSBuildForwardingApp(Array.Empty<string>(), "<msbuildpath>").GetProcessStartInfo();
+
+            startInfo.Environment[Activities.TRACEPARENT]
+                .Should().Be($"00-{activity.TraceId}-{activity.SpanId}-{(activity.ActivityTraceFlags == ActivityTraceFlags.Recorded ? "01" : "00")}");
+            startInfo.Environment[Activities.TRACESTATE].Should().Be(activity.TraceStateString);
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
@@ -145,6 +145,27 @@ public class TelemetryClientTests : SdkTest
 
     [TestMethod]
     [DoNotParallelize]
+    public void DisabledForTestsDoesNotInitializeTelemetry()
+    {
+        TelemetryClient.DisabledForTests = true;
+
+        try
+        {
+            _ = new TelemetryClient();
+            TelemetryClient.DisabledForTests = false;
+
+            TelemetryClient.IsInitialized.Should().BeFalse();
+            TelemetryClient.Instance.Should().BeNull();
+            TelemetryClient.CurrentSessionId.Should().BeNull();
+        }
+        finally
+        {
+            TelemetryClient.DisabledForTests = true;
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
     public void MSBuildLoggerDoesNotReinitializeDisabledTelemetry()
     {
         var environmentProvider = new Mock<IEnvironmentProvider>(MockBehavior.Strict);

--- a/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
@@ -111,12 +111,31 @@ public class TelemetryClientTests : SdkTest
 
             var msbuildActivities = activities.Where(activity =>
                 activity?["events"]?.AsArray()
-                    .Any(@event => @event?["name"]?.GetValue<string>().StartsWith("dotnet/cli/msbuild/") == true) == true);
+                    .Any(@event => @event?["name"]?.GetValue<string>().StartsWith("dotnet/cli/msbuild/") == true) == true)
+                .ToArray();
 
             var msbuildTraceIds = msbuildActivities
                 .Select(activity => activity?["identifiers"]?["traceId"]?.GetValue<string>())
                 .Distinct();
             msbuildTraceIds.Should().HaveCount(2);
+
+            var invocationTraceIds = activities
+                .Where(activity => activity?["operationName"]?.GetValue<string>() == "invocation")
+                .Select(activity => activity?["identifiers"]?["traceId"]?.GetValue<string>())
+                .ToHashSet();
+            var activityContexts = activities
+                .Select(activity => (
+                    traceId: activity?["identifiers"]?["traceId"]?.GetValue<string>(),
+                    spanId: activity?["identifiers"]?["spanId"]?.GetValue<string>()))
+                .ToHashSet();
+
+            var msbuildParentContexts = msbuildActivities
+                .Select(activity => (
+                    traceId: activity?["identifiers"]?["traceId"]?.GetValue<string>(),
+                    spanId: activity?["identifiers"]?["parentSpanId"]?.GetValue<string>()))
+                .ToArray();
+            msbuildParentContexts.Should().OnlyContain(
+                context => invocationTraceIds.Contains(context.traceId) && activityContexts.Contains(context));
         }
         finally
         {

--- a/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
@@ -87,7 +87,8 @@ public class TelemetryClientTests : SdkTest
 
         try
         {
-            new BuildCommand(testAsset)
+            new DotnetCommand(Log, "build")
+                .WithWorkingDirectory(testAsset.TestRoot)
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "false")
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT", "true")
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_LOG_PATH", logFile)
@@ -96,7 +97,8 @@ public class TelemetryClientTests : SdkTest
                 .Should()
                 .Pass();
 
-            new BuildCommand(testAsset)
+            new DotnetCommand(Log, "build")
+                .WithWorkingDirectory(testAsset.TestRoot)
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "false")
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT", "true")
                 .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_LOG_PATH", logFile)

--- a/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
@@ -3,8 +3,10 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Commands.MSBuild;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
 using Moq;
 
 namespace Microsoft.DotNet.Tests.TelemetryTests;
@@ -72,6 +74,85 @@ public class TelemetryClientTests : SdkTest
     }
 
     [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    [DoNotParallelize]
+    public void ItProcessesMSBuildTelemetryWithTheServerEnabled()
+    {
+        var testAsset = TestAssetsManager.CopyTestAsset("HelloWorld")
+            .WithSource();
+        var logFile = Path.Combine(testAsset.TestRoot, "msbuild-server-telemetry.json");
+        File.Delete(logFile);
+
+        ShutdownMSBuildServer(testAsset.TestRoot);
+
+        try
+        {
+            new BuildCommand(testAsset)
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "false")
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT", "true")
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_LOG_PATH", logFile)
+                .WithEnvironmentVariable("MSBUILDUSESERVER", "1")
+                .Execute()
+                .Should()
+                .Pass();
+
+            new BuildCommand(testAsset)
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "false")
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_DISABLE_TRACE_EXPORT", "true")
+                .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_LOG_PATH", logFile)
+                .WithEnvironmentVariable("MSBUILDUSESERVER", "1")
+                .Execute()
+                .Should()
+                .Pass();
+
+            var telemetryJson = JsonNode.Parse(File.ReadAllText(logFile));
+            var activities = telemetryJson?["activities"]?.AsArray();
+            activities.Should().NotBeNull();
+
+            var msbuildActivities = activities.Where(activity =>
+                activity?["events"]?.AsArray()
+                    .Any(@event => @event?["name"]?.GetValue<string>().StartsWith("dotnet/cli/msbuild/") == true) == true);
+
+            var msbuildTraceIds = msbuildActivities
+                .Select(activity => activity?["identifiers"]?["traceId"]?.GetValue<string>())
+                .Distinct();
+            msbuildTraceIds.Should().HaveCount(2);
+        }
+        finally
+        {
+            ShutdownMSBuildServer(testAsset.TestRoot);
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void MSBuildLoggerDoesNotReinitializeDisabledTelemetry()
+    {
+        var environmentProvider = new Mock<IEnvironmentProvider>(MockBehavior.Strict);
+
+        TelemetryClient.DisabledForTests = true;
+        TelemetryClient.DisabledForTests = false;
+
+        try
+        {
+            environmentProvider
+                .Setup(p => p.GetEnvironmentVariableAsBool(EnvironmentVariableNames.TELEMETRY_OPTOUT, It.IsAny<bool>()))
+                .Returns(true);
+
+            var telemetry = new TelemetryClient(sessionId: null, environmentProvider: environmentProvider.Object);
+            _ = new MSBuildLogger();
+
+            telemetry.Enabled.Should().BeFalse();
+            TelemetryClient.IsInitialized.Should().BeTrue();
+            TelemetryClient.Instance.Should().BeSameAs(telemetry);
+        }
+        finally
+        {
+            TelemetryClient.DisabledForTests = true;
+        }
+    }
+
+    [TestMethod]
     [DoNotParallelize]
     public void ItSeedsCurrentSessionIdFromEnvironmentWhenSessionIdIsNotProvided()
     {
@@ -126,5 +207,14 @@ public class TelemetryClientTests : SdkTest
         {
             TelemetryClient.DisabledForTests = true;
         }
+    }
+
+    private void ShutdownMSBuildServer(string workingDirectory)
+    {
+        new BuildServerCommand(Log)
+            .WithWorkingDirectory(workingDirectory)
+            .Execute("shutdown", "--msbuild")
+            .Should()
+            .Pass();
     }
 }


### PR DESCRIPTION
Fixes #55578

## Summary

- initialize and reuse the telemetry client when `MSBuildLogger` runs in the persistent MSBuild server
- create an internal MSBuild activity at `BuildStarted`, set its result at `BuildFinished`, and drain pending telemetry during logger shutdown
- forward W3C trace context from the invoking CLI and resolve it for every server build so MSBuild spans remain nested under the correct command invocation
- flush completed disk-log activities after successful writes so consecutive server builds do not duplicate prior spans
- cover activity ownership, trace propagation, and consecutive builds through one persistent MSBuild server

## Testing

- focused `TelemetryClientTests`, `GivenMSBuildLogger`, and propagation suite (24 tests)
- managed CLI and Native AOT shared-source builds
- two builds through one persistent server using the local `11.0.100-dev` redist SDK and Aspire Dashboard; each trace contained a nested internal `msbuild` span with `Ok` status and the expected MSBuild telemetry events