### PR TITLE
Teach ApiCompat about the Experimental attribute

### DIFF
--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStability.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStability.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ApiCompatibility
+{
+    internal enum ApiStability
+    {
+        Stable,
+        Experimental,
+    }
+}

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DotNet.ApiCompatibility
@@ -9,20 +10,21 @@ namespace Microsoft.DotNet.ApiCompatibility
     {
         internal const string ExperimentalAttributeMetadataName = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
 
-        public static ApiStability Classify(ISymbol? symbol)
-        {
-            for (ISymbol? current = symbol; current != null; current = current.ContainingSymbol)
-            {
-                if (current.GetAttributes().Any(IsExperimentalAttribute))
-                {
-                    return ApiStability.Experimental;
-                }
-            }
+        private static readonly ConditionalWeakTable<ISymbol, CacheEntry> s_classifications = new();
 
-            return ApiStability.Stable;
-        }
+        public static ApiStability Classify(ISymbol? symbol) => symbol is null
+            ? ApiStability.Stable
+            : s_classifications.GetValue(symbol, static current => new(
+                current.GetAttributes().Any(IsExperimentalAttribute) || Classify(current.ContainingSymbol) == ApiStability.Experimental
+                    ? ApiStability.Experimental
+                    : ApiStability.Stable)).Stability;
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
             attribute.AttributeClass?.ToDisplayString() == ExperimentalAttributeMetadataName;
+
+        private sealed class CacheEntry(ApiStability stability)
+        {
+            public ApiStability Stability { get; } = stability;
+        }
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -61,6 +61,10 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
+            attribute.AttributeConstructor is
+            {
+                Parameters: [{ Type.SpecialType: SpecialType.System_String }]
+            } &&
             attribute.AttributeClass is
             {
                 MetadataName: ExperimentalAttributeName,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -24,8 +24,12 @@ namespace Microsoft.DotNet.ApiCompatibility
                 return cached.Stability;
             }
 
+            ISymbol? parentSymbol = symbol is IMethodSymbol { AssociatedSymbol: { } associatedSymbol }
+                ? associatedSymbol
+                : symbol.ContainingSymbol;
+
             ApiStability stability = symbol.GetAttributes().Any(IsExperimentalAttribute) ||
-                Classify(symbol.ContainingSymbol) == ApiStability.Experimental
+                Classify(parentSymbol) == ApiStability.Experimental
                     ? ApiStability.Experimental
                     : ApiStability.Stable;
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.DotNet.ApiCompatibility
+{
+    internal static class ApiStabilityClassifier
+    {
+        internal const string ExperimentalAttributeMetadataName = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
+
+        public static ApiStability Classify(ISymbol? symbol)
+        {
+            for (ISymbol? current = symbol; current != null; current = current.ContainingType)
+            {
+                if (current.GetAttributes().Any(IsExperimentalAttribute))
+                {
+                    return ApiStability.Experimental;
+                }
+            }
+
+            return ApiStability.Stable;
+        }
+
+        public static bool IsExperimentalAttribute(AttributeData attribute) =>
+            attribute.AttributeClass?.ToDisplayString() == ExperimentalAttributeMetadataName;
+    }
+}

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -12,12 +12,25 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         private static readonly ConditionalWeakTable<ISymbol, CacheEntry> s_classifications = new();
 
-        public static ApiStability Classify(ISymbol? symbol) => symbol is null
-            ? ApiStability.Stable
-            : s_classifications.GetValue(symbol, static current => new(
-                current.GetAttributes().Any(IsExperimentalAttribute) || Classify(current.ContainingSymbol) == ApiStability.Experimental
+        public static ApiStability Classify(ISymbol? symbol)
+        {
+            if (symbol is null)
+            {
+                return ApiStability.Stable;
+            }
+
+            if (s_classifications.TryGetValue(symbol, out CacheEntry? cached))
+            {
+                return cached.Stability;
+            }
+
+            ApiStability stability = symbol.GetAttributes().Any(IsExperimentalAttribute) ||
+                Classify(symbol.ContainingSymbol) == ApiStability.Experimental
                     ? ApiStability.Experimental
-                    : ApiStability.Stable)).Stability;
+                    : ApiStability.Stable;
+
+            return s_classifications.GetValue(symbol, _ => new(stability)).Stability;
+        }
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
             attribute.AttributeClass?.ToDisplayString() == ExperimentalAttributeMetadataName;

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         public static ApiStability Classify(ISymbol? symbol)
         {
-            for (ISymbol? current = symbol; current != null; current = current.ContainingType)
+            for (ISymbol? current = symbol; current != null; current = current.ContainingSymbol)
             {
                 if (current.GetAttributes().Any(IsExperimentalAttribute))
                 {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -21,7 +21,8 @@ namespace Microsoft.DotNet.ApiCompatibility
             }
 
             CacheEntry classification = s_classifications.GetValue(symbol, CreateCacheEntry);
-            return classification.ExperimentalAttributeClasses.Any(attributeDataSymbolFilter.Include)
+            return classification.ExperimentalAttributeClasses.Any(
+                attributeClass => IsIncluded(attributeClass, attributeDataSymbolFilter))
                 ? ApiStability.Experimental
                 : ApiStability.Stable;
         }
@@ -61,10 +62,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
-            attribute.AttributeConstructor is
-            {
-                Parameters: [{ Type.SpecialType: SpecialType.System_String }]
-            } &&
             attribute.AttributeClass is
             {
                 MetadataName: ExperimentalAttributeName,
@@ -81,7 +78,33 @@ namespace Microsoft.DotNet.ApiCompatibility
                         }
                     }
                 }
+            } &&
+            HasExpectedConstructor(attribute);
+
+        private static bool HasExpectedConstructor(AttributeData attribute)
+        {
+            // ApiCompat commonly loads metadata without assembly references, in which case Roslyn cannot bind the constructor.
+            return attribute.AttributeConstructor is null ||
+                attribute.AttributeConstructor.Parameters is [{ Type.SpecialType: SpecialType.System_String }];
+        }
+
+        private static bool IsIncluded(INamedTypeSymbol attributeClass, ISymbolFilter filter)
+        {
+            if (attributeClass is not IErrorTypeSymbol)
+            {
+                return filter.Include(attributeClass);
+            }
+
+            return filter switch
+            {
+                AccessibilitySymbolFilter => true,
+                CompositeSymbolFilter { Mode: CompositeSymbolFilterMode.And } composite =>
+                    composite.Filters.All(innerFilter => IsIncluded(attributeClass, innerFilter)),
+                CompositeSymbolFilter { Mode: CompositeSymbolFilterMode.Or } composite =>
+                    composite.Filters.Any(innerFilter => IsIncluded(attributeClass, innerFilter)),
+                _ => filter.Include(attributeClass)
             };
+        }
 
         private sealed class CacheEntry(INamedTypeSymbol[] experimentalAttributeClasses)
         {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -24,12 +24,13 @@ namespace Microsoft.DotNet.ApiCompatibility
                 return cached.Stability;
             }
 
-            ISymbol? parentSymbol = symbol is IMethodSymbol { AssociatedSymbol: { } associatedSymbol }
-                ? associatedSymbol
-                : symbol.ContainingSymbol;
-
             ApiStability stability = symbol.GetAttributes().Any(IsExperimentalAttribute) ||
-                Classify(parentSymbol) == ApiStability.Experimental
+                symbol is IMethodSymbol { AssociatedSymbol: { } associatedSymbol } &&
+                    associatedSymbol.GetAttributes().Any(IsExperimentalAttribute) ||
+                symbol is not IModuleSymbol &&
+                    symbol.ContainingModule?.GetAttributes().Any(IsExperimentalAttribute) == true ||
+                symbol is not IAssemblySymbol &&
+                    symbol.ContainingAssembly?.GetAttributes().Any(IsExperimentalAttribute) == true
                     ? ApiStability.Experimental
                     : ApiStability.Stable;
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ApiCompatibility
 {
     internal static class ApiStabilityClassifier
     {
-        internal const string ExperimentalAttributeMetadataName = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
+        private const string ExperimentalAttributeName = "ExperimentalAttribute";
 
         private static readonly ConditionalWeakTable<ISymbol, CacheEntry> s_classifications = new();
 
@@ -33,7 +33,23 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
-            attribute.AttributeClass?.ToDisplayString() == ExperimentalAttributeMetadataName;
+            attribute.AttributeClass is
+            {
+                MetadataName: ExperimentalAttributeName,
+                ContainingNamespace:
+                {
+                    Name: "CodeAnalysis",
+                    ContainingNamespace:
+                    {
+                        Name: "Diagnostics",
+                        ContainingNamespace:
+                        {
+                            Name: "System",
+                            ContainingNamespace.IsGlobalNamespace: true
+                        }
+                    }
+                }
+            };
 
         private sealed class CacheEntry(ApiStability stability)
         {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/ApiStabilityClassifier.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 
 namespace Microsoft.DotNet.ApiCompatibility
 {
@@ -12,29 +13,51 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         private static readonly ConditionalWeakTable<ISymbol, CacheEntry> s_classifications = new();
 
-        public static ApiStability Classify(ISymbol? symbol)
+        public static ApiStability Classify(ISymbol? symbol, ISymbolFilter attributeDataSymbolFilter)
         {
             if (symbol is null)
             {
                 return ApiStability.Stable;
             }
 
-            if (s_classifications.TryGetValue(symbol, out CacheEntry? cached))
+            CacheEntry classification = s_classifications.GetValue(symbol, CreateCacheEntry);
+            return classification.ExperimentalAttributeClasses.Any(attributeDataSymbolFilter.Include)
+                ? ApiStability.Experimental
+                : ApiStability.Stable;
+        }
+
+        private static CacheEntry CreateCacheEntry(ISymbol symbol)
+        {
+            List<INamedTypeSymbol> experimentalAttributeClasses = [];
+            AddExperimentalAttributeClasses(symbol, experimentalAttributeClasses);
+
+            if (symbol is IMethodSymbol { AssociatedSymbol: { } associatedSymbol })
             {
-                return cached.Stability;
+                AddExperimentalAttributeClasses(associatedSymbol, experimentalAttributeClasses);
             }
 
-            ApiStability stability = symbol.GetAttributes().Any(IsExperimentalAttribute) ||
-                symbol is IMethodSymbol { AssociatedSymbol: { } associatedSymbol } &&
-                    associatedSymbol.GetAttributes().Any(IsExperimentalAttribute) ||
-                symbol is not IModuleSymbol &&
-                    symbol.ContainingModule?.GetAttributes().Any(IsExperimentalAttribute) == true ||
-                symbol is not IAssemblySymbol &&
-                    symbol.ContainingAssembly?.GetAttributes().Any(IsExperimentalAttribute) == true
-                    ? ApiStability.Experimental
-                    : ApiStability.Stable;
+            if (symbol is not IModuleSymbol && symbol.ContainingModule is { } containingModule)
+            {
+                AddExperimentalAttributeClasses(containingModule, experimentalAttributeClasses);
+            }
 
-            return s_classifications.GetValue(symbol, _ => new(stability)).Stability;
+            if (symbol is not IAssemblySymbol && symbol.ContainingAssembly is { } containingAssembly)
+            {
+                AddExperimentalAttributeClasses(containingAssembly, experimentalAttributeClasses);
+            }
+
+            return new([.. experimentalAttributeClasses]);
+        }
+
+        private static void AddExperimentalAttributeClasses(ISymbol symbol, List<INamedTypeSymbol> experimentalAttributeClasses)
+        {
+            foreach (AttributeData attribute in symbol.GetAttributes())
+            {
+                if (IsExperimentalAttribute(attribute) && attribute.AttributeClass is { } attributeClass)
+                {
+                    experimentalAttributeClasses.Add(attributeClass);
+                }
+            }
         }
 
         public static bool IsExperimentalAttribute(AttributeData attribute) =>
@@ -56,9 +79,9 @@ namespace Microsoft.DotNet.ApiCompatibility
                 }
             };
 
-        private sealed class CacheEntry(ApiStability stability)
+        private sealed class CacheEntry(INamedTypeSymbol[] experimentalAttributeClasses)
         {
-            public ApiStability Stability { get; } = stability;
+            public INamedTypeSymbol[] ExperimentalAttributeClasses { get; } = experimentalAttributeClasses;
         }
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
@@ -15,7 +15,8 @@ namespace Microsoft.DotNet.ApiCompatibility
     /// <param name="message"><see cref="string"/> message describing the difference.</param>
     /// <param name="type"><see cref="DifferenceType"/> to describe the type of the difference.</param>
     /// <param name="memberId"><see cref="string"/> containing the member ID for which the difference is associated to.</param>
-    public readonly struct CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity = DifferenceSeverity.Error) : IDiagnostic, IEquatable<CompatDifference>
+    /// <param name="severity">The severity of the compatibility difference.</param>
+    public readonly struct CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity) : IDiagnostic, IEquatable<CompatDifference>
     {
         /// <inheritdoc />
         public string DiagnosticId { get; } = diagnosticId;
@@ -49,6 +50,20 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// The right's metadata information.
         /// </summary>
         public MetadataInformation Right { get; } = right;
+
+        /// <summary>
+        /// Instantiate a new object representing the compatibility difference.
+        /// </summary>
+        /// <param name="left">The metadata information of the left comparison side.</param>
+        /// <param name="right">The metadata information of the right comparison side.</param>
+        /// <param name="diagnosticId"><see cref="string"/> representing the diagnostic ID.</param>
+        /// <param name="message"><see cref="string"/> message describing the difference.</param>
+        /// <param name="type"><see cref="DifferenceType"/> to describe the type of the difference.</param>
+        /// <param name="memberId"><see cref="string"/> containing the member ID for which the difference is associated to.</param>
+        public CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId)
+            : this(left, right, diagnosticId, message, type, memberId, DifferenceSeverity.Error)
+        {
+        }
 
         /// <summary>
         /// Instantiate a new object representing the compatibility difference.

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ApiCompatibility
     /// <param name="message"><see cref="string"/> message describing the difference.</param>
     /// <param name="type"><see cref="DifferenceType"/> to describe the type of the difference.</param>
     /// <param name="memberId"><see cref="string"/> containing the member ID for which the difference is associated to.</param>
