### PR TITLE
[release/9.0.1xx] Fix the workaround for obtaining GitHub app tokens

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -65,9 +65,19 @@ jobs:
       vmrBranch: ${{ parameters.vmrBranch }}
       targetRef: ${{ parameters.targetRef }}
 
+  # For official runs that push to GitHub, we need to get a GitHub App token to push to dotnet/dotnet
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
     # Push main and release branches to the public VMR
     - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
+      # The template that signs GitHub App tokens does not support multi-repo checkout, so we need this workaround
+      - script: |
+          target_dir='$(System.DefaultWorkingDirectory)/eng/common'
+          mkdir -p "$target_dir"
+          cp -r Get-GitHubAppToken.ps1 "$target_dir/Get-GitHubAppToken.ps1"
+          cp -r pipeline-logging-functions.ps1 "$target_dir/pipeline-logging-functions.ps1"
+        displayName: Prepare scripts for GitHub App token generation
+        workingDirectory: $(Build.Repository.LocalPath)/eng/common
+
       - template: /eng/common/templates-official/steps/get-github-app-token.yml
         parameters:
           azureSubscription: DncEng-VSTS

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -68,17 +68,11 @@ jobs:
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
     # Push main and release branches to the public VMR
     - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
-      # Make sure the script is where we expect it to be, since the template does not support multi-repo checkout
-      - script: |
-          mkdir -p $(System.DefaultWorkingDirectory)/eng/common
-          cp -r $(Build.Repository.LocalPath)/eng/common/Get-GitHubAppToken.ps1 $(System.DefaultWorkingDirectory)/eng/common
-        displayName: Copy GitHub App token script
-
       - template: /eng/common/templates-official/steps/get-github-app-token.yml
         parameters:
           azureSubscription: DncEng-VSTS
           keyVaultName: dnceng-pipeline-secrets
-          keyName: vmr-synchronization-app-client-secret
+          keyName: vmr-synchronization-app-secret
           appClientId: $(vmr-synchronization-app-client-id)
           installationOwner: dotnet
           outputVariableName: vmrPushToken

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -22,6 +22,20 @@ steps:
   displayName: Clone dotnet/sdk
   path: sdk
 
+
+- ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
+  # Push main and release branches to the public VMR
+  - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
+    # The template that signs GitHub App tokens does not support multi-repo checkout, so we need this workaround
+    - script: |
+        set -ex
+        target_dir='$(System.DefaultWorkingDirectory)/eng/common'
+        mkdir -p "$target_dir"
+        cp -r Get-GitHubAppToken.ps1 "$target_dir/Get-GitHubAppToken.ps1"
+        cp -r pipeline-logging-functions.ps1 "$target_dir/pipeline-logging-functions.ps1"
+      displayName: Prepare scripts for GitHub App token generation
+      workingDirectory: $(Build.Repository.LocalPath)/eng/common
+
 # This step is needed so that when we get a detached HEAD / shallow clone,
 # we still pull the commit into the temporary sdk clone to use it during the sync.
 - script: |

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -22,20 +22,6 @@ steps:
   displayName: Clone dotnet/sdk
   path: sdk
 
-
-- ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
-  # Push main and release branches to the public VMR
-  - ${{ if or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')) }}:
-    # The template that signs GitHub App tokens does not support multi-repo checkout, so we need this workaround
-    - script: |
-        set -ex
-        target_dir='$(System.DefaultWorkingDirectory)/eng/common'
-        mkdir -p "$target_dir"
-        cp -r Get-GitHubAppToken.ps1 "$target_dir/Get-GitHubAppToken.ps1"
-        cp -r pipeline-logging-functions.ps1 "$target_dir/pipeline-logging-functions.ps1"
-      displayName: Prepare scripts for GitHub App token generation
-      workingDirectory: $(Build.Repository.LocalPath)/eng/common
-
 # This step is needed so that when we get a detached HEAD / shallow clone,
 # we still pull the commit into the temporary sdk clone to use it during the sync.
 - script: |


### PR DESCRIPTION
The Arcade template does not work in a multi-repo checkout context