### PR TITLE
Update implicit versions for August 2026

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,9 +34,9 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>28</VersionFeature80>
-    <VersionFeature90>17</VersionFeature90>
-    <VersionFeature100>9</VersionFeature100>
+    <VersionFeature80>30</VersionFeature80>
+    <VersionFeature90>19</VersionFeature90>
+    <VersionFeature100>11</VersionFeature100>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
Update VersionFeature properties to match the August 2026 .NET releases:

- .NET 8.0.30 (VersionFeature80: 28 → 30)
- .NET 9.0.19 (VersionFeature90: 17 → 19)
- .NET 10.0.11 (VersionFeature100: 9 → 11)

These values are sourced from the official releases.json:
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/10.0/releases.json
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/9.0/releases.json
- https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json

Note: The July 2026 PR (#55531) is still open and appears to be superseded by this change.