-    public readonly struct CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId) : IDiagnostic, IEquatable<CompatDifference>
+    public readonly struct CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity = DifferenceSeverity.Error) : IDiagnostic, IEquatable<CompatDifference>
     {
         /// <inheritdoc />
         public string DiagnosticId { get; } = diagnosticId;
@@ -24,6 +24,15 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// The <see cref="DifferenceType"/>.
         /// </summary>
         public DifferenceType Type { get; } = type;
+
+        /// <summary>
+        /// The severity of the compatibility difference.
+        /// </summary>
+        public DifferenceSeverity Severity { get; } = severity;
+
+        internal ISymbol? LeftSymbol { get; }
+
+        internal ISymbol? RightSymbol { get; }
 
         /// <inheritdoc />
         public string Message { get; } = message;
@@ -55,6 +64,19 @@ namespace Microsoft.DotNet.ApiCompatibility
         {
         }
 
+        internal CompatDifference WithSeverity(DifferenceSeverity newSeverity) =>
+            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, newSeverity, LeftSymbol, RightSymbol);
+
+        internal CompatDifference WithSymbols(ISymbol? leftSymbol, ISymbol? rightSymbol) =>
+            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, Severity, leftSymbol, rightSymbol);
+
+        private CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity, ISymbol? leftSymbol, ISymbol? rightSymbol)
+            : this(left, right, diagnosticId, message, type, memberId, severity)
+        {
+            LeftSymbol = leftSymbol;
+            RightSymbol = rightSymbol;
+        }
+
         /// <summary>
         /// Create a compatibility difference object with default left and right metadata for which the difference occurred.
         /// </summary>
@@ -78,6 +100,7 @@ namespace Microsoft.DotNet.ApiCompatibility
             Right.Equals(other.Right) &&
             DiagnosticId.Equals(other.DiagnosticId, StringComparison.InvariantCultureIgnoreCase) &&
             Type.Equals(other.Type) &&
+            Severity.Equals(other.Severity) &&
             string.Equals(ReferenceId, other.ReferenceId, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
@@ -91,6 +114,7 @@ namespace Microsoft.DotNet.ApiCompatibility
             hashCode = hashCode * -1521134295 + Right.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(DiagnosticId.ToLowerInvariant());
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Type.ToString().ToLowerInvariant());
+            hashCode = hashCode * -1521134295 + Severity.GetHashCode();
             if (ReferenceId != null)
             {
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ReferenceId.ToLowerInvariant());

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
@@ -115,7 +115,6 @@ namespace Microsoft.DotNet.ApiCompatibility
             Right.Equals(other.Right) &&
             DiagnosticId.Equals(other.DiagnosticId, StringComparison.InvariantCultureIgnoreCase) &&
             Type.Equals(other.Type) &&
-            Severity.Equals(other.Severity) &&
             string.Equals(ReferenceId, other.ReferenceId, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
@@ -129,7 +128,6 @@ namespace Microsoft.DotNet.ApiCompatibility
             hashCode = hashCode * -1521134295 + Right.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(DiagnosticId.ToLowerInvariant());
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Type.ToString().ToLowerInvariant());
-            hashCode = hashCode * -1521134295 + Severity.GetHashCode();
             if (ReferenceId != null)
             {
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ReferenceId.ToLowerInvariant());

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/CompatDifference.cs
@@ -31,9 +31,9 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// </summary>
         public DifferenceSeverity Severity { get; } = severity;
 
-        internal ISymbol? LeftSymbol { get; }
+        internal ApiStability? LeftStability { get; }
 
-        internal ISymbol? RightSymbol { get; }
+        internal ApiStability? RightStability { get; }
 
         /// <inheritdoc />
         public string Message { get; } = message;
@@ -80,16 +80,16 @@ namespace Microsoft.DotNet.ApiCompatibility
         }
 
         internal CompatDifference WithSeverity(DifferenceSeverity newSeverity) =>
-            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, newSeverity, LeftSymbol, RightSymbol);
+            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, newSeverity, LeftStability, RightStability);
 
-        internal CompatDifference WithSymbols(ISymbol? leftSymbol, ISymbol? rightSymbol) =>
-            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, Severity, leftSymbol, rightSymbol);
+        internal CompatDifference WithStabilities(ApiStability? leftStability, ApiStability? rightStability) =>
+            new(Left, Right, DiagnosticId, Message, Type, ReferenceId, Severity, leftStability, rightStability);
 
-        private CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity, ISymbol? leftSymbol, ISymbol? rightSymbol)
+        private CompatDifference(MetadataInformation left, MetadataInformation right, string diagnosticId, string message, DifferenceType type, string? memberId, DifferenceSeverity severity, ApiStability? leftStability, ApiStability? rightStability)
             : this(left, right, diagnosticId, message, type, memberId, severity)
         {
-            LeftSymbol = leftSymbol;
-            RightSymbol = rightSymbol;
+            LeftStability = leftStability;
+            RightStability = rightStability;
         }
 
         /// <summary>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
@@ -29,5 +29,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         public const string CannotReduceVisibility = "CP0019";
         public const string CannotExpandVisibility = "CP0020";
         public const string CannotChangeGenericConstraint = "CP0021";
+        public const string ExperimentalApiBecomesStable = "CP0022";
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DiagnosticIds.cs
@@ -30,5 +30,6 @@ namespace Microsoft.DotNet.ApiCompatibility
         public const string CannotExpandVisibility = "CP0020";
         public const string CannotChangeGenericConstraint = "CP0021";
         public const string ExperimentalApiBecomesStable = "CP0022";
+        public const string StableApiBecomesExperimental = "CP0023";
     }
 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceSeverity.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceSeverity.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.ApiCompatibility
+{
+    public enum DifferenceSeverity
+    {
+        Error,
+        Informational,
+    }
+}

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Mapping;
 
 namespace Microsoft.DotNet.ApiCompatibility
