### PR TITLE
Show modified `shell` in `dotnetup` to explain modes

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/DotnetInstallException.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/DotnetInstallException.cs
@@ -133,6 +133,12 @@ public enum DotnetInstallErrorCode
     /// Distinct from <see cref="NoMatchingReleaseFileForPlatform"/>
     /// </summary>
     NoUserInstallableArtifact,
+
+    /// <summary>
+    /// An access mode reached a workflow that does not support it, indicating inconsistent
+    /// product state rather than invalid user input.
+    /// </summary>
+    InvalidModeSelection,
 }
 
 /// <summary>

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
@@ -28,7 +28,8 @@ internal static class InitWorkflowDefaults
         List<ResolvedInstallRequest>? preResolvedRequests,
         IDotnetEnvironmentManager dotnetEnvironment)
     {
-        DotnetAccessMode accessMode = GetDefaultAccessMode(command.ShellProvider);
+        IEnvShellProvider? shellProvider = command.ShellProvider ?? ShellDetection.GetCurrentShellProvider();
+        DotnetAccessMode accessMode = GetDefaultAccessMode(shellProvider);
 
         if (preResolvedRequests is { Count: > 0 })
         {
@@ -41,7 +42,8 @@ internal static class InitWorkflowDefaults
                 resolvedRoot,
                 accessMode,
                 resolvedMigrations,
-                new DefaultChannelDisplay(first.Request.Channel.Name, first.Request.Options.GlobalJsonPath));
+                new DefaultChannelDisplay(first.Request.Channel.Name, first.Request.Options.GlobalJsonPath),
+                shellProvider);
         }
 
         var globalJson = GlobalJsonModifier.GetGlobalJsonInfo(Environment.CurrentDirectory);
@@ -54,7 +56,7 @@ internal static class InitWorkflowDefaults
         var migrations = ResolveDefaultMigrations(
             dotnetEnvironment, accessMode, installRoot, command.ManifestPath, existingRequests: null);
 
-        return new WalkthroughPlan(installRoot, accessMode, migrations, ResolveChannelDisplay(globalJson));
+        return new WalkthroughPlan(installRoot, accessMode, migrations, ResolveChannelDisplay(globalJson), shellProvider);
     }
 
     /// <summary>

--- a/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/InitWorkflowDefaults.cs
@@ -30,6 +30,9 @@ internal static class InitWorkflowDefaults
     {
         IEnvShellProvider? shellProvider = command.ShellProvider ?? ShellDetection.GetCurrentShellProvider();
         DotnetAccessMode accessMode = GetDefaultAccessMode(shellProvider);
+        var globalJson = GlobalJsonModifier.GetGlobalJsonInfo(Environment.CurrentDirectory);
+        var pathResolution = new InstallPathResolver(dotnetEnvironment).Resolve(
+            command.InstallPath, globalJson);
 
         if (preResolvedRequests is { Count: > 0 })
         {
@@ -43,12 +46,10 @@ internal static class InitWorkflowDefaults
                 accessMode,
                 resolvedMigrations,
                 new DefaultChannelDisplay(first.Request.Channel.Name, first.Request.Options.GlobalJsonPath),
-                shellProvider);
+                shellProvider,
+                GetInstallRootGlobalJsonPath(pathResolution, globalJson, resolvedRoot));
         }
 
-        var globalJson = GlobalJsonModifier.GetGlobalJsonInfo(Environment.CurrentDirectory);
-        var pathResolution = new InstallPathResolver(dotnetEnvironment).Resolve(
-            command.InstallPath, globalJson);
         var installRoot = new DotnetInstallRoot(
             pathResolution.ResolvedInstallPath,
             InstallerUtilities.GetDefaultInstallArchitecture());
@@ -56,8 +57,23 @@ internal static class InitWorkflowDefaults
         var migrations = ResolveDefaultMigrations(
             dotnetEnvironment, accessMode, installRoot, command.ManifestPath, existingRequests: null);
 
