### PR TITLE
Enable method-level parallelism for TemplateEngine CLI tests

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -31,12 +31,14 @@ Guidance for changes under `test/`.
   `test/TestAssets/`. They are automatically deployed to Helix via `test/UnitTests.proj`.
 - **Don't raise parallelism.** MSTest is repo-defaulted to `None` in
   `test/Directory.Build.props` because of concurrency flakiness; a few projects opt
-  into `ClassLevel`. Cranking it up causes Helix over-subscription/timeouts.
+  into `ClassLevel` or `MethodLevel` after auditing their shared resources. Cranking it
+  up without that audit causes Helix over-subscription/timeouts and test interference.
 - **In parallelized projects, prefer `[ResourceLock]` over `[DoNotParallelize]`.** In the
   projects that do opt in (`Microsoft.NET.Build.Tests`, `dotnet-watch.Tests`,
-  `Microsoft.NET.Build.Containers.UnitTests`), MSTest's parallel-safety analyzers
-  (MSTEST0073–MSTEST0077) are active, and `MSTestAnalysisMode=Recommended` plus
-  `TreatWarningsAsErrors` makes them build errors. Fix them in this order:
+  `Microsoft.NET.Build.Containers.UnitTests`, `Microsoft.TemplateEngine.Cli.UnitTests`),
+  MSTest's parallel-safety analyzers (MSTEST0073–MSTEST0077) are active, and
+  `MSTestAnalysisMode=Recommended` plus `TreatWarningsAsErrors` makes them build errors.
+  Fix them in this order:
   1. **Eliminate the shared state** — pass an environment variable to the child process
      via `TestCommand.WithEnvironmentVariable(...)` instead of
      `Environment.SetEnvironmentVariable`, and give each test its own scratch directory

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/PostActionTests/AddJsonPropertyPostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/PostActionTests/AddJsonPropertyPostActionTests.cs
@@ -14,6 +14,8 @@ using Moq;
 namespace Microsoft.TemplateEngine.Cli.UnitTests.PostActionTests
 {
     [TestClass]
+    // These tests mutate the process-global Microsoft.DotNet.Cli.Utils.Reporter.
+    [ResourceLock(nameof(Reporter))]
     public class AddJsonPropertyPostActionTests
     {
         // MSTest has no IClassFixture equivalent; a lazily-initialized static helper
@@ -22,13 +24,21 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.PostActionTests
             new(() => new EnvironmentSettingsHelper());
 
         private IEngineEnvironmentSettings _engineEnvironmentSettings = null!;
+        private IReporter _originalErrorReporter = null!;
 
         [TestInitialize]
         public void TestInitialize()
         {
+            _originalErrorReporter = Reporter.Error;
             _engineEnvironmentSettings = s_environmentSettingsHelper.Value.CreateEnvironment(
                 hostIdentifier: GetType().Name,
                 virtualize: true);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Reporter.SetError(_originalErrorReporter);
         }
 
         [ClassCleanup]


### PR DESCRIPTION
## Summary

- opt `Microsoft.TemplateEngine.Cli.UnitTests` into MSTest method-level parallelization
- replace broad serialization of `AddJsonPropertyPostActionTests` with a named `ResourceLock`
- restore the process-global `Reporter.Error` value after each test

## Validation

- built `Microsoft.TemplateEngine.Cli.UnitTests`
- ran the full test application with 32 method-level workers: 776 passed, 6 skipped, 0 failed