### PR TITLE
Update XML transform for apphost.exe

### DIFF
--- a/src/Layout/pkg/windows/StableFileIdForApphostTransform.xslt
+++ b/src/Layout/pkg/windows/StableFileIdForApphostTransform.xslt
@@ -1,9 +1,7 @@
 <xsl:stylesheet version="1.0"
             xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-            xmlns:msxsl="urn:schemas-microsoft-com:xslt"
-            exclude-result-prefixes="msxsl"
-            xmlns:wix="http://schemas.microsoft.com/wix/2006/wi"
-            xmlns:my="my:my">
+            xmlns:wix="http://wixtoolset.org/schemas/v4/wxs"
+            exclude-result-prefixes="wix">
 
     <xsl:output method="xml" indent="yes" />
 
@@ -15,12 +13,10 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match='wix:Wix/wix:Fragment/wix:ComponentGroup/wix:Component/wix:File[contains(@Source, "AppHostTemplate\apphost.exe")]'>
+    <xsl:template match="wix:Directory[@Name='AppHostTemplate']/wix:Component/wix:File">
         <xsl:copy>
-            <xsl:apply-templates select="@*"/>
-            <xsl:attribute name="Id">
-                <xsl:text>apphosttemplateapphostexe</xsl:text>
-            </xsl:attribute>
+            <xsl:attribute name="Id">apphosttemplateapphostexe</xsl:attribute>
+            <xsl:apply-templates select="@*[name() != 'Id']|node()"/>
         </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Update the XML transform to set the file ID for apphost.exe to a known value. The current transform is outdated since updating to WiX 5+

* The schema has changed
* HEAT generates the content a bit differently and the previous pattern won't match the node.

From the 10.0.103 build

<img width="986" height="76" alt="image" src="https://github.com/user-attachments/assets/cd83c897-b4b5-4346-81f2-bdf9577c883d" />

Local build with the fix

<img width="924" height="46" alt="image" src="https://github.com/user-attachments/assets/6b1ff2af-364f-41a6-af1f-852f706b4fd8" />
