### PR TITLE
Add WebAssembly project reference discovery targets

### DIFF
--- a/src/StaticWebAssetsSdk/Sdk/Sdk.targets
+++ b/src/StaticWebAssetsSdk/Sdk/Sdk.targets
@@ -23,15 +23,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- It is explicitly ok to take a dependency on _MSBuildProjectReferenceExistent as it is
         something many other products already take a dependency on. -->
-      <_WebAssemblyProjectReference Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != ''" />
+      <_WebAssemblyProjectReferenceCandidate Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != ''" />
     </ItemGroup>
 
     <MSBuild
-      Condition="'@(_WebAssemblyProjectReference)' != ''"
-      Projects="@(_WebAssemblyProjectReference)"
+      Condition="'@(_WebAssemblyProjectReferenceCandidate)' != ''"
+      Projects="@(_WebAssemblyProjectReferenceCandidate)"
       Targets="GetWebAssemblyProjectReference"
-      Properties="%(_WebAssemblyProjectReference.SetConfiguration);%(_WebAssemblyProjectReference.SetPlatform);%(_WebAssemblyProjectReference.SetTargetFramework)"
-      RemoveProperties="%(_WebAssemblyProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemoveFromProjectReferences)"
+      Properties="%(_WebAssemblyProjectReferenceCandidate.SetConfiguration);%(_WebAssemblyProjectReferenceCandidate.SetPlatform);%(_WebAssemblyProjectReferenceCandidate.SetTargetFramework)"
+      RemoveProperties="%(_WebAssemblyProjectReferenceCandidate.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemoveFromProjectReferences)"
       BuildInParallel="$(BuildInParallel)"
       SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="WebAssemblyProjectReference" />

--- a/src/StaticWebAssetsSdk/Sdk/Sdk.targets
+++ b/src/StaticWebAssetsSdk/Sdk/Sdk.targets
@@ -19,12 +19,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(StaticWebAssetsSdkCurrentVersionTargets)" />
 
-  <Target Name="ResolveWebAssemblyProjectReferences">
+  <Target Name="ResolveWebAssemblyProjectReferences" DependsOnTargets="PrepareProjectReferences">
+    <ItemGroup>
+      <!-- It is explicitly ok to take a dependency on _MSBuildProjectReferenceExistent as it is
+        something many other products already take a dependency on. -->
+      <_WebAssemblyProjectReference Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != ''" />
+    </ItemGroup>
+
     <MSBuild
-        Projects="@(ProjectReference)"
-        Targets="GetWebAssemblyProjectReference"
-        BuildInParallel="true"
-        SkipNonexistentTargets="true">
+      Condition="'@(_WebAssemblyProjectReference)' != ''"
+      Projects="@(_WebAssemblyProjectReference)"
+      Targets="GetWebAssemblyProjectReference"
+      Properties="%(_WebAssemblyProjectReference.SetConfiguration);%(_WebAssemblyProjectReference.SetPlatform);%(_WebAssemblyProjectReference.SetTargetFramework)"
+      RemoveProperties="%(_WebAssemblyProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemoveFromProjectReferences)"
+      BuildInParallel="$(BuildInParallel)"
+      SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="WebAssemblyProjectReference" />
     </MSBuild>
   </Target>

--- a/src/StaticWebAssetsSdk/Sdk/Sdk.targets
+++ b/src/StaticWebAssetsSdk/Sdk/Sdk.targets
@@ -19,4 +19,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Project="$(StaticWebAssetsSdkCurrentVersionTargets)" />
 
+  <Target Name="ResolveWebAssemblyProjectReferences">
+    <MSBuild
+        Projects="@(ProjectReference)"
+        Targets="GetWebAssemblyProjectReference"
+        BuildInParallel="true"
+        SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="WebAssemblyProjectReference" />
+    </MSBuild>
+  </Target>
 </Project>