-        return new WalkthroughPlan(installRoot, accessMode, migrations, ResolveChannelDisplay(globalJson), shellProvider);
+        return new WalkthroughPlan(
+            installRoot,
+            accessMode,
+            migrations,
+            ResolveChannelDisplay(globalJson),
+            shellProvider,
+            GetInstallRootGlobalJsonPath(pathResolution, globalJson, installRoot));
     }
+
+    private static string? GetInstallRootGlobalJsonPath(
+        InstallPathResolver.InstallPathResolutionResult pathResolution,
+        GlobalJsonInfo globalJson,
+        DotnetInstallRoot installRoot)
+        => pathResolution.PathSource is PathSource.GlobalJson
+            && DotnetupUtilities.PathsEqual(pathResolution.ResolvedInstallPath, installRoot.Path)
+                ? globalJson.GlobalJsonPath
+                : null;
 
     /// <summary>
     /// Resolves the default install requests. Uses the pre-resolved requests when supplied;

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughPlan.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughPlan.cs
@@ -17,9 +17,11 @@ namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
 /// <param name="Migrations">The system installs eligible for migration under the recommended mode.</param>
 /// <param name="ChannelDisplay">Display information for the SDK channel line.</param>
 /// <param name="ShellProvider">The resolved shell provider used to recommend and describe terminal mode.</param>
+/// <param name="InstallRootGlobalJsonPath">The global.json that supplied the install root, if any.</param>
 internal sealed record WalkthroughPlan(
     DotnetInstallRoot InstallRoot,
     DotnetAccessMode AccessMode,
     List<MigrationWorkflow.MigrationSelection> Migrations,
     DefaultChannelDisplay ChannelDisplay,
-    IEnvShellProvider? ShellProvider);
+    IEnvShellProvider? ShellProvider,
+    string? InstallRootGlobalJsonPath);

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughPlan.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughPlan.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+using Microsoft.DotNet.Tools.Bootstrapper.Shell;
 
 namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
 
@@ -15,8 +16,10 @@ namespace Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
 /// <param name="AccessMode">The recommended access mode.</param>
 /// <param name="Migrations">The system installs eligible for migration under the recommended mode.</param>
 /// <param name="ChannelDisplay">Display information for the SDK channel line.</param>
+/// <param name="ShellProvider">The resolved shell provider used to recommend and describe terminal mode.</param>
 internal sealed record WalkthroughPlan(
     DotnetInstallRoot InstallRoot,
     DotnetAccessMode AccessMode,
     List<MigrationWorkflow.MigrationSelection> Migrations,
-    DefaultChannelDisplay ChannelDisplay);
+    DefaultChannelDisplay ChannelDisplay,
+    IEnvShellProvider? ShellProvider);

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
@@ -109,8 +109,7 @@ internal static class WalkthroughSummary
     {
         string mode = DotnetupTheme.Accent(DotnetAccessModeDisplay.GetName(plan.AccessMode).EscapeMarkup());
 
-        if (plan.AccessMode is DotnetAccessMode.None
-            || (plan.AccessMode is DotnetAccessMode.Shell && plan.ShellProvider is null))
+        if (plan.AccessMode is DotnetAccessMode.None)
         {
             string currentShell = DotnetupTheme.Accent(ShellDetection.GetCurrentShellDisplayName().EscapeMarkup());
             string supportedShells = DotnetupTheme.Accent(
@@ -131,7 +130,9 @@ internal static class WalkthroughSummary
                 shellProvider.GetProfilePaths().Select(path => DotnetupTheme.Accent(path.EscapeMarkup()))),
             DotnetAccessMode.Everywhere => DotnetupTheme.Accent(
                 Strings.SummaryModeSystemEnvironmentVariables.EscapeMarkup()),
-            _ => throw new InvalidOperationException($"Unsupported access mode '{plan.AccessMode}'."),
+            _ => throw new DotnetInstallException(
+                DotnetInstallErrorCode.Unknown,
+                $"Unable to describe access mode '{plan.AccessMode}' with the resolved shell provider."),
         };
 
         return string.Format(

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
@@ -131,7 +131,7 @@ internal static class WalkthroughSummary
             DotnetAccessMode.Everywhere => DotnetupTheme.Accent(
                 Strings.SummaryModeSystemEnvironmentVariables.EscapeMarkup()),
             _ => throw new DotnetInstallException(
-                DotnetInstallErrorCode.Unknown,
+                DotnetInstallErrorCode.InvalidModeSelection,
                 $"Unable to describe access mode '{plan.AccessMode}' with the resolved shell provider."),
         };
 

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
@@ -135,6 +135,15 @@ internal static class WalkthroughSummary
                 $"Unable to describe access mode '{plan.AccessMode}' with the resolved shell provider."),
         };
 
