### PR TITLE
Add HTTP transport for WebAssembly test hosts

### DIFF
--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -8,8 +8,12 @@ internal static class CliConstants
     public const string ServerOptionKey = "--server";
     public const string HelpOptionKey = "--help";
     public const string DotNetTestPipeOptionKey = "--dotnet-test-pipe";
+    public const string DotNetTestTransportOptionKey = "--dotnet-test-transport";
+    public const string DotNetTestHttpEndpointOptionKey = "--dotnet-test-http-endpoint";
+    public const string DotNetTestHttpTokenOptionKey = "--dotnet-test-http-token";
 
     public const string ServerOptionValue = "dotnettestcli";
+    public const string DotNetTestHttpTransportValue = "http";
     public const string ArtifactPostProcessingToolName = "internal-merge-artifacts";
     public const string ArtifactPostProcessingManifestOptionKey = "--manifest";
 

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
@@ -90,8 +90,22 @@ internal sealed class ArtifactPostProcessingManager
         ArtifactPostProcessingPlan plan = ArtifactPostProcessingPlanner.Plan(
             SnapshotApplications(),
             SnapshotArtifacts());
+        ArtifactPostProcessingJob[] runnableJobs =
+        [
+            .. plan.Jobs.Where(job =>
+            {
+                bool supported = !TestApplication.RequiresHttpTransport(job.Application.Module);
+                if (!supported)
+                {
+                    Logger.LogTrace(
+                        $"Skipping artifact post-processing for WebAssembly module '{job.Application.Module.TargetPath}' because no browser-aware merge host is available.");
+                }
 
-        if (plan.Jobs.Count == 0)
+                return supported;
+            }),
+        ];
+
+        if (runnableJobs.Length == 0)
         {
             return;
         }
@@ -105,7 +119,7 @@ internal sealed class ArtifactPostProcessingManager
         int executedJobs = 0;
         int failedJobs = 0;
 
