### PR TITLE
Fix invalid argument handling for workload search version

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Workload/WorkloadSearchVersionsCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/Workload/WorkloadSearchVersionsCommandDefinition.cs
@@ -51,10 +51,13 @@ internal sealed class WorkloadSearchVersionsCommandDefinition : WorkloadCommandD
 
         Validators.Add(result =>
         {
-            var versionArgument = result.GetValue(WorkloadVersionArgument);
-            if (versionArgument is not null && !versionArgument.All(v => v.Contains('@')) && !WorkloadSetVersion.IsWorkloadSetPackageVersion(versionArgument.SingleOrDefault(defaultValue: string.Empty)))
+            string[] versionArguments = result.GetValue(WorkloadVersionArgument)?.ToArray() ?? [];
+            bool validManifestVersions = versionArguments.All(version => version.Contains('@'));
+            bool validWorkloadSetVersion = versionArguments is [var version] && WorkloadSetVersion.IsWorkloadSetPackageVersion(version);
+
+            if (!validManifestVersions && !validWorkloadSetVersion)
             {
-                result.AddError(string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, string.Join(' ', versionArgument)));
+                result.AddError(string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, string.Join(' ', versionArguments)));
             }
         });
     }

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.CommandLine.Help;
-using System.CommandLine.Invocation;
 using System.Reflection;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Format;
@@ -349,8 +348,8 @@ public static class Parser
     /// before parsing, which is not as efficient as using the array overload.
     /// And also won't always split tokens the way the user will expect on their shell.
     /// </summary>
-    public static ParseResult Parse(string commandLineUnsplit) => ConfigureParseResult(RootCommand.Parse(commandLineUnsplit, ParserConfiguration));
-    public static ParseResult Parse(string[] args) => ConfigureParseResult(RootCommand.Parse(args, ParserConfiguration));
+    public static ParseResult Parse(string commandLineUnsplit) => RootCommand.Parse(commandLineUnsplit, ParserConfiguration);
+    public static ParseResult Parse(string[] args) => RootCommand.Parse(args, ParserConfiguration);
     public static int Invoke(ParseResult parseResult) => parseResult.Invoke(InvocationConfiguration);
     public static Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default) => parseResult.InvokeAsync(InvocationConfiguration, cancellationToken);
     public static int Invoke(string[] args) => Invoke(Parse(args));
@@ -396,17 +395,6 @@ public static class Parser
         }
 
         return 1;
-    }
-
-    private static ParseResult ConfigureParseResult(ParseResult parseResult)
-    {
-        if (parseResult.CommandResult.Command is WorkloadSearchVersionsCommandDefinition
-            && parseResult.Action is ParseErrorAction parseErrorAction)
-        {
-            parseErrorAction.ShowHelp = false;
-        }
-
-        return parseResult;
     }
 
     internal class DotnetHelpBuilder : HelpBuilder

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using System.Reflection;
 using Microsoft.DotNet.Cli.Commands;
 using Microsoft.DotNet.Cli.Commands.Format;
@@ -348,8 +349,8 @@ public static class Parser
     /// before parsing, which is not as efficient as using the array overload.
     /// And also won't always split tokens the way the user will expect on their shell.
     /// </summary>
-    public static ParseResult Parse(string commandLineUnsplit) => RootCommand.Parse(commandLineUnsplit, ParserConfiguration);
-    public static ParseResult Parse(string[] args) => RootCommand.Parse(args, ParserConfiguration);
+    public static ParseResult Parse(string commandLineUnsplit) => ConfigureParseResult(RootCommand.Parse(commandLineUnsplit, ParserConfiguration));
+    public static ParseResult Parse(string[] args) => ConfigureParseResult(RootCommand.Parse(args, ParserConfiguration));
     public static int Invoke(ParseResult parseResult) => parseResult.Invoke(InvocationConfiguration);
     public static Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default) => parseResult.InvokeAsync(InvocationConfiguration, cancellationToken);
     public static int Invoke(string[] args) => Invoke(Parse(args));
@@ -395,6 +396,17 @@ public static class Parser
         }
 
         return 1;
+    }
+
+    private static ParseResult ConfigureParseResult(ParseResult parseResult)
+    {
+        if (parseResult.CommandResult.Command is WorkloadSearchVersionsCommandDefinition
+            && parseResult.Action is ParseErrorAction parseErrorAction)
+        {
+            parseErrorAction.ShowHelp = false;
+        }
+
+        return parseResult;
     }
 
     internal class DotnetHelpBuilder : HelpBuilder