+        string installRoot = DotnetupTheme.Accent(plan.InstallRoot.Path.EscapeMarkup());
+        if (plan.InstallRootGlobalJsonPath is { } globalJsonPath)
+        {
+            installRoot += " " + string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.SummaryModeInstallRootGlobalJsonSuffix,
+                DotnetupTheme.Accent(globalJsonPath.EscapeMarkup()));
+        }
+
         return string.Format(
             CultureInfo.InvariantCulture,
             Strings.SummaryModeConfiguration,
@@ -142,7 +151,7 @@ internal static class WalkthroughSummary
             configurationTarget,
             DotnetupTheme.Accent("PATH"),
             DotnetupTheme.Accent("DOTNET_ROOT"),
-            DotnetupTheme.Accent(plan.InstallRoot.Path.EscapeMarkup()));
+            installRoot);
     }
 
     private static void RenderChannelLine(DefaultChannelDisplay channel)

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Shared;
+using Microsoft.DotNet.Tools.Bootstrapper.Shell;
 using Spectre.Console;
 using SpectreAnsiConsole = Spectre.Console.AnsiConsole;
 
@@ -97,9 +98,50 @@ internal static class WalkthroughSummary
 
         RenderChannelLine(plan.ChannelDisplay);
         RenderModeLine(plan.AccessMode, configuredAccessMode);
+        SpectreAnsiConsole.WriteLine();
+        SpectreAnsiConsole.MarkupLine(BuildModeDescription(plan));
         RenderMigrationSummary(plan.Migrations);
 
         SpectreAnsiConsole.WriteLine();
+    }
+
+    internal static string BuildModeDescription(WalkthroughPlan plan)
+    {
+        string mode = DotnetupTheme.Accent(DotnetAccessModeDisplay.GetName(plan.AccessMode).EscapeMarkup());
+
+        if (plan.AccessMode is DotnetAccessMode.None
+            || (plan.AccessMode is DotnetAccessMode.Shell && plan.ShellProvider is null))
+        {
+            string currentShell = DotnetupTheme.Accent(ShellDetection.GetCurrentShellDisplayName().EscapeMarkup());
+            string supportedShells = DotnetupTheme.Accent(
+                string.Join(", ", ShellDetection.s_supportedShells.Select(shell => shell.ArgumentName)).EscapeMarkup());
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                Strings.SummaryModeUnsupportedShell,
+                mode,
+                currentShell,
+                supportedShells);
+        }
+
+        string configurationTarget = plan.AccessMode switch
+        {
+            DotnetAccessMode.Shell when plan.ShellProvider is { } shellProvider => string.Join(
+                ", ",
+                shellProvider.GetProfilePaths().Select(path => DotnetupTheme.Accent(path.EscapeMarkup()))),
+            DotnetAccessMode.Everywhere => DotnetupTheme.Accent(
+                Strings.SummaryModeSystemEnvironmentVariables.EscapeMarkup()),
+            _ => throw new InvalidOperationException($"Unsupported access mode '{plan.AccessMode}'."),
+        };
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            Strings.SummaryModeConfiguration,
+            mode,
+            configurationTarget,
+            DotnetupTheme.Accent("PATH"),
+            DotnetupTheme.Accent("DOTNET_ROOT"),
+            DotnetupTheme.Accent(plan.InstallRoot.Path.EscapeMarkup()));
     }
 
     private static void RenderChannelLine(DefaultChannelDisplay channel)

