### PR TITLE
Flow CodeAnalysis analyzers version automatically

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -38,6 +38,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>18.11.0-1.26406.108</MicrosoftBuildTaskAuthoringAnalyzerPackageVersion>
     <MicrosoftBuildTasksGitPackageVersion>11.0.100-rc.1.26406.108</MicrosoftBuildTasksGitPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>5.11.0-1.26406.108</MicrosoftCodeAnalysisPackageVersion>
+    <MicrosoftCodeAnalysisAnalyzersPackageVersion>5.11.0-1.26406.108</MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <MicrosoftCodeAnalysisBuildClientPackageVersion>5.11.0-1.26406.108</MicrosoftCodeAnalysisBuildClientPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>5.11.0-1.26406.108</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpCodeStylePackageVersion>5.11.0-1.26406.108</MicrosoftCodeAnalysisCSharpCodeStylePackageVersion>
@@ -176,6 +177,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftBuildTaskAuthoringAnalyzerVersion>$(MicrosoftBuildTaskAuthoringAnalyzerPackageVersion)</MicrosoftBuildTaskAuthoringAnalyzerVersion>
     <MicrosoftBuildTasksGitVersion>$(MicrosoftBuildTasksGitPackageVersion)</MicrosoftBuildTasksGitVersion>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisPackageVersion)</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisBuildClientVersion>$(MicrosoftCodeAnalysisBuildClientPackageVersion)</MicrosoftCodeAnalysisBuildClientVersion>
     <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(MicrosoftCodeAnalysisCSharpCodeStylePackageVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -495,6 +495,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>50dbab4de210e882172b07934e9666313b7065f1</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="5.11.0-1.26406.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>6c7fa710f4337334575f0c30f1691edc244518d1</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26406.108">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,6 @@
     <SystemDataSqlClientPackageVersion>4.8.6</SystemDataSqlClientPackageVersion>
     <WebDeploymentPackageVersion>4.0.5</WebDeploymentPackageVersion>
     <SystemCommandLineNamingConventionBinderVersion>2.0.0-beta5.25279.2</SystemCommandLineNamingConventionBinderVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>5.10.0-1.26365.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.2</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <MicrosoftVisualBasicVersion>10.3.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>3.2.2146</MicrosoftVisualStudioSetupConfigurationInteropVersion>


### PR DESCRIPTION
The centrally pinned `Microsoft.CodeAnalysis.Analyzers` version can fall behind the Roslyn packages supplied by codeflow, causing package downgrade restore failures such as the one fixed in #55654.

Move the analyzer version into Maestro dependency metadata so the existing `dotnet/dotnet` codeflow updates it alongside the other Roslyn components. The initial flowed version is `5.11.0-1.26406.108`, matching the current Roslyn dependency set, while the existing `MicrosoftCodeAnalysisAnalyzersVersion` consumer property remains available through the generated compatibility alias.