### PR TITLE
Stop promoting NU1605 to an error by default

### DIFF
--- a/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.Generated.cs
+++ b/src/Cli/dotnet/Commands/Run/CSharpCompilerCommand.Generated.cs
@@ -49,7 +49,7 @@ partial class CSharpCompilerCommand
             $"{objDir}/{FileName}.GlobalUsings.g.cs",
             $"{objDir}/.NETCoreApp,Version=v{TargetFrameworkVersion}.AssemblyAttributes.cs",
             $"{objDir}/{FileName}.AssemblyInfo.cs",
-            "/warnaserror+:NU1605,SYSLIB0011",
+            "/warnaserror+:SYSLIB0011",
         ];
     }
 

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props
@@ -13,9 +13,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <NoWarn Condition=" '$(NoWarn)' == '' ">1701;1702</NoWarn>
-
-    <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
-    <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition=" '$(DefineConstants)' != '' ">$(DefineConstants);</DefineConstants>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.props
@@ -18,9 +18,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <OptionCompare Condition=" '$(OptionCompare)' == '' ">Binary</OptionCompare>
     <OptionStrict Condition=" '$(OptionStrict)' == '' ">Off</OptionStrict>
     <OptionInfer Condition=" '$(OptionInfer)' == '' ">On</OptionInfer>
-
-    <!-- Remove the line below once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
-    <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props
@@ -128,9 +128,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildCopyContentTransitively Condition="'$(MSBuildCopyContentTransitively)' == ''">true</MSBuildCopyContentTransitively>
     <ResolveAssemblyReferenceOutputUnresolvedAssemblyConflicts Condition="'$(ResolveAssemblyReferenceOutputUnresolvedAssemblyConflicts)' == ''">true</ResolveAssemblyReferenceOutputUnresolvedAssemblyConflicts>
 
-    <!-- Uncomment this once https://github.com/Microsoft/visualfsharp/issues/3207 gets fixed -->
-    <!-- <WarningsAsErrors>$(WarningsAsErrors);NU1605</WarningsAsErrors> -->
-
     <!-- Implicitly set UserSecretsId for file-based apps. -->
     <_ImplicitFileBasedProgramUserSecretsId Condition="'$(FileBasedProgram)' == 'true'">$(AssemblyName)-$([MSBuild]::StableStringHash($(MSBuildProjectFullPath.ToLowerInvariant()), 'Sha256'))</_ImplicitFileBasedProgramUserSecretsId>
     <UserSecretsId Condition="'$(FileBasedProgram)' == 'true' and '$(UserSecretsId)' == ''">$(_ImplicitFileBasedProgramUserSecretsId)</UserSecretsId>

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsWithPackageDowngrades.cs
@@ -7,7 +7,7 @@ namespace Microsoft.NET.Restore.Tests
     public class GivenThatWeWantToRestoreProjectsWithPackageDowngrades : SdkTest
     {
         [TestMethod]
-        public void DowngradeWarningsAreErrorsByDefault()
+        public void DowngradeWarningsAreWarningsByDefault()
         {
             const string testProjectName = "ProjectWithDowngradeWarning";
             var testProject = new TestProject()
@@ -26,18 +26,17 @@ namespace Microsoft.NET.Restore.Tests
             var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand
                 .Execute($"/p:RestorePackagesPath={packagesFolder}")
-                .Should().Fail()
-                .And.HaveStdOutContaining("NU1605");
+                .Should().Pass()
+                .And.HaveStdOutContaining("warning NU1605");
 
             var buildCommand = new BuildCommand(testAsset);
             buildCommand
                 .Execute()
-                .Should().Fail()
-                .And.HaveStdOutContaining("NU1605");
+                .Should().Pass();
         }
 
         [TestMethod]
-        public void ItIsPossibleToTurnOffDowngradeWarningsAsErrors()
+        public void DowngradeWarningsCanBePromotedToErrors()
         {
             const string testProjectName = "ProjectWithDowngradeWarning";
             var testProject = new TestProject()
@@ -46,7 +45,7 @@ namespace Microsoft.NET.Restore.Tests
                 TargetFrameworks = "netstandard2.0",
             };
 
-            testProject.AdditionalProperties.Add("WarningsAsErrors", string.Empty);
+            testProject.AdditionalProperties.Add("WarningsAsErrors", "NU1605");
             testProject.PackageReferences.Add(new TestPackageReference("NuGet.Packaging", "3.5.0", null));
             testProject.PackageReferences.Add(new TestPackageReference("NuGet.Commands", "4.0.0", null));
 
@@ -57,7 +56,35 @@ namespace Microsoft.NET.Restore.Tests
             var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
             restoreCommand
                 .Execute($"/p:RestorePackagesPath={packagesFolder}")
-                .Should().Pass(); ;
+                .Should().Fail()
+                .And.HaveStdOutContaining("error NU1605");
+        }
+
+        [TestMethod]
+        public void WarningsNotAsErrorsExcludesDowngradeWarningsFromTreatWarningsAsErrors()
+        {
+            const string testProjectName = "ProjectWithDowngradeWarning";
+            var testProject = new TestProject()
+            {
+                Name = testProjectName,
+                TargetFrameworks = "netstandard2.0",
+            };
+
+            testProject.AdditionalProperties.Add("NuGetAudit", "false");
+            testProject.AdditionalProperties.Add("TreatWarningsAsErrors", "true");
+            testProject.AdditionalProperties.Add("WarningsNotAsErrors", "NU1605");
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Packaging", "3.5.0", null));
+            testProject.PackageReferences.Add(new TestPackageReference("NuGet.Commands", "4.0.0", null));
+
+            var testAsset = TestAssetsManager.CreateTestProject(testProject);
+
+            var packagesFolder = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "packages", testProjectName);
+
+            var restoreCommand = testAsset.GetRestoreCommand(Log, relativePath: testProjectName);
+            restoreCommand
+                .Execute($"/p:RestorePackagesPath={packagesFolder}")
+                .Should().Pass()
+                .And.HaveStdOutContaining("warning NU1605");
         }
     }
 }


### PR DESCRIPTION
Fixes #55709

Remove the SDK's explicit `NU1605` additions to `WarningsAsErrors` for C# and Visual Basic, along with the stale common-props placeholder. Package downgrade diagnostics now follow the standard warning controls:

- `NU1605` is a warning by default.
- `WarningsAsErrors=NU1605` explicitly promotes it.
- `WarningsNotAsErrors=NU1605` excludes it when `TreatWarningsAsErrors=true`.

Also update the generated file-based compiler arguments and restore regression coverage.

**Validation**
- Full SDK build
- Focused package-downgrade restore tests
- File-based compiler argument equivalence test