### PR TITLE
[release/9.0.1xx] Cloak SignatureCycle2 from source build

### DIFF
--- a/src/SourceBuild/patches/roslyn/0001-Conditionally-include-cloaked-Roslyn-resource.patch
+++ b/src/SourceBuild/patches/roslyn/0001-Conditionally-include-cloaked-Roslyn-resource.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Mon, 10 Aug 2026 13:39:21 -0500
+Subject: [PATCH] Conditionally include cloaked Roslyn resource
+
+Backport: https://github.com/dotnet/dotnet/pull/8214
+---
+ .../Core/Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj  | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Compilers/Test/Resources/Core/Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj b/src/Compilers/Test/Resources/Core/Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj
+index 2e52cad71d4..08fde349893 100644
+--- a/src/Compilers/Test/Resources/Core/Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj
++++ b/src/Compilers/Test/Resources/Core/Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj
+@@ -66,7 +66,7 @@
+     <Content Include="MetadataTests\Invalid\Signatures\munge.csx" />
+     <Content Include="MetadataTests\Invalid\Signatures\SignatureCycle2.il" />
+     <Content Include="MetadataTests\Invalid\Signatures\TypeSpecInWrongPlace.il" />
+-    <EmbeddedResource Include="MetadataTests\Invalid\Signatures\SignatureCycle2.exe" />
++    <EmbeddedResource Include="MetadataTests\Invalid\Signatures\SignatureCycle2.exe" Condition="Exists('MetadataTests\Invalid\Signatures\SignatureCycle2.exe')" />
+     <EmbeddedResource Include="MetadataTests\Invalid\Signatures\TypeSpecInWrongPlace.exe" />
+     <Content Include="MetadataTests\Members.cs" />
+     <EmbeddedResource Include="MetadataTests\Members.dll" />

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -108,7 +108,8 @@
             "defaultRemote": "https://github.com/dotnet/roslyn",
             "exclude": [
                 // Obfuscated files are blocking the source tarball signing
-                "src/Compilers/Test/Resources/Core/MetadataTests/Invalid/Obfuscated*.dll"
+                "src/Compilers/Test/Resources/Core/MetadataTests/Invalid/Obfuscated*.dll",
+                "src/Compilers/Test/Resources/Core/MetadataTests/Invalid/Signatures/SignatureCycle2.exe"
             ]
         },
         {


### PR DESCRIPTION
SDK-side backport of dotnet/dotnet#8214.

- Excludes `SignatureCycle2.exe` from Roslyn VMR synchronization.
- Adds a source-build patch that includes the Roslyn embedded resource only when the file is present.