### PR TITLE
Optimize the NativeAOT CLI for size

### DIFF
--- a/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -19,6 +19,7 @@
     <NativeLib>Shared</NativeLib>
     <PublishAot>true</PublishAot>
     <IsAotCompatible>true</IsAotCompatible>
+    <OptimizationPreference>Size</OptimizationPreference>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>


### PR DESCRIPTION
## Summary

Set `OptimizationPreference=Size` for the NativeAOT CLI.

This setting reduces the NativeAOT binary size in exchange for a small, mostly fixed startup cost.

## Benchmark results

The measurements used Release builds for `win-x64` on dotnet/sdk PR #55497. The [full benchmark report](https://gist.github.com/baronfel/57fc30de5811fd10c235c8434ef8849c) contains the setup and caveats.

### Binary size

| Build | Speed | Size | Reduction |
|---|---:|---:|---:|
| PR base | 20.60 MiB | 17.16 MiB | 3.44 MiB / 16.7% |
| PR head | 45.79 MiB | 36.28 MiB | 9.51 MiB / 20.8% |

Invariant globalization reduced the PR-head binary by only 0.22–0.25 MiB, or approximately 0.6%. This PR does not change globalization behavior.

Most PR growth was native code and read-only data. `.rdata` contributed 13.09 MiB, and `.text` contributed 9.60 MiB.

### Startup time

Each result is the median of 150 launches on the PR head.

| Command | Speed | Size | Difference |
|---|---:|---:|---:|
| `--version` | 27.40 ms | 40.47 ms | +13.07 ms |
| `--info` | 55.47 ms | 68.87 ms | +13.40 ms |
| `--help` | 27.79 ms | 40.84 ms | +13.05 ms |
| `build --help` | 27.97 ms | 41.36 ms | +13.39 ms |
| `restore --help` | 28.74 ms | 41.89 ms | +13.15 ms |
| `sdk check` | 108.06 ms | 117.27 ms | +9.21 ms |

Size optimization added approximately 9–13 ms with normal globalization. The fixed cost creates a larger percentage change for commands that do little work.

## Validation

Published `src/Cli/dotnet-aot/dotnet-aot.csproj` for Release and `win-x64`. The NativeAOT compiler evaluated `OptimizationPreference=Size` and produced the native library.