### PR TITLE
Extend the single `dotnet test -bl` build session to the device (MAUI) paths

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs
@@ -26,16 +26,19 @@ internal sealed class RunCommandSelector : IDisposable
     private readonly string _projectFilePath;
     private readonly Dictionary<string, string> _globalProperties;
     private readonly FacadeLogger? _binaryLogger;
+    private readonly MSBuildSession? _buildSession;
     private readonly bool _isInteractive;
     private readonly MSBuildArgs _msbuildArgs;
     private readonly IReadOnlyDictionary<string, string> _environmentVariables;
     private readonly string _commandName;
-    
-    private ProjectCollection? _collection;
+
+    // Every project this class evaluates lives in a single collection: MSBuild refuses to build
+    // project instances coming from different collections inside one build session, and the projects
+    // built here (restore, device computation, deployment) differ only by their global properties.
+    private ProjectCollection? _ownedCollection;
     private Microsoft.Build.Evaluation.Project? _project;
 
-    // Project/collection without TargetFramework, used for restore. Lazily populated.
-    private ProjectCollection? _restoreCollection;
+    // Project without TargetFramework, used for restore. Lazily populated.
     private Microsoft.Build.Evaluation.Project? _restoreProject;
 
     /// <summary>
@@ -85,13 +88,19 @@ internal sealed class RunCommandSelector : IDisposable
     /// <param name="environmentVariables">Environment variables to pass to MSBuild targets as items</param>
     /// <param name="commandName">The command name used when rendering example messages, e.g. "dotnet run" or "dotnet test".</param>
     /// <param name="binaryLogger">Optional binary logger for MSBuild operations. The logger will not be disposed by this class.</param>
+    /// <param name="buildSession">
+    /// Optional MSBuild session shared with the rest of the command. When provided, the targets this class
+    /// invokes run inside that single build instead of one build each, so a binary log attached to the
+    /// command holds one well formed build. The session is owned by the caller and is not disposed here.
+    /// </param>
     public RunCommandSelector(
         string projectFilePath,
         bool isInteractive,
         MSBuildArgs msbuildArgs,
         IReadOnlyDictionary<string, string> environmentVariables,
         string commandName,
-        FacadeLogger? binaryLogger = null)
+        FacadeLogger? binaryLogger = null,
+        MSBuildSession? buildSession = null)
     {
         _projectFilePath = projectFilePath;
         _globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
@@ -100,6 +109,7 @@ internal sealed class RunCommandSelector : IDisposable
         _environmentVariables = environmentVariables;
         _commandName = commandName;
         _binaryLogger = binaryLogger;
+        _buildSession = buildSession;
     }
 
     /// <summary>
@@ -145,19 +155,14 @@ internal sealed class RunCommandSelector : IDisposable
     /// </summary>
     public void InvalidateGlobalProperties(Dictionary<string, string> updatedProperties)
     {
-        // When TargetFramework is first added, save the current project for restore use
-        // instead of disposing it. See https://github.com/dotnet/sdk/issues/53488
+        // When TargetFramework is first added, keep the current project for restore use
+        // instead of dropping it. See https://github.com/dotnet/sdk/issues/53488
         if (_restoreProject is null &&
             _project is not null &&
             updatedProperties.ContainsKey("TargetFramework") &&
             !_globalProperties.ContainsKey("TargetFramework"))
         {
             _restoreProject = _project;
-            _restoreCollection = _collection;
-        }
-        else
-        {
-            _collection?.Dispose();
         }
 
         // Update our stored global properties
@@ -168,49 +173,69 @@ internal sealed class RunCommandSelector : IDisposable
 
         // Reset to force re-evaluation with new global properties
         _project = null;
-        _collection = null;
         HasValidProject = false;
     }
+
+    /// <summary>
+    /// The collection every project of this selector is evaluated in: the one shared with the rest of
+    /// the command when a build session was provided, otherwise one of its own. It deliberately carries
+    /// no global properties, because MSBuild merges those of a collection into every project loaded from
+    /// it and restore has to run without the TargetFramework the rest of the command uses
+    /// (see https://github.com/dotnet/sdk/issues/53488).
+    /// </summary>
+    private ProjectCollection Collection
+        => _buildSession?.ProjectCollection
+            ?? (_ownedCollection ??= new ProjectCollection(
+                globalProperties: null,
+                loggers: GetLoggers(),
+                toolsetDefinitionLocations: ToolsetDefinitionLocations.Default));
 
     /// <summary>
     /// Opens the project if it hasn't been opened yet.
     /// </summary>
     private bool OpenProjectIfNeeded([NotNullWhen(true)] out ProjectInstance? projectInstance)
     {
-        if (_project is not null)
+        if (_project is null)
         {
-            // Create a fresh ProjectInstance for each build operation
-            // to avoid accumulating state (existing item groups) from previous builds
-            projectInstance = _project.CreateProjectInstance();
-            HasValidProject = true;
-            return true;
+            try
+            {
+                // The global properties are passed explicitly rather than taken from the collection:
+                // they change as the target framework and the device get selected, and the collection
+                // is shared with the projects of the rest of the command.
+                _project = Collection.LoadProject(_projectFilePath, new Dictionary<string, string>(_globalProperties), toolsVersion: null);
+            }
+            catch (InvalidProjectFileException)
+            {
+                // Invalid project file, return false
+                projectInstance = null;
+                HasValidProject = false;
+                return false;
+            }
         }
 
-        try
-        {
-            _collection = new ProjectCollection(
-                globalProperties: _globalProperties,
-                loggers: GetLoggers(),
-                toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
-            _project = _collection.LoadProject(_projectFilePath);
-            projectInstance = _project.CreateProjectInstance();
-            HasValidProject = true;
-            return true;
-        }
-        catch (InvalidProjectFileException)
-        {
-            // Invalid project file, return false
-            projectInstance = null;
-            HasValidProject = false;
-            return false;
-        }
+        // Create a fresh ProjectInstance for each build operation
+        // to avoid accumulating state (existing item groups) from previous builds
+        projectInstance = _project.CreateProjectInstance();
+        HasValidProject = true;
+        return true;
     }
+
+    /// <summary>
+    /// Builds targets of an evaluated project, either in the build session shared with the rest of the
+    /// command (so a binary log attached to it holds a single build) or, when no session was provided,
+    /// in a build of its own.
+    /// </summary>
+    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary unblock for dotnet/msbuild#14064 (MSBuild build APIs are now [RequiresUnreferencedCode]). dotnet CLI runs MSBuild in-proc (not trimmed). Remove when dotnet/sdk#55225 is fixed.")]
+    private bool BuildTargets(ProjectInstance projectInstance, string[] targets, out IDictionary<string, TargetResult> targetOutputs)
+        => _buildSession is { } buildSession
+            ? buildSession.Build(projectInstance, targets, out targetOutputs)
+            : projectInstance.Build(targets, GetLoggers(), remoteLoggers: null, out targetOutputs);
 
     public void Dispose()
     {
-        // NOTE: _binaryLogger is not disposed here because it is *owned* by the caller
-        _collection?.Dispose();
-        _restoreCollection?.Dispose();
+        // NOTE: neither _binaryLogger nor the collection of _buildSession are disposed here,
+        // because they are *owned* by the caller
+        _ownedCollection?.Dispose();
     }
 
     /// <summary>
@@ -233,14 +258,11 @@ internal sealed class RunCommandSelector : IDisposable
         }
 
         // TargetFramework is set and no pre-TF project was saved (e.g. --framework was explicit).
