### PR TITLE
Reconcile testfx terminal reporter drift

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -19,14 +19,14 @@
     {
       "id": "dotnet-test-wire-contract-constants",
       "local_path": "src/Cli/dotnet/Commands/Test/CliConstants.cs",
-      "notes": "Handshake/session/state string constants for the 'dotnet test' named-pipe protocol. Upstream lives in testfx IPC/Constants.cs; the SDK inlines the same constants into CliConstants.cs (TestStates, SessionEventTypes, HandshakeMessagePropertyNames, HandshakeMessageExecutionModes, ProtocolConstants). Watch the upstream file for added/changed wire constants.",
+      "notes": "Handshake/session/state string constants for the 'dotnet test' named-pipe protocol. Upstream lives in testfx IPC/Constants.cs; the SDK inlines the same constants into CliConstants.cs (TestStates, SessionEventTypes, HandshakeMessagePropertyNames, HandshakeMessageExecutionModes, HandshakeMessageHostTypes, ProtocolConstants). Watch the upstream file for added/changed wire constants. Reconciled at f935d2d3: the upstream additions since the previous baseline (SupportedPostProcessorKinds/SupportedPostProcessorExtensionsLegacy, the ArtifactPostProcessor host type and the 'tool' execution mode) are already mirrored in CliConstants.cs, so this was a baseline bump only. Intentional divergences: the SDK does not mirror TestStates.InProgress or HandshakeMessagePropertyNames.OrchestratorFeature (it consumes neither), and ProtocolConstants.SupportedVersions deliberately stops at 1.3.0 because the SDK does not implement the 1.4.0 reverse server-control channel.",
       "sources": [
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs",
-          "baseline_ref_sha": "1285203f4cea535b9386e0e8712b4ec078de16f2",
-          "baseline_blob_sha": "d21531909dd2620f3d0f4c61190f05a82b383f44",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "8e11c4ba1b8472a4d28178f28ef088c0c0948580",
           "scope": "wire constants (TestStates, SessionEventTypes, HandshakeMessage*, ProtocolConstants)"
         }
       ]
@@ -34,7 +34,7 @@
     {
       "id": "dotnet-test-terminal-reporter",
       "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs",
-      "notes": "The Microsoft.Testing.Platform terminal UI reporter, hard-forked into 'dotnet test'. testfx has since split TerminalTestReporter into partial files; the SDK keeps a single TerminalTestReporter.cs. Each upstream partial is tracked so any upstream reporter change pings the SDK to reconcile. Upstream includes the whole folder via a glob (TerminalReporterContract.props), so when testfx adds a partial it must be appended here by hand -- see microsoft/testfx#10390. Sources are append-only: the tracking issue marker keys on the source index. NOT YET PORTED: the coverage summary (TerminalTestReporter.Coverage.cs), the flaky-test listing (.FlakyTests.cs), the slowest-test listing (.SlowestTests.cs), the flaky/retried counter lines, their TerminalTestReporterOptions switches, and the TestProgressState retry/flaky accounting. This work remains tracked by #55472 and #55473. Those features landed upstream after the .Summary.cs baseline and were then moved into their own partials, so the .Summary.cs drift diff no longer shows all of them; the newly tracked partials are baselined at the split, so no drift issue will surface this backlog either. This is a hard fork: local content intentionally diverges; the signal is 'upstream changed', not 'files differ'.",
+      "notes": "The Microsoft.Testing.Platform terminal UI reporter, hard-forked into 'dotnet test'. testfx has since split TerminalTestReporter into partial files; the SDK keeps a single TerminalTestReporter.cs. Each upstream partial is tracked so any upstream reporter change pings the SDK to reconcile. Upstream includes the whole folder via a glob (TerminalReporterContract.props), so when testfx adds a partial it must be appended here by hand -- see microsoft/testfx#10390. Sources are append-only: the tracking issue marker keys on the source index. Reconciled at f935d2d3 (#55472/#55473): the retry/flaky accounting (TestProgressState.RetriedTests/RetriedExecutions/FlakyTests/GetFlakyTests), the 'flaky: N' and 'retried: N test(s), M extra run(s)' summary lines, the 'Flaky tests:' listing (.FlakyTests.cs), the 'Slowest tests:' listing (.SlowestTests.cs, fed by TestProgressState.RecordTestDuration/GetSlowestTests) and the TerminalTestReporterOptions switches (ShowFlakyTests, SlowestTestsCount, ShowRunSummary) are now ported. The '(+N retried)' suffix on the total line was replaced by the two dedicated lines, matching upstream. INTENTIONALLY NOT PORTED: (1) the coverage summary (TerminalTestReporter.Coverage.cs) -- it renders CoverageScopeSummary/TestCoverageThresholdMessage, which are in-process Microsoft.Testing.Platform message types with no representation in the 'dotnet test' IPC contract, so the orchestrator never receives the data; porting it requires a wire-protocol addition first. (2) In-process retry attribution (RetryAttemptProperty) and TerminalTestReporter.TestCompletedWithoutResult -- upstream's own orchestrator path passes 'retryAttempt: null' because the attempt number of a framework-level [Retry] is not carried over the pipe either; the SDK attributes retries per test-host instance id instead. (3) ShowRunSummary is never set to false by 'dotnet test': it exists so the fork stays shape-compatible, but the SDK keeps one reporter for the whole execution and aggregates every attempt, so its summary already describes the whole run. This is a hard fork: local content intentionally diverges; the signal is 'upstream changed', not 'files differ'.",
       "sources": [
         {
           "repo": "microsoft/testfx",
@@ -96,16 +96,16 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs",
-          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
-          "baseline_blob_sha": "9987fc30e3b7f0ab2948b10e3ef4572d83d87aa4",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "70615451a89acbc84f4ab235bb0957ee4061f6a0",
           "scope": "reporter partial"
         },
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs",
-          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
-          "baseline_blob_sha": "b8aee10a39ad8b5a7a64d6b9d5b2e1571de1f698",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "ea0de7643f09d8a37239f7cb60218a15d35ace33",
           "scope": "reporter partial"
         },
         {
@@ -190,15 +190,39 @@
     {
       "id": "dotnet-test-terminal-ansiterminaltestprogressframe",
       "local_path": "src/Cli/dotnet/Commands/Test/MTP/Terminal/AnsiTerminalTestProgressFrame.cs",
-      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx.",
+      "notes": "Terminal reporter support type hard-forked from testfx OutputDevice/Terminal. Source of truth is testfx. Reconciled at f935d2d3 (#55474): the only upstream change since the previous baseline is microsoft/testfx#10093, which split the type into AnsiTerminalTestProgressFrame.{Append,Render,TextLayout}.cs without changing behavior, so nothing was ported and the SDK keeps its single-file fork. The three new partials are tracked below so a future behavioral change in any of them raises drift. The SDK fork also intentionally lacks upstream's frame/RenderedProgressItem pooling (Reset/GetOrAllocateNextSlot/RenderedLinesCount) and the progress-message text-layout helpers, which belong to upstream-only features.",
       "sources": [
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs",
-          "baseline_ref_sha": "1285203f4cea535b9386e0e8712b4ec078de16f2",
-          "baseline_blob_sha": "831f5e0718bb1a61f3a41a4c3092f4d765fad01a",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "58fd5ab224a93119727cefa638f03c75a3a6a137",
           "scope": "entire file"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Append.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "4cbbe919121d1790f3bc3e713e297d3fb0acc960",
+          "scope": "frame partial; split out of AnsiTerminalTestProgressFrame.cs"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Render.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "cb915390fbb283d3d40578a381dc98c7f20a782e",
+          "scope": "frame partial; split out of AnsiTerminalTestProgressFrame.cs"
+        },
+        {
+          "repo": "microsoft/testfx",
+          "ref": "main",
+          "path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.TextLayout.cs",
+          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
+          "baseline_blob_sha": "628b12b511692c96112e4db8c6f2791403186ed4",
+          "scope": "frame partial; split out of AnsiTerminalTestProgressFrame.cs"
         }
       ]
     },

--- a/src/Cli/dotnet/Commands/CliCommandStrings.resx
+++ b/src/Cli/dotnet/Commands/CliCommandStrings.resx
@@ -2719,8 +2719,33 @@ Proceed?</value>
   <data name="TotalColon" xml:space="preserve">
     <value>total:</value>
   </data>
-  <data name="Retried" xml:space="preserve">
-    <value>retried</value>
+  <data name="RetriedColon" xml:space="preserve">
+    <value>retried:</value>
+    <comment>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</comment>
+  </data>
+  <data name="RetriedTestsAndRuns" xml:space="preserve">
+    <value>{0} test(s), {1} extra run(s)</value>
+    <comment>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</comment>
+  </data>
+  <data name="FlakyLowercase" xml:space="preserve">
+    <value>flaky: {0} (passed after retry)</value>
+    <comment>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</comment>
+  </data>
+  <data name="FlakyTests" xml:space="preserve">
+    <value>Flaky tests:</value>
+    <comment>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</comment>
+  </data>
+  <data name="FlakyTransition" xml:space="preserve">
+    <value>failed -&gt; passed</value>
+    <comment>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</comment>
+  </data>
+  <data name="FlakyAttempts" xml:space="preserve">
+    <value>{0} attempts</value>
+    <comment>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</comment>
+  </data>
+  <data name="SlowestTests" xml:space="preserve">
+    <value>Slowest tests:</value>
+    <comment>Header of the run summary section that lists the longest-running tests.</comment>
   </data>
   <data name="FailedColon" xml:space="preserve">
     <value>failed:</value>

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
@@ -258,6 +259,8 @@ internal partial class MicrosoftTestingPlatformTestCommand
             ShowAssemblyStartAndComplete = !isJsonDiscovery,
             MinimumExpectedTests = parseResult.GetValue(definition.MinimumExpectedTestsOption),
             ListTestsFormat = testOptions.ListTestsFormat,
+            SlowestTestsCount = GetSlowestTestsCount(parseResult.GetArguments()),
+            ShowFlakyTests = GetShowFlakyTests(parseResult.GetArguments()),
         });
 
         // Ctrl+C handling is wired in Run() through CtrlCCancellationManager so that
