### PR TITLE
Validate PAT pool entries before selection

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -25,10 +25,10 @@
       "version": "v7.0.1",
       "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     },
-    "github/gh-aw-actions/setup@v0.82.9": {
+    "github/gh-aw-actions/setup@v0.83.1": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.82.9",
-      "sha": "ca8678ca22a7aab577514482576720da641e5661"
+      "version": "v0.83.1",
+      "sha": "8bdba8075360648fe6802302a5b4e016361dc6ac"
     }
   }
 }

--- a/.github/workflows/add-tactics-template-on-comment.lock.yml
+++ b/.github/workflows/add-tactics-template-on-comment.lock.yml
@@ -1568,27 +1568,56 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
+          # Collect pool entries that authenticate successfully with GitHub.
           PAT_NUMBERS=()
           POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          CONFIGURED_PAT_COUNT=0
 
           for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
-              PAT_NUMBERS+=(${i})
-              POOL_INDICATORS[${i}]="🟪"
+              CONFIGURED_PAT_COUNT=$((CONFIGURED_PAT_COUNT + 1))
+              if status=$(printf 'Authorization: Bearer %s\nAccept: application/vnd.github+json\nX-GitHub-Api-Version: 2022-11-28\n' "$val" | \
+                curl --silent --show-error \
+                  --output /dev/null \
+                  --write-out '%{http_code}' \
+                  --connect-timeout 5 \
+                  --max-time 15 \
+                  --proto '=https' \
+                  --tlsv1.2 \
+                  --header @- \
+                  https://api.github.com/user); then
+                if [ "$status" = 200 ]; then
+                  PAT_NUMBERS+=("${i}")
+                  POOL_INDICATORS[${i}]="🟪"
+                else
+                  POOL_INDICATORS[${i}]="❌"
+                  echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check returned HTTP ${status}"
+                fi
+              else
+                POOL_INDICATORS[${i}]="❔"
+                echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check could not reach GitHub"
+              fi
             fi
           done
 
           # If none of the entries in the pool have values, emit a warning
           # and do not set an output value. The consumer can fall back to
           # using COPILOT_GITHUB_TOKEN.
-          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+          if [ "$CONFIGURED_PAT_COUNT" -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
             warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
+          fi
+
+          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+            echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+            echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+            (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::None of the configured PAT pool entries authenticated successfully"
+            exit 1
           fi
 
           # Select a random index using the seed if specified

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1652,27 +1652,56 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
+          # Collect pool entries that authenticate successfully with GitHub.
           PAT_NUMBERS=()
           POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          CONFIGURED_PAT_COUNT=0
 
           for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
-              PAT_NUMBERS+=(${i})
-              POOL_INDICATORS[${i}]="🟪"
+              CONFIGURED_PAT_COUNT=$((CONFIGURED_PAT_COUNT + 1))
+              if status=$(printf 'Authorization: Bearer %s\nAccept: application/vnd.github+json\nX-GitHub-Api-Version: 2022-11-28\n' "$val" | \
+                curl --silent --show-error \
+                  --output /dev/null \
+                  --write-out '%{http_code}' \
+                  --connect-timeout 5 \
+                  --max-time 15 \
+                  --proto '=https' \
+                  --tlsv1.2 \
+                  --header @- \
+                  https://api.github.com/user); then
+                if [ "$status" = 200 ]; then
+                  PAT_NUMBERS+=("${i}")
+                  POOL_INDICATORS[${i}]="🟪"
+                else
+                  POOL_INDICATORS[${i}]="❌"
+                  echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check returned HTTP ${status}"
+                fi
+              else
+                POOL_INDICATORS[${i}]="❔"
+                echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check could not reach GitHub"
+              fi
             fi
           done
 
           # If none of the entries in the pool have values, emit a warning
           # and do not set an output value. The consumer can fall back to
           # using COPILOT_GITHUB_TOKEN.
-          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+          if [ "$CONFIGURED_PAT_COUNT" -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
             warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
+          fi
+
+          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+            echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+            echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+            (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::None of the configured PAT pool entries authenticated successfully"
+            exit 1
           fi
 
           # Select a random index using the seed if specified

--- a/.github/workflows/parallel-safety-audit-command.lock.yml
+++ b/.github/workflows/parallel-safety-audit-command.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"d328792260c06fd513141a8f9da8bf3276de990079a2188d141f15d34627e0a1","body_hash":"ee2d3c95c5c3c8869a7a73162ecbbfe27c32e757022172a537bb004bf0eb4c19","compiler_version":"v0.83.1","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.73"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"820762786026740c76f36085b0efc47a31fe5020","version":"v7.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"v0.83.1","version":"v0.83.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.38","digest":"sha256:cb928eb62d9139a013c2d278dab19af232d35a2d83dca71a3d98eb431f786243","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.38@sha256:cb928eb62d9139a013c2d278dab19af232d35a2d83dca71a3d98eb431f786243"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.38","digest":"sha256:cd6145620d96acee46e1ede25180a13aa36002467e663db0caa453a8bc8eb60c","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.38@sha256:cd6145620d96acee46e1ede25180a13aa36002467e663db0caa453a8bc8eb60c"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.27.38","digest":"sha256:c30c5319da37505d42f95cb3faa2cfa55e794ccb5cc805dbd9201410d1ac2a3e","pinned_image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.27.38@sha256:c30c5319da37505d42f95cb3faa2cfa55e794ccb5cc805dbd9201410d1ac2a3e"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.38","digest":"sha256:6c19094d95aad5f9f128ad5e583f0f2b894b158aa66c3b86dd9bcc90970a2917","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.38@sha256:6c19094d95aad5f9f128ad5e583f0f2b894b158aa66c3b86dd9bcc90970a2917"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.4.3","digest":"sha256:3c744710ea275cd5ee65db92a1099e0d980754bd9fafda9ce67704c67004dc83","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.4.3@sha256:3c744710ea275cd5ee65db92a1099e0d980754bd9fafda9ce67704c67004dc83"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.6.0","digest":"sha256:2b0c48b070f61e9d3969269ead600f62d00fb237b60ac849ef3d166ee7de9ad3","pinned_image":"ghcr.io/github/github-mcp-server:v1.6.0@sha256:2b0c48b070f61e9d3969269ead600f62d00fb237b60ac849ef3d166ee7de9ad3"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6246a45d73ee88b77258813329ca595cc9bc53b6a1eb1fa2d7e1724479ff44ed","body_hash":"ee2d3c95c5c3c8869a7a73162ecbbfe27c32e757022172a537bb004bf0eb4c19","compiler_version":"v0.83.1","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.73"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"820762786026740c76f36085b0efc47a31fe5020","version":"v7.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"8bdba8075360648fe6802302a5b4e016361dc6ac","version":"v0.83.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.38","digest":"sha256:cb928eb62d9139a013c2d278dab19af232d35a2d83dca71a3d98eb431f786243","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.38@sha256:cb928eb62d9139a013c2d278dab19af232d35a2d83dca71a3d98eb431f786243"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.38","digest":"sha256:cd6145620d96acee46e1ede25180a13aa36002467e663db0caa453a8bc8eb60c","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.38@sha256:cd6145620d96acee46e1ede25180a13aa36002467e663db0caa453a8bc8eb60c"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.27.38","digest":"sha256:c30c5319da37505d42f95cb3faa2cfa55e794ccb5cc805dbd9201410d1ac2a3e","pinned_image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.27.38@sha256:c30c5319da37505d42f95cb3faa2cfa55e794ccb5cc805dbd9201410d1ac2a3e"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.38","digest":"sha256:6c19094d95aad5f9f128ad5e583f0f2b894b158aa66c3b86dd9bcc90970a2917","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.38@sha256:6c19094d95aad5f9f128ad5e583f0f2b894b158aa66c3b86dd9bcc90970a2917"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.4.3","digest":"sha256:3c744710ea275cd5ee65db92a1099e0d980754bd9fafda9ce67704c67004dc83","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.4.3@sha256:3c744710ea275cd5ee65db92a1099e0d980754bd9fafda9ce67704c67004dc83"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.6.0","digest":"sha256:2b0c48b070f61e9d3969269ead600f62d00fb237b60ac849ef3d166ee7de9ad3","pinned_image":"ghcr.io/github/github-mcp-server:v1.6.0@sha256:2b0c48b070f61e9d3969269ead600f62d00fb237b60ac849ef3d166ee7de9ad3"}]}
 # This file was automatically generated by gh-aw (v0.83.1). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _
@@ -54,7 +54,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@v0.83.1
+#   - github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.27.38@sha256:cb928eb62d9139a013c2d278dab19af232d35a2d83dca71a3d98eb431f786243
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -482,7 +482,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1348,7 +1348,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1623,7 +1623,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1869,27 +1869,56 @@ jobs:
       - name: Select Copilot token from pool
         id: select-pat-number
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
+          # Collect pool entries that authenticate successfully with GitHub.
           PAT_NUMBERS=()
           POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          CONFIGURED_PAT_COUNT=0
 
           for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
-              PAT_NUMBERS+=(${i})
-              POOL_INDICATORS[${i}]="🟪"
+              CONFIGURED_PAT_COUNT=$((CONFIGURED_PAT_COUNT + 1))
+              if status=$(printf 'Authorization: Bearer %s\nAccept: application/vnd.github+json\nX-GitHub-Api-Version: 2022-11-28\n' "$val" | \
+                curl --silent --show-error \
+                  --output /dev/null \
+                  --write-out '%{http_code}' \
+                  --connect-timeout 5 \
+                  --max-time 15 \
+                  --proto '=https' \
+                  --tlsv1.2 \
+                  --header @- \
+                  https://api.github.com/user); then
+                if [ "$status" = 200 ]; then
+                  PAT_NUMBERS+=("${i}")
+                  POOL_INDICATORS[${i}]="🟪"
+                else
+                  POOL_INDICATORS[${i}]="❌"
+                  echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check returned HTTP ${status}"
+                fi
+              else
+                POOL_INDICATORS[${i}]="❔"
+                echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check could not reach GitHub"
+              fi
             fi
           done
 
           # If none of the entries in the pool have values, emit a warning
           # and do not set an output value. The consumer can fall back to
           # using COPILOT_GITHUB_TOKEN.
-          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+          if [ "$CONFIGURED_PAT_COUNT" -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
             warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
+          fi
+
+          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+            echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+            echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+            (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::None of the configured PAT pool entries authenticated successfully"
+            exit 1
           fi
 
           # Select a random index using the seed if specified
@@ -1942,7 +1971,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -2020,7 +2049,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@v0.83.1
+        uses: github/gh-aw-actions/setup@8bdba8075360648fe6802302a5b4e016361dc6ac # v0.83.1
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}

--- a/.github/workflows/shared/pat_pool.README.md
+++ b/.github/workflows/shared/pat_pool.README.md
@@ -152,8 +152,13 @@ There are several details of this implementation that keep our workflows and rep
    provided to a dedicated step within the `pat_pool` job. That job runs
    after `pre_activation` and contains only the trusted checkout and action
    steps--no untrusted context or input is within scope. The
-   `select-pat-number` action only references the secret values to determine
-   which are non-empty, filtering the secret numbers to those with values.
+  `select-pat-number` action sends each non-empty secret only to the fixed
+  `https://api.github.com/user` endpoint and includes only entries that return
+  HTTP 200. Response bodies are discarded. This excludes expired, revoked,
+  and otherwise unauthenticated PATs before random selection. This check does
+  not verify Copilot permissions or licensing; the scheduled
+  [`validate-pat-pool.yml`](../validate-pat-pool.yml) workflow exercises those
+  separately with an actual Copilot request.
 1. **The `pat_pool` job emits only a number, never a secret.** Its sole output,
    `pat_number`, is the 0-9 index of the selected PAT (or empty when the pool
    is empty). The actual secret materializes only later, in the activation
@@ -162,9 +167,11 @@ There are several details of this implementation that keep our workflows and rep
    [passing secrets][passing-secrets] between jobs or workflows, with the
    `case` statement acting as a very simple secret store.
 1. **The `select-pat-number` action does not require any permissions.** It
-   reads only the `COPILOT_PAT_#` environment variables passed to it and writes
-   only to `GITHUB_OUTPUT`. The job that hosts it sets `permissions:` to the
-   workflow defaults (no elevated scopes).
+  reads only the `COPILOT_PAT_#` environment variables passed to it, makes
+  authentication checks against GitHub, and writes only the selected number
+  to `GITHUB_OUTPUT`. The job that hosts it sets `permissions:` to the workflow
+  defaults (no elevated scopes). PAT values and API response bodies are never
+  written to logs, summaries, artifacts, outputs, or command arguments.
 1. **The implementation uses supported Agentic Workflow extensibility hooks.**
    Defining a custom job inside an [imported workflow file][imports] is
    supported by `gh aw compile`. gh-aw automatically

--- a/.github/workflows/shared/pat_pool.md
+++ b/.github/workflows/shared/pat_pool.md
@@ -25,27 +25,56 @@ jobs:
           RANDOM_SEED:   ${{ github.aw.import-inputs.random_seed   }}
         shell: bash
         run: |
-          # Collect pool entries with non-empty secrets from COPILOT_PAT_0..COPILOT_PAT_9.
+          # Collect pool entries that authenticate successfully with GitHub.
           PAT_NUMBERS=()
           POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+          CONFIGURED_PAT_COUNT=0
 
           for i in $(seq 0 9); do
             var="COPILOT_PAT_${i}"
             val="${!var}"
             if [ -n "$val" ]; then
-              PAT_NUMBERS+=(${i})
-              POOL_INDICATORS[${i}]="🟪"
+              CONFIGURED_PAT_COUNT=$((CONFIGURED_PAT_COUNT + 1))
+              if status=$(printf 'Authorization: Bearer %s\nAccept: application/vnd.github+json\nX-GitHub-Api-Version: 2022-11-28\n' "$val" | \
+                curl --silent --show-error \
+                  --output /dev/null \
+                  --write-out '%{http_code}' \
+                  --connect-timeout 5 \
+                  --max-time 15 \
+                  --proto '=https' \
+                  --tlsv1.2 \
+                  --header @- \
+                  https://api.github.com/user); then
+                if [ "$status" = 200 ]; then
+                  PAT_NUMBERS+=("${i}")
+                  POOL_INDICATORS[${i}]="🟪"
+                else
+                  POOL_INDICATORS[${i}]="❌"
+                  echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check returned HTTP ${status}"
+                fi
+              else
+                POOL_INDICATORS[${i}]="❔"
+                echo "::warning::Ignoring COPILOT_PAT_${i}: authentication check could not reach GitHub"
+              fi
             fi
           done
 
           # If none of the entries in the pool have values, emit a warning
           # and do not set an output value. The consumer can fall back to
           # using COPILOT_GITHUB_TOKEN.
-          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+          if [ "$CONFIGURED_PAT_COUNT" -eq 0 ]; then
             warning_message="::warning::None of the PAT pool entries had values "
             warning_message+="(checked COPILOT_PAT_0 through COPILOT_PAT_9)"
             echo "$warning_message"
             exit 0
+          fi
+
+          if [ ${#PAT_NUMBERS[@]} -eq 0 ]; then
+            echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+            echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+            (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::None of the configured PAT pool entries authenticated successfully"
+            exit 1
           fi
 
           # Select a random index using the seed if specified


### PR DESCRIPTION
The PAT Pool Provider will still use an expired pat. `validate_pat_pool` only runs periodically to tell users to update their PAT but that doesn't mean that the PATs get updated right away, and this blocks workflows from running, which is why some issues randomly have not been triaged by the agentic triager. 

See https://github.com/dotnet/sdk/actions/runs/31006386647 as an example.

The only repo or skill doing PAT validation is https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-eval.yml which uses this same pattern but did not apply the fix to the overall PAT pool PAT selector. 

If this is acceptable, this should likely be migrated to the other PAT pool implementations.
https://github.com/nagilson/sdk/actions/runs/31051484546 demonstrates a run where PAT_0 is valid and PAT_1 is invalid, and the PAT pool provider disregards expired PATs. It does not disregard PATS with incorrect permissions. 

<img width="2121" height="521" alt="image" src="https://github.com/user-attachments/assets/58e04fc7-ce64-4e37-914a-1763ae279cae" />

A :x: now appears on invalid tokens in the provider summary.