-        // Create a new project without TargetFramework.
+        // Evaluate the project without TargetFramework, in the same collection so that it can be
+        // built in the same session as the rest of the command.
         var restoreProperties = new Dictionary<string, string>(_globalProperties, StringComparer.OrdinalIgnoreCase);
         restoreProperties.Remove("TargetFramework");
-        _restoreCollection = new ProjectCollection(
-            globalProperties: restoreProperties,
-            loggers: null,
-            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
-        _restoreProject = _restoreCollection.LoadProject(_projectFilePath);
+        _restoreProject = Collection.LoadProject(_projectFilePath, restoreProperties, toolsVersion: null);
         return _restoreProject.CreateProjectInstance();
     }
 
@@ -347,12 +369,7 @@ internal sealed class RunCommandSelector : IDisposable
         {
             // Run restore without TargetFramework to prevent it from cascading to
             // dependency projects. See https://github.com/dotnet/sdk/issues/53488
-            var restoreResult = CreateRestoreProjectInstance().Build(
-                targets: ["Restore"],
-                loggers: GetLoggers(),
-                remoteLoggers: null,
-                out _);
-            if (!restoreResult)
+            if (!BuildTargets(CreateRestoreProjectInstance(), ["Restore"], out _))
             {
                 return false;
             }
@@ -361,11 +378,7 @@ internal sealed class RunCommandSelector : IDisposable
         }
 
         // Build the target
-        var buildResult = projectInstance.Build(
-            targets: [Constants.ComputeAvailableDevices],
-            loggers: GetLoggers(),
-            remoteLoggers: null,
-            out var targetOutputs);
+        var buildResult = BuildTargets(projectInstance, [Constants.ComputeAvailableDevices], out var targetOutputs);
 
         if (!buildResult)
         {
@@ -591,13 +604,7 @@ internal sealed class RunCommandSelector : IDisposable
         }
 
         // Build the DeployToDevice target
-        var buildResult = projectInstance.Build(
-            targets: [Constants.DeployToDevice],
-            loggers: GetLoggers(),
-            remoteLoggers: null,
-            out _);
-
-        return buildResult;
+        return BuildTargets(projectInstance, [Constants.DeployToDevice], out _);
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildHandler.cs
@@ -9,10 +9,10 @@ using Microsoft.DotNet.Cli.Utils.Extensions;
 namespace Microsoft.DotNet.Cli.Commands.Test;
 
 [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
-internal sealed class MSBuildHandler(BuildOptions buildOptions, FacadeLogger? logger) : ITestHandler
+internal sealed class MSBuildHandler(BuildOptions buildOptions, MSBuildSession buildSession) : ITestHandler
 {
     private readonly BuildOptions _buildOptions = buildOptions;
-    private readonly FacadeLogger? _logger = logger;
+    private readonly MSBuildSession _buildSession = buildSession;
 
     private readonly ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules> _testApplications = [];
 
@@ -27,8 +27,8 @@ internal sealed class MSBuildHandler(BuildOptions buildOptions, FacadeLogger? lo
         }
 
         (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects, int buildExitCode) = isSolution ?
-            MSBuildUtility.GetProjectsFromSolution(projectOrSolutionFilePath, _buildOptions, _logger) :
-            MSBuildUtility.GetProjectsFromProject(projectOrSolutionFilePath, _buildOptions, _logger);
+            MSBuildUtility.GetProjectsFromSolution(projectOrSolutionFilePath, _buildOptions, _buildSession) :
+            MSBuildUtility.GetProjectsFromProject(projectOrSolutionFilePath, _buildOptions, _buildSession);
 
         LogProjectProperties(projects);
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -31,7 +31,7 @@ internal static class MSBuildUtility
     public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) GetProjectsFromSolution(
         string solutionFilePath,
         BuildOptions buildOptions,
-        FacadeLogger? logger)
+        MSBuildSession buildSession)
     {
         int buildExitCode = BuildOrRestoreProjectOrSolution(solutionFilePath, buildOptions);
 
@@ -70,12 +70,9 @@ internal static class MSBuildUtility
             .Where(p => p.Item1.IncludeInBuild)
             .Select(p => (p.AbsolutePath, (string?)p.Item1.ConfigurationName, (string?)p.Item1.PlatformName));
 
-        using var collection = new ProjectCollection(globalProperties, loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+        var collection = buildSession.ProjectCollection;
         var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
-        using var buildSession = new TestBuildSession(collection, msbuildArgs, logger);
-        var (projects, deviceBuildExitCode) = GetProjectsProperties(collection, evaluationContext, projectPaths, buildOptions, logger, buildSession);
-        buildSession.Complete();
-        collection.UnloadAllProjects();
+        var (projects, deviceBuildExitCode) = GetProjectsProperties(collection, evaluationContext, projectPaths, buildOptions, globalProperties, buildSession);
 
         return (projects, deviceBuildExitCode != 0 ? deviceBuildExitCode : buildExitCode);
     }
@@ -84,18 +81,18 @@ internal static class MSBuildUtility
     public static (IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> Projects, int BuildExitCode) GetProjectsFromProject(
         string projectFilePath,
         BuildOptions buildOptions,
-        FacadeLogger? logger)
+        MSBuildSession buildSession)
     {
         // Pre-build device selection: evaluate the project to select devices BEFORE building,
         // so that device-provided RuntimeIdentifiers are included in the build.
         var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(
             projectFilePath,
             buildOptions,
-            logger: logger);
+            buildSession);
 
         if (deviceSelection is not null)
         {
-            return BuildPerTfmWithDevices(projectFilePath, buildOptions, deviceSelection, logger);
+            return BuildPerTfmWithDevices(projectFilePath, buildOptions, deviceSelection, buildSession);
         }
 
         int buildExitCode = BuildOrRestoreProjectOrSolution(projectFilePath, buildOptions);
@@ -105,14 +102,14 @@ internal static class MSBuildUtility
             return (Array.Empty<ParallelizableTestModuleGroupWithSequentialInnerModules>(), buildExitCode);
         }
 
-        var msbuildArgs = MSBuildArgs.AnalyzeMSBuildArguments(buildOptions.MSBuildArgs, CommonOptions.CreatePropertyOption(), CommonOptions.CreateRestorePropertyOption(), CommonOptions.CreateMSBuildTargetOption(), CommonOptions.CreateVerbosityOption(), CommonOptions.CreateNoLogoOption());
-
-        using var collection = new ProjectCollection(globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs), logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+        var collection = buildSession.ProjectCollection;
+        // A fresh evaluation context: the one device selection used above ran before the build, so it
+        // caches a view of the file system that predates the build outputs.
         var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