@@ -72,7 +73,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <inheritdoc />
         public void Visit(ITypeMapper type)
         {
-            AddDifferences(type);
+            AddSymbolDifferences(type);
 
             if (type.ShouldDiffMembers)
             {
@@ -91,7 +92,26 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <inheritdoc />
         public void Visit(IMemberMapper member)
         {
-            AddDifferences(member);
+            AddSymbolDifferences(member);
+        }
+
+        private void AddSymbolDifferences<T>(IElementMapper<T> mapper)
+            where T : ISymbol
+        {
+            foreach (CompatDifference item in mapper.GetDifferences())
+            {
+                ApiStability leftStability = ApiStabilityClassifier.Classify(item.LeftSymbol);
+                ApiStability rightStability = ApiStabilityClassifier.Classify(item.RightSymbol);
+
+                bool isExperimentalDifference =
+                    (item.LeftSymbol is null && rightStability == ApiStability.Experimental) ||
+                    (item.RightSymbol is null && leftStability == ApiStability.Experimental) ||
+                    (leftStability == ApiStability.Experimental && rightStability == ApiStability.Experimental);
+
+                _compatDifferences.Add(isExperimentalDifference
+                    ? item.WithSeverity(DifferenceSeverity.Informational)
+                    : item);
+            }
         }
 
         private void AddDifferences<T>(IElementMapper<T> mapper)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -108,9 +108,23 @@ namespace Microsoft.DotNet.ApiCompatibility
                     (item.RightStability is null && item.LeftStability == ApiStability.Experimental) ||
                     (item.LeftStability == ApiStability.Experimental && item.RightStability == ApiStability.Experimental);
 
-                _compatDifferences.Add(isExperimentalDifference
+                CompatDifference difference = isExperimentalDifference
                     ? item.WithSeverity(DifferenceSeverity.Informational)
-                    : item);
+                    : item;
+
+                if (_compatDifferences.TryGetValue(difference, out CompatDifference existingDifference))
+                {
+                    if (existingDifference.Severity == DifferenceSeverity.Informational &&
+                        difference.Severity == DifferenceSeverity.Error)
+                    {
+                        _compatDifferences.Remove(existingDifference);
+                        _compatDifferences.Add(difference);
+                    }
+                }
+                else
+                {
+                    _compatDifferences.Add(difference);
+                }
             }
         }
     }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.ApiCompatibility
         /// <inheritdoc />
         public void Visit(IAssemblyMapper assembly)
         {
-            AddDifferences(assembly);
+            AddSymbolDifferences(assembly.GetDifferences());
 
             foreach (INamespaceMapper @namespace in assembly.GetNamespaces())
             {
@@ -97,8 +97,11 @@ namespace Microsoft.DotNet.ApiCompatibility
 
         private void AddSymbolDifferences<T>(IElementMapper<T> mapper)
             where T : ISymbol
+            => AddSymbolDifferences(mapper.GetDifferences());
+
+        private void AddSymbolDifferences(IEnumerable<CompatDifference> differences)
         {
-            foreach (CompatDifference item in mapper.GetDifferences())
+            foreach (CompatDifference item in differences)
             {
                 ApiStability leftStability = ApiStabilityClassifier.Classify(item.LeftSymbol);
                 ApiStability rightStability = ApiStabilityClassifier.Classify(item.RightSymbol);
@@ -111,14 +114,6 @@ namespace Microsoft.DotNet.ApiCompatibility
                 _compatDifferences.Add(isExperimentalDifference
                     ? item.WithSeverity(DifferenceSeverity.Informational)
                     : item);
-            }
-        }
-
-        private void AddDifferences<T>(IElementMapper<T> mapper)
-        {
-            foreach (CompatDifference item in mapper.GetDifferences())
-            {
-                _compatDifferences.Add(item);
             }
         }
     }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/DifferenceVisitor.cs
@@ -103,13 +103,10 @@ namespace Microsoft.DotNet.ApiCompatibility
         {
             foreach (CompatDifference item in differences)
             {
-                ApiStability leftStability = ApiStabilityClassifier.Classify(item.LeftSymbol);
-                ApiStability rightStability = ApiStabilityClassifier.Classify(item.RightSymbol);
-
                 bool isExperimentalDifference =
-                    (item.LeftSymbol is null && rightStability == ApiStability.Experimental) ||
-                    (item.RightSymbol is null && leftStability == ApiStability.Experimental) ||
-                    (leftStability == ApiStability.Experimental && rightStability == ApiStability.Experimental);
+                    (item.LeftStability is null && item.RightStability == ApiStability.Experimental) ||
+                    (item.RightStability is null && item.LeftStability == ApiStability.Experimental) ||
+                    (item.LeftStability == ApiStability.Experimental && item.RightStability == ApiStability.Experimental);
 
                 _compatDifferences.Add(isExperimentalDifference
                     ? item.WithSeverity(DifferenceSeverity.Informational)

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -186,6 +186,9 @@
   <data name="ExperimentalApiBecomesStable" xml:space="preserve">
     <value>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</value>
   </data>
+  <data name="StableApiBecomesExperimental" xml:space="preserve">
+    <value>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</value>
+  </data>
   <data name="CannotAddVirtualToMember" xml:space="preserve">
     <value>Cannot add virtual keyword to member '{0}'.</value>
   </data>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Resources.resx
@@ -183,6 +183,9 @@
   <data name="EnumTypesMustMatch" xml:space="preserve">
     <value>Underlying type of enum '{0}' changed from '{1}' to '{2}'.</value>
   </data>
+  <data name="ExperimentalApiBecomesStable" xml:space="preserve">
+    <value>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</value>
+  </data>
   <data name="CannotAddVirtualToMember" xml:space="preserve">
     <value>Cannot add virtual keyword to member '{0}'.</value>
   </data>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -156,6 +156,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                                 rightContaining,
                                 leftMetadata,
                                 rightMetadata,
+                                _settings.AttributeDataSymbolFilter,
                                 differences);
                             continue;
                         }
@@ -183,6 +184,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                             rightContaining,
                             leftMetadata,
                             rightMetadata,
+                            _settings.AttributeDataSymbolFilter,
                             differences);
                         continue;
                     }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
         }
 
         // Attribute diagnostics retain the left containing symbol for compatibility with existing behavior.
-        // The right containing symbol is only used when handing an experimental API promotion to CP0022.
+        // The right containing symbol is only used when handing an experimental API stability transition to CP0022 or CP0023.
         private void ReportAttributeDifferences(ISymbol leftContaining,
             ISymbol rightContaining,
             MetadataInformation leftMetadata,
@@ -176,6 +176,17 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 // Loop over right and issue "added" diagnostic for each one.
                 foreach (AttributeData rightAttribute in rightGroup.Attributes)
                 {
+                    if (ApiStabilityClassifier.IsExperimentalAttribute(rightAttribute))
+                    {
+                        ExperimentalApiBecomesStable.AddDifference(
+                            leftContaining,
+                            rightContaining,
+                            leftMetadata,
+                            rightMetadata,
+                            differences);
+                        continue;
+                    }
+
                     AddDifference(differences, DifferenceType.Added, leftMetadata, rightMetadata, leftContaining, itemRef, rightAttribute);
                 }
             }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -66,6 +66,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             differences.Add(difference);
         }
 
+        // Attribute diagnostics retain the left containing symbol for compatibility with existing behavior.
+        // The right containing symbol is only used when handing an experimental API promotion to CP0022.
         private void ReportAttributeDifferences(ISymbol leftContaining,
             ISymbol rightContaining,
             MetadataInformation leftMetadata,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -146,6 +146,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     // Loop over left and issue "removed" diagnostic for each one.
                     foreach (AttributeData leftAttribute in leftGroup.Attributes)
                     {
+                        if (ApiStabilityClassifier.IsExperimentalAttribute(leftAttribute))
+                        {
+                            continue;
+                        }
+
                         AddDifference(differences, DifferenceType.Removed, leftMetadata, rightMetadata, containing, itemRef, leftAttribute);
                     }
                 }

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/AttributesMustMatch.cs
@@ -66,7 +66,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             differences.Add(difference);
         }
 
-        private void ReportAttributeDifferences(ISymbol containing,
+        private void ReportAttributeDifferences(ISymbol leftContaining,
+            ISymbol rightContaining,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
             string itemRef,
@@ -119,7 +120,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         {
                             // Attribute arguments exist on left but not right.
                             // Issue "changed" diagnostic.
-                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, leftAttribute);
+                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, leftContaining, itemRef, leftAttribute);
                         }
                     }
 
@@ -136,7 +137,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                             //   [Foo("b")]
                             //   void F()
                             // Issue "changed" diagnostic when in strict mode.
-                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, containing, itemRef, rightGroup.Attributes[i]);
+                            AddDifference(differences, DifferenceType.Changed, leftMetadata, rightMetadata, leftContaining, itemRef, rightGroup.Attributes[i]);
                         }
                     }
                 }
@@ -148,10 +149,16 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     {
                         if (ApiStabilityClassifier.IsExperimentalAttribute(leftAttribute))
                         {
+                            ExperimentalApiBecomesStable.AddDifference(
+                                leftContaining,
+                                rightContaining,
+                                leftMetadata,
+                                rightMetadata,
+                                differences);
                             continue;
                         }
 
-                        AddDifference(differences, DifferenceType.Removed, leftMetadata, rightMetadata, containing, itemRef, leftAttribute);
+                        AddDifference(differences, DifferenceType.Removed, leftMetadata, rightMetadata, leftContaining, itemRef, leftAttribute);
                     }
                 }
             }
@@ -167,7 +174,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 // Loop over right and issue "added" diagnostic for each one.
                 foreach (AttributeData rightAttribute in rightGroup.Attributes)
                 {
-                    AddDifference(differences, DifferenceType.Added, leftMetadata, rightMetadata, containing, itemRef, rightAttribute);
+                    AddDifference(differences, DifferenceType.Added, leftMetadata, rightMetadata, leftContaining, itemRef, rightAttribute);
                 }
             }
         }