--- a/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
+++ b/src/Installer/dotnetup.Library/Commands/Init/WalkthroughSummary.cs
@@ -138,10 +138,10 @@ internal static class WalkthroughSummary
         string installRoot = DotnetupTheme.Accent(plan.InstallRoot.Path.EscapeMarkup());
         if (plan.InstallRootGlobalJsonPath is { } globalJsonPath)
         {
-            installRoot += " " + string.Format(
+            installRoot += " " + DotnetupTheme.Dim(string.Format(
                 CultureInfo.InvariantCulture,
                 Strings.SummaryModeInstallRootGlobalJsonSuffix,
-                DotnetupTheme.Accent(globalJsonPath.EscapeMarkup()));
+                globalJsonPath.EscapeMarkup()));
         }
 
         return string.Format(

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -457,6 +457,10 @@ Or open a new terminal.</value>
   <data name="SummaryModeSystemEnvironmentVariables" xml:space="preserve">
     <value>the system environment variables</value>
   </data>
+  <data name="SummaryModeInstallRootGlobalJsonSuffix" xml:space="preserve">
+    <value>(inferred from {0})</value>
+    <comment>{0} is the path to the global.json file that supplied the dotnetup install root.</comment>
+  </data>
   <data name="SummaryModeUnsupportedShell" xml:space="preserve">
     <value>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</value>
     <comment>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</comment>

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -451,7 +451,7 @@ Or open a new terminal.</value>
     <comment>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</comment>
   </data>
   <data name="SummaryModeConfiguration" xml:space="preserve">
-    <value>{0} modifies {1} to set {2} and {3} to {4}.</value>
+    <value>{0} modifies {1} to set {2} and {3} to prefer {4}.</value>
     <comment>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</comment>
   </data>
   <data name="SummaryModeSystemEnvironmentVariables" xml:space="preserve">

--- a/src/Installer/dotnetup.Library/Strings.resx
+++ b/src/Installer/dotnetup.Library/Strings.resx
@@ -450,6 +450,17 @@ Or open a new terminal.</value>
     <value>current: {0}</value>
     <comment>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</comment>
   </data>
+  <data name="SummaryModeConfiguration" xml:space="preserve">
+    <value>{0} modifies {1} to set {2} and {3} to {4}.</value>
+    <comment>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</comment>
+  </data>
+  <data name="SummaryModeSystemEnvironmentVariables" xml:space="preserve">
+    <value>the system environment variables</value>
+  </data>
+  <data name="SummaryModeUnsupportedShell" xml:space="preserve">
+    <value>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</value>
+    <comment>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</comment>
+  </data>
   <data name="SummaryMigrateHeader" xml:space="preserve">
     <value>System installs to migrate:</value>
   </data>

--- a/src/Installer/dotnetup.Library/Telemetry/ErrorCategoryClassifier.cs
+++ b/src/Installer/dotnetup.Library/Telemetry/ErrorCategoryClassifier.cs
@@ -57,6 +57,7 @@ internal static class ErrorCategoryClassifier
             DotnetInstallErrorCode.UninstallTargetNotFound => ErrorCategory.User,
             DotnetInstallErrorCode.UnsignedDownloadBlockedByPolicy => ErrorCategory.User,
             DotnetInstallErrorCode.NoUserInstallableArtifact => ErrorCategory.User,
+            DotnetInstallErrorCode.InvalidModeSelection => ErrorCategory.Product,
             DotnetInstallErrorCode.Unknown => ErrorCategory.Product,
 
             _ => ErrorCategory.Product

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.cs.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.de.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.es.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.fr.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.it.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ja.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ko.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pl.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.pt-BR.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.ru.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.tr.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hans.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -501,6 +501,11 @@ Or open a new terminal.</target>
         <target state="new">... and {0} more</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeConfiguration">
+        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeCurrent">
         <source>current: {0}</source>
         <target state="new">current: {0}</target>
@@ -510,6 +515,16 @@ Or open a new terminal.</target>
         <source>Mode:</source>
         <target state="new">Mode:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeSystemEnvironmentVariables">
+        <source>the system environment variables</source>
+        <target state="new">the system environment variables</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryModeUnsupportedShell">
+        <source>{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</source>
+        <target state="new">{0} is suggested because the current shell ({1}) cannot be detected or is not supported. Supported shells: {2}.</target>
+        <note>{0} is the suggested isolation mode name; {1} is the current SHELL value or "(not set)"; {2} is the list of supported shell names.</note>
       </trans-unit>
       <trans-unit id="SummaryProceedDescriptionConfigured">
         <source>Replace your current settings with the recommended ones above.</source>

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -511,6 +511,11 @@ Or open a new terminal.</target>
         <target state="new">current: {0}</target>
         <note>{0} is the user's currently configured mode name. Shown in parentheses after the recommended mode.</note>
       </trans-unit>
+      <trans-unit id="SummaryModeInstallRootGlobalJsonSuffix">
+        <source>(inferred from {0})</source>
+        <target state="new">(inferred from {0})</target>
+        <note>{0} is the path to the global.json file that supplied the dotnetup install root.</note>
+      </trans-unit>
       <trans-unit id="SummaryModeLabel">
         <source>Mode:</source>
         <target state="new">Mode:</target>

--- a/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
+++ b/src/Installer/dotnetup.Library/xlf/Strings.zh-Hant.xlf
@@ -502,8 +502,8 @@ Or open a new terminal.</target>
         <note>{0} is the count of additional migration candidates not individually listed.</note>
       </trans-unit>
       <trans-unit id="SummaryModeConfiguration">
-        <source>{0} modifies {1} to set {2} and {3} to {4}.</source>
-        <target state="new">{0} modifies {1} to set {2} and {3} to {4}.</target>
+        <source>{0} modifies {1} to set {2} and {3} to prefer {4}.</source>
+        <target state="new">{0} modifies {1} to set {2} and {3} to prefer {4}.</target>
         <note>{0} is the suggested mode name; {1} is one or more shell profile paths or the system environment variables; {2} is PATH; {3} is DOTNET_ROOT; {4} is the dotnetup install path.</note>
       </trans-unit>
       <trans-unit id="SummaryModeCurrent">

--- a/test/dotnetup.Tests/WalkthroughSummaryTests.cs
+++ b/test/dotnetup.Tests/WalkthroughSummaryTests.cs
@@ -105,8 +105,7 @@ public class WalkthroughSummaryTests
 
         string description = WalkthroughSummary.BuildModeDescription(plan);
 
-        description.Should().Contain("inferred from");
-        description.Should().Contain(DotnetupTheme.Accent(globalJsonPath));
+        description.Should().Contain(DotnetupTheme.Dim($"(inferred from {globalJsonPath})"));
     }
 
     [TestMethod]

--- a/test/dotnetup.Tests/WalkthroughSummaryTests.cs
+++ b/test/dotnetup.Tests/WalkthroughSummaryTests.cs
@@ -94,6 +94,21 @@ public class WalkthroughSummaryTests
     }
 
     [TestMethod]
