### PR TITLE
Use partial evaluation in dotnet test setup

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -389,6 +389,7 @@ internal static class MSBuildUtility
                 var project = ProjectInstance.FromFile(filePath, new ProjectOptions
                 {
                     GlobalProperties = globalProperties,
+                    EvaluationStage = ProjectEvaluationStage.Items,
                     ProjectCollection = collection,
                 });
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -762,6 +762,7 @@ internal partial class MicrosoftTestingPlatformTestCommand
             var projectInstance = ProjectInstance.FromFile(projectPath, new ProjectOptions
             {
                 GlobalProperties = globalProperties,
+                EvaluationStage = ProjectEvaluationStage.Properties,
                 ProjectCollection = collection,
             });
 

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -173,8 +173,7 @@ internal static class SolutionAndProjectUtility
         string? tfm,
         string? configuration,
         string? platform,
-        IReadOnlyDictionary<string, string>? additionalGlobalProperties,
-        ProjectEvaluationStage evaluationStage)
+        IReadOnlyDictionary<string, string>? additionalGlobalProperties)
     {
         Debug.Assert(projectFilePath is not null);
 
@@ -245,7 +244,6 @@ internal static class SolutionAndProjectUtility
         {
             GlobalProperties = globalProperties,
             EvaluationContext = evaluationContext,
-            EvaluationStage = evaluationStage,
             ProjectCollection = collection,
         });
     }
@@ -263,25 +261,7 @@ internal static class SolutionAndProjectUtility
         HashSet<string>? visitedTraversalProjects = null)
     {
         var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
-        ProjectInstance Evaluate(string? tfm, ProjectEvaluationStage evaluationStage)
-            => EvaluateProject(
-                projectCollection,
-                evaluationContext,
-                projectFilePath,
-                tfm,
-                configuration,
-                platform,
-                additionalGlobalProperties,
-                evaluationStage);
-
-        ProjectInstance EnsureFullEvaluationForTestingPlatformApplication(ProjectInstance project, string? tfm)
-            // Reuse the same collection and shared context so the full evaluation benefits from the
-            // project XML, SDK resolution, and file-system observations cached by the properties pass.
-            => IsTestingPlatformApplication(project)
-                ? Evaluate(tfm, ProjectEvaluationStage.Full)
-                : project;
-
-        ProjectInstance projectInstance = Evaluate(tfm: null, ProjectEvaluationStage.Properties);
+        ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform, additionalGlobalProperties);
 
         // Traversal projects (e.g. Microsoft.Build.Traversal "dirs.proj") are not test projects themselves.
         // They act as a container that forwards build/test operations to their ProjectReference items.
@@ -289,8 +269,6 @@ internal static class SolutionAndProjectUtility
         // evaluate each of them. This is done recursively so that nested traversal projects work as well.
         if (IsTraversalProject(projectInstance))
         {
-            projectInstance = Evaluate(tfm: null, ProjectEvaluationStage.Items);
-
             // Track visited (project, configuration, platform) tuples across the whole traversal graph so
             // that a project referenced by multiple traversal projects with the same configuration/platform
             // (a "diamond") is only tested once, while the same project referenced with a *different*
@@ -321,8 +299,6 @@ internal static class SolutionAndProjectUtility
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
-            projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, tfm: null);
-
             if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
             {
                 projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -348,8 +324,7 @@ internal static class SolutionAndProjectUtility
             {
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = Evaluate(framework, ProjectEvaluationStage.Properties);
-                    projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, framework);
+                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -363,8 +338,7 @@ internal static class SolutionAndProjectUtility
                 List<TestModule>? innerModules = null;
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = Evaluate(framework, ProjectEvaluationStage.Properties);
-                    projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, framework);
+                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -392,10 +366,6 @@ internal static class SolutionAndProjectUtility
     /// </summary>
     private static bool IsTraversalProject(ProjectInstance projectInstance)
         => bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.IsTraversal), out bool isTraversal) && isTraversal;
-
-    private static bool IsTestingPlatformApplication(ProjectInstance projectInstance)
-        => bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication)
-            && isTestingPlatformApplication;
 
     /// <summary>
     /// Builds a stable key identifying a (project, configuration, platform) combination for