-        using var buildSession = new TestBuildSession(collection, msbuildArgs, logger);
-        IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = SolutionAndProjectUtility.GetProjectProperties(projectFilePath, collection, evaluationContext, buildOptions, buildSession, configuration: null, platform: null);
-        buildSession.Complete();
-        collection.UnloadAllProjects();
+        var msbuildArgs = SolutionAndProjectUtility.AnalyzeStandardTestMSBuildArgs(buildOptions.MSBuildArgs);
+        IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projects = SolutionAndProjectUtility.GetProjectProperties(
+            projectFilePath, collection, evaluationContext, buildOptions, buildSession, configuration: null, platform: null,
+            CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs));
         return (projects, buildExitCode);
     }
 
@@ -125,7 +122,7 @@ internal static class MSBuildUtility
         string projectFilePath,
         BuildOptions buildOptions,
         SolutionAndProjectUtility.DeviceSelectionResult deviceSelection,
-        FacadeLogger? logger,
+        MSBuildSession buildSession,
         string? configuration = null,
         string? platform = null)
     {
@@ -173,19 +170,13 @@ internal static class MSBuildUtility
 
             var msbuildArgs = SolutionAndProjectUtility.AnalyzeStandardTestMSBuildArgs(perTfmBuildOptions.MSBuildArgs);
 
-            using var collection = new ProjectCollection(
-                globalProperties: CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs),
-                logger is null ? null : [logger],
-                toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+            // The target framework, device and runtime identifier of this iteration are passed as
+            // per-project global properties instead of through a project collection of their own: every
+            // project built in the session has to come from the collection the session owns.
+            var perTfmGlobalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
             var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
-            // The session is scoped to this iteration because the next one runs another restore/build
-            // through BuildManager.DefaultBuildManager, which must not overlap an open session. A
-            // multi-target-framework device run therefore still writes one build per target framework
-            // into the binary log. Tracked by https://github.com/dotnet/sdk/issues/55561.
-            using var buildSession = new TestBuildSession(collection, msbuildArgs, logger);
             IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> modules = SolutionAndProjectUtility.GetProjectProperties(
-                projectFilePath, collection, evaluationContext, perTfmBuildOptions, buildSession, configuration, platform);
-            buildSession.Complete();
+                projectFilePath, buildSession.ProjectCollection, evaluationContext, perTfmBuildOptions, buildSession, configuration, platform, perTfmGlobalProperties);
 
             allGroups.AddRange(modules);
         }
@@ -419,25 +410,22 @@ internal static class MSBuildUtility
         EvaluationContext evaluationContext,
         IEnumerable<(string ProjectFilePath, string? Configuration, string? Platform)> projects,
         BuildOptions buildOptions,
-        FacadeLogger? logger,
-        TestBuildSession buildSession)
+        IReadOnlyDictionary<string, string> globalProperties,
+        MSBuildSession buildSession)
     {
         var allProjects = new ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules>();
         var nonDeviceProjects = new List<(string ProjectFilePath, string? Configuration, string? Platform)>();
 
         // Phase 1: Handle device projects sequentially. Per-TFM builds use in-process MSBuild
         // (BuildManager.DefaultBuildManager), which is a process-wide singleton and cannot run concurrently.
-        // Phase 1 must also complete before phase 2 starts using the session: the session's dedicated
-        // BuildManager must never be open across one of those builds. The session starts lazily, so it
-        // stays unstarted until phase 2 issues the first request.
+        // The shared session may stay open across them, because it owns a build manager of its own.
         foreach (var project in projects)
         {
             var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(
                 project.ProjectFilePath,
                 buildOptions,
-                projectCollection,
-                evaluationContext,
-                logger);
+                buildSession,
+                evaluationContext);
 
             if (deviceSelection is not null)
             {
@@ -445,7 +433,7 @@ internal static class MSBuildUtility
                     project.ProjectFilePath,
                     buildOptions,
                     deviceSelection,
-                    logger,
+                    buildSession,
                     project.Configuration,
                     project.Platform);
                 if (exitCode != 0)
@@ -475,7 +463,7 @@ internal static class MSBuildUtility
             {
                 try
                 {
-                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, buildSession, project.Configuration, project.Platform);
+                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, buildSession, project.Configuration, project.Platform, globalProperties);
                     foreach (var projectMetadata in projectsMetadata)
                     {
                         allProjects.Add(projectMetadata);

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -41,13 +41,21 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         FacadeLogger? logger = LoggerUtility.DetermineBinlogger([.. buildOptions.MSBuildArgs], "dotnet-test");
         ITestHandler testHandler;
+        MSBuildSession? buildSession = null;
         try
         {
             // --list-devices: list available devices for the project and exit early.
             // Never builds, deploys, or runs tests.
             if (buildOptions.ListDevices)
             {
-                return HandleListDevices(buildOptions, logger);
+                using var listDevicesSession = CreateBuildSession(buildOptions, logger);
+                int listDevicesExitCode = HandleListDevices(buildOptions, listDevicesSession);
+                if (listDevicesExitCode == ExitCode.Success)
+                {
+                    listDevicesSession.Complete();
+                }
+
+                return listDevicesExitCode;
             }
 
             // When --device is specified, force single target framework selection because
@@ -57,18 +65,30 @@ internal partial class MicrosoftTestingPlatformTestCommand
                 buildOptions = HandleDeviceWithTargetFrameworkSelection(buildOptions, logger);
             }
 
+            // Every MSBuild target the test command invokes itself - device selection, deployment and
+            // ComputeRunArguments for every test module - runs inside this single build session, so the
+            // binary log behind -bl holds one well formed build instead of one per target invocation.
+            buildSession = CreateBuildSession(buildOptions, logger);
+
             testHandler = buildOptions.PathOptions.TestModules is { } testModules
                 ? new TestModulesFilterHandler(testModules, parseResult)
-                : RuntimeFeature.IsDynamicCodeSupported ? new MSBuildHandler(buildOptions, logger)
+                : RuntimeFeature.IsDynamicCodeSupported ? new MSBuildHandler(buildOptions, buildSession)
                     : throw new PlatformNotSupportedException("Dynamic code is not supported on this platform.");
 
             if (!testHandler.Initialize())
             {
                 return ExitCode.GenericFailure;
             }
+
+            // Ends the session on the success path, so a failure MSBuild only reports from EndBuild -
+            // a binary logger failing to write, for example - is surfaced rather than swallowed.
+            buildSession.Complete();
         }
         finally
         {
+            // Ends the build session (and so writes its build-finished event) before the binary
+            // logger behind it is shut down. A no-op once Complete() has run.
+            buildSession?.Dispose();
             logger?.ReallyShutdown();
         }
 
@@ -262,6 +282,14 @@ internal partial class MicrosoftTestingPlatformTestCommand
     }
 
     /// <summary>
