### PR TITLE
Add a workaround for obtaining GitHub app tokens

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -66,8 +66,16 @@ jobs:
       targetRef: ${{ parameters.targetRef }}
 
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
+
     # Push main and release branches to the public VMR
     - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
+      
+      # Make sure the script is where we expect it to be, since the template does not support multi-repo checkout
+      - script: |
+          mkdir -p $(System.DefaultWorkingDirectory)/eng/common
+          cp -r $(System.DefaultWorkingDirectory)/sdk/eng/common/Get-GitHubAppToken.ps1 $(System.DefaultWorkingDirectory)/eng/common
+        displayName: Copy GitHub App token script
+
       - template: /eng/common/templates-official/steps/get-github-app-token.yml
         parameters:
           azureSubscription: DncEng-VSTS

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -66,10 +66,8 @@ jobs:
       targetRef: ${{ parameters.targetRef }}
 
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
-
     # Push main and release branches to the public VMR
     - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
-      
       # Make sure the script is where we expect it to be, since the template does not support multi-repo checkout
       - script: |
           mkdir -p $(System.DefaultWorkingDirectory)/eng/common


### PR DESCRIPTION
The Arcade template does not work in a multi-repo checkout context