--- a/src/WasmSdk/Sdk/Sdk.targets
+++ b/src/WasmSdk/Sdk/Sdk.targets
@@ -81,4 +81,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Import Sdk="Microsoft.NET.Sdk.Publish" Project="Sdk.targets" Condition="'$(_WasmSdkImportsMicrosoftNETSdkPublish)' == 'true'" />
   <Import Project="$(_WebAssemblyTargetsFile)" Condition="'$(_WebAssemblyTargetsFile)' != ''" />
+
+  <Target Name="GetWebAssemblyProjectReference"
+          Returns="@(_WebAssemblyProjectReference)">
+    <ItemGroup>
+      <_WebAssemblyProjectReference Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
@@ -33,8 +33,8 @@ public class StaticWebAssetsDesignTimeTest : AspNetSdkBaselineTest
         var msbuild = new MSBuildCommand(
             testAsset,
             "ResolveWebAssemblyProjectReferences",
-            "blazorhosted")
-            .WithWorkingDirectory(testAsset.TestRoot);
+            "blazorhosted");
+        msbuild.WithWorkingDirectory(testAsset.TestRoot);
 
         var result = msbuild.ExecuteWithoutRestore("-getItem:WebAssemblyProjectReference", "-nologo");
         result.Should().Pass();

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
@@ -36,7 +36,7 @@ public class StaticWebAssetsDesignTimeTest : AspNetSdkBaselineTest
             "blazorhosted");
         msbuild.WithWorkingDirectory(testAsset.TestRoot);
 
-        var result = msbuild.ExecuteWithoutRestore("-getItem:WebAssemblyProjectReference", "-nologo");
+        var result = msbuild.Execute("-getItem:WebAssemblyProjectReference", "-nologo");
         result.Should().Pass();
 
         using var output = JsonDocument.Parse(result.StdOut);

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssetsDesignTimeTest.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
@@ -24,6 +25,31 @@ public class StaticWebAssetsDesignTimeTest : AspNetSdkBaselineTest
 #else
     public const string Configuration = "Release";
 #endif
+
+    [TestMethod]
+    public void ResolveWebAssemblyProjectReferences_ReturnsReferencedWebAssemblyProject()
+    {
+        var testAsset = CreateAspNetSdkTestAsset("BlazorHosted");
+        var msbuild = new MSBuildCommand(
+            testAsset,
+            "ResolveWebAssemblyProjectReferences",
+            "blazorhosted")
+            .WithWorkingDirectory(testAsset.TestRoot);
+
+        var result = msbuild.ExecuteWithoutRestore("-getItem:WebAssemblyProjectReference", "-nologo");
+        result.Should().Pass();
+
+        using var output = JsonDocument.Parse(result.StdOut);
+        var projectReferences = output.RootElement
+            .GetProperty("Items")
+            .GetProperty("WebAssemblyProjectReference")
+            .EnumerateArray()
+            .Select(item => item.GetProperty("Identity").GetString())
+            .ToArray();
+
+        projectReferences.Should().ContainSingle().Which.Should().Be(
+            Path.GetFullPath(Path.Combine(testAsset.TestRoot, "blazorwasm", "blazorwasm.csproj")));
+    }
 
     [TestMethod]
     public void CollectUpToDateCheckInputOutputsDesignTime_ReportsAddedFiles()


### PR DESCRIPTION
## Why

Blazor hosted projects need a consistent SDK-provided way to discover referenced WebAssembly projects without duplicating MSBuild targets in each server and client project.

## What changed

- Adds `GetWebAssemblyProjectReference` to `Microsoft.NET.Sdk.WebAssembly`, returning the evaluated project path.
- Adds `ResolveWebAssemblyProjectReferences` to `Microsoft.NET.Sdk.StaticWebAssets`, querying referenced projects and collecting WebAssembly project paths.
- Adds a focused integration test using the `BlazorHosted` test asset and the MSBuild JSON item-output interface.

The targets preserve the prototype's `TargetOutputs` contract and skip referenced projects that do not implement the discovery target.

## Testing

- `restore.cmd`
- `build.cmd -c Debug`
- Focused targeted test: `ResolveWebAssemblyProjectReferences_ReturnsReferencedWebAssemblyProject` (passed)
