### PR TITLE
[wasm] Support browser-wasm/wasi-wasm ReadyToRun in ResolveReadyToRunCompilers

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -170,6 +170,12 @@ namespace Microsoft.NET.Build.Tasks
                 (!version5 || _targetRuntimeIdentifier == _hostRuntimeIdentifier) &&
                 GetCrossgen2ComponentsPaths(version5);
 
+            // WebAssembly ReadyToRun is only supported with the .NET 11+ crossgen2 pack, which ships the wasm cross-JIT.
+            if ((_targetPlatform == "browser" || _targetPlatform == "wasi") && crossgen2PackVersion.Major < 11)
+            {
+                isSupportedTarget = false;
+            }
+
             if (!isSupportedTarget)
             {
                 Log.LogError(Strings.ReadyToRunTargetNotSupportedError);

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ResolveReadyToRunCompilers.cs
@@ -210,7 +210,7 @@ namespace Microsoft.NET.Build.Tasks
             string portablePlatform = NuGetUtils.GetBestMatchingRid(
                     runtimeGraph,
                     _targetRuntimeIdentifier,
-                    ["linux", "android", "osx", "win", "ios", "iossimulator", "tvos", "tvossimulator", "maccatalyst", "freebsd", "openbsd", "illumos", "solaris", "haiku"],
+                    ["linux", "android", "osx", "win", "ios", "iossimulator", "tvos", "tvossimulator", "maccatalyst", "freebsd", "openbsd", "illumos", "solaris", "haiku", "browser", "wasi"],
                     out _);
 
             targetOS = portablePlatform switch
@@ -229,6 +229,8 @@ namespace Microsoft.NET.Build.Tasks
                 "illumos" => "illumos",
                 "solaris" => "solaris",
                 "haiku" => "haiku",
+                "browser" => "browser",
+                "wasi" => "wasi",
                 _ => null
             };
 
@@ -288,6 +290,11 @@ namespace Microsoft.NET.Build.Tasks
                 case "x86":
                     architecture = Architecture.X86;
                     break;
+#if !NETFRAMEWORK
+                case "wasm":
+                    architecture = Architecture.Wasm;
+                    break;
+#endif
                 default:
                     return false;
             }
@@ -452,6 +459,7 @@ namespace Microsoft.NET.Build.Tasks
 #if !NETFRAMEWORK
                 Architecture.RiscV64 => "riscv64",
                 Architecture.LoongArch64 => "loongarch64",
+                Architecture.Wasm => "wasm",
 #endif
                 _ => null
             };

--- a/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/RunReadyToRunCompiler.cs
@@ -379,9 +379,10 @@ namespace Microsoft.NET.Build.Tasks
                 result.AppendLine("--partial");
             }
 
-            // Emit --composite for composite images, or for non-PE container formats
-            // (we only support PE as the envelope for metadata).
-            if (_createCompositeImage || (!string.IsNullOrEmpty(Crossgen2ContainerFormat) && Crossgen2ContainerFormat != "pe"))
+            // Emit --composite for composite images, or for non-PE container formats that can only
+            // carry metadata in a composite manifest. The wasm container format wraps a per-assembly
+            // manifest, so it does not require (and must not be forced into) composite compilation.
+            if (_createCompositeImage || (!string.IsNullOrEmpty(Crossgen2ContainerFormat) && Crossgen2ContainerFormat != "pe" && Crossgen2ContainerFormat != "wasm"))
             {
                 result.AppendLine("--composite");
 


### PR DESCRIPTION
## Summary

crossgen2 can already target WebAssembly (`--obj-format:wasm`), but the SDK's `ResolveReadyToRunCompilers` task rejected `browser-wasm` / `wasi-wasm` target RIDs, so `PublishReadyToRun` failed with `ReadyToRunTargetNotSupportedError` before crossgen2 was ever invoked.

Two gaps in the task:
- `ExtractTargetPlatformAndArchitecture` had no `wasm` architecture case → returned `false`.
- `GetCrossgen2TargetOS` did not include `browser` / `wasi` in the runtime-graph match list or the OS switch → returned `null`.

Related https://github.com/dotnet/runtime/pull/132339

## Change

- Add `case "wasm" → Architecture.Wasm` (guarded by `#if !NETFRAMEWORK`, since `Architecture.Wasm` is .NET 5+, matching the existing `RiscV64`/`LoongArch64` handling).
- Add `Architecture.Wasm => "wasm"` in `ArchitectureToString`.
- Add `browser` and `wasi` to the `GetCrossgen2TargetOS` candidate list and switch.
- **Gate WebAssembly R2R on the .NET 11+ crossgen2 pack** (`crossgen2PackVersion.Major >= 11`): the wasm cross-JIT ships only in the .NET 11+ crossgen2 pack, so for older packs `browser`/`wasi` targets fall back to the existing `ReadyToRunTargetNotSupportedError` rather than resolving and then failing to load the JIT.

No `JitPath` plumbing is needed: for crossgen2 v6+ the task sets no jit path, and crossgen2 auto-loads the wasm cross-JIT (`clrjit_universal_wasm_<hostArch>`) from its own `tools/` directory.

## Merge ordering

This can merge independently of the dotnet/runtime side. The change is inert for every existing scenario:
- Non-wasm targets are unaffected (the previously-`default → false` cases now match, but only for `wasm`/`browser`/`wasi`).
- For wasm targets it only advertises support when a .NET 11+ crossgen2 pack is resolved, and the actual wasm cross-JIT + the targets that turn `PublishReadyToRun` on live in dotnet/runtime. Until those ship, nothing in the shipped SDK reaches this path by default (browser/wasi CoreCLR R2R is experimental and not enabled by default).

## Context

Unblocks ReadyToRun for the experimental CoreCLR-on-WebAssembly target. The consuming runtime-pack / SDK targets work (per-assembly R2R webcil-in-wasm) lives in dotnet/runtime and is validated end-to-end there. The runtime repo currently masks this task gap with an in-tree `ResolveReadyToRunCompilers` target override that is not shipped; this PR removes the need for that override in the shipped SDK.

## Validation

Verified in dotnet/runtime by forcing the SDK-native task path (bypassing the in-tree override): the task resolves `arch = Wasm`, `os = browser`, and — given the standard crossgen2 pack `tools/` layout — locates crossgen2, runs it, and the published assemblies are byte-identical to the crossgen R2R output. Compiles clean; no new strings/localization.

> [!NOTE]
> This PR description and change were drafted with GitHub Copilot.