### PR TITLE
Fix preview workload version search

### DIFF
--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -772,14 +772,17 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
             if (stableVersions.Any())
             {
                 var results = stableVersions.OrderByDescending(r => r.package.Identity.Version);
-                return numberOfResults > 0 /* 0 indicates 'all' */ ? results.Take(numberOfResults) : results;
+                return TakeRequestedResults(results, numberOfResults);
             }
         }
 
         IEnumerable<(PackageSource, IPackageSearchMetadata)> latestVersions = accumulativeSearchResults
             .OrderByDescending(r => r.package.Identity.Version);
-        return latestVersions.Take(numberOfResults);
+        return TakeRequestedResults(latestVersions, numberOfResults);
     }
+
+    private static IEnumerable<T> TakeRequestedResults<T>(IEnumerable<T> results, int numberOfResults)
+        => numberOfResults > 0 ? results.Take(numberOfResults) : results;
 
     public async Task<NuGetVersion> GetBestPackageVersionAsync(PackageId packageId,
         VersionRange versionRange,

--- a/test/dotnet.Tests/NuGetPackageDownloaderTests.cs
+++ b/test/dotnet.Tests/NuGetPackageDownloaderTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.Cli.NuGetPackageDownloader.Tests
+{
+    [TestClass]
+    public class NuGetPackageDownloaderTests : SdkTest
+    {
+        [TestMethod]
+        public async Task GetLatestPackageVersionsReturnsAllPreviewVersionsWhenCountIsZero()
+        {
+            TestDirectory testDirectory = TestAssetsManager.CreateTestDirectory();
+            string feedDirectory = Path.Combine(testDirectory.Path, "feed");
+            Directory.CreateDirectory(feedDirectory);
+            CreatePackage(feedDirectory, "Test.Package", "1.0.0-preview.1");
+            CreatePackage(feedDirectory, "Test.Package", "1.0.0-preview.2");
+
+            NuGetPackageDownloader downloader = new(
+                new DirectoryPath(Path.Combine(testDirectory.Path, "packages")),
+                currentWorkingDirectory: testDirectory.Path);
+            PackageSourceLocation sourceLocation = new(sourceFeedOverrides: [feedDirectory]);
+
+            var versions = await downloader.GetLatestPackageVersions(
+                new ToolPackage.PackageId("Test.Package"),
+                numberOfResults: 0,
+                sourceLocation,
+                includePreview: true);
+
+            versions.Select(version => version.ToNormalizedString())
+                .Should().Equal("1.0.0-preview.2", "1.0.0-preview.1");
+        }
+
+        private static void CreatePackage(string feedDirectory, string packageId, string version)
+        {
+            string packagePath = Path.Combine(feedDirectory, $"{packageId}.{version}.nupkg");
+            using ZipArchive archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+            ZipArchiveEntry nuspec = archive.CreateEntry($"{packageId}.nuspec");
+            using StreamWriter writer = new(nuspec.Open());
+            writer.Write($"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <id>{packageId}</id>
+                    <version>{version}</version>
+                    <authors>Test</authors>
+                    <description>Test package</description>
+                  </metadata>
+                </package>
+                """);
+        }
+    }
+}


### PR DESCRIPTION
Preview workload version searches such as `dotnet workload search version ios@<version>` request all workload-set package versions by passing a result count of zero. The preview-inclusive NuGet query path interpreted that as `Take(0)`, so it returned no candidates.

Treat zero as unlimited consistently for both stable and preview-inclusive queries. Add downloader-level coverage with an isolated local feed containing preview packages to verify all versions are returned in descending order.