### PR TITLE
Skip redundant container uploads for existing manifests

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -12,6 +12,7 @@ internal static class ImagePublisher
         BuiltImage singleArchImage,
         SourceImageReference sourceImageReference,
         DestinationImageReference destinationImageReference,
+        bool skipPushIfAlreadyPresent,
         Microsoft.Build.Utilities.TaskLoggingHelper Log,
         Telemetry telemetry,
         CancellationToken cancellationToken)
@@ -37,7 +38,12 @@ internal static class ImagePublisher
                     destinationImageReference,
                     Log,
                     cancellationToken,
-                    destinationImageReference.RemoteRegistry!.PushAsync,
+                    (image, source, destination, token) => destinationImageReference.RemoteRegistry!.PushAsync(
+                        image,
+                        source,
+                        destination,
+                        skipPushIfAlreadyPresent,
+                        token),
                     Strings.ContainerBuilder_ImageUploadedToRegistry).ConfigureAwait(false);
                 break;
             default:

--- a/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImagePublisher.cs
@@ -12,7 +12,7 @@ internal static class ImagePublisher
         BuiltImage singleArchImage,
         SourceImageReference sourceImageReference,
         DestinationImageReference destinationImageReference,
-        bool skipPushIfAlreadyPresent,
+        bool noCache,
         Microsoft.Build.Utilities.TaskLoggingHelper Log,
         Telemetry telemetry,
         CancellationToken cancellationToken)
@@ -42,7 +42,7 @@ internal static class ImagePublisher
                         image,
                         source,
                         destination,
-                        skipPushIfAlreadyPresent,
+                        noCache,
                         token),
                     Strings.ContainerBuilder_ImageUploadedToRegistry).ConfigureAwait(false);
                 break;

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -253,8 +253,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> b
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.set -> void
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPushIfAlreadyPresent.get -> bool
-Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPushIfAlreadyPresent.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.NoCache.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.NoCache.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -253,6 +253,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.get -> b
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GenerateDigestLabel.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.get -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPublishing.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPushIfAlreadyPresent.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.SkipPushIfAlreadyPresent.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerNames.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageFormat.get -> string?

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/DefaultManifestOperations.cs
@@ -24,6 +24,19 @@ internal class DefaultManifestOperations : IManifestOperations
         _registryName = registryName;
     }
 
+    public async Task<bool> ExistsAsync(string repositoryName, string reference, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Head, new Uri(_baseUri, $"/v2/{repositoryName}/manifests/{reference}")).AcceptManifestFormats();
+        using HttpResponseMessage response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return response.StatusCode switch
+        {
+            HttpStatusCode.OK => true,
+            _ when (int)response.StatusCode >= 500 => await LogAndThrowContainerHttpException<bool>(response, cancellationToken).ConfigureAwait(false),
+            _ => false,
+        };
+    }
+
     public async Task<HttpResponseMessage> GetAsync(string repositoryName, string reference, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/IManifestOperations.cs
@@ -11,6 +11,8 @@ namespace Microsoft.NET.Build.Containers;
 /// </remarks>
 internal interface IManifestOperations
 {
+    public Task<bool> ExistsAsync(string repositoryName, string reference, CancellationToken cancellationToken);
+
     public Task<HttpResponseMessage> GetAsync(string repositoryName, string reference, CancellationToken cancellationToken);
 
     public Task PutAsync(string repositoryName, string reference, string manifestListJson, string mediaType, CancellationToken cancellationToken);

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -595,12 +595,23 @@ internal sealed class Registry
     }
 
     public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
-        => PushAsync(builtImage, source, destination, pushTags: true, cancellationToken);
+        => PushAsync(builtImage, source, destination, skipIfManifestExists: false, cancellationToken);
 
-    private async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool pushTags, CancellationToken cancellationToken)
+    public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool skipIfManifestExists, CancellationToken cancellationToken)
+        => PushAsync(builtImage, source, destination, pushTags: true, skipIfManifestExists, cancellationToken);
+
+    private async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool pushTags, bool skipIfManifestExists, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Registry destinationRegistry = destination.RemoteRegistry!;
+
+        bool manifestExists = skipIfManifestExists &&
+            await _registryAPI.Manifest.ExistsAsync(destination.Repository, builtImage.ManifestDigest, cancellationToken).ConfigureAwait(false);
+
+        if (manifestExists)
+        {
+            _logger.LogInformation(Strings.Registry_ManifestExists, builtImage.ManifestDigest, destination.Repository);
+        }
 
         Func<Descriptor, Task> uploadLayerFunc = async (descriptor) =>
         {
@@ -634,25 +645,28 @@ internal sealed class Registry
             }
         };
 