+    /// Creates the MSBuild session shared by every target the test command invokes itself. It owns the
+    /// project collection all those projects have to be evaluated in; the collection has no global
+    /// properties of its own, so each project passes the ones it needs when it is evaluated.
+    /// </summary>
+    private static MSBuildSession CreateBuildSession(BuildOptions buildOptions, FacadeLogger? logger)
+        => new(SolutionAndProjectUtility.AnalyzeStandardTestMSBuildArgs(buildOptions.MSBuildArgs), logger);
+
+    /// <summary>
     /// When --device is specified, we need to ensure a single target framework is selected
     /// because a device is platform-specific. If -f/--framework wasn't provided, this method
     /// evaluates the project to get TargetFrameworks and prompts for selection.
@@ -346,7 +374,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
     /// <see cref="RunCommandSelector.TrySelectDevice"/>, and exits without
     /// building, deploying, or running tests.
     /// </summary>
-    private static int HandleListDevices(BuildOptions buildOptions, FacadeLogger? logger)
+    private static int HandleListDevices(BuildOptions buildOptions, MSBuildSession buildSession)
     {
         if (!ValidationUtility.ValidateBuildPathOptions(buildOptions.PathOptions, out var projectPath, out bool isSolution))
         {
@@ -373,7 +401,8 @@ internal partial class MicrosoftTestingPlatformTestCommand
             standardArgs,
             buildOptions.EnvironmentVariables,
             commandName: "dotnet test",
-            logger);
+            binaryLogger: null,
+            buildSession: buildSession);
 
         // Step 1: Prompt for TargetFramework if the project is multi-targeted and -f wasn't provided.
         if (!selector.TrySelectTargetFramework(out string? selectedFramework))

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -172,7 +172,8 @@ internal static class SolutionAndProjectUtility
         string projectFilePath,
         string? tfm,
         string? configuration,
-        string? platform)
+        string? platform,
+        IReadOnlyDictionary<string, string>? additionalGlobalProperties)
     {
         Debug.Assert(projectFilePath is not null);
 
@@ -213,6 +214,21 @@ internal static class SolutionAndProjectUtility
             }
         }
 
+        // Properties that apply to this project only - for example the device and runtime identifier
+        // selected for a target framework. They are passed explicitly rather than through a dedicated
+        // project collection, because all the projects of the run share the collection of the build
+        // session so that they can be built together.
+        if (additionalGlobalProperties is not null)
+        {
+            foreach (var property in additionalGlobalProperties)
+            {
+                if (!(globalProperties ??= new Dictionary<string, string>()).ContainsKey(property.Key))
+                {
+                    globalProperties.Add(property.Key, property.Value);
+                }
+            }
+        }
+
         // Merge the global properties from the project collection.
         // It's unclear why MSBuild isn't considering the global properties defined in the ProjectCollection when
         // the collection is passed in ProjectOptions below.
@@ -238,13 +254,14 @@ internal static class SolutionAndProjectUtility
         ProjectCollection projectCollection,
         EvaluationContext evaluationContext,
         BuildOptions buildOptions,
-        TestBuildSession buildSession,
+        MSBuildSession buildSession,
         string? configuration,
         string? platform,
+        IReadOnlyDictionary<string, string>? additionalGlobalProperties = null,
         HashSet<string>? visitedTraversalProjects = null)
     {
         var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
-        ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform);
+        ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform, additionalGlobalProperties);
 
         // Traversal projects (e.g. Microsoft.Build.Traversal "dirs.proj") are not test projects themselves.
         // They act as a container that forwards build/test operations to their ProjectReference items.
@@ -269,7 +286,7 @@ internal static class SolutionAndProjectUtility
                     continue;
                 }
 
-                projects.AddRange(GetProjectProperties(reference.FullPath, projectCollection, evaluationContext, buildOptions, buildSession, reference.Configuration, reference.Platform, visitedTraversalProjects));
+                projects.AddRange(GetProjectProperties(reference.FullPath, projectCollection, evaluationContext, buildOptions, buildSession, reference.Configuration, reference.Platform, additionalGlobalProperties, visitedTraversalProjects));
             }
 
             return projects;
@@ -307,7 +324,7 @@ internal static class SolutionAndProjectUtility
             {
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
+                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -321,7 +338,7 @@ internal static class SolutionAndProjectUtility
                 List<TestModule>? innerModules = null;
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform);
+                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -398,14 +415,15 @@ internal static class SolutionAndProjectUtility
     /// <summary>
     /// RuntimeIdentifiers are included in the build. Returns a result with device mappings
     /// and TestTfmsInParallel setting, or null if no device selection is needed.
-    /// When projectCollection/evaluationContext are provided, reuses them to avoid redundant evaluation.
+    /// The evaluation happens in the collection of <paramref name="buildSession"/>, which is the one
+    /// every project of the run has to share; pass an <paramref name="evaluationContext"/> to reuse an
+    /// existing one and avoid redundant evaluation.
     /// </summary>
     internal static DeviceSelectionResult? SelectDevicesBeforeBuild(
         string projectFilePath,
         BuildOptions buildOptions,
-        ProjectCollection? projectCollection = null,
-        EvaluationContext? evaluationContext = null,
-        FacadeLogger? logger = null)
+        MSBuildSession buildSession,
+        EvaluationContext? evaluationContext = null)
     {
         // --device is already handled by HandleDeviceWithTargetFrameworkSelection
         if (!string.IsNullOrWhiteSpace(buildOptions.Device))
@@ -423,16 +441,12 @@ internal static class SolutionAndProjectUtility
             return null;
         }
 
-        // Create a ProjectCollection if one wasn't provided
-        using var ownedCollection = projectCollection is null
-            ? new ProjectCollection(globalProperties, loggers: logger is null ? null : [logger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default)
-            : null;
-        var collection = projectCollection ?? ownedCollection!;
+        var collection = buildSession.ProjectCollection;
         evaluationContext ??= EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 
         var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions
         {
-            GlobalProperties = collection.GlobalProperties,
+            GlobalProperties = globalProperties,
             EvaluationContext = evaluationContext,
             ProjectCollection = collection,
         });
@@ -473,7 +487,7 @@ internal static class SolutionAndProjectUtility
         var devicesByTfm = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
         foreach (var framework in frameworks)
         {
-            var (device, rid) = SelectDeviceForTfm(projectFilePath, buildOptions, framework, isInteractive, logger);
+            var (device, rid) = SelectDeviceForTfm(projectFilePath, buildOptions, framework, isInteractive, buildSession);
             devicesByTfm[framework] = (device, rid);
         }
 
@@ -495,7 +509,7 @@ internal static class SolutionAndProjectUtility
         BuildOptions buildOptions,
         string? tfm,
         bool isInteractive,
