### PR TITLE
Allow Copilot assignment even if >= 2 issues are assigned to Copilot

### DIFF
--- a/.github/workflows/issue-monster.md
+++ b/.github/workflows/issue-monster.md
@@ -12,7 +12,7 @@ on:
   schedule: every 24h
   skip-if-match:
     query: "is:pr is:open is:draft author:app/copilot-swe-agent"
-    max: 2
+    max: 80
   skip-if-no-match: "is:issue is:open"
   permissions:
     issues: read


### PR DESCRIPTION
The limit for 'skip-if-match' is meant to help prevent the possibility of accidental assignment to too many copilot issues, and also to prevent the issuer assigner from overwhelming engineers with PRs.

This is different from the limit on how many assignments can be sent out at a time, which is dispatch-workflow: max, which is already `3`.

Right now, we have quite a few https://github.com/dotnet/sdk/pulls/@copilot copilot PRs so this limit unintentionally blocks the issue monster. Those existing PRs are not from the issue-monster but individuals.

`2` is clearly too low of a limit and blocking the assigner from running at all, as observed in https://github.com/dotnet/sdk/actions/runs/31646249249 - `80` seems reasonable for now to unblock but I will own revisiting this if we are not attentive to the PRs generated.