+    public void BuildModeDescription_GlobalJsonInstallRoot_ShowsSourcePath()
+    {
+        const string globalJsonPath = "repo-root/global.json";
+        var plan = CreatePlan(
+            DotnetAccessMode.Everywhere,
+            shellProvider: null,
+            installRootGlobalJsonPath: globalJsonPath);
+
+        string description = WalkthroughSummary.BuildModeDescription(plan);
+
+        description.Should().Contain("inferred from");
+        description.Should().Contain(DotnetupTheme.Accent(globalJsonPath));
+    }
+
+    [TestMethod]
     public void BuildModeDescription_IsolationMode_ExplainsUnsupportedShell()
     {
         var plan = CreatePlan(DotnetAccessMode.None, shellProvider: null);
@@ -119,11 +134,15 @@ public class WalkthroughSummaryTests
         exception.ErrorCode.Should().Be(DotnetInstallErrorCode.Unknown);
     }
 
-    private static WalkthroughPlan CreatePlan(DotnetAccessMode accessMode, IEnvShellProvider? shellProvider)
+    private static WalkthroughPlan CreatePlan(
+        DotnetAccessMode accessMode,
+        IEnvShellProvider? shellProvider,
+        string? installRootGlobalJsonPath = null)
         => new(
             new DotnetInstallRoot("dotnetup-hive", InstallArchitecture.x64),
             accessMode,
             [],
             new DefaultChannelDisplay("latest", GlobalJsonPath: null),
-            shellProvider);
+            shellProvider,
+            installRootGlobalJsonPath);
 }