-        FacadeLogger? logger)
+        MSBuildSession buildSession)
     {
         var msbuildArgsToAppend = buildOptions.MSBuildArgs;
         if (!string.IsNullOrEmpty(tfm))
@@ -511,7 +525,8 @@ internal static class SolutionAndProjectUtility
             msbuildArgs,
             buildOptions.EnvironmentVariables,
             commandName: "dotnet test",
-            logger);
+            binaryLogger: null,
+            buildSession: buildSession);
 
         lock (s_buildLock)
         {
@@ -534,7 +549,7 @@ internal static class SolutionAndProjectUtility
     private static TestModule? GetModuleFromProject(
         ProjectInstance project,
         BuildOptions buildOptions,
-        TestBuildSession buildSession)
+        MSBuildSession buildSession)
     {
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestProject), out bool isTestProject);
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
@@ -602,7 +617,7 @@ internal static class SolutionAndProjectUtility
         [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary unblock for dotnet/msbuild#14064 (MSBuild build APIs are now [RequiresUnreferencedCode]). dotnet CLI runs MSBuild in-proc (not trimmed). Remove when dotnet/sdk#55225 is fixed.")]
         static RunProperties DeployAndGetRunProperties(
             ProjectInstance project,
-            TestBuildSession buildSession,
+            MSBuildSession buildSession,
             IReadOnlyDictionary<string, string> environmentVariables,
             out IReadOnlyDictionary<string, string> runtimeEnvironmentVariables)
         {
@@ -612,27 +627,24 @@ internal static class SolutionAndProjectUtility
                 EnvironmentVariablesToMSBuild.AddAsItems(project, environmentVariables);
             }
 
-            // The MSBuild build APIs cannot be called in parallel, even for different projects:
-            // BuildManager throws "The operation cannot be completed because a build is already in progress."
-            // Every project of the run shares the same build session, so the requests are serialized here.
-            lock (s_buildLock)
+            // Every project of the run shares the same build session, which serializes the requests
+            // internally: the MSBuild build APIs cannot be called in parallel, even for different
+            // projects ("The operation cannot be completed because a build is already in progress.").
+            if (project.Targets.ContainsKey(Constants.DeployToDevice))
             {
-                if (project.Targets.ContainsKey(Constants.DeployToDevice))
+                // Deploy on a fresh ProjectInstance to avoid accumulating state (existing item
+                // groups) that would leak into the ComputeRunArguments build below, which has to
+                // build the original instance since the run properties are read back from it.
+                // Same reason as dotnet run, see RunCommandSelector.OpenProjectIfNeeded.
+                if (!buildSession.Build(project.DeepCopy(), [Constants.DeployToDevice]))
                 {
-                    // Deploy on a fresh ProjectInstance to avoid accumulating state (existing item
-                    // groups) that would leak into the ComputeRunArguments build below, which has to
-                    // build the original instance since the run properties are read back from it.
-                    // Same reason as dotnet run, see RunCommandSelector.OpenProjectIfNeeded.
-                    if (!buildSession.Build(project.DeepCopy(), [Constants.DeployToDevice]))
-                    {
-                        throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
-                    }
+                    throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
                 }
+            }
 
-                if (!buildSession.Build(project, s_computeRunArgumentsTarget))
-                {
-                    throw new GracefulException(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, s_computeRunArgumentsTarget[0]);
-                }
+            if (!buildSession.Build(project, s_computeRunArgumentsTarget))
+            {
+                throw new GracefulException(CliCommandStrings.RunCommandEvaluationExceptionBuildFailed, s_computeRunArgumentsTarget[0]);
             }
 
             runtimeEnvironmentVariables = hasRuntimeEnvironmentVariableSupport

--- a/src/Cli/dotnet/MSBuildSession.cs
+++ b/src/Cli/dotnet/MSBuildSession.cs
@@ -8,11 +8,12 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 
-namespace Microsoft.DotNet.Cli.Commands.Test;
+namespace Microsoft.DotNet.Cli;
 
 /// <summary>
-/// Runs the MSBuild targets that <c>dotnet test</c> needs on top of the build (for example
-/// <c>ComputeRunArguments</c>) for every test project of a run inside a single MSBuild build session.
+/// Runs every MSBuild target a single CLI command needs to invoke on top of the build - for example
+/// <c>Restore</c>, <c>ComputeAvailableDevices</c>, <c>DeployToDevice</c> and <c>ComputeRunArguments</c> -
+/// inside one MSBuild build session, so the binary log behind <c>-bl</c> holds a single well formed build.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,33 +22,28 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 /// <see cref="BuildEventContext"/> ids it hands out - project context ids, target ids, task ids -
 /// restart from zero, and every build emits its own build-started/build-finished pair.
 /// Attaching the same binary logger to several of those builds, which is what <c>dotnet test -bl</c>
-/// does when a run contains more than one test project, produces a binlog holding several builds
-/// with colliding ids: readers attribute every project's targets to whichever project claimed the id
-/// first, and the other projects appear to have executed no targets at all.
+/// does when a run contains more than one test project or performs device selection, produces a binlog
+/// holding several builds with colliding ids: readers attribute every project's targets to whichever
+/// project claimed the id first, and the other projects appear to have executed no targets at all.
+/// The underlying engine limitation is tracked by
+/// <see href="https://github.com/dotnet/msbuild/issues/14609"/>.
 /// </para>
 /// <para>
 /// Sending all the requests to a single <see cref="BuildManager"/> session instead yields one build
-/// with unique ids, so the binlog produced by <c>dotnet test -bl</c> is well formed and shows the
-/// targets executed for each test project.
+/// with unique ids, so the binlog is well formed and shows the targets executed for each project.
+/// MSBuild requires every project instance built in one session to come from the same
+/// <see cref="Evaluation.ProjectCollection"/>, so the session owns the collection every project of the
+/// command has to be evaluated in - see <see cref="ProjectCollection"/>.
 /// </para>
 /// <para>
-/// The session is started lazily, so a caller can create it up front and still run MSBuild through
-/// <see cref="BuildManager.DefaultBuildManager"/> (for example to build or restore the projects
-/// under test) before the first target invocation. A session must never be left started across such
-/// a call.
-/// </para>
-/// <para>
-/// This covers the ordinary project and solution paths. Runs that involve device selection still
-/// emit more than one build into the log, because device selection and the per-target-framework
-/// rebuilds it drives interleave MSBuild builds with target invocations; see
-/// <see href="https://github.com/dotnet/sdk/issues/55561"/>. The underlying engine limitation is
-/// tracked by <see href="https://github.com/dotnet/msbuild/issues/14609"/>.
+/// The session is started lazily and owns a dedicated <see cref="BuildManager"/> rather than using
+/// <see cref="BuildManager.DefaultBuildManager"/>, so it can stay open across the in-process MSBuild
+/// invocations the CLI makes to build or restore the projects it is working on (which go through the
+/// default build manager and write their own binary log).
 /// </para>
 /// </remarks>
-[RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
-internal sealed class TestBuildSession : IDisposable
+internal sealed class MSBuildSession : IDisposable
 {
-    private readonly ProjectCollection _projectCollection;
     private readonly MSBuildArgs _msbuildArgs;
     private readonly FacadeLogger? _logger;
     private readonly Lock _lock = new();
@@ -55,21 +51,47 @@ internal sealed class TestBuildSession : IDisposable
     private BuildManager? _buildManager;
     private bool _disposed;
 
-    public TestBuildSession(ProjectCollection projectCollection, MSBuildArgs msbuildArgs, FacadeLogger? logger)
+    public MSBuildSession(MSBuildArgs msbuildArgs, FacadeLogger? logger)
     {
-        _projectCollection = projectCollection;
         _msbuildArgs = msbuildArgs;
         _logger = logger;
+        // Deliberately without global properties: MSBuild merges the global properties of a collection
+        // into every project loaded from it, and the projects of a command do not all want the same ones
+        // (restore, for instance, must run without the TargetFramework the rest of the command uses -
+        // see https://github.com/dotnet/sdk/issues/53488). Every project passes its own instead.
+        ProjectCollection = new ProjectCollection(
+            globalProperties: null,
+            loggers: logger is null ? null : [logger],
+            toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
     }
+
+    /// <summary>
+    /// The collection every project built in this session must be evaluated in. MSBuild rejects a build
+    /// whose submissions mix project instances coming from different collections ("All build submissions
+    /// in a build must use project instances originating from the same project collection.").
+    /// </summary>
+    /// <remarks>
+    /// The collection carries no global properties of its own: each project passes the ones it needs -
+    /// its target framework, device or runtime identifier - when it is evaluated.
+    /// </remarks>
+    public ProjectCollection ProjectCollection { get; }
 
     /// <summary>
     /// Builds the given targets of an already evaluated project in the shared build session.
     /// The results are applied to <paramref name="project"/> itself, so properties produced by the
     /// targets can be read from it afterwards.
     /// </summary>
-    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary unblock for dotnet/msbuild#14064 (MSBuild build APIs are now [RequiresUnreferencedCode]). dotnet CLI runs MSBuild in-proc (not trimmed). Remove when dotnet/sdk#55225 is fixed.")]
     public bool Build(ProjectInstance project, string[] targets)
+        => Build(project, targets, out _);
+
+    /// <inheritdoc cref="Build(ProjectInstance, string[])"/>
+    /// <param name="targetOutputs">The outputs of the requested targets.</param>
+    [UnconditionalSuppressMessage("AOT", "IL2026", Justification = "Temporary unblock for dotnet/msbuild#14064 (MSBuild build APIs are now [RequiresUnreferencedCode]). dotnet CLI runs MSBuild in-proc (not trimmed). Remove when dotnet/sdk#55225 is fixed.")]
+    public bool Build(ProjectInstance project, string[] targets, out IDictionary<string, TargetResult> targetOutputs)
     {
+        // The MSBuild build APIs cannot be called in parallel, even for different projects:
+        // BuildManager throws "The operation cannot be completed because a build is already in progress."
+        // Every project of the command shares this session, so the requests are serialized here.
         lock (_lock)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
@@ -87,6 +109,7 @@ internal sealed class TestBuildSession : IDisposable
                 BuildRequestDataFlags.ReplaceExistingProjectInstance);
 
             BuildResult result = GetOrStartBuildManager().BuildRequest(requestData);
+            targetOutputs = result.ResultsByTarget;
             return result.OverallResult == BuildResultCode.Success;
         }
     }
@@ -120,6 +143,7 @@ internal sealed class TestBuildSession : IDisposable
             finally
             {
                 buildManager.Dispose();
+                ProjectCollection.Dispose();
             }
         }
     }