-        foreach (ArtifactPostProcessingJob job in plan.Jobs)
+        foreach (ArtifactPostProcessingJob job in runnableJobs)
         {
             if (ctrlC.Token.IsCancellationRequested)
             {

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/HttpTestHostGateway.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/HttpTestHostGateway.cs
@@ -155,7 +155,8 @@ internal sealed class HttpTestHostGateway : IDisposable
                 return;
             }
 
-            if (!string.Equals(request.ContentType, BinaryContentType, StringComparison.OrdinalIgnoreCase))
+            if (!MediaTypeHeaderValue.TryParse(request.ContentType, out MediaTypeHeaderValue? contentType) ||
+                !string.Equals(contentType.MediaType, BinaryContentType, StringComparison.OrdinalIgnoreCase))
             {
                 await CompleteErrorResponseAsync(response, HttpStatusCode.UnsupportedMediaType, cancellationToken);
                 return;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/HttpTestHostGateway.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/HttpTestHostGateway.cs
@@ -1,0 +1,352 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC;
+
+internal sealed class HttpTestHostGateway : IDisposable
+{
+    internal const int MaximumFrameSize = 256 * 1024 * 1024;
+    private const string BinaryContentType = "application/octet-stream";
+
+    private readonly Func<IRequest, Task<IResponse>> _callback;
+    private readonly HttpListener _listener;
+    private readonly ProtocolMessageSerializer _serializer = new();
+    private readonly CancellationTokenRegistration _cancellationRegistration;
+    private readonly Task _listenerTask;
+    private readonly Lock _originLock = new();
+    private string? _allowedOrigin;
+    private bool _disposed;
+
+    public HttpTestHostGateway(
+        Func<IRequest, Task<IResponse>> callback,
+        CancellationToken cancellationToken,
+        string? allowedOrigin = null)
+    {
+        _callback = callback;
+        _allowedOrigin = NormalizeOrigin(allowedOrigin);
+        _serializer.RegisterAllSerializers();
+
+        Token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        (_listener, Endpoint) = StartListener();
+        _cancellationRegistration = cancellationToken.Register(
+            static state => ((HttpListener)state!).Close(),
+            _listener);
+        _listenerTask = ListenAsync(cancellationToken);
+    }
+
+    public Uri Endpoint { get; }
+
+    public string Token { get; }
+
+    private static (HttpListener Listener, Uri Endpoint) StartListener()
+    {
+        const int maximumAttempts = 10;
+        for (int attempt = 0; attempt < maximumAttempts; attempt++)
+        {
+            int port = GetAvailableLoopbackPort();
+            string path = $"dotnettest/{Guid.NewGuid():N}/";
+            var endpoint = new Uri($"http://127.0.0.1:{port}/{path}");
+            var listener = new HttpListener();
+            listener.Prefixes.Add(endpoint.AbsoluteUri);
+
+            try
+            {
+                listener.Start();
+                return (listener, endpoint);
+            }
+            catch (HttpListenerException) when (attempt + 1 < maximumAttempts)
+            {
+                listener.Close();
+            }
+        }
+
+        throw new InvalidOperationException("Unable to start the dotnet test HTTP gateway on loopback.");
+    }
+
+    private static int GetAvailableLoopbackPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private async Task ListenAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                HttpListenerContext context = await _listener.GetContextAsync().WaitAsync(cancellationToken);
+                await HandleRequestAsync(context, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (HttpListenerException) when (cancellationToken.IsCancellationRequested || !_listener.IsListening)
+        {
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested || !_listener.IsListening)
+        {
+        }
+    }
+
+    private async Task HandleRequestAsync(HttpListenerContext context, CancellationToken cancellationToken)
+    {
+        HttpListenerRequest request = context.Request;
+        HttpListenerResponse response = context.Response;
+
+        try
+        {
+            if (!string.Equals(request.Url?.AbsolutePath, Endpoint.AbsolutePath, StringComparison.Ordinal))
+            {
+                await CompleteErrorResponseAsync(response, HttpStatusCode.NotFound, cancellationToken);
+                return;
+            }
+
+            if (string.Equals(request.HttpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!TryApplyCorsHeaders(request, response, pinOrigin: true))
+                {
+                    await CompleteErrorResponseAsync(response, HttpStatusCode.Forbidden, cancellationToken);
+                    return;
+                }
+
+                response.Headers["Access-Control-Allow-Methods"] = "POST";
+                response.Headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type";
+                if (string.Equals(request.Headers["Access-Control-Request-Private-Network"], "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    response.Headers["Access-Control-Allow-Private-Network"] = "true";
+                }
+
+                response.StatusCode = (int)HttpStatusCode.NoContent;
+                response.ContentLength64 = 0;
+                response.Close();
+                return;
+            }
+
+            if (!string.Equals(request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase))
+            {
+                TryApplyCorsHeaders(request, response, pinOrigin: false);
+                response.Headers["Allow"] = "POST, OPTIONS";
+                await CompleteErrorResponseAsync(response, HttpStatusCode.MethodNotAllowed, cancellationToken);
+                return;
+            }
+
+            if (!IsAuthorized(request))
+            {
+                TryApplyCorsHeaders(request, response, pinOrigin: false);
+                response.Headers["WWW-Authenticate"] = "Bearer";
+                await CompleteErrorResponseAsync(response, HttpStatusCode.Unauthorized, cancellationToken);
+                return;
+            }
+
+            if (!TryApplyCorsHeaders(request, response, pinOrigin: true))
+            {
+                await CompleteErrorResponseAsync(response, HttpStatusCode.Forbidden, cancellationToken);
+                return;
+            }
+
+            if (!string.Equals(request.ContentType, BinaryContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                await CompleteErrorResponseAsync(response, HttpStatusCode.UnsupportedMediaType, cancellationToken);
+                return;
+            }
+
+            byte[] frame;
+            try
+            {
+                frame = await ReadFrameAsync(request, cancellationToken);
+            }
+            catch (InvalidDataException)
+            {
+                await CompleteErrorResponseAsync(response, HttpStatusCode.BadRequest, cancellationToken);
+                return;
+            }
+
+            IRequest protocolRequest;
+            try
+            {
+                protocolRequest = (IRequest)_serializer.Deserialize(frame, skipUnknownMessages: true);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogTrace($"The dotnet test HTTP gateway rejected a malformed protocol frame of type '{ex.GetType().FullName}'.");
+                await CompleteErrorResponseAsync(response, HttpStatusCode.BadRequest, cancellationToken);
+                return;
+            }
+
+            IResponse protocolResponse = await _callback(protocolRequest);
+            byte[] responseFrame = _serializer.Serialize(protocolResponse);
+
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentType = BinaryContentType;
+            response.ContentLength64 = responseFrame.Length;
+            await response.OutputStream.WriteAsync(responseFrame, cancellationToken);
+            response.Close();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.LogTrace($"The dotnet test HTTP gateway failed to process a request: {ex}");
+            try
+            {
+                if (response.OutputStream.CanWrite)
+                {
+                    await CompleteErrorResponseAsync(response, HttpStatusCode.InternalServerError, cancellationToken);
+                }
+            }
+            catch (Exception responseException)
+            {
+                Logger.LogTrace($"The dotnet test HTTP gateway failed to send an error response: {responseException}");
+            }
+        }
+        finally
+        {
+            try
+            {
+                response.Close();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+    }
+
+    private bool IsAuthorized(HttpListenerRequest request)
+    {
+        string? authorization = request.Headers["Authorization"];
+        if (!AuthenticationHeaderValue.TryParse(authorization, out AuthenticationHeaderValue? header) ||
+            !string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) ||
+            header.Parameter is null)
+        {
+            return false;
+        }
+
+        byte[] providedToken = Encoding.UTF8.GetBytes(header.Parameter);
+        byte[] expectedToken = Encoding.UTF8.GetBytes(Token);
+        return providedToken.Length == expectedToken.Length &&
+            CryptographicOperations.FixedTimeEquals(providedToken, expectedToken);
+    }
+
+    private bool TryApplyCorsHeaders(
+        HttpListenerRequest request,
+        HttpListenerResponse response,
+        bool pinOrigin)
+    {
+        string? requestOrigin = NormalizeOrigin(request.Headers["Origin"]);
+        if (requestOrigin is null)
+        {
+            return request.Headers["Origin"] is null;
+        }
+
+        lock (_originLock)
+        {
+            if (pinOrigin)
+            {
+                _allowedOrigin ??= requestOrigin;
+            }
+
+            if (!string.Equals(_allowedOrigin, requestOrigin, StringComparison.Ordinal))
+            {
+                Logger.LogTrace($"The dotnet test HTTP gateway rejected origin '{requestOrigin}' because it does not match the origin established for this run.");
+                return false;
+            }
+        }
+
+        response.Headers["Access-Control-Allow-Origin"] = requestOrigin;
+        response.Headers["Vary"] = "Origin, Access-Control-Request-Private-Network";
+        return true;
+    }
+
+    private static string? NormalizeOrigin(string? origin)
+    {
+        if (origin is null ||
+            !Uri.TryCreate(origin, UriKind.Absolute, out Uri? uri) ||
+            uri.Scheme is not ("http" or "https") ||
+            uri.UserInfo.Length != 0 ||
+            uri.Query.Length != 0 ||
+            uri.Fragment.Length != 0 ||
+            uri.AbsolutePath != "/")
+        {
+            return null;
+        }
+
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(HttpListenerRequest request, CancellationToken cancellationToken)
+    {
+        if (request.ContentLength64 > MaximumFrameSize)
+        {
+            throw new InvalidDataException("The dotnet test HTTP request is too large.");
+        }
+
+        using var buffer = request.ContentLength64 is >= 0 and <= 1024 * 1024
+            ? new MemoryStream((int)request.ContentLength64)
+            : new MemoryStream();
+
+        byte[] bytes = new byte[81920];
+        int totalBytes = 0;
+        int bytesRead;
+        while ((bytesRead = await request.InputStream.ReadAsync(bytes, cancellationToken)) != 0)
+        {
+            totalBytes = checked(totalBytes + bytesRead);
+            if (totalBytes > MaximumFrameSize)
+            {
+                throw new InvalidDataException("The dotnet test HTTP request is too large.");
+            }
+
+            await buffer.WriteAsync(bytes.AsMemory(0, bytesRead), cancellationToken);
+        }
+
+        if (request.ContentLength64 >= 0 && totalBytes != request.ContentLength64)
+        {
+            throw new InvalidDataException("The dotnet test HTTP request ended before its declared content length.");
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static async Task CompleteErrorResponseAsync(
+        HttpListenerResponse response,
+        HttpStatusCode statusCode,
+        CancellationToken cancellationToken)
+    {
+        response.StatusCode = (int)statusCode;
+        response.ContentLength64 = 0;
+        await response.OutputStream.FlushAsync(cancellationToken);
+        response.Close();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _cancellationRegistration.Dispose();
+        _listener.Close();
+        try
+        {
+            _listenerTask.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogTrace($"The dotnet test HTTP gateway listener failed during shutdown: {ex}");
+        }
+
+        _disposed = true;
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ProtocolMessageSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ProtocolMessageSerializer.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Cli.Commands.Test.IPC;
+
+internal sealed class ProtocolMessageSerializer : NamedPipeBase
+{
+    private const int FrameHeaderSize = sizeof(int) + sizeof(int);
+
+    public object Deserialize(byte[] frame, bool skipUnknownMessages)
+    {
+        if (frame.Length < FrameHeaderSize)
+        {
+            throw new InvalidDataException("The dotnet test protocol frame is shorter than its header.");
+        }
+
+        int payloadLength = BitConverter.ToInt32(frame.AsSpan());
+        if (payloadLength < sizeof(int) || payloadLength != frame.Length - sizeof(int))
+        {
+            throw new InvalidDataException("The dotnet test protocol frame length is invalid.");
+        }
+
+        int serializerId = BitConverter.ToInt32(frame.AsSpan(sizeof(int)));
+        INamedPipeSerializer serializer = GetSerializer(serializerId, skipUnknownMessages);
+
+        using var body = new MemoryStream(
+            frame,
+            FrameHeaderSize,
+            frame.Length - FrameHeaderSize,
+            writable: false);
+        return serializer.Deserialize(body);
+    }
+
+    public byte[] Serialize(object message)
+    {
+        INamedPipeSerializer serializer = GetSerializer(message.GetType());
+
+        using var body = new MemoryStream();
+        serializer.Serialize(message, body);
+
+        int payloadLength = checked(sizeof(int) + (int)body.Length);
+        byte[] frame = new byte[checked(sizeof(int) + payloadLength)];
+        if (!BitConverter.TryWriteBytes(frame.AsSpan(0, sizeof(int)), payloadLength) ||
+            !BitConverter.TryWriteBytes(frame.AsSpan(sizeof(int), sizeof(int)), serializer.Id))
+        {
+            throw new UnreachableException();
+        }
+
+        body.GetBuffer().AsSpan(0, (int)body.Length).CopyTo(frame.AsSpan(FrameHeaderSize));
+        return frame;
+    }
+}

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplication.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 using Microsoft.DotNet.Cli.Commands.Test.IPC;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
@@ -54,6 +56,8 @@ internal sealed class TestApplication(
     private readonly ArtifactPostProcessingInvocation? _artifactPostProcessingInvocation = artifactPostProcessingInvocation;
     private readonly TestRunPolicy? _testRunPolicy = testRunPolicy;
     private readonly CancellationTokenSource _pipeCancellationTokenSource = new();
+    private HttpTestHostGateway? _httpGateway;
+    private string? _httpResponseFilePath;
 
     private readonly string _pipeName = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
     private readonly string _controlPipeName = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
@@ -88,14 +92,18 @@ internal sealed class TestApplication(
         var processStartInfo = CreateProcessStartInfo();
 
         var cancellationToken = _pipeCancellationTokenSource.Token;
-        var testAppPipeConnectionLoop = Task.Run(async () => await WaitConnectionAsync(cancellationToken));
-        var controlPipeConnectionLoop = Task.Run(async () => await WaitControlConnectionAsync(cancellationToken));
+        var testAppPipeConnectionLoop = _httpGateway is null
+            ? Task.Run(async () => await WaitConnectionAsync(cancellationToken))
+            : Task.CompletedTask;
+        var controlPipeConnectionLoop = _httpGateway is null
+            ? Task.Run(async () => await WaitControlConnectionAsync(cancellationToken))
+            : Task.CompletedTask;
 
         Process? process = null;
         bool testApplicationStarted = false;
         try
         {
-            Logger.LogTrace($"Starting test process with command '{processStartInfo.FileName}' and arguments '{processStartInfo.Arguments}'.");
+            Logger.LogTrace($"Starting test process with command '{processStartInfo.FileName}' and arguments '{GetArgumentsForLogging(processStartInfo.Arguments)}'.");
 
             process = Process.Start(processStartInfo)!;
             _testRunPolicy?.OnTestApplicationStarted();
@@ -351,7 +359,7 @@ internal sealed class TestApplication(
                 builder,
                 _buildOptions.PathOptions,
                 _artifactPostProcessingInvocation.ManifestPath,
-                _pipeName);
+                AppendTestHostTransportArguments);
         }
 
         if (TestOptions.IsHelp)
@@ -394,9 +402,113 @@ internal sealed class TestApplication(
             builder.Append($" {ArgumentEscaper.EscapeSingleArg(arg)}");
         }
 
-        builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
+        AppendTestHostTransportArguments(builder);
 
         return builder.ToString();
+    }
+
+    private void AppendTestHostTransportArguments(StringBuilder builder)
+    {
+        if (RequiresHttpTransport(Module))
+        {
+            _httpGateway ??= new HttpTestHostGateway(
+                OnHttpRequest,
+                _pipeCancellationTokenSource.Token);
+            _httpResponseFilePath ??= CreateHttpTransportResponseFile(_httpGateway);
+            builder.Append($" {ArgumentEscaper.EscapeSingleArg("@" + _httpResponseFilePath)}");
+        }
+        else
+        {
+            builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue}");
+            builder.Append($" {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(_pipeName)}");
+        }
+    }
+
+    internal static bool RequiresHttpTransport(TestModule module)
+    {
+        string runtimeIdentifier = module.RunProperties.RuntimeIdentifier;
+        return runtimeIdentifier.StartsWith("browser-", StringComparison.OrdinalIgnoreCase) ||
+            runtimeIdentifier.StartsWith("wasi-", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal string? HttpResponseFilePath => _httpResponseFilePath;
+
+    private static string CreateHttpTransportResponseFile(HttpTestHostGateway gateway)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"dotnet-test-http-{Guid.NewGuid():N}.rsp");
+        try
+        {
+            FileStream stream;
+            if (OperatingSystem.IsWindows())
+            {
+                using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                SecurityIdentifier currentUser = identity.User
+                    ?? throw new InvalidOperationException("Unable to determine the current Windows user.");
+                var security = new FileSecurity();
+                security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+                security.AddAccessRule(new FileSystemAccessRule(
+                    currentUser,
+                    FileSystemRights.FullControl,
+                    AccessControlType.Allow));
+                stream = FileSystemAclExtensions.Create(
+                    new FileInfo(path),
+                    FileMode.CreateNew,
+                    FileSystemRights.FullControl,
+                    FileShare.None,
+                    bufferSize: 4096,
+                    FileOptions.WriteThrough,
+                    security);
+            }
+            else
+            {
+                stream = new FileStream(path, new FileStreamOptions
+                {
+                    Mode = FileMode.CreateNew,
+                    Access = FileAccess.Write,
+                    Share = FileShare.None,
+                    BufferSize = 4096,
+                    Options = FileOptions.WriteThrough,
+                    UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                });
+            }
+
+            using (stream)
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                writer.WriteLine($"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue}");
+                writer.WriteLine($"{CliConstants.DotNetTestTransportOptionKey} {CliConstants.DotNetTestHttpTransportValue}");
+                writer.WriteLine($"{CliConstants.DotNetTestHttpEndpointOptionKey} {gateway.Endpoint.AbsoluteUri}");
+                writer.WriteLine($"{CliConstants.DotNetTestHttpTokenOptionKey} {gateway.Token}");
+            }
+
+            return path;
+        }
+        catch
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception cleanupException)
+            {
+                Logger.LogTrace($"Failed to clean up the dotnet test HTTP transport response file after creation failed: {cleanupException}");
+            }
+
+            throw;
+        }
+    }
+
+    internal string GetArgumentsForLogging(string arguments)
+    {
+        if (_httpGateway is null)
+        {
+            return arguments;
+        }
+
+        string redactedEndpoint = $"{_httpGateway.Endpoint.GetLeftPart(UriPartial.Authority)}/[REDACTED]";
+        return arguments
+            .Replace(_httpGateway.Endpoint.AbsoluteUri, redactedEndpoint, StringComparison.Ordinal)
+            .Replace(_httpGateway.Token, "[REDACTED]", StringComparison.Ordinal);
     }
 
     internal static string GetArtifactPostProcessingLaunchArguments(TestModule module)
@@ -418,6 +530,18 @@ internal sealed class TestApplication(
         PathOptions pathOptions,
         string manifestPath,
         string pipeName)
+        => BuildArtifactPostProcessingArguments(
+            builder,
+            pathOptions,
+            manifestPath,
+            transportArgumentsBuilder => transportArgumentsBuilder.Append(
+                $" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}"));
+
+    private static string BuildArtifactPostProcessingArguments(
+        StringBuilder builder,
+        PathOptions pathOptions,
+        string manifestPath,
+        Action<StringBuilder> appendTransportArguments)
     {
         builder.Append($" {CliConstants.ArtifactPostProcessingToolName}");
         builder.Append($" {CliConstants.ArtifactPostProcessingManifestOptionKey} {ArgumentEscaper.EscapeSingleArg(manifestPath)}");
@@ -438,7 +562,7 @@ internal sealed class TestApplication(
 
         // The results directory is deliberately not forwarded: the merged output location travels in
         // the manifest instead, so the SDK keeps control of it even when it has to be derived.
-        builder.Append($" {CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue} {CliConstants.DotNetTestPipeOptionKey} {ArgumentEscaper.EscapeSingleArg(pipeName)}");
+        appendTransportArguments(builder);
         return builder.ToString();
     }
 
@@ -584,7 +708,18 @@ internal sealed class TestApplication(
         }
     }
 
-    private Task<IResponse> OnRequest(NamedPipeServer server, IRequest request)
+    private Task<IResponse> OnHttpRequest(IRequest request)
+    {
+        if (request is WaitForServerControlRequest)
+        {
+            Logger.LogTrace("The dotnet test HTTP transport does not support the reverse server-control channel.");
+            return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
+        }
+
+        return OnRequest(server: null, request);
+    }
+
+    private Task<IResponse> OnRequest(NamedPipeServer? server, IRequest request)
     {
         // We need to lock as we might be called concurrently when test app child processes all communicate with us.
         // For example, in a case of a sharding extension, we could get test result messages concurrently.
@@ -596,7 +731,7 @@ internal sealed class TestApplication(
                 switch (request)
                 {
                     case HandshakeMessage handshakeMessage:
-                        if (!_handshakes.TryAdd(server, handshakeMessage))
+                        if (server is not null && !_handshakes.TryAdd(server, handshakeMessage))
                         {
                             throw new InvalidOperationException(CliCommandStrings.DotnetTestDuplicateHandshakeOnConnection);
                         }
@@ -606,7 +741,9 @@ internal sealed class TestApplication(
                         // Microsoft.Testing.Platform stops sending further messages on this connection.
                         bool handshakeAccepted = OnHandshakeMessage(handshakeMessage, negotiatedVersion.Length > 0);
                         SetNegotiatedProtocolVersion(handshakeAccepted ? negotiatedVersion : string.Empty);
-                        return Task.FromResult((IResponse)CreateHandshakeMessage(handshakeAccepted ? negotiatedVersion : string.Empty));
+                        return Task.FromResult((IResponse)CreateHandshakeMessage(
+                            handshakeAccepted ? negotiatedVersion : string.Empty,
+                            includeControlPipe: _httpGateway is null));
 
                     case CommandLineOptionMessages commandLineOptionMessages:
                         OnCommandLineOptionMessages(commandLineOptionMessages);
@@ -714,7 +851,7 @@ internal sealed class TestApplication(
         return highestCommonVersionText;
     }
 
-    private HandshakeMessage CreateHandshakeMessage(string version)
+    private HandshakeMessage CreateHandshakeMessage(string version, bool includeControlPipe = true)
     {
         var properties = new Dictionary<byte, string>(capacity: 6)
         {
@@ -725,7 +862,7 @@ internal sealed class TestApplication(
             { HandshakeMessagePropertyNames.SupportedProtocolVersions, version }
         };
 
-        if (version.Length > 0)
+        if (version.Length > 0 && includeControlPipe)
         {
             properties.Add(HandshakeMessagePropertyNames.ServerControlPipeName, _controlPipeName);
         }
@@ -998,6 +1135,19 @@ internal sealed class TestApplication(
 
                 HasFailureDuringDispose = true;
                 Reporter.Error.WriteLine(messageBuilder.ToString());
+            }
+        }
+
+        _httpGateway?.Dispose();
+        if (_httpResponseFilePath is not null)
+        {
+            try
+            {
+                File.Delete(_httpResponseFilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogTrace($"Failed to delete the dotnet test HTTP transport response file: {ex}");
             }
         }
 

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/VanillaWasmTests.cs
@@ -43,6 +43,21 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tests
 
         [TestMethod]
         [CoreMSBuildOnly]
+        public void Build_TestApplicationBuilds()
+        {
+            var testInstance = CreateAspNetSdkTestAsset("BlazorWasmTestApp");
+
+            ExecuteCommand(CreateBuildCommand(testInstance))
+                .Should()
+                .Pass();
+
+            var buildOutputDirectory = Path.Combine(testInstance.Path, "bin", "Debug", ToolsetInfo.CurrentTargetFramework);
+            new FileInfo(Path.Combine(buildOutputDirectory, "BlazorWasmTestApp.dll")).Should().Exist();
+            new FileInfo(Path.Combine(buildOutputDirectory, "BlazorWasmTestApp.staticwebassets.endpoints.json")).Should().Exist();
+        }
+
+        [TestMethod]
+        [CoreMSBuildOnly]
         [DataRow(null, false, "true", "true")]
         [DataRow("false", false, "false", "false")]
         // Setting the property from the project body must take effect (dotnet/sdk#55489): the defaults are

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/App.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/App.razor
@@ -1,0 +1,5 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+</Router>

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/BlazorWasmTestApp.csproj
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/BlazorWasmTestApp.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <CurrentTargetFramework Condition="'$(CurrentTargetFramework)' == ''">net$(NETCoreAppMaximumVersion)</CurrentTargetFramework>
+    <TargetFramework>$(CurrentTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <StaticWebAssetSpaFallbackEnabled>true</StaticWebAssetSpaFallbackEnabled>
+
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+
+    <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Gateway" Version="$(MicrosoftAspNetCoreAppRefPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="MSTest" Version="$(MSTestVersion)" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/BrowserTestRunner.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/BrowserTestRunner.cs
@@ -1,0 +1,16 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlazorWasmTestApp;
+
+public sealed class BrowserTestRunner
+{
+    public async Task<int> RunAsync()
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync([]);
+        builder.AddMSTest(() => [typeof(SampleTests).Assembly]);
+
+        using ITestApplication application = await builder.BuildAsync();
+        return await application.RunAsync();
+    }
+}

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/Pages/Home.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/Pages/Home.razor
@@ -1,0 +1,27 @@
+@page "/"
+@inject BrowserTestRunner TestRunner
+
+<PageTitle>Blazor browser tests</PageTitle>
+
+<h1>Blazor browser tests</h1>
+
+<button @onclick="RunTests" disabled="@_running">Run tests</button>
+<p role="status">@_status</p>
+
+@code {
+    private bool _running;
+    private string _status = "Tests have not run.";
+
+    protected override Task OnInitializedAsync() => RunTests();
+
+    private async Task RunTests()
+    {
+        _running = true;
+        _status = "Running...";
+
+        int exitCode = await TestRunner.RunAsync();
+
+        _status = exitCode == 0 ? "Passed" : $"Failed (exit code {exitCode})";
+        _running = false;
+    }
+}

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/Program.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/Program.cs
@@ -1,0 +1,8 @@
+using BlazorWasmTestApp;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+WebAssemblyHostBuilder builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.Services.AddSingleton<BrowserTestRunner>();
+
+await builder.Build().RunAsync();

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/README.md
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/README.md
@@ -1,0 +1,58 @@
+# Blazor WebAssembly test app probe
+
+This test asset exercises the part of
+[dotnet/sdk#54091](https://github.com/dotnet/sdk/issues/54091) that works today:
+
+- the Blazor SDK builds and serves the application;
+- MSTest and Microsoft.Testing.Platform run inside `browser-wasm`; and
+- the page displays the test application's exit code.
+
+Run the app and open the printed URL in a browser:
+
+```powershell
+dotnet run --project test\TestAssets\TestProjects\BlazorWasmTestApp\BlazorWasmTestApp.csproj
+```
+
+The single test starts automatically and the page changes to `Passed`. The button can run it again.
+This requires the SDK, runtime packs, and flowed Blazor packages to come from a compatible
+product build; a repository bootstrap SDK can temporarily be on an older preview band than
+the packages in `eng\Version.Details.props`.
+
+## Why `dotnet test` does not work yet
+
+The `MSTest` package marks this project as both `IsTestProject` and
+`IsTestingPlatformApplication`. The current SDK consequently treats the command returned by
+`ComputeRunArguments` as the test host. For a Blazor WebAssembly project that command is the
+host-side Blazor Gateway:
+
+```text
+dotnet blazor-gateway.dll --staticWebAssets <manifest>
+    @<owner-only-http-bootstrap.rsp>
+```
+
+The SDK hosts that authenticated endpoint and routes its existing binary protocol frames to
+the normal `dotnet test` handlers. The Gateway serves the application, but it does not yet
+consume the owner-only response file, launch a browser, or provide the bootstrap values to
+Microsoft.Testing.Platform inside the page. The token is deliberately kept out of process
+arguments and URLs.
+
+The remaining integration needs a host-side bridge that:
+
+1. starts the Blazor server and waits for its URL;
+2. launches a selected browser, including a headless mode;
+3. injects the HTTP endpoint and token into the page without putting the token in a URL;
+4. starts Microsoft.Testing.Platform with those bootstrap options;
+5. closes the browser and server when the test session completes; and
+6. provides a browser-compatible reverse cancellation path.
+
+Per-test results and output can flow live through the HTTP transport. A physical TRX still
+needs an explicit export path because a browser's virtual file system disappears with the page.
+
+The reusable pieces already exist, but are not connected for Blazor:
+
+- [`dotnet test` device orchestration](../../../../documentation/specs/dotnet-run-for-maui.md)
+  supplies `ComputeAvailableDevices`, `DeployToDevice`, and `ComputeRunArguments`.
+- [TestFX BrowserPlayground](https://github.com/microsoft/testfx/tree/main/samples/BrowserPlayground)
+  proves Microsoft.Testing.Platform and MSTest can run on `browser-wasm`.
+- [dotnet/sdk#55389](https://github.com/dotnet/sdk/pull/55389) is draft foundational work
+  for standalone WASM test hosts, but does not implement the Blazor server/browser lifecycle.

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/SampleTests.cs
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/SampleTests.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlazorWasmTestApp;
+
+[TestClass]
+public sealed class SampleTests
+{
+    [TestMethod]
+    public void RunsInsideBrowserWasm()
+    {
+        Assert.IsTrue(OperatingSystem.IsBrowser());
+    }
+}

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/_Imports.razor
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using BlazorWasmTestApp

--- a/test/TestAssets/TestProjects/BlazorWasmTestApp/wwwroot/index.html
+++ b/test/TestAssets/TestProjects/BlazorWasmTestApp/wwwroot/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blazor browser tests</title>
+    <base href="/" />
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -85,10 +85,21 @@
           Condition="'@(RuntimeEnvironmentVariable)' != ''">
     <Message Text="ComputeRunArguments: RuntimeEnvironmentVariable=@(RuntimeEnvironmentVariable->'%(Identity)=%(Value)', ', ')" />
   </Target>
+
+  <Target Name="_UseHttpTestTransport"
+          BeforeTargets="ComputeRunArguments"
+          Condition="'$(UseHttpTestTransport)' == 'true'">
+    <PropertyGroup>
+      <!-- Keep the host executable runnable on the build machine while exercising the browser transport selection. -->
+      <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    </PropertyGroup>
+  </Target>
+
   <!-- Unlike dotnet run, dotnet test builds DeployToDevice first and ComputeRunArguments second,
        so ResolveFrameworkReferences has to run in the second build too to mimic Android. -->
   <Target Name="_ComputeRunArgumentsDependsOnResolveFrameworkReferences"
           BeforeTargets="ComputeRunArguments"
-          DependsOnTargets="ResolveFrameworkReferences" />
+          DependsOnTargets="ResolveFrameworkReferences"
+          Condition="'$(UseHttpTestTransport)' != 'true'" />
 
 </Project>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/Program.cs
@@ -9,6 +9,25 @@ using Microsoft.Testing.Platform.Extensions.TestFramework;
 Console.WriteLine(
     $"Runtime environment variables: FOO={Environment.GetEnvironmentVariable("FOO")}, INJECTED={Environment.GetEnvironmentVariable("INJECTED")}");
 
+int transportOptionIndex = Array.IndexOf(args, "--dotnet-test-transport");
+bool httpTransportSelected = transportOptionIndex >= 0 &&
+    transportOptionIndex + 1 < args.Length &&
+    string.Equals(args[transportOptionIndex + 1], "http", StringComparison.OrdinalIgnoreCase);
+if (!httpTransportSelected)
+{
+    string? responseFileArgument = args.FirstOrDefault(static arg => arg.StartsWith('@'));
+    if (responseFileArgument is not null && File.Exists(responseFileArgument[1..]))
+    {
+        httpTransportSelected = File.ReadLines(responseFileArgument[1..])
+            .Any(static line => line.Equals("--dotnet-test-transport http", StringComparison.OrdinalIgnoreCase));
+    }
+}
+
+if (httpTransportSelected)
+{
+    Console.WriteLine("HTTP transport selected.");
+}
+
 var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestAdapter());

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
@@ -411,6 +411,22 @@ public class ArtifactPostProcessingManagerTests
     }
 
     [TestMethod]
+    public async Task ExecuteAsync_WebAssemblyModule_SkipsUnsupportedPostProcessing()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        ArtifactPostProcessingManager manager = CreateManagerWithMergeableArtifacts(
+            CreateModule("browser-wasm"),
+            "first.trx",
+            "second.trx");
+        using var ctrlC = CreateCancellationManager();
+
+        await manager.ExecuteAsync(CreateBuildOptions(), reporter, ctrlC);
+
+        console.GetOutput().Should().NotContain(CliCommandStrings.ArtifactPostProcessingStarted);
+    }
+
+    [TestMethod]
     public void ReportFailureUnlessCancelled_WhenNotCancelled_WritesWarning()
     {
         var console = new CapturingConsole();
@@ -438,9 +454,13 @@ public class ArtifactPostProcessingManagerTests
     }
 
     private static ArtifactPostProcessingManager CreateManagerWithMergeableArtifacts(params string[] artifactPaths)
+        => CreateManagerWithMergeableArtifacts(CreateModule(), artifactPaths);
+
+    private static ArtifactPostProcessingManager CreateManagerWithMergeableArtifacts(
+        TestModule module,
+        params string[] artifactPaths)
     {
         var manager = new ArtifactPostProcessingManager();
-        TestModule module = CreateModule();
         manager.RecordCapabilities(
             module,
             "net10.0",
@@ -513,9 +533,9 @@ public class ArtifactPostProcessingManagerTests
             new HashSet<string>(StringComparer.Ordinal));
     }
 
-    private static TestModule CreateModule()
+    private static TestModule CreateModule(string runtimeIdentifier = "")
         => new(
-            new RunProperties("dotnet", "A.dll", null),
+            new RunProperties("dotnet", "A.dll", null, runtimeIdentifier, string.Empty, string.Empty),
             ProjectFullPath: null,
             TargetFramework: "net10.0",
             IsTestingPlatformApplication: true,

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -738,4 +738,23 @@ public class GivenDotnetTestSelectsDevice : SdkTest
                 messages.Should().Contain(message => message.Text.Contains(ToolsetInfo.CurrentTargetFramework));
             });
     }
+
+    [TestMethod]
+    public void ItRunsBrowserWasmTestHostOverHttpTransport()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices", identifier: "HttpTransport")
+            .WithSource();
+
+        new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute(
+                "--framework",
+                ToolsetInfo.CurrentTargetFramework,
+                "-p:SingleDevice=true",
+                "-p:UseHttpTestTransport=true")
+            .Should()
+            .Pass()
+            .And.HaveStdOutContaining("HTTP transport selected.")
+            .And.HaveStdOutContaining("total: 1");
+    }
 }

--- a/test/dotnet.Tests/CommandTests/Test/HttpTestHostGatewayTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/HttpTestHostGatewayTests.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.DotNet.Cli.Commands.Test;
+using Microsoft.DotNet.Cli.Commands.Test.IPC;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
+using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
+
+namespace dotnet.Tests.CommandTests.Test;
+
+[TestClass]
+public sealed class HttpTestHostGatewayTests
+{
+    private const string BrowserOrigin = "http://127.0.0.1:5000";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task Post_AuthenticatedFrame_RoundTripsProtocolResponse()
+    {
+        HandshakeMessage? receivedHandshake = null;
+        using var gateway = new HttpTestHostGateway(
+            request =>
+            {
+                receivedHandshake = Assert.IsInstanceOfType<HandshakeMessage>(request);
+                return Task.FromResult<IResponse>(new HandshakeMessage(new Dictionary<byte, string>
+                {
+                    [HandshakeMessagePropertyNames.SupportedProtocolVersions] = "1.3.0",
+                }));
+            },
+            TestContext.CancellationToken,
+            BrowserOrigin);
+
+        var requestHandshake = new HandshakeMessage(new Dictionary<byte, string>
+        {
+            [HandshakeMessagePropertyNames.SupportedProtocolVersions] = "1.0.0;1.3.0",
+        });
+
+        using HttpResponseMessage response = await SendAsync(gateway, requestHandshake, gateway.Token);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual("application/octet-stream", response.Content.Headers.ContentType?.MediaType);
+        Assert.AreEqual(BrowserOrigin, response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+        Assert.IsNotNull(receivedHandshake);
+
+        var responseHandshake = Assert.IsInstanceOfType<HandshakeMessage>(
+            Deserialize(await response.Content.ReadAsByteArrayAsync(TestContext.CancellationToken)));
+        Assert.AreEqual(
+            "1.3.0",
+            responseHandshake.Properties[HandshakeMessagePropertyNames.SupportedProtocolVersions]);
+    }
+
+    [TestMethod]
+    public async Task Post_InvalidToken_IsRejectedBeforeDispatch()
+    {
+        bool dispatched = false;
+        using var gateway = new HttpTestHostGateway(
+            _ =>
+            {
+                dispatched = true;
+                return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
+            },
+            TestContext.CancellationToken,
+            BrowserOrigin);
+
+        using HttpResponseMessage response = await SendAsync(
+            gateway,
+            new HandshakeMessage([]),
+            token: "invalid-token");
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.AreEqual(BrowserOrigin, response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+        Assert.IsFalse(dispatched);
+    }
+
+    [TestMethod]
+    public async Task Options_WithoutAuthorization_ReturnsCorsAndPrivateNetworkHeaders()
+    {
+        using var gateway = new HttpTestHostGateway(
+            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
+            TestContext.CancellationToken,
+            BrowserOrigin);
+        using var request = new HttpRequestMessage(HttpMethod.Options, gateway.Endpoint);
+        request.Headers.Add("Origin", BrowserOrigin);
+        request.Headers.Add("Access-Control-Request-Method", "POST");
+        request.Headers.Add("Access-Control-Request-Headers", "authorization,content-type");
+        request.Headers.Add("Access-Control-Request-Private-Network", "true");
+
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        using HttpResponseMessage response = await client.SendAsync(request, TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.AreEqual(BrowserOrigin, response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+        Assert.AreEqual("POST", response.Headers.GetValues("Access-Control-Allow-Methods").Single());
+        Assert.AreEqual("Authorization, Content-Type", response.Headers.GetValues("Access-Control-Allow-Headers").Single());
+        Assert.AreEqual("true", response.Headers.GetValues("Access-Control-Allow-Private-Network").Single());
+    }
+
+    [TestMethod]
+    public async Task Options_FirstBrowserOriginPinsCorsPolicy()
+    {
+        using var gateway = new HttpTestHostGateway(
+            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
+            TestContext.CancellationToken);
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Options, gateway.Endpoint);
+        firstRequest.Headers.Add("Origin", BrowserOrigin);
+
+        using HttpResponseMessage firstResponse = await client.SendAsync(firstRequest, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.NoContent, firstResponse.StatusCode);
+        Assert.AreEqual(BrowserOrigin, firstResponse.Headers.GetValues("Access-Control-Allow-Origin").Single());
+
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Options, gateway.Endpoint);
+        secondRequest.Headers.Add("Origin", "http://127.0.0.1:5001");
+        using HttpResponseMessage secondResponse = await client.SendAsync(secondRequest, TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, secondResponse.StatusCode);
+        Assert.IsFalse(secondResponse.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [TestMethod]
+    public async Task Options_WrongPathCannotPinCorsPolicy()
+    {
+        using var gateway = new HttpTestHostGateway(
+            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
+            TestContext.CancellationToken);
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        using var wrongPathRequest = new HttpRequestMessage(
+            HttpMethod.Options,
+            new Uri(gateway.Endpoint.GetLeftPart(UriPartial.Authority) + "/"));
+        wrongPathRequest.Headers.Add("Origin", "http://127.0.0.1:5001");
+
+        using HttpResponseMessage wrongPathResponse = await client.SendAsync(wrongPathRequest, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.NotFound, wrongPathResponse.StatusCode);
+
+        using var validRequest = new HttpRequestMessage(HttpMethod.Options, gateway.Endpoint);
+        validRequest.Headers.Add("Origin", BrowserOrigin);
+        using HttpResponseMessage validResponse = await client.SendAsync(validRequest, TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.NoContent, validResponse.StatusCode);
+        Assert.AreEqual(BrowserOrigin, validResponse.Headers.GetValues("Access-Control-Allow-Origin").Single());
+    }
+
+    [TestMethod]
+    public async Task Post_MalformedFrame_ReturnsBadRequest()
+    {
+        using var gateway = new HttpTestHostGateway(
+            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
+            TestContext.CancellationToken,
+            BrowserOrigin);
+        using var request = CreateRequest(gateway, gateway.Token, [1, 2, 3, 4]);
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+
+        using HttpResponseMessage response = await client.SendAsync(request, TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Post_CorruptMessage_DoesNotStopGateway()
+    {
+        int dispatchedRequests = 0;
+        using var gateway = new HttpTestHostGateway(
+            _ =>
+            {
+                dispatchedRequests++;
+                return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
+            },
+            TestContext.CancellationToken,
+            BrowserOrigin);
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        byte[] corruptHandshakeFrame =
+        [
+            4, 0, 0, 0,
+            9, 0, 0, 0,
+        ];
+        using var corruptRequest = CreateRequest(gateway, gateway.Token, corruptHandshakeFrame);
+
+        using HttpResponseMessage corruptResponse = await client.SendAsync(corruptRequest, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.BadRequest, corruptResponse.StatusCode);
+
+        using var validRequest = CreateRequest(
+            gateway,
+            gateway.Token,
+            Serialize(new HandshakeMessage([])));
+        using HttpResponseMessage validResponse = await client.SendAsync(validRequest, TestContext.CancellationToken);
+
+        Assert.AreEqual(HttpStatusCode.OK, validResponse.StatusCode);
+        Assert.AreEqual(1, dispatchedRequests);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpTestHostGateway gateway,
+        object message,
+        string token)
+    {
+        using var request = CreateRequest(gateway, token, Serialize(message));
+        var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        try
+        {
+            return await client.SendAsync(request, TestContext.CancellationToken);
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    private static HttpRequestMessage CreateRequest(
+        HttpTestHostGateway gateway,
+        string token,
+        byte[] frame)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, gateway.Endpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.Add("Origin", BrowserOrigin);
+        request.Content = new ByteArrayContent(frame);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return request;
+    }
+
+    private static byte[] Serialize(object message)
+    {
+        var serializer = new ProtocolMessageSerializer();
+        serializer.RegisterAllSerializers();
+        return serializer.Serialize(message);
+    }
+
+    private static object Deserialize(byte[] frame)
+    {
+        var serializer = new ProtocolMessageSerializer();
+        serializer.RegisterAllSerializers();
+        return serializer.Deserialize(frame, skipUnknownMessages: false);
+    }
+}

--- a/test/dotnet.Tests/CommandTests/Test/HttpTestHostGatewayTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/HttpTestHostGatewayTests.cs
@@ -217,7 +217,10 @@ public sealed class HttpTestHostGatewayTests
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         request.Headers.Add("Origin", BrowserOrigin);
         request.Content = new ByteArrayContent(frame);
-        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream")
+        {
+            CharSet = "utf-8",
+        };
         return request;
     }
 

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationLaunchTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationLaunchTests.cs
@@ -106,6 +106,71 @@ public sealed class TestApplicationLaunchTests
     }
 
     [TestMethod]
+    [DataRow("browser-wasm")]
+    [DataRow("wasi-wasm")]
+    public void CreateProcessStartInfo_WebAssembly_UsesAuthenticatedHttpTransport(string runtimeIdentifier)
+    {
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text),
+            runtimeIdentifier: runtimeIdentifier);
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+        Assert.IsNotNull(application.HttpResponseFilePath);
+        string responseFilePath = application.HttpResponseFilePath!;
+        string responseFileContents = File.ReadAllText(responseFilePath);
+
+        startInfo.Arguments.Should().Contain("@" + responseFilePath);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestPipeOptionKey);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestHttpEndpointOptionKey);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestHttpTokenOptionKey);
+        responseFileContents.Should().Contain($"{CliConstants.ServerOptionKey} {CliConstants.ServerOptionValue}");
+        responseFileContents.Should().Contain($"{CliConstants.DotNetTestTransportOptionKey} {CliConstants.DotNetTestHttpTransportValue}");
+        responseFileContents.Should().Contain(CliConstants.DotNetTestHttpEndpointOptionKey);
+        responseFileContents.Should().Contain(CliConstants.DotNetTestHttpTokenOptionKey);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.GetUnixFileMode(responseFilePath)
+                .Should()
+                .Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
+        string loggedArguments = application.GetArgumentsForLogging(startInfo.Arguments);
+        loggedArguments.Should().NotContain("http://127.0.0.1:");
+        loggedArguments.Should().NotContain(CliConstants.DotNetTestHttpTokenOptionKey);
+    }
+
+    [TestMethod]
+    public void Dispose_BrowserWasm_DeletesHttpTransportResponseFile()
+    {
+        string responseFilePath;
+        using (TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text),
+            runtimeIdentifier: "browser-wasm"))
+        {
+            application.CreateProcessStartInfo();
+            responseFilePath = application.HttpResponseFilePath!;
+            File.Exists(responseFilePath).Should().BeTrue();
+        }
+
+        File.Exists(responseFilePath).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void CreateProcessStartInfo_Desktop_UsesNamedPipeTransport()
+    {
+        using TestApplication application = CreateApplication(
+            new TestOptions(false, false, TestListFormat.Text),
+            runtimeIdentifier: "win-x64");
+
+        ProcessStartInfo startInfo = application.CreateProcessStartInfo();
+
+        startInfo.Arguments.Should().Contain(CliConstants.DotNetTestPipeOptionKey);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestTransportOptionKey);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestHttpEndpointOptionKey);
+        startInfo.Arguments.Should().NotContain(CliConstants.DotNetTestHttpTokenOptionKey);
+    }
+
+    [TestMethod]
     public void CreateProcessStartInfo_LaunchProfileAffectedOption_DoesNotCreateSdkMarker()
     {
         var launchProfile = new ProjectLaunchProfile
@@ -128,10 +193,11 @@ public sealed class TestApplicationLaunchTests
         TestOptions testOptions,
         IEnumerable<string>? forwardedArguments = null,
         IReadOnlyDictionary<string, string>? environmentVariables = null,
-        ProjectLaunchProfile? launchProfile = null)
+        ProjectLaunchProfile? launchProfile = null,
+        string runtimeIdentifier = "")
     {
         var module = new TestModule(
-            new RunProperties("dotnet", "test.dll", null),
+            new RunProperties("dotnet", "test.dll", null, runtimeIdentifier, string.Empty, string.Empty),
             ProjectFullPath: "test.csproj",
             TargetFramework: "net11.0",
             IsTestingPlatformApplication: true,


### PR DESCRIPTION
WebAssembly test hosts cannot connect to the named-pipe transport currently used by `dotnet test`. Microsoft.Testing.Platform now supports the existing `dotnettestcli` binary protocol over authenticated HTTP, so the SDK needs a matching gateway to enable browser and WASI test execution.

## Summary

- host a unique authenticated loopback HTTP endpoint for each WebAssembly test application
- route the existing protocol frames through the normal `dotnet test` handlers without changing the wire contract
- preserve named pipes for desktop test applications
- support browser CORS and Private Network Access preflight
- keep the endpoint and bearer token out of process arguments by using an atomically owner-only response file
- skip WebAssembly artifact post-processing until a browser-aware merge host exists
- add a Blazor WebAssembly MSTest probe that documents the remaining browser lifecycle integration

The HTTP path is covered both at the gateway boundary and end-to-end with a real MTP application reporting a passing test through `dotnet test`. The remaining Blazor-specific work is for Blazor Gateway to consume the bootstrap response file, launch the browser, and provide those values to MTP inside the page.

## Validation

- focused HTTP gateway, launch, protocol negotiation, desktop pipe, WASI/browser selection, and artifact-processing tests
- end-to-end `dotnet test` execution through the MTP HTTP client
- focused Blazor WebAssembly sample build test

Related to #54091