@@ -269,6 +272,64 @@ internal partial class MicrosoftTestingPlatformTestCommand
 
         output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, testOptions.IsDiscovery, testOptions.IsHelp, isRetry);
         return output;
+    }
+
+    /// <summary>
+    /// Reads the Microsoft.Testing.Platform <c>--show-slowest-tests N</c> option out of the raw command line.
+    /// </summary>
+    /// <remarks>
+    /// The option belongs to the test application, not to the 'dotnet test' CLI, so it is forwarded verbatim. Under
+    /// the pipe protocol the test host's own terminal reporter is not plugged in (the SDK owns user-facing output),
+    /// so the section has to be rendered by the SDK's reporter instead — which means the SDK has to observe the
+    /// option. Same approach as the '--retry-failed-tests' detection above. A missing, non-numeric or non-positive
+    /// argument leaves the section off, mirroring the upstream option validator.
+    /// </remarks>
+    internal static int GetSlowestTestsCount(IReadOnlyList<string> arguments)
+    {
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            if (!string.Equals(arguments[i], "--show-slowest-tests", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (i + 1 < arguments.Count &&
+                int.TryParse(arguments[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int count) &&
+                count >= 1)
+            {
+                return count;
+            }
+
+            return 0;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Reads the Microsoft.Testing.Platform <c>--show-flaky-tests [on|off]</c> option out of the raw command line.
+    /// A bare '--show-flaky-tests' means "on", which is also the default when the option is absent.
+    /// See <see cref="GetSlowestTestsCount"/> for why the SDK inspects the forwarded arguments.
+    /// </summary>
+    internal static bool GetShowFlakyTests(IReadOnlyList<string> arguments)
+    {
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            if (!string.Equals(arguments[i], "--show-flaky-tests", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return i + 1 >= arguments.Count || !IsOffValue(arguments[i + 1]);
+        }
+
+        return true;
+
+        static bool IsOffValue(string argument)
+            => string.Equals(argument, "off", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(argument, "false", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(argument, "disable", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(argument, "0", StringComparison.Ordinal);
     }
 
     private static int GetDegreeOfParallelism(ParseResult parseResult)

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -262,14 +262,53 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         terminal.AppendLine();
 
-        int totalTests = _assemblies.Values.Sum(a => a.TotalTests);
-        int totalFailedTests = _assemblies.Values.Sum(a => a.FailedTests);
-        int totalSkippedTests = _assemblies.Values.Sum(a => a.SkippedTests);
+        List<TestProgressState> assemblies = [.. _assemblies.Values.OrderBy(static a => a.Id)];
+
+        // Retry attempt (second or later) of an orchestrator that re-creates the reporter per attempt: skip
+        // straight to the sections the orchestrator does not restate. 'dotnet test' keeps one reporter for the
+        // whole execution and aggregates every attempt, so ShowRunSummary is never turned off here; the branch
+        // exists so the fork stays shape-compatible with upstream.
+        if (!_options.ShowRunSummary)
+        {
+            AppendSlowestTests(terminal, assemblies);
+            AppendHandshakeFailureRecap(terminal);
+            return;
+        }
+
+        // Single-pass aggregation: compute all summary counters in one foreach instead of separate LINQ calls.
+        int totalTests = 0;
+        int totalFailedTests = 0;
+        int totalSkippedTests = 0;
+        int totalPassedTests = 0;
+        int totalRetriedTests = 0;
+        int totalRetriedExecutions = 0;
+        int totalFlakyTests = 0;
+        bool anyAssemblyUnsuccessful = false;
+        int failedAssembliesWithoutFailedTests = 0;
+
+        foreach (TestProgressState assembly in assemblies)
+        {
+            totalTests += assembly.TotalTests;
+            totalFailedTests += assembly.FailedTests;
+            totalSkippedTests += assembly.SkippedTests;
+            totalPassedTests += assembly.PassedTests;
+            totalRetriedTests += assembly.RetriedTests;
+            totalRetriedExecutions += assembly.RetriedExecutions;
+            totalFlakyTests += assembly.FlakyTests;
+            if (!assembly.Success)
+            {
+                anyAssemblyUnsuccessful = true;
+                if (assembly.FailedTests == 0)
+                {
+                    failedAssembliesWithoutFailedTests++;
+                }
+            }
+        }
 
         bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
         bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
         bool anyTestFailed = totalFailedTests > 0;
-        bool anyAssemblyFailed = _assemblies.Values.Any(a => !a.Success) || HasHandshakeFailure;
+        bool anyAssemblyFailed = anyAssemblyUnsuccessful || HasHandshakeFailure;
         bool runFailed = anyAssemblyFailed || anyTestFailed || notEnoughTests || allTestsWereSkipped || _wasCancelled;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 
@@ -306,9 +345,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.Append(string.Format(CultureInfo.CurrentCulture, "{0}!", CliCommandStrings.Passed));
         }
 
-        if (!_options.ShowAssembly && _assemblies.Count == 1)
+        if (!_options.ShowAssembly && assemblies.Count == 1)
         {
-            TestProgressState testProgressState = _assemblies.Values.Single();
+            TestProgressState testProgressState = assemblies[0];
             terminal.SetColor(TerminalColor.DarkGray);
             terminal.Append(" - ");
             terminal.ResetColor();
@@ -317,9 +356,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         terminal.AppendLine();
 
-        if (_options.ShowAssembly && _assemblies.Count > 1)
+        if (_options.ShowAssembly && assemblies.Count > 1)
         {
-            foreach (TestProgressState assemblyRun in _assemblies.Values)
+            foreach (TestProgressState assemblyRun in assemblies)
             {
                 terminal.Append(SingleIndentation);
                 AppendAssemblySummary(assemblyRun, terminal);
@@ -328,18 +367,17 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.AppendLine();
         }
 
-        int total = _assemblies.Values.Sum(t => t.TotalTests);
-        int failed = _assemblies.Values.Sum(t => t.FailedTests);
-        int passed = _assemblies.Values.Sum(t => t.PassedTests);
-        int skipped = _assemblies.Values.Sum(t => t.SkippedTests);
-        int retried = _assemblies.Values.Sum(t => t.RetriedFailedTests);
+        int total = totalTests;
+        int failed = totalFailedTests;
+        int passed = totalPassedTests;
+        int skipped = totalSkippedTests;
 
         // If the process exited with non-zero exit code (t.Success is false)
         // And also we didn't receive any failed tests, we consider these as errors.
         // In addition, failing to handshake is also considered as an error.
         // Note: In case of handshake failure, we shouldn't add any entries to _assemblies dictionary.
         // So, this line cannot be double-counting handshake failures twice.
-        int error = _assemblies.Values.Count(t => !t.Success && t.FailedTests == 0) + _handshakeFailuresCount;
+        int error = failedAssembliesWithoutFailedTests + _handshakeFailuresCount;
         TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
 
         bool colorizeFailed = failed > 0;
@@ -349,7 +387,6 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         string errorText = $"{SingleIndentation}{CliCommandStrings.ErrorColon} {error}";
         string totalText = $"{SingleIndentation}{CliCommandStrings.TotalColon} {total}";
-        string retriedText = $" (+{retried} {CliCommandStrings.Retried})";
         string failedText = $"{SingleIndentation}{CliCommandStrings.FailedColon} {failed}";
         string passedText = $"{SingleIndentation}{CliCommandStrings.SucceededColon} {passed}";
         string skippedText = $"{SingleIndentation}{CliCommandStrings.SkippedColon} {skipped}";
@@ -364,14 +401,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
 
         terminal.ResetColor();
-        terminal.Append(totalText);
-        if (retried > 0)
-        {
-            terminal.SetColor(TerminalColor.DarkGray);
-            terminal.Append(retriedText);
-            terminal.ResetColor();
-        }
-        terminal.AppendLine();
+        terminal.AppendLine(totalText);
 
         if (colorizeFailed)
         {
@@ -409,13 +439,195 @@ internal sealed partial class TerminalTestReporter : IDisposable
             terminal.ResetColor();
         }
 
+        AppendRetrySummaryLines(terminal, totalFlakyTests, totalRetriedTests, totalRetriedExecutions);
+
         terminal.Append(durationText);
         AppendLongDuration(terminal, runDuration, wrapInParentheses: false, colorize: false);
         terminal.AppendLine();
 
+        // Optional "Flaky tests" section (on by default, suppressed by '--show-flaky-tests off'). No-op when
+        // nothing was retried, so the summary stays byte-identical for a run without retries.
+        AppendFlakyTests(terminal, assemblies);
+
+        // Optional "Slowest tests" section (opt-in via '--show-slowest-tests N'). Additive: no-op when the feature
+        // is off, so the summary stays byte-identical for the default run.
+        AppendSlowestTests(terminal, assemblies);
+
         AppendExitCodeAndUrl(terminal, exitCode, isRun: true);
 
         AppendHandshakeFailureRecap(terminal);
+    }
+
+    /// <summary>
+    /// Appends the retry accounting lines that sit between the skipped count and the duration:
+    /// <c>flaky: N</c> (tests that failed at least once but eventually passed) and
+    /// <c>retried: N test(s), M extra run(s)</c>. Both are omitted entirely when nothing was retried, so a run
+    /// without retries keeps its historical summary byte-for-byte.
+    /// </summary>
+    private void AppendRetrySummaryLines(ITerminal terminal, int flakyTests, int retriedTests, int retriedExecutions)
+    {
+        // "flaky" is the headline value of retrying, so it is reported whenever it is non-zero unless the user
+        // explicitly turned the feature off.
+        if (flakyTests > 0 && _options.ShowFlakyTests)
+        {
+            terminal.SetColor(TerminalColor.DarkYellow);
+            terminal.AppendLine($"{SingleIndentation}{string.Format(CultureInfo.CurrentCulture, CliCommandStrings.FlakyLowercase, flakyTests)}");
+            terminal.ResetColor();
+        }
+
+        if (retriedTests > 0)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append($"{SingleIndentation}{CliCommandStrings.RetriedColon} ");
+            terminal.AppendLine(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.RetriedTestsAndRuns, retriedTests, retriedExecutions));
+            terminal.ResetColor();
+        }
+    }
+
+    /// <summary>
+    /// Appends the "Flaky tests" section listing, by name, the tests that failed at least once but whose final
+    /// attempt passed. Retried tests that never recovered are deliberately not listed: they are already reported as
+    /// failures with their full error output, so a second listing would only duplicate. For a single assembly a flat
+    /// list is rendered; the multi-assembly orchestrator groups per assembly. No-op when the feature is off or when
+    /// no test was flaky.
+    /// </summary>
+    private void AppendFlakyTests(ITerminal terminal, List<TestProgressState> assemblies)
+    {
+        if (!_options.ShowFlakyTests)
+        {
+            return;
+        }
+
+        if (_options.ShowAssembly && assemblies.Count > 1)
+        {
+            bool headerWritten = false;
+            foreach (TestProgressState assembly in assemblies)
+            {
+                IReadOnlyList<(string DisplayName, int Attempts)> flaky = assembly.GetFlakyTests();
+                if (flaky.Count == 0)
+                {
+                    continue;
+                }
+
+                if (!headerWritten)
+                {
+                    terminal.AppendLine();
+                    terminal.AppendLine(CliCommandStrings.FlakyTests);
+                    headerWritten = true;
+                }
+
+                terminal.Append(SingleIndentation);
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly.Assembly, assembly.TargetFramework, assembly.Architecture);
+                terminal.AppendLine();
+                foreach ((string displayName, int attempts) in flaky)
+                {
+                    terminal.Append(DoubleIndentation);
+                    AppendFlakyTestLine(terminal, displayName, attempts);
+                }
+            }
+
+            return;
+        }
+
+        IReadOnlyList<(string DisplayName, int Attempts)> tests = assemblies.Count == 1
+            ? assemblies[0].GetFlakyTests()
+            : [];
+        if (tests.Count == 0)
+        {
+            return;
+        }
+
+        terminal.AppendLine();
+        terminal.AppendLine(CliCommandStrings.FlakyTests);
+        foreach ((string displayName, int attempts) in tests)
+        {
+            terminal.Append(SingleIndentation);
+            AppendFlakyTestLine(terminal, displayName, attempts);
+        }
+    }
+
+    private static void AppendFlakyTestLine(ITerminal terminal, string displayName, int attempts)
+    {
+        terminal.Append(displayName);
+        terminal.SetColor(TerminalColor.DarkGray);
+        terminal.Append(' ');
+        terminal.Append(CliCommandStrings.FlakyTransition);
+        terminal.Append(" (");
+        terminal.Append(string.Format(CultureInfo.CurrentCulture, CliCommandStrings.FlakyAttempts, attempts));
+        terminal.Append(')');
+        terminal.ResetColor();
+        terminal.AppendLine();
+    }
+
+    /// <summary>
+    /// Appends the opt-in "Slowest tests" section, ranking the longest-running tests by their reported execution
+    /// duration. For a single assembly a flat list is rendered; for the multi-assembly orchestrator each assembly
+    /// gets its own sub-list so the ranking stays scoped per assembly. No-op when the feature is off or when no
+    /// timed tests were recorded.
+    /// </summary>
+    private void AppendSlowestTests(ITerminal terminal, List<TestProgressState> assemblies)
+    {
+        int count = _options.SlowestTestsCount;
+        if (count <= 0)
+        {
+            return;
+        }
+
+        if (_options.ShowAssembly && assemblies.Count > 1)
+        {
+            bool headerWritten = false;
+            foreach (TestProgressState assembly in assemblies)
+            {
+                IReadOnlyList<(string DisplayName, TimeSpan Duration)> slowest = assembly.GetSlowestTests(count);
+                if (slowest.Count == 0)
+                {
+                    continue;
+                }
+
+                if (!headerWritten)
+                {
+                    terminal.AppendLine();
+                    terminal.AppendLine(CliCommandStrings.SlowestTests);
+                    headerWritten = true;
+                }
+
+                terminal.Append(SingleIndentation);
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly.Assembly, assembly.TargetFramework, assembly.Architecture);
+                terminal.AppendLine();
+                foreach ((string displayName, TimeSpan duration) in slowest)
+                {
+                    terminal.Append(DoubleIndentation);
+                    AppendSlowestTestLine(terminal, displayName, duration);
+                }
+            }
+
+            return;
+        }
+
+        // Single assembly: a flat list.
+        IReadOnlyList<(string DisplayName, TimeSpan Duration)> tests = assemblies.Count == 1
+            ? assemblies[0].GetSlowestTests(count)
+            : [];
+        if (tests.Count == 0)
+        {
+            return;
+        }
+
+        terminal.AppendLine();
+        terminal.AppendLine(CliCommandStrings.SlowestTests);
+        foreach ((string displayName, TimeSpan duration) in tests)
+        {
+            terminal.Append(SingleIndentation);
+            AppendSlowestTestLine(terminal, displayName, duration);
+        }
+    }
+
+    private static void AppendSlowestTestLine(ITerminal terminal, string displayName, TimeSpan duration)
+    {
+        AppendLongDuration(terminal, duration, wrapInParentheses: false);
+        terminal.Append(' ');
+        terminal.Append(displayName);
+        terminal.AppendLine();
     }
 
     private void AppendHandshakeFailureRecap(ITerminal terminal)
@@ -512,19 +724,27 @@ internal sealed partial class TerminalTestReporter : IDisposable
             asm.TestNodeResultsState?.RemoveRunningTestNode(instanceId, testNodeUid);
         }
 
+        // Record the reported duration for the "slowest tests" summary section. All outcomes are included (a slow
+        // test that then fails is still slow). Called on every completion so a retry that reports no timing clears
+        // the stale duration of its earlier attempt instead of leaving it in the ranking.
+        if (_options.SlowestTestsCount > 0)
+        {
+            asm.RecordTestDuration(testNodeUid, displayName, duration);
+        }
+
         switch (outcome)
         {
             case TestOutcome.Error:
             case TestOutcome.Timeout:
             case TestOutcome.Canceled:
             case TestOutcome.Fail:
-                asm.ReportFailedTest(testNodeUid, instanceId);
+                asm.ReportFailedTest(testNodeUid, displayName, instanceId);
                 break;
             case TestOutcome.Passed:
-                asm.ReportPassingTest(testNodeUid, instanceId);
+                asm.ReportPassingTest(testNodeUid, displayName, instanceId);
                 break;
             case TestOutcome.Skipped:
-                asm.ReportSkippedTest(testNodeUid, instanceId);
+                asm.ReportSkippedTest(testNodeUid, displayName, instanceId);
                 break;
         }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporterOptions.cs
@@ -50,6 +50,31 @@ internal sealed class TerminalTestReporterOptions
     /// Gets the format used when listing discovered tests ('--list-tests'). Only relevant in discovery mode.
     /// </summary>
     public TestListFormat ListTestsFormat { get; init; }
+
+    /// <summary>
+    /// Gets the number of slowest tests to list in the run summary. When greater than zero, a "Slowest tests"
+    /// section ranking the longest-running tests (by their reported execution duration) is appended to the summary.
+    /// Zero (the default) disables the section.
+    /// </summary>
+    public int SlowestTestsCount { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether tests that failed at least once but eventually passed after a retry are
+    /// reported (the "flaky: N" summary line and the "Flaky tests" section). On by default; turned off by
+    /// <c>--show-flaky-tests off</c>. Has no effect on a run where nothing was retried.
+    /// </summary>
+    public bool ShowFlakyTests { get; init; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether the run-summary verdict and its counts are rendered. Upstream
+    /// (Microsoft.Testing.Platform) turns this off for the second and later attempts of its in-process
+    /// <c>--retry-failed-tests</c> orchestrator, whose summary would otherwise report the filtered subset that
+    /// attempt re-ran as if it were the whole run. The 'dotnet test' orchestrator keeps a single reporter for the
+    /// whole execution and aggregates every attempt into one tally, so it never turns this off; the property is
+    /// kept so the hard fork stays shape-compatible with upstream. Everything else — produced artifacts, the
+    /// slowest-tests section and the error recaps — is rendered regardless.
+    /// </summary>
+    public bool ShowRunSummary { get; init; } = true;
 }
 
 internal enum AnsiMode

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TestProgressState.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using TestNodeInfoEntry = (int Passed, int Skipped, int Failed, int LastAttemptNumber);
+using TestNodeInfoEntry = (int Passed, int Skipped, int Failed, int LastAttemptNumber, int Attempts);
 
 namespace Microsoft.DotNet.Cli.Commands.Test.Terminal;
 
@@ -11,12 +11,42 @@ internal sealed class TestProgressState(long id, string assembly, string? target
     private readonly Lock _lock = new();
     private readonly Dictionary<string, TestNodeInfoEntry> _testUidToResults = new();
     private readonly Dictionary<string, int> _instanceIdToAttemptNumber = new();
+
+    /// <summary>
+    /// Records the last-seen (display name, duration) for every test node, keyed by test node uid, so the
+    /// "slowest tests" summary section can rank them. Keyed by uid (not appended to a list) so a retried test
+    /// replaces its earlier attempt's timing instead of appearing twice, mirroring the pass/fail tally above.
+    /// Only populated when the slowest-tests feature is enabled (the reporter gates the RecordTestDuration call),
+    /// so a run without the feature pays no memory cost here.
+    /// </summary>
+    private readonly Dictionary<string, (string DisplayName, TimeSpan Duration)> _testUidToDuration = new();
+
+    /// <summary>
+    /// Test nodes whose result was superseded by a later attempt while the earlier attempt had at least one failure.
+    /// Combined with the final tally in <see cref="_testUidToResults"/> this yields the "flaky" set (failed at least
+    /// once, but the final attempt passed). Kept separate from the tally so a test that keeps failing is
+    /// retried-but-not-flaky. The value is the last-seen display name so the summary can list the test by name.
+    /// </summary>
+    private readonly Dictionary<string, string> _uidWithEarlierFailure = new();
+
+    /// <summary>
+    /// Distinct test nodes that produced results in more than one attempt. This is the "how many tests were retried"
+    /// figure, as opposed to <see cref="_retriedExecutions"/> ("how many extra runs did that cost").
+    /// </summary>
+    private readonly HashSet<string> _retriedUids = new(StringComparer.Ordinal);
+
     private readonly List<DiscoveredTestInfo> _discoveredTestNames = [];
     private int _discoveredTests;
     private int _failedTests;
     private int _passedTests;
     private int _skippedTests;
     private int _retriedFailedTests;
+
+    /// <summary>
+    /// Total number of extra executions caused by retries (every result that superseded an earlier attempt), so the
+    /// summary can distinguish "2 tests were retried" from "those retries cost 4 extra runs".
+    /// </summary>
+    private int _retriedExecutions;
     private int _tryCount;
     private TestNodeResultsState? _testNodeResultsState;
     private bool _success;
@@ -97,6 +127,57 @@ internal sealed class TestProgressState(long id, string assembly, string? target
         }
     }
 
+    /// <summary>
+    /// Gets the number of distinct tests that produced results in more than one attempt.
+    /// </summary>
+    public int RetriedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _retriedUids.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of extra executions caused by retries (results that superseded an earlier attempt).
+    /// </summary>
+    public int RetriedExecutions
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _retriedExecutions;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of tests that failed at least once but whose final attempt passed.
+    /// </summary>
+    public int FlakyTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                int count = 0;
+                foreach (KeyValuePair<string, string> entry in _uidWithEarlierFailure)
+                {
+                    if (IsFlakyCore(entry.Key))
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
+        }
+    }
+
     public TestNodeResultsState? TestNodeResultsState
     {
         get
@@ -161,6 +242,7 @@ internal sealed class TestProgressState(long id, string assembly, string? target
 
     private void ReportGenericTestResult(
         string testNodeUid,
+        string displayName,
         string instanceId,
         Func<TestNodeInfoEntry, TestNodeInfoEntry> incrementTestNodeInfoEntry,
         Action<TestProgressState> incrementCountAction)
@@ -173,6 +255,15 @@ internal sealed class TestProgressState(long id, string assembly, string? target
             {
                 if (value.LastAttemptNumber == currentAttemptNumber)
                 {
+                    // Another result for the same test node in the same attempt — just increment. When the uid has
+                    // already been superseded once, this result belongs to a retry attempt and is itself an extra
+                    // execution: a folded data-driven test reports one result per row, so counting only the first
+                    // would undercount the extra runs those rows actually cost.
+                    if (_retriedUids.Contains(testNodeUid))
+                    {
+                        _retriedExecutions++;
+                    }
+
                     _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
                 }
                 else if (currentAttemptNumber > value.LastAttemptNumber)
@@ -181,7 +272,18 @@ internal sealed class TestProgressState(long id, string assembly, string? target
                     _passedTests -= value.Passed;
                     _skippedTests -= value.Skipped;
                     _failedTests -= value.Failed;
-                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+                    _retriedUids.Add(testNodeUid);
+                    _retriedExecutions++;
+
+                    // Remember that an earlier attempt failed. Whether that makes the test flaky depends on the
+                    // final tally, which is only known once the run ends, so the decision is deferred to
+                    // IsFlakyCore rather than made here.
+                    if (value.Failed > 0)
+                    {
+                        _uidWithEarlierFailure[testNodeUid] = displayName;
+                    }
+
+                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber, Attempts: value.Attempts + 1));
                 }
                 else
                 {
@@ -190,39 +292,116 @@ internal sealed class TestProgressState(long id, string assembly, string? target
             }
             else
             {
-                _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
+                _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber, Attempts: 1)));
             }
 
             incrementCountAction(this);
         }
     }
 
-    public void ReportPassingTest(string testNodeUid, string instanceId)
+    public void ReportPassingTest(string testNodeUid, string displayName, string instanceId)
     {
-        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        ReportGenericTestResult(testNodeUid, displayName, instanceId, static entry =>
         {
             entry.Passed++;
             return entry;
         }, static @this => @this._passedTests++);
     }
 
-    public void ReportSkippedTest(string testNodeUid, string instanceId)
+    public void ReportSkippedTest(string testNodeUid, string displayName, string instanceId)
     {
-        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        ReportGenericTestResult(testNodeUid, displayName, instanceId, static entry =>
         {
             entry.Skipped++;
             return entry;
         }, static @this => @this._skippedTests++);
     }
 
-    public void ReportFailedTest(string testNodeUid, string instanceId)
+    public void ReportFailedTest(string testNodeUid, string displayName, string instanceId)
     {
-        ReportGenericTestResult(testNodeUid, instanceId, static entry =>
+        ReportGenericTestResult(testNodeUid, displayName, instanceId, static entry =>
         {
             entry.Failed++;
             return entry;
         }, static @this => @this._failedTests++);
     }
+
+    /// <summary>
+    /// Records (or clears) the last-seen duration reported for a test node so it can be ranked in the "slowest
+    /// tests" summary section. Keyed by <paramref name="testNodeUid"/> so a retry (which re-reports the same uid)
+    /// replaces the earlier attempt's timing rather than adding a duplicate entry. A <see langword="null"/>
+    /// <paramref name="duration"/> means the latest attempt reported no timing, so the earlier attempt's stale
+    /// duration is removed rather than kept. Only invoked when the slowest-tests feature is enabled.
+    /// </summary>
+    public void RecordTestDuration(string testNodeUid, string displayName, TimeSpan? duration)
+    {
+        lock (_lock)
+        {
+            if (duration.HasValue)
+            {
+                _testUidToDuration[testNodeUid] = (displayName, duration.Value);
+            }
+            else
+            {
+                _testUidToDuration.Remove(testNodeUid);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns up to <paramref name="count"/> recorded tests ordered from slowest to fastest. Ties are broken by
+    /// display name (ordinal) so the ranking is deterministic for snapshot-based tests.
+    /// </summary>
+    public IReadOnlyList<(string DisplayName, TimeSpan Duration)> GetSlowestTests(int count)
+    {
+        lock (_lock)
+        {
+            return count <= 0 || _testUidToDuration.Count == 0
+                ? []
+                : [.. _testUidToDuration.Values
+                    .OrderByDescending(static entry => entry.Duration)
+                    .ThenBy(static entry => entry.DisplayName, StringComparer.Ordinal)
+                    .Take(count)];
+        }
+    }
+
+    /// <summary>
+    /// Returns the tests that failed at least once but eventually passed, as (display name, total attempts) pairs
+    /// ordered by display name so the rendering is deterministic for snapshot-based tests.
+    /// </summary>
+    public IReadOnlyList<(string DisplayName, int Attempts)> GetFlakyTests()
+    {
+        lock (_lock)
+        {
+            if (_uidWithEarlierFailure.Count == 0)
+            {
+                return [];
+            }
+
+            List<(string DisplayName, int Attempts)> flaky = [];
+            foreach (KeyValuePair<string, string> entry in _uidWithEarlierFailure)
+            {
+                if (IsFlakyCore(entry.Key))
+                {
+                    flaky.Add((entry.Value, _testUidToResults[entry.Key].Attempts));
+                }
+            }
+
+            flaky.Sort(static (left, right) => StringComparer.Ordinal.Compare(left.DisplayName, right.DisplayName));
+            return flaky;
+        }
+    }
+
+    /// <summary>
+    /// A test is flaky when an earlier attempt failed but the final attempt produced only passing results. Callers
+    /// must hold <see cref="_lock"/>.
+    /// </summary>
+    private bool IsFlakyCore(string testNodeUid)
+        // A skipped row under a folded uid is not recovery either: not every result of the final attempt passed.
+        => _testUidToResults.TryGetValue(testNodeUid, out TestNodeInfoEntry entry)
+            && entry.Failed == 0
+            && entry.Skipped == 0
+            && entry.Passed > 0;
 
     public void DiscoverTest(DiscoveredTestInfo test)
     {

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.cs.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ Ve výchozím nastavení je publikována aplikace závislá na architektuře.</t
         <target state="translated">Nástroj {0} (verze {1}) se obnovil. Dostupné příkazy: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">zkoušeno opakovaně</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Cílem projektu je více architektur. Pomocí parametru {0} určete, která arch
         <source>.slnx file {0} generated.</source>
         <target state="translated">.slnx soubor {0} byl vygenerován.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.de.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ Standardmäßig wird eine Framework-abhängige Anwendung veröffentlicht.</targe
         <target state="translated">Das Tool "{0}" (Version {1}) wurde wiederhergestellt. Verfügbare Befehle: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">Wiederholung</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Ihr Projekt verwendet mehrere Zielframeworks. Geben Sie über "{0}" an, welches 
         <source>.slnx file {0} generated.</source>
         <target state="translated">Die SLNX-Datei "{0}" wurde generiert.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.es.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ El valor predeterminado es publicar una aplicación dependiente del marco.</targ
         <target state="translated">Se restauró la herramienta "{0}" (versión "{1}"). Comandos disponibles: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">volver a intentarlo</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Su proyecto tiene como destino varias plataformas. Especifique la que quiere usa
         <source>.slnx file {0} generated.</source>
         <target state="translated">Archivo .slnx {0} generado.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.fr.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ La valeur par défaut est de publier une application dépendante du framework.</
         <target state="translated">L'outil '{0}' (version '{1}') a été restauré. Commandes disponibles : {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">réessayé</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Votre projet cible plusieurs frameworks. Spécifiez le framework à exécuter à
         <source>.slnx file {0} generated.</source>
         <target state="translated">Fichier .slnx {0} généré.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.it.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ Per impostazione predefinita, viene generato un pacchetto dipendente dal framewo
         <target state="translated">Lo strumento '{0}' (versione '{1}') è stato ripristinato. Comandi disponibili: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">ripetuto</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Il progetto è destinato a più framework. Specificare il framework da eseguire 
         <source>.slnx file {0} generated.</source>
         <target state="translated">File .slnx {0} generato.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ja.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">ツール '{0}' (バージョン '{1}') は復元されました。使用できるコマンド: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">再試行済み</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>.slnx file {0} generated.</source>
         <target state="translated">.slnx ファイル {0} が生成されました。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ko.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">'{0}' 도구(버전 '{1}')가 복원되었습니다. 사용 가능한 명령: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">다시 시도됨</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>.slnx file {0} generated.</source>
         <target state="translated">.slnx 파일 {0}이(가) 생성되었습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pl.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ Domyślnie publikowana jest aplikacja zależna od struktury.</target>
         <target state="translated">Narzędzie „{0}” (wersja „{1}”) zostało przywrócone. Dostępne polecenia: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">próbowano ponownie</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Projekt ma wiele platform docelowych. Określ platformę do uruchomienia przy u�
         <source>.slnx file {0} generated.</source>
         <target state="translated">Wygenerowano plik .slnx {0}.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.pt-BR.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ O padrão é publicar uma aplicação dependente de framework.</target>
         <target state="translated">A ferramenta '{0}' (versão '{1}') foi restaurada. Comandos disponíveis: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">repetido</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Ele tem diversas estruturas como destino. Especifique que estrutura executar usa
         <source>.slnx file {0} generated.</source>
         <target state="translated">Arquivo .slnx {0} gerado.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.ru.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">Средство "{0}" (версия "{1}") было восстановлено. Доступные команды: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">повторено</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>.slnx file {0} generated.</source>
         <target state="translated">Файл SLNX {0} создан.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.tr.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ Varsayılan durum, çerçeveye bağımlı bir uygulama yayımlamaktır.</target>
         <target state="translated">'{0}' aracı (sürüm '{1}') geri yüklendi. Kullanılabilen komutlar: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">yeniden denendi</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Projeniz birden fazla Framework'ü hedefliyor. '{0}' kullanarak hangi Framework'
         <source>.slnx file {0} generated.</source>
         <target state="translated">.slnx dosyası {0} oluşturuldu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hans.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">工具“{0}”(版本“{1}”)已还原。可用的命令: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">已重试</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>.slnx file {0} generated.</source>
         <target state="translated">已生成 .slnx 文件 {0}。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/Commands/xlf/CliCommandStrings.zh-Hant.xlf
@@ -152,6 +152,26 @@
         <target state="new">The required property '{0}' was missing or empty in the message of type '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlakyAttempts">
+        <source>{0} attempts</source>
+        <target state="new">{0} attempts</target>
+        <note>{0} is the total number of times the test ran (first run plus retries), shown next to a flaky test's name.</note>
+      </trans-unit>
+      <trans-unit id="FlakyLowercase">
+        <source>flaky: {0} (passed after retry)</source>
+        <target state="new">flaky: {0} (passed after retry)</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Rendered in the run summary after the 'skipped:' line. The parenthetical is important: it states that these tests are already included in the 'succeeded:' count rather than forming a fourth outcome category alongside failed/succeeded/skipped.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTests">
+        <source>Flaky tests:</source>
+        <target state="new">Flaky tests:</target>
+        <note>Header of the run summary section that lists tests which failed at least once but eventually passed after a retry.</note>
+      </trans-unit>
+      <trans-unit id="FlakyTransition">
+        <source>failed -&gt; passed</source>
+        <target state="new">failed -&gt; passed</target>
+        <note>Describes the outcome change of a flaky test, shown next to its name in the 'Flaky tests:' section. The arrow reads left (first outcome) to right (final outcome).</note>
+      </trans-unit>
       <trans-unit id="HandshakeFailuresHeader">
         <source>Handshake failures:</source>
         <target state="new">Handshake failures:</target>
@@ -2658,10 +2678,15 @@ The default is to publish a framework-dependent application.</source>
         <target state="translated">已還原工具 '{0}' (版本 '{1}')。可用的命令: {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="Retried">
-        <source>retried</source>
-        <target state="translated">已重試</target>
-        <note />
+      <trans-unit id="RetriedColon">
+        <source>retried:</source>
+        <target state="new">retried:</target>
+        <note>Label of the run summary line counting distinct tests that ran more than once because of a retry, e.g. 'retried: 2 test(s), 4 extra run(s)'. Keep parallel to the 'failed:'/'succeeded:'/'skipped:' labels. The colon is part of the string so locales can punctuate it appropriately.</note>
+      </trans-unit>
+      <trans-unit id="RetriedTestsAndRuns">
+        <source>{0} test(s), {1} extra run(s)</source>
+        <target state="new">{0} test(s), {1} extra run(s)</target>
+        <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label.</note>
       </trans-unit>
       <trans-unit id="RollForwardDefinition">
         <source>Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).</source>
@@ -3041,6 +3066,11 @@ Your project targets multiple frameworks. Specify which framework to run using '
         <source>.slnx file {0} generated.</source>
         <target state="translated">產生的 .slnx 檔案 {0}。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SlowestTests">
+        <source>Slowest tests:</source>
+        <target state="new">Slowest tests:</target>
+        <note>Header of the run summary section that lists the longest-running tests.</note>
       </trans-unit>
       <trans-unit id="SolutionAddReferencedProjectsOptionDescription">
         <source>Recursively add projects' ReferencedProjects to solution</source>

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -64,10 +64,15 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                     .Should().Contain("(try 2)")
                     .And.NotContain("(try 3)")
                     .And.NotContain("(try 4)")
-                    .And.Contain("total: 1 (+1 retried)")
+                    .And.Contain("total: 1")
                     .And.Contain("succeeded: 1")
                     .And.Contain("failed: 0")
-                    .And.Contain("skipped: 0");
+                    .And.Contain("skipped: 0")
+                    // The test failed on the first attempt and passed on the retry, so it is reported as flaky and
+                    // accounted for by the retry lines that replaced the old 'total: 1 (+1 retried)' suffix.
+                    .And.Contain("flaky: 1 (passed after retry)")
+                    .And.Contain("retried: 1 test(s), 1 extra run(s)")
+                    .And.Contain("Flaky tests:");
             }
 
             result.ExitCode.Should().Be(ExitCodes.Success);

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -422,13 +422,6 @@ public class TerminalTestReporterTests
     }
 
     /// <summary>
-    /// Finds the per-assembly summary line for the given assembly. Multiple lines may mention the
-    /// assembly (e.g. the "Running tests from ..." banner and the summary line). The summary line
-    /// is the one that contains the compact counts block written by <c>AppendAssemblyTestCounts</c>.
-    /// ANSI color escape sequences are stripped so callers can use plain-text assertions like
-    /// <c>Contain("[+3/x0/?1]")</c> (SimpleAnsi/SimpleTerminal mode uses the ASCII glyph set).
-    /// </summary>
-    /// <summary>
     /// A test that failed on its first attempt and passed on a retry is "flaky": the run summary reports it in the
     /// dedicated <c>flaky:</c> counter line, in the <c>retried:</c> accounting line, and by name in the
     /// "Flaky tests:" section. See dotnet/sdk#55472 / dotnet/sdk#55473.
@@ -689,6 +682,13 @@ public class TerminalTestReporterTests
     public void GetShowFlakyTests_ParsesForwardedOption(string[] arguments, bool expected)
         => MicrosoftTestingPlatformTestCommand.GetShowFlakyTests(arguments).Should().Be(expected);
 
+    /// <summary>
+    /// Finds the per-assembly summary line for the given assembly. Multiple lines may mention the
+    /// assembly (e.g. the "Running tests from ..." banner and the summary line). The summary line
+    /// is the one that contains the compact counts block written by <c>AppendAssemblyTestCounts</c>.
+    /// ANSI color escape sequences are stripped so callers can use plain-text assertions like
+    /// <c>Contain("[+3/x0/?1]")</c> (SimpleAnsi/SimpleTerminal mode uses the ASCII glyph set).
+    /// </summary>
     private static string GetAssemblySummaryLine(string output, string assemblyPath)
     {
         foreach (string line in output.Split('\n'))

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -399,6 +399,9 @@ public class TerminalTestReporterTests
     }
 
     private static void ReportTest(TerminalTestReporter reporter, string assembly, string executionId, string instanceId, string testUid, TestOutcome outcome)
+        => ReportTest(reporter, assembly, executionId, instanceId, testUid, outcome, TimeSpan.FromMilliseconds(1));
+
+    private static void ReportTest(TerminalTestReporter reporter, string assembly, string executionId, string instanceId, string testUid, TestOutcome outcome, TimeSpan? duration)
     {
         reporter.TestCompleted(
             assembly: assembly,
@@ -410,7 +413,7 @@ public class TerminalTestReporterTests
             displayName: testUid,
             informativeMessage: null,
             outcome: outcome,
-            duration: TimeSpan.FromMilliseconds(1),
+            duration: duration,
             exceptions: null,
             expected: null,
             actual: null,
@@ -425,6 +428,267 @@ public class TerminalTestReporterTests
     /// ANSI color escape sequences are stripped so callers can use plain-text assertions like
     /// <c>Contain("[+3/x0/?1]")</c> (SimpleAnsi/SimpleTerminal mode uses the ASCII glyph set).
     /// </summary>
+    /// <summary>
+    /// A test that failed on its first attempt and passed on a retry is "flaky": the run summary reports it in the
+    /// dedicated <c>flaky:</c> counter line, in the <c>retried:</c> accounting line, and by name in the
+    /// "Flaky tests:" section. See dotnet/sdk#55472 / dotnet/sdk#55473.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WhenRetriedTestRecovers_PrintsFlakyAccountingAndSection()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Flaky.Tests.dll";
+        const string executionId = "exec-flaky";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 0);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+
+        output.Should().Contain("flaky: 1 (passed after retry)");
+        output.Should().Contain("retried: 1 test(s), 1 extra run(s)");
+        output.Should().Contain("Flaky tests:");
+        output.Should().Contain("flaky-1 failed -> passed (2 attempts)");
+
+        // The old '(+N retried)' suffix on the total line was replaced by the dedicated lines above.
+        output.Should().NotContain("(+1 retried)");
+    }
+
+    /// <summary>
+    /// A test that is retried but keeps failing is retried-but-not-flaky: it is accounted for by the
+    /// <c>retried:</c> line, but must not be counted as flaky nor listed in the "Flaky tests:" section, where it
+    /// would only duplicate the failure that is already reported with its full error output.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WhenRetriedTestNeverRecovers_ReportsRetriedButNotFlaky()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Broken.Tests.dll";
+        const string executionId = "exec-broken";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "broken-1", TestOutcome.Fail);
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-2", testUid: "broken-1", TestOutcome.Fail);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 1, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 1);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+
+        output.Should().Contain("retried: 1 test(s), 1 extra run(s)");
+        output.Should().NotContain("flaky:");
+        output.Should().NotContain("Flaky tests:");
+    }
+
+    /// <summary>
+    /// '--show-flaky-tests off' suppresses both the <c>flaky:</c> counter line and the "Flaky tests:" section, while
+    /// the neutral <c>retried:</c> accounting stays.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WhenShowFlakyTestsIsOff_OmitsFlakyLineAndSection()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+            ShowFlakyTests = false,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Flaky.Tests.dll";
+        const string executionId = "exec-flaky";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 0);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+
+        output.Should().Contain("retried: 1 test(s), 1 extra run(s)");
+        output.Should().NotContain("flaky:");
+        output.Should().NotContain("Flaky tests:");
+    }
+
+    /// <summary>
+    /// A run without retries keeps its historical summary: neither retry accounting line nor the flaky section is
+    /// rendered.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WithoutRetries_OmitsRetryAccountingLines()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Stable.Tests.dll";
+        const string executionId = "exec-stable";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "stable-1", TestOutcome.Passed);
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 0);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+
+        output.Should().NotContain("retried:");
+        output.Should().NotContain("flaky:");
+        output.Should().NotContain("Flaky tests:");
+        output.Should().NotContain("Slowest tests:");
+    }
+
+    /// <summary>
+    /// '--show-slowest-tests N' appends a "Slowest tests:" section ranking the N longest-running tests by their
+    /// reported duration, slowest first.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WithSlowestTestsCount_PrintsSlowestSectionInDurationOrder()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+            SlowestTestsCount = 2,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Slow.Tests.dll";
+        const string executionId = "exec-slow";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "fast", TestOutcome.Passed, TimeSpan.FromSeconds(1));
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "slowest", TestOutcome.Passed, TimeSpan.FromSeconds(9));
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "middle", TestOutcome.Passed, TimeSpan.FromSeconds(5));
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 0);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+        string section = output[output.IndexOf("Slowest tests:", StringComparison.Ordinal)..];
+
+        section.Should().Contain("slowest");
+        section.Should().Contain("middle");
+        // Only the two slowest are listed, in descending duration order.
+        section.Should().NotContain("fast");
+        section.IndexOf("slowest", StringComparison.Ordinal).Should().BeLessThan(section.IndexOf("middle", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The slowest-tests ranking is keyed by test node uid, so a retried test replaces its earlier attempt's timing
+    /// instead of appearing twice.
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionCompleted_WithSlowestTests_RetryReplacesEarlierAttemptDuration()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = false,
+            SlowestTestsCount = 5,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        const string assembly = "/repo/bin/Debug/net9.0/Flaky.Tests.dll";
+        const string executionId = "exec-flaky";
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-1", testUid: "retried-1", TestOutcome.Fail, TimeSpan.FromSeconds(30));
+
+        reporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportTest(reporter, assembly, executionId, instanceId: "inst-2", testUid: "retried-1", TestOutcome.Passed, TimeSpan.FromSeconds(2));
+
+        reporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, exitCode: 0);
+
+        string output = StripAnsi(capturingConsole.GetOutput());
+        string section = output[output.IndexOf("Slowest tests:", StringComparison.Ordinal)..];
+
+        // The final attempt's 2s timing wins; the superseded 30s entry is gone.
+        section.Should().Contain("2s 000ms retried-1");
+        section.Should().NotContain("30s");
+    }
+
+    [TestMethod]
+    [DataRow(new string[0], 0)]
+    [DataRow(new[] { "--show-slowest-tests" }, 0)]
+    [DataRow(new[] { "--show-slowest-tests", "0" }, 0)]
+    [DataRow(new[] { "--show-slowest-tests", "abc" }, 0)]
+    [DataRow(new[] { "--show-slowest-tests", "-1" }, 0)]
+    [DataRow(new[] { "--show-slowest-tests", "3" }, 3)]
+    [DataRow(new[] { "test", "--", "--show-slowest-tests", "7" }, 7)]
+    public void GetSlowestTestsCount_ParsesForwardedOption(string[] arguments, int expected)
+        => MicrosoftTestingPlatformTestCommand.GetSlowestTestsCount(arguments).Should().Be(expected);
+
+    [TestMethod]
+    [DataRow(new string[0], true)]
+    [DataRow(new[] { "--show-flaky-tests" }, true)]
+    [DataRow(new[] { "--show-flaky-tests", "on" }, true)]
+    [DataRow(new[] { "--show-flaky-tests", "off" }, false)]
+    [DataRow(new[] { "--show-flaky-tests", "Off" }, false)]
+    [DataRow(new[] { "--show-flaky-tests", "false" }, false)]
+    [DataRow(new[] { "--show-flaky-tests", "disable" }, false)]
+    [DataRow(new[] { "--show-flaky-tests", "0" }, false)]
+    public void GetShowFlakyTests_ParsesForwardedOption(string[] arguments, bool expected)
+        => MicrosoftTestingPlatformTestCommand.GetShowFlakyTests(arguments).Should().Be(expected);
+
     private static string GetAssemblySummaryLine(string output, string assemblyPath)
     {
         foreach (string line in output.Split('\n'))

--- a/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestProgressStateTests.cs
@@ -25,17 +25,17 @@ public class TestProgressStateTests
         state.NotifyHandshake(instanceA);
         state.NotifyHandshake(instanceB);
 
-        state.ReportSkippedTest(testUid, instanceA);
+        state.ReportSkippedTest(testUid, testUid, instanceA);
         state.SkippedTests.Should().Be(1);
         state.RetriedFailedTests.Should().Be(0);
         state.TotalTests.Should().Be(1);
 
-        state.ReportSkippedTest(testUid, instanceA);
+        state.ReportSkippedTest(testUid, testUid, instanceA);
         state.SkippedTests.Should().Be(2);
         state.RetriedFailedTests.Should().Be(0);
         state.TotalTests.Should().Be(2);
 
-        state.ReportSkippedTest(testUid, instanceB);
+        state.ReportSkippedTest(testUid, testUid, instanceB);
         state.SkippedTests.Should().Be(1);
         state.RetriedFailedTests.Should().Be(0);
         state.TotalTests.Should().Be(1);
@@ -53,7 +53,7 @@ public class TestProgressStateTests
         Parallel.For(0, 100, i =>
         {
             string instanceId = i % 2 == 0 ? "shard-a" : "shard-b";
-            state.ReportPassingTest($"test-{i}", instanceId);
+            state.ReportPassingTest($"test-{i}", $"test-{i}", instanceId);
         });
 
         state.TryCount.Should().Be(1);
@@ -70,9 +70,9 @@ public class TestProgressStateTests
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
 
         state.NotifyHandshake("attempt-1-shard", attemptNumber: 1);
-        state.ReportFailedTest("flaky-test", "attempt-1-shard");
+        state.ReportFailedTest("flaky-test", "flaky-test", "attempt-1-shard");
         state.NotifyHandshake("attempt-2-shard", attemptNumber: 2);
-        state.ReportPassingTest("flaky-test", "attempt-2-shard");
+        state.ReportPassingTest("flaky-test", "flaky-test", "attempt-2-shard");
 
         state.TryCount.Should().Be(2);
         state.RetriedFailedTests.Should().Be(1);
@@ -92,12 +92,12 @@ public class TestProgressStateTests
         string instanceA = "instanceA";
         string instanceB = "instanceB";
         state.NotifyHandshake("instanceA");
-        state.ReportSkippedTest(testUid, instanceA);
-        state.ReportSkippedTest(testUid, instanceA);
+        state.ReportSkippedTest(testUid, testUid, instanceA);
+        state.ReportSkippedTest(testUid, testUid, instanceA);
         state.NotifyHandshake("instanceB");
-        state.ReportSkippedTest(testUid, instanceB);
+        state.ReportSkippedTest(testUid, testUid, instanceB);
 
-        Action act = () => state.ReportSkippedTest(testUid, instanceA);
+        Action act = () => state.ReportSkippedTest(testUid, testUid, instanceA);
         act.Should().Throw<UnreachableException>()
            .WithMessage("Unexpected test result for attempt '1' while the last attempt is '2'");
     }
