### PR TITLE
[release/9.0.1xx] Add a workaround for obtaining GitHub app tokens

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -71,7 +71,7 @@ jobs:
       # Make sure the script is where we expect it to be, since the template does not support multi-repo checkout
       - script: |
           mkdir -p $(System.DefaultWorkingDirectory)/eng/common
-          cp -r $(System.DefaultWorkingDirectory)/sdk/eng/common/Get-GitHubAppToken.ps1 $(System.DefaultWorkingDirectory)/eng/common
+          cp -r $(Build.Repository.LocalPath)/eng/common/Get-GitHubAppToken.ps1 $(System.DefaultWorkingDirectory)/eng/common
         displayName: Copy GitHub App token script
 
       - template: /eng/common/templates-official/steps/get-github-app-token.yml


### PR DESCRIPTION
The Arcade template does not work in a multi-repo checkout context