### PR TITLE
Avoid TFM resolution during workload discovery

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets
@@ -44,8 +44,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--  This target is not part of the build. Only used by dotnet workload restore command. Global property "SkipResolvePackageAssets"
         need to be set to "true" to avoid requiring restore (which would likely fail if the required workloads aren't already installed).
         In addition, since this is a target that is called on potentially-unsupported project types like esproj, we need to not fail
-        if the Target is missing. -->
-  <Target Name="_GetRequiredWorkloads" DependsOnTargets="GetSuggestedWorkloads;PrepareProjectReferences" Returns="@(_ResolvedSuggestedWorkload)">
+        if the Target is missing. Workload discovery must not use PrepareProjectReferences because it traverses references that may not
+        have a target framework compatible with the current project. -->
+  <Target Name="_GetRequiredWorkloads"
+          DependsOnTargets="GetSuggestedWorkloads;_AddOutputPathToGlobalPropertiesToRemove;AssignProjectConfiguration;_SplitProjectReferencesByFileExistence"
+          Returns="@(_ResolvedSuggestedWorkload)">
     <MSBuild
       Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="_GetRequiredWorkloads"

--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -83,6 +83,46 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
+        public void It_should_get_required_workloads_from_a_transitive_incompatible_project_reference()
+        {
+            var mainProject = new TestProject()
+            {
+                Name = "MainProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var intermediateProject = new TestProject()
+            {
+                Name = "IntermediateProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var workloadProject = new TestProject()
+            {
+                Name = "WorkloadProject",
+                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework}-missingworkloadtestplatform"
+            };
+
+            mainProject.ReferencedProjects.Add(intermediateProject);
+            intermediateProject.ReferencedProjects.Add(workloadProject);
+
+            var testAsset = TestAssetsManager.CreateTestProject(mainProject);
+            var getValuesCommand = new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "_GetRequiredWorkloads",
+                ShouldRestore = false
+            };
+
+            getValuesCommand.Execute("/p:SkipResolvePackageAssets=true")
+                .Should()
+                .Pass();
+
+            getValuesCommand.GetValues()
+                .Should()
+                .BeEquivalentTo("microsoft-net-sdk-missingtestworkload");
+        }
+
+        [TestMethod]
         public void It_should_fail_to_restore_without_workload_when_multitargeted()
         {
             var testProject = new TestProject()

--- a/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
+++ b/test/Microsoft.NET.Build.Tests/WorkloadTests.cs
@@ -85,6 +85,46 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [Fact]
+        public void It_should_get_required_workloads_from_a_transitive_incompatible_project_reference()
+        {
+            var mainProject = new TestProject()
+            {
+                Name = "MainProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var intermediateProject = new TestProject()
+            {
+                Name = "IntermediateProject",
+                TargetFrameworks = ToolsetInfo.CurrentTargetFramework
+            };
+
+            var workloadProject = new TestProject()
+            {
+                Name = "WorkloadProject",
+                TargetFrameworks = $"{ToolsetInfo.CurrentTargetFramework}-missingworkloadtestplatform"
+            };
+
+            mainProject.ReferencedProjects.Add(intermediateProject);
+            intermediateProject.ReferencedProjects.Add(workloadProject);
+
+            var testAsset = _testAssetsManager.CreateTestProject(mainProject);
+            var getValuesCommand = new GetValuesCommand(testAsset, "_ResolvedSuggestedWorkload", GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "_GetRequiredWorkloads",
+                ShouldRestore = false
+            };
+
+            getValuesCommand.Execute("/p:SkipResolvePackageAssets=true")
+                .Should()
+                .Pass();
+
+            getValuesCommand.GetValues()
+                .Should()
+                .BeEquivalentTo("microsoft-net-sdk-missingtestworkload");
+        }
+
+        [Fact]
         public void It_should_fail_to_restore_without_workload_when_multitargeted()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/54420

## Summary

- avoid `PrepareProjectReferences` when recursively discovering required workloads
- retain output-path global-property cleanup while preparing project references
- add coverage for a transitive project reference with an incompatible target framework

## Testing

- `It_should_get_required_workloads_from_a_transitive_incompatible_project_reference` passes against the updated SDK
- the same test fails against the previous target dependency chain with the incompatible TFM error