### PR TITLE
Temporarily quarantine dotnet-watch tests on macOS

### DIFF
--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -25,6 +25,9 @@
     <!-- Projects suffixed with UnitTests or IntegrationTests are not matched by *.Tests.csproj above, so include them with a separate glob. -->
     <SDKCustomTestProject Include="**\*UnitTests.csproj;**\*IntegrationTests.csproj" Exclude="TestAssets\**\*" />
 
+    <!-- Temporarily disabled on macOS due to https://github.com/dotnet/runtime/issues/131944 -->
+    <SDKCustomTestProject Remove="dotnet-watch.Tests\dotnet-watch.Tests.csproj" Condition="'$(TargetOS)' == 'osx'" />
+
     <!-- Don't run MSI installation tests in Helix / CI -->
     <SDKCustomTestProject Remove="dotnet-MsiInstallation.Tests\**\*" />
 


### PR DESCRIPTION
Temporarily exclude `dotnet-watch.Tests` from macOS test legs while dotnet/runtime#131944 is unresolved. Other operating systems continue to select the project normally.

This is needed because Known Issues isn't correctly identifying https://github.com/dotnet/sdk/issues/55636 because of https://github.com/dotnet/build-insights/issues/105.