--- a/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
 
         [TestMethod]
         [DataRow("--invalidArgument")]
+        [DataRow("-foo bar")]
         [DataRow("notAVersion")]
         [DataRow("1.2")] // too short
         [DataRow("1.2.3.4.5")] // too long
@@ -47,7 +48,8 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
             var workloadResolver = new MockWorkloadResolver(Enumerable.Empty<WorkloadResolver.WorkloadInfo>());
             var workloadResolverFactory = new MockWorkloadResolverFactory(dotnetPath: null, "9.0.100", workloadResolver);
             var command = () => new WorkloadSearchVersionsCommand(parseResult, _reporter, workloadResolverFactory);
-            command.Should().Throw<CommandParsingException>();
+            command.Should().Throw<CommandParsingException>()
+                .WithMessage(string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, argument));
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.CommandLine.Invocation;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Commands.Workload.Search;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -50,6 +51,30 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
             var command = () => new WorkloadSearchVersionsCommand(parseResult, _reporter, workloadResolverFactory);
             command.Should().Throw<CommandParsingException>()
                 .WithMessage(string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, argument));
+        }
+
+        [TestMethod]
+        public void GivenMistypedOptionToWorkloadSearchVersionItOnlyPrintsTheError()
+        {
+            var result = new DotnetCommand(Log)
+                .Execute("workload", "search", "version", "-foo", "bar");
+
+            result.Should().Fail();
+            result.StdErr.Trim().Should().Be(
+                string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, "-foo bar"));
+            result.StdOut.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void ParseErrorsOnlySuppressHelpForWorkloadSearchVersion()
+        {
+            var versionParseError = Parser.Parse(["workload", "search", "version", "-foo", "bar"])
+                .Action.Should().BeOfType<ParseErrorAction>().Which;
+            var otherParseError = Parser.Parse(["workload", "list", "--invalid"])
+                .Action.Should().BeOfType<ParseErrorAction>().Which;
+
+            versionParseError.ShowHelp.Should().BeFalse();
+            otherParseError.ShowHelp.Should().BeTrue();
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Search/GivenDotnetWorkloadSearch.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.CommandLine.Invocation;
 using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.DotNet.Cli.Commands.Workload.Search;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -51,30 +50,6 @@ namespace Microsoft.DotNet.Cli.Workload.Search.Tests
             var command = () => new WorkloadSearchVersionsCommand(parseResult, _reporter, workloadResolverFactory);
             command.Should().Throw<CommandParsingException>()
                 .WithMessage(string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, argument));
-        }
-
-        [TestMethod]
-        public void GivenMistypedOptionToWorkloadSearchVersionItOnlyPrintsTheError()
-        {
-            var result = new DotnetCommand(Log)
-                .Execute("workload", "search", "version", "-foo", "bar");
-
-            result.Should().Fail();
-            result.StdErr.Trim().Should().Be(
-                string.Format(CommandDefinitionStrings.UnrecognizedCommandOrArgument, "-foo bar"));
-            result.StdOut.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParseErrorsOnlySuppressHelpForWorkloadSearchVersion()
-        {
-            var versionParseError = Parser.Parse(["workload", "search", "version", "-foo", "bar"])
-                .Action.Should().BeOfType<ParseErrorAction>().Which;
-            var otherParseError = Parser.Parse(["workload", "list", "--invalid"])
-                .Action.Should().BeOfType<ParseErrorAction>().Which;
-
-            versionParseError.ShowHelp.Should().BeFalse();
-            otherParseError.ShowHelp.Should().BeTrue();
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

- preserve all three supported `dotnet workload search version` modes:
  - no arguments to list workload-set versions
  - one or more `package@version` arguments to find matching workload sets
  - exactly one workload-set package version to inspect that set
- reject mixed or multiple non-component arguments through the normal CLI parsing path instead of throwing `InvalidOperationException`
- add regression coverage for mistyped options such as `-foo bar` and assert the localized unrecognized-argument message

This is intentionally compatible with #55681, which adds NuGet options to the same command. Recognized options continue to parse as options, while typos captured by the variadic positional argument now fail cleanly.

Help-output behavior is intentionally unchanged and will be addressed separately.

## Validation

- `build.cmd`
- `GivenInvalidArgumentToWorkloadSearchVersionItFailsCleanly` (6 cases)
- built SDK invocation returns help plus `Unrecognized command or argument '-foo bar'` with exit code 1