### PR TITLE
Fix logic bug in file mode calculation in sdk container builds

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -216,7 +216,7 @@ internal class Layer
 
                     // On Unix, we can determine the x-bit based on the filesystem permission.
                     // On Windows, we use executable permissions for all entries.
-                    return (OperatingSystem.IsWindows() || ((file.UnixFileMode | UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
+                    return (OperatingSystem.IsWindows() || ((file.UnixFileMode & UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
                 }
             }
         }

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -191,7 +191,7 @@ internal class Layer
 
                     // On Unix, we can determine the x-bit based on the filesystem permission.
                     // On Windows, we use executable permissions for all entries.
-                    return (OperatingSystem.IsWindows() || ((file.UnixFileMode | UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
+                    return (OperatingSystem.IsWindows() || ((file.UnixFileMode & UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
                 }
             }
         }

--- a/test/Microsoft.NET.Build.Containers.UnitTests/LayerTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/LayerTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Tar;
+using System.IO.Compression;
+
+namespace Microsoft.NET.Build.Containers.UnitTests;
+
+[TestClass]
+public class LayerTests
+{
+    [TestMethod]
+    // Windows does not expose Unix execute permissions, so Layer.FromDirectory marks all entries executable there.
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+    public void FromDirectorySetsFileModeBasedOnUnixExecutePermission()
+    {
+        DirectoryInfo folder = Directory.CreateTempSubdirectory();
+        string? backingFile = null;
+
+        try
+        {
+            const UnixFileMode nonExecuteMode = UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                                                UnixFileMode.GroupRead |
+                                                UnixFileMode.OtherRead;
+            const UnixFileMode executeMode = nonExecuteMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+            string nonExecutableFilePath = Path.Join(folder.FullName, "non-executable.txt");
+            string executableFilePath = Path.Join(folder.FullName, "executable.txt");
+            File.WriteAllText(nonExecutableFilePath, Guid.NewGuid().ToString());
+            File.WriteAllText(executableFilePath, Guid.NewGuid().ToString());
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(nonExecutableFilePath, nonExecuteMode);
+                File.SetUnixFileMode(executableFilePath, executeMode);
+            }
+
+            Layer layer = Layer.FromDirectory(folder.FullName, "/app", false, SchemaTypes.DockerManifestV2);
+            backingFile = layer.BackingFile;
+
+            Dictionary<string, TarEntry> entries = LoadAllTarEntries(backingFile);
+            Assert.AreEqual(nonExecuteMode, entries["app/non-executable.txt"].Mode);
+            Assert.AreEqual(executeMode, entries["app/executable.txt"].Mode);
+        }
+        finally
+        {
+            if (backingFile is not null)
+            {
+                File.Delete(backingFile);
+            }
+
+            folder.Delete(recursive: true);
+        }
+    }
+
+    private static Dictionary<string, TarEntry> LoadAllTarEntries(string file)
+    {
+        using var gzip = new GZipStream(File.OpenRead(file), CompressionMode.Decompress);
+        using var tar = new TarReader(gzip);
+
+        Dictionary<string, TarEntry> entries = [];
+        TarEntry? entry;
+        while ((entry = tar.GetNextEntry()) is not null)
+        {
+            entries[entry.Name] = entry;
+        }
+
+        return entries;
+    }
+}


### PR DESCRIPTION
The bitwise or here always produced a nonzero value, marking every Unix file as 755 when some should be 644.