@@ -118,7 +118,7 @@ public class TestProgressStateTests
         state.NotifyHandshake("instance1");
         for (int i = 0; i < callCount; i++)
         {
-            state.ReportFailedTest("testUid", "instance1");
+            state.ReportFailedTest("testUid", "testUid", "instance1");
         }
 
         state.FailedTests.Should().Be(callCount);
@@ -136,10 +136,10 @@ public class TestProgressStateTests
         var stopwatchMock = new Mock<IStopwatch>();
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
-        state.ReportFailedTest("testUid", "id1");
-        state.ReportFailedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
         state.NotifyHandshake("id2");
-        state.ReportFailedTest("testUid", "id2");
+        state.ReportFailedTest("testUid", "testUid", "id2");
 
         state.RetriedFailedTests.Should().Be(2);
         state.FailedTests.Should().Be(1);
@@ -155,11 +155,11 @@ public class TestProgressStateTests
         var stopwatchMock = new Mock<IStopwatch>();
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
-        state.ReportFailedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
         state.NotifyHandshake("id2");
-        state.ReportFailedTest("testUid", "id2");
+        state.ReportFailedTest("testUid", "testUid", "id2");
 
-        Action act = () => state.ReportFailedTest("testUid", "id1");
+        Action act = () => state.ReportFailedTest("testUid", "testUid", "id1");
 
         act.Should()
            .Throw<UnreachableException>()