@@ -146,18 +170,20 @@ internal sealed class TestBuildSession : IDisposable
             }
             catch (Exception ex)
             {
-                Reporter.Verbose.WriteLine($"Failed to end the dotnet test MSBuild session: {ex}");
+                Reporter.Verbose.WriteLine($"Failed to end the MSBuild session: {ex}");
             }
             finally
             {
                 buildManager.Dispose();
+                ProjectCollection.Dispose();
             }
         }
     }
 
     /// <summary>
     /// Marks the session finished and hands back the build manager to close, or <see langword="null"/>
-    /// if it was never started or has already been closed.
+    /// if it has already been closed. The collection is released even when the session was never
+    /// started, because the projects of the command are evaluated in it whether or not a target ran.
     /// </summary>
     private BuildManager? TakeBuildManager()
     {
@@ -170,6 +196,12 @@ internal sealed class TestBuildSession : IDisposable
 
         BuildManager? buildManager = _buildManager;
         _buildManager = null;
+
+        if (buildManager is null)
+        {
+            ProjectCollection.Dispose();
+        }
+
         return buildManager;
     }
 
@@ -183,11 +215,11 @@ internal sealed class TestBuildSession : IDisposable
 
         // A dedicated build manager is used instead of BuildManager.DefaultBuildManager so that keeping
         // this session open never conflicts with the in-process MSBuild invocations the CLI makes to
-        // build or restore the projects under test.
-        var buildManager = new BuildManager("dotnet-test");
+        // build or restore the projects it is working on.
+        var buildManager = new BuildManager("dotnet-cli-session");
         try
         {
-            var parameters = new BuildParameters(_projectCollection)
+            var parameters = new BuildParameters(ProjectCollection)
             {
                 Loggers = CreateLoggers(),
                 // ProjectInstance.Build defaults to a single in-process node, keep that behavior.
@@ -237,8 +269,8 @@ internal sealed class TestBuildSession : IDisposable
 
         if (!LoggerUtility.HasNoConsoleLoggerArgument(_msbuildArgs.OtherMSBuildArgs))
         {
-            // These builds only compute run arguments and deploy, so keep them quiet - at this verbosity
-            // MSBuild still reports errors and warnings.
+            // These builds only select devices, deploy and compute run arguments, so keep them quiet -
+            // at this verbosity MSBuild still reports errors and warnings.
             loggers.Add(CommonRunHelpers.GetConsoleLogger(
                 _msbuildArgs.CloneWithExplicitArgs([$"--verbosity:{LoggerVerbosity.Quiet.ToString().ToLowerInvariant()}", .. _msbuildArgs.OtherMSBuildArgs])));
         }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestProducesBinaryLog.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestProducesBinaryLog.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests;
 
 /// <summary>
 /// Covers the binary log that `dotnet test -bl` writes for the MSBuild work the test command drives
-/// itself (project evaluation plus the ComputeRunArguments target of every test project), which lands
-/// in msbuild-dotnet-test.binlog next to the msbuild.binlog of the build.
+/// itself (project evaluation, device selection and deployment, plus the ComputeRunArguments target of
+/// every test project), which lands in msbuild-dotnet-test.binlog next to the msbuild.binlog of the build.
 /// </summary>
 [TestClass]
 public class GivenDotnetTestProducesBinaryLog : SdkTest
@@ -33,11 +33,13 @@ public class GivenDotnetTestProducesBinaryLog : SdkTest
             .Execute("-bl")
             .Should().Pass();
 
-        StructuredLoggerBuild build = ReadTestBinaryLog(testInstance.Path);
+        string binlogPath = GetTestBinaryLogPath(testInstance.Path);
+        ShouldHoldASingleBuild(binlogPath);
 
-        GetComputeRunArgumentsProjects(build).Should().ContainSingle()
+        GetComputeRunArgumentsProjects(BinaryLog.ReadBuild(binlogPath)).Should().ContainSingle()
             .Which.ProjectFile.Should().EndWith("TestProject.csproj");
     }
+
     /// <summary>
     /// Regression test for https://github.com/dotnet/sdk/issues/49386: every test project used to run
     /// ComputeRunArguments in its own MSBuild build, so all those builds shared the same
@@ -58,20 +60,15 @@ public class GivenDotnetTestProducesBinaryLog : SdkTest
             .Execute("-bl")
             .ExitCode.Should().Be(ExitCodes.AtLeastOneTestFailed);
 
-        StructuredLoggerBuild build = ReadTestBinaryLog(testInstance.Path);
+        string binlogPath = GetTestBinaryLogPath(testInstance.Path);
+        ShouldHoldASingleBuild(binlogPath);
 
-        var projects = GetComputeRunArgumentsProjects(build);
+        var projects = GetComputeRunArgumentsProjects(BinaryLog.ReadBuild(binlogPath));
 
         projects.Select(project => Path.GetFileName(project.ProjectFile))
             .Should().BeEquivalentTo(["TestProject.csproj", "OtherTestProject.csproj"]);
 
-        // Each project must own its targets, instead of one project holding the targets of both.
-        foreach (StructuredLoggerProject project in projects)
-        {
-            project.Children.OfType<StructuredLoggerTarget>()
-                .Should().Contain(target => target.Name == "ComputeRunArguments",
-                    $"'{project.ProjectFile}' should record the targets that ran for it");
-        }
+        ShouldOwnItsTargets(projects);
     }
 
     /// <summary>