@@ -191,6 +198,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     for (int i = 0; i < leftNamed.TypeParameters.Length; i++)
                     {
                         ReportAttributeDifferences(left,
+                            right,
                             leftMetadata,
                             rightMetadata,
                             left.GetDocumentationCommentId() + $"<{i}>",
@@ -202,6 +210,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
 
             ReportAttributeDifferences(left,
+                right,
                 leftMetadata,
                 rightMetadata,
                 left.GetDocumentationCommentId() ?? "",
@@ -228,6 +237,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 // If member is a method,
                 // compare return type attributes,
                 ReportAttributeDifferences(left,
+                    right,
                     leftMetadata,
                     rightMetadata,
                     left.GetDocumentationCommentId() + "->" + leftMethod.ReturnType,
@@ -241,6 +251,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     for (int i = 0; i < leftMethod.Parameters.Length; i++)
                     {
                         ReportAttributeDifferences(left,
+                            right,
                             leftMetadata,
                             rightMetadata,
                             left.GetDocumentationCommentId() + $"${i}",
@@ -256,6 +267,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     for (int i = 0; i < leftMethod.TypeParameters.Length; i++)
                     {
                         ReportAttributeDifferences(left,
+                            right,
                             leftMetadata,
                             rightMetadata,
                             left.GetDocumentationCommentId() + $"<{i}>",
@@ -267,6 +279,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             }
 
             ReportAttributeDifferences(left,
+                right,
                 leftMetadata,
                 rightMetadata,
                 left.GetDocumentationCommentId() ?? "",

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
     public class ExperimentalApiBecomesStable : IRule
     {
-        public ExperimentalApiBecomesStable(IRuleRegistrationContext context)
+        public ExperimentalApiBecomesStable(IRuleSettings settings, IRuleRegistrationContext context)
         {
             context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
             context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             IList<CompatDifference> differences) =>
             AddDifference(left, right, leftMetadata, rightMetadata, differences);
 
-        private static void AddDifference(ISymbol? left,
+        internal static void AddDifference(ISymbol? left,
             ISymbol? right,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
@@ -3,37 +3,42 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiSymbolExtensions;
+using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
 {
     public class ExperimentalApiBecomesStable : IRule
     {
+        private readonly IRuleSettings _settings;
+
         public ExperimentalApiBecomesStable(IRuleSettings settings, IRuleRegistrationContext context)
         {
+            _settings = settings;
             context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
             context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);
         }
 
-        private static void RunOnTypeSymbol(ITypeSymbol? left,
+        private void RunOnTypeSymbol(ITypeSymbol? left,
             ITypeSymbol? right,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
             IList<CompatDifference> differences) =>
-            AddDifference(left, right, leftMetadata, rightMetadata, differences);
+            AddDifference(left, right, leftMetadata, rightMetadata, _settings.AttributeDataSymbolFilter, differences);
 
-        private static void RunOnMemberSymbol(ISymbol? left,
+        private void RunOnMemberSymbol(ISymbol? left,
             ISymbol? right,
             ITypeSymbol leftContainingType,
             ITypeSymbol rightContainingType,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
             IList<CompatDifference> differences) =>
-            AddDifference(left, right, leftMetadata, rightMetadata, differences);
+            AddDifference(left, right, leftMetadata, rightMetadata, _settings.AttributeDataSymbolFilter, differences);
 
         internal static void AddDifference(ISymbol? left,
             ISymbol? right,
             MetadataInformation leftMetadata,
             MetadataInformation rightMetadata,
+            ISymbolFilter attributeDataSymbolFilter,
             IList<CompatDifference> differences)
         {
             if (left is null || right is null)
@@ -41,8 +46,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 return;
             }
 
-            ApiStability leftStability = ApiStabilityClassifier.Classify(left);
-            ApiStability rightStability = ApiStabilityClassifier.Classify(right);
+            ApiStability leftStability = ApiStabilityClassifier.Classify(left, attributeDataSymbolFilter);
+            ApiStability rightStability = ApiStabilityClassifier.Classify(right, attributeDataSymbolFilter);
             (string diagnosticId, string message) = (leftStability, rightStability) switch
             {
                 (ApiStability.Experimental, ApiStability.Stable) => (

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
@@ -36,9 +36,25 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             MetadataInformation rightMetadata,
             IList<CompatDifference> differences)
         {
-            if (left is null || right is null ||
-                ApiStabilityClassifier.Classify(left) != ApiStability.Experimental ||
-                ApiStabilityClassifier.Classify(right) != ApiStability.Stable)
+            if (left is null || right is null)
+            {
+                return;
+            }
+
+            ApiStability leftStability = ApiStabilityClassifier.Classify(left);
+            ApiStability rightStability = ApiStabilityClassifier.Classify(right);
+            (string diagnosticId, string message) = (leftStability, rightStability) switch
+            {
+                (ApiStability.Experimental, ApiStability.Stable) => (
+                    DiagnosticIds.ExperimentalApiBecomesStable,
+                    string.Format(Resources.ExperimentalApiBecomesStable, right.ToDisplayString(SymbolExtensions.DisplayFormat))),
+                (ApiStability.Stable, ApiStability.Experimental) => (
+                    DiagnosticIds.StableApiBecomesExperimental,
+                    string.Format(Resources.StableApiBecomesExperimental, right.ToDisplayString(SymbolExtensions.DisplayFormat))),
+                _ => default,
+            };
+
+            if (diagnosticId is null)
             {
                 return;
             }
@@ -46,8 +62,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             differences.Add(new CompatDifference(
                 leftMetadata,
                 rightMetadata,
-                DiagnosticIds.ExperimentalApiBecomesStable,
-                string.Format(Resources.ExperimentalApiBecomesStable, right.ToDisplayString(SymbolExtensions.DisplayFormat)),
+                diagnosticId,
+                message,
                 DifferenceType.Changed,
                 right.GetDocumentationCommentId(),
                 DifferenceSeverity.Error));

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/ExperimentalApiBecomesStable.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiSymbolExtensions;
+
+namespace Microsoft.DotNet.ApiCompatibility.Rules
+{
+    public class ExperimentalApiBecomesStable : IRule
+    {
+        public ExperimentalApiBecomesStable(IRuleRegistrationContext context)
+        {
+            context.RegisterOnTypeSymbolAction(RunOnTypeSymbol);
+            context.RegisterOnMemberSymbolAction(RunOnMemberSymbol);
+        }
+
+        private static void RunOnTypeSymbol(ITypeSymbol? left,
+            ITypeSymbol? right,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences) =>
+            AddDifference(left, right, leftMetadata, rightMetadata, differences);
+
+        private static void RunOnMemberSymbol(ISymbol? left,
+            ISymbol? right,
+            ITypeSymbol leftContainingType,
+            ITypeSymbol rightContainingType,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences) =>
+            AddDifference(left, right, leftMetadata, rightMetadata, differences);
+
+        private static void AddDifference(ISymbol? left,
+            ISymbol? right,
+            MetadataInformation leftMetadata,
+            MetadataInformation rightMetadata,
+            IList<CompatDifference> differences)
+        {
+            if (left is null || right is null ||
+                ApiStabilityClassifier.Classify(left) != ApiStability.Experimental ||
+                ApiStabilityClassifier.Classify(right) != ApiStability.Stable)
+            {
+                return;
+            }
+
+            differences.Add(new CompatDifference(
+                leftMetadata,
+                rightMetadata,
+                DiagnosticIds.ExperimentalApiBecomesStable,
+                string.Format(Resources.ExperimentalApiBecomesStable, right.ToDisplayString(SymbolExtensions.DisplayFormat)),
+                DifferenceType.Changed,
+                right.GetDocumentationCommentId(),
+                DifferenceSeverity.Error));
+        }
+    }
+}

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 new CannotRemoveBaseTypeOrInterface(settings, context),
                 new CannotSealType(settings, context),
                 new EnumsMustMatch(settings, context),
+                new ExperimentalApiBecomesStable(context),
                 new MembersMustExist(settings, context),
                 new CannotChangeVisibility(settings, context),
                 new CannotChangeGenericConstraints(settings, context),

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 new CannotRemoveBaseTypeOrInterface(settings, context),
                 new CannotSealType(settings, context),
                 new EnumsMustMatch(settings, context),
-                new ExperimentalApiBecomesStable(context),
+                new ExperimentalApiBecomesStable(settings, context),
                 new MembersMustExist(settings, context),
                 new CannotChangeVisibility(settings, context),
                 new CannotChangeGenericConstraints(settings, context),

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -91,11 +91,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                     throw new ArgumentOutOfRangeException(nameof(mapper));
                 }
 
-                for (int differenceIndex = initialDifferenceCount; differenceIndex < differences.Count; differenceIndex++)
+                if (initialDifferenceCount < differences.Count)
                 {
-                    differences[differenceIndex] = differences[differenceIndex].WithStabilities(
-                        leftSymbol is null ? null : ApiStabilityClassifier.Classify(leftSymbol),
-                        rightSymbol is null ? null : ApiStabilityClassifier.Classify(rightSymbol));
+                    ApiStability? leftStability = leftSymbol is null ? null : ApiStabilityClassifier.Classify(leftSymbol);
+                    ApiStability? rightStability = rightSymbol is null ? null : ApiStabilityClassifier.Classify(rightSymbol);
+
+                    for (int differenceIndex = initialDifferenceCount; differenceIndex < differences.Count; differenceIndex++)
+                    {
+                        differences[differenceIndex] = differences[differenceIndex].WithStabilities(leftStability, rightStability);
+                    }
                 }
             }
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -93,7 +93,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
                 for (int differenceIndex = initialDifferenceCount; differenceIndex < differences.Count; differenceIndex++)
                 {
-                    differences[differenceIndex] = differences[differenceIndex].WithSymbols(leftSymbol, rightSymbol);
+                    differences[differenceIndex] = differences[differenceIndex].WithStabilities(
+                        leftSymbol is null ? null : ApiStabilityClassifier.Classify(leftSymbol),
+                        rightSymbol is null ? null : ApiStabilityClassifier.Classify(rightSymbol));
                 }
             }
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -12,9 +12,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
     /// </summary>
     public class RuleRunner(IRuleFactory ruleFactory, IRuleContext context) : IRuleRunner
     {
+        private IRuleSettings _settings = null!;
+
         /// <inheritdoc />
         public void InitializeRules(IRuleSettings settings)
         {
+            _settings = settings;
+
             // Instantiate the rules but don't invoke anything on them as they register themselves on "events" inside their constructor.
             _ = ruleFactory.CreateRules(settings, context);
         }
@@ -93,8 +97,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
 
                 if (initialDifferenceCount < differences.Count)
                 {
-                    ApiStability? leftStability = leftSymbol is null ? null : ApiStabilityClassifier.Classify(leftSymbol);
-                    ApiStability? rightStability = rightSymbol is null ? null : ApiStabilityClassifier.Classify(rightSymbol);
+                    ApiStability? leftStability = leftSymbol is null ? null : ApiStabilityClassifier.Classify(leftSymbol, _settings.AttributeDataSymbolFilter);
+                    ApiStability? rightStability = rightSymbol is null ? null : ApiStabilityClassifier.Classify(rightSymbol, _settings.AttributeDataSymbolFilter);
 
                     for (int differenceIndex = initialDifferenceCount; differenceIndex < differences.Count; differenceIndex++)
                     {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Rules/RuleRunner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Mapping;
 
 namespace Microsoft.DotNet.ApiCompatibility.Rules
@@ -26,6 +27,10 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
             int rightLength = mapper.Right.Length;
             for (int rightIndex = 0; rightIndex < rightLength; rightIndex++)
             {
+                int initialDifferenceCount = differences.Count;
+                ISymbol? leftSymbol = null;
+                ISymbol? rightSymbol = null;
+
                 if (mapper is AssemblyMapper am)
                 {
                     // Ignore assembly mappings which are null on both sides, i.e. when different assembly identities are marked as compatible.
@@ -37,8 +42,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                        the assembly mapper is directly visited. */
                     bool containsSingleAssembly = am.ContainingAssemblySet == null || am.ContainingAssemblySet.AssemblyCount < 2;
 
-                    context.RunOnAssemblySymbolActions(am.Left?.Element,
-                        am.Right[rightIndex]?.Element,
+                    leftSymbol = am.Left?.Element;
+                    rightSymbol = am.Right[rightIndex]?.Element;
+
+                    context.RunOnAssemblySymbolActions(leftSymbol as IAssemblySymbol,
+                        rightSymbol as IAssemblySymbol,
                         am.Left?.MetadataInformation ?? MetadataInformation.DefaultLeft,
                         am.Right[rightIndex]?.MetadataInformation ?? MetadataInformation.DefaultRight,
                         containsSingleAssembly,
@@ -48,6 +56,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 {
                     if (tm.ShouldDiffElement(rightIndex))
                     {
+                        leftSymbol = tm.Left;
+                        rightSymbol = tm.Right[rightIndex];
                         context.RunOnTypeSymbolActions(tm.Left,
                             tm.Right[rightIndex],
                             tm.ContainingNamespace.ContainingAssembly.Left?.MetadataInformation ?? MetadataInformation.DefaultLeft,
@@ -63,6 +73,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                         Debug.Assert(mm.ContainingType.Left != null);
                         Debug.Assert(mm.ContainingType.Right[rightIndex] != null);
 
+                        leftSymbol = mm.Left;
+                        rightSymbol = mm.Right[rightIndex];
+
                         context.RunOnMemberSymbolActions(
                             mm.Left,
                             mm.Right[rightIndex],
@@ -76,6 +89,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules
                 else
                 {
                     throw new ArgumentOutOfRangeException(nameof(mapper));
+                }
+
+                for (int differenceIndex = initialDifferenceCount; differenceIndex < differences.Count; differenceIndex++)
+                {
+                    differences[differenceIndex] = differences[differenceIndex].WithSymbols(leftSymbol, rightSymbol);
                 }
             }
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -65,12 +65,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
 
                     foreach (CompatDifference difference in differenceGroup)
                     {
-                        if (difference.Severity == DifferenceSeverity.Informational)
-                        {
-                            log.LogMessage(MessageImportance.Normal, $"info {difference.DiagnosticId}: {difference.Message}");
-                            continue;
-                        }
-
                         Suppression suppression = new(difference.DiagnosticId)
                         {
                             Target = difference.ReferenceId,
@@ -82,6 +76,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
                         // If the error is suppressed, don't log anything.
                         if (suppressionEngine.IsErrorSuppressed(suppression))
                             continue;
+
+                        if (difference.Severity == DifferenceSeverity.Informational)
+                        {
+                            log.LogMessage(MessageImportance.Normal, $"info {difference.DiagnosticId}: {difference.Message}");
+                            continue;
+                        }
 
                         if (logHeader)
                         {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -65,6 +65,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
 
                     foreach (CompatDifference difference in differenceGroup)
                     {
+                        if (difference.Severity == DifferenceSeverity.Informational)
+                        {
+                            log.LogMessage(MessageImportance.Normal, $"info {difference.DiagnosticId}: {difference.Message}");
+                            continue;
+                        }
+
                         Suppression suppression = new(difference.DiagnosticId)
                         {
                             Target = difference.ReferenceId,
@@ -76,12 +82,6 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
                         // If the error is suppressed, don't log anything.
                         if (suppressionEngine.IsErrorSuppressed(suppression))
                             continue;
-
-                        if (difference.Severity == DifferenceSeverity.Informational)
-                        {
-                            log.LogMessage(MessageImportance.Normal, $"info {difference.DiagnosticId}: {difference.Message}");
-                            continue;
-                        }
 
                         if (logHeader)
                         {

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -65,6 +65,12 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
 
                     foreach (CompatDifference difference in differenceGroup)
                     {
+                        if (difference.Severity == DifferenceSeverity.Informational)
+                        {
+                            log.LogMessage(MessageImportance.Normal, difference.ToString());
+                            continue;
+                        }
+
                         Suppression suppression = new(difference.DiagnosticId)
                         {
                             Target = difference.ReferenceId,

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/Runner/ApiCompatRunner.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner
                     {
                         if (difference.Severity == DifferenceSeverity.Informational)
                         {
-                            log.LogMessage(MessageImportance.Normal, difference.ToString());
+                            log.LogMessage(MessageImportance.Normal, $"info {difference.DiagnosticId}: {difference.Message}");
                             continue;
                         }
 

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Hodnota pole {1} ve výčtu {0} se změnila z {2} na {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">Index {0} by měl být v rozsahu nula až {1} včetně.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Hodnota {0} by měla být větší než 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Typ {0} má zapečetěný modifikátor na {1} ale ne na {2}.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Wert des Felds „{1}2 in der Enumeration „{0}2 wurde von „{2}“ in „{3}“ geändert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">Der {0} Index sollte zwischen null und einschließlich {1} liegen.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Der Wert von „{0}“ muss größer als 0 sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Der Typ „{0}“ verfügt über den versiegelten Modifizierer auf {1}, auf {2} aber nicht.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -142,6 +142,11 @@
         <target state="translated">El valor del campo "{1}" en la enumeración "{0}" ha cambiado de "{2}" a "{3}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">El índice de {0} debe estar comprendido entre cero y {1} inclusive.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">El valor de '{0}' debe ser superior a 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">El tipo '{0}' tiene el modificador sellado en {1}, pero no en {2}</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">La valeur de « {0} » doit être supérieure à 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Le type' {0} 'a le modificateur est scellé sur {1} mais pas sur {2}.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.fr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">La valeur du champ '{1}' dans l'énumération '{0}' est passée de '{2}' à '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">L’index {0} doit être compris entre zéro et {1} inclus.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Il valore del campo '{1}' nell'enumerazione '{0}' è stato modificato da '{2}' a '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">L'indice {0} deve essere compreso nell'intervallo compreso tra zero e {1} incluso.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Il valore di '{0}' deve essere maggiore di 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Il tipo '{0}' ha il modificatore sealed in {1} ma non in {2}</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">'{0}' は 0 より大きい値にする必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">型 '{0}' は {1} に sealed 修飾子がありますが、{2} にはありません</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ja.xlf
@@ -142,6 +142,11 @@
         <target state="translated">列挙型 '{0}' のフィールド '{1}' の値が '{2}' から '{3}' に変更されました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">{0} インデックスは、0 から {1} の範囲内である必要があります。</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">‘{0}’의 값은 0보다 커야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">'{0}' 유형은 {1}에 봉인된 한정자가 있지만 {2}에는 없습니다</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ko.xlf
@@ -142,6 +142,11 @@
         <target state="translated">열거형 '{0}'의 필드 '{1}' 값이 '{2}'에서 '{3}'(으)로 변경되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">{0} 인덱스는 0 이상 {1} 이하의 범위 안에 있어야 합니다.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Wartość „{0}” powinna być większa niż 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Typ „{0}” ma zapieczętowany modyfikator w {1}, ale nie w {2}</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pl.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Wartość pola „{1}” w wyliczeniu „{0}” zmieniona z „{2}” na „{3}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">Indeks {0} powinien należeć do zakresu od zera do {1} włącznie.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">O valor de '{0}' deve ser maior que 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">O tipo '{0}' tem o modificador selado em {1}, mas não em {2}</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Valor do campo '{1}' na enumeração '{0}' alterado de '{2}' para '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">O índice {0} deve estar no intervalo de zero até {1} inclusivo.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -142,6 +142,11 @@
         <target state="translated">Значение поля "{1}" в перечислении "{0}" изменено с "{2}" на "{3}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">Индекс {0} должен находиться в диапазоне от нуля до {1} включительно.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Значение "{0}" должно быть больше 0.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">Тип "{0}" имеет запечатанный модификатор для {1}, но не для {2}</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">'{0}' değeri 0'dan büyük olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">'{0}' türü, {1} üzerinde mühürlü değiştiriciye sahip ancak {2} üzerinde sahip değil</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.tr.xlf
@@ -142,6 +142,11 @@
         <target state="translated">'{0}' sabit listesindeki '{1}' alan değeri, '{2}' öğesinden '{3}' öğesine değiştirildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">{0} dizini sıfırdan başlayarak {1} dahil olmak üzere bu aralıkta olmalıdır.</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="translated">枚举“{0}”中字段“{1}”的值已从“{2}”更改为“{3}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">{0} 索引应在 0 到 {1} (含)范围内。</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">"{0}" 的值应大于 0。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">类型“{0}”在 {1} 上具有密封修饰符，但在 {2} 上没有</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="translated">列舉 '{1}' 中的欄位 '{0}' 值已從 '{2}' 變更為 '{3}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExperimentalApiBecomesStable">
+        <source>API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</source>
+        <target state="new">API '{0}' was previously marked experimental and is now stable. Treat this as a new stable API and complete the required API documentation and review.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IndexShouldBeWithinSetSizeRange">
         <source>The {0} index should be in the range zero through {1} inclusive.</source>
         <target state="translated">{0} 索引應在零到 {1} (含) 之間的範圍。</target>

--- a/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
+++ b/src/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility/xlf/Resources.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">'{0}' 的值應大於 0。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StableApiBecomesExperimental">
+        <source>API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</source>
+        <target state="new">API '{0}' was previously stable and is now marked experimental. Existing consumers will receive diagnostics when using this API.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TypeIsActuallySealed">
         <source>Type '{0}' has the sealed modifier on {1} but not on {2}</source>
         <target state="translated">類型 '{0}' 在 {1} 上有密封的修飾元，但在 {2} 上沒有</target>

--- a/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
+++ b/src/Compatibility/Microsoft.DotNet.ApiSymbolExtensions/Filtering/DocIdSymbolFilter.cs
@@ -66,6 +66,11 @@ namespace Microsoft.DotNet.ApiSymbolExtensions.Filtering
         public bool Include(ISymbol symbol)
         {
             string? docId = symbol.GetDocumentationCommentId();
+            if (symbol is IErrorTypeSymbol errorType && (docId is null || docId.StartsWith("!:", StringComparison.Ordinal)))
+            {
+                docId = $"T:{errorType.ContainingNamespace}.{errorType.MetadataName}";
+            }
+
             if (docId is not null && _docIds.Contains(docId))
             {
                 return _includeDocIds;

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
     {
         private const string TestAssetName = "ApiCompatValidateAssembliesTestProject";
 
-        [TestMethod] 
+        [TestMethod]
         public void ApiCompatTool_AssembliesIdentical_ExitsZero()
         {
             string assembly = BuildAsset(nameof(ApiCompatTool_AssembliesIdentical_ExitsZero), forceBreakingChange: false);
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             result.Should().Pass();
         }
 
-        [TestMethod] 
+        [TestMethod]
         public void ApiCompatTool_BreakingChange_ReportsCP0002()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_BreakingChange_ReportsCP0002)}_left", forceBreakingChange: false);
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
                 .And.Contain("Goodbye");
         }
 
-        [TestMethod] 
+        [TestMethod]
         public void ApiCompatTool_SuppressionFile_RoundTrip()
         {
             string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_SuppressionFile_RoundTrip)}_left", forceBreakingChange: false);
@@ -68,7 +68,55 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
             consumeResult.StdOut.Should().NotContain("error CP0002");
         }
 
-        [TestMethod] 
+        [TestMethod]
+        public void ApiCompatTool_ExperimentalRemoval_IsInformational()
+        {
+            string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_ExperimentalRemoval_IsInformational)}_left", forceBreakingChange: false,
+                "-p:IncludeExperimentalApis=true");
+            string implementationAssembly = BuildAsset($"{nameof(ApiCompatTool_ExperimentalRemoval_IsInformational)}_right", forceBreakingChange: false);
+
+            var result = Run("--left", contractAssembly, "--right", implementationAssembly);
+
+            result.Should().Pass();
+            string output = result.StdOut + result.StdErr;
+            output.Should().Contain("CP0002")
+                .And.Contain("ExperimentalRemoved");
+        }
+
+        [TestMethod]
+        public void ApiCompatTool_ExperimentalPromotion_FailsAndCanBeSuppressed()
+        {
+            string contractAssembly = BuildAsset($"{nameof(ApiCompatTool_ExperimentalPromotion_FailsAndCanBeSuppressed)}_left", forceBreakingChange: false,
+                "-p:IncludeExperimentalApis=true");
+            string implementationAssembly = BuildAsset($"{nameof(ApiCompatTool_ExperimentalPromotion_FailsAndCanBeSuppressed)}_right", forceBreakingChange: false,
+                "-p:IncludeStablePromotedApi=true");
+            string suppressionFile = Path.Combine(Path.GetDirectoryName(implementationAssembly)!, "experimental-suppressions.xml");
+
+            var result = Run("--left", contractAssembly, "--right", implementationAssembly);
+
+            result.Should().Fail();
+            (result.StdOut + result.StdErr).Should().Contain("CP0022")
+                .And.Contain("Promoted");
+
+            Run(
+                "--left", contractAssembly,
+                "--right", implementationAssembly,
+                "--generate-suppression-file",
+                "--suppression-output-file", suppressionFile)
+                .Should().Pass();
+
+            string suppressions = File.ReadAllText(suppressionFile);
+            suppressions.Should().Contain("CP0022")
+                .And.NotContain("CP0002");
+
+            Run(
+                "--left", contractAssembly,
+                "--right", implementationAssembly,
+                "--suppression-file", suppressionFile)
+                .Should().Pass();
+        }
+
+        [TestMethod]
         public void ApiCompatTool_PackageMode_DetectsRemovedApi()
         {
             // Pack the existing PackageValidationTestProject twice to produce two .nupkg files
@@ -99,14 +147,19 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
         /// <summary>
         /// Builds a copy of the test asset and returns the absolute path to the produced assembly.
         /// </summary>
-        private string BuildAsset(string identifier, bool forceBreakingChange)
+        private string BuildAsset(string identifier, bool forceBreakingChange, params string[] additionalArguments)
         {
             TestAsset asset = TestAssetsManager
                 .CopyTestAsset(TestAssetName, identifier: identifier)
                 .WithSource();
 
-            var args = forceBreakingChange ? new[] { "-p:ForceBreakingChange=true" } : Array.Empty<string>();
-            new BuildCommand(asset).Execute(args).Should().Pass();
+            var args = new List<string>(additionalArguments);
+            if (forceBreakingChange)
+            {
+                args.Add("-p:ForceBreakingChange=true");
+            }
+
+            new BuildCommand(asset).Execute(args.ToArray()).Should().Pass();
 
             return Path.Combine(asset.TestRoot, "bin", "Debug",
                 ToolsetInfo.CurrentTargetFramework, $"{TestAssetName}.dll");

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Tool/ApiCompatToolIntegrationTests.cs
@@ -79,7 +79,8 @@ namespace Microsoft.DotNet.ApiCompat.IntegrationTests
 
             result.Should().Pass();
             string output = result.StdOut + result.StdErr;
-            output.Should().Contain("CP0002")
+            output.Should().Contain("info CP0002")
+                .And.NotContain("error CP0002")
                 .And.Contain("ExperimentalRemoved");
         }
 

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/CompatDifferenceTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/CompatDifferenceTests.cs
@@ -47,6 +47,14 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             CompatDifference differentType = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Added, "T:Foo");
             CompatDifference differentMemberId = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, string.Empty, DifferenceType.Removed, "T:FooBar");
             CompatDifference differentMessage = CompatDifference.CreateWithDefaultMetadata(DiagnosticIds.TypeMustExist, "Hello", DifferenceType.Removed, "T:Foo");
+            CompatDifference differentSeverity = new(
+                difference.Left,
+                difference.Right,
+                difference.DiagnosticId,
+                difference.Message,
+                difference.Type,
+                difference.ReferenceId,
+                DifferenceSeverity.Informational);
 
             Assert.IsFalse(difference.Equals(null));
             Assert.IsTrue(difference.Equals(otherEqual));
@@ -55,6 +63,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.IsFalse(difference.Equals(differentType));
             Assert.IsFalse(difference.Equals(differentMemberId));
             Assert.IsTrue(difference.Equals(differentMessage));
+            Assert.IsTrue(difference.Equals(differentSeverity));
+            Assert.AreEqual(difference.GetHashCode(), differentSeverity.GetHashCode());
         }
     }
 }

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/DifferenceVisitorTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/DifferenceVisitorTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.ApiCompatibility.Mapping;
+using Moq;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    [TestClass]
+    public class DifferenceVisitorTests
+    {
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void DuplicateDifferencesRetainError(bool informationalFirst)
+        {
+            CompatDifference error = CompatDifference.CreateWithDefaultMetadata(
+                DiagnosticIds.TypeMustExist,
+                "Duplicate",
+                DifferenceType.Removed,
+                "T:Foo");
+            CompatDifference informational = new(
+                error.Left,
+                error.Right,
+                error.DiagnosticId,
+                error.Message,
+                error.Type,
+                error.ReferenceId,
+                DifferenceSeverity.Informational);
+            CompatDifference[] differences = informationalFirst ? [informational, error] : [error, informational];
+            Mock<IMemberMapper> mapper = new();
+            mapper.Setup(m => m.GetDifferences()).Returns(differences);
+            DifferenceVisitor visitor = new();
+
+            visitor.Visit(mapper.Object);
+
+            CompatDifference difference = Assert.ContainsSingle(visitor.CompatDifferences);
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+    }
+}

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Rules;
+using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
 namespace Microsoft.DotNet.ApiCompatibility.Tests
@@ -164,6 +165,51 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             Assert.IsNotEmpty(differences);
             Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
+        }
+
+        [TestMethod]
+        public void ExcludedExperimentalAttributeDoesNotChangeDifferenceSeverity()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Removed() { }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { }";
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(
+                leftSyntax,
+                rightSyntax,
+                attributeDataSymbolFilter: CreateExperimentalAttributeExclusionFilter()));
+
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void ExcludedExperimentalAttributeDoesNotReportStabilityTransition(bool experimentalOnLeft)
+        {
+            string experimentalSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Changed() { }
+                }
+                """;
+            const string stableSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+
+            CompatDifference[] differences = GetDifferences(
+                experimentalOnLeft ? experimentalSyntax : stableSyntax,
+                experimentalOnLeft ? stableSyntax : experimentalSyntax,
+                includeAttributesRule: true,
+                attributeDataSymbolFilter: CreateExperimentalAttributeExclusionFilter());
+
+            Assert.IsEmpty(differences);
         }
 
         [TestMethod]
@@ -485,7 +531,13 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
                 SymbolFactory.GetAssemblyFromSyntax(rightSyntax)).ToArray();
         }
 
-        private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false, bool includeVirtualRule = false)
+        private static CompatDifference[] GetDifferences(
+            string leftSyntax,
+            string rightSyntax,
+            bool strictMode = false,
+            bool includeAttributesRule = false,
+            bool includeVirtualRule = false,
+            ISymbolFilter? attributeDataSymbolFilter = null)
         {
             TestRuleFactory ruleFactory = new(
                 (settings, context) => new MembersMustExist(settings, context),
@@ -504,8 +556,15 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
             IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
             ApiComparer comparer = new(ruleFactory, new ApiComparerSettings(strictMode: strictMode));
+            if (attributeDataSymbolFilter is not null)
+            {
+                comparer.Settings.AttributeDataSymbolFilter = attributeDataSymbolFilter;
+            }
 
             return comparer.GetDifferences(left, right).ToArray();
         }
+
+        private static ISymbolFilter CreateExperimentalAttributeExclusionFilter() =>
+            DocIdSymbolFilter.CreateFromLists(["T:System.Diagnostics.CodeAnalysis.ExperimentalAttribute"]);
     }
 }

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -268,7 +268,9 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
-        public void StableToExperimentalRemainsGenericAttributeError()
+        [DataRow(false)]
+        [DataRow(true)]
+        public void StableToExperimentalIsReportedByDefault(bool includeAttributesRule)
         {
             string leftSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
             string rightSyntax = $$"""
@@ -280,8 +282,109 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
                 }
                 """;
 
-            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax, strictMode: true, includeAttributesRule: true)
-                .Where(difference => difference.DiagnosticId == DiagnosticIds.CannotAddAttribute));
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax, includeAttributesRule: includeAttributesRule));
+
+            Assert.AreEqual(DiagnosticIds.StableApiBecomesExperimental, difference.DiagnosticId);
+            Assert.AreEqual("M:CompatTests.Api.Changed", difference.ReferenceId);
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
+        public void StableTypeToExperimentalIsReportedByDefault()
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { }";
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class Api { }
+                """;
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.HasCount(2, differences);
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "T:CompatTests.Api"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.#ctor"));
+            Assert.IsTrue(differences.All(difference => difference.DiagnosticId == DiagnosticIds.StableApiBecomesExperimental));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
+        }
+
+        [TestMethod]
+        public void StablePropertyAndEventToExperimentalReportAccessorsByDefault()
+        {
+            const string leftSyntax = """
+                namespace CompatTests;
+                public delegate void Handler();
+                public class Api
+                {
+                    public int Property { get; set; }
+                    public event Handler Event;
+                }
+                """;
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                public delegate void Handler();
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public int Property { get; set; }
+                    {{ExperimentalAttribute}}
+                    public event Handler Event;
+                }
+                """;
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.HasCount(6, differences);
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "P:CompatTests.Api.Property"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.get_Property"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.set_Property(System.Int32)"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "E:CompatTests.Api.Event"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.add_Event(CompatTests.Handler)"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.remove_Event(CompatTests.Handler)"));
+            Assert.IsTrue(differences.All(difference => difference.DiagnosticId == DiagnosticIds.StableApiBecomesExperimental));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
+        }
+
+        [TestMethod]
+        [DataRow("assembly")]
+        [DataRow("module")]
+        public void AddingExperimentalCompilationScopeIsReportedByDefault(string attributeTarget)
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+            string rightSyntax = $$"""
+                [{{attributeTarget}}: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                namespace CompatTests;
+                public class Api { public void Changed() { } }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
+                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
+
+            Assert.AreEqual(DiagnosticIds.StableApiBecomesExperimental, difference.DiagnosticId);
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
+        public void AttributesRuleAloneReportsStableToExperimental()
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Changed() { }
+                }
+                """;
+            TestRuleFactory ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
+            ApiComparer comparer = new(ruleFactory);
+
+            CompatDifference difference = Assert.ContainsSingle(comparer.GetDifferences(
+                SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                SymbolFactory.GetAssemblyFromSyntax(rightSyntax)));
+
+            Assert.AreEqual(DiagnosticIds.StableApiBecomesExperimental, difference.DiagnosticId);
+            Assert.AreEqual("M:CompatTests.Api.Changed", difference.ReferenceId);
             Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
         }
 

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -129,6 +129,45 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
+        [DataRow("assembly")]
+        [DataRow("module")]
+        public void MemberInExperimentalCompilationScopeIsInformational(string attributeTarget)
+        {
+            string leftSyntax = $$"""
+                [{{attributeTarget}}: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                namespace CompatTests;
+                public class Api { public void Changed() { } }
+                """;
+            string rightSyntax = $$"""
+                [{{attributeTarget}}: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                namespace CompatTests;
+                public class Api { }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
+                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
+            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+        }
+
+        [TestMethod]
+        [DataRow("assembly")]
+        [DataRow("module")]
+        public void RemovingExperimentalCompilationScopeReportsPromotion(string attributeTarget)
+        {
+            string leftSyntax = $$"""
+                [{{attributeTarget}}: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                namespace CompatTests;
+                public class Api { public void Changed() { } }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
+                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
+            Assert.AreEqual(DiagnosticIds.ExperimentalApiBecomesStable, difference.DiagnosticId);
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
         public void StableToExperimentalRemainsGenericAttributeError()
         {
             string leftSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -204,6 +204,30 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.IsTrue(differences.All(difference => difference.DiagnosticId == DiagnosticIds.ExperimentalApiBecomesStable));
         }
 
+        [TestMethod]
+        public void AttributesRuleAloneReportsPromotion()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Changed() { }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+            TestRuleFactory ruleFactory = new((settings, context) => new AttributesMustMatch(settings, context));
+            ApiComparer comparer = new(ruleFactory);
+
+            CompatDifference difference = Assert.ContainsSingle(comparer.GetDifferences(
+                SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                SymbolFactory.GetAssemblyFromSyntax(rightSyntax)));
+
+            Assert.AreEqual(DiagnosticIds.ExperimentalApiBecomesStable, difference.DiagnosticId);
+            Assert.AreEqual("M:CompatTests.Api.Changed", difference.ReferenceId);
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
         private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false)
         {
             TestRuleFactory ruleFactory = new(

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -283,7 +283,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         {
             TestRuleFactory ruleFactory = new(
                 (settings, context) => new MembersMustExist(settings, context),
-                (settings, context) => new ExperimentalApiBecomesStable(context));
+                (settings, context) => new ExperimentalApiBecomesStable(settings, context));
 
             if (includeAttributesRule)
             {

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
-        public void BreakingChangesRemainInformationalWhileApiRemainsExperimental()
+        public void BreakingChangesToMemberInExperimentalTypeRemainErrors()
         {
             string leftSyntax = $$"""
                 namespace CompatTests;
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
 
             Assert.IsNotEmpty(differences);
-            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
         }
 
         [TestMethod]
@@ -210,22 +210,26 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
-        public void MemberInExperimentalContainingTypeUsesContainingTypeStability()
+        public void ExperimentalContainingTypeDoesNotMakeMemberExperimental()
         {
             string leftSyntax = $$"""
                 namespace CompatTests;
-                {{ExperimentalAttribute}}
-                public class Api { public void Changed() { } }
+                {{ExperimentalAttribute}} public class ExperimentalBase { public void Changed() { } }
+                #pragma warning disable TEST001
+                public class StableDerived : ExperimentalBase { }
+                #pragma warning restore TEST001
                 """;
             string rightSyntax = $$"""
                 namespace CompatTests;
-                {{ExperimentalAttribute}}
-                public class Api { }
+                {{ExperimentalAttribute}} public class ExperimentalBase { }
+                #pragma warning disable TEST001
+                public class StableDerived : ExperimentalBase { }
+                #pragma warning restore TEST001
                 """;
 
             CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
-                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
-            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+                .Where(difference => difference.ReferenceId == "M:CompatTests.ExperimentalBase.Changed"));
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
         }
 
         [TestMethod]
@@ -301,9 +305,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
 
             CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
 
-            Assert.HasCount(2, differences);
+            Assert.HasCount(1, differences);
             Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "T:CompatTests.Api"));
-            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.#ctor"));
             Assert.IsTrue(differences.All(difference => difference.DiagnosticId == DiagnosticIds.StableApiBecomesExperimental));
             Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
         }

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -213,6 +213,51 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void UserDefinedExperimentalAttributeRequiresStringConstructor(bool hasStringConstructor)
+        {
+            string constructorParameterType = hasStringConstructor ? "string" : "int";
+            string constructorArgument = hasStringConstructor ? "\"TEST001\"" : "1";
+            string attributeDefinition = $$"""
+                #pragma warning disable CS0436
+                namespace System.Diagnostics.CodeAnalysis
+                {
+                    [global::System.AttributeUsage(global::System.AttributeTargets.All)]
+                    public sealed class ExperimentalAttribute : global::System.Attribute
+                    {
+                        public ExperimentalAttribute({{constructorParameterType}} diagnosticId) { }
+                    }
+                }
+                """;
+            string leftSyntax = $$"""
+                {{attributeDefinition}}
+                namespace CompatTests
+                {
+                    public class Api
+                    {
+                        [System.Diagnostics.CodeAnalysis.Experimental({{constructorArgument}})]
+                        public void Removed() { }
+                    }
+                }
+                """;
+            string rightSyntax = $$"""
+                {{attributeDefinition}}
+                namespace CompatTests
+                {
+                    public class Api { }
+                }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
+                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Removed"));
+
+            Assert.AreEqual(
+                hasStringConstructor ? DifferenceSeverity.Informational : DifferenceSeverity.Error,
+                difference.Severity);
+        }
+
+        [TestMethod]
         public void BreakingChangesToMemberInExperimentalTypeRemainErrors()
         {
             string leftSyntax = $$"""

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Rules;
+using Microsoft.DotNet.ApiSymbolExtensions;
 using Microsoft.DotNet.ApiSymbolExtensions.Filtering;
 using Microsoft.DotNet.ApiSymbolExtensions.Tests;
 
@@ -255,6 +256,49 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.AreEqual(
                 hasStringConstructor ? DifferenceSeverity.Informational : DifferenceSeverity.Error,
                 difference.Severity);
+        }
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void FrameworkExperimentalAttributeWithoutAssemblyReferencesHonorsFilter(bool excludeExperimentalAttribute)
+        {
+            string leftAssemblyPath = SymbolFactory.EmitAssemblyFromSyntax($$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Experimental() { }
+                }
+                """, assemblyName: "ExperimentalAttributeMetadataLeft");
+            string rightAssemblyPath = SymbolFactory.EmitAssemblyFromSyntax(
+                "namespace CompatTests; public class Api { }",
+                assemblyName: "ExperimentalAttributeMetadataRight");
+
+            try
+            {
+                IAssemblySymbol left = new AssemblySymbolLoader(new SuppressibleTestLog()).LoadAssembly(leftAssemblyPath)
+                    ?? throw new InvalidOperationException($"Failed to load '{leftAssemblyPath}'.");
+                IAssemblySymbol right = new AssemblySymbolLoader(new SuppressibleTestLog()).LoadAssembly(rightAssemblyPath)
+                    ?? throw new InvalidOperationException($"Failed to load '{rightAssemblyPath}'.");
+                TestRuleFactory ruleFactory = new((settings, context) => new MembersMustExist(settings, context));
+                ApiComparer comparer = new(ruleFactory);
+                ISymbolFilter filter = SymbolFilterFactory.GetFilterFromList(
+                    excludeExperimentalAttribute ? ["T:System.Diagnostics.CodeAnalysis.ExperimentalAttribute"] : null);
+                comparer.Settings.AttributeDataSymbolFilter = filter;
+
+                CompatDifference difference = Assert.ContainsSingle(comparer.GetDifferences(left, right)
+                    .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Experimental"));
+
+                Assert.AreEqual(
+                    excludeExperimentalAttribute ? DifferenceSeverity.Error : DifferenceSeverity.Informational,
+                    difference.Severity);
+            }
+            finally
+            {
+                Directory.Delete(Path.GetDirectoryName(leftAssemblyPath)!, recursive: true);
+                Directory.Delete(Path.GetDirectoryName(rightAssemblyPath)!, recursive: true);
+            }
         }
 
         [TestMethod]

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -228,6 +228,57 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
         }
 
+        [TestMethod]
+        public void ExperimentalAssemblyIdentityDifferenceIsInformational()
+        {
+            const string leftSyntax = """
+                [assembly: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                [assembly: System.Reflection.AssemblyVersion("2.0.0.0")]
+                """;
+            const string rightSyntax = """
+                [assembly: System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+                [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetAssemblyIdentityDifferences(leftSyntax, rightSyntax));
+
+            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+        }
+
+        [TestMethod]
+        public void StableAssemblyIdentityDifferenceRemainsError()
+        {
+            const string leftSyntax = "[assembly: System.Reflection.AssemblyVersion(\"2.0.0.0\")]";
+            const string rightSyntax = "[assembly: System.Reflection.AssemblyVersion(\"1.0.0.0\")]";
+
+            CompatDifference difference = Assert.ContainsSingle(GetAssemblyIdentityDifferences(leftSyntax, rightSyntax));
+
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
+        public void RemovedExperimentalAssemblyIsInformational()
+        {
+            const string leftSyntax = "[assembly: System.Diagnostics.CodeAnalysis.Experimental(\"TEST001\")]";
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            TestRuleFactory ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(new SuppressibleTestLog(), settings, context));
+            ApiComparer comparer = new(ruleFactory);
+
+            CompatDifference difference = Assert.ContainsSingle(comparer.GetDifferences([left], Array.Empty<IAssemblySymbol>()));
+
+            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+        }
+
+        private static CompatDifference[] GetAssemblyIdentityDifferences(string leftSyntax, string rightSyntax)
+        {
+            TestRuleFactory ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(new SuppressibleTestLog(), settings, context));
+            ApiComparer comparer = new(ruleFactory);
+
+            return comparer.GetDifferences(
+                SymbolFactory.GetAssemblyFromSyntax(leftSyntax),
+                SymbolFactory.GetAssemblyFromSyntax(rightSyntax)).ToArray();
+        }
+
         private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false)
         {
             TestRuleFactory ruleFactory = new(

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -34,6 +34,106 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
         }
 
         [TestMethod]
+        public void RemovedExperimentalPropertyIsInformational()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public int Removed { get; set; }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.HasCount(2, differences);
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.get_Removed"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.set_Removed(System.Int32)"));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
+        public void MutatedExperimentalPropertyIsInformational()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public int Changed { get; set; }
+                }
+                """;
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public int Changed { get; }
+                }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax));
+
+            Assert.AreEqual("M:CompatTests.Api.set_Changed(System.Int32)", difference.ReferenceId);
+            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+        }
+
+        [TestMethod]
+        public void RemovedExperimentalEventIsInformational()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public delegate void Handler();
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public event Handler Removed;
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public delegate void Handler(); public class Api { }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.HasCount(2, differences);
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.add_Removed(CompatTests.Handler)"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.remove_Removed(CompatTests.Handler)"));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
+        public void MutatedExperimentalEventIsInformational()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public delegate void Handler();
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public virtual event Handler Changed;
+                }
+                """;
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                public delegate void Handler();
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public event Handler Changed;
+                }
+                """;
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax, includeVirtualRule: true);
+
+            Assert.HasCount(3, differences);
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.add_Changed(CompatTests.Handler)"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.remove_Changed(CompatTests.Handler)"));
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "E:CompatTests.Api.Changed"));
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
         public void NewExperimentalTypeAndMemberAreInformationalInStrictMode()
         {
             string leftSyntax = "namespace CompatTests; public class Api { }";
@@ -279,7 +379,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
                 SymbolFactory.GetAssemblyFromSyntax(rightSyntax)).ToArray();
         }
 
-        private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false)
+        private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false, bool includeVirtualRule = false)
         {
             TestRuleFactory ruleFactory = new(
                 (settings, context) => new MembersMustExist(settings, context),
@@ -288,6 +388,11 @@ namespace Microsoft.DotNet.ApiCompatibility.Tests
             if (includeAttributesRule)
             {
                 ruleFactory = ruleFactory.WithRule((settings, context) => new AttributesMustMatch(settings, context));
+            }
+
+            if (includeVirtualRule)
+            {
+                ruleFactory = ruleFactory.WithRule((settings, context) => new CannotAddOrRemoveVirtualKeyword(settings, context));
             }
 
             IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/ExperimentalApiTests.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.ApiCompatibility.Rules;
+using Microsoft.DotNet.ApiSymbolExtensions.Tests;
+
+namespace Microsoft.DotNet.ApiCompatibility.Tests
+{
+    [TestClass]
+    public class ExperimentalApiTests
+    {
+        private const string ExperimentalAttribute = "[System.Diagnostics.CodeAnalysis.Experimental(\"TEST001\")]";
+
+        [TestMethod]
+        public void RemovedExperimentalTypeAndMemberAreInformational()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class RemovedType { }
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Removed() { }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.IsNotEmpty(differences);
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
+        public void NewExperimentalTypeAndMemberAreInformationalInStrictMode()
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { }";
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class AddedType { }
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Added() { }
+                }
+                """;
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax, strictMode: true);
+
+            Assert.IsNotEmpty(differences);
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
+        public void NewStableTypeAndMemberRemainErrorsInStrictMode()
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { }";
+            string rightSyntax = "namespace CompatTests; public class AddedType { } public class Api { public void Added() { } }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax, strictMode: true);
+
+            Assert.IsNotEmpty(differences);
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Error));
+        }
+
+        [TestMethod]
+        public void BreakingChangesRemainInformationalWhileApiRemainsExperimental()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class Api { public string Changed() => string.Empty; }
+                """;
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class Api { public int Changed() => 0; }
+                """;
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.IsNotEmpty(differences);
+            Assert.IsTrue(differences.All(difference => difference.Severity == DifferenceSeverity.Informational));
+        }
+
+        [TestMethod]
+        public void ExperimentalTypeAndMemberPromotionIsReportedAsError()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class ExperimentalType { }
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void ExperimentalMember() { }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class ExperimentalType { } public class Api { public void ExperimentalMember() { } }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax);
+
+            Assert.HasCount(1, differences.Where(difference => difference.DiagnosticId == DiagnosticIds.ExperimentalApiBecomesStable && difference.ReferenceId == "T:CompatTests.ExperimentalType"));
+            Assert.HasCount(1, differences.Where(difference => difference.DiagnosticId == DiagnosticIds.ExperimentalApiBecomesStable && difference.ReferenceId == "M:CompatTests.Api.ExperimentalMember"));
+            Assert.IsTrue(differences.Where(difference => difference.DiagnosticId == DiagnosticIds.ExperimentalApiBecomesStable)
+                .All(difference => difference.Severity == DifferenceSeverity.Error));
+        }
+
+        [TestMethod]
+        public void MemberInExperimentalContainingTypeUsesContainingTypeStability()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class Api { public void Changed() { } }
+                """;
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                {{ExperimentalAttribute}}
+                public class Api { }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax)
+                .Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
+            Assert.AreEqual(DifferenceSeverity.Informational, difference.Severity);
+        }
+
+        [TestMethod]
+        public void StableToExperimentalRemainsGenericAttributeError()
+        {
+            string leftSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+            string rightSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Changed() { }
+                }
+                """;
+
+            CompatDifference difference = Assert.ContainsSingle(GetDifferences(leftSyntax, rightSyntax, strictMode: true, includeAttributesRule: true)
+                .Where(difference => difference.DiagnosticId == DiagnosticIds.CannotAddAttribute));
+            Assert.AreEqual(DifferenceSeverity.Error, difference.Severity);
+        }
+
+        [TestMethod]
+        public void PromotionDoesNotDuplicateGenericAttributeDiagnostic()
+        {
+            string leftSyntax = $$"""
+                namespace CompatTests;
+                public class Api
+                {
+                    {{ExperimentalAttribute}}
+                    public void Changed() { }
+                }
+                """;
+            string rightSyntax = "namespace CompatTests; public class Api { public void Changed() { } }";
+
+            CompatDifference[] differences = GetDifferences(leftSyntax, rightSyntax, includeAttributesRule: true);
+
+            Assert.ContainsSingle(differences.Where(difference => difference.ReferenceId == "M:CompatTests.Api.Changed"));
+            Assert.IsTrue(differences.All(difference => difference.DiagnosticId == DiagnosticIds.ExperimentalApiBecomesStable));
+        }
+
+        private static CompatDifference[] GetDifferences(string leftSyntax, string rightSyntax, bool strictMode = false, bool includeAttributesRule = false)
+        {
+            TestRuleFactory ruleFactory = new(
+                (settings, context) => new MembersMustExist(settings, context),
+                (settings, context) => new ExperimentalApiBecomesStable(context));
+
+            if (includeAttributesRule)
+            {
+                ruleFactory = ruleFactory.WithRule((settings, context) => new AttributesMustMatch(settings, context));
+            }
+
+            IAssemblySymbol left = SymbolFactory.GetAssemblyFromSyntax(leftSyntax);
+            IAssemblySymbol right = SymbolFactory.GetAssemblyFromSyntax(rightSyntax);
+            ApiComparer comparer = new(ruleFactory, new ApiComparerSettings(strictMode: strictMode));
+
+            return comparer.GetDifferences(left, right).ToArray();
+        }
+    }
+}

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
         }
 
         [TestMethod]
-        public void ExecuteWorkItems_SuppressedInformationalDifference_IsNotLogged()
+        public void ExecuteWorkItems_InformationalDifference_IsLoggedWithoutSuppression()
         {
             MetadataInformation left = new("A.dll", @"lib\netstandard2.0\A.dll");
             MetadataInformation right = new("A.dll", @"lib\net462\A.dll");
@@ -153,9 +153,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
 
             apiCompatRunner.ExecuteWorkItems();
 
-            suppressionEngineMock.Verify(m => m.IsErrorSuppressed(It.Is<Suppression>(suppression =>
-                suppression.DiagnosticId == "CP0001" && suppression.Target == "X01")), Times.Once);
-            logMock.Verify(m => m.LogMessage(MessageImportance.Normal, It.IsAny<string>()), Times.Never);
+            suppressionEngineMock.Verify(m => m.IsErrorSuppressed(It.IsAny<Suppression>()), Times.Never);
+            logMock.Verify(m => m.LogMessage(MessageImportance.Normal, "info CP0001: Invalid"), Times.Once);
         }
     }
 }

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Runner/ApiCompatRunnerTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.DotNet.ApiCompatibility.Logging;
 using Microsoft.DotNet.ApiSymbolExtensions;
+using Microsoft.DotNet.ApiSymbolExtensions.Logging;
 using Moq;
 
 namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
@@ -14,26 +15,35 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
     public class ApiCompatRunnerTests
     {
         private static ApiCompatRunner MockApiCompatRunner(MetadataInformation left = default,
-            MetadataInformation right = default)
+            MetadataInformation right = default,
+            DifferenceSeverity severity = DifferenceSeverity.Error,
+            bool isSuppressed = false,
+            Mock<ISuppressibleLog> logMock = null,
+            Mock<ISuppressionEngine> suppressionEngineMock = null)
         {
             // Mock the api comparer's GetDifferences method so that it returns items.
             Mock<IApiComparer> apiComparerMock = new();
             apiComparerMock
-                .Setup(y => y.GetDifferences(It.IsAny<ElementContainer<IAssemblySymbol>>(), It.IsAny<IReadOnlyList<ElementContainer<IAssemblySymbol>>>()))
+                .Setup(y => y.GetDifferences(
+                    It.IsAny<IEnumerable<ElementContainer<IAssemblySymbol>>>(),
+                    It.IsAny<IReadOnlyList<IEnumerable<ElementContainer<IAssemblySymbol>>>>()))
                 .Returns(new CompatDifference[]
                 {
-                    new CompatDifference(left, right, "CP0001", "Invalid", DifferenceType.Removed, "X01")
+                    new CompatDifference(left, right, "CP0001", "Invalid", DifferenceType.Removed, "X01", severity)
                 });
+            apiComparerMock
+                .SetupGet(y => y.Settings)
+                .Returns(new ApiComparerSettings());
             Mock<IApiComparerFactory> apiComparerFactoryMock = new();
             apiComparerFactoryMock
                 .Setup(x => x.Create())
                 .Returns(apiComparerMock.Object);
 
             // Mock the suppression engine
-            Mock<ISuppressionEngine> suppressionEngineMock = new();
+            suppressionEngineMock ??= new();
             suppressionEngineMock
                 .Setup(m => m.IsErrorSuppressed(It.IsAny<Suppression>()))
-                .Returns(false);
+                .Returns(isSuppressed);
 
             // Mock the assembly symbol loader factory to return a default assembly symbol loader.
             Mock<IAssemblySymbolLoader> assemblySymbolLoaderMock = new();
@@ -41,7 +51,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
                 .Setup(y => y.LoadAssemblies(It.IsAny<string[]>()))
                 .Returns(new IAssemblySymbol[]
                 {
-                    null
+                    Mock.Of<IAssemblySymbol>()
                 });
 
             Mock<IAssemblySymbolLoaderFactory> assemblyLoaderFactoryMock = new();
@@ -49,7 +59,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
                 .Setup(m => m.Create(It.IsAny<bool>()))
                 .Returns(assemblySymbolLoaderMock.Object);
 
-            return new(Mock.Of<ISuppressibleLog>(),
+            return new((logMock ?? new()).Object,
                 suppressionEngineMock.Object,
                 apiComparerFactoryMock.Object,
                 assemblyLoaderFactoryMock.Object);
@@ -123,6 +133,29 @@ namespace Microsoft.DotNet.ApiCompatibility.Runner.Tests
             apiCompatRunner.ExecuteWorkItems();
 
             Assert.IsEmpty(apiCompatRunner.WorkItems);
+        }
+
+        [TestMethod]
+        public void ExecuteWorkItems_SuppressedInformationalDifference_IsNotLogged()
+        {
+            MetadataInformation left = new("A.dll", @"lib\netstandard2.0\A.dll");
+            MetadataInformation right = new("A.dll", @"lib\net462\A.dll");
+            Mock<ISuppressibleLog> logMock = new();
+            Mock<ISuppressionEngine> suppressionEngineMock = new();
+            ApiCompatRunner apiCompatRunner = MockApiCompatRunner(
+                left,
+                right,
+                DifferenceSeverity.Informational,
+                isSuppressed: true,
+                logMock,
+                suppressionEngineMock);
+            apiCompatRunner.EnqueueWorkItem(new ApiCompatRunnerWorkItem(left, new ApiCompatRunnerOptions(), right));
+
+            apiCompatRunner.ExecuteWorkItems();
+
+            suppressionEngineMock.Verify(m => m.IsErrorSuppressed(It.Is<Suppression>(suppression =>
+                suppression.DiagnosticId == "CP0001" && suppression.Target == "X01")), Times.Once);
+            logMock.Verify(m => m.LogMessage(MessageImportance.Normal, It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/ApiCompatValidateAssembliesTestProject.csproj
+++ b/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/ApiCompatValidateAssembliesTestProject.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
     <DefineConstants Condition="'$(ForceBreakingChange)' == 'true'">$(DefineConstants);ForceBreakingChange</DefineConstants>
     <DefineConstants Condition="'$(AddNewMember)' == 'true'">$(DefineConstants);AddNewMember</DefineConstants>
+    <DefineConstants Condition="'$(IncludeExperimentalApis)' == 'true'">$(DefineConstants);IncludeExperimentalApis</DefineConstants>
+    <DefineConstants Condition="'$(IncludeStablePromotedApi)' == 'true'">$(DefineConstants);IncludeStablePromotedApi</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/Greeter.cs
+++ b/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/Greeter.cs
@@ -21,9 +21,7 @@ namespace ApiCompatValidateAssembliesTestProject
 
         [System.Diagnostics.CodeAnalysis.Experimental("TEST002")]
         public string Promoted(string name) => $"Promoted hello, {name}!";
-#endif
-
-#if IncludeStablePromotedApi
+#elif IncludeStablePromotedApi
         public string Promoted(string name) => $"Promoted hello, {name}!";
 #endif
     }

--- a/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/Greeter.cs
+++ b/test/TestAssets/TestProjects/ApiCompatValidateAssembliesTestProject/Greeter.cs
@@ -14,5 +14,17 @@ namespace ApiCompatValidateAssembliesTestProject
 #if AddNewMember
         public string Welcome(string name) => $"Welcome, {name}!";
 #endif
+
+#if IncludeExperimentalApis
+        [System.Diagnostics.CodeAnalysis.Experimental("TEST001")]
+        public string ExperimentalRemoved(string name) => $"Experimental goodbye, {name}!";
+
+        [System.Diagnostics.CodeAnalysis.Experimental("TEST002")]
+        public string Promoted(string name) => $"Promoted hello, {name}!";
+#endif
+
+#if IncludeStablePromotedApi
+        public string Promoted(string name) => $"Promoted hello, {name}!";
+#endif
     }
 }


### PR DESCRIPTION
Adds a new `DifferenceSeverity` (`Error` / `Informational`) to `CompatDifference` and uses it so that ApiCompat no longer hard-fails on compatibility differences that are confined to `System.Diagnostics.CodeAnalysis.Experimental` APIs. Instead:

- Differences where the affected API is `Experimental` on both sides (or was added/removed while experimental) are logged as informational messages, not build errors, and are excluded from suppression-file generation. Property and event accessors inherit the stability of their associated symbol.
- When an API stops being `Experimental` (i.e. "graduates" to stable), `CP0022` (`ExperimentalApiBecomesStable`) is raised as an error, prompting the author to treat it as a new stable API requiring doc/review.
- When a stable API becomes `Experimental`, `CP0023` (`StableApiBecomesExperimental`) is raised as an error because existing consumers will begin receiving compiler diagnostics.
- `AttributesMustMatch` routes `Experimental` additions and removals through these diagnostics regardless of strict mode, avoiding generic attribute diagnostics and duplicate reports.

Resolves https://github.com/dotnet/sdk/issues/50637