@@ -175,18 +175,18 @@ public class TestProgressStateTests
         var stopwatchMock = new Mock<IStopwatch>();
         var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
         state.NotifyHandshake("id1");
-        state.ReportFailedTest("testUid", "id1");
-        state.ReportFailedTest("testUid", "id1");
-        state.ReportFailedTest("testUid", "id1");
-        state.ReportSkippedTest("testUid", "id1");
-        state.ReportSkippedTest("testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
+        state.ReportFailedTest("testUid", "testUid", "id1");
+        state.ReportSkippedTest("testUid", "testUid", "id1");
+        state.ReportSkippedTest("testUid", "testUid", "id1");
 
         state.NotifyHandshake("id2");
-        state.ReportFailedTest("testUid", "id2");
-        state.ReportPassingTest("testUid", "id2");
-        state.ReportPassingTest("testUid", "id2");
-        state.ReportPassingTest("testUid", "id2");
-        state.ReportSkippedTest("testUid", "id2");
+        state.ReportFailedTest("testUid", "testUid", "id2");
+        state.ReportPassingTest("testUid", "testUid", "id2");
+        state.ReportPassingTest("testUid", "testUid", "id2");
+        state.ReportPassingTest("testUid", "testUid", "id2");
+        state.ReportSkippedTest("testUid", "testUid", "id2");
 
         state.PassedTests.Should().Be(3);
         state.FailedTests.Should().Be(1);
@@ -254,9 +254,9 @@ public class TestProgressStateTests
 
         // First run
         state.NotifyHandshake("run1");
-        state.ReportFailedTest("failed-test", "run1");
-        state.ReportPassingTest("passed-test", "run1");
-        state.ReportSkippedTest("skipped-test", "run1");
+        state.ReportFailedTest("failed-test", "failed-test", "run1");
+        state.ReportPassingTest("passed-test", "passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "skipped-test", "run1");
         
         state.RetriedFailedTests.Should().Be(0);
         state.FailedTests.Should().Be(1);
@@ -266,7 +266,7 @@ public class TestProgressStateTests
 
         // Second run (first retry)
         state.NotifyHandshake("run2");
-        state.ReportFailedTest("failed-test", "run2");
+        state.ReportFailedTest("failed-test", "failed-test", "run2");
 
         state.RetriedFailedTests.Should().Be(1);
         state.FailedTests.Should().Be(1);
@@ -276,7 +276,7 @@ public class TestProgressStateTests
 
         // Third run (second retry) - failing test passes
         state.NotifyHandshake("run3");
-        state.ReportPassingTest("failed-test", "run3");
+        state.ReportPassingTest("failed-test", "failed-test", "run3");
         state.RetriedFailedTests.Should().Be(2);
         state.FailedTests.Should().Be(0);
         state.PassedTests.Should().Be(2);
@@ -293,11 +293,11 @@ public class TestProgressStateTests
 
         // First run
         state.NotifyHandshake("run1");
-        state.ReportFailedTest("failed-test1", "run1"); // 2 test cases
-        state.ReportFailedTest("failed-test1", "run1");
+        state.ReportFailedTest("failed-test1", "failed-test1", "run1"); // 2 test cases
+        state.ReportFailedTest("failed-test1", "failed-test1", "run1");
 
-        state.ReportPassingTest("passed-test", "run1");
-        state.ReportSkippedTest("skipped-test", "run1");
+        state.ReportPassingTest("passed-test", "passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "skipped-test", "run1");
 
         state.RetriedFailedTests.Should().Be(0);
         state.FailedTests.Should().Be(2);
@@ -307,7 +307,7 @@ public class TestProgressStateTests
 
         // Second run (first retry)
         state.NotifyHandshake("run2");
-        state.ReportPassingTest("failed-test1", "run2"); // 1 test case, now passes
+        state.ReportPassingTest("failed-test1", "failed-test1", "run2"); // 1 test case, now passes
 
         state.RetriedFailedTests.Should().Be(2);
         state.FailedTests.Should().Be(0);
@@ -325,11 +325,11 @@ public class TestProgressStateTests
 
         // First run
         state.NotifyHandshake("run1");
-        state.ReportFailedTest("failed-test1", "run1"); // 2 test cases, one passes, one fails
-        state.ReportPassingTest("failed-test1", "run1");
+        state.ReportFailedTest("failed-test1", "failed-test1", "run1"); // 2 test cases, one passes, one fails
+        state.ReportPassingTest("failed-test1", "failed-test1", "run1");
 
-        state.ReportPassingTest("passed-test", "run1");
-        state.ReportSkippedTest("skipped-test", "run1");
+        state.ReportPassingTest("passed-test", "passed-test", "run1");
+        state.ReportSkippedTest("skipped-test", "skipped-test", "run1");
 
         state.RetriedFailedTests.Should().Be(0);
         state.FailedTests.Should().Be(1);
@@ -339,13 +339,128 @@ public class TestProgressStateTests
 
         // Second run (first retry)
         state.NotifyHandshake("run2");
-        state.ReportFailedTest("failed-test1", "run2"); // 1 test case still fails, but we also re-run the passing one
-        state.ReportPassingTest("failed-test1", "run2");
+        state.ReportFailedTest("failed-test1", "failed-test1", "run2"); // 1 test case still fails, but we also re-run the passing one
+        state.ReportPassingTest("failed-test1", "failed-test1", "run2");
 
         state.RetriedFailedTests.Should().Be(1);
         state.FailedTests.Should().Be(1);
         state.PassedTests.Should().Be(2);
         state.SkippedTests.Should().Be(1);
         state.TotalTests.Should().Be(4);
+    }
+
+    /// <summary>
+    /// A test that failed on the first attempt and passed on a retry is flaky; the retry accounting reports it as
+    /// one retried test costing one extra run.
+    /// </summary>
+    [TestMethod]
+    public void RetriedTestThatRecovers_IsCountedAsFlaky()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("uid-1", "My.Flaky.Test", "run1");
+
+        state.NotifyHandshake("run2");
+        state.ReportPassingTest("uid-1", "My.Flaky.Test", "run2");
+
+        state.FlakyTests.Should().Be(1);
+        state.RetriedTests.Should().Be(1);
+        state.RetriedExecutions.Should().Be(1);
+        state.GetFlakyTests().Should().BeEquivalentTo([("My.Flaky.Test", 2)]);
+    }
+
+    /// <summary>
+    /// A test that is retried but never recovers is retried, not flaky.
+    /// </summary>
+    [TestMethod]
+    public void RetriedTestThatKeepsFailing_IsRetriedButNotFlaky()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("uid-1", "My.Broken.Test", "run1");
+
+        state.NotifyHandshake("run2");
+        state.ReportFailedTest("uid-1", "My.Broken.Test", "run2");
+
+        state.FlakyTests.Should().Be(0);
+        state.GetFlakyTests().Should().BeEmpty();
+        state.RetriedTests.Should().Be(1);
+        state.RetriedExecutions.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A test that was never retried is neither flaky nor retried, so a run without retries reports zeroes.
+    /// </summary>
+    [TestMethod]
+    public void TestWithoutRetry_ReportsNoRetryAccounting()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("run1");
+        state.ReportPassingTest("uid-1", "My.Test", "run1");
+        state.ReportFailedTest("uid-2", "My.Other.Test", "run1");
+
+        state.FlakyTests.Should().Be(0);
+        state.RetriedTests.Should().Be(0);
+        state.RetriedExecutions.Should().Be(0);
+        state.GetFlakyTests().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A folded (data-driven) test reports one result per row, so every row of a retry attempt counts as an extra
+    /// execution — otherwise the "extra runs" figure would undercount what the retry actually cost. A row of the
+    /// final attempt that is skipped means not every result passed, so the test is not reported as recovered.
+    /// </summary>
+    [TestMethod]
+    public void FoldedTestRetry_CountsEveryRowAsExtraExecution()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.NotifyHandshake("run1");
+        state.ReportFailedTest("uid-1", "My.Data.Test", "run1");
+        state.ReportPassingTest("uid-1", "My.Data.Test", "run1");
+
+        state.NotifyHandshake("run2");
+        state.ReportPassingTest("uid-1", "My.Data.Test", "run2");
+        state.ReportSkippedTest("uid-1", "My.Data.Test", "run2");
+
+        state.RetriedTests.Should().Be(1);
+        state.RetriedExecutions.Should().Be(2);
+        state.FlakyTests.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The slowest-tests ranking is keyed by test node uid so a retry replaces the earlier attempt's timing, and a
+    /// later attempt that reports no timing clears the stale entry instead of keeping it.
+    /// </summary>
+    [TestMethod]
+    public void RecordTestDuration_RanksSlowestTestsAndReplacesRetriedTimings()
+    {
+        var stopwatchMock = new Mock<IStopwatch>();
+        var state = new TestProgressState(1, "assembly.dll", null, null, stopwatchMock.Object, isDiscovery: false);
+
+        state.RecordTestDuration("uid-1", "Slow", TimeSpan.FromSeconds(30));
+        state.RecordTestDuration("uid-2", "Medium", TimeSpan.FromSeconds(5));
+        state.RecordTestDuration("uid-3", "Fast", TimeSpan.FromSeconds(1));
+
+        state.GetSlowestTests(2).Should().BeEquivalentTo(
+            [("Slow", TimeSpan.FromSeconds(30)), ("Medium", TimeSpan.FromSeconds(5))],
+            static options => options.WithStrictOrdering());
+
+        // A retry of 'uid-1' that is much faster replaces the earlier 30s timing.
+        state.RecordTestDuration("uid-1", "Slow", TimeSpan.FromSeconds(2));
+        state.GetSlowestTests(1).Should().BeEquivalentTo([("Medium", TimeSpan.FromSeconds(5))]);
+
+        // A retry that reports no timing at all drops the entry.
+        state.RecordTestDuration("uid-2", "Medium", duration: null);
+        state.GetSlowestTests(5).Should().NotContain(entry => entry.DisplayName == "Medium");
+
+        state.GetSlowestTests(0).Should().BeEmpty();
     }
 }


### PR DESCRIPTION
Fixes #55471
Fixes #55472
Fixes #55473
Fixes #55474

## Summary

- port testfx retry accounting into the SDK terminal reporter, including distinct retried tests, extra executions, and flaky-test detection
- add localized flaky/retried summary lines plus flaky-test and opt-in slowest-test listings
- honor the forwarded Microsoft.Testing.Platform `--show-flaky-tests` and `--show-slowest-tests` options while preserving the existing `dotnet test` CLI surface
- reconcile the four reviewed vendored baselines and track the newly split `AnsiTerminalTestProgressFrame` partials without changing the SDK's single-file fork

The coverage summary and in-process `RetryAttemptProperty` attribution remain intentionally unported because that data is not carried by the `dotnet test` IPC contract; the manifest documents those boundaries.

## Validation

- `build.cmd`
- `dotnet build src\Cli\dotnet\dotnet.csproj --no-restore`
- focused `TerminalTestReporterTests` and `TestProgressStateTests`
- focused retry end-to-end test in Debug and Release
- adjacent dotnet test command suites
- `python .github\scripts\check_vendored_files.py validate`