@@ -90,30 +87,113 @@ public class GivenDotnetTestProducesBinaryLog : SdkTest
             .Execute("--property", "TestTfmsInParallel=false", "-bl")
             .ExitCode.Should().Be(ExitCodes.Success);
 
-        StructuredLoggerBuild build = ReadTestBinaryLog(testInstance.Path);
+        string binlogPath = GetTestBinaryLogPath(testInstance.Path);
+        ShouldHoldASingleBuild(binlogPath);
 
-        var projects = GetComputeRunArgumentsProjects(build);
+        var projects = GetComputeRunArgumentsProjects(BinaryLog.ReadBuild(binlogPath));
 
         // One node per target framework. Under the old behavior the second build reused the first
         // build's ids, so the reader collapsed both onto a single node.
         projects.Should().HaveCount(2, "the project targets two frameworks, so it yields one test module per framework");
 
-        foreach (StructuredLoggerProject project in projects)
-        {
-            project.Children.OfType<StructuredLoggerTarget>()
-                .Should().Contain(target => target.Name == "ComputeRunArguments",
-                    $"'{project.ProjectFile}' should record the targets that ran for it");
-        }
+        ShouldOwnItsTargets(projects);
     }
 
-    private static StructuredLoggerBuild ReadTestBinaryLog(string testInstancePath)
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/55561: device selection used to run its
+    /// own MSBuild builds (restore plus ComputeAvailableDevices) and each target framework of a device
+    /// project used to get a build session of its own, so a device run wrote several builds with
+    /// colliding BuildEventContext ids into the same binary log.
+    /// </summary>
+    [TestMethod]
+    public void ItRecordsOneBuildForEveryTargetFrameworkOfADeviceProject()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", Guid.NewGuid().ToString())
+            .WithSource();
+
+        // SingleDevice=true auto-selects one device per target framework, so the run goes through
+        // device selection, a build per target framework, deployment and ComputeRunArguments.
+        new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("-p:SingleDevice=true", "-bl")
+            .Should().Pass();
+
+        string binlogPath = GetTestBinaryLogPath(testInstance.Path);
+        ShouldHoldASingleBuild(binlogPath);
+
+        StructuredLoggerBuild build = BinaryLog.ReadBuild(binlogPath);
+
+        var projects = GetComputeRunArgumentsProjects(build);
+        projects.Should().HaveCount(2, "the project is deployed and run for each of its two target frameworks");
+        ShouldOwnItsTargets(projects);
+
+        build.FindChildrenRecursive<StructuredLoggerTarget>(target => target.Name == "ComputeAvailableDevices")
+            .Should().NotBeEmpty("device selection should be part of the same build");
+    }
+
+    /// <summary>
+    /// Regression test for https://github.com/dotnet/sdk/issues/55561: a solution containing device
+    /// projects used to emit the device builds of every project on top of the build of the run itself.
+    /// </summary>
+    [TestMethod]
+    public void ItRecordsOneBuildForASolutionOfDeviceProjects()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", Guid.NewGuid().ToString())
+            .WithSource();
+
+        var project1Dir = Path.Combine(testInstance.Path, "Project1");
+        var project2Dir = Path.Combine(testInstance.Path, "Project2");
+        Directory.CreateDirectory(project1Dir);
+        Directory.CreateDirectory(project2Dir);
+
+        foreach (var dir in new[] { project1Dir, project2Dir })
+        {
+            File.Copy(Path.Combine(testInstance.Path, "Program.cs"), Path.Combine(dir, "Program.cs"));
+            File.Copy(
+                Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"),
+                Path.Combine(dir, Path.GetFileName(dir) + ".csproj"));
+        }
+
+        File.Delete(Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"));
+        File.Delete(Path.Combine(testInstance.Path, "Program.cs"));
+
+        File.WriteAllText(Path.Combine(testInstance.Path, "TestSolution.slnx"),
+            """
+            <Solution>
+              <Project Path="Project1\Project1.csproj" />
+              <Project Path="Project2\Project2.csproj" />
+            </Solution>
+            """);
+
+        new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute("--solution", "TestSolution.slnx", "-p:SingleDevice=true", "-bl")
+            .Should().Pass();
+
+        string binlogPath = GetTestBinaryLogPath(testInstance.Path);
+        ShouldHoldASingleBuild(binlogPath);
+
+        var projects = GetComputeRunArgumentsProjects(BinaryLog.ReadBuild(binlogPath));
+        projects.Should().HaveCount(4, "both projects are deployed and run for each of their two target frameworks");
+        ShouldOwnItsTargets(projects);
+    }
+
+    private static string GetTestBinaryLogPath(string testInstancePath)
     {
         string binlogPath = Path.Combine(testInstancePath, "msbuild-dotnet-test.binlog");
         File.Exists(binlogPath).Should().BeTrue($"'{binlogPath}' should have been written by 'dotnet test -bl'");
 
-        // The invariant behind the fix: the test command must contribute exactly one MSBuild build.
-        // More than one means BuildEventContext ids restart mid-file, which is the corruption this
-        // test class guards against.
+        return binlogPath;
+    }
+
+    /// <summary>
+    /// The invariant behind the fix: the test command must contribute exactly one MSBuild build.
+    /// More than one means BuildEventContext ids restart mid-file, so readers attribute the projects
+    /// and targets of the later builds to whichever project of the first build claimed the id, which
+    /// is the corruption this test class guards against.
+    /// </summary>
+    private static void ShouldHoldASingleBuild(string binlogPath)
+    {
         int buildStarted = 0;
         int buildFinished = 0;
         foreach (var record in BinaryLog.ReadRecords(binlogPath))
@@ -131,8 +211,17 @@ public class GivenDotnetTestProducesBinaryLog : SdkTest
 
         buildStarted.Should().Be(1, "'dotnet test -bl' must record exactly one build, otherwise BuildEventContext ids collide");
         buildFinished.Should().Be(1, "the single recorded build must be closed");
+    }
 