-        if (SupportsParallelUploads)
+        if (!manifestExists)
         {
-            await Task.WhenAll(builtImage.LayerDescriptors.Select(descriptor => uploadLayerFunc(descriptor))).ConfigureAwait(false);
-        }
-        else
-        {
-            foreach (var descriptor in builtImage.LayerDescriptors)
+            if (SupportsParallelUploads)
             {
-                await uploadLayerFunc(descriptor).ConfigureAwait(false);
+                await Task.WhenAll(builtImage.LayerDescriptors.Select(descriptor => uploadLayerFunc(descriptor))).ConfigureAwait(false);
             }
-        }
+            else
+            {
+                foreach (var descriptor in builtImage.LayerDescriptors)
+                {
+                    await uploadLayerFunc(descriptor).ConfigureAwait(false);
+                }
+            }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        using (MemoryStream stringStream = new(Encoding.UTF8.GetBytes(builtImage.Config)))
-        {
-            var configDigest = builtImage.ImageDigest!;
-            _logger.LogInformation(Strings.Registry_ConfigUploadStarted, configDigest);
-            await UploadBlobAsync(destination.Repository, configDigest, stringStream, cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(Strings.Registry_ConfigUploaded);
+            cancellationToken.ThrowIfCancellationRequested();
+            using (MemoryStream stringStream = new(Encoding.UTF8.GetBytes(builtImage.Config)))
+            {
+                var configDigest = builtImage.ImageDigest!;
+                _logger.LogInformation(Strings.Registry_ConfigUploadStarted, configDigest);
+                await UploadBlobAsync(destination.Repository, configDigest, stringStream, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation(Strings.Registry_ConfigUploaded);
+            }
         }
 
         // Tags can refer to an image manifest or an image manifest list.
@@ -668,7 +682,7 @@ internal sealed class Registry
                 _logger.LogInformation(Strings.Registry_TagUploaded, tag, RegistryName);
             }
         }
-        else
+        else if (!manifestExists)
         {
             _logger.LogInformation(Strings.Registry_ManifestUploadStarted, RegistryName, builtImage.ManifestDigest);
             await _registryAPI.Manifest.PutAsync(destination.Repository, builtImage.ManifestDigest, builtImage.Manifest, builtImage.ManifestMediaType, cancellationToken).ConfigureAwait(false);

--- a/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Registry/Registry.cs
@@ -595,17 +595,17 @@ internal sealed class Registry
     }
 
     public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, CancellationToken cancellationToken)
-        => PushAsync(builtImage, source, destination, skipIfManifestExists: false, cancellationToken);
+        => PushAsync(builtImage, source, destination, noCache: false, cancellationToken);
 
-    public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool skipIfManifestExists, CancellationToken cancellationToken)
-        => PushAsync(builtImage, source, destination, pushTags: true, skipIfManifestExists, cancellationToken);
+    public Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool noCache, CancellationToken cancellationToken)
+        => PushAsync(builtImage, source, destination, pushTags: true, noCache, cancellationToken);
 