@@ -582,7 +552,7 @@ internal static class SolutionAndProjectUtility
         MSBuildSession buildSession)
     {
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestProject), out bool isTestProject);
-        bool isTestingPlatformApplication = IsTestingPlatformApplication(project);
+        _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
 
         if (!isTestProject && !isTestingPlatformApplication)
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -173,7 +173,8 @@ internal static class SolutionAndProjectUtility
         string? tfm,
         string? configuration,
         string? platform,
-        IReadOnlyDictionary<string, string>? additionalGlobalProperties)
+        IReadOnlyDictionary<string, string>? additionalGlobalProperties,
+        ProjectEvaluationStage evaluationStage)
     {
         Debug.Assert(projectFilePath is not null);
 
@@ -244,6 +245,7 @@ internal static class SolutionAndProjectUtility
         {
             GlobalProperties = globalProperties,
             EvaluationContext = evaluationContext,
+            EvaluationStage = evaluationStage,
             ProjectCollection = collection,
         });
     }
@@ -261,7 +263,25 @@ internal static class SolutionAndProjectUtility
         HashSet<string>? visitedTraversalProjects = null)
     {
         var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
-        ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform, additionalGlobalProperties);
+        ProjectInstance Evaluate(string? tfm, ProjectEvaluationStage evaluationStage)
+            => EvaluateProject(
+                projectCollection,
+                evaluationContext,
+                projectFilePath,
+                tfm,
+                configuration,
+                platform,
+                additionalGlobalProperties,
+                evaluationStage);
+
+        ProjectInstance EnsureFullEvaluationForTestingPlatformApplication(ProjectInstance project, string? tfm)
+            // Reuse the same collection and shared context so the full evaluation benefits from the
+            // project XML, SDK resolution, and file-system observations cached by the properties pass.
+            => IsTestingPlatformApplication(project)
+                ? Evaluate(tfm, ProjectEvaluationStage.Full)
+                : project;
+
+        ProjectInstance projectInstance = Evaluate(tfm: null, ProjectEvaluationStage.Properties);
 
         // Traversal projects (e.g. Microsoft.Build.Traversal "dirs.proj") are not test projects themselves.
         // They act as a container that forwards build/test operations to their ProjectReference items.
@@ -269,6 +289,8 @@ internal static class SolutionAndProjectUtility
         // evaluate each of them. This is done recursively so that nested traversal projects work as well.
         if (IsTraversalProject(projectInstance))
         {
+            projectInstance = Evaluate(tfm: null, ProjectEvaluationStage.Items);
+
             // Track visited (project, configuration, platform) tuples across the whole traversal graph so
             // that a project referenced by multiple traversal projects with the same configuration/platform
             // (a "diamond") is only tested once, while the same project referenced with a *different*
@@ -299,6 +321,8 @@ internal static class SolutionAndProjectUtility
 
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
         {
+            projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, tfm: null);
+
             if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
             {
                 projects.Add(new ParallelizableTestModuleGroupWithSequentialInnerModules(module));
@@ -324,7 +348,8 @@ internal static class SolutionAndProjectUtility
             {
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
+                    projectInstance = Evaluate(framework, ProjectEvaluationStage.Properties);
+                    projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -338,7 +363,8 @@ internal static class SolutionAndProjectUtility
                 List<TestModule>? innerModules = null;
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
+                    projectInstance = Evaluate(framework, ProjectEvaluationStage.Properties);
+                    projectInstance = EnsureFullEvaluationForTestingPlatformApplication(projectInstance, framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -366,6 +392,10 @@ internal static class SolutionAndProjectUtility
     /// </summary>
     private static bool IsTraversalProject(ProjectInstance projectInstance)
         => bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.IsTraversal), out bool isTraversal) && isTraversal;
+
+    private static bool IsTestingPlatformApplication(ProjectInstance projectInstance)
+        => bool.TryParse(projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication)
+            && isTestingPlatformApplication;
 
     /// <summary>
     /// Builds a stable key identifying a (project, configuration, platform) combination for
@@ -552,7 +582,7 @@ internal static class SolutionAndProjectUtility
         MSBuildSession buildSession)
     {
         _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestProject), out bool isTestProject);
