### PR TITLE
Install preview version of dotnetup by default instead of daily

### DIFF
--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -10,7 +10,7 @@
 
 ## Download dotnetup
 
-The easiest way to download `dotnetup` is to use the installation script:
+The easiest way to download the latest preview build of `dotnetup` is to use the installation script:
 
 ```bash
 curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash
@@ -25,13 +25,26 @@ iwr https://aka.ms/dotnetup/get-dotnetup.ps1 -OutFile $s
 & $s
 ```
 
-If you prefer a one-liner and don't need signature verification, you can pipe the script straight into PowerShell (this bypasses execution-policy signature checks):
+To install the latest daily build instead, pass the quality explicitly:
+
+```bash
+curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash -s -- --quality daily
+```
+
+For a PowerShell one-liner, create a script block from the downloaded script and pass the
+parameter when invoking it:
+
+```pwsh
+& ([scriptblock]::Create((iwr https://aka.ms/dotnetup/get-dotnetup.ps1).Content)) -Quality daily
+```
+
+These PowerShell one-liners bypass Authenticode signature verification:
 
 ```pwsh
 iwr https://aka.ms/dotnetup/get-dotnetup.ps1 | iex
 ```
 
-These scripts will download the latest version of `dotnetup` and install it in your user directory, then print instructions to update your $PATH so that `dotnetup` is available in your terminal.
+These scripts default to the `preview` channel. They download `dotnetup` and install it in your user directory, then print instructions to update your $PATH so that `dotnetup` is available in your terminal.
 
 ## First-Time Setup
 
@@ -173,3 +186,7 @@ This lets you change your path preference (Isolation → Terminal, etc.) or inst
 - [Install SDKs with global.json](./usecases/install-with-global-json.md) — Install the right SDK version for a project automatically
 - [Update SDK and Runtime Installations](./usecases/update-installations.md) — Keep your .NET installations current
 - [Try Daily Builds](./usecases/try-daily-builds.md) — Safely test pre-release .NET builds
+
+## Maintainer Documentation
+
+- [Publish, update, and roll back preview builds](./releasing.md)

