### PR TITLE
Fix dotnet-watch dependency output races

### DIFF
--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
@@ -122,8 +122,7 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         await hasUpdatedOutput.Task;
 
         Log("Waiting for dependency resolution...");
-        using var dependencyWaitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await hasResolvedDependency.Task.WaitAsync(dependencyWaitCts.Token);
+        await hasResolvedDependency.Task.WaitAsync(w.ShutdownSource.Token);
 
         // Wait for the fire-and-forget task in CompilationHandler.CompleteApplyOperationAsync
         // to finish logging ManagedCodeChangesApplied. The app output arrives before this task
@@ -193,8 +192,7 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         await hasUpdatedOutput.Task;
 
         Log("Waiting for dependency resolution...");
-        using var dependencyWaitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await hasResolvedDependency.Task.WaitAsync(dependencyWaitCts.Token);
+        await hasResolvedDependency.Task.WaitAsync(w.ShutdownSource.Token);
 
         // Wait for the fire-and-forget task in CompilationHandler.CompleteApplyOperationAsync
         // to finish logging ManagedCodeChangesApplied. The app output arrives before this task

--- a/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/ProjectUpdateInProcTests.cs
@@ -84,11 +84,17 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         var managedCodeChangesApplied = w.Observer.RegisterSemaphore(MessageDescriptor.ManagedCodeChangesApplied);
 
         var hasUpdatedOutput = w.CreateCompletionSource();
+        var hasResolvedDependency = w.CreateCompletionSource();
         w.Reporter.OnProcessOutput += line =>
         {
             if (line.Content.Contains("<Lib>"))
             {
                 hasUpdatedOutput.TrySetResult();
+            }
+
+            if (line.Content.Contains("Resolving 'Dependency, Version=1.0.0.0'"))
+            {
+                hasResolvedDependency.TrySetResult();
             }
         };
 
@@ -115,7 +121,9 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         Log("Waiting for output '<Lib>'...");
         await hasUpdatedOutput.Task;
 
-        AssertEx.ContainsSubstring("Resolving 'Dependency, Version=1.0.0.0'", w.Reporter.ProcessOutput);
+        Log("Waiting for dependency resolution...");
+        using var dependencyWaitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await hasResolvedDependency.Task.WaitAsync(dependencyWaitCts.Token);
 
         // Wait for the fire-and-forget task in CompilationHandler.CompleteApplyOperationAsync
         // to finish logging ManagedCodeChangesApplied. The app output arrives before this task
@@ -149,11 +157,17 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         var managedCodeChangesApplied = w.Observer.RegisterSemaphore(MessageDescriptor.ManagedCodeChangesApplied);
 
         var hasUpdatedOutput = w.CreateCompletionSource();
+        var hasResolvedDependency = w.CreateCompletionSource();
         w.Reporter.OnProcessOutput += line =>
         {
             if (line.Content.Contains("Newtonsoft.Json.Linq.JToken"))
             {
                 hasUpdatedOutput.TrySetResult();
+            }
+
+            if (line.Content.Contains("Resolving 'Newtonsoft.Json, Version=13.0.0.0'"))
+            {
+                hasResolvedDependency.TrySetResult();
             }
         };
 
@@ -178,7 +192,9 @@ public class ProjectUpdateInProcTests : DotNetWatchTestBase
         Log("Waiting for output 'Newtonsoft.Json.Linq.JToken'...");
         await hasUpdatedOutput.Task;
 
-        AssertEx.ContainsSubstring("Resolving 'Newtonsoft.Json, Version=13.0.0.0'", w.Reporter.ProcessOutput);
+        Log("Waiting for dependency resolution...");
+        using var dependencyWaitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await hasResolvedDependency.Task.WaitAsync(dependencyWaitCts.Token);
 
         // Wait for the fire-and-forget task in CompilationHandler.CompleteApplyOperationAsync
         // to finish logging ManagedCodeChangesApplied. The app output arrives before this task


### PR DESCRIPTION
## Summary

Fix timing races in the `dotnet-watch` project- and package-reference update tests.

The tests wait for application output and then immediately inspect a concurrently populated process-output list for the dependency resolver diagnostic. Application stdout can be delivered before the resolver diagnostic from the other redirected stream, even though resolution completed successfully. This caused `ProjectAndSourceFileChange_AddPackageReference` to fail intermittently on macOS arm64; the CI log showed the expected diagnostic arriving during teardown immediately after the assertion.

Register completion signals for the resolver diagnostics before starting watch and await them directly using the watcher's shutdown token. Apply the same fix to the project-reference variant tracked by #53661.

Fixes #53661

## Validation

- `dotnet-watch.Tests` builds successfully.
- `ProjectAndSourceFileChange_AddPackageReference`: passed.
- Package- and project-reference variants: 5 iterations, 10/10 passed using fresh scratch directories.
- Complete `ProjectUpdateInProcTests` class: 3/3 passed after the review update.