-    private async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool pushTags, bool skipIfManifestExists, CancellationToken cancellationToken)
+    private async Task PushAsync(BuiltImage builtImage, SourceImageReference source, DestinationImageReference destination, bool pushTags, bool noCache, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Registry destinationRegistry = destination.RemoteRegistry!;
 
-        bool manifestExists = skipIfManifestExists &&
+        bool manifestExists = !noCache &&
             await _registryAPI.Manifest.ExistsAsync(destination.Repository, builtImage.ManifestDigest, cancellationToken).ConfigureAwait(false);
 
         if (manifestExists)

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.Designer.cs
@@ -763,6 +763,15 @@ namespace Microsoft.NET.Build.Containers.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads..
+        /// </summary>
+        internal static string Registry_ManifestExists {
+            get {
+                return ResourceManager.GetString("Registry_ManifestExists", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Uploading manifest to registry &apos;{0}&apos; as blob &apos;{1}&apos;..
         /// </summary>
         internal static string Registry_ManifestUploadStarted {

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/Strings.resx
@@ -453,6 +453,10 @@
     <value>Uploaded manifest to '{0}'.</value>
     <comment>{0} is the registry name</comment>
   </data>
+  <data name="Registry_ManifestExists" xml:space="preserve">
+    <value>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</value>
+    <comment>{0} is the manifest digest, {1} is the repository name</comment>
+  </data>
   <data name="Registry_ManifestUploadStarted" xml:space="preserve">
     <value>Uploading manifest to registry '{0}' as blob '{1}'.</value>
     <comment>{0} is the registry name</comment>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.cs.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Nahrávání vrstvy {0} do {1} bylo dokončeno.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Manifest se nahrává do registru {0} jako objekt blob {1}.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.de.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Das Hochladen der Ebene „{0}“ nach „{1}“ wurde abgeschlossen.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Das Manifest wird in die Registrierung „{0}“ als Blob „{1}“ hochgeladen.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.es.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Finalizó la carga de la capa "{0}" en "{1}".</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Cargando manifiesto en el Registro "{0}" como blob "{1}".</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.fr.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Fin du chargement de la couche «{0}» vers «{1}».</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Chargement du manifeste dans le Registre '{0}' en tant qu’objet blob '{1}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.it.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Caricamento del livello '{0}' in '{1}' completato.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Caricamento del manifesto nel Registro di sistema '{0}' come BLOB '{1}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ja.xlf
@@ -399,6 +399,11 @@
         <target state="translated">レイヤー '{0}' の '{1}' へのアップロードが完了しました。</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">BLOB '{0}' としてレジストリ '{1}' にマニフェストをアップロードしています。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ko.xlf
@@ -399,6 +399,11 @@
         <target state="translated">'{1}'에 '{0}' 계층을 업로드했습니다.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">'{0}' 레지스트리에 매니페스트를 '{1}' Blob으로 업로드하는 중입니다.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pl.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Zakończono przekazywanie warstwy „{0}” do rejestru „{1}”.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Przekazywanie manifestu do rejestru „{0}” jako obiektu blob „{1}”.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.pt-BR.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Camada de carregamento concluída '{0}' para '{1}'.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Carregamento do manifesto para o registro '{0}' como blob '{1}'.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.ru.xlf
@@ -399,6 +399,11 @@
         <target state="translated">Завершена отправка слоя "{0}" в "{1}".</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Отправка манифеста в реестр "{0}" как BLOB-объект "{1}".</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.tr.xlf
@@ -399,6 +399,11 @@
         <target state="translated">'{0}' katmanının, '{1}' kayıt defterine karşıya yüklenmesi tamamlandı.</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">Bildirim, '{0}' kayıt defterine '{1}' blob olarak karşıya yükleniyor.</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hans.xlf
@@ -399,6 +399,11 @@
         <target state="translated">已完成将层“{0}”上传到“{1}”。</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">正在将清单作为 blob“{1}”上传到注册表“{0}”。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Containers/Microsoft.NET.Build.Containers/Resources/xlf/Strings.zh-Hant.xlf
@@ -399,6 +399,11 @@
         <target state="translated">已完成上傳圖層 '{0}' 至 '{1}'。</target>
         <note>{0} is the layer digest, {1} is the registry name</note>
       </trans-unit>
+      <trans-unit id="Registry_ManifestExists">
+        <source>Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</source>
+        <target state="new">Manifest '{0}' already exists in repository '{1}'. Skipping layer and configuration uploads.</target>
+        <note>{0} is the manifest digest, {1} is the repository name</note>
+      </trans-unit>
       <trans-unit id="Registry_ManifestUploadStarted">
         <source>Uploading manifest to registry '{0}' as blob '{1}'.</source>
         <target state="translated">上傳資訊清單至登錄 '{0}' 做為 blob '{1}'。</target>

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -167,9 +167,9 @@ partial class CreateNewImage
     public bool SkipPublishing { get; set; }
 
     /// <summary>
-    /// If true, the tooling will skip layer and configuration uploads when the generated manifest already exists in the destination registry.
+    /// If true, the tooling will upload the image without checking whether its manifest already exists in the destination registry.
     /// </summary>
-    public bool SkipPushIfAlreadyPresent { get; set; }
+    public bool NoCache { get; set; }
 
     [Output]
     public string GeneratedContainerManifest { get; set; }

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -166,6 +166,11 @@ partial class CreateNewImage
     /// </summary>
     public bool SkipPublishing { get; set; }
 
+    /// <summary>
+    /// If true, the tooling will skip layer and configuration uploads when the generated manifest already exists in the destination registry.
+    /// </summary>
+    public bool SkipPushIfAlreadyPresent { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -227,7 +227,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         if (!SkipPublishing)
         {
-            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, Log, telemetry, cancellationToken)
+            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, SkipPushIfAlreadyPresent, Log, telemetry, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -227,7 +227,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         if (!SkipPublishing)
         {
-            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, SkipPushIfAlreadyPresent, Log, telemetry, cancellationToken)
+            await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, NoCache, Log, telemetry, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -100,6 +100,7 @@
       <!-- Only default a tag name if no tag names at all are provided -->
       <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">latest</ContainerImageTag>
       <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true' and '$(ContainerImageTags)' == ''">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
+      <ContainerPushNoCache Condition="'$(ContainerPushNoCache)' == ''">false</ContainerPushNoCache>
     </PropertyGroup>
 
     <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
@@ -135,7 +136,6 @@
       <ContainerGenerateLabelsImageBaseDigest Condition="'$(ContainerGenerateLabelsImageBaseDigest)' == ''">true</ContainerGenerateLabelsImageBaseDigest>
       <ContainerGenerateLabelsImageBaseName Condition="'$(ContainerGenerateLabelsImageBaseName)' == ''">true</ContainerGenerateLabelsImageBaseName>
       <ContainerGenerateLabelsDotnetToolset Condition="'$(ContainerGenerateLabelsDotnetToolset)' == ''">true</ContainerGenerateLabelsDotnetToolset>
-      <ContainerSkipPushIfAlreadyPresent Condition="'$(ContainerSkipPushIfAlreadyPresent)' == ''">false</ContainerSkipPushIfAlreadyPresent>
     </PropertyGroup>
 
     <PropertyGroup Label="Defaults for Container Labels">
@@ -278,7 +278,7 @@
                     ContainerUser="$(ContainerUser)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
                     SkipPublishing="$(_SkipContainerPublishing)"
-                    SkipPushIfAlreadyPresent="$(ContainerSkipPushIfAlreadyPresent)"
+                    NoCache="$(ContainerPushNoCache)"
                     GenerateLabels="$(ContainerGenerateLabels)"
                     GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"> <!-- The RID graph path is provided as a property by the SDK. -->
 
@@ -335,7 +335,7 @@
           _ContainerEnvironmentVariables=@(ContainerEnvironmentVariable->'%(Identity):%(Value)');
           ContainerGenerateLabels=$(ContainerGenerateLabels);
           ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest);
-          ContainerSkipPushIfAlreadyPresent=$(ContainerSkipPushIfAlreadyPresent);
+          ContainerPushNoCache=$(ContainerPushNoCache);
           _SkipContainerPublishing=$(_SkipContainerPublishing);
           ContainerImageFormat=$(_SingleImageContainerFormat);
           _IsMultiRIDBuild=false;

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -135,6 +135,7 @@
       <ContainerGenerateLabelsImageBaseDigest Condition="'$(ContainerGenerateLabelsImageBaseDigest)' == ''">true</ContainerGenerateLabelsImageBaseDigest>
       <ContainerGenerateLabelsImageBaseName Condition="'$(ContainerGenerateLabelsImageBaseName)' == ''">true</ContainerGenerateLabelsImageBaseName>
       <ContainerGenerateLabelsDotnetToolset Condition="'$(ContainerGenerateLabelsDotnetToolset)' == ''">true</ContainerGenerateLabelsDotnetToolset>
+      <ContainerSkipPushIfAlreadyPresent Condition="'$(ContainerSkipPushIfAlreadyPresent)' == ''">false</ContainerSkipPushIfAlreadyPresent>
     </PropertyGroup>
 
     <PropertyGroup Label="Defaults for Container Labels">
@@ -277,6 +278,7 @@
                     ContainerUser="$(ContainerUser)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"
                     SkipPublishing="$(_SkipContainerPublishing)"
+                    SkipPushIfAlreadyPresent="$(ContainerSkipPushIfAlreadyPresent)"
                     GenerateLabels="$(ContainerGenerateLabels)"
                     GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"> <!-- The RID graph path is provided as a property by the SDK. -->
 
@@ -333,6 +335,7 @@
           _ContainerEnvironmentVariables=@(ContainerEnvironmentVariable->'%(Identity):%(Value)');
           ContainerGenerateLabels=$(ContainerGenerateLabels);
           ContainerGenerateLabelsImageBaseDigest=$(ContainerGenerateLabelsImageBaseDigest);
+          ContainerSkipPushIfAlreadyPresent=$(ContainerSkipPushIfAlreadyPresent);
           _SkipContainerPublishing=$(_SkipContainerPublishing);
           ContainerImageFormat=$(_SingleImageContainerFormat);
           _IsMultiRIDBuild=false;

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -1628,8 +1628,8 @@ public class EndToEndTests : SdkTest, IDisposable
         (var taskLog, var errors) = SetupTaskLog();
         var telemetry = new Telemetry(sourceReference, destinationReference, taskLog);
 
-        await ImagePublisher.PublishImageAsync(builtImage, sourceReference, destinationReference, taskLog, telemetry, CancellationToken.None)
-                .ConfigureAwait(false);
+        await ImagePublisher.PublishImageAsync(builtImage, sourceReference, destinationReference, false, taskLog, telemetry, CancellationToken.None)
+            .ConfigureAwait(false);
 
         // Assert the error message
         Assert.IsTrue(taskLog.HasLoggedErrors);

--- a/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -52,6 +52,130 @@ public class RegistryTests : IDisposable
         Assert.AreEqual("registry-1.docker.io", registry.BaseUri.Host);
     }
 
+    [DataRow(HttpStatusCode.OK, true)]
+    [DataRow(HttpStatusCode.NotFound, false)]
+    [DataRow(HttpStatusCode.Unauthorized, false)]
+    [DataRow(HttpStatusCode.Forbidden, false)]
+    [DataRow(HttpStatusCode.MethodNotAllowed, false)]
+    [TestMethod]
+    public async Task ManifestExistsAsync_ReturnsExpectedResult(HttpStatusCode statusCode, bool expected)
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(ManifestExistsAsync_ReturnsExpectedResult));
+        Mock<HttpClient> client = new(MockBehavior.Loose);
+        HttpRequestMessage? request = null;
+        client.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => request = message)
+            .ReturnsAsync(new HttpResponseMessage(statusCode));
+        DefaultManifestOperations operations = new(new Uri("https://example.com"), "example.com", client.Object, logger);
+
+        bool actual = await operations.ExistsAsync("test/repository", "sha256:1234", CancellationToken.None);
+
+        Assert.AreEqual(expected, actual);
+        Assert.IsNotNull(request);
+        Assert.AreEqual(HttpMethod.Head, request.Method);
+        Assert.AreEqual("https://example.com/v2/test/repository/manifests/sha256:1234", request.RequestUri!.AbsoluteUri);
+        Assert.IsNotEmpty(request.Headers.Accept);
+    }
+
+    [TestMethod]
+    public async Task ManifestExistsAsync_PropagatesServerErrors()
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(ManifestExistsAsync_PropagatesServerErrors));
+        Mock<HttpClient> client = new(MockBehavior.Loose);
+        client.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        DefaultManifestOperations operations = new(new Uri("https://example.com"), "example.com", client.Object, logger);
+
+        await Assert.ThrowsAsync<ContainerHttpException>(() => operations.ExistsAsync("test/repository", "sha256:1234", CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task PushAsync_SkipsBlobUploadsWhenManifestAlreadyExists()
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_SkipsBlobUploadsWhenManifestAlreadyExists));
+        const string repository = "test/repository";
+        const string manifestDigest = "sha256:manifest";
+        string[] tags = ["latest", "stable"];
+
+        Mock<IManifestOperations> manifestOperations = new(MockBehavior.Strict);
+        manifestOperations
+            .Setup(m => m.ExistsAsync(repository, manifestDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        foreach (string tag in tags)
+        {
+            manifestOperations
+                .Setup(m => m.PutAsync(repository, tag, "{}", SchemaTypes.OciManifestV1, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+        }
+
+        Mock<IRegistryAPI> api = new(MockBehavior.Strict);
+        api.SetupGet(a => a.Manifest).Returns(manifestOperations.Object);
+        Registry registry = new("example.com", logger, api.Object);
+        BuiltImage image = new()
+        {
+            Config = "{}",
+            ImageDigest = "sha256:config",
+            Manifest = "{}",
+            ManifestDigest = manifestDigest,
+            ManifestMediaType = SchemaTypes.OciManifestV1,
+            Layers = [new ManifestLayer(SchemaTypes.OciLayerGzipV1, 123, "sha256:layer", null)],
+            OS = "linux",
+            Architecture = "amd64",
+        };
+        SourceImageReference source = new(registry, "base/image", "latest", null);
+        DestinationImageReference destination = new(registry, repository, tags);
+
+        await registry.PushAsync(image, source, destination, skipIfManifestExists: true, CancellationToken.None);
+
+        manifestOperations.Verify(m => m.ExistsAsync(repository, manifestDigest, It.IsAny<CancellationToken>()), Times.Once);
+        foreach (string tag in tags)
+        {
+            manifestOperations.Verify(m => m.PutAsync(repository, tag, "{}", SchemaTypes.OciManifestV1, It.IsAny<CancellationToken>()), Times.Once);
+        }
+        api.VerifyGet(a => a.Blob, Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PushAsync_DoesNotCheckManifestUnlessEnabled()
+    {
+        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_DoesNotCheckManifestUnlessEnabled));
+        const string repository = "test/repository";
+        const string configDigest = "sha256:config";
+
+        Mock<IBlobOperations> blobOperations = new(MockBehavior.Strict);
+        blobOperations
+            .Setup(b => b.ExistsAsync(repository, configDigest, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        Mock<IManifestOperations> manifestOperations = new(MockBehavior.Strict);
+        manifestOperations
+            .Setup(m => m.PutAsync(repository, "latest", "{}", SchemaTypes.OciManifestV1, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        Mock<IRegistryAPI> api = new(MockBehavior.Strict);
+        api.SetupGet(a => a.Blob).Returns(blobOperations.Object);
+        api.SetupGet(a => a.Manifest).Returns(manifestOperations.Object);
+
+        Registry registry = new("example.com", logger, api.Object);
+        BuiltImage image = new()
+        {
+            Config = "{}",
+            ImageDigest = configDigest,
+            Manifest = "{}",
+            ManifestDigest = "sha256:manifest",
+            ManifestMediaType = SchemaTypes.OciManifestV1,
+            Layers = [],
+            OS = "linux",
+            Architecture = "amd64",
+        };
+        SourceImageReference source = new(registry, "base/image", "latest", null);
+        DestinationImageReference destination = new(registry, repository, ["latest"]);
+
+        await registry.PushAsync(image, source, destination, CancellationToken.None);
+
+        manifestOperations.Verify(m => m.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        blobOperations.Verify(b => b.ExistsAsync(repository, configDigest, It.IsAny<CancellationToken>()), Times.Once);
+        manifestOperations.Verify(m => m.PutAsync(repository, "latest", "{}", SchemaTypes.OciManifestV1, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [TestMethod]
     public async Task RegistriesThatProvideNoUploadSizeAttemptFullUpload()
     {

--- a/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/RegistryTests.cs
@@ -90,9 +90,9 @@ public class RegistryTests : IDisposable
     }
 
     [TestMethod]
-    public async Task PushAsync_SkipsBlobUploadsWhenManifestAlreadyExists()
+    public async Task PushAsync_SkipsBlobUploadsByDefaultWhenManifestAlreadyExists()
     {
-        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_SkipsBlobUploadsWhenManifestAlreadyExists));
+        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_SkipsBlobUploadsByDefaultWhenManifestAlreadyExists));
         const string repository = "test/repository";
         const string manifestDigest = "sha256:manifest";
         string[] tags = ["latest", "stable"];
@@ -125,7 +125,7 @@ public class RegistryTests : IDisposable
         SourceImageReference source = new(registry, "base/image", "latest", null);
         DestinationImageReference destination = new(registry, repository, tags);
 
-        await registry.PushAsync(image, source, destination, skipIfManifestExists: true, CancellationToken.None);
+        await registry.PushAsync(image, source, destination, CancellationToken.None);
 
         manifestOperations.Verify(m => m.ExistsAsync(repository, manifestDigest, It.IsAny<CancellationToken>()), Times.Once);
         foreach (string tag in tags)
@@ -136,9 +136,9 @@ public class RegistryTests : IDisposable
     }
 
     [TestMethod]
-    public async Task PushAsync_DoesNotCheckManifestUnlessEnabled()
+    public async Task PushAsync_DoesNotCheckManifestWhenNoCacheIsEnabled()
     {
-        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_DoesNotCheckManifestUnlessEnabled));
+        ILogger logger = _loggerFactory.CreateLogger(nameof(PushAsync_DoesNotCheckManifestWhenNoCacheIsEnabled));
         const string repository = "test/repository";
         const string configDigest = "sha256:config";
 
@@ -169,7 +169,7 @@ public class RegistryTests : IDisposable
         SourceImageReference source = new(registry, "base/image", "latest", null);
         DestinationImageReference destination = new(registry, repository, ["latest"]);
 
-        await registry.PushAsync(image, source, destination, CancellationToken.None);
+        await registry.PushAsync(image, source, destination, noCache: true, CancellationToken.None);
 
         manifestOperations.Verify(m => m.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         blobOperations.Verify(b => b.ExistsAsync(repository, configDigest, It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
## Summary

Add an opt-in `ContainerSkipPushIfAlreadyPresent` property for remote registry publishes.

When enabled, the SDK checks whether the locally computed manifest digest already exists in the destination repository. If it does, the publish skips layer and configuration blob uploads while still applying every requested image tag to the existing manifest. If it does not, publishing follows the existing upload path.

The property defaults to `false`, so existing behavior is unchanged.

## Details

- add manifest `HEAD` support through `IManifestOperations.ExistsAsync`
- treat a successful response as present and ordinary client/auth/method failures as a safe fall-through to the normal push path
- propagate registry server errors
- thread the opt-in through `CreateNewImage`, `ImagePublisher`, and the container targets
- retain tag updates when blob uploads are skipped
- emit a localized log message when an existing manifest is reused
- apply the optimization to the individual image manifests in multi-platform publishing, while leaving image-index publishing unchanged

This intentionally does not skip the local image build. The SDK must still build the image locally to compute `BuiltImage.ManifestDigest`. The optimization avoids redundant registry blob transfer.

## Dependency

The common unchanged-build case depends on deterministic image output. #55689 implements the deterministic timestamps, layer ordering, and PAX normalization needed for independently built identical inputs to produce the same digest.

## Verification

- focused `RegistryTests`: 32 passed, 5 skipped
- full `Microsoft.NET.Build.Containers.UnitTests`: 322 passed, 6 skipped, with one unrelated environment-specific failure in `DockerDaemonTests.Can_detect_when_no_daemon_is_running`; the isolated rerun reproduced because a runtime is available at the test's supposedly unused endpoint
- package-based end-to-end publish against a local registry: second identical publish emitted the manifest-reuse message, performed zero layer/config uploads, preserved the blob count at 8, added the `reused` tag, and kept both tags on digest `sha256:1754b379…`
- remote registry validation using the unified #55689 plus this change payload: all four single/multi-RID × OCI/Docker cells preserved their first digest across `stable` and `reused`, emitted one skip per single manifest or two skips for multi-platform inner manifests, performed zero repeated layer/config uploads, and reported the expected manifest/index media type; all four temporary repositories were deleted afterward

Fixes #54038
