### PR TITLE
Address remaining telemetry exporter review feedback

### DIFF
--- a/dotnetup.slnf
+++ b/dotnetup.slnf
@@ -6,6 +6,7 @@
       "src\\Installer\\dotnetup\\dotnetup.csproj",
       "src\\Installer\\dotnetup.Library\\dotnetup.Library.csproj",
       "src\\Installer\\Microsoft.Dotnet.Installation\\Microsoft.Dotnet.Installation.csproj",
+      "test\\Microsoft.DotNet.Cli.Telemetry.Tests\\Microsoft.DotNet.Cli.Telemetry.Tests.csproj",
       "test\\dotnetup.Tests\\dotnetup.Tests.csproj"
     ]
   }

--- a/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
@@ -10,7 +10,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
 {
     private readonly Func<CancellationToken, Task<TelemetryDrainResult>> _drainAsync;
     private readonly SemaphoreSlim _drainSignal = new(0, 1);
-    private readonly object _sync = new();
+    private readonly object _syncLock = new();
     private CancellationTokenSource? _cancellation;
     private int _drainRequested;
     private bool _shutdown;
@@ -32,7 +32,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
 
     public void RequestDrain()
     {
-        lock (_sync)
+        lock (_syncLock)
         {
             if (_shutdown)
             {
@@ -56,7 +56,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
     {
         CancellationTokenSource? cancellation;
         Task? task;
-        lock (_sync)
+        lock (_syncLock)
         {
             _shutdown = true;
             cancellation = _cancellation;

--- a/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.Cli.Telemetry.Implementation;
 internal sealed class PersistentStorageTelemetryBackgroundWorker
 {
     private readonly Func<CancellationToken, Task<TelemetryDrainResult>> _drainAsync;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private readonly SemaphoreSlim _drainSignal = new(0, 1);
     private readonly object _syncLock = new();
     private CancellationTokenSource? _cancellation;
@@ -26,8 +27,16 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
     }
 
     internal PersistentStorageTelemetryBackgroundWorker(Func<CancellationToken, Task<TelemetryDrainResult>> drainAsync)
+        : this(drainAsync, static (delay, cancellationToken) => Task.Delay(delay, cancellationToken))
+    {
+    }
+
+    internal PersistentStorageTelemetryBackgroundWorker(
+        Func<CancellationToken, Task<TelemetryDrainResult>> drainAsync,
+        Func<TimeSpan, CancellationToken, Task> delayAsync)
     {
         _drainAsync = drainAsync;
+        _delayAsync = delayAsync;
     }
 
     public void RequestDrain()
@@ -95,6 +104,13 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
                 while (result.DeletedBlobCount > 0
                     && !result.ShouldBackOff
                     && !cancellationToken.IsCancellationRequested);
+
+                if (result.RetryAfter is { } retryAfter)
+                {
+                    await _delayAsync(
+                        PersistentStorageTelemetryDrainer.ClampToSupportedTimerDelay(retryAfter),
+                        cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Telemetry/Implementation/PersistentStorageTelemetryBackgroundWorker.cs
@@ -13,7 +13,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
     private readonly object _syncLock = new();
     private CancellationTokenSource? _cancellation;
     private int _drainRequested;
-    private bool _shutdown;
+    private bool _isShutdown;
     private Task? _task;
 
     public PersistentStorageTelemetryBackgroundWorker(
@@ -34,7 +34,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
     {
         lock (_syncLock)
         {
-            if (_shutdown)
+            if (_isShutdown)
             {
                 return;
             }
@@ -58,7 +58,7 @@ internal sealed class PersistentStorageTelemetryBackgroundWorker
         Task? task;
         lock (_syncLock)
         {
-            _shutdown = true;
+            _isShutdown = true;
             cancellation = _cancellation;
             task = _task;
         }

--- a/src/Cli/Microsoft.DotNet.Cli.Telemetry/PersistentStorageTelemetryExporter.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Telemetry/PersistentStorageTelemetryExporter.cs
@@ -47,13 +47,12 @@ internal abstract class PersistentStorageTelemetryExporter<T> : BaseExporter<T>
                 return ExportResult.Success;
             }
 
-            if (!_storage.TryPersist(bytes))
-            {
-                return ExportResult.Failure;
-            }
-
+            var persisted = _storage.TryPersist(bytes);
             _backgroundWorker?.RequestDrain();
-            return ExportResult.Success;
+
+            return persisted
+                ? ExportResult.Success
+                : ExportResult.Failure;
         }
         catch (Exception e)
         {

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryBackgroundWorkerTests.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryBackgroundWorkerTests.cs
@@ -84,4 +84,45 @@ public class PersistentStorageTelemetryBackgroundWorkerTests
         worker.Shutdown(1_000).Should().BeTrue();
         passes.Should().Be(3);
     }
+
+    [TestMethod]
+    public async Task RequestDrain_HonorsRetryAfterBeforeDrainingAgain()
+    {
+        var expectedDelay = TimeSpan.FromSeconds(17);
+        var delayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelay = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondDrain = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var passes = 0;
+        var worker = new PersistentStorageTelemetryBackgroundWorker(
+            _ =>
+            {
+                if (Interlocked.Increment(ref passes) == 1)
+                {
+                    return Task.FromResult(new TelemetryDrainResult(
+                        deletedBlobCount: 0,
+                        shouldBackOff: true,
+                        retryAfter: expectedDelay));
+                }
+
+                secondDrain.SetResult();
+                return Task.FromResult(new TelemetryDrainResult(0, shouldBackOff: false, retryAfter: null));
+            },
+            (delay, _) =>
+            {
+                delay.Should().Be(expectedDelay);
+                delayStarted.SetResult();
+                return releaseDelay.Task;
+            });
+
+        worker.RequestDrain();
+        await delayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+        worker.RequestDrain();
+
+        secondDrain.Task.IsCompleted.Should().BeFalse();
+        releaseDelay.SetResult();
+        await secondDrain.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+
+        worker.Shutdown(1_000).Should().BeTrue();
+        passes.Should().Be(2);
+    }
 }

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryDrainerTests.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryDrainerTests.cs
@@ -11,8 +11,8 @@ public class PersistentStorageTelemetryDrainerTests
     [TestMethod]
     public async Task RunCoreAsync_EscalatesRetryDelaysAndHonorsRetryAfter()
     {
-        var storage = new FakeBlobStorage(new FakeBlob([1]));
-        var transport = new FakeTransport(
+        var storage = new FakeTelemetryBlobStorage(new FakeTelemetryBlob([1]));
+        var transport = new FakeTelemetryUploadTransport(
             TelemetryUploadResult.Rejected,
             TelemetryUploadResult.Rejected,
             TelemetryUploadResult.RejectedRetryAfter(TimeSpan.FromSeconds(7)),
@@ -38,8 +38,8 @@ public class PersistentStorageTelemetryDrainerTests
     [TestMethod]
     public async Task RunCoreAsync_StopsWhenRetryDelayIsCancelled()
     {
-        var storage = new FakeBlobStorage(new FakeBlob([1]));
-        var transport = new FakeTransport(TelemetryUploadResult.Rejected, TelemetryUploadResult.Rejected);
+        var storage = new FakeTelemetryBlobStorage(new FakeTelemetryBlob([1]));
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.Rejected, TelemetryUploadResult.Rejected);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
         using var cancellation = new CancellationTokenSource();
         var delays = new CancellingDelay(cancellation);
@@ -57,8 +57,8 @@ public class PersistentStorageTelemetryDrainerTests
     [TestMethod]
     public async Task RunCoreAsync_DrainsBacklogBeforePostDrainGracePeriod()
     {
-        var storage = new FakeBlobStorage(new FakeBlob([1]), new FakeBlob([2]));
-        var transport = new FakeTransport(
+        var storage = new FakeTelemetryBlobStorage(new FakeTelemetryBlob([1]), new FakeTelemetryBlob([2]));
+        var transport = new FakeTelemetryUploadTransport(
             TelemetryUploadResult.Accepted,
             TelemetryUploadResult.Accepted);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport, maxBlobsPerDrain: 1);
@@ -143,44 +143,4 @@ public class PersistentStorageTelemetryDrainerTests
         public override double NextDouble() => value;
     }
 
-    private sealed class FakeBlobStorage(params FakeBlob[] blobs) : ITelemetryBlobStorage
-    {
-        public IEnumerable<ITelemetryBlob> GetBlobs() => blobs.Where(blob => !blob.Deleted);
-
-        public bool TryPersist(byte[] data) => true;
-    }
-
-    private sealed class FakeBlob(byte[] data) : ITelemetryBlob
-    {
-        public bool Deleted { get; private set; }
-
-        public bool TryLease(int leasePeriodMilliseconds) => !Deleted;
-
-        public bool TryRead(out byte[]? buffer)
-        {
-            buffer = data;
-            return true;
-        }
-
-        public bool TryRelease() => true;
-
-        public bool TryDelete()
-        {
-            Deleted = true;
-            return true;
-        }
-    }
-
-    private sealed class FakeTransport(params TelemetryUploadResult[] results) : ITelemetryUploadTransport
-    {
-        private readonly Queue<TelemetryUploadResult> _results = new(results);
-
-        public int UploadCount { get; private set; }
-
-        public Task<TelemetryUploadResult> TryUploadAsync(byte[] payload, CancellationToken cancellationToken)
-        {
-            UploadCount++;
-            return Task.FromResult(_results.Dequeue());
-        }
-    }
 }

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryUploaderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTelemetryUploaderTests.cs
@@ -11,8 +11,12 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItUploadsAndDeletesBlobsOnSuccess()
     {
-        var storage = new FakeBlobStorage(new FakeBlob([1, 2, 3]), new FakeBlob([4, 5, 6]));
-        var transport = new FakeTransport(TelemetryUploadResult.Accepted);
+        var storage = new FakeTelemetryBlobStorage(
+            new FakeTelemetryBlob([1, 2, 3]),
+            new FakeTelemetryBlob([4, 5, 6]));
+        var transport = new FakeTelemetryUploadTransport(
+            TelemetryUploadResult.Accepted,
+            TelemetryUploadResult.Accepted);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         await uploader.DrainAsync(CancellationToken.None);
@@ -24,9 +28,9 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItDeletesBlobWhenUploadSucceeds()
     {
-        var blob = new FakeBlob([10, 20, 30]);
-        var storage = new FakeBlobStorage(blob);
-        var transport = new FakeTransport(TelemetryUploadResult.Accepted);
+        var blob = new FakeTelemetryBlob([10, 20, 30]);
+        var storage = new FakeTelemetryBlobStorage(blob);
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.Accepted);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         await uploader.DrainAsync(CancellationToken.None);
@@ -38,8 +42,8 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItRetainsBlobsWhenUploadFails()
     {
-        var storage = new FakeBlobStorage(new FakeBlob([1, 2, 3]));
-        var transport = new FakeTransport(TelemetryUploadResult.Rejected);
+        var storage = new FakeTelemetryBlobStorage(new FakeTelemetryBlob([1, 2, 3]));
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.Rejected);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         await uploader.DrainAsync(CancellationToken.None);
@@ -52,10 +56,10 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItDeletesPermanentlyRejectedBlobAndContinuesDraining()
     {
-        var permanentlyRejected = new FakeBlob([1, 2, 3]);
-        var accepted = new FakeBlob([4, 5, 6]);
-        var storage = new FakeBlobStorage(permanentlyRejected, accepted);
-        var transport = new SequenceTransport(
+        var permanentlyRejected = new FakeTelemetryBlob([1, 2, 3]);
+        var accepted = new FakeTelemetryBlob([4, 5, 6]);
+        var storage = new FakeTelemetryBlobStorage(permanentlyRejected, accepted);
+        var transport = new FakeTelemetryUploadTransport(
             TelemetryUploadResult.PermanentlyRejected,
             TelemetryUploadResult.Accepted);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
@@ -71,8 +75,8 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItReleasesLeaseWhenUploadIsCancelled()
     {
-        var blob = new FakeBlob([1, 2, 3]);
-        var storage = new FakeBlobStorage(blob);
+        var blob = new FakeTelemetryBlob([1, 2, 3]);
+        var storage = new FakeTelemetryBlobStorage(blob);
         using var cancellationSource = new CancellationTokenSource();
         var uploader = new PersistentStorageTelemetryUploader(storage, new CancellingTransport(cancellationSource));
 
@@ -85,10 +89,10 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItSkipsBlobsThatCannotBeLeased()
     {
-        var leasable = new FakeBlob([1]);
-        var locked = new FakeBlob([2]) { CanLease = false };
-        var storage = new FakeBlobStorage(locked, leasable);
-        var transport = new FakeTransport(TelemetryUploadResult.Accepted);
+        var leasable = new FakeTelemetryBlob([1]);
+        var locked = new FakeTelemetryBlob([2]) { CanLease = false };
+        var storage = new FakeTelemetryBlobStorage(locked, leasable);
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.Accepted);
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         await uploader.DrainAsync(CancellationToken.None);
@@ -101,9 +105,9 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItDeletesUnreadableBlobsWithoutUploading()
     {
-        var unreadable = new FakeBlob(null);
-        var storage = new FakeBlobStorage(unreadable);
-        var transport = new FakeTransport(TelemetryUploadResult.Accepted);
+        var unreadable = new FakeTelemetryBlob(null);
+        var storage = new FakeTelemetryBlobStorage(unreadable);
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.Accepted);
 
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
@@ -117,8 +121,8 @@ public class PersistentStorageTelemetryUploaderTests
     public async Task ItPersistsRetriableRemainderAndDeletesBlobOnPartialAcceptance()
     {
         var remainder = new byte[] { 9, 9, 9 };
-        var storage = new FakeBlobStorage(new FakeBlob([1, 2, 3]));
-        var transport = new FakeTransport(TelemetryUploadResult.PartiallyAccepted(remainder));
+        var storage = new FakeTelemetryBlobStorage(new FakeTelemetryBlob([1, 2, 3]));
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.PartiallyAccepted(remainder));
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         var result = await uploader.DrainAsync(CancellationToken.None);
@@ -135,10 +139,10 @@ public class PersistentStorageTelemetryUploaderTests
     public async Task ItStopsPassAndReportsRetryAfterOnRetryableResponse()
     {
         var expectedDelay = TimeSpan.FromSeconds(17);
-        var first = new FakeBlob([1, 2, 3]);
-        var second = new FakeBlob([4, 5, 6]);
-        var storage = new FakeBlobStorage(first, second);
-        var transport = new FakeTransport(TelemetryUploadResult.RejectedRetryAfter(expectedDelay));
+        var first = new FakeTelemetryBlob([1, 2, 3]);
+        var second = new FakeTelemetryBlob([4, 5, 6]);
+        var storage = new FakeTelemetryBlobStorage(first, second);
+        var transport = new FakeTelemetryUploadTransport(TelemetryUploadResult.RejectedRetryAfter(expectedDelay));
         var uploader = new PersistentStorageTelemetryUploader(storage, transport);
 
         var result = await uploader.DrainAsync(CancellationToken.None);
@@ -154,9 +158,9 @@ public class PersistentStorageTelemetryUploaderTests
     [TestMethod]
     public async Task ItStopsPassAndBacksOffWhenTransportThrows()
     {
-        var first = new FakeBlob([1, 2, 3]);
-        var second = new FakeBlob([4, 5, 6]);
-        var storage = new FakeBlobStorage(first, second);
+        var first = new FakeTelemetryBlob([1, 2, 3]);
+        var second = new FakeTelemetryBlob([4, 5, 6]);
+        var storage = new FakeTelemetryBlobStorage(first, second);
         var uploader = new PersistentStorageTelemetryUploader(storage, new ThrowingTransport());
 
         var result = await uploader.DrainAsync(CancellationToken.None);
@@ -166,81 +170,6 @@ public class PersistentStorageTelemetryUploaderTests
         result.DeletedBlobCount.Should().Be(0);
         result.ShouldBackOff.Should().BeTrue();
         result.RetryAfter.Should().BeNull();
-    }
-
-    private sealed class FakeBlobStorage(params FakeBlob[] blobs) : ITelemetryBlobStorage
-    {
-        public List<FakeBlob> Blobs { get; } = [.. blobs];
-
-        public bool TryPersist(byte[] data)
-        {
-            Blobs.Add(new FakeBlob(data));
-            return true;
-        }
-
-        public IEnumerable<ITelemetryBlob> GetBlobs() => Blobs;
-    }
-
-    private sealed class FakeBlob(byte[]? data) : ITelemetryBlob
-    {
-        public bool CanLease { get; set; } = true;
-        public bool Leased { get; private set; }
-        public bool Released { get; private set; }
-        public bool Deleted { get; private set; }
-        public byte[]? Data => data;
-
-        public bool TryLease(int leasePeriodMilliseconds)
-        {
-            if (!CanLease)
-            {
-                return false;
-            }
-
-            Leased = true;
-            return true;
-        }
-
-        public bool TryRead(out byte[]? buffer)
-        {
-            buffer = data;
-            return data is not null;
-        }
-
-        public bool TryRelease()
-        {
-            Released = true;
-            return true;
-        }
-
-        public bool TryDelete()
-        {
-            Deleted = true;
-            return true;
-        }
-    }
-
-    private sealed class FakeTransport(TelemetryUploadResult result) : ITelemetryUploadTransport
-    {
-        public int UploadCount { get; private set; }
-
-        public Task<TelemetryUploadResult> TryUploadAsync(byte[] payload, CancellationToken cancellationToken)
-        {
-            UploadCount++;
-            return Task.FromResult(result);
-        }
-    }
-
-    private sealed class SequenceTransport(params TelemetryUploadResult[] results) : ITelemetryUploadTransport
-    {
-        private readonly Queue<TelemetryUploadResult> _results = new(results);
-
-        public int UploadCount { get; private set; }
-
-        public Task<TelemetryUploadResult> TryUploadAsync(byte[] payload, CancellationToken cancellationToken)
-        {
-            UploadCount++;
-            return Task.FromResult(_results.Dequeue());
-        }
     }
 
     private sealed class CancellingTransport(CancellationTokenSource cancellationSource) : ITelemetryUploadTransport

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTraceExporterTests.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/PersistentStorageTraceExporterTests.cs
@@ -34,7 +34,28 @@ public class PersistentStorageTraceExporterTests
         exporter.Shutdown(1_000).Should().BeTrue();
     }
 
-    private sealed class RecordingBlobStorage : ITelemetryBlobStorage
+    [TestMethod]
+    public async Task Export_RequestsBackgroundDrainWhenPersistFails()
+    {
+        var storage = new RecordingBlobStorage(persistResult: false);
+        var exporter = new PersistentStorageTraceExporter(
+            storage,
+            Guid.NewGuid().ToString(),
+            new Uri("http://127.0.0.1:1/"),
+            leasePeriodMilliseconds: 30_000,
+            maxBlobsPerDrain: 200);
+        using var activity = new Activity("test").Start();
+        activity.Stop();
+        var batch = new Batch<Activity>([activity], 1);
+
+        exporter.Export(in batch).Should().Be(ExportResult.Failure);
+        await storage.DrainRequested.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+
+        storage.DrainSequence.Should().BeGreaterThan(storage.PersistSequence);
+        exporter.Shutdown(1_000).Should().BeTrue();
+    }
+
+    private sealed class RecordingBlobStorage(bool persistResult = true) : ITelemetryBlobStorage
     {
         private int _sequence;
 
@@ -55,7 +76,7 @@ public class PersistentStorageTraceExporterTests
         public bool TryPersist(byte[] data)
         {
             PersistSequence = Interlocked.Increment(ref _sequence);
-            return true;
+            return persistResult;
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/TelemetryTestFakes.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/TelemetryTestFakes.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Telemetry.Implementation;
+
+namespace Microsoft.DotNet.Cli.Telemetry.Tests;
+
+internal sealed class FakeTelemetryBlobStorage(params FakeTelemetryBlob[] blobs) : ITelemetryBlobStorage
+{
+    public List<FakeTelemetryBlob> Blobs { get; } = [.. blobs];
+
+    public IEnumerable<ITelemetryBlob> GetBlobs() => Blobs.Where(blob => !blob.Deleted);
+
+    public bool TryPersist(byte[] data)
+    {
+        Blobs.Add(new FakeTelemetryBlob(data));
+        return true;
+    }
+}
+
+internal sealed class FakeTelemetryBlob(byte[]? data) : ITelemetryBlob
+{
+    public bool CanLease { get; set; } = true;
+    public bool Leased { get; private set; }
+    public bool Released { get; private set; }
+    public bool Deleted { get; private set; }
+    public byte[]? Data => data;
+
+    public bool TryLease(int leasePeriodMilliseconds)
+    {
+        if (!CanLease || Deleted)
+        {
+            return false;
+        }
+
+        Leased = true;
+        return true;
+    }
+
+    public bool TryRead(out byte[]? buffer)
+    {
+        buffer = data;
+        return data is not null;
+    }
+
+    public bool TryRelease()
+    {
+        Released = true;
+        return true;
+    }
+
+    public bool TryDelete()
+    {
+        Deleted = true;
+        return true;
+    }
+}
+
+internal sealed class FakeTelemetryUploadTransport(params TelemetryUploadResult[] results) : ITelemetryUploadTransport
+{
+    private readonly Queue<TelemetryUploadResult> _results = new(results);
+
+    public int UploadCount { get; private set; }
+
+    public Task<TelemetryUploadResult> TryUploadAsync(byte[] payload, CancellationToken cancellationToken)
+    {
+        UploadCount++;
+        return Task.FromResult(_results.Dequeue());
+    }
+}

--- a/test/dotnetup.Tests/TelemetryDrainE2ETests.cs
+++ b/test/dotnetup.Tests/TelemetryDrainE2ETests.cs
@@ -14,9 +14,8 @@ public class TelemetryDrainE2ETests
     private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(20);
 
     [TestMethod]
-    public async Task NativeAotDrainMode_UploadsAndDeletesPersistedTelemetry()
+    public async Task DrainMode_UploadsAndDeletesPersistedTelemetry()
     {
-        DotnetupTestUtilities.GetNativeDotnetupExecutablePath();
         using var server = new MockTelemetryIngestionServer();
         using var environment = new TelemetryTestEnvironment(server.IngestionEndpoint);
 
@@ -32,9 +31,8 @@ public class TelemetryDrainE2ETests
     }
 
     [TestMethod]
-    public async Task NativeAotNormalMode_SpawnsDetachedDrainerThatUploadsTelemetry()
+    public async Task NormalMode_SpawnsDetachedDrainerThatUploadsTelemetry()
     {
-        DotnetupTestUtilities.GetNativeDotnetupExecutablePath();
         using var server = new MockTelemetryIngestionServer();
         using var environment = new TelemetryTestEnvironment(server.IngestionEndpoint);
 
@@ -47,9 +45,8 @@ public class TelemetryDrainE2ETests
     }
 
     [TestMethod]
-    public void NativeAotEnvScript_UsesShellStartupShutdownBudget()
+    public void EnvScript_UsesShellStartupShutdownBudget()
     {
-        DotnetupTestUtilities.GetNativeDotnetupExecutablePath();
         using var server = new MockTelemetryIngestionServer();
         using var environment = new TelemetryTestEnvironment(server.IngestionEndpoint);
         environment.ConfigureShutdownBudgetObservation();

--- a/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
+++ b/test/dotnetup.Tests/Utilities/DotnetupTestUtilities.cs
@@ -318,18 +318,6 @@ internal static class DotnetupTestUtilities
             $"or 'dotnet build src/Installer/dotnetup/dotnetup.csproj -c {configuration}' for the managed binary.");
     }
 
-    public static string GetNativeDotnetupExecutablePath()
-    {
-        string path = GetDotnetupExecutablePath();
-        if (!string.Equals(Path.GetFileName(Path.GetDirectoryName(path)), "publish", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new FileNotFoundException(
-                $"Native AOT dotnetup executable not found. Expected a published executable, but resolved '{path}'.");
-        }
-
-        return path;
-    }
-
     /// <summary>
     /// Runs the dotnetup executable as a separate process
     /// </summary>


### PR DESCRIPTION
Follow-up to #55421 addressing its remaining unresolved review threads commit-by-commit.

- Clarifies the background worker synchronization and shutdown field names.
- Honors server `Retry-After` delays before processing another background drain request.
- Drains existing telemetry even when persisting the current export fails.
- Consolidates duplicate persistent telemetry test fakes.
- Includes telemetry tests in `dotnetup.slnf`.
- Removes the redundant publish-directory assertion from dotnetup telemetry E2E tests.

The cross-component SDK/dotnetup telemetry-store test requested in [r3693799134](https://github.com/dotnet/sdk/pull/55421#discussion_r3693799134) remains tracked by #55649 because reliable coverage first needs compatible Stage 0 SDK storage and ingestion-endpoint test hooks. The suggested implementation is to create telemetry with one producer, drain it with the other into a mock endpoint, then reverse the roles.

Each commit message links the specific original review discussion it addresses.