### PR TITLE
Fix Microsoft.CodeAnalysis.Analyzers version mismatch

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,7 @@
     <SystemDataSqlClientPackageVersion>4.8.6</SystemDataSqlClientPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta5.25279.2</SystemCommandLineNamingConventionBinderVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>5.10.0-1.26363.117</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>5.10.0-1.26365.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.2</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <MicrosoftVisualBasicVersion>10.3.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>3.2.2146</MicrosoftVisualStudioSetupConfigurationInteropVersion>


### PR DESCRIPTION
Public main CI builds 1543163 and 1543195 fail restore with NU1109 because the newly added central `Microsoft.CodeAnalysis.Analyzers` pin is lower than the minimum required by the Roslyn packages currently flowing into main.

Update the central version from `5.10.0-1.26363.117` to the minimum compatible `5.10.0-1.26365.3`. This preserves the intended analyzer dogfooding while avoiding unnecessary dependency churn.

Validated by restoring the Razor SDK tool and Template Engine unit test projects that failed in CI.