--- a/test/dotnetup.Tests/WalkthroughSummaryTests.cs
+++ b/test/dotnetup.Tests/WalkthroughSummaryTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
+using Microsoft.Dotnet.Installation;
+using Microsoft.DotNet.Tools.Bootstrapper;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
+using Microsoft.DotNet.Tools.Bootstrapper.Shell;
 
 namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
 
@@ -55,4 +58,61 @@ public class WalkthroughSummaryTests
 
         choices[index].Decision.Should().Be(WalkthroughDecision.Customize);
     }
+
+    [TestMethod]
+    public void BuildModeDescription_TerminalMode_ShowsProfilePathsAndInstallRoot()
+    {
+        var shellProvider = new TestShellProvider("profile-root", ".bashrc", ".profile");
+        var plan = CreatePlan(DotnetAccessMode.Shell, shellProvider);
+
+        string description = WalkthroughSummary.BuildModeDescription(plan);
+
+        description.Should().Contain(DotnetupTheme.Accent("Terminal Mode"));
+        foreach (string path in shellProvider.GetProfilePaths())
+        {
+            description.Should().Contain(DotnetupTheme.Accent(path));
+        }
+
+        description.Should().Contain(DotnetupTheme.Accent("PATH"));
+        description.Should().Contain(DotnetupTheme.Accent("DOTNET_ROOT"));
+        description.Should().Contain(DotnetupTheme.Accent(plan.InstallRoot.Path));
+    }
+
+    [TestMethod]
+    public void BuildModeDescription_EverywhereMode_ShowsSystemEnvironmentVariablesAndInstallRoot()
+    {
+        var plan = CreatePlan(DotnetAccessMode.Everywhere, shellProvider: null);
+
+        string description = WalkthroughSummary.BuildModeDescription(plan);
+
+        description.Should().Contain(DotnetupTheme.Accent("Everywhere Mode"));
+        description.Should().Contain(DotnetupTheme.Accent(
+            Microsoft.DotNet.Tools.Bootstrapper.Strings.SummaryModeSystemEnvironmentVariables));
+        description.Should().Contain(DotnetupTheme.Accent("PATH"));
+        description.Should().Contain(DotnetupTheme.Accent("DOTNET_ROOT"));
+        description.Should().Contain(DotnetupTheme.Accent(plan.InstallRoot.Path));
+    }
+
+    [TestMethod]
+    public void BuildModeDescription_IsolationMode_ExplainsUnsupportedShell()
+    {
+        var plan = CreatePlan(DotnetAccessMode.None, shellProvider: null);
+
+        string description = WalkthroughSummary.BuildModeDescription(plan);
+
+        description.Should().Contain(DotnetupTheme.Accent("Isolation Mode"));
+        description.Should().Contain("cannot be detected or is not supported");
+        foreach (IEnvShellProvider supportedShell in ShellDetection.s_supportedShells)
+        {
+            description.Should().Contain(supportedShell.ArgumentName);
+        }
+    }
+
+    private static WalkthroughPlan CreatePlan(DotnetAccessMode accessMode, IEnvShellProvider? shellProvider)
+        => new(
+            new DotnetInstallRoot("dotnetup-hive", InstallArchitecture.x64),
+            accessMode,
+            [],
+            new DefaultChannelDisplay("latest", GlobalJsonPath: null),
+            shellProvider);
 }