-        return BinaryLog.ReadBuild(binlogPath);
+    private static void ShouldOwnItsTargets(IEnumerable<StructuredLoggerProject> projects)
+    {
+        // Each project must own its targets, instead of one project holding the targets of all of them.
+        foreach (StructuredLoggerProject project in projects)
+        {
+            project.Children.OfType<StructuredLoggerTarget>()
+                .Should().Contain(target => target.Name == "ComputeRunArguments",
+                    $"'{project.ProjectFile}' should record the targets that ran for it");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #55561. Stacked on #55521 — review that one first; the diff here is the single commit on top of it.

## Symptom

#55521 gives the ordinary project and solution paths of `dotnet test -bl` a single MSBuild build, but a run that selects a device still writes several builds into `msbuild-dotnet-test.binlog`, so MAUI users keep the corruption of #55187 / #49386:

```dotnetcli
dotnet test -p:SingleDevice=true -bl     # multi-TFM device project
```

```
BuildStarted                                    <-- device selection (Restore + ComputeAvailableDevices)
BuildFinished
BuildStarted                                    <-- net9.0: DeployToDevice + ComputeRunArguments
BuildFinished
BuildStarted                                    <-- net11.0: same ids again
BuildFinished
```

Every `BeginBuild` creates a new MSBuild `LoggingService` whose `_nextProjectId` / `_nextTargetId` / `_nextTaskId` restart, so the ids collide across those builds and readers attribute every project's targets to whichever project claimed the id first (dotnet/msbuild#14609).

## Root cause

Three sources of extra builds remained on the device path:

1. **`MSBuildUtility.BuildPerTfmWithDevices`** created a session inside the per-target-framework loop, so a multi-TFM device project emitted one build per TFM.
2. **`MSBuildUtility.GetProjectsProperties` phase 1** called that method per device project, so a solution mixing device and non-device projects emitted those builds plus the outer session.
3. **`RunCommandSelector`** ran `Restore`, `ComputeAvailableDevices` and `DeployToDevice` through `ProjectInstance.Build`, which is a complete build — begin, request, end — on every call.

## Fix

Hoist the session up to the command. `MicrosoftTestingPlatformTestCommand.Run` opens one `MSBuildSession` (the `TestBuildSession` of #55521, generalized and moved to `src/Cli/dotnet/MSBuildSession.cs` next to the other shared CLI MSBuild helpers) and threads it through `MSBuildHandler` → `MSBuildUtility` → `SolutionAndProjectUtility` → `RunCommandSelector`. Device selection, deployment and `ComputeRunArguments` for every test module now land in one build with unique ids.

The session can stay open across the `RestoringCommand` builds of the run because it owns a `BuildManager` of its own instead of `BuildManager.DefaultBuildManager` — that was already true in #55521 and is what makes hoisting possible at all. Everything the review feedback on #55521 added carries over unchanged: `BuildRequestDataFlags.ReplaceExistingProjectInstance` (needed even more here, since far more requests now share one results cache), the `Complete()`/`Dispose()` split so `EndBuild` failures surface on the success path without replacing an in-flight `GracefulException`, and the console logger so MSBuild errors are reported when `-bl` was not passed.

### The project collection has to move with the session

MSBuild rejects a build whose submissions mix project instances from different collections:

> All build submissions in a build must use project instances originating from the same project collection.

([`BuildManager.cs`](https://github.com/dotnet/msbuild/blob/main/src/Build/BackEnd/BuildManager/BuildManager.cs) — `OM_BuildSubmissionsMultipleProjectCollections`)

So the session owns the collection every project of the run is evaluated in, and the per-TFM/per-device collections are gone. That collection deliberately carries **no global properties**: `Project.Initialize` merges a collection's global properties into every project loaded from it, and restore must run *without* the `TargetFramework` the rest of the command uses (#53488). The per-project properties — target framework, device, runtime identifier, configuration, platform — are passed explicitly at evaluation time instead, via a new `additionalGlobalProperties` parameter on `SolutionAndProjectUtility.GetProjectProperties`/`EvaluateProject` and the explicit-properties overload of `ProjectCollection.LoadProject` in `RunCommandSelector`.

`RunCommandSelector` keeps its current `ProjectInstance.Build` behaviour when no session is passed, so **`dotnet run` is unchanged**. It can opt in later to fix the same latent issue there (the fourth open question of #55521); the plumbing is now in place.

## Validation

`msbuild-dotnet-test.binlog` for a multi-TFM device project, after:

```
BuildStarted
ProjectStarted  DotnetTestDevices.csproj  ComputeAvailableDevices
ProjectStarted  DotnetTestDevices.csproj  net9.0    DeployToDevice / ComputeRunArguments
ProjectStarted  DotnetTestDevices.csproj  net11.0   DeployToDevice / ComputeRunArguments
BuildFinished
```

`GivenDotnetTestProducesBinaryLog` now asserts the single-build invariant on every scenario through the shared `ShouldHoldASingleBuild` helper (the `ReadTestBinaryLog` check added by the review feedback on #55521, extracted so the device tests reuse it), plus two new device cases on the multi-TFM `DotnetTestDevices` asset as the issue suggested:

| Test | Asserts |
| --- | --- |
| `ItRecordsTheTargetsItRunsForASingleTestProject` | 1 build, 1 `ComputeRunArguments` project |
| `ItRecordsOneBuildWithTheTargetsOfEveryTestProjectOfASolution` | 1 build, both projects own their targets |
| `ItRecordsOneBuildWithTheTargetsOfEveryTargetFrameworkOfAProject` | 1 build, one module per TFM |
| `ItRecordsOneBuildForEveryTargetFrameworkOfADeviceProject` (new) | 1 build, 2 modules, `ComputeAvailableDevices` in the same build |
| `ItRecordsOneBuildForASolutionOfDeviceProjects` (new) | 1 build, 4 modules, each owns its targets |

Both new tests fail on the tip of #55521 (`Expected … to be 1 … but found 3`) and pass here.

Test runs against the built SDK:

- `GivenDotnetTestProducesBinaryLog` + `GivenDotnetTestSelectsDevice` — 35/35 passed
- Full `Microsoft.DotNet.Cli.Test.Tests` — **429 tests, 0 failed** (403 passed, 26 skipped)
- `dotnet run` suites (`GivenDotnetRunSelectsDevice`, `GivenDotnetRunSelectsTargetFramework`, `GivenDotnetRunBuildsCsProj`, `RunCommandTests`) — 105/105 passed, including the #53488 regression tests `ItCanRunWindowsAppReferencingNonPlatformSpecificLibrary{,WithoutExplicitFramework}` that guard the restore-without-TargetFramework behaviour the collection change touches.
