### PR TITLE
Document dotnetup for internal previews

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,6 +6,7 @@ Documents Index
 - [Intro to .NET Core CLI](general/intro-to-cli.md)
 - [Publishing a solution and its pitfalls](general/solution-publish.md)
 - [CLI UX Guidelines](general/cli-ux-guidelines.md)
+- [dotnetup documentation](general/dotnetup/README.md)
 - [.NET Core native pre-requisities document](https://github.com/dotnet/core/blob/main/Documentation/prereqs.md)
 - [Roadmap and OS support](https://github.com/dotnet/core/blob/main/roadmap.md)
 - [Comprehensive CLI documentation](https://docs.microsoft.com/en-us/dotnet/articles/core/preview3/tools/)
@@ -26,4 +27,3 @@ Documents Index
 
 - [CLI installation scenarios](specs/cli-installation-scenarios.md)
 - [Runtime configuration file specification](specs/runtime-configuration-file.md)
-

--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -1,8 +1,150 @@
-# dotnetup documentation
+# Get started with dotnetup
 
-This directory contains the in-repository documentation for `dotnetup`.
-The public-facing articles use the structure and front matter expected by
-the dotnet/docs repository.
+`dotnetup` is a cross-platform toolchain manager for user-level .NET
+installations. It installs, updates, and removes .NET SDKs and runtimes without
+using a system package manager.
+
+## Prerequisites
+
+- Windows, macOS, or Linux.
+- A terminal.
+- Bash on macOS or Linux, or PowerShell on Windows, to run the download script.
+
+The default installation and all access modes use your user profile. They do
+not require administrator access. A custom installation path can require
+additional file permissions.
+
+## Download dotnetup
+
+The download scripts install the latest `preview` build by default. They verify
+the downloaded executable with its SHA-512 checksum and install it in
+`~/.dotnetup`.
+
+On macOS or Linux, run:
+
+```bash
+curl -fsSL https://aka.ms/dotnet/dotnetup/preview/get-dotnetup.sh | bash
+```
+
+On Windows, save and run the PowerShell script:
+
+```powershell
+$script = Join-Path $env:TEMP 'get-dotnetup.ps1'
+Invoke-WebRequest https://aka.ms/dotnet/dotnetup/preview/get-dotnetup.ps1 -OutFile $script
+& $script
+```
+
+To install the latest `daily` build on macOS or Linux, run:
+
+```bash
+curl -fsSL https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh |
+  bash -s -- --quality daily
+```
+
+To install the latest `daily` build on Windows, run:
+
+```powershell
+$script = Join-Path $env:TEMP 'get-dotnetup-daily.ps1'
+Invoke-WebRequest https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 -OutFile $script
+& $script -Quality daily
+```
+
+> [!IMPORTANT]
+> Daily builds have not completed release validation and are not code-signed.
+> Use daily builds only for short-lived testing.
+
+The scripts print instructions to add `dotnetup` to `PATH`. Open a new terminal
+after you apply the instructions.
+
+## Run first-time setup
+
+Run the interactive setup:
+
+```dotnetcli
+> dotnetup init
+Welcome to dotnetup!
+
+SDK Channel: latest
+Mode: <recommended-mode> (Suggested)
+
+Would you like to install .NET with the recommended settings?
+> Yes, proceed with defaults and install
+
+Downloading SDK <resolved-version>
+Installing SDK <resolved-version>
+Installed SDK <resolved-version>
+Setup complete!
+```
+
+The recommended mode is Everywhere Mode on Windows. On macOS and Linux, it is
+Terminal Mode when `dotnetup` detects a supported shell. It is Isolation Mode
+when shell detection is not available.
+
+Select **No, customize setup** to choose the SDK channel, access mode, and
+migration options.
+
+### Choose an SDK channel
+
+An SDK channel tells `dotnetup` which SDK to install and how to update it.
+
+| Channel form | Example | Result |
+| --- | --- | --- |
+| Latest stable | `latest` | Latest active stable SDK |
+| Latest LTS | `lts` | Latest active stable LTS SDK |
+| Latest preview | `preview` | Latest preview SDK |
+| Latest daily | `daily` | Latest available daily SDK |
+| Major | `10` | Latest SDK for the specified major version |
+| Major and minor | `10.0` | Latest SDK for the specified major and minor version |
+| Feature band | `10.0.1xx` | Latest SDK in the specified feature band |
+| Exact version | `10.0.103` | Only the specified SDK version |
+| No initial SDK | `none` | Skip installation during setup |
+
+Exact versions do not advance during updates. For all accepted forms, see
+[dotnetup channels and versions](concepts/channels.md).
+
+### Choose how to access .NET
+
+The access mode controls how terminals and applications find the managed
+`dotnet` command.
+
+| Mode | Behavior |
+| --- | --- |
+| Isolation Mode | Use `dotnetup dotnet <command>`. Existing .NET installations remain the default. |
+| Terminal Mode | Update the selected shell profile. Applications launched from that shell use the managed installation. |
+| Everywhere Mode | Update the Windows user environment and shell profile. New terminals and user applications use the managed installation. Windows only. |
+
+Terminal Mode supports Bash, Z shell, Fish, PowerShell Core, and Windows
+PowerShell.
+
+For more information, see
+[dotnetup environment configuration](concepts/environment.md).
+
+### Migrate existing installations
+
+Setup can find SDKs and runtimes in the system-managed .NET directory. It can
+install matching native-architecture versions in the dotnetup-managed
+directory. This keeps existing projects working after you change the access
+mode.
+
+## Verify setup
+
+Open a new terminal after setup changes your environment.
+
+For Terminal Mode or Everywhere Mode, run:
+
+```dotnetcli
+dotnet --version
+dotnetup list
+```
+
+For Isolation Mode, run:
+
+```dotnetcli
+dotnetup dotnet --version
+dotnetup list
+```
+
+Run `dotnetup init` again to change the setup.
 
 ## Public documentation
 
@@ -20,7 +162,6 @@ the dotnet/docs repository.
 - [Release engineering](releasing.md)
 - [Signature verification](signature-verification.md)
 
-The command reference follows the generated runtime help. Command handlers
-and tests verify product behavior. Hidden compatibility and elevation
-commands are implementation details. They are not part of the public command
-reference.
+The command reference follows the generated runtime help. Command handlers and
+tests verify product behavior. Hidden compatibility and elevation commands are
+implementation details. They are not part of the public command reference.

--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -67,14 +67,21 @@ Welcome to dotnetup!
 SDK Channel: latest
 Mode: <recommended-mode> (Suggested)
 
+<recommended-mode> modifies <configuration-target> to set PATH and DOTNET_ROOT to prefer <install-path>.
+
 Would you like to install .NET with the recommended settings?
 > Yes, proceed with defaults and install
 
-Downloading SDK <resolved-version>
-Installing SDK <resolved-version>
-Installed SDK <resolved-version>
+Installing SDK <resolved-version> to <install-path>...
+<download and installation progress>
+Installed at <install-path>:
+  SDK <resolved-version>
+<mode-specific environment guidance>
 Setup complete!
 ```
+
+The paths, progress display, and environment guidance depend on your system and
+the selected mode.
 
 The recommended mode is Everywhere Mode on Windows. On macOS and Linux, it is
 Terminal Mode when `dotnetup` detects a supported shell. It is Isolation Mode

--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -1,192 +1,26 @@
-# Getting Started with dotnetup
+# dotnetup documentation
 
-`dotnetup` is the .NET toolchain manager for user-level installs. It lets you install, update, and manage .NET SDKs and runtimes without needing administrator privileges or system package managers.
+This directory contains the in-repository documentation for `dotnetup`.
+The public-facing articles use the structure and front matter expected by
+the dotnet/docs repository.
 
-## Prerequisites
+## Public documentation
 
-- **Windows**, **macOS**, or **Linux**
-- A terminal (like bash, zsh, or PowerShell (Core))
-- No administrator / root access required for Isolation or Terminal Mode. Replacement Mode on Windows requires administrator privileges.
+- [dotnetup overview](index.md)
+- [Table of contents](toc.yml)
+- [Core concepts](concepts/how-dotnetup-works.md)
+- [Release channels](channels/preview.md)
+- [CLI reference](reference/dotnetup.md)
+- [Scenarios](usecases/install-with-global-json.md)
 
-## Download dotnetup
+## Maintainer documentation
 
-The easiest way to download the latest preview build of `dotnetup` is to use the installation script:
+- [Design notes](designs/)
+- [How dotnetup is included in the SDK](dotnetup_in_sdk.md)
+- [Release engineering](releasing.md)
+- [Signature verification](signature-verification.md)
 
-```bash
-curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash
-```
-
-On Windows, save the script and run it so PowerShell can verify its Authenticode signature (the `.ps1` served from https://aka.ms/dotnetup/get-dotnetup.ps1 is signed by the .NET signing certificate):
-
-```pwsh
-$s = Join-Path $env:TEMP 'get-dotnetup.ps1'
-iwr https://aka.ms/dotnetup/get-dotnetup.ps1 -OutFile $s
-# Get-AuthenticodeSignature $s   # optional: inspect the signature
-& $s
-```
-
-To install the latest daily build instead, pass the quality explicitly:
-
-```bash
-curl -fsSL https://aka.ms/dotnetup/get-dotnetup.sh | bash -s -- --quality daily
-```
-
-For a PowerShell one-liner, create a script block from the downloaded script and pass the
-parameter when invoking it:
-
-```pwsh
-& ([scriptblock]::Create((iwr https://aka.ms/dotnetup/get-dotnetup.ps1).Content)) -Quality daily
-```
-
-These PowerShell one-liners bypass Authenticode signature verification:
-
-```pwsh
-iwr https://aka.ms/dotnetup/get-dotnetup.ps1 | iex
-```
-
-These scripts default to the `preview` channel. They download `dotnetup` and install it in your user directory, then print instructions to update your $PATH so that `dotnetup` is available in your terminal.
-
-## First-Time Setup
-
-When you run `dotnetup` for the first time (or run `dotnetup init` explicitly), it walks you through an interactive setup flow:
-
-```
-$ dotnetup
-╭─────────────────────────────────────────────────╮
-│ dotnetup v0.2.0-dev                             │
-│ .NET toolchain manager for user level installs. │
-╰─────────────────────────────────────────────────╯
-
-Welcome to dotnetup!
-
-dotnetup updates and groups installations using dotnetup channels.
-
-Select an example channel to get started: (Enter to confirm)
-> latest       (suggested)  Latest stable release  → 10.0.300
-  none          I'll tell you what to install later.
-  lts           Long Term Support  → 10.0.300
-  preview       Latest preview  → 11.0.100-preview.4.26230.115
-  10.0          Major.Minor channel  → 10.0.300
-
-(use ↑↓ arrows)
-```
-
-### Step 1: Choose a Channel
-
-Channels determine which version of .NET to install and how it gets updated. Pick one that matches your needs:
-
-| Channel     | What It Installs | Update Behavior |
-|-------------|-----------------|-----------------|
-| `latest`    | The newest stable .NET SDK | Updates to the latest GA release |
-| `lts`       | The current Long Term Support release | Updates within the LTS line |
-| `preview`   | The latest preview/RC release | Updates to newer previews |
-| `10.0`      | The latest SDK for .NET 10.0 | Updates within the 10.0 major.minor |
-| `10.0.1xx`  | The latest SDK in the 10.0.1xx feature band | Updates within the feature band |
-| `10.0.100`  | Exactly SDK 10.0.100 | Never updates (pinned) |
-| `11.0.100-preview.6.26277.104` (or any other nightly build number)     | A specific version number of a daily VMR builds | Never updates |
-| `none`      | Skips the initial install | You can install later with `dotnetup sdk install` |
-
-In general, there are two kinds of channels: **version-based** and **feature-based**.
-- **Version-based** channels specify an exact version or a range of versions - `10`,  `10.0.2xx`, and so on
-- **Feature-based** channels group versions by their characteristics - `preview`, `lts`, and so on
-
-### Step 2: Choose How to Access .NET
-
-Next, dotnetup asks how you'd like to use the managed .NET installation:
-
-```
-How would you like to use dotnetup?
-
-  Isolation Mode
-  Use 'dotnetup dotnet' to consume installs managed by dotnetup.
-  New installs can be used alongside your existing installs.
-
-> Terminal Mode (Suggested)
-  Configure the current shell profile to use installs managed by dotnetup.
-  Only applications launched from the shell will leverage dotnetup installs.
-
-  Replacement Mode      (Windows only)
-  The system will be configured to use dotnetup installs over any other installs.
-```
-
-| Mode | How It Works | Best For |
-|------|-------------|----------|
-| **Isolation Mode** | Run .NET via `dotnetup dotnet <command>` | Users who want to keep their system .NET as-is |
-| **Terminal Mode** | Updates your shell profile (`.bashrc`, `.zshrc`, or PowerShell `$PROFILE`) so `dotnet` resolves to the dotnetup-managed install | Most developers (suggested) |
-| **Replacement Mode** | Modifies system PATH and DOTNET_ROOT (Windows only, requires admin) | Users who want dotnetup to be the default everywhere |
-
-In general, we think most developers will want to use **Terminal Mode**. This ensures that the `dotnetup`-managed .NET installations are used by default in most contexts.  Visual Studio users *may* want to use **Replacement Mode** to ensure that the .NET SDK is used by default even in Visual Studio, but this will require both administrator permissions and monthly maintenance as Visual Studio re-installs .NET SDK bundles.
-
-### Step 3: Migrate Existing Installs (Optional)
-
-If you chose Terminal Mode or Replacement Mode and have existing system-level .NET installations that are installed to the default locations, dotnetup will offer to track matching versions:
-
-```
-You have existing system-managed .NET installs in C:\Program Files\dotnet.
-  SDK 10.0.100
-  Runtime 10.0.0
-  ASP.NET Core 10.0.0
-Do you want dotnetup to install matching versions in its managed directory? [y/n]
-```
-
-Accepting this migration downloads the same versions into the dotnetup-managed directory so that your existing projects continue to work seamlessly after the switch.
-
-### Step 4: Installation Completes
-
-```
-Downloading .NET SDK 10.0.100...  ████████████████████████ 100%
-Installed .NET SDK 10.0.100 to C:\Users\you\AppData\Local\dotnetup\dotnet
-
-Your shell profile has been updated. Restart your terminal or source your profile
-to use 'dotnet' directly.
-Setup complete!
-```
-
-## After Setup
-
-Once setup is complete, you can verify the installation:
-
-```
-# If using Terminal Mode, restart your terminal first, then:
-$ dotnet --version
-10.0.100
-
-# If using Isolation Mode:
-$ dotnetup dotnet --version
-10.0.100
-
-# View what dotnetup is managing:
-$ dotnetup list
-
-Installations (managed by dotnetup):
-
-  C:\Users\you\AppData\Local\dotnetup\dotnet
-
-    Tracked channels:
-      SDK latest                          (source: explicit)
-
-    Installed versions:
-      SDK 10.0.100                        (x64)
-
-Total: 1
-```
-
-## Re-Running Setup
-
-You can re-run the setup flow at any time with:
-
-```
-$ dotnetup init
-```
-
-This lets you change your path preference (Isolation → Terminal, etc.) or install additional .NET versions.
-
-## Next Steps
-
-- [Install SDKs with global.json](./usecases/install-with-global-json.md) — Install the right SDK version for a project automatically
-- [Update SDK and Runtime Installations](./usecases/update-installations.md) — Keep your .NET installations current
-- [Try Daily Builds](./usecases/try-daily-builds.md) — Safely test pre-release .NET builds
-
-## Maintainer Documentation
-
-- [Publish, update, and roll back preview builds](./releasing.md)
+The command reference follows the generated runtime help. Command handlers
+and tests verify product behavior. Hidden compatibility and elevation
+commands are implementation details. They are not part of the public command
+reference.

--- a/documentation/general/dotnetup/channels/daily.md
+++ b/documentation/general/dotnetup/channels/daily.md
@@ -12,10 +12,7 @@ Use them to test changes that are not yet available in a stable or preview
 release.
 
 > [!CAUTION]
-> Daily builds can change frequently and are not supported releases. The
-> current implementation warns that a daily source can provide weaker
-> authenticity guarantees than release-manifest downloads. Use daily builds
-> only in environments where you accept this risk.
+> Daily builds can change frequently and are not supported releases. They are not code-signed.
 
 ## Daily channel forms
 

--- a/documentation/general/dotnetup/channels/daily.md
+++ b/documentation/general/dotnetup/channels/daily.md
@@ -1,0 +1,84 @@
+---
+title: Use dotnetup daily channels
+description: Install and update .NET daily builds with scoped dotnetup channels.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Use dotnetup daily channels
+
+Daily channels select builds from component-specific daily-build endpoints.
+Use them to test changes that are not yet available in a stable or preview
+release.
+
+> [!CAUTION]
+> Daily builds can change frequently and are not supported releases. The
+> current implementation warns that a daily source can provide weaker
+> authenticity guarantees than release-manifest downloads. Use daily builds
+> only in environments where you accept this risk.
+
+## Daily channel forms
+
+| Form | Example | Scope |
+| --- | --- | --- |
+| Unscoped | `daily` | Searches the next major version first, then the latest major version in release metadata |
+| Major | `11-daily` | One major version |
+| Major and minor | `11.0-daily` | One major and minor version |
+| SDK feature band | `11.0.1xx-daily` | One SDK feature band |
+| SDK preview phase | `11.0.1xx-preview.5-daily` | One SDK feature band and preview phase |
+| Runtime preview phase | `11.0-preview.5-daily` | One runtime major/minor and preview phase |
+
+The compact phase form `preview5` is also accepted where
+`preview.5` is accepted.
+
+`preview-daily` and daily channels with a complete patch version, such as
+`11.0.103-daily`, are not valid.
+
+## Install a daily SDK
+
+```dotnetcli
+dotnetup sdk install 11.0.1xx-daily
+```
+
+Track a specific preview phase:
+
+```dotnetcli
+dotnetup sdk install 11.0.1xx-preview.5-daily
+```
+
+## Install daily runtimes
+
+```dotnetcli
+dotnetup runtime install runtime@11.0-daily aspnetcore@11.0-daily
+```
+
+On Windows, you can also install the Windows Desktop daily runtime:
+
+```dotnetcli
+dotnetup runtime install windowsdesktop@11.0-daily
+```
+
+## Update a daily build
+
+Daily channels are tracked like other channels:
+
+```dotnetcli
+dotnetup update
+```
+
+If the endpoint resolves to a newer matching build, `dotnetup` installs it.
+Garbage collection removes older files that no remaining specification needs.
+
+## Isolate daily builds
+
+Use a separate hive when you do not want daily builds to share files with your
+default managed installation:
+
+```dotnetcli
+dotnetup sdk install 11.0.1xx-daily --install-path .\.dotnet-daily
+.\.dotnet-daily\dotnet.exe --version
+```
+
+The `dotnetup dotnet` forwarding command does not automatically select an
+arbitrary custom hive. To run a custom hive directly, use its `dotnet`
+executable or activate it with `dotnetup env script --dotnet-install-path`.

--- a/documentation/general/dotnetup/channels/preview.md
+++ b/documentation/general/dotnetup/channels/preview.md
@@ -1,0 +1,64 @@
+---
+title: Use the dotnetup preview channel
+description: Install and update supported .NET preview releases with dotnetup.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Use the dotnetup preview channel
+
+The `preview` channel selects the latest available preview or GoLive .NET
+release. If no active preview is available, the resolver selects an active
+release.
+
+## Install a preview SDK
+
+```dotnetcli
+dotnetup sdk install preview
+```
+
+The tracked specification remains `preview`. A later update can move it to a
+newer preview:
+
+```dotnetcli
+dotnetup sdk update
+```
+
+## Install preview runtimes
+
+Select one or more runtime components:
+
+```dotnetcli
+dotnetup runtime install runtime@preview aspnetcore@preview
+```
+
+The Windows Desktop runtime is available only on Windows:
+
+```dotnetcli
+dotnetup runtime install windowsdesktop@preview
+```
+
+## Pin a prerelease version
+
+Use a complete prerelease version when you need reproducible selection:
+
+```dotnetcli
+dotnetup sdk install 11.0.100-preview.5.25277.114
+```
+
+An exact prerelease version is pinned. Update commands do not advance it.
+
+## Preview and daily are different
+
+The `preview` channel uses published release metadata. A daily channel uses
+daily-build endpoints and can select builds that are not published previews.
+For more information, see [Daily channels](daily.md).
+
+## Remove the preview requirement
+
+```dotnetcli
+dotnetup sdk uninstall preview
+```
+
+This command removes the explicit `preview` specification. Files remain if
+another specification still requires them.

--- a/documentation/general/dotnetup/concepts/channels.md
+++ b/documentation/general/dotnetup/concepts/channels.md
@@ -8,7 +8,7 @@ ms.date: 08/07/2026
 # dotnetup channels and versions
 
 A channel describes a set of .NET versions. An exact version describes one
-version. `dotnetup` stores the text that you requested and resolves it for the
+version. `dotnetup` stores `channels` and resolves it for the
 selected component.
 
 ## Named channels

--- a/documentation/general/dotnetup/concepts/channels.md
+++ b/documentation/general/dotnetup/concepts/channels.md
@@ -1,0 +1,70 @@
+---
+title: dotnetup channels and versions
+description: Learn how dotnetup resolves stable, preview, daily, numeric, and exact .NET version specifications.
+ms.topic: conceptual
+ms.date: 08/07/2026
+---
+
+# dotnetup channels and versions
+
+A channel describes a set of .NET versions. An exact version describes one
+version. `dotnetup` stores the text that you requested and resolves it for the
+selected component.
+
+## Named channels
+
+| Channel | SDK selection |
+| --- | --- |
+| `latest` | Latest active stable .NET SDK release |
+| `lts` | Latest stable release whose support phase is LTS |
+| `preview` | Latest active preview or GoLive SDK. Selects an active release when no preview is available. |
+| `daily` | Latest available daily build from the daily channel search |
+
+`sts` is not a supported named channel.
+
+## Numeric SDK channels
+
+| Form | Example | Selection |
+| --- | --- | --- |
+| Major | `10` | Latest SDK release for that major version |
+| Major and minor | `10.0` | Latest SDK release for that major and minor version |
+| Feature band | `10.0.1xx` | Latest SDK in that feature band |
+| Exact SDK version | `10.0.103` | Only that SDK version |
+| Exact prerelease SDK version | `11.0.100-preview.5.25277.114` | Only that prerelease SDK version |
+
+An exact version is pinned. `dotnetup update` does not replace it.
+
+## Runtime channels and versions
+
+Runtime commands use runtime versions, not SDK feature bands. Use a
+major/minor channel, such as `10.0`, or an exact runtime version, such as
+`10.0.3`.
+
+Use `component@version-or-channel` to select a runtime component:
+
+```dotnetcli
+dotnetup runtime install runtime@10.0
+dotnetup runtime install aspnetcore@10.0
+dotnetup runtime install windowsdesktop@10.0
+```
+
+When you omit the component name, `dotnetup` selects the core .NET runtime:
+
+```dotnetcli
+dotnetup runtime install 10.0
+```
+
+## Channel matching during updates
+
+An update resolves each tracked channel independently. If a newer matching
+version exists, `dotnetup` installs it. Exact versions are skipped. After a
+successful update, garbage collection removes versions that no remaining
+specification needs.
+
+The command continues with other tracked specifications if one update fails.
+It returns a failure after it processes the remaining specifications.
+
+## Release-channel details
+
+- [Preview channel](../channels/preview.md)
+- [Daily channels](../channels/daily.md)

--- a/documentation/general/dotnetup/concepts/environment.md
+++ b/documentation/general/dotnetup/concepts/environment.md
@@ -29,6 +29,7 @@ Profile and script generation support:
 - Bash
 - Z shell
 - Fish
+- Pwsh (PowerShell Core)
 - PowerShell
 
 If you do not pass `--shell`, `dotnetup` detects the current shell. Use an

--- a/documentation/general/dotnetup/concepts/environment.md
+++ b/documentation/general/dotnetup/concepts/environment.md
@@ -1,0 +1,91 @@
+---
+title: dotnetup environment configuration
+description: Learn how dotnetup configures PATH and DOTNET_ROOT for managed .NET installations.
+ms.topic: conceptual
+ms.date: 08/07/2026
+---
+
+# dotnetup environment configuration
+
+Installing .NET and making the managed `dotnet` command available are
+separate operations. The `dotnetup env` commands control `PATH` and
+`DOTNET_ROOT` configuration.
+
+## .NET access modes
+
+| Mode | Behavior |
+| --- | --- |
+| `none` | Does not add the managed `dotnet` to `PATH` or set `DOTNET_ROOT`. Run .NET with `dotnetup dotnet`. |
+| `shell` | Writes a managed block to the selected shell profile. Processes started from that shell use the managed `dotnet`. |
+| `everywhere` | Configures the Windows user environment and the shell profile so terminals and other user applications use the managed `dotnet`. Windows only. |
+
+The `dotnetup` executable has a separate `PATH` setting. For example, you can
+choose `none` for .NET access but keep `dotnetup` on `PATH`.
+
+## Supported shells
+
+Profile and script generation support:
+
+- Bash
+- Z shell
+- Fish
+- PowerShell
+
+If you do not pass `--shell`, `dotnetup` detects the current shell. Use an
+explicit shell when detection is not available or when you want to update a
+different profile:
+
+```dotnetcli
+dotnetup env set shell --shell zsh
+```
+
+## Stored and observed state
+
+`dotnetup.config.json` stores the selected access mode and whether
+`dotnetup` should be on `PATH`. `dotnetup env show` compares that
+configuration with the current profile and environment. It reports drift if
+the observed state does not match.
+
+Reapply the stored configuration to correct drift:
+
+```dotnetcli
+dotnetup env set
+```
+
+## Current terminal
+
+Profile and Windows environment changes do not rewrite the environment of the
+current process. Open a new terminal, source the modified profile, or evaluate
+the generated script.
+
+For Bash or Z shell:
+
+```bash
+eval "$(dotnetup env script)"
+```
+
+For PowerShell:
+
+```powershell
+dotnetup env script --shell pwsh | Invoke-Expression
+```
+
+`env script` follows the stored configuration when you do not pass selection
+options. Use `--dotnet`, `--dotnetup`, or both to select the generated
+content.
+
+## Remove environment configuration
+
+Remove all managed environment wiring:
+
+```dotnetcli
+dotnetup env clear
+```
+
+This command is equivalent to:
+
+```dotnetcli
+dotnetup env set none --dotnetup-on-path false
+```
+
+It does not uninstall SDKs or runtimes.

--- a/documentation/general/dotnetup/concepts/how-dotnetup-works.md
+++ b/documentation/general/dotnetup/concepts/how-dotnetup-works.md
@@ -58,35 +58,7 @@ An **install specification** records a component and a channel or exact
 version. For example, an SDK specification for `10.0.1xx` means "keep the
 latest SDK in the 10.0.1xx feature band."
 
-Use one of these forms for the version or channel part of an install
-specification:
-
-| Form | Pattern or value | Example | Selection |
-| --- | --- | --- | --- |
-| Latest stable | `latest` | `latest` | Latest active stable version |
-| Latest LTS | `lts` | `lts` | Latest active stable LTS version |
-| Latest preview | `preview` | `preview` | Latest preview or GoLive version, or the latest active version when no preview exists |
-| Major | `<major>` | `10` | Latest version for the specified major version |
-| Major and minor | `<major>.<minor>` | `10.0` | Latest version for the specified major and minor version |
-| SDK feature band | `<major>.<minor>.<band>xx` | `10.0.1xx` | Latest SDK in the specified feature band |
-| Exact stable version | `<major>.<minor>.<patch>` | SDK `10.0.103` or runtime `10.0.3` | Only the specified version |
-| Exact prerelease version | `<major>.<minor>.<patch>-<prerelease-label>` | `11.0.100-preview.5.25277.114` | Only the specified prerelease version |
-| Latest daily | `daily` | `daily` | Latest available daily build |
-| Scoped daily | Add `-daily` to a major, major/minor, or feature-band scope | `11-daily`, `11.0-daily`, or `11.0.1xx-daily` | Latest daily build in the specified scope |
-| Phase-qualified daily | Add `-<phase>.<number>-daily` to a numeric scope | `11.0-preview.5-daily` or `11.0.1xx-preview.5-daily` | Latest daily build for the specified scope and prerelease phase |
-
-Daily phase names contain letters, and the phase number contains digits.
-For example, `preview.5` and `rc.1` are valid phases. The compact form
-`preview5` is also valid.
-
-Feature-band specifications are valid only for SDK installations. Runtime
-commands accept major, major/minor, named, daily, and exact runtime versions.
-The `sts` channel, `preview-daily`, and a complete version with `-daily` are
-not valid.
-
-A valid specification format does not guarantee that a matching release
-exists. Resolution fails when the selected release source has no matching
-version.
+You can learn more about the different kinds of supported channels and versions in [Channels and versions](channels.md).
 
 Each specification has one of these sources:
 

--- a/documentation/general/dotnetup/concepts/how-dotnetup-works.md
+++ b/documentation/general/dotnetup/concepts/how-dotnetup-works.md
@@ -17,7 +17,7 @@ A **hive** is a .NET installation root that `dotnetup` tracks. A hive has:
 
 - A fully qualified directory path.
 - An architecture: `x86`, `x64`, or `arm64`.
-- Zero or more install specifications.
+- Zero or more install specifications, specified as `channels`.
 - Zero or more concrete installations.
 
 The current CLI installs for the architecture of the running `dotnetup`

--- a/documentation/general/dotnetup/concepts/how-dotnetup-works.md
+++ b/documentation/general/dotnetup/concepts/how-dotnetup-works.md
@@ -1,0 +1,126 @@
+---
+title: How dotnetup works
+description: Learn about dotnetup hives, components, install specifications, installations, and state files.
+ms.topic: conceptual
+ms.date: 08/07/2026
+---
+
+# How dotnetup works
+
+`dotnetup` separates what you request from the files that it installs. This
+model lets several requirements share one .NET installation and lets
+`dotnetup` remove files that are no longer required.
+
+## Hives
+
+A **hive** is a .NET installation root that `dotnetup` tracks. A hive has:
+
+- A fully qualified directory path.
+- An architecture: `x86`, `x64`, or `arm64`.
+- Zero or more install specifications.
+- Zero or more concrete installations.
+
+The current CLI installs for the architecture of the running `dotnetup`
+process. It does not have an architecture option.
+
+The default hive is the `dotnet` subdirectory of the dotnetup data directory:
+
+| Platform | Default hive |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\dotnetup\dotnet` |
+| macOS | `~/Library/Application Support/dotnetup/dotnet` |
+| Linux | `$XDG_DATA_HOME/dotnetup/dotnet`, or `~/.local/share/dotnetup/dotnet` when `XDG_DATA_HOME` is not set |
+
+Use `--install-path` to select another hive. An explicit install path takes
+precedence over a path from `global.json`, which takes precedence over the
+default hive.
+
+`dotnetup` does not write to a system-managed .NET directory, such as
+`Program Files\dotnet` or `/usr/share/dotnet`.
+
+## Components
+
+`dotnetup` manages these component types:
+
+| Component | Runtime specification name | Installed content |
+| --- | --- | --- |
+| .NET SDK | Not applicable | SDK, host, runtime, targeting packs, and related SDK content |
+| .NET runtime | `runtime` | `Microsoft.NETCore.App` runtime |
+| ASP.NET Core runtime | `aspnetcore` | `Microsoft.AspNetCore.App` runtime |
+| Windows Desktop runtime | `windowsdesktop` | `Microsoft.WindowsDesktop.App` runtime on Windows |
+
+The ASP.NET Core aliases `aspnet` and the Windows Desktop alias `desktop` are
+accepted in runtime component specifications.
+
+## Install specifications
+
+An **install specification** records a component and a channel or exact
+version. For example, an SDK specification for `10.0.1xx` means "keep the
+latest SDK in the 10.0.1xx feature band."
+
+Each specification has one of these sources:
+
+- `Explicit`: You supplied the channel or version on the command line.
+- `GlobalJson`: `dotnetup` derived the SDK requirement from a `global.json`
+  file.
+
+`All` is an uninstall filter. It is not stored as a specification source.
+
+An exact version is a pinned specification. Update commands do not advance it.
+A channel specification can resolve to a newer version during an update.
+
+## Installations and shared files
+
+An **installation** records one concrete component version and the
+subcomponent directories that it uses. Two specifications can resolve to the
+same installation.
+
+Uninstall commands first remove matching specifications. Garbage collection
+then keeps the newest installed version that matches each remaining
+specification. It removes an installation and its unshared subcomponents only
+when no remaining specification needs them.
+
+## Tracked and untracked installs
+
+By default, an install command records its specification and result in the
+manifest. A tracked install can be listed, updated, and removed by
+`dotnetup`.
+
+The `--untracked` option installs files without recording them. `dotnetup`
+does not list, update, or remove those files. Use this option only when another
+process owns the target directory.
+
+To prevent accidental mixing, a tracked install fails if the target contains
+an existing .NET installation that is not in the selected manifest. Select a
+different directory, remove the existing installation, or use `--untracked`.
+
+## State files
+
+The dotnetup data directory contains these user-level state files:
+
+| File | Purpose |
+| --- | --- |
+| `dotnetup_manifest.json` | Tracks hives, install specifications, installations, and shared subcomponents. |
+| `dotnetup_manifest.json.sha256` | Detects changes to manifest content that dotnetup did not write. |
+| `dotnetup.config.json` | Stores the .NET access mode and whether the `dotnetup` directory is on `PATH`. |
+
+Do not edit these files. Use `dotnetup install`, `update`, `uninstall`, and
+`env` commands to change the related state.
+
+The `DOTNET_DOTNETUP_DATA_DIR` environment variable changes the data
+directory. The `--manifest-path` option changes only the manifest used by one
+command. It does not change the configuration file or default hive.
+
+## Concurrent operations
+
+Install, update, uninstall, list, and garbage-collection workflows coordinate
+access to shared installation state. A command that accepts several
+specifications resolves them before installation and can download them
+concurrently. Manifest changes remain serialized.
+
+## See also
+
+- [Channels and versions](channels.md)
+- [Repository SDK requirements](repositories.md)
+- [Environment configuration](environment.md)
+- [`dotnetup list`](../reference/dotnetup-list.md)

--- a/documentation/general/dotnetup/concepts/how-dotnetup-works.md
+++ b/documentation/general/dotnetup/concepts/how-dotnetup-works.md
@@ -58,6 +58,36 @@ An **install specification** records a component and a channel or exact
 version. For example, an SDK specification for `10.0.1xx` means "keep the
 latest SDK in the 10.0.1xx feature band."
 
+Use one of these forms for the version or channel part of an install
+specification:
+
+| Form | Pattern or value | Example | Selection |
+| --- | --- | --- | --- |
+| Latest stable | `latest` | `latest` | Latest active stable version |
+| Latest LTS | `lts` | `lts` | Latest active stable LTS version |
+| Latest preview | `preview` | `preview` | Latest preview or GoLive version, or the latest active version when no preview exists |
+| Major | `<major>` | `10` | Latest version for the specified major version |
+| Major and minor | `<major>.<minor>` | `10.0` | Latest version for the specified major and minor version |
+| SDK feature band | `<major>.<minor>.<band>xx` | `10.0.1xx` | Latest SDK in the specified feature band |
+| Exact stable version | `<major>.<minor>.<patch>` | SDK `10.0.103` or runtime `10.0.3` | Only the specified version |
+| Exact prerelease version | `<major>.<minor>.<patch>-<prerelease-label>` | `11.0.100-preview.5.25277.114` | Only the specified prerelease version |
+| Latest daily | `daily` | `daily` | Latest available daily build |
+| Scoped daily | Add `-daily` to a major, major/minor, or feature-band scope | `11-daily`, `11.0-daily`, or `11.0.1xx-daily` | Latest daily build in the specified scope |
+| Phase-qualified daily | Add `-<phase>.<number>-daily` to a numeric scope | `11.0-preview.5-daily` or `11.0.1xx-preview.5-daily` | Latest daily build for the specified scope and prerelease phase |
+
+Daily phase names contain letters, and the phase number contains digits.
+For example, `preview.5` and `rc.1` are valid phases. The compact form
+`preview5` is also valid.
+
+Feature-band specifications are valid only for SDK installations. Runtime
+commands accept major, major/minor, named, daily, and exact runtime versions.
+The `sts` channel, `preview-daily`, and a complete version with `-daily` are
+not valid.
+
+A valid specification format does not guarantee that a matching release
+exists. Resolution fails when the selected release source has no matching
+version.
+
 Each specification has one of these sources:
 
 - `Explicit`: You supplied the channel or version on the command line.

--- a/documentation/general/dotnetup/concepts/repositories.md
+++ b/documentation/general/dotnetup/concepts/repositories.md
@@ -1,0 +1,85 @@
+---
+title: Repository SDK requirements with dotnetup
+description: Learn how dotnetup reads global.json and tracks repository SDK requirements.
+ms.topic: conceptual
+ms.date: 08/07/2026
+---
+
+# Repository SDK requirements with dotnetup
+
+`dotnetup` uses `global.json` to associate an SDK requirement with a
+repository or directory tree. From the current directory, it searches for
+`global.json` and then searches each parent directory until it finds one.
+
+## Install from global.json
+
+Run an SDK install command without a channel:
+
+```dotnetcli
+dotnetup install
+```
+
+If the nearest `global.json` has an `sdk.version`, `dotnetup` derives an
+install specification from the version and `rollForward` value. It records
+the full path to the file as the specification source. If no usable
+`global.json` exists, the command uses the `latest` channel.
+
+## rollForward mapping
+
+`dotnetup` maps `global.json` SDK selection policies to updateable channels:
+
+| `rollForward` value | Stored dotnetup requirement for SDK `10.0.103` |
+| --- | --- |
+| Omitted or `latestPatch` | `10.0.1xx` |
+| `latestFeature` | `10.0` |
+| `latestMinor` | `10` |
+| `latestMajor` | `latest` |
+| `disable`, `patch`, `feature`, `minor`, or `major` | `10.0.103` |
+
+The exact-version mappings are pinned and are not advanced by an update.
+
+## Installation path from global.json
+
+If `sdk.paths` contains an entry, `dotnetup` uses the first path. A relative
+path is resolved from the directory that contains `global.json`.
+
+Installation-path precedence is:
+
+1. `--install-path`.
+1. The first `sdk.paths` entry in the nearest `global.json`.
+1. The default dotnetup hive.
+
+## Keep repository files current
+
+Pass `--update-global-json` to replace `sdk.version` with the concrete SDK
+version that was installed or updated:
+
+```dotnetcli
+dotnetup install --update-global-json
+dotnetup sdk update --update-global-json
+```
+
+Only global.json-sourced SDK specifications are updated by the update
+workflow. The modifier preserves the other JSON properties, formatting, and
+detected text encoding.
+
+## Remove a repository requirement
+
+A tracked `global.json` specification is refreshed during garbage collection.
+If the file no longer exists or no longer contains an SDK version, the
+specification is removed.
+
+You can also remove it explicitly. Match the stored channel and select the
+`globaljson` source:
+
+```dotnetcli
+dotnetup sdk uninstall 10.0.1xx --source globaljson
+```
+
+Use `dotnetup list` to find the stored channel and source path.
+
+## See also
+
+- [Manage repository SDK requirements](../usecases/install-with-global-json.md)
+- [`global.json` overview](https://learn.microsoft.com/dotnet/core/tools/global-json)
+- [`dotnetup sdk install`](../reference/dotnetup-sdk-install.md)

--- a/documentation/general/dotnetup/designs/runtime-install.md
+++ b/documentation/general/dotnetup/designs/runtime-install.md
@@ -72,7 +72,7 @@ Essentially, we could remove `global.json` lookup from the chain of consideratio
 
 ## Versions
 
-Runtime versions don't have a feature band. The version parsing handled by the [`Microsoft.Deployment.DotNet.Releases`](https://github.com/dotnet/deployment-tools/tree/main/src/Microsoft.Deployment.DotNet.Releases) library (see [`ChannelVersionResolver`](../../../src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs)), however, should account for this. Minimal changes are expected.
+Runtime versions don't have a feature band. The version parsing handled by the [`Microsoft.Deployment.DotNet.Releases`](https://github.com/dotnet/deployment-tools/tree/main/src/Microsoft.Deployment.DotNet.Releases) library (see [`ChannelVersionResolver`](../../../../src/Installer/Microsoft.Dotnet.Installation/Internal/ChannelVersionResolver.cs)), however, should account for this. Minimal changes are expected.
 
 ## Muxer Handling
 
@@ -80,7 +80,7 @@ The .NET Runtime archives also include `dotnet.exe`. The host replacement logic 
 
 ## Runtime Component Selection
 
-There are 3 runtime archives produced: the runtime, aspnetcore runtime, and windows desktop runtime (see [`InstallComponent`](../../../src/Installer/Microsoft.Dotnet.Installation/InstallComponent.cs)).
+There are 3 runtime archives produced: the runtime, aspnetcore runtime, and windows desktop runtime (see [`InstallComponent`](../../../../src/Installer/Microsoft.Dotnet.Installation/InstallComponent.cs)).
 
 The component is specified using the `<component>@<version>` syntax described above:
 
@@ -114,7 +114,7 @@ The .NET SDK install may include the .NET Runtime.
 2. Explicit user actions (install commands) are tracked in the manifest
 3. Uninstall operations should not break other installed components
 
-What we will do is check `shared/{runtime-type}/{runtime-version}` and `host/fxr/{runtime-version}` in the hive location. We could also query the muxer itself (via [`HostFxrWrapper`](../../../src/Installer/Microsoft.Dotnet.Installation/Internal/HostFxrWrapper.cs)) for a more concrete answer as to if the install exists on disk.
+What we will do is check `shared/{runtime-type}/{runtime-version}` and `host/fxr/{runtime-version}` in the hive location. We could also query the muxer itself (via [`HostFxrWrapper`](../../../../src/Installer/Microsoft.Dotnet.Installation/Internal/HostFxrWrapper.cs)) for a more concrete answer as to if the install exists on disk.
 
 Consider performance (folder check vs muxer invocation) vs accuracy (folder faking via rename) in this decision.
 

--- a/documentation/general/dotnetup/index.md
+++ b/documentation/general/dotnetup/index.md
@@ -1,0 +1,84 @@
+---
+title: dotnetup overview
+description: Learn how dotnetup installs and manages user-level .NET SDKs and runtimes.
+ms.topic: overview
+ms.date: 08/07/2026
+---
+
+# dotnetup overview
+
+`dotnetup` is a cross-platform toolchain manager for user-level .NET
+installations. It installs .NET SDKs and runtimes without writing to a
+system-managed .NET directory. It also tracks the installation requirements
+that you select so that it can update or remove the related files later.
+
+Use `dotnetup` to:
+
+- Install stable, preview, daily, or exact .NET versions.
+- Keep multiple SDK and runtime requirements in one managed installation.
+- Install the SDK required by the nearest `global.json` file.
+- Update tracked channels without changing exact-version requirements.
+- Configure how terminals and applications find the managed `dotnet`.
+- Run the managed `dotnet` without changing `PATH`.
+
+## Start
+
+Run the interactive setup:
+
+```dotnetcli
+dotnetup init
+```
+
+The setup asks which SDK channel to install and how you want to access the
+managed `dotnet` command.
+
+For a concise, noninteractive setup, install an SDK and configure the current
+shell:
+
+```dotnetcli
+dotnetup install latest
+dotnetup env set shell
+dotnetup list
+dotnet --version
+```
+
+If you do not want to change your shell profile, use the forwarding command:
+
+```dotnetcli
+dotnetup install latest
+dotnetup env set none
+dotnetup dotnet --version
+```
+
+## How dotnetup manages .NET
+
+An installation starts with an **install specification**. The specification
+identifies a component, such as the .NET SDK, and a channel or exact version.
+`dotnetup` resolves that specification to a concrete version and installs it
+in a managed **hive**.
+
+The manifest records both the specification and the concrete installation.
+More than one specification can refer to the same files. When you uninstall a
+specification, `dotnetup` removes files only when no remaining specification
+requires them.
+
+For more information, see [How dotnetup works](concepts/how-dotnetup-works.md).
+
+## Choose what to read next
+
+| Goal | Article |
+| --- | --- |
+| Understand channels, hives, and tracking | [How dotnetup works](concepts/how-dotnetup-works.md) |
+| Use a repository's `global.json` | [Manage repository SDK requirements](usecases/install-with-global-json.md) |
+| Install SDKs and runtimes | [Install .NET components](usecases/install-components.md) |
+| Update or remove installations | [Update installations](usecases/update-installations.md) |
+| Configure `PATH` and `DOTNET_ROOT` | [Manage the dotnetup environment](usecases/manage-environment.md) |
+| Try preview or daily builds | [Use preview and daily builds](usecases/try-daily-builds.md) |
+| Look up command syntax | [dotnetup command reference](reference/dotnetup.md) |
+
+## Availability
+
+This documentation describes the current in-repository implementation of
+`dotnetup`. Distribution instructions can differ for each internal release.
+After the `dotnetup` executable is available, run `dotnetup --version` to
+confirm the version and `dotnetup --help` to see its command surface.

--- a/documentation/general/dotnetup/index.md
+++ b/documentation/general/dotnetup/index.md
@@ -97,15 +97,9 @@ on your system and the available releases.
 
 ## How dotnetup manages .NET
 
-An installation starts with an **install specification**. The specification
-identifies a component, such as the .NET SDK, and a channel or exact version.
-`dotnetup` resolves that specification to a concrete version and installs it
-in a managed **hive**.
-
-The manifest records both the specification and the concrete installation.
-More than one specification can refer to the same files. When you uninstall a
-specification, `dotnetup` removes files only when no remaining specification
-requires them.
+`dotnetup` tracks the SDK installations that you request. This tracking lets
+`dotnetup` update many installations at the same time. It also lets `dotnetup`
+safely remove unused or out-of-support installations.
 
 For more information, see [How dotnetup works](concepts/how-dotnetup-works.md).
 

--- a/documentation/general/dotnetup/index.md
+++ b/documentation/general/dotnetup/index.md
@@ -26,7 +26,19 @@ Use `dotnetup` to:
 Run the interactive setup:
 
 ```dotnetcli
-dotnetup init
+> dotnetup init
+Welcome to dotnetup!
+
+SDK Channel: latest
+Mode: Terminal Mode (Suggested)
+
+Would you like to install .NET with the recommended settings?
+> Yes, proceed with defaults and install
+
+Downloading SDK <resolved-version>
+Installing SDK <resolved-version>
+Installed SDK <resolved-version>
+Setup complete!
 ```
 
 The setup asks which SDK channel to install and how you want to access the
@@ -36,19 +48,52 @@ For a concise, noninteractive setup, install an SDK and configure the current
 shell:
 
 ```dotnetcli
-dotnetup install latest
-dotnetup env set shell
-dotnetup list
-dotnet --version
+> dotnetup install latest
+Downloading SDK <resolved-version>
+Installing SDK <resolved-version>
+Installed SDK <resolved-version>
+
+> dotnetup env set shell
+dotnet and dotnetup are on your PATH.
+To apply the change to this terminal now, run:
+<shell-specific command>
+Or open a new terminal.
+
+> dotnetup list
+Installations (managed by dotnetup):
+
+  <default-hive>
+
+    Tracked channels:
+      SDK latest  (source: explicit)
+
+    Installed versions:
+      SDK <resolved-version>  (<architecture>)
+
+Total: 1
+
+> dotnet --version
+<resolved-version>
 ```
 
 If you do not want to change your shell profile, use the forwarding command:
 
 ```dotnetcli
-dotnetup install latest
-dotnetup env set none
-dotnetup dotnet --version
+> dotnetup install latest
+Downloading SDK <resolved-version>
+Installing SDK <resolved-version>
+Installed SDK <resolved-version>
+
+> dotnetup env set none
+dotnetup is on your PATH. dotnet is not — run it with 'dotnetup dotnet <command>'.
+Open a new terminal for the change to take effect.
+
+> dotnetup dotnet --version
+<resolved-version>
 ```
+
+The mode, resolved version, architecture, hive path, and shell command depend
+on your system and the available releases.
 
 ## How dotnetup manages .NET
 

--- a/documentation/general/dotnetup/reference/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/reference/dotnetup-dotnet.md
@@ -32,6 +32,14 @@ process exit code.
 This command does not automatically select an arbitrary hive supplied earlier
 with `--install-path`.
 
+`dotnetup dotnet` changes the environment only for the command that it starts.
+Other applications do not use this hive by default. This includes IDEs such as
+Visual Studio Code.
+
+Use Terminal Mode and launch the IDE from that terminal. On Windows, use
+Everywhere Mode to configure all applications. For more information, see
+[dotnetup environment configuration](../concepts/environment.md).
+
 ## Arguments
 
 `ARGUMENT`

--- a/documentation/general/dotnetup/reference/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/reference/dotnetup-dotnet.md
@@ -12,13 +12,10 @@ ms.date: 08/07/2026
 `dotnetup dotnet` - Run a command with the dotnetup-managed `dotnet`
 executable.
 
-The command alias is `dotnetup do`.
-
 ## Synopsis
 
 ```console
 dotnetup dotnet [--] [<ARGUMENT>...]
-dotnetup do [--] [<ARGUMENT>...]
 ```
 
 ## Description
@@ -40,7 +37,7 @@ with `--install-path`.
 `ARGUMENT`
 
 Zero or more arguments to pass to `dotnet`. The optional `--` separator makes
-the forwarding boundary explicit.
+the forwarding boundary explicit and should be used whenever an argument passed to `dotnet` could overlap with an option that `dotnetup dotnet` also accepts.
 
 ## Options
 

--- a/documentation/general/dotnetup/reference/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/reference/dotnetup-dotnet.md
@@ -1,0 +1,57 @@
+---
+title: dotnetup dotnet command
+description: Command reference for running the dotnetup-managed dotnet command.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup dotnet command
+
+## Name
+
+`dotnetup dotnet` - Run a command with the dotnetup-managed `dotnet`
+executable.
+
+The command alias is `dotnetup do`.
+
+## Synopsis
+
+```console
+dotnetup dotnet [--] [<ARGUMENT>...]
+dotnetup do [--] [<ARGUMENT>...]
+```
+
+## Description
+
+The command selects the current default dotnetup hive. It uses the `PATH`
+location if that location is the default managed hive. Otherwise, it uses the
+default hive.
+
+Before it starts the child process, it sets `DOTNET_ROOT` to the selected
+hive and prepends the hive to `PATH`. It forwards all remaining arguments and
+inherits standard input, output, and error. Its exit code is the child
+process exit code.
+
+This command does not automatically select an arbitrary hive supplied earlier
+with `--install-path`.
+
+## Arguments
+
+`ARGUMENT`
+
+Zero or more arguments to pass to `dotnet`. The optional `--` separator makes
+the forwarding boundary explicit.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-?`, `-h`, `--help` | Show dotnetup command help. Add `--` before a `dotnet` help option when necessary. |
+
+## Examples
+
+```dotnetcli
+dotnetup dotnet -- --version
+dotnetup dotnet build --configuration Release
+dotnetup do test
+```

--- a/documentation/general/dotnetup/reference/dotnetup-env-clear.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-clear.md
@@ -32,7 +32,7 @@ It does not uninstall .NET.
 
 | Option | Description |
 | --- | --- |
-| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell to update. If omitted, detect the current shell. |
+| `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the profile shell to update. If omitted, detect the current shell. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Example

--- a/documentation/general/dotnetup/reference/dotnetup-env-clear.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-clear.md
@@ -1,0 +1,42 @@
+---
+title: dotnetup env clear command
+description: Command reference for removing dotnetup environment settings.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup env clear command
+
+## Name
+
+`dotnetup env clear` - Remove all dotnetup environment wiring.
+
+## Synopsis
+
+```console
+dotnetup env clear [options]
+```
+
+## Description
+
+The command removes managed `PATH` and `DOTNET_ROOT` changes and stores the
+`none` access mode with `dotnetup` removed from `PATH`. It is equivalent to:
+
+```dotnetcli
+dotnetup env set none --dotnetup-on-path false
+```
+
+It does not uninstall .NET.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell to update. If omitted, detect the current shell. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Example
+
+```dotnetcli
+dotnetup env clear --shell pwsh
+```

--- a/documentation/general/dotnetup/reference/dotnetup-env-script.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-script.md
@@ -29,15 +29,11 @@ With selection options, it includes only the requested parts.
 
 | Option | Description |
 | --- | --- |
-| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the script syntax. If omitted, detect the current shell. |
+| `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the script syntax. If omitted, detect the current shell. |
 | `-d`, `--dotnet-install-path <PATH>` | Use a specific .NET installation root. The default is the default dotnetup hive. |
 | `--dotnet` | Add the selected .NET root to `PATH` and set `DOTNET_ROOT`. |
 | `--dotnetup` | Add the directory that contains `dotnetup` to `PATH`. |
 | `-?`, `-h`, `--help` | Show command help. |
-
-The hidden `--dotnetup-only` compatibility option emits only the dotnetup
-`PATH` change. Do not combine it with `--dotnet` or `--dotnetup`. New
-scripts should use `--dotnetup`.
 
 ## Examples
 

--- a/documentation/general/dotnetup/reference/dotnetup-env-script.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-script.md
@@ -1,0 +1,61 @@
+---
+title: dotnetup env script command
+description: Command reference for generating a dotnetup shell activation script.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup env script command
+
+## Name
+
+`dotnetup env script` - Generate shell code that activates dotnetup settings.
+
+## Synopsis
+
+```console
+dotnetup env script [options]
+```
+
+## Description
+
+Without selection options, the generated script follows the stored
+configuration. If no configuration exists, it includes both the managed
+`dotnet` and `dotnetup`.
+
+With selection options, it includes only the requested parts.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the script syntax. If omitted, detect the current shell. |
+| `-d`, `--dotnet-install-path <PATH>` | Use a specific .NET installation root. The default is the default dotnetup hive. |
+| `--dotnet` | Add the selected .NET root to `PATH` and set `DOTNET_ROOT`. |
+| `--dotnetup` | Add the directory that contains `dotnetup` to `PATH`. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+The hidden `--dotnetup-only` compatibility option emits only the dotnetup
+`PATH` change. Do not combine it with `--dotnet` or `--dotnetup`. New
+scripts should use `--dotnetup`.
+
+## Examples
+
+Activate the stored configuration in Bash:
+
+```bash
+eval "$(dotnetup env script --shell bash)"
+```
+
+Activate only a repository-local .NET installation in PowerShell:
+
+```powershell
+dotnetup env script --shell pwsh --dotnet --dotnet-install-path .\.dotnet |
+  Invoke-Expression
+```
+
+Generate script text without evaluating it:
+
+```dotnetcli
+dotnetup env script --shell fish --dotnet --dotnetup
+```

--- a/documentation/general/dotnetup/reference/dotnetup-env-set.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-set.md
@@ -36,8 +36,8 @@ fails if no readable configuration exists.
 
 | Option | Description |
 | --- | --- |
-| `--dotnetup-on-path <true|false>` | Add or remove the directory that contains `dotnetup` from `PATH`. If omitted, preserve the stored value. The first stored configuration defaults to `true`. |
-| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
+| `--dotnetup-on-path <true\|false>` | Add or remove the directory that contains `dotnetup` from `PATH`. If omitted, preserve the stored value. The first stored configuration defaults to `true`. |
+| `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-env-set.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-set.md
@@ -1,0 +1,61 @@
+---
+title: dotnetup env set command
+description: Command reference for applying dotnetup environment settings.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup env set command
+
+## Name
+
+`dotnetup env set` - Apply or reapply dotnetup environment settings.
+
+## Synopsis
+
+```console
+dotnetup env set [<MODE>] [options]
+```
+
+## Arguments
+
+`MODE`
+
+The optional .NET access mode:
+
+| Value | Behavior |
+| --- | --- |
+| `none` | Do not wire the managed `dotnet`. |
+| `shell` | Wire the managed `dotnet` through a shell profile. |
+| `everywhere` | Wire the managed `dotnet` through the Windows user environment and shell profile. Windows only. |
+
+When you omit `MODE`, the command reapplies the stored mode. The command
+fails if no readable configuration exists.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--dotnetup-on-path <true|false>` | Add or remove the directory that contains `dotnetup` from `PATH`. If omitted, preserve the stored value. The first stored configuration defaults to `true`. |
+| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+Use the managed `dotnet` from Bash:
+
+```dotnetcli
+dotnetup env set shell --shell bash
+```
+
+Keep only `dotnetup` on `PATH`:
+
+```dotnetcli
+dotnetup env set none --dotnetup-on-path true
+```
+
+Correct drift by reapplying stored settings:
+
+```dotnetcli
+dotnetup env set
+```

--- a/documentation/general/dotnetup/reference/dotnetup-env-show.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-show.md
@@ -30,7 +30,7 @@ If the configuration has drifted, run `dotnetup env set` to reapply it.
 
 | Option | Description |
 | --- | --- |
-| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell to inspect. If omitted, detect the current shell. |
+| `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the profile shell to inspect. If omitted, detect the current shell. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Example

--- a/documentation/general/dotnetup/reference/dotnetup-env-show.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-show.md
@@ -1,0 +1,40 @@
+---
+title: dotnetup env show command
+description: Command reference for inspecting dotnetup environment configuration and drift.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup env show command
+
+## Name
+
+`dotnetup env show` - Show environment settings and report detected drift.
+
+## Synopsis
+
+```console
+dotnetup env show [options]
+```
+
+## Description
+
+The command displays the stored .NET access mode and `dotnetup` `PATH`
+setting. It compares the stored configuration with the selected shell profile
+and persisted environment. It also reports whether the current process has
+the requested settings.
+
+If the configuration has drifted, run `dotnetup env set` to reapply it.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell to inspect. If omitted, detect the current shell. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Example
+
+```dotnetcli
+dotnetup env show --shell zsh
+```

--- a/documentation/general/dotnetup/reference/dotnetup-env.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env.md
@@ -1,0 +1,36 @@
+---
+title: dotnetup env command
+description: Command reference for the dotnetup environment command group.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup env command
+
+## Name
+
+`dotnetup env` - Manage `PATH` and `DOTNET_ROOT` configuration.
+
+## Synopsis
+
+```console
+dotnetup env <command> [options]
+```
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| [`set`](dotnetup-env-set.md) | Apply or reapply environment settings. |
+| [`clear`](dotnetup-env-clear.md) | Remove all dotnetup environment wiring. |
+| [`show`](dotnetup-env-show.md) | Show stored settings and detected drift. |
+| [`script`](dotnetup-env-script.md) | Generate a shell activation script. |
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-?`, `-h`, `--help` | Show command help. |
+
+For the access-mode model, see
+[Environment configuration](../concepts/environment.md).

--- a/documentation/general/dotnetup/reference/dotnetup-init.md
+++ b/documentation/general/dotnetup/reference/dotnetup-init.md
@@ -1,0 +1,49 @@
+---
+title: dotnetup init command
+description: Command reference for interactive dotnetup setup.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup init command
+
+## Name
+
+`dotnetup init` - Configure dotnetup and install .NET through an interactive
+setup flow.
+
+## Synopsis
+
+```console
+dotnetup init [options]
+```
+
+## Description
+
+The setup flow presents the effective install path and starter SDK channel.
+It lets you select an access mode and whether the `dotnetup` executable is on
+`PATH`. It can also offer to migrate matching native-architecture
+system-managed installations.
+
+Run this command again to reconfigure dotnetup.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--interactive [<true|false>]` | Allow the command to wait for input. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+```dotnetcli
+dotnetup init
+dotnetup init --shell bash
+dotnetup init --install-path .\.dotnet
+```

--- a/documentation/general/dotnetup/reference/dotnetup-init.md
+++ b/documentation/general/dotnetup/reference/dotnetup-init.md
@@ -33,11 +33,11 @@ Run this command again to reconfigure dotnetup.
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-s`, `--shell [<bash|zsh|fish|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
-| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
-| `--interactive [<true|false>]` | Allow the command to wait for input. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the profile shell. If omitted, detect the current shell. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true\|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--interactive [<true\|false>]` | Allow the command to wait for input. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-install.md
@@ -1,0 +1,70 @@
+---
+title: dotnetup install command
+description: Command reference for installing .NET SDKs with dotnetup.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup install command
+
+## Name
+
+`dotnetup install` - Install one or more .NET SDK requirements.
+
+This command is an alias for [`dotnetup sdk install`](dotnetup-sdk-install.md).
+
+## Synopsis
+
+```console
+dotnetup install [<CHANNEL>...] [options]
+```
+
+## Arguments
+
+`CHANNEL`
+
+One or more SDK channels or exact versions. If you omit this argument,
+`dotnetup` derives a channel from the nearest `global.json`. If it cannot
+derive one, it uses `latest`.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--update-global-json [<true|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+Install the latest stable SDK:
+
+```dotnetcli
+dotnetup install latest
+```
+
+Install several requirements:
+
+```dotnetcli
+dotnetup install 9.0 10.0.1xx preview
+```
+
+Install the requirement from `global.json` and write the resolved version:
+
+```dotnetcli
+dotnetup install --update-global-json
+```
+
+Install in a repository-local hive:
+
+```dotnetcli
+dotnetup install 10.0.1xx --install-path .\.dotnet
+```

--- a/documentation/general/dotnetup/reference/dotnetup-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-install.md
@@ -32,15 +32,15 @@ derive one, it uses `latest`.
 | Option | Description |
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
-| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
-| `--update-global-json [<true|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
+| `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--update-global-json [<true\|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
-| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
-| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
-| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true\|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true\|false>]` | Install without adding a manifest record. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-list.md
+++ b/documentation/general/dotnetup/reference/dotnetup-list.md
@@ -34,8 +34,8 @@ Property names use camel case. Enum values use their names.
 
 | Option | Description |
 | --- | --- |
-| `--format <text|json>` | Select text or JSON output. The default is `text`. |
-| `--no-verify [<true|false>]` | Do not validate each recorded installation on disk. |
+| `--format <text\|json>` | Select text or JSON output. The default is `text`. |
+| `--no-verify [<true\|false>]` | Do not validate each recorded installation on disk. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Show only the matching installation root. |
 | `-?`, `-h`, `--help` | Show command help. |

--- a/documentation/general/dotnetup/reference/dotnetup-list.md
+++ b/documentation/general/dotnetup/reference/dotnetup-list.md
@@ -1,0 +1,55 @@
+---
+title: dotnetup list command
+description: Command reference for listing and verifying dotnetup installations.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup list command
+
+## Name
+
+`dotnetup list` - List tracked .NET requirements and installations.
+
+## Synopsis
+
+```console
+dotnetup list [options]
+```
+
+## Description
+
+The text output groups tracked channels and installed versions by
+installation root. Each specification includes its source. Each installation
+includes its architecture and, by default, its validation state.
+
+JSON output has two arrays:
+
+- `installSpecs`
+- `installations`
+
+Property names use camel case. Enum values use their names.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--format <text|json>` | Select text or JSON output. The default is `text`. |
+| `--no-verify [<true|false>]` | Do not validate each recorded installation on disk. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Show only the matching installation root. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+List and verify all tracked installations:
+
+```dotnetcli
+dotnetup list
+```
+
+Create JSON output without file validation:
+
+```dotnetcli
+dotnetup list --format json --no-verify
+```

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
@@ -1,0 +1,59 @@
+---
+title: dotnetup runtime install command
+description: Command reference for installing .NET runtimes with dotnetup.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup runtime install command
+
+## Name
+
+`dotnetup runtime install` - Install one or more .NET runtime requirements.
+
+## Synopsis
+
+```console
+dotnetup runtime install [<COMPONENT_SPEC>...] [options]
+```
+
+## Arguments
+
+`COMPONENT_SPEC`
+
+One or more runtime channels or versions. Use
+`component@version-or-channel` to select a component. A value without a
+component selects the core .NET runtime.
+
+If you omit all values, the command installs the latest core runtime.
+
+Valid components are `runtime`, `aspnetcore`, and `windowsdesktop`.
+`aspnet` and `desktop` are accepted aliases. Windows Desktop is available
+only on Windows.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true|false>]` | Install matching native-architecture runtimes from a system-managed installation into the selected hive. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+SDK feature bands and SDK patch versions are not valid runtime versions. For
+example, use `10.0` or `10.0.3`, not `10.0.1xx` or `10.0.103`.
+
+## Examples
+
+```dotnetcli
+dotnetup runtime install
+dotnetup runtime install 10.0
+dotnetup runtime install aspnetcore@10.0
+dotnetup runtime install runtime@9.0 aspnetcore@9.0
+```

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
@@ -36,14 +36,14 @@ only on Windows.
 | Option | Description |
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
-| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true|false>]` | Install matching native-architecture runtimes from a system-managed installation into the selected hive. |
+| `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture runtimes from a system-managed installation into the selected hive. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
-| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
-| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
-| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true\|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true\|false>]` | Install without adding a manifest record. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 SDK feature bands and SDK patch versions are not valid runtime versions. For

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-uninstall.md
@@ -1,0 +1,44 @@
+---
+title: dotnetup runtime uninstall command
+description: Command reference for removing tracked .NET runtime requirements.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup runtime uninstall command
+
+## Name
+
+`dotnetup runtime uninstall` - Remove a runtime specification and unused
+files.
+
+## Synopsis
+
+```console
+dotnetup runtime uninstall <COMPONENT_SPEC> [options]
+```
+
+## Arguments
+
+`COMPONENT_SPEC`
+
+The stored runtime requirement to remove. Use
+`component@version-or-channel` to select a component. A value without a
+component selects the core .NET runtime.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. Runtime specifications are normally explicit. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+```dotnetcli
+dotnetup runtime uninstall 10.0
+dotnetup runtime uninstall aspnetcore@10.0
+dotnetup runtime uninstall windowsdesktop@10.0 --install-path .\.dotnet
+```

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-uninstall.md
@@ -30,7 +30,7 @@ component selects the core .NET runtime.
 
 | Option | Description |
 | --- | --- |
-| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. Runtime specifications are normally explicit. |
+| `--source <explicit\|globaljson\|all>` | Remove specifications from the selected source. The default is `explicit`. Runtime specifications are normally explicit. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `-?`, `-h`, `--help` | Show command help. |

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-update.md
@@ -1,0 +1,44 @@
+---
+title: dotnetup runtime update command
+description: Command reference for updating tracked .NET runtime requirements.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup runtime update command
+
+## Name
+
+`dotnetup runtime update` - Update tracked .NET runtime channels.
+
+## Synopsis
+
+```console
+dotnetup runtime update [options]
+```
+
+## Description
+
+The command processes the core .NET and ASP.NET Core runtime components. On
+Windows, it also processes the Windows Desktop runtime. It skips exact-version
+specifications.
+
+The command tries each supported runtime component even if an earlier
+component fails.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Update only the matching installation root. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+```dotnetcli
+dotnetup runtime update
+dotnetup runtime update --install-path .\.dotnet --no-progress
+```

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-update.md
@@ -32,8 +32,8 @@ component fails.
 | --- | --- |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Update only the matching installation root. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-runtime.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime.md
@@ -1,0 +1,40 @@
+---
+title: dotnetup runtime command
+description: Command reference for the dotnetup runtime command group.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup runtime command
+
+## Name
+
+`dotnetup runtime` - Manage .NET runtime installations.
+
+## Synopsis
+
+```console
+dotnetup runtime <command> [options]
+```
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| [`install`](dotnetup-runtime-install.md) | Install one or more runtime requirements. |
+| [`update`](dotnetup-runtime-update.md) | Update tracked runtime requirements. |
+| [`uninstall`](dotnetup-runtime-uninstall.md) | Remove a runtime requirement and unused files. |
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Runtime components
+
+| Name | Component |
+| --- | --- |
+| `runtime` | Core .NET runtime |
+| `aspnetcore` or `aspnet` | ASP.NET Core runtime |
+| `windowsdesktop` or `desktop` | Windows Desktop runtime. Windows only. |

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
@@ -32,19 +32,16 @@ When no value is present, `dotnetup` derives the channel from the nearest
 | Option | Description |
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
-| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
-| `--update-global-json [<true|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
+| `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--update-global-json [<true\|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
-| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
-| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
-| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true\|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true\|false>]` | Install without adding a manifest record. |
 | `-?`, `-h`, `--help` | Show command help. |
-
-The `--shell` option is not accepted. Run `dotnetup init --shell <name>` or
-`dotnetup env set shell --shell <name>` to select a shell.
 
 ## Examples
 

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
@@ -1,0 +1,56 @@
+---
+title: dotnetup sdk install command
+description: Command reference for installing .NET SDKs with dotnetup sdk install.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup sdk install command
+
+## Name
+
+`dotnetup sdk install` - Install one or more .NET SDK requirements.
+
+## Synopsis
+
+```console
+dotnetup sdk install [<CHANNEL>...] [options]
+```
+
+## Arguments
+
+`CHANNEL`
+
+One or more SDK channels or exact versions. Multiple values are resolved
+before installation and can be installed concurrently.
+
+When no value is present, `dotnetup` derives the channel from the nearest
+`global.json`. If no usable file exists, it selects `latest`.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `--set-default-install [<true|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
+| `--migrate-from-system [<true|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--update-global-json [<true|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--interactive [<true|false>]` | Allow first-use onboarding to wait for input. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--require-muxer-update [<true|false>]` | Fail if the command cannot update the `dotnet` executable. By default, installation continues with a warning. |
+| `--untracked [<true|false>]` | Install without adding a manifest record. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+The `--shell` option is not accepted. Run `dotnetup init --shell <name>` or
+`dotnetup env set shell --shell <name>` to select a shell.
+
+## Examples
+
+```dotnetcli
+dotnetup sdk install latest
+dotnetup sdk install 10 10.0.1xx
+dotnetup sdk install 10.0.103
+dotnetup sdk install preview --no-progress
+```

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-uninstall.md
@@ -1,0 +1,42 @@
+---
+title: dotnetup sdk uninstall command
+description: Command reference for removing tracked .NET SDK requirements.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup sdk uninstall command
+
+## Name
+
+`dotnetup sdk uninstall` - Remove an SDK specification and unused files.
+
+## Synopsis
+
+```console
+dotnetup sdk uninstall <CHANNEL> [options]
+```
+
+## Arguments
+
+`CHANNEL`
+
+The stored SDK channel or exact version to remove. Matching is
+case-insensitive.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Select the installation root. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+```dotnetcli
+dotnetup sdk uninstall latest
+dotnetup sdk uninstall 10.0.1xx --source globaljson
+dotnetup sdk uninstall preview --source all --install-path .\.dotnet
+```

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-uninstall.md
@@ -28,7 +28,7 @@ case-insensitive.
 
 | Option | Description |
 | --- | --- |
-| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. |
+| `--source <explicit\|globaljson\|all>` | Remove specifications from the selected source. The default is `explicit`. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `-?`, `-h`, `--help` | Show command help. |

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-update.md
@@ -1,0 +1,44 @@
+---
+title: dotnetup sdk update command
+description: Command reference for updating tracked .NET SDK requirements.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup sdk update command
+
+## Name
+
+`dotnetup sdk update` - Update tracked .NET SDK channels.
+
+## Synopsis
+
+```console
+dotnetup sdk update [options]
+```
+
+## Description
+
+By default, the command processes only SDK specifications. It skips exact SDK
+versions. Use `--all` to process SDK and runtime specifications.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--all` | Update all tracked components, including runtimes. |
+| `--update-global-json` | Update applicable global.json-sourced SDK versions. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Update only the matching installation root. |
+| `--interactive [<true|false>]` | The current parser accepts this option. The current update handler does not use it. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+```dotnetcli
+dotnetup sdk update
+dotnetup sdk update --all
+dotnetup sdk update --update-global-json
+```

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-update.md
@@ -30,9 +30,9 @@ versions. Use `--all` to process SDK and runtime specifications.
 | `--update-global-json` | Update applicable global.json-sourced SDK versions. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Update only the matching installation root. |
-| `--interactive [<true|false>]` | The current parser accepts this option. The current update handler does not use it. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--interactive [<true\|false>]` | The current parser accepts this option. The current update handler does not use it. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-sdk.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk.md
@@ -1,0 +1,40 @@
+---
+title: dotnetup sdk command
+description: Command reference for the dotnetup SDK command group.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup sdk command
+
+## Name
+
+`dotnetup sdk` - Manage .NET SDK installations.
+
+## Synopsis
+
+```console
+dotnetup sdk <command> [options]
+```
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| [`install`](dotnetup-sdk-install.md) | Install one or more SDK requirements. |
+| [`update`](dotnetup-sdk-update.md) | Update tracked SDK requirements. |
+| [`uninstall`](dotnetup-sdk-uninstall.md) | Remove an SDK requirement and unused files. |
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Example
+
+```dotnetcli
+dotnetup sdk install 10.0.1xx
+dotnetup sdk update
+dotnetup sdk uninstall 10.0.1xx
+```

--- a/documentation/general/dotnetup/reference/dotnetup-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-uninstall.md
@@ -1,0 +1,53 @@
+---
+title: dotnetup uninstall command
+description: Command reference for removing a tracked .NET SDK requirement.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup uninstall command
+
+## Name
+
+`dotnetup uninstall` - Remove an SDK install specification and unused files.
+
+This command is an alias for
+[`dotnetup sdk uninstall`](dotnetup-sdk-uninstall.md).
+
+## Synopsis
+
+```console
+dotnetup uninstall <CHANNEL> [options]
+```
+
+## Arguments
+
+`CHANNEL`
+
+The stored SDK channel or exact version to remove. Use `dotnetup list` to
+find the stored value.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Select the installation root. Without this option, use the current managed default or the default hive. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+Remove an explicit feature-band requirement:
+
+```dotnetcli
+dotnetup uninstall 10.0.1xx
+```
+
+Remove matching requirements from any source:
+
+```dotnetcli
+dotnetup uninstall 10.0.1xx --source all
+```
+
+An installation remains when another specification still refers to it.

--- a/documentation/general/dotnetup/reference/dotnetup-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-uninstall.md
@@ -31,7 +31,7 @@ find the stored value.
 
 | Option | Description |
 | --- | --- |
-| `--source <explicit|globaljson|all>` | Remove specifications from the selected source. The default is `explicit`. |
+| `--source <explicit\|globaljson\|all>` | Remove specifications from the selected source. The default is `explicit`. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Select the installation root. Without this option, use the current managed default or the default hive. |
 | `-?`, `-h`, `--help` | Show command help. |

--- a/documentation/general/dotnetup/reference/dotnetup-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-update.md
@@ -33,9 +33,9 @@ failure after it processes the remaining specifications.
 | `--update-global-json` | Update applicable global.json-sourced SDK versions. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--install-path <INSTALL_PATH>` | Update only the matching installation root. Without this option, update all roots in the manifest. |
-| `--interactive [<true|false>]` | The current parser accepts this option. The current update handler does not use it. |
-| `--no-progress [<true|false>]` | Disable progress display. |
-| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `--interactive [<true\|false>]` | The current parser accepts this option. The current update handler does not use it. |
+| `--no-progress [<true\|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal\|detailed>` | Set output verbosity. The default is `normal`. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-update.md
@@ -1,0 +1,53 @@
+---
+title: dotnetup update command
+description: Command reference for updating all tracked dotnetup installations.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup update command
+
+## Name
+
+`dotnetup update` - Update all tracked SDK and runtime channels.
+
+## Synopsis
+
+```console
+dotnetup update [options]
+```
+
+## Description
+
+The command checks every tracked SDK and runtime specification. It installs a
+newer matching version when one is available and skips exact-version
+specifications. It then removes unreferenced files.
+
+The command continues after an individual update failure. It returns a
+failure after it processes the remaining specifications.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--update-global-json` | Update applicable global.json-sourced SDK versions. |
+| `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
+| `--install-path <INSTALL_PATH>` | Update only the matching installation root. Without this option, update all roots in the manifest. |
+| `--interactive [<true|false>]` | The current parser accepts this option. The current update handler does not use it. |
+| `--no-progress [<true|false>]` | Disable progress display. |
+| `-v`, `--verbosity <normal|detailed>` | Set output verbosity. The default is `normal`. |
+| `-?`, `-h`, `--help` | Show command help. |
+
+## Examples
+
+Update all tracked components:
+
+```dotnetcli
+dotnetup update
+```
+
+Update one hive and its repository files:
+
+```dotnetcli
+dotnetup update --install-path .\.dotnet --update-global-json
+```

--- a/documentation/general/dotnetup/reference/dotnetup.md
+++ b/documentation/general/dotnetup/reference/dotnetup.md
@@ -1,0 +1,80 @@
+---
+title: dotnetup command
+description: Command reference for the dotnetup toolchain manager.
+ms.topic: reference
+ms.date: 08/07/2026
+---
+
+# dotnetup command
+
+## Name
+
+`dotnetup` - Install and manage user-level .NET SDKs and runtimes.
+
+## Synopsis
+
+```console
+dotnetup [command] [options]
+dotnetup
+dotnetup --info [--format <text|json>] [--no-list]
+```
+
+## Description
+
+`dotnetup` tracks .NET installation requirements and the concrete SDK or
+runtime versions that satisfy them. A bare `dotnetup` invocation runs the SDK
+install workflow. When interactive input is available and no configuration
+exists, it can start first-use onboarding.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| [`sdk`](dotnetup-sdk.md) | Manage .NET SDK installations. |
+| [`runtime`](dotnetup-runtime.md) | Manage .NET runtime installations. |
+| [`install`](dotnetup-install.md) | Install .NET SDKs. Alias for `sdk install`. |
+| [`update`](dotnetup-update.md) | Update all tracked components. |
+| [`uninstall`](dotnetup-uninstall.md) | Remove an SDK specification. Alias for `sdk uninstall`. |
+| [`list`](dotnetup-list.md) | List tracked specifications and installations. |
+| [`init`](dotnetup-init.md) | Run interactive setup. |
+| [`env`](dotnetup-env.md) | Manage environment configuration. |
+| [`dotnet`](dotnetup-dotnet.md) | Run the dotnetup-managed `dotnet`. |
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--info` | Display the dotnetup version, commit, process architecture, runtime identifier, and verified installation information. |
+| `--version` | Display the dotnetup version. |
+| `--interactive [<true|false>]` | Allow a bare invocation to wait for user input. The default is `true` in an interactive terminal and `false` in CI or when output is redirected. |
+| `-h`, `/h`, `-?`, `/?`, `--help` | Show root help. |
+
+### --info options
+
+| Option | Description |
+| --- | --- |
+| `--format <text|json>` | Select text or JSON output. The default is `text`. |
+| `--no-list [<true|false>]` | Omit tracked specifications and installations. Without this option, `--info` verifies installations. |
+
+## Examples
+
+Show help and version information:
+
+```dotnetcli
+dotnetup --help
+dotnetup --version
+dotnetup --info
+dotnetup --info --format json --no-list
+```
+
+Start first-use installation:
+
+```dotnetcli
+dotnetup
+```
+
+For predictable automation, select an explicit command and channel:
+
+```dotnetcli
+dotnetup install latest --interactive false --no-progress
+```

--- a/documentation/general/dotnetup/reference/dotnetup.md
+++ b/documentation/general/dotnetup/reference/dotnetup.md
@@ -32,9 +32,9 @@ exists, it can start first-use onboarding.
 | --- | --- |
 | [`sdk`](dotnetup-sdk.md) | Manage .NET SDK installations. |
 | [`runtime`](dotnetup-runtime.md) | Manage .NET runtime installations. |
-| [`install`](dotnetup-install.md) | Install .NET SDKs. Alias for `sdk install`. |
+| [`install`](dotnetup-install.md) | Install a component. |
 | [`update`](dotnetup-update.md) | Update all tracked components. |
-| [`uninstall`](dotnetup-uninstall.md) | Remove an SDK specification. Alias for `sdk uninstall`. |
+| [`uninstall`](dotnetup-uninstall.md) | Remove a tracked component. |
 | [`list`](dotnetup-list.md) | List tracked specifications and installations. |
 | [`init`](dotnetup-init.md) | Run interactive setup. |
 | [`env`](dotnetup-env.md) | Manage environment configuration. |
@@ -46,7 +46,7 @@ exists, it can start first-use onboarding.
 | --- | --- |
 | `--info` | Display the dotnetup version, commit, process architecture, runtime identifier, and verified installation information. |
 | `--version` | Display the dotnetup version. |
-| `--interactive [<true|false>]` | Allow a bare invocation to wait for user input. The default is `true` in an interactive terminal and `false` in CI or when output is redirected. |
+| `--interactive [<true\|false>]` | Allow a bare invocation to wait for user input. The default is `true` in an interactive terminal and `false` in CI or when output is redirected. |
 | `-h`, `/h`, `-?`, `/?`, `--help` | Show root help. |
 
 ### --info options

--- a/documentation/general/dotnetup/reference/dotnetup.md
+++ b/documentation/general/dotnetup/reference/dotnetup.md
@@ -53,8 +53,8 @@ exists, it can start first-use onboarding.
 
 | Option | Description |
 | --- | --- |
-| `--format <text|json>` | Select text or JSON output. The default is `text`. |
-| `--no-list [<true|false>]` | Omit tracked specifications and installations. Without this option, `--info` verifies installations. |
+| `--format <text\|json>` | Select text or JSON output. The default is `text`. |
+| `--no-list [<true\|false>]` | Omit tracked specifications and installations. Without this option, `--info` verifies installations. |
 
 ## Examples
 

--- a/documentation/general/dotnetup/toc.yml
+++ b/documentation/general/dotnetup/toc.yml
@@ -1,0 +1,76 @@
+- name: dotnetup
+  href: index.md
+- name: Concepts
+  items:
+  - name: How dotnetup works
+    href: concepts/how-dotnetup-works.md
+  - name: Channels and versions
+    href: concepts/channels.md
+  - name: Repository SDK requirements
+    href: concepts/repositories.md
+  - name: Environment configuration
+    href: concepts/environment.md
+- name: Release channels
+  items:
+  - name: Preview channel
+    href: channels/preview.md
+  - name: Daily channels
+    href: channels/daily.md
+- name: CLI reference
+  items:
+  - name: dotnetup
+    href: reference/dotnetup.md
+  - name: dotnetup install
+    href: reference/dotnetup-install.md
+  - name: dotnetup update
+    href: reference/dotnetup-update.md
+  - name: dotnetup uninstall
+    href: reference/dotnetup-uninstall.md
+  - name: dotnetup sdk
+    href: reference/dotnetup-sdk.md
+  - name: dotnetup sdk install
+    href: reference/dotnetup-sdk-install.md
+  - name: dotnetup sdk update
+    href: reference/dotnetup-sdk-update.md
+  - name: dotnetup sdk uninstall
+    href: reference/dotnetup-sdk-uninstall.md
+  - name: dotnetup runtime
+    href: reference/dotnetup-runtime.md
+  - name: dotnetup runtime install
+    href: reference/dotnetup-runtime-install.md
+  - name: dotnetup runtime update
+    href: reference/dotnetup-runtime-update.md
+  - name: dotnetup runtime uninstall
+    href: reference/dotnetup-runtime-uninstall.md
+  - name: dotnetup list
+    href: reference/dotnetup-list.md
+  - name: dotnetup init
+    href: reference/dotnetup-init.md
+  - name: dotnetup env
+    href: reference/dotnetup-env.md
+  - name: dotnetup env set
+    href: reference/dotnetup-env-set.md
+  - name: dotnetup env clear
+    href: reference/dotnetup-env-clear.md
+  - name: dotnetup env show
+    href: reference/dotnetup-env-show.md
+  - name: dotnetup env script
+    href: reference/dotnetup-env-script.md
+  - name: dotnetup dotnet
+    href: reference/dotnetup-dotnet.md
+- name: Scenarios
+  items:
+  - name: Manage repository SDK requirements
+    href: usecases/install-with-global-json.md
+  - name: Install .NET components
+    href: usecases/install-components.md
+  - name: Update installations
+    href: usecases/update-installations.md
+  - name: Manage the environment
+    href: usecases/manage-environment.md
+  - name: Manage custom hives
+    href: usecases/manage-custom-hives.md
+  - name: Use preview and daily builds
+    href: usecases/try-daily-builds.md
+  - name: Use dotnetup in automation
+    href: usecases/automation.md

--- a/documentation/general/dotnetup/usecases/automation.md
+++ b/documentation/general/dotnetup/usecases/automation.md
@@ -1,0 +1,66 @@
+---
+title: Use dotnetup in automation
+description: Use deterministic dotnetup commands and machine-readable output in scripts and CI.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Use dotnetup in automation
+
+`dotnetup` disables first-use onboarding when it detects CI or redirected
+output. Use explicit commands and options so scripts do not depend on terminal
+detection.
+
+## Install for a build
+
+Install a rolling feature band:
+
+```dotnetcli
+dotnetup sdk install 10.0.1xx --no-progress --interactive false
+dotnetup dotnet test -- --logger trx
+```
+
+Install an exact version when a build must stay pinned:
+
+```dotnetcli
+dotnetup sdk install 10.0.103 --no-progress --interactive false
+```
+
+Exact requirements are not changed by update commands.
+
+## Use a repository-local root
+
+```dotnetcli
+dotnetup sdk install 10.0.1xx --install-path .\.dotnet --no-progress
+```
+
+Run the local executable directly or activate it with `dotnetup env script`.
+The forwarding command uses the default dotnetup hive.
+
+## Read state as JSON
+
+```dotnetcli
+dotnetup list --format json --no-verify
+```
+
+Omit `--no-verify` when the automation must check that recorded files are
+present and valid.
+
+## Keep output useful
+
+- Use `--no-progress` when logs do not support terminal progress.
+- Use `--verbosity normal` for normal automation.
+- Use `--verbosity detailed` to diagnose resolution or installation.
+- Check the command exit code. Update commands can continue after an
+  individual failure and report failure after processing other requirements.
+
+## Coordinate writers
+
+Do not run concurrent install, update, or uninstall commands against the same
+manifest. Use an isolated `--manifest-path` for independent jobs.
+
+## See also
+
+- [dotnetup list](../reference/dotnetup-list.md)
+- [Manage custom hives](manage-custom-hives.md)
+- [Update tracked installations](update-installations.md)

--- a/documentation/general/dotnetup/usecases/install-components.md
+++ b/documentation/general/dotnetup/usecases/install-components.md
@@ -1,0 +1,82 @@
+---
+title: Install .NET SDKs and runtimes with dotnetup
+description: Install stable, preview, and exact .NET component requirements.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Install .NET SDKs and runtimes with dotnetup
+
+## Install SDKs
+
+With no channel, dotnetup uses the nearest usable `global.json` requirement.
+If none exists, it uses `latest`.
+
+```dotnetcli
+dotnetup sdk install
+dotnetup sdk install lts
+dotnetup sdk install 10.0 11.0
+dotnetup sdk install 10.0.103
+```
+
+The top-level `install` command is an SDK alias:
+
+```dotnetcli
+dotnetup install 10.0
+```
+
+## Install runtimes
+
+Use `component@channel` to select a runtime component:
+
+```dotnetcli
+dotnetup runtime install 10.0
+dotnetup runtime install aspnetcore@10.0
+dotnetup runtime install windowsdesktop@10.0
+```
+
+A value without a component selects the core .NET runtime.
+`windowsdesktop` is available only on Windows.
+
+## Install without tracking
+
+Use `--untracked` when you want files but do not want a manifest record:
+
+```dotnetcli
+dotnetup sdk install 10.0 --untracked --install-path .\.dotnet
+```
+
+`dotnetup` does not list, update, or uninstall an untracked installation.
+
+Tracked installation protects roots that already contain unmanaged .NET
+artifacts. Use a new root, migrate the installation, or explicitly choose an
+untracked install.
+
+## Migrate native-architecture components
+
+To copy matching components from system-managed .NET locations into the
+selected hive, run:
+
+```dotnetcli
+dotnetup sdk install --migrate-from-system
+```
+
+Migration considers only installations that match the running process
+architecture.
+
+## Check installed state
+
+```dotnetcli
+dotnetup list
+dotnetup dotnet -- --info
+```
+
+The current parser accepts `--set-default-install`. The install handlers do
+not apply environment changes from it. Use `dotnetup env set` after
+installation.
+
+## See also
+
+- [SDK channels and versions](../concepts/channels.md)
+- [dotnetup sdk install](../reference/dotnetup-sdk-install.md)
+- [dotnetup runtime install](../reference/dotnetup-runtime-install.md)

--- a/documentation/general/dotnetup/usecases/install-components.md
+++ b/documentation/general/dotnetup/usecases/install-components.md
@@ -19,7 +19,7 @@ dotnetup sdk install 10.0 11.0
 dotnetup sdk install 10.0.103
 ```
 
-The top-level `install` command is an SDK alias:
+The top-level `install` command is an alias for `dotnetup sdk install`:
 
 ```dotnetcli
 dotnetup install 10.0
@@ -66,14 +66,11 @@ architecture.
 
 ## Check installed state
 
+You can see the list of install specifications, the installed versions, and the source of each requirement with:
+
 ```dotnetcli
 dotnetup list
-dotnetup dotnet -- --info
 ```
-
-The current parser accepts `--set-default-install`. The install handlers do
-not apply environment changes from it. Use `dotnetup env set` after
-installation.
 
 ## See also
 

--- a/documentation/general/dotnetup/usecases/install-with-global-json.md
+++ b/documentation/general/dotnetup/usecases/install-with-global-json.md
@@ -1,158 +1,99 @@
-# Installing SDKs with global.json
+---
+title: Install an SDK for a repository with dotnetup
+description: Use global.json to install and track the SDK requirement for a repository.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
 
-`dotnetup` integrates with [`global.json`](https://learn.microsoft.com/dotnet/core/tools/global-json) files so you can install exactly the right .NET SDK version for a project — just by running `dotnetup` in the project directory.
+# Install an SDK for a repository with dotnetup
 
-## How It Works
+When you do not supply an SDK channel, `dotnetup sdk install` searches from
+the current directory toward the file system root. It uses the first usable
+`global.json` file that it finds.
 
-When you run `dotnetup sdk install` (or just `dotnetup install`) without specifying a channel, dotnetup looks for a `global.json` file in the current directory or any parent directory. If one is found, dotnetup reads the SDK version and `rollForward` policy to determine which channel to install.
+## Install the repository requirement
 
+From the repository directory, run:
+
+```dotnetcli
+dotnetup sdk install
 ```
-$ cat global.json
+
+For this `global.json` file, dotnetup tracks the `10.0.1xx` feature band:
+
+```json
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestPatch"
-  }
-}
-
-$ dotnetup sdk install
-SDK 10.0.1xx will be installed since C:\src\myproject\global.json specifies that version.
-Downloading .NET SDK 10.0.102...  ████████████████████████ 100%
-Installed .NET SDK 10.0.102 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
-
-These SDKs are installed into the 'dotnetup install root' and are available for use in your projects. `dotnetup` tracks which versions and channels are required by your projects and ensures that when you install or update new versions that none of your existing projects needs are broken.
-
-## Channel Resolution from global.json
-
-The combination of `sdk.version` and `sdk.rollForward` determines the channel that dotnetup tracks:
-
-| global.json `rollForward` | SDK version in global.json | dotnetup Channel | What Gets Installed |
-|---------------------------|---------------------------|-----------------|---------------------|
-| `latestPatch` (default)   | `10.0.100`                | `10.0.1xx`      | Latest in the 10.0.1xx feature band |
-| `latestFeature`           | `10.0.100`                | `10.0`          | Latest 10.0.x SDK |
-| `latestMinor`             | `10.0.100`                | `10`            | Latest 10.x SDK |
-| `latestMajor`             | `10.0.100`                | `latest`        | Latest stable SDK |
-| `disable`                 | `10.0.100`                | `10.0.100`      | Exactly 10.0.100 (pinned) |
-| `patch`                   | `10.0.100`                | `10.0.100`      | Exactly 10.0.100 (pinned) |
-| `feature`                 | `10.0.100`                | `10.0.100`      | Exactly 10.0.100 (pinned) |
-| `minor`                   | `10.0.100`                | `10.0.100`      | Exactly 10.0.100 (pinned) |
-| `major`                   | `10.0.100`                | `10.0.100`      | Exactly 10.0.100 (pinned) |
-
-> **Note:** The `rollForward` policies with a `latest` prefix (`latestPatch`, `latestFeature`, `latestMinor`, `latestMajor`) tell dotnetup to track a rolling channel — you'll get the newest SDK within that scope when you install or update. The policies without `latest` (e.g. `patch`, `feature`, `minor`, `major`, `disable`) pin the channel to the exact version specified in `global.json`, meaning `dotnetup update` will not change it.
-
-## Examples
-
-### Install the SDK specified by global.json
-
-Navigate to your project directory and run:
-
-```
-$ cd ~/src/my-project
-$ dotnetup sdk install
-SDK 10.0.1xx will be installed since /home/you/src/my-project/global.json specifies that version.
-Downloading .NET SDK 10.0.102...  ████████████████████████ 100%
-Installed .NET SDK 10.0.102 to /home/you/.local/share/dotnetup/dotnet
-```
-
-### Install an explicit channel alongside global.json
-
-You can override the global.json by specifying a channel explicitly:
-
-```
-$ dotnetup sdk install 9.0
-Downloading .NET SDK 9.0.304...  ████████████████████████ 100%
-Installed .NET SDK 9.0.304 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
-
-### Install and update global.json
-
-Use `--update-global-json` to have dotnetup write the resolved version back to your `global.json`:
-
-```
-$ cat global.json
-{
-  "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestPatch"
-  }
-}
-
-$ dotnetup sdk install --update-global-json
-SDK 10.0.1xx will be installed since C:\src\myproject\global.json specifies that version.
-Downloading .NET SDK 10.0.102...  ████████████████████████ 100%
-Installed .NET SDK 10.0.102 to C:\Users\you\AppData\Local\dotnetup\dotnet
-
-$ cat global.json
-{
-  "sdk": {
-    "version": "10.0.102",
+    "version": "10.0.103",
     "rollForward": "latestPatch"
   }
 }
 ```
 
-### Install multiple channels at once
+The `global.json` path is the source of the stored requirement. You can see
+the source and installed version with:
 
-You can install multiple SDK channels in a single command:
-
-```
-$ dotnetup sdk install 9.0 10.0
-Downloading .NET SDK 9.0.304...  ████████████████████████ 100%
-Downloading .NET SDK 10.0.100... ████████████████████████ 100%
-Installed .NET SDK 9.0.304 to C:\Users\you\AppData\Local\dotnetup\dotnet
-Installed .NET SDK 10.0.100 to C:\Users\you\AppData\Local\dotnetup\dotnet
+```dotnetcli
+dotnetup list
 ```
 
-### Install when no global.json exists
+## Understand roll-forward mapping
 
-When there's no `global.json` and no channel is specified, dotnetup defaults to the `latest` channel:
+For an SDK version such as `10.0.103`, dotnetup maps `rollForward` as follows:
 
-```
-$ dotnetup sdk install
-Downloading .NET SDK 10.0.100...  ████████████████████████ 100%
-Installed .NET SDK 10.0.100 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
+| `rollForward` value | Stored dotnetup channel |
+| --- | --- |
+| Omitted or `latestPatch` | `10.0.1xx` |
+| `latestFeature` | `10.0` |
+| `latestMinor` | `10` |
+| `latestMajor` | `latest` |
+| `disable`, `patch`, `feature`, `minor`, or `major` | Exact version `10.0.103` |
 
-## Viewing What's Tracked
+An exact requirement is pinned and is not changed by `dotnetup update`.
 
-After installing, you can see which channels dotnetup is tracking and which versions are installed:
+## Use `sdk.paths`
 
-```
-$ dotnetup list
+If `global.json` contains `sdk.paths`, dotnetup uses the first path when no
+`--install-path` option is present. It resolves a relative value from the
+directory that contains `global.json`.
 
-Installations (managed by dotnetup):
+The install-path precedence is:
 
-  C:\Users\you\AppData\Local\dotnetup\dotnet
+1. `--install-path`
+2. The first `sdk.paths` entry
+3. The default dotnetup hive
 
-    Tracked channels:
-      SDK 10.0.1xx                        (source: C:\src\myproject\global.json)
-      SDK 9.0                             (source: explicit)
+## Update `global.json`
 
-    Installed versions:
-      SDK 9.0.304                         (x64)
-      SDK 10.0.102                        (x64)
+To install the newest version in the derived channel and write that version
+back to `global.json`, run:
 
-Total: 2
-```
-
-Notice that the `source` column shows whether a channel came from a `global.json` file or was specified explicitly on the command line.
-
-## How global.json Search Works
-
-dotnetup searches for `global.json` by walking up from the current directory toward the filesystem root — the same behavior as the `dotnet` CLI itself. This means:
-
-```
-/home/you/src/my-project/          ← looks here first
-/home/you/src/                     ← then here
-/home/you/                         ← then here
-/home/                             ← and so on...
-/
+```dotnetcli
+dotnetup sdk install --update-global-json
 ```
 
-dotnetup uses the first `global.json` found while walking upward. If that file contains an SDK version, dotnetup derives the channel from it.
+Later, update all tracked repository requirements and their files with:
 
-## Next Steps
+```dotnetcli
+dotnetup sdk update --update-global-json
+```
 
-- [Update SDK and Runtime Installations](./update-installations.md) — Keep your channels up to date
-- [Try Daily Builds](./try-daily-builds.md) — Test pre-release .NET builds safely
+The update changes only `sdk.version`. It preserves the existing formatting,
+other properties, and detected text encoding.
+
+## Remove a repository requirement
+
+Run the uninstall command from any directory and select `globaljson` as the
+source:
+
+```dotnetcli
+dotnetup sdk uninstall 10.0.1xx --source globaljson
+```
+
+`dotnetup` removes files only when no remaining requirement needs them.
+
+## See also
+
+- [Repository and global.json integration](../concepts/repositories.md)
+- [dotnetup sdk install](../reference/dotnetup-sdk-install.md)
+- [Update tracked installations](update-installations.md)

--- a/documentation/general/dotnetup/usecases/manage-custom-hives.md
+++ b/documentation/general/dotnetup/usecases/manage-custom-hives.md
@@ -1,0 +1,72 @@
+---
+title: Manage custom dotnetup hives
+description: Install and manage .NET in custom roots and isolated manifests.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Manage custom dotnetup hives
+
+A custom hive can isolate repository, test, or tool installations from the
+default dotnetup root.
+
+## Track a custom root in the default manifest
+
+Select the root with `--install-path`:
+
+```dotnetcli
+dotnetup sdk install 10.0 --install-path D:\tools\dotnet
+dotnetup runtime install aspnetcore@10.0 --install-path D:\tools\dotnet
+```
+
+The default manifest records both requirements and their root. A later
+unfiltered update can process this root:
+
+```dotnetcli
+dotnetup update
+```
+
+Limit list, update, or uninstall to the root when needed:
+
+```dotnetcli
+dotnetup list --install-path D:\tools\dotnet
+dotnetup update --install-path D:\tools\dotnet
+dotnetup sdk uninstall 10.0 --install-path D:\tools\dotnet
+```
+
+## Isolate the manifest
+
+Use `--manifest-path` when the tracking state must also be separate:
+
+```dotnetcli
+dotnetup sdk install 10.0 \
+  --install-path D:\tools\dotnet \
+  --manifest-path D:\tools\dotnetup_manifest.json
+```
+
+Repeat `--manifest-path` for later list, update, and uninstall operations.
+This option applies to one command. It does not move the dotnetup configuration
+file or change the default hive.
+
+## Run the custom hive
+
+Run its executable directly, or activate it for the current shell:
+
+```powershell
+dotnetup env script --shell pwsh --dotnet \
+  --dotnet-install-path D:\tools\dotnet |
+  Invoke-Expression
+```
+
+`dotnetup dotnet` does not automatically select arbitrary custom roots.
+
+## Avoid concurrent manifest writes
+
+`dotnetup` coordinates manifest access with a lock. Do not run concurrent write
+commands against the same manifest. Use separate manifests for independent
+automation.
+
+## See also
+
+- [How dotnetup works](../concepts/how-dotnetup-works.md)
+- [dotnetup env script](../reference/dotnetup-env-script.md)

--- a/documentation/general/dotnetup/usecases/manage-environment.md
+++ b/documentation/general/dotnetup/usecases/manage-environment.md
@@ -24,7 +24,7 @@ The managed `dotnet` is not added to your shell `PATH`.
 
 ## Configure a shell profile
 
-Use the `shell` mode to write a managed block to your shellprofile:
+Use the `shell` mode to write a managed block to your shell profile:
 
 ```dotnetcli
 dotnetup env set shell --shell pwsh

--- a/documentation/general/dotnetup/usecases/manage-environment.md
+++ b/documentation/general/dotnetup/usecases/manage-environment.md
@@ -12,7 +12,7 @@ the access mode that fits your workflow.
 
 ## Use command forwarding
 
-The least persistent option is the `none` mode:
+The least persistent option is the `none` mode. In this mode, no changes are made to your shell profile or user environment. Instead, `dotnetup dotnet` allows you to run `dotnet` commands via the `dotnetup`-managed installation:
 
 ```dotnetcli
 dotnetup env set none --dotnetup-on-path true
@@ -24,7 +24,7 @@ The managed `dotnet` is not added to your shell `PATH`.
 
 ## Configure a shell profile
 
-Use the `shell` mode to write a managed block to a supported profile:
+Use the `shell` mode to write a managed block to your shellprofile:
 
 ```dotnetcli
 dotnetup env set shell --shell pwsh
@@ -32,7 +32,7 @@ dotnetup env set shell --shell pwsh
 
 Supported shell values are `bash`, `zsh`, `fish`, and `pwsh`.
 
-Open a new shell after the command finishes, or activate the current shell:
+Open a new shell after the command finishes, or activate the current shell to apply the changes:
 
 ```powershell
 dotnetup env script --shell pwsh | Invoke-Expression

--- a/documentation/general/dotnetup/usecases/manage-environment.md
+++ b/documentation/general/dotnetup/usecases/manage-environment.md
@@ -1,0 +1,77 @@
+---
+title: Configure access to dotnetup-managed .NET
+description: Configure shell profiles, user environment variables, or command forwarding.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
+
+# Configure access to dotnetup-managed .NET
+
+Installation and environment configuration are separate operations. Select
+the access mode that fits your workflow.
+
+## Use command forwarding
+
+The least persistent option is the `none` mode:
+
+```dotnetcli
+dotnetup env set none --dotnetup-on-path true
+dotnetup dotnet -- --info
+dotnetup dotnet build
+```
+
+The managed `dotnet` is not added to your shell `PATH`.
+
+## Configure a shell profile
+
+Use the `shell` mode to write a managed block to a supported profile:
+
+```dotnetcli
+dotnetup env set shell --shell pwsh
+```
+
+Supported shell values are `bash`, `zsh`, `fish`, and `pwsh`.
+
+Open a new shell after the command finishes, or activate the current shell:
+
+```powershell
+dotnetup env script --shell pwsh | Invoke-Expression
+```
+
+## Configure the Windows user environment
+
+On Windows, the `everywhere` mode updates the persistent user environment
+and the selected shell profile:
+
+```dotnetcli
+dotnetup env set everywhere --shell pwsh
+```
+
+This mode is not available on Linux or macOS.
+
+## Inspect and correct drift
+
+Show stored settings and compare them with the current environment:
+
+```dotnetcli
+dotnetup env show
+```
+
+Reapply stored settings:
+
+```dotnetcli
+dotnetup env set
+```
+
+## Remove environment changes
+
+```dotnetcli
+dotnetup env clear
+```
+
+This command removes dotnetup environment wiring. It does not uninstall .NET.
+
+## See also
+
+- [Environment configuration](../concepts/environment.md)
+- [dotnetup env](../reference/dotnetup-env.md)

--- a/documentation/general/dotnetup/usecases/try-daily-builds.md
+++ b/documentation/general/dotnetup/usecases/try-daily-builds.md
@@ -7,8 +7,8 @@ ms.date: 08/07/2026
 
 # Try .NET daily builds with dotnetup
 
-Daily channels give you recent builds from the .NET build feeds. `dotnetup`
-displays a trust warning for these unsigned sources.
+Daily channels give you bleeding-edge builds from the .NET build feeds. `dotnetup`
+makes it easy to try these daily builds in your workspaces.
 
 ## Install a daily SDK
 

--- a/documentation/general/dotnetup/usecases/try-daily-builds.md
+++ b/documentation/general/dotnetup/usecases/try-daily-builds.md
@@ -1,220 +1,78 @@
-# Trying Daily Builds Safely
+---
+title: Try .NET daily builds with dotnetup
+description: Install, run, update, and remove daily .NET builds.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
 
-> **Note:** Daily channel support (`daily`, `10.0-daily`, etc.) is being added in [PR #54312](https://github.com/dotnet/sdk/pull/54312). Installing public monthly preview versions by their full version string is already supported. The examples below reflect the intended experience once daily channels are fully available.
+# Try .NET daily builds with dotnetup
 
-Daily builds are the latest CI-produced .NET builds — they haven't gone through the full release process but let you test upcoming features, verify bug fixes, or validate your code against the bleeding edge. `dotnetup` makes it easy to install daily builds alongside your stable installations without affecting your day-to-day workflow.
+Daily channels give you recent builds from the .NET build feeds. `dotnetup`
+displays a trust warning for these unsigned sources.
 
-## Quick Reference
+## Install a daily SDK
 
-```bash
-# Install the latest daily SDK build
+Install the latest daily SDK:
+
+```dotnetcli
 dotnetup sdk install daily
-
-# Install a daily build for a specific .NET version
-dotnetup sdk install 10.0-daily
-
-# Install a daily build for a specific feature band
-dotnetup sdk install 10.0.1xx-daily
-
-# Install a specific non-public preview version from the daily feed
-dotnetup sdk install 10.0.100-preview.7.25351.1
-
-# Run a command using the dotnetup-managed SDK
-dotnetup dotnet build
-dotnetup dotnet test
 ```
 
-## Daily Channels
+Limit the request to a release, feature band, or development phase:
 
-Daily builds are expressed as channels — the same mental model you already use with `latest`, `lts`, and `preview`. Just add a `-daily` suffix to any version scope:
-
-| Channel | What It Installs |
-|---------|-----------------|
-| `daily` | Latest daily build for the newest major version |
-| `10.0-daily` | Latest daily build for .NET 10.0 |
-| `10.0.1xx-daily` | Latest daily build for the 10.0.1xx feature band |
-
-### Installing a daily SDK
-
-```
-$ dotnetup sdk install daily
-⚠ Daily builds are not code-signed. Only the SHA-512 hash is verified.
-Downloading .NET SDK 11.0.100-preview.1.25310.1...  ████████████████████████ 100%
-Installed .NET SDK 11.0.100-preview.1.25310.1 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
-
-### Installing a daily runtime
-
-```
-$ dotnetup runtime install 10.0-daily
-⚠ Daily builds are not code-signed. Only the SHA-512 hash is verified.
-Downloading .NET Runtime 10.0.0-preview.7.25351.1...  ████████████████████████ 100%
-Installed .NET Runtime 10.0.0-preview.7.25351.1 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
-
-### Installing a specific pre-release version
-
-If you know the exact version (e.g. from a GitHub issue or a colleague), you can install it directly:
-
-```
-$ dotnetup sdk install 10.0.100-preview.7.25351.1
-Downloading .NET SDK 10.0.100-preview.7.25351.1...  ████████████████████████ 100%
-Installed .NET SDK 10.0.100-preview.7.25351.1 to C:\Users\you\AppData\Local\dotnetup\dotnet
-```
-
-When you provide a fully specified pre-release version that isn't in the official release manifest, dotnetup automatically falls back to the daily build feed.
-
-## Running Commands with `dotnetup dotnet`
-
-The `dotnetup dotnet` command forwards any arguments to the `dotnet` CLI from your dotnetup-managed install. This is the easiest way to use daily builds without modifying your system PATH:
-
-```
-$ dotnetup dotnet --version
-11.0.100-preview.1.25310.1
-
-$ dotnetup dotnet build
-  myproject → bin\Debug\net11.0\myproject.dll
-
-Build succeeded.
-
-$ dotnetup dotnet test
-  Starting test execution...
-  Passed! - 42 tests passed.
-
-$ dotnetup do run -- --my-app-arg
-  Hello from .NET 11!
-```
-
-### How `dotnetup dotnet` works
-
-When you run `dotnetup dotnet <args>`:
-
-1. dotnetup resolves the managed install directory where it stores .NET SDK installations
-2. It sets `DOTNET_ROOT` to that directory
-3. It prepends the install directory to `PATH`
-4. It launches `dotnet <args>` as a child process
-5. The child process exit code becomes the `dotnetup` exit code
-
-This means your system `dotnet` remains untouched — IDE integrations, other terminal sessions, and system services continue to use the system .NET.
-
-## Side-by-Side with Stable Installs
-
-Daily builds install into the same dotnetup-managed directory as your stable SDKs. The .NET SDK host naturally handles multiple installed versions via `global.json` and roll-forward policies:
-
-```
-$ dotnetup list
-
-Installations (managed by dotnetup):
-
-  C:\Users\you\AppData\Local\dotnetup\dotnet
-
-    Tracked channels:
-      SDK latest                          (source: explicit)
-      SDK daily                           (source: explicit)
-
-    Installed versions:
-      SDK 10.0.100                        (x64)
-      SDK 11.0.100-preview.1.25310.1      (x64)
-
-Total: 2
-```
-
-Your stable projects continue to use 10.0.100 (via their `global.json`), while you can test against the daily build when needed.
-
-## Updating Daily Builds
-
-Daily channel installs support updates, just like any other tracked channel:
-
-```
-$ dotnetup update
-Downloading .NET SDK 11.0.100-preview.1.25315.1... ████████████████████████ 100%
-Installed .NET SDK 11.0.100-preview.1.25315.1 to C:\Users\you\AppData\Local\dotnetup\dotnet
-SDK 10.0.100 is already up to date.
-```
-
-Running `dotnetup sdk update` re-resolves the `daily` channel and installs a newer version if one is available.
-
-> **Note:** Specific-version installs (e.g. `dotnetup sdk install 10.0.100-preview.7.25351.1`) are pinned — they record the exact version as the channel and won't be updated.
-
-## Using Daily Builds with global.json
-
-If your project's `global.json` specifies a pre-release version that isn't in the official release manifest, dotnetup automatically resolves it from the daily build feed:
-
-```json
-{
-  "sdk": {
-    "version": "11.0.100-preview.1.25310.1",
-    "allowPrerelease": true
-  }
-}
-```
-
-```
-$ dotnetup sdk install
-SDK 11.0.100-preview.1.25310.1 will be installed since ~/src/myproject/global.json
-specifies that version.
-Downloading .NET SDK 11.0.100-preview.1.25310.1...  ████████████████████████ 100%
-Installed .NET SDK 11.0.100-preview.1.25310.1 to /home/you/.local/share/dotnetup/dotnet
-```
-
-## Trust and Security
-
-Daily builds have a different trust model compared to official releases:
-
-| | Official Releases | Daily Builds |
-|--|-------------------|-------------|
-| **Hash source** | Release manifest (independent metadata) | `.sha512` companion file (same feed as archive) |
-| **Code signing** | Authenticode-signed binaries | Not code-signed |
-| **Release process** | Full validation and signing pipeline | CI-produced on every commit or daily schedule |
-
-dotnetup verifies the SHA-512 hash of every download, but daily builds are not code-signed. dotnetup clearly indicates this during installation:
-
-```
-⚠ Daily builds are not code-signed. Only the SHA-512 hash is verified.
-```
-
-## Common Workflows
-
-### Testing a bug fix before it ships
-
-```bash
-# Install the latest daily build
-dotnetup sdk install daily
-
-# Test your project against it
-dotnetup dotnet build
-dotnetup dotnet test
-```
-
-### Validating your library against a future .NET version
-
-```bash
-# Install the next major version's daily
+```dotnetcli
+dotnetup sdk install 11-daily
 dotnetup sdk install 11.0-daily
-
-# Build your library targeting the new TFM
-dotnetup dotnet build -f net11.0
+dotnetup sdk install 11.0.1xx-daily
+dotnetup sdk install 11.0.1xx-preview.5-daily
 ```
 
-### CI pipeline testing against daily builds
+## Isolate a daily SDK
 
-In a CI environment (non-interactive), daily builds install without prompts:
+Use a separate hive when you do not want daily and stable installations in the
+same root:
+
+```dotnetcli
+dotnetup sdk install daily --install-path .\.dotnet-daily
+```
+
+Run the hive executable directly:
+
+```powershell
+.\.dotnet-daily\dotnet.exe --version
+```
+
+On Linux or macOS, run:
 
 ```bash
-dotnetup sdk install daily --no-progress
-dotnetup dotnet test --logger "trx"
+./.dotnet-daily/dotnet --version
 ```
 
-### Cleaning up
+`dotnetup dotnet` selects the default dotnetup hive. It does not automatically
+select an arbitrary `--install-path`.
 
-To stop tracking a daily channel and clean up:
+## Install daily runtimes
 
-```bash
-dotnetup sdk uninstall daily
+Runtime daily channels use the same suffix:
+
+```dotnetcli
+dotnetup runtime install 11.0-daily
+dotnetup runtime install aspnetcore@11.0-daily
 ```
 
-## Next Steps
+## Update or remove the daily requirement
 
-- [Getting Started](./getting-started.md) — First-time setup and configuration
-- [Install SDKs with global.json](./install-with-global-json.md) — Project-specific SDK management
-- [Update Installations](./update-installations.md) — Keep all your .NET installations current
+A daily channel is a rolling requirement:
+
+```dotnetcli
+dotnetup sdk update
+dotnetup sdk uninstall daily --install-path .\.dotnet-daily
+```
+
+An exact prerelease version is pinned and is not changed by update commands.
+
+## See also
+
+- [Daily channels](../channels/daily.md)
+- [Preview channels](../channels/preview.md)
+- [Manage custom hives](manage-custom-hives.md)

--- a/documentation/general/dotnetup/usecases/update-installations.md
+++ b/documentation/general/dotnetup/usecases/update-installations.md
@@ -1,176 +1,85 @@
-# Updating SDK and Runtime Installations
+---
+title: Update tracked .NET installations with dotnetup
+description: Update rolling SDK and runtime requirements and remove unused versions.
+ms.topic: how-to
+ms.date: 08/07/2026
+---
 
-`dotnetup` tracks your installations by channel (and by workspace if you have `global.json` files), so updating is straightforward. Run `dotnetup update` and every tracked channel resolves to its latest matching version.
+# Update tracked .NET installations with dotnetup
 
-## Quick Reference
+`dotnetup` stores the requested channel separately from the resolved version.
+An update resolves each rolling channel again.
 
-```bash
-# Update everything (all SDKs and runtimes)
+## Choose an update scope
+
+Use one of these commands:
+
+```dotnetcli
+# Update all tracked SDK and runtime requirements.
 dotnetup update
 
-# Update SDKs only
+# Update SDK requirements only.
 dotnetup sdk update
 
-# Update runtimes only
-dotnetup runtime update
+# Update SDK and runtime requirements.
+dotnetup sdk update --all
 
-# Update and write new versions back to global.json files
+# Update runtime requirements only.
+dotnetup runtime update
+```
+
+Runtime updates include the core .NET and ASP.NET Core runtimes. On Windows,
+they also include Windows Desktop runtime requirements.
+
+## Limit the installation root
+
+By default, an update can process requirements for all roots in the selected
+manifest. Use `--install-path` to limit the operation:
+
+```dotnetcli
+dotnetup update --install-path D:\tools\dotnet
+```
+
+## Update repository files
+
+SDK requirements can use `global.json` as their source. To write the newly
+resolved SDK version back to each source file, run:
+
+```dotnetcli
 dotnetup sdk update --update-global-json
 ```
 
-## How Updates Work
+Without this option, dotnetup installs the update but does not edit the
+repository file.
 
-When you install a channel like `10.0` or `latest`, dotnetup records that channel in its manifest. Running `dotnetup update` re-resolves each channel to its newest version and installs it if it's newer than what you already have.
+## Understand update behavior
 
-```
-$ dotnetup update
-Downloading .NET SDK 10.0.103...  ████████████████████████ 100%
-Installed .NET SDK 10.0.103 to C:\Users\you\AppData\Local\dotnetup\dotnet
-Runtime 9.0.5 is already up to date.
-ASP.NET Core 9.0.5 is already up to date.
-```
+- Exact SDK and runtime versions are skipped.
+- Each requirement is processed independently.
+- Processing continues after an individual failure.
+- The command reports failure after it processes the remaining requirements.
+- Successful updates run garbage collection.
+- An installed version remains if another requirement still needs it.
 
-If everything is current:
+The `--interactive` option is present in the current root and SDK update help.
+The update handler does not use it.
 
-```
-$ dotnetup update
-Everything is up to date.
-```
+## Review the result
 
-### What Gets Updated
+Verify tracked state and on-disk installations:
 
-| Channel Type | Update Behavior |
-|-------------|----------------|
-| `latest` | Updates to the newest stable .NET SDK |
-| `lts` | Updates to the newest LTS release |
-| `preview` | Updates to the newest preview/RC |
-| `10.0` | Updates to the latest 10.0.x SDK |
-| `10.0.1xx` | Updates within the 10.0.1xx feature band |
-| `10.0.100` | **Never updates** — pinned to an exact version |
-
-Pinned versions (fully-specified like `10.0.100`) are point-in-time snapshots. They will never be changed by `dotnetup update` because the channel matches exactly one version.
-
-## Updating SDKs
-
-### Update all tracked SDKs
-
-```
-$ dotnetup sdk update
-Downloading .NET SDK 10.0.103...  ████████████████████████ 100%
-Installed .NET SDK 10.0.103 to C:\Users\you\AppData\Local\dotnetup\dotnet
+```dotnetcli
+dotnetup list
 ```
 
-### Update SDKs and global.json
+For machine-readable output:
 
-If your SDK was installed from a `global.json` file, you can update both the SDK and the `global.json` in one step:
-
-```
-$ dotnetup sdk update --update-global-json
-Downloading .NET SDK 10.0.103...  ████████████████████████ 100%
-Installed .NET SDK 10.0.103 to C:\Users\you\AppData\Local\dotnetup\dotnet
-Updated C:\src\myproject\global.json: 10.0.100 → 10.0.103
+```dotnetcli
+dotnetup list --format json
 ```
 
-This is useful for keeping your project's `global.json` pinned to a consistent minimum version while still using a rolling channel for installation tracking.
+## See also
 
-When updating SDKs that are managed via `global.json`, `dotnetup` will adhere to any roll-forward policies defined in the `global.json` file. If you want to 'bump' the version in `global.json` to the latest available, you can use the `--update-global-json` flag and `dotnetup` will take care of that for you as part of the update.
-
-## Updating Runtimes
-
-### Update all tracked runtimes
-
-```
-$ dotnetup runtime update
-Downloading .NET Runtime 10.0.1...       ████████████████████████ 100%
-Downloading ASP.NET Core Runtime 10.0.1... ████████████████████████ 100%
-```
-
-Runtime updates cover all tracked runtime components:
-- **.NET Runtime** (`runtime`)
-- **ASP.NET Core Runtime** (`aspnetcore`)
-- **Windows Desktop Runtime** (`windowsdesktop`, Windows only)
-
-### Best-effort updates
-
-When updating multiple components, dotnetup continues even if one component fails. After processing all components, it reports the first failure:
-
-```
-$ dotnetup runtime update
-Downloading .NET Runtime 10.0.1...       ████████████████████████ 100%
-Error: Could not resolve channel '9.0' for ASP.NET Core.
-Downloading Windows Desktop Runtime 10.0.1... ████████████████████████ 100%
-2 update(s) failed; reporting the first failure.
-```
-
-This ensures that a transient failure on one component doesn't block updates to the others.
-
-## Installing Runtimes
-
-You can also install runtimes directly without an SDK:
-
-```bash
-# Install the latest .NET 10.0 runtime
-dotnetup runtime install 10.0
-
-# Install a specific runtime type
-dotnetup runtime install aspnetcore@10.0
-dotnetup runtime install windowsdesktop@9.0
-
-# Install the latest runtime
-dotnetup runtime install latest
-```
-
-The component spec format is `<type>@<channel>`, where `<type>` is one of:
-- `runtime` (or omit the type for the default .NET runtime)
-- `aspnetcore` / `aspnet`
-- `windowsdesktop` / `desktop` (Windows only)
-
-## Updating Across Multiple Install Roots
-
-If you have installations in multiple directories, `dotnetup update` processes all of them:
-
-```
-$ dotnetup list
-
-Installations (managed by dotnetup):
-
-  C:\Users\you\AppData\Local\dotnetup\dotnet
-    Tracked channels:
-      SDK latest                          (source: explicit)
-
-  D:\projects\.dotnet
-    Tracked channels:
-      SDK 10.0.1xx                        (source: D:\projects\global.json)
-
-Total: 2
-
-$ dotnetup update
-Downloading .NET SDK 10.0.103...  ████████████████████████ 100%
-Installed .NET SDK 10.0.103 to C:\Users\you\AppData\Local\dotnetup\dotnet
-SDK 10.0.102 in D:\projects\.dotnet is already up to date.
-```
-
-To update only a specific install root:
-
-```
-$ dotnetup sdk update --install-path D:\projects\.dotnet
-```
-
-## Uninstalling
-
-To stop tracking a channel and clean up unused installations:
-
-```bash
-# Remove the SDK channel "9.0" and clean up unused versions
-dotnetup sdk uninstall 9.0
-
-# Remove a runtime channel
-dotnetup runtime uninstall aspnetcore@9.0
-```
-
-The uninstall command removes the tracking spec from the manifest and then garbage-collects any versions that are no longer needed by any remaining specs.
-
-## Next Steps
-
-- [Install SDKs with global.json](./install-with-global-json.md) — Let global.json drive your SDK installs
-- [Try Daily Builds](./try-daily-builds.md) — Safely test pre-release .NET builds
+- [dotnetup update](../reference/dotnetup-update.md)
+- [dotnetup sdk update](../reference/dotnetup-sdk-update.md)
+- [dotnetup runtime update](../reference/dotnetup-runtime-update.md)

--- a/documentation/general/dotnetup/usecases/update-installations.md
+++ b/documentation/general/dotnetup/usecases/update-installations.md
@@ -54,15 +54,12 @@ repository file.
 
 ## Understand update behavior
 
-- Exact SDK and runtime versions are skipped.
-- Each requirement is processed independently.
-- Processing continues after an individual failure.
-- The command reports failure after it processes the remaining requirements.
-- Successful updates run garbage collection.
+- Exact SDK and runtime versions are skipped - they were explicitly requested, so can never be updated.
+- Each installation requirement is processed independently.
+- Processing of all installation requirements continues after an individual failure.
+- The command reports failure after it processes all remaining installation requirements.
+- Successful updates run garbage collection - a cleanup process that removes any installed components that none of your configured installation requirements actually need.
 - An installed version remains if another requirement still needs it.
-
-The `--interactive` option is present in the current root and SDK update help.
-The update handler does not use it.
 
 ## Review the result
 


### PR DESCRIPTION
## Summary

- add a dotnet/docs-style dotnetup overview, concept guides, and table-of-contents navigation
- document every public command, argument, and option with source-backed examples and expected terminal output
- document stable, preview, and daily specification forms, including feature bands, exact versions, and scoped daily channels
- add scenario guides for SDK and runtime installation, repository `global.json` management, updates, automation, environment configuration, and custom hives
- update existing dotnetup scenario pages and repair related design-document links

## Validation

- validated relative Markdown links and table-of-contents targets
- checked article front matter and Simplified Technical English constraints
- compared command and option coverage with runtime `--help` output and parser definitions
- ran representative parser smoke tests and root `--info` and `--version` checks

## Notes

This change is documentation-only. Daily-build availability still depends on the current component-specific daily endpoints.