-        _ = bool.TryParse(project.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication), out bool isTestingPlatformApplication);
+        bool isTestingPlatformApplication = IsTestingPlatformApplication(project);
 
         if (!isTestProject && !isTestingPlatformApplication)
         {

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+  <Import Project="post-build-discovery.props" Condition="Exists('post-build-discovery.props')" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,7 +12,7 @@
     <Nullable>enable</Nullable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <IsTestingPlatformApplication Condition="'$(GeneratePostBuildDiscoveryProps)' != 'true'">true</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>
@@ -67,6 +68,22 @@
           BeforeTargets="_MTPBuild"
           Condition="'@(RuntimeEnvironmentVariable)' != ''">
     <Message Text="Build: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
+  </Target>
+
+  <Target Name="_GeneratePostBuildDiscoveryProps"
+          BeforeTargets="_MTPBuild"
+          Condition="'$(GeneratePostBuildDiscoveryProps)' == 'true'">
+    <ItemGroup>
+      <_PostBuildDiscoveryPropsLines Include="&lt;Project&gt;" />
+      <_PostBuildDiscoveryPropsLines Include="  &lt;PropertyGroup&gt;" />
+      <_PostBuildDiscoveryPropsLines Include="    &lt;IsTestingPlatformApplication&gt;true&lt;/IsTestingPlatformApplication&gt;" />
+      <_PostBuildDiscoveryPropsLines Include="  &lt;/PropertyGroup&gt;" />
+      <_PostBuildDiscoveryPropsLines Include="&lt;/Project&gt;" />
+    </ItemGroup>
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\post-build-discovery.props"
+      Lines="@(_PostBuildDiscoveryPropsLines)"
+      Overwrite="true" />
   </Target>
 
   <Target Name="_ModifyRuntimeEnvironmentVariable"

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
-  <Import Project="post-build-discovery.props" Condition="Exists('post-build-discovery.props')" />
+  <PropertyGroup>
+    <_PostBuildDiscoveryPropsPath>$(MSBuildProjectDirectory)\post-build-discovery.props</_PostBuildDiscoveryPropsPath>
+  </PropertyGroup>
+  <Import Project="$(_PostBuildDiscoveryPropsPath)" Condition="Exists('$(_PostBuildDiscoveryPropsPath)')" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -81,7 +84,7 @@
       <_PostBuildDiscoveryPropsLines Include="&lt;/Project&gt;" />
     </ItemGroup>
     <WriteLinesToFile
-      File="$(MSBuildProjectDirectory)\post-build-discovery.props"
+      File="$(_PostBuildDiscoveryPropsPath)"
       Lines="@(_PostBuildDiscoveryPropsLines)"
       Overwrite="true" />
   </Target>

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -110,6 +110,24 @@ public class GivenDotnetTestSelectsDevice : SdkTest
     }
 
     [TestMethod]
+    public void ItUsesFreshEvaluationContextAfterBuild()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", "FreshEvaluationContext")
+            .WithSource();
+        File.Delete(Path.Combine(testInstance.Path, "post-build-discovery.props"));
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute(
+                "--framework", ToolsetInfo.CurrentTargetFramework,
+                "-p:SingleDevice=true",
+                "-p:GeneratePostBuildDiscoveryProps=true");
+
+        result.Should().Pass()
+            .And.HaveStdOutContaining("Runtime environment variables:");
+    }
+
+    [TestMethod]
     public void ItPassesEnvironmentVariablesToBuildDeployAndRunArgumentsTargets()
     {
         var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", "EnvironmentVariables")


### PR DESCRIPTION
## Summary

Use MSBuild partial evaluation in two `dotnet test` setup paths that consume only early evaluation results:

- stop after properties when device handling only needs `TargetFramework` and `TargetFrameworks`
- stop after items when the pre-build environment-variable path checks `ProjectCapability` and `IntermediateOutputPath`

Core project/module discovery continues to fully evaluate each project and target framework exactly once. MTP applications execute `DeployToDevice` and `ComputeRunArguments`, so their `ProjectInstance` must contain registered targets; partial `ProjectInstance` evaluation is not resumable and must not be followed by a second full evaluation.

The existing shared `EvaluationContext` remains scoped across each post-build discovery operation to reuse SDK resolution and filesystem observations between its full project evaluations.

## Evaluation lifetime

The pre-build device-selection evaluation and post-build discovery intentionally use different shared evaluation contexts. This prevents filesystem observations cached before the build from hiding imports or generated files created by the build.

The regression test creates a conditional props import during the build and verifies that post-build discovery observes it. It also removes the generated import before each invocation so repeated local runs continue to exercise the cache boundary.

## Tests

- `ItUsesFreshEvaluationContextAfterBuild`
- focused `dotnet.Tests` coverage for MTP multi-target discovery, traversal/non-test filtering, VSTest non-test handling, and device/environment target execution