--- a/documentation/general/dotnetup/releasing.md
+++ b/documentation/general/dotnetup/releasing.md
@@ -1,0 +1,63 @@
+# Publishing dotnetup Preview Builds
+
+The `dotnetup` bootstrap scripts install from the `preview` quality by default. Publishing a
+build to that quality updates links under:
+
+```text
+https://aka.ms/dotnet/dotnetup/preview/
+```
+
+Publishing an older build through the same process rolls those links back without rebuilding.
+
+## Select a build
+
+Use a successful
+[`dotnet-dnup-official-ci`](https://dev.azure.com/dnceng/internal/_build?definitionId=1544)
+run from the `release/dnup` branch. The build's tags include:
+
+```text
+BAR ID - <build-id>
+```
+
+Use that numeric Build Asset Registry (BAR) ID when promoting the build. Normal non-test runs
+of the official pipeline are PME-signed and have a `PME Signed` tag. Use the tag to confirm
+signing completed; do not promote a test build or a build without the tag.
+
+## Promote the build
+
+Run the
+[`Maestro Build Promotion`](https://dev.azure.com/dnceng/internal/_build?definitionId=750)
+pipeline with these parameters:
+
+| Parameter | Value |
+| --- | --- |
+| `BARBuildId` | The BAR ID from the selected build |
+| `PromoteToChannelIds` | `10506` (`dotnetup Daily`) |
+| `ArtifactsPublishingAdditionalParameters` | `/p:BuildQuality=preview` |
+
+Leave the remaining parameters at their defaults. The Maestro channel retains its historical
+`dotnetup Daily` name; `BuildQuality=preview` controls the quality segment in the generated
+aka.ms links.
+
+The overall pipeline can report `PartiallySucceeded` because optional artifacts are downloaded
+with `continueOnError`. The `Publish packages, blobs and symbols` step must succeed.
+
+## Verify the promotion
+
+Check that the executable link resolves to the selected build's version:
+
+```pwsh
+curl.exe -sI https://aka.ms/dotnet/dotnetup/preview/dotnetup-win-x64.exe |
+  Select-String Location
+```
+
+Then install into an isolated directory and check the running executable:
+
+```pwsh
+$script = Join-Path $env:TEMP 'get-dotnetup-preview.ps1'
+$installDir = Join-Path $env:TEMP 'dotnetup-preview-test'
+
+Invoke-WebRequest https://aka.ms/dotnet/dotnetup/preview/get-dotnetup.ps1 -OutFile $script
+& $script -InstallDir $installDir
+& (Join-Path $installDir 'dotnetup.exe') --info
+```

--- a/eng/dotnetup-shared.ps1
+++ b/eng/dotnetup-shared.ps1
@@ -51,7 +51,7 @@ function Invoke-GetDotnetupScript([string]$ScriptPath, [string]$InstallDir, [str
     $prevEAP = $ErrorActionPreference
     try {
         $ErrorActionPreference = 'Continue'
-        & $psExe -NoProfile -ExecutionPolicy Bypass -File $ScriptPath -InstallDir $InstallDir
+        & $psExe -NoProfile -ExecutionPolicy Bypass -File $ScriptPath -InstallDir $InstallDir -Quality daily
     }
     finally {
         $ErrorActionPreference = $prevEAP

--- a/eng/dotnetup-shared.sh
+++ b/eng/dotnetup-shared.sh
@@ -67,7 +67,7 @@ function AcquireDotnetup {
   # Prefer the repo-local script when available (e.g. on release/dnup).
   if [[ -f "$local_getter" ]]; then
     echo "Using local get-dotnetup.sh from '$local_getter'."
-    bash "$local_getter" --install-dir "$dotnetup_dir"
+    bash "$local_getter" --install-dir "$dotnetup_dir" --quality daily
     return $?
   fi
 
@@ -87,7 +87,7 @@ function AcquireDotnetup {
   fi
 
   local result=0
-  if [[ "$downloaded" != true ]] || ! bash "$getter_script" --install-dir "$dotnetup_dir"; then
+  if [[ "$downloaded" != true ]] || ! bash "$getter_script" --install-dir "$dotnetup_dir" --quality daily; then
     result=1
   fi
 

--- a/scripts/get-dotnetup.ps1
+++ b/scripts/get-dotnetup.ps1
@@ -1,18 +1,18 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Downloads the latest dotnetup daily build and installs it locally.
+    Downloads the latest dotnetup preview build and installs it locally.
 
 .DESCRIPTION
     Downloads dotnetup from the public aka.ms shortlinks (e.g.
-    https://aka.ms/dotnet/dotnetup/daily/dotnetup-win-x64.exe), verifies the
+    https://aka.ms/dotnet/dotnetup/preview/dotnetup-win-x64.exe), verifies the
     SHA-512 checksum, and installs the binary to a local directory.
 
 .PARAMETER InstallDir
     Directory to install dotnetup into. Defaults to ~/.dotnetup.
 
 .PARAMETER Quality
-    Build quality to install. Defaults to 'daily'.
+    Build quality to install. Defaults to 'preview'. Use 'daily' for the latest daily build.
 
 .PARAMETER RuntimeId
     Override automatic OS/architecture detection with an explicit RID
@@ -23,11 +23,14 @@
 
 .EXAMPLE
     ./get-dotnetup.ps1 -RuntimeId linux-musl-x64 -InstallDir /opt/dotnetup
+
+.EXAMPLE
+    ./get-dotnetup.ps1 -Quality daily
 #>
 [CmdletBinding()]
 param(
     [string]$InstallDir = (Join-Path $HOME ".dotnetup"),
-    [string]$Quality = "daily",
+    [string]$Quality = "preview",
     [string]$RuntimeId
 )
 

--- a/scripts/get-dotnetup.sh
+++ b/scripts/get-dotnetup.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # get-dotnetup.sh
 #
-# Downloads the latest dotnetup daily build and installs it locally.
+# Downloads the latest dotnetup preview build and installs it locally.
 #
 # Downloads dotnetup from the public aka.ms shortlinks (e.g.
-# https://aka.ms/dotnet/dotnetup/daily/dotnetup-linux-x64), verifies the
+# https://aka.ms/dotnet/dotnetup/preview/dotnetup-linux-x64), verifies the
 # SHA-512 checksum, and installs the binary to a local directory.
 #
 # Usage:
@@ -17,7 +17,7 @@ set -euo pipefail
 
 # --- Defaults ---
 INSTALL_DIR="$HOME/.dotnetup"
-QUALITY="daily"
+QUALITY="preview"
 RUNTIME_ID=""
 
 # --- Colors (disabled if not a terminal) ---
@@ -48,16 +48,17 @@ while [[ $# -gt 0 ]]; do
             cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Downloads the latest dotnetup daily build from aka.ms and installs it locally.
+Downloads the latest dotnetup build from aka.ms and installs it locally.
 
 Options:
   --install-dir DIR     Installation directory (default: ~/.dotnetup)
-  --quality QUALITY     Build quality (default: daily)
+  --quality QUALITY     Build quality (default: preview; use daily for the latest daily build)
   --runtime-id RID      Override OS/architecture detection (e.g. linux-musl-x64, osx-arm64)
   --help, -h            Show this help message
 
 Examples:
   ./get-dotnetup.sh
+  ./get-dotnetup.sh --quality daily
   ./get-dotnetup.sh --runtime-id linux-musl-x64
   ./get-dotnetup.sh --install-dir /opt/dotnetup
 EOF


### PR DESCRIPTION
- Install preview version of dotnetup by default instead of daily
- Update repo scripts to use daily version
- Also add instructions on how to promote builds to preview