### PR TITLE
Fix flaky FileWatcher event assertions

### DIFF
--- a/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
+++ b/test/dotnet-watch.Tests/FileWatcher/FileWatcherTests.cs
@@ -47,6 +47,8 @@ public class FileWatcherTests
         }
 
         var operationCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expectedSet = new HashSet<ChangedPath>(expectedChanges);
+        Assert.HasCount(expectedChanges.Length, expectedSet, "expectedChanges must not contain duplicates.");
         var filesChanged = new HashSet<ChangedPath>();
 
         EventHandler<ChangedPath> handler = null;
@@ -54,14 +56,14 @@ public class FileWatcherTests
         {
             if (filesChanged.Add(f))
             {
-                Output.WriteLine($"Observed new {f.Kind}: '{f.Path}' ({filesChanged.Count} out of {expectedChanges.Length})");
+                Output.WriteLine($"Observed new {f.Kind}: '{f.Path}' ({filesChanged.Count} changes, {expectedSet.Count(filesChanged.Contains)} out of {expectedChanges.Length} expected)");
             }
             else
             {
                 Output.WriteLine($"Already seen {f.Kind}: '{f.Path}'");
             }
 
-            if (filesChanged.Count == expectedChanges.Length)
+            if (expectedSet.IsSubsetOf(filesChanged))
             {
                 watcher.EnableRaisingEvents = false;
                 watcher.OnFileChange -= handler;
@@ -85,7 +87,10 @@ public class FileWatcherTests
         var task = operationCompletionSource.Task;
         await (Debugger.IsAttached ? task : task.TimeoutAfter(DefaultTimeout));
 
-        AssertEx.SequenceEqual(expectedChanges, filesChanged.OrderBy(x => x.Path));
+        var missing = expectedSet.Except(filesChanged).OrderBy(x => x.Path).ToArray();
+        Assert.IsEmpty(
+            missing,
+            $"Expected changes not observed: {string.Join(", ", missing.Select(m => $"{m.Kind}: '{m.Path}'"))}\nActual changes: {string.Join(", ", filesChanged.OrderBy(x => x.Path).Select(m => $"{m.Kind}: '{m.Path}'"))}");
     }
 
     private sealed class TestFileWatcher(ILogger logger)


### PR DESCRIPTION
## Summary

Restore subset-based matching in `FileWatcherTests.TestOperation` so expected file-system events can arrive in any order and unrelated extra OS events do not complete the wait early.

An unrelated backport in #55483 recreated `FileWatcherTests.cs` from an older branch and removed this behavior, which had originally been added to stabilize platform-specific file watcher notifications. On macOS, `NewFileInNewDirectory` can report the expected `Add` and `Update` notifications in either order.

Fixes #55357

## Testing

- `FileWatcherTests.NewFileInNewDirectory`: 4 passed
- All `FileWatcherTests`: 25 passed