--- a/test/dotnetup.Tests/WalkthroughSummaryTests.cs
+++ b/test/dotnetup.Tests/WalkthroughSummaryTests.cs
@@ -108,6 +108,17 @@ public class WalkthroughSummaryTests
         }
     }
 
+    [TestMethod]
+    public void BuildModeDescription_TerminalModeWithoutShellProvider_ThrowsProductException()
+    {
+        var plan = CreatePlan(DotnetAccessMode.Shell, shellProvider: null);
+
+        var exception = Assert.ThrowsExactly<DotnetInstallException>(
+            () => WalkthroughSummary.BuildModeDescription(plan));
+
+        exception.ErrorCode.Should().Be(DotnetInstallErrorCode.Unknown);
+    }
+
     private static WalkthroughPlan CreatePlan(DotnetAccessMode accessMode, IEnvShellProvider? shellProvider)
         => new(
             new DotnetInstallRoot("dotnetup-hive", InstallArchitecture.x64),

--- a/test/dotnetup.Tests/WalkthroughSummaryTests.cs
+++ b/test/dotnetup.Tests/WalkthroughSummaryTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Dotnet.Installation;
 using Microsoft.DotNet.Tools.Bootstrapper;
 using Microsoft.DotNet.Tools.Bootstrapper.Commands.Init;
 using Microsoft.DotNet.Tools.Bootstrapper.Shell;
+using Microsoft.DotNet.Tools.Bootstrapper.Telemetry;
 
 namespace Microsoft.DotNet.Tools.Dotnetup.Tests;
 
@@ -131,7 +132,8 @@ public class WalkthroughSummaryTests
         var exception = Assert.ThrowsExactly<DotnetInstallException>(
             () => WalkthroughSummary.BuildModeDescription(plan));
 
-        exception.ErrorCode.Should().Be(DotnetInstallErrorCode.Unknown);
+        exception.ErrorCode.Should().Be(DotnetInstallErrorCode.InvalidModeSelection);
+        ErrorCategoryClassifier.ClassifyInstallError(exception.ErrorCode).Should().Be(ErrorCategory.Product);
     }
 
     private static WalkthroughPlan CreatePlan(


### PR DESCRIPTION
While this is not a complete resolution of https://github.com/dotnet/sdk/issues/53963#issue-4283476888, (it does not fix the UX for 'env' commands), it does change the summary walkthrough to be more clear about the changes you are making and what each `dotnetup` `mode` does.

We likely want to enhance the walkthrough further,  but I felt this was a large positive net change for only needing a small code change, and the logic here will need to exist in any future walkthrough improvement anyways. 

In addition, this makes it more clear for users to understand what files we are about to modify, and whether `dotnetup` will work at all (example: if they were on an unsupported shell we might still pick terminal mode without any warning.)

The only functional change is the messaging - no behavioral changes were added.

# New examples:

Replacement mode (default on Win):
<img width="1683" height="818" alt="image" src="https://github.com/user-attachments/assets/2fc048e5-d112-41f9-b655-fb54f3e38f49" />(it also shows if the path is inferred from global.json) 

Terminal mode (default on unix):
<img width="1137" height="451" alt="image" src="https://github.com/user-attachments/assets/ee218fe0-c8d4-4059-be3e-2ef93bc3fe23" />

When you're on an unsupported shell:
<img width="1141" height="457" alt="image" src="https://github.com/user-attachments/assets/e82a8b5c-8953-4ebe-8b9a-c9f6533eff05" />

# Old Behavior:

<img width="1063" height="624" alt="image" src="https://github.com/user-attachments/assets/1a25f7c8-01d3-4601-9efc-da901c3d0cb5" />
