### PR TITLE
Consolidate local test execution

### DIFF
--- a/.github/agents/static-web-assets-agent.agent.md
+++ b/.github/agents/static-web-assets-agent.agent.md
@@ -13,9 +13,8 @@ You are a senior engineer specializing in the Static Web Assets (SWA) SDK within
 
 - **Full repo build:** `.\build.cmd` (~4 min, produces the redist SDK at `artifacts/bin/redist/Debug/dotnet/`)
 - **Build tasks only:** `cd src/StaticWebAssetsSdk/Tasks; dotnet build` (~15 s, inner loop)
-- **Build test project:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj -c Debug --no-restore`
-- **Run filtered tests:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll --no-build --filter "FullyQualifiedName~ClassName"`
-- **Run all unit tests:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe test artifacts\bin\Microsoft.NET.Sdk.StaticWebAssets.Tests\Debug\net11.0\Microsoft.NET.Sdk.StaticWebAssets.Tests.dll --no-build --filter "FullyQualifiedName!~IntegrationTest"`
+- **Run filtered tests:** `.\.dotnet\dotnet.exe scripts\RunTests.cs -- --project test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj --filter "FullyQualifiedName~ClassName"`
+- **Run all unit tests:** `.\.dotnet\dotnet.exe scripts\RunTests.cs -- --project test\Microsoft.NET.Sdk.StaticWebAssets.Tests\Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj --filter "FullyQualifiedName!~IntegrationTest"`
 - **Test with a real project:** `.\artifacts\bin\redist\Debug\dotnet\dotnet.exe build <project> -bl`
 
 ## Project Knowledge
@@ -32,7 +31,7 @@ Read `src/StaticWebAssetsSdk/AGENTS.md` at the start of every session — it has
 
 ## Boundaries
 
-- ✅ **Always do:** Read AGENTS.md at session start, patch instead of full-building when only SWA files changed, use `--filter` during development, build the test project before running tests after code changes, validate through the full process before declaring done.
+- ✅ **Always do:** Read AGENTS.md at session start, patch instead of full-building when only SWA files changed, use `run-tests` with a filter during development, validate through the full process before declaring done.
 - ⚠️ **Ask first:** Before running `.\build.cmd`, before editing files outside `src/StaticWebAssetsSdk/` and `test/Microsoft.NET.Sdk.StaticWebAssets.Tests/`, before running the full unfiltered test suite, before modifying shared test asset projects.
 - 🚫 **Never do:** Modify the system-installed dotnet SDK, push commits, run `git clean -xdff` without reviewing unstaged files or `git reset --hard`, skip steps in the process, run integration tests during the inner development loop.
 
@@ -65,9 +64,8 @@ This is the fast feedback cycle. Do not write or run tests during this phase.
 
 Once the change works manually, run tests. The goal is fast regression detection while avoiding slow integration and baseline tests.
 
-1. **Build the test project** — required after any code change so the test DLL picks up the new code.
-2. **Run affected unit test classes** — unit tests live in `StaticWebAssets/` and do not extend SDK base classes. Filter to the specific class you changed or added.
-3. **Run all unit tests** — use the `!~IntegrationTest` filter to run every unit test without triggering integration or baseline tests. This catches regressions outside the class you focused on.
+1. **Run affected unit test classes** — `run-tests` builds the test project first so the test DLL is current. Unit tests live in `StaticWebAssets/` and do not extend SDK base classes. Filter to the specific class you changed or added.
+2. **Run all unit tests** — use the `!~IntegrationTest` filter to run every unit test without triggering integration or baseline tests. This catches regressions outside the class you focused on.
 
 Fix any failures before proceeding.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,20 +151,12 @@ Canonical scenarios:
     that resolves against this repo.
   - The built SDK is output to `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
   - The first build is slow; subsequent builds are incremental.
-- Run tests through the `run-tests` skill — prefer a single test project, class, or method
-  (see the [Testing](#testing) section). `build.cmd -test` /
-  `./build.sh --test` runs the **entire** suite, which is very large and takes a long time;
-  avoid running the full suite for routine local or agent work.
+- Run tests through the `run-tests` skill. It selects the appropriate focused, scoped, or
+  full-suite workflow and retains actionable diagnostics for focused runs (see
+  [Testing](#testing)).
 - Release build: `build.cmd -c Release`.
-- Run a single test through the centralized runner:
-  `./.dotnet/dotnet scripts/RunTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "FullyQualifiedName~TestName"`.
-  See the [Testing](#testing) section for project selection and more examples.
 - Validate changes locally using the SDK you built at
   `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
-- Use the `run-tests` skill to select projects from the shared
-  `test/ConditionalTests.props` scopes when available and retain detailed failure output,
-  a TRX, and a binlog. For fast inner-loop runs of `dotnet.Tests` without a full rebuild,
-  use `incremental-test`.
 
 ## Guardrails
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,17 +151,17 @@ Canonical scenarios:
     that resolves against this repo.
   - The built SDK is output to `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
   - The first build is slow; subsequent builds are incremental.
-- Run tests: prefer targeted runs — a single test project or test (see the
-  [Testing](#testing) section) and the `targeted-test` skill. `build.cmd -test` /
+- Run tests through the `run-tests` skill — prefer a single test project, class, or method
+  (see the [Testing](#testing) section). `build.cmd -test` /
   `./build.sh --test` runs the **entire** suite, which is very large and takes a long time;
   avoid running the full suite for routine local or agent work.
 - Release build: `build.cmd -c Release`.
-- Run a single test project after a full build:
-  `./.dotnet/dotnet test test/dotnet.Tests/dotnet.Tests.csproj --filter "FullyQualifiedName~TestName"`.
-  See the [Testing](#testing) section for assembly filtering and more examples.
+- Run a single test through the centralized runner:
+  `./.dotnet/dotnet scripts/RunTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "FullyQualifiedName~TestName"`.
+  See the [Testing](#testing) section for project selection and more examples.
 - Validate changes locally using the SDK you built at
   `artifacts/bin/redist/<configuration>/dotnet` (`Debug` by default).
-- Use the `targeted-test` skill to select projects from the shared
+- Use the `run-tests` skill to select projects from the shared
   `test/ConditionalTests.props` scopes when available and retain detailed failure output,
   a TRX, and a binlog. For fast inner-loop runs of `dotnet.Tests` without a full rebuild,
   use `incremental-test`.
@@ -256,7 +256,8 @@ property:
 
 - Large changes should always include test changes.
 - The Skip parameter of the Fact attribute to point to the specific issue link.
-- Use the `targeted-test` skill to choose projects from `test/ConditionalTests.props`
+- Use the `run-tests` skill for every local test execution. Choose projects from
+  `test/ConditionalTests.props`
   when the changed paths match a configured scope, or use its fallback mappings for
   unscoped common areas. Run one project, class, or method with detailed live output and
   retained TRX/binlog diagnostics.

--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -359,4 +359,4 @@ Report:
 - **code-review** - findings-first review presentation for PR or local changes.
 - **dotnet-aot-compat** - resolve IL trim/AOT warnings surfaced by native publish.
 - **incremental-test** - run managed `dotnet.Tests` against the redist SDK layout.
-- **targeted-test** - select and run the smallest relevant SDK tests with retained diagnostics.
+- **run-tests** - select and run SDK tests through the diagnostic-preserving local entry point.

--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -195,8 +195,9 @@ and binary-size delta.
 - **`DotnetCsproj` is defined for dotnet-aot.** A newly linked file can expose extra conditional code.
   Inspect that closure and narrow the owning conditional; do not copy a helper merely to avoid tracing it.
 - **Do not pass `-noRestore` with `-getItem`.** The response file already appends it (`MSB1001`).
-- **`dotnet-aot.Tests` uses Microsoft.Testing.Platform.** Use `run-tests` for a focused managed
-  iteration and `run-aot-tests.ps1` for native execution.
+- **`dotnet-aot.Tests` uses Microsoft.Testing.Platform.** Invoke the
+  [`run-tests`](../run-tests/SKILL.md) skill for a
+  focused managed iteration and use `run-aot-tests.ps1` for native execution.
 - **Existing tests may assert exclusions.** Search before enabling a command; an intentional
   `DoesNotContain` can need a carefully justified inversion.
 - **A Roslyn pragma is not native-publish evidence.** ILC can report the same trim/AOT warning during
@@ -264,19 +265,17 @@ Common blockers:
 
 ## Validation ladder
 
-Run the cheapest discriminating check after each edit, then broaden. Use the **run-tests** skill when
+Run the cheapest discriminating check after each edit, then broaden. Invoke the
+[`run-tests`](../run-tests/SKILL.md) skill when
 the request explicitly asks to select or run SDK tests.
 
 ### 1. Focused parser/entry-point test
 
-Use the run-tests runner so it builds the project, resolves the evaluated `TargetPath`, and invokes
-the Microsoft.Testing.Platform application without assuming its generated executable is on `PATH`:
-
-```powershell
-.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
-  --project test\dotnet-aot.Tests\dotnet-aot.Tests.csproj `
-  --filter "FullyQualifiedName~<name>"
-```
+Invoke the [`run-tests`](../run-tests/SKILL.md) skill for
+`test/dotnet-aot.Tests/dotnet-aot.Tests.csproj` with a
+filter for the affected test. It builds the project, resolves the evaluated `TargetPath`,
+and invokes the Microsoft.Testing.Platform application without assuming its generated
+executable is on `PATH`.
 
 Record whether the test asserts AOT handling, fallback, or semantics. Do not call this a native run.
 
@@ -359,4 +358,4 @@ Report:
 - **code-review** - findings-first review presentation for PR or local changes.
 - **dotnet-aot-compat** - resolve IL trim/AOT warnings surfaced by native publish.
 - **incremental-test** - run managed `dotnet.Tests` against the redist SDK layout.
-- **run-tests** - select and run SDK tests through the diagnostic-preserving local entry point.
+- [**run-tests**](../run-tests/SKILL.md) - select and run SDK tests through the diagnostic-preserving local entry point.

--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -195,8 +195,8 @@ and binary-size delta.
 - **`DotnetCsproj` is defined for dotnet-aot.** A newly linked file can expose extra conditional code.
   Inspect that closure and narrow the owning conditional; do not copy a helper merely to avoid tracing it.
 - **Do not pass `-noRestore` with `-getItem`.** The response file already appends it (`MSB1001`).
-- **`dotnet-aot.Tests` uses Microsoft.Testing.Platform.** `dotnet test` is not the runner; invoke the
-  built executable for a focused managed iteration or use `run-aot-tests.ps1` for native execution.
+- **`dotnet-aot.Tests` uses Microsoft.Testing.Platform.** Use `run-tests` for a focused managed
+  iteration and `run-aot-tests.ps1` for native execution.
 - **Existing tests may assert exclusions.** Search before enabling a command; an intentional
   `DoesNotContain` can need a carefully justified inversion.
 - **A Roslyn pragma is not native-publish evidence.** ILC can report the same trim/AOT warning during
@@ -264,16 +264,16 @@ Common blockers:
 
 ## Validation ladder
 
-Run the cheapest discriminating check after each edit, then broaden. Use the **targeted-test** skill when
-the request explicitly asks to select or run narrow SDK tests.
+Run the cheapest discriminating check after each edit, then broaden. Use the **run-tests** skill when
+the request explicitly asks to select or run SDK tests.
 
 ### 1. Focused parser/entry-point test
 
-Use the targeted-test runner so it builds the project, resolves the evaluated `TargetPath`, and invokes
+Use the run-tests runner so it builds the project, resolves the evaluated `TargetPath`, and invokes
 the Microsoft.Testing.Platform application without assuming its generated executable is on `PATH`:
 
 ```powershell
-.\.dotnet\dotnet.exe .github\skills\targeted-test\scripts\RunTargetedTests.cs -- `
+.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
   --project test\dotnet-aot.Tests\dotnet-aot.Tests.csproj `
   --filter "FullyQualifiedName~<name>"
 ```

--- a/.github/skills/add-net-analyzer/SKILL.md
+++ b/.github/skills/add-net-analyzer/SKILL.md
@@ -141,12 +141,12 @@ mirroring the analyzer's folder. Full conventions are in
 ```powershell
 # ~10s incremental once .dotnet is provisioned; the first run provisions it.
 ./build.cmd -projects src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.slnx -c Debug
-
-.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
-  --project src\Microsoft.CodeAnalysis.NetAnalyzers\tests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj `
-  --filter "FullyQualifiedName~<Name>Tests" `
-  --skip-redist-check
 ```
+
+Then invoke the [`run-tests`](../run-tests/SKILL.md) skill for
+`src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj`
+with a filter for `<Name>Tests`. This project does not consume the assembled SDK, so the
+runner may skip its redist check.
 
 Then `git status` and commit the regenerated files along with your change. `./build.sh` on
 Linux/macOS; never pass `-restore`/`-build` alongside `-projects`.

--- a/.github/skills/add-net-analyzer/SKILL.md
+++ b/.github/skills/add-net-analyzer/SKILL.md
@@ -142,7 +142,10 @@ mirroring the analyzer's folder. Full conventions are in
 # ~10s incremental once .dotnet is provisioned; the first run provisions it.
 ./build.cmd -projects src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.slnx -c Debug
 
-./.dotnet/dotnet test src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj --filter "FullyQualifiedName~<Name>Tests"
+.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
+  --project src\Microsoft.CodeAnalysis.NetAnalyzers\tests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj `
+  --filter "FullyQualifiedName~<Name>Tests" `
+  --skip-redist-check
 ```
 
 Then `git status` and commit the regenerated files along with your change. `./build.sh` on
@@ -186,4 +189,3 @@ dead help link in every user's IDE.
 - [ ] Every shape the fix offers itself on produces compiling code.
 - [ ] Rule run against a real codebase and hits triaged, at `IdeSuggestion` or stronger.
 - [ ] `dotnet/docs` PR raised with the user as a condition of merging.
-

--- a/.github/skills/incremental-test/SKILL.md
+++ b/.github/skills/incremental-test/SKILL.md
@@ -70,21 +70,13 @@ Copy-Item artifacts\bin\dotnet\Debug\net10.0\dotnet.dll artifacts\bin\redist\Deb
 - Some projects multi-target (e.g., `net10.0` and `net472`). Always use the `net10.0` output.
 - If localization resource DLLs were changed (in subdirectories like `cs\`, `de\`, etc.), copy those too.
 
-### Step 4: Build the test project (if test code was modified)
+### Step 4: Run the tests
 
-The test project `test\dotnet.Tests\dotnet.Tests.csproj` outputs directly to `artifacts\bin\redist\Debug\` (via `TestHostFolder`), so just build it:
-
-```
-.\.dotnet\dotnet build test\dotnet.Tests\dotnet.Tests.csproj
-```
-
-### Step 5: Run the tests
-
-Use the **targeted-test** runner so failures retain detailed output, a TRX, and a
-binlog:
+Use the **run-tests** runner so the test project is built incrementally and failures
+retain detailed output, a TRX, and a binlog:
 
 ```shell
-./.dotnet/dotnet .github/skills/targeted-test/scripts/RunTargetedTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~TestMethodName" --no-build
+./.dotnet/dotnet scripts/RunTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~TestMethodName"
 ```
 
 ## Common project paths

--- a/.github/skills/incremental-test/SKILL.md
+++ b/.github/skills/incremental-test/SKILL.md
@@ -72,12 +72,9 @@ Copy-Item artifacts\bin\dotnet\Debug\net10.0\dotnet.dll artifacts\bin\redist\Deb
 
 ### Step 4: Run the tests
 
-Use the **run-tests** runner so the test project is built incrementally and failures
-retain detailed output, a TRX, and a binlog:
-
-```shell
-./.dotnet/dotnet scripts/RunTests.cs -- --project test/dotnet.Tests/dotnet.Tests.csproj --filter "Name~TestMethodName"
-```
+Invoke the [`run-tests`](../run-tests/SKILL.md) skill for `test/dotnet.Tests/dotnet.Tests.csproj` with a filter for
+the affected tests. It builds the test project incrementally and retains detailed output,
+a TRX, and a binlog.
 
 ## Common project paths
 

--- a/.github/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/.github/skills/migrate-xunit-to-mstest/SKILL.md
@@ -504,7 +504,7 @@ Custom orderers/test framework hooks must be reimplemented against MSTest's exte
 ### Step 13: Build and verify parity
 
 1. `dotnet build` -- must succeed with zero errors. Address remaining errors using the mapping reference.
-2. `dotnet test` -- run with the **same** filter/runner combination as before migration.
+2. Use **run-tests** with the same project, framework, and filter as the Step 1.7 baseline.
 3. **Compare pass/fail counts** to the baseline from Step 1.7. Investigate any deltas:
    - **New failures on shared-state tests** -- you enabled parallelization (Choice A/C in Step 11) and tests are now stomping each other. Add `[DoNotParallelize]` to the specific class(es), or fix the shared state.
    - **Tests previously parallel now serial (wall-clock much longer)** -- you forgot `[assembly: Parallelize]`. See Step 11 Choice A.

--- a/.github/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/.github/skills/migrate-xunit-to-mstest/SKILL.md
@@ -504,7 +504,7 @@ Custom orderers/test framework hooks must be reimplemented against MSTest's exte
 ### Step 13: Build and verify parity
 
 1. `dotnet build` -- must succeed with zero errors. Address remaining errors using the mapping reference.
-2. Use **run-tests** with the same project, framework, and filter as the Step 1.7 baseline.
+2. Invoke the [`run-tests`](../run-tests/SKILL.md) skill to test the same project, framework, and filter as the Step 1.7 baseline.
 3. **Compare pass/fail counts** to the baseline from Step 1.7. Investigate any deltas:
    - **New failures on shared-state tests** -- you enabled parallelization (Choice A/C in Step 11) and tests are now stomping each other. Add `[DoNotParallelize]` to the specific class(es), or fix the shared state.
    - **Tests previously parallel now serial (wall-clock much longer)** -- you forgot `[assembly: Parallelize]`. See Step 11 Choice A.

--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   entry point. REQUIRED whenever an agent will select, run, or rerun local dotnet/sdk
   tests, including a project, class, method, targeted test, focused test, smallest
   relevant test, or completed-change validation. NEVER invoke when the user says not to
-  run tests yet. DO NOT USE for the complete repository test suite.
+  run tests yet.
 license: MIT
 ---
 
@@ -15,6 +15,15 @@ Use this workflow for every local SDK test execution. Select the smallest projec
 filter that cover the changed behavior, then invoke the centralized runner. It streams
 detailed output and writes a TRX plus an MSBuild binlog under
 `artifacts/log/test-runs/`.
+
+## Choose the execution scope
+
+- For one test, class, or project, invoke `scripts/RunTests.cs` as described below.
+- For an area represented in `test/ConditionalTests.props`, expand the scope and invoke
+  `scripts/RunTests.cs` once per concrete project.
+- When the user explicitly requests the complete repository test suite, explain that it
+  is very large and then run `build.cmd -test` on Windows or `./build.sh --test` on
+  macOS/Linux. Do not use the complete suite for routine validation.
 
 ## Select configured test scopes first
 

--- a/.github/skills/run-tests/SKILL.md
+++ b/.github/skills/run-tests/SKILL.md
@@ -1,22 +1,20 @@
 ---
-name: targeted-test
+name: run-tests
 description: >-
-  Select and run the smallest relevant .NET SDK tests with live output and retained
-  TRX/binlog diagnostics. REQUIRED: invoke before answering any dotnet/sdk request
-  containing an explicit deliverable to select, run, or rerun narrow local tests. Use
-  the owning workflow for the change, then this skill for test selection and execution.
-  Also use to test a completed change, choose tests from changed files, run targeted,
-  focused, or smallest relevant tests, or run one project, class, or method, including
-  plans and dry runs. NEVER invoke when the user says not to run tests yet. DO NOT USE
-  for full suites, end-to-end validation, repo investigations, or review.
+  Select and run .NET SDK tests through the repository's diagnostic-preserving test
+  entry point. REQUIRED whenever an agent will select, run, or rerun local dotnet/sdk
+  tests, including a project, class, method, targeted test, focused test, smallest
+  relevant test, or completed-change validation. NEVER invoke when the user says not to
+  run tests yet. DO NOT USE for the complete repository test suite.
 license: MIT
 ---
 
-# Targeted tests
+# Run tests
 
-Run the smallest project and filter that cover the changed behavior. This workflow
-streams detailed test output and writes a TRX plus an MSBuild binlog under
-`artifacts/log/targeted-tests/`.
+Use this workflow for every local SDK test execution. Select the smallest project and
+filter that cover the changed behavior, then invoke the centralized runner. It streams
+detailed output and writes a TRX plus an MSBuild binlog under
+`artifacts/log/test-runs/`.
 
 ## Select configured test scopes first
 
@@ -89,19 +87,23 @@ assemblies built beside the test project.
    - Otherwise rebuild the repository. Building only a test project can leave the SDK
      under test stale even when the test assembly itself is current.
 3. If only test code changed, the runner can build the selected test project directly.
+4. Tests that do not exercise the assembled SDK, such as NetAnalyzers unit tests, may
+   pass `--skip-redist-check`. Use it only when the owning workflow confirms that the
+   project does not consume `artifacts/bin/redist`; it does not make stale product bits
+   safe to test.
 
 ## Run
 
-Start with a build-producing run. The runner builds the selected project by default,
-which keeps the test assembly current and produces the binlog needed to diagnose build
-failures. Add `--no-build` only after this session built that exact project after the
-latest test-code change and confirmed its expected output exists. Do not infer readiness
-from another project or an older artifact; when uncertain, omit `--no-build`.
+The runner always performs an incremental build of the selected test project before
+execution. This keeps the test assembly current and guarantees that the run reports an
+MSBuild binlog path. Do not replace the runner with a hand-written `dotnet test`,
+`dotnet exec`, or test-application command: those commands can execute zero tests under
+the wrong platform or omit the diagnostics needed after a failure.
 
 From the repository root on Windows:
 
 ```powershell
-.\.dotnet\dotnet.exe .github\skills\targeted-test\scripts\RunTargetedTests.cs -- `
+.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
   --project test\Microsoft.NET.Build.Tests\Microsoft.NET.Build.Tests.csproj `
   --filter "FullyQualifiedName~GivenThatWeWantToBuildALibrary"
 ```
@@ -109,17 +111,19 @@ From the repository root on Windows:
 On macOS/Linux:
 
 ```bash
-./.dotnet/dotnet .github/skills/targeted-test/scripts/RunTargetedTests.cs -- \
+./.dotnet/dotnet scripts/RunTests.cs -- \
   --project test/Microsoft.NET.Build.Tests/Microsoft.NET.Build.Tests.csproj \
   --filter "FullyQualifiedName~GivenThatWeWantToBuildALibrary"
 ```
 
-Omit `--filter` to run the whole project. Use `--configuration Release` when validating
-a Release redist layout. A `--no-build` run does not produce a new build binlog.
+Omit `--filter` to run the whole project. Multi-targeted projects select
+`SdkTargetFramework` by default; pass `--framework <TFM>` to choose another supported
+target. Use `--configuration Release` when validating a Release redist layout. Unfiltered
+project runs can be expensive; do not treat one as the complete repository suite.
 
-The runner evaluates the project to select its test platform. It executes MSTest.Sdk
-projects through their built Microsoft.Testing.Platform executable and keeps
-`dotnet test` for other projects. It prints the exact command before execution. On
-failure it also prints failed test names when a TRX is available, the retained
-TRX/binlog paths, and the rerun command. Do not replace it with a command that
-suppresses console output or discards those artifacts.
+All supported SDK test projects use MSTest.Sdk/Microsoft.Testing.Platform. The runner
+evaluates the selected framework, builds it, then invokes its test application directly.
+It only requests a TRX when the project enables the TRX report extension. It prints the
+run directory and exact command before execution. At completion it prints the retained
+TRX/binlog paths; on failure it also prints failed test names when a TRX is available and
+the rerun command.

--- a/documentation/project-docs/developer-guide.md
+++ b/documentation/project-docs/developer-guide.md
@@ -153,12 +153,15 @@ Run "dotnet --debug <command>" which will launch dotnet and pause waiting for us
 
 ## Run tests from the command line
 
-```shell
+```powershell
 build.cmd # to have a full build first
-.\artifacts\sdk-build-env.bat
-cd test\YOURTEST.Tests # cd to the test folder that contains the test csproj file
-dotnet test --filter "FullyQualifiedName~TESTNAME" # run individual test
+.\.dotnet\dotnet.exe scripts\RunTests.cs -- `
+  --project test\YOURTEST.Tests\YOURTEST.Tests.csproj `
+  --filter "FullyQualifiedName~TESTNAME"
 ```
+
+The runner builds the selected test project incrementally and retains its TRX and MSBuild
+binlog paths under `artifacts/log/test-runs/`.
 
 ## Run tests in Visual Studio
 

--- a/documentation/project-docs/pr-test-filtering.md
+++ b/documentation/project-docs/pr-test-filtering.md
@@ -157,7 +157,7 @@ scope into concrete project paths with:
 The command writes one repo-relative `Targeted test project:` line for each project
 matched by the scope's `TestProjects` globs. Run those projects individually so a
 failure identifies the affected project. The
-[`targeted-test`](../../.github/skills/targeted-test/SKILL.md) agent skill provides the
+[`run-tests`](../../.github/skills/run-tests/SKILL.md) agent skill provides the
 runner and fallback mappings for change areas that do not yet have a `ConditionalTestScope`.
 
 If a changed file matches `GlobalTriggerPaths`, do not use an individual conditional
@@ -168,7 +168,7 @@ shared changes.
 
 1. Add a `<ConditionalTestScope>` item in `test/ConditionalTests.props`.
 2. Reconcile the fallback table in the
-   [`targeted-test`](../../.github/skills/targeted-test/SKILL.md) agent skill. Remove an
+   [`run-tests`](../../.github/skills/run-tests/SKILL.md) agent skill. Remove an
    entry when the new scope now covers that area, or update it if test-project ownership
    changed. Do not copy configured mappings into the fallback table.
 3. The evaluation script and `UnitTests.proj` are generic and require no per-scope
@@ -254,7 +254,7 @@ too coarse, it can be tuned later — see [Future enhancements](#future-enhancem
 
 - **Single source of truth**: `test/ConditionalTests.props` defines everything about a
   scope — trigger paths, projects, and conditions. The
-  [`targeted-test`](../../.github/skills/targeted-test/SKILL.md) skill reads these mappings
+  [`run-tests`](../../.github/skills/run-tests/SKILL.md) skill reads these mappings
   directly; its separate fallback table contains only common unscoped areas and must be
   reconciled when scopes or test-project ownership change.
 - **Safe by default**: when in doubt, tests run. The system only skips tests when it has

--- a/scripts/RunTests.cs
+++ b/scripts/RunTests.cs
@@ -3,6 +3,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Contributor-facing entry point for local dotnet/sdk test execution.
+
 #:package System.CommandLine
 
 using System.CommandLine;
@@ -22,7 +24,7 @@ Option<string> projectOption = new("--project")
 Option<string?> filterOption = new("--filter")
 {
     Arity = ArgumentArity.ExactlyOne,
-    Description = "VSTest filter, for example FullyQualifiedName~TestClass."
+    Description = "Test filter expression, for example FullyQualifiedName~TestClass."
 };
 Option<string> configurationOption = new("--configuration", "-c")
 {
@@ -39,28 +41,28 @@ configurationOption.Validators.Add(optionResult =>
         optionResult.AddError($"Unsupported configuration '{configuration}'. Use Debug or Release.");
     }
 });
-Option<bool> noBuildOption = new("--no-build")
-{
-    Description = "Do not build the test project before running it."
-};
-Option<string?> repoRootOption = new("--repo-root")
+Option<string?> frameworkOption = new("--framework", "-f")
 {
     Arity = ArgumentArity.ExactlyOne,
-    Description = "Repository root; inferred from the current directory by default."
+    Description = "Target framework to run. Multi-targeted projects default to SdkTargetFramework, then their first TFM."
+};
+Option<bool> skipRedistCheckOption = new("--skip-redist-check")
+{
+    Description = "Allow tests that do not exercise the assembled SDK to run without a redist layout."
 };
 
 rootCommand.Options.Add(projectOption);
 rootCommand.Options.Add(filterOption);
 rootCommand.Options.Add(configurationOption);
-rootCommand.Options.Add(noBuildOption);
-rootCommand.Options.Add(repoRootOption);
+rootCommand.Options.Add(frameworkOption);
+rootCommand.Options.Add(skipRedistCheckOption);
 
 rootCommand.SetAction((parseResult, cancellationToken) => RunAsync(
     parseResult.GetValue(projectOption)!,
     parseResult.GetValue(filterOption),
     parseResult.GetValue(configurationOption)!,
-    parseResult.GetValue(noBuildOption),
-    parseResult.GetValue(repoRootOption),
+    parseResult.GetValue(frameworkOption),
+    parseResult.GetValue(skipRedistCheckOption),
     cancellationToken));
 
 return await rootCommand
@@ -71,8 +73,8 @@ static async Task<int> RunAsync(
     string project,
     string? filter,
     string configuration,
-    bool noBuild,
-    string? repoRootArgument,
+    string? framework,
+    bool skipRedistCheck,
     CancellationToken cancellationToken)
 {
     cancellationToken.ThrowIfCancellationRequested();
@@ -80,13 +82,10 @@ static async Task<int> RunAsync(
     // Resolve every path from the repository root. Agents may launch this script from a
     // subdirectory, and allowing the current directory to influence individual paths would
     // make the same command target different projects or artifact locations.
-    var repoRoot = repoRootArgument is null
-        ? FindRepoRoot(Environment.CurrentDirectory)
-        : Path.GetFullPath(repoRootArgument);
-    if (repoRoot is null || !IsRepoRoot(repoRoot))
+    var repoRoot = FindRepoRoot(Environment.CurrentDirectory);
+    if (repoRoot is null)
     {
-        return Fail(
-            "Could not find the dotnet/sdk repository root. Run from inside the checkout or pass --repo-root <path>.");
+        return Fail("Could not find the dotnet/sdk repository root. Run from inside the checkout.");
     }
 
     var projectPath = Path.GetFullPath(project, repoRoot);
@@ -126,12 +125,12 @@ static async Task<int> RunAsync(
     // while still testing stale or missing product bits, so fail early when that layout does
     // not exist instead of producing a misleading test result.
     var redistRoot = Path.Combine(repoRoot, "artifacts", "bin", "redist", configuration, "dotnet");
-    if (!Directory.Exists(redistRoot))
+    if (!skipRedistCheck && !Directory.Exists(redistRoot))
     {
         return Fail(
             $"The {configuration} redist SDK does not exist at {redistRoot}.{Environment.NewLine}"
-            + $"Run {(OperatingSystem.IsWindows() ? @".\build.cmd" : "./build.sh")} "
-            + $"{(configuration.Equals("Release", StringComparison.OrdinalIgnoreCase) ? "-c Release" : "")} first.");
+            + $"Run {(OperatingSystem.IsWindows() ? @".\build.cmd" : "./build.sh")}"
+            + $"{(configuration.Equals("Release", StringComparison.OrdinalIgnoreCase) ? " -c Release" : string.Empty)} first.");
     }
 
     // Give each invocation its own directory. The timestamp makes runs easy to inspect while
@@ -141,128 +140,224 @@ static async Task<int> RunAsync(
         repoRoot,
         "artifacts",
         "log",
-        "targeted-tests",
+        "test-runs",
         projectName,
         $"{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Environment.ProcessId}");
     Directory.CreateDirectory(runDirectory);
 
     var trxPath = Path.Combine(runDirectory, "test-results.trx");
     var binlogPath = Path.Combine(runDirectory, "build.binlog");
+    var rerunCommand = GetRerunCommand(
+        dotnetPath,
+        repoRoot,
+        relativeProjectPath,
+        configuration,
+        framework,
+        filter,
+        skipRedistCheck);
 
-    // The repository contains both MSTest.Sdk/Microsoft.Testing.Platform projects and projects
-    // that still run through `dotnet test`. Query evaluated MSBuild properties instead of
-    // guessing from package references or project text, which may be supplied by imports.
+    // Query evaluated MSBuild properties instead of guessing from project text, which may be
+    // supplied by imports.
     var projectProperties = await GetProjectProperties(
         dotnetPath,
         projectPath,
         configuration,
+        framework,
         repoRoot,
         cancellationToken);
     if (projectProperties is null)
     {
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
         return 1;
     }
+    framework = projectProperties.TargetFramework;
+    rerunCommand = GetRerunCommand(
+        dotnetPath,
+        repoRoot,
+        relativeProjectPath,
+        configuration,
+        framework,
+        filter,
+        skipRedistCheck);
 
-    // MSTest.Sdk projects are executable test applications. Build them explicitly so the
-    // build failure has its own exit code and binlog, then execute TargetPath below. Running
-    // `dotnet test` for these projects can succeed while discovering zero tests.
-    if (projectProperties.Value.UsesMSTestSdk && !noBuild)
+    if (!projectProperties.UsesMSTestSdk)
     {
-        var buildArguments = new List<string>
-        {
-            "build",
-            projectPath,
-            "--configuration",
-            configuration,
-            "--nologo",
-            $"-bl:{binlogPath}"
-        };
-        Console.WriteLine($"Build command: {FormatCommand(dotnetPath, buildArguments, repoRoot)}");
-        Console.WriteLine();
-        var buildExitCode = await RunProcess(dotnetPath, buildArguments, repoRoot, cancellationToken);
-        if (buildExitCode != 0)
-        {
-            Console.Error.WriteLine($"Targeted test project build failed with exit code {buildExitCode}.");
-            PrintArtifacts(repoRoot, trxPath, binlogPath);
-            return buildExitCode;
-        }
+        var exitCode = Fail(
+            "The project does not use MSTest.Sdk. All supported dotnet/sdk test projects "
+            + "must use the repository's Microsoft.Testing.Platform configuration.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
+        return exitCode;
     }
 
-    // Microsoft.Testing.Platform accepts test options after the assembly path, while the
-    // traditional path accepts them through `dotnet test`. Construct the appropriate command
-    // once so logging, filtering, display, and rerun guidance all describe the exact process.
-    var testArguments = projectProperties.Value.UsesMSTestSdk
-        ? new List<string>
-        {
-            "exec",
-            projectProperties.Value.TargetPath,
-            "--report-trx",
-            "--report-trx-filename",
-            "test-results.trx",
-            "--results-directory",
-            runDirectory
-        }
-        : new List<string>
-        {
-            "test",
-            projectPath,
-            "--configuration",
-            configuration,
-            "--logger",
-            "console;verbosity=detailed",
-            "--logger",
-            "trx;LogFileName=test-results.trx",
-            "--results-directory",
-            runDirectory,
-            $"-bl:{binlogPath}"
-        };
-
-    // The explicit MSTest.Sdk build above is already skipped when --no-build is set. Only the
-    // `dotnet test` command needs the switch forwarded.
-    if (noBuild && !projectProperties.Value.UsesMSTestSdk)
+    int buildExitCode = await BuildTestProject(
+        dotnetPath,
+        projectPath,
+        configuration,
+        framework,
+        binlogPath,
+        repoRoot,
+        cancellationToken);
+    if (buildExitCode != 0)
     {
-        testArguments.Add("--no-build");
+        Console.Error.WriteLine($"Test project build failed with exit code {buildExitCode}.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
+        return buildExitCode;
+    }
+
+    if (!projectProperties.IsTestApplication)
+    {
+        var exitCode = Fail(
+            $"The project uses MSTest.Sdk but IsTestApplication is false for this configuration. "
+            + "It cannot be executed as a Microsoft.Testing.Platform test application on this platform.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
+        return exitCode;
+    }
+
+    if (string.Equals(
+        projectProperties.TargetFrameworkIdentifier,
+        ".NETFramework",
+        StringComparison.OrdinalIgnoreCase)
+        && !OperatingSystem.IsWindows())
+    {
+        var exitCode = Fail(
+            $"Target framework '{framework}' requires a .NET Framework test executable, "
+            + "which can only run on Windows.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
+        return exitCode;
+    }
+
+    if (!File.Exists(projectProperties.TargetPath))
+    {
+        var exitCode = Fail(
+            $"Built MSTest test assembly not found at {projectProperties.TargetPath}. "
+            + "The test project build completed without producing its expected output.");
+        PrintArtifacts(repoRoot, trxPath, binlogPath);
+        Console.Error.WriteLine($"Rerun: {rerunCommand}");
+        return exitCode;
+    }
+
+    TestInvocation invocation = CreateTestInvocation(
+        dotnetPath,
+        projectProperties,
+        runDirectory,
+        filter);
+    Console.WriteLine($"Project: {relativeProjectPath}");
+    Console.WriteLine($"Framework: {framework}");
+    Console.WriteLine($"Run directory: {Path.GetRelativePath(repoRoot, runDirectory)}");
+    Console.WriteLine($"Command: {FormatCommand(invocation.Executable, invocation.Arguments, repoRoot)}");
+    Console.WriteLine();
+
+    int testExitCode = await RunProcess(
+        invocation.Executable,
+        invocation.Arguments,
+        repoRoot,
+        cancellationToken);
+    return ReportTestResult(
+        testExitCode,
+        repoRoot,
+        trxPath,
+        binlogPath,
+        rerunCommand);
+}
+
+static async Task<int> BuildTestProject(
+    string dotnetPath,
+    string projectPath,
+    string configuration,
+    string? framework,
+    string binlogPath,
+    string repoRoot,
+    CancellationToken cancellationToken)
+{
+    var arguments = new List<string>
+    {
+        "build",
+        projectPath,
+        "--configuration",
+        configuration,
+        "--nologo",
+        $"-bl:{binlogPath}"
+    };
+    if (!string.IsNullOrWhiteSpace(framework))
+    {
+        arguments.Add("--framework");
+        arguments.Add(framework);
+    }
+
+    Console.WriteLine($"Build command: {FormatCommand(dotnetPath, arguments, repoRoot)}");
+    Console.WriteLine();
+    return await RunProcess(dotnetPath, arguments, repoRoot, cancellationToken);
+}
+
+static TestInvocation CreateTestInvocation(
+    string dotnetPath,
+    TestProjectProperties projectProperties,
+    string runDirectory,
+    string? filter)
+{
+    string executable;
+    List<string> arguments;
+    if (string.Equals(
+        projectProperties.TargetFrameworkIdentifier,
+        ".NETFramework",
+        StringComparison.OrdinalIgnoreCase))
+    {
+        executable = projectProperties.TargetPath;
+        arguments = [];
+    }
+    else
+    {
+        executable = dotnetPath;
+        arguments = ["exec", projectProperties.TargetPath];
+    }
+
+    if (projectProperties.TrxReportEnabled)
+    {
+        arguments.Add("--report-trx");
+        arguments.Add("--report-trx-filename");
+        arguments.Add("test-results.trx");
+        arguments.Add("--results-directory");
+        arguments.Add(runDirectory);
+    }
+    else
+    {
+        Console.Error.WriteLine(
+            "The project does not enable Microsoft.Testing.Extensions.TrxReport; "
+            + "the test run will continue without a TRX.");
     }
 
     if (!string.IsNullOrWhiteSpace(filter))
     {
-        testArguments.Add("--filter");
-        testArguments.Add(filter);
+        arguments.Add("--filter");
+        arguments.Add(filter);
     }
 
-    // Print the command before execution so live logs remain useful if the process hangs or is
-    // cancelled before it can produce a TRX.
-    var displayCommand = FormatCommand(dotnetPath, testArguments, repoRoot);
-    Console.WriteLine($"Project: {relativeProjectPath}");
-    Console.WriteLine($"Artifacts: {Path.GetRelativePath(repoRoot, runDirectory)}");
-    Console.WriteLine($"Command: {displayCommand}");
+    return new TestInvocation(executable, arguments);
+}
+
+static int ReportTestResult(
+    int exitCode,
+    string repoRoot,
+    string trxPath,
+    string binlogPath,
+    string rerunCommand)
+{
     Console.WriteLine();
-
-    // In --no-build mode, TargetPath may describe where output would be written even when the
-    // file is absent. Detect that case here and explain how to recover instead of forwarding a
-    // less actionable dotnet exec "file not found" error.
-    if (projectProperties.Value.UsesMSTestSdk && !File.Exists(projectProperties.Value.TargetPath))
+    if (exitCode == 0)
     {
-        return Fail(
-            $"Built MSTest test assembly not found at {projectProperties.Value.TargetPath}. "
-            + "Build the project or omit --no-build.");
-    }
-
-    var testExitCode = await RunProcess(dotnetPath, testArguments, repoRoot, cancellationToken);
-
-    Console.WriteLine();
-    if (testExitCode == 0)
-    {
-        Console.WriteLine("Targeted tests passed.");
+        Console.WriteLine("Tests passed.");
         PrintArtifacts(repoRoot, trxPath, binlogPath);
         return 0;
     }
 
-    Console.Error.WriteLine($"Targeted tests failed with exit code {testExitCode}.");
+    Console.Error.WriteLine($"Tests failed with exit code {exitCode}.");
     if (File.Exists(trxPath))
     {
-        // Surface names in the console for immediate triage while retaining the complete TRX
-        // for stack traces, output, timings, and larger failure sets.
         PrintFailedTests(trxPath);
     }
     else
@@ -270,12 +365,9 @@ static async Task<int> RunAsync(
         Console.Error.WriteLine("No TRX was produced; the failure occurred before test results were written.");
     }
 
-    // Always show whatever diagnostics exist. Build failures may produce only a binlog, while
-    // early test-host failures may produce neither; stating that explicitly is more actionable
-    // than making the caller search the artifact tree.
     PrintArtifacts(repoRoot, trxPath, binlogPath);
-    Console.Error.WriteLine($"Rerun: {displayCommand}");
-    return testExitCode;
+    Console.Error.WriteLine($"Rerun: {rerunCommand}");
+    return exitCode;
 }
 
 static string? FindRepoRoot(string startDirectory)
@@ -302,26 +394,116 @@ static bool IsRepoRoot(string path) =>
     && File.Exists(Path.Combine(path, "sdk.slnx"))
     && (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")));
 
-static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties(
+static async Task<TestProjectProperties?> GetProjectProperties(
     string dotnetPath,
     string projectPath,
     string configuration,
+    string? requestedFramework,
+    string repoRoot,
+    CancellationToken cancellationToken)
+{
+    Dictionary<string, string>? properties = await EvaluateProjectProperties(
+        dotnetPath,
+        projectPath,
+        configuration,
+        requestedFramework,
+        repoRoot,
+        cancellationToken);
+    if (properties is null)
+    {
+        return null;
+    }
+
+    string targetFramework = properties["TargetFramework"];
+    string targetFrameworks = properties["TargetFrameworks"];
+    string[] frameworks = targetFrameworks.Split(
+        ';',
+        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    if (requestedFramework is not null
+        && frameworks.Length > 0
+        && !frameworks.Contains(requestedFramework, StringComparer.OrdinalIgnoreCase))
+    {
+        Console.Error.WriteLine(
+            $"Error: Target framework '{requestedFramework}' is not listed in TargetFrameworks "
+            + $"('{targetFrameworks}') for {Path.GetRelativePath(repoRoot, projectPath)}.");
+        return null;
+    }
+
+    if (string.IsNullOrWhiteSpace(targetFramework) && !string.IsNullOrWhiteSpace(targetFrameworks))
+    {
+        string? selectedFramework = requestedFramework;
+        selectedFramework ??= frameworks.FirstOrDefault(framework =>
+            string.Equals(
+                framework,
+                properties["SdkTargetFramework"],
+                StringComparison.OrdinalIgnoreCase));
+        selectedFramework ??= frameworks.First();
+
+        properties = await EvaluateProjectProperties(
+            dotnetPath,
+            projectPath,
+            configuration,
+            selectedFramework,
+            repoRoot,
+            cancellationToken);
+        if (properties is null)
+        {
+            return null;
+        }
+
+        targetFramework = properties["TargetFramework"];
+    }
+
+    bool usesMSTestSdk = IsTrue(properties["UsingMSTestSdk"]);
+    string targetPath = properties["TargetPath"];
+    if (usesMSTestSdk && string.IsNullOrWhiteSpace(targetPath))
+    {
+        Console.Error.WriteLine(
+            "Error: MSBuild returned an empty TargetPath for the selected MSTest.Sdk target framework.");
+        return null;
+    }
+
+    if (!string.IsNullOrWhiteSpace(targetPath))
+    {
+        targetPath = Path.GetFullPath(
+            targetPath,
+            Path.GetDirectoryName(projectPath)
+                ?? throw new InvalidOperationException($"Could not determine project directory for {projectPath}."));
+    }
+
+    return new TestProjectProperties(
+        usesMSTestSdk,
+        IsTrue(properties["IsTestApplication"]),
+        IsTrue(properties["EnableMicrosoftTestingExtensionsTrxReport"]),
+        targetPath,
+        targetFramework,
+        properties["TargetFrameworkIdentifier"]);
+}
+
+static async Task<Dictionary<string, string>?> EvaluateProjectProperties(
+    string dotnetPath,
+    string projectPath,
+    string configuration,
+    string? framework,
     string repoRoot,
     CancellationToken cancellationToken)
 {
     // -getProperty asks MSBuild for the fully evaluated values and emits a small JSON document.
     // Running the repo-local MSBuild process guarantees evaluation with this checkout's pinned
-    // SDK, imports, workload resolvers, and MSBuild version. Using the MSBuild APIs in-process
-    // would require package dependencies, toolset registration, assembly-load management, and
-    // isolation from MSBuild's global state for the sake of reading only these two properties.
-    var arguments = new[]
+    // SDK, imports, workload resolvers, and MSBuild version.
+    var arguments = new List<string>
     {
         "msbuild",
         projectPath,
-        "-getProperty:UsingMSTestSdk,TargetPath",
+        "-getProperty:UsingMSTestSdk,IsTestApplication,EnableMicrosoftTestingExtensionsTrxReport,TargetPath,TargetFramework,TargetFrameworks,SdkTargetFramework,TargetFrameworkIdentifier",
         $"-p:Configuration={configuration}",
         "--nologo"
     };
+    if (!string.IsNullOrWhiteSpace(framework))
+    {
+        arguments.Add($"-p:TargetFramework={framework}");
+    }
+
     var startInfo = CreateProcessStartInfo(dotnetPath, arguments, repoRoot);
     startInfo.RedirectStandardOutput = true;
     startInfo.RedirectStandardError = true;
@@ -365,25 +547,17 @@ static async Task<(bool UsesMSTestSdk, string TargetPath)?> GetProjectProperties
     using (document)
     {
         var properties = document.RootElement.GetProperty("Properties");
-
-        // UsingMSTestSdk is a string-valued MSBuild property, so compare it using MSBuild's
-        // case-insensitive boolean convention instead of relying on JSON boolean parsing.
-        var usesMSTestSdk = string.Equals(
-            properties.GetProperty("UsingMSTestSdk").GetString(),
-            "true",
-            StringComparison.OrdinalIgnoreCase);
-        var targetPath = properties.GetProperty("TargetPath").GetString();
-        if (string.IsNullOrWhiteSpace(targetPath))
-        {
-            Console.Error.WriteLine("Error: MSBuild returned an empty TargetPath for the test project.");
-            return null;
-        }
-
-        // TargetPath may be relative depending on project configuration. Normalize it now so the
-        // later existence check and dotnet exec invocation are independent of process cwd.
-        return (usesMSTestSdk, Path.GetFullPath(targetPath, repoRoot));
+        return properties
+            .EnumerateObject()
+            .ToDictionary(
+                property => property.Name,
+                property => property.Value.GetString() ?? string.Empty,
+                StringComparer.OrdinalIgnoreCase);
     }
 }
+
+static bool IsTrue(string value) =>
+    string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
 
 static async Task<int> RunProcess(
     string executable,
@@ -482,6 +656,42 @@ static void PrintArtifacts(string repoRoot, string trxPath, string binlogPath)
             : "  Binlog: not produced");
 }
 
+static string GetRerunCommand(
+    string dotnetPath,
+    string repoRoot,
+    string relativeProjectPath,
+    string configuration,
+    string? framework,
+    string? filter,
+    bool skipRedistCheck)
+{
+    var arguments = new List<string>
+    {
+        Path.Combine("scripts", "RunTests.cs"),
+        "--",
+        "--project",
+        relativeProjectPath,
+        "--configuration",
+        configuration
+    };
+    if (!string.IsNullOrWhiteSpace(framework))
+    {
+        arguments.Add("--framework");
+        arguments.Add(framework);
+    }
+    if (skipRedistCheck)
+    {
+        arguments.Add("--skip-redist-check");
+    }
+    if (!string.IsNullOrWhiteSpace(filter))
+    {
+        arguments.Add("--filter");
+        arguments.Add(filter);
+    }
+
+    return FormatCommand(dotnetPath, arguments, repoRoot);
+}
+
 static string FormatCommand(string executable, IEnumerable<string> arguments, string repoRoot)
 {
     // Display the repo-local executable as a relative path so the rerun command is portable to
@@ -519,3 +729,13 @@ static int Fail(string message)
     Console.Error.WriteLine($"Error: {message}");
     return 1;
 }
+
+sealed record TestProjectProperties(
+    bool UsesMSTestSdk,
+    bool IsTestApplication,
+    bool TrxReportEnabled,
+    string TargetPath,
+    string TargetFramework,
+    string TargetFrameworkIdentifier);
+
+sealed record TestInvocation(string Executable, IReadOnlyList<string> Arguments);

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -58,12 +58,12 @@ Guidance for changes under `test/`.
 - **MSTest output is live.** `test/testconfig.json` is copied beside each MSTest
   test executable as `<AssemblyName>.testconfig.json`, so console, trace, and
   `TestContext` output is both captured in the result and shown while the test runs.
-- **Run focused tests through `targeted-test`.** It runs the smallest relevant tests and
-  preserves actionable output and diagnostics when a local run fails.
+- **Run all local tests through `run-tests`.** It selects and executes the appropriate
+  test platform while preserving actionable output and diagnostics.
 - **Map new substantive test areas for targeted testing.** Prefer adding a
   `ConditionalTestScope` when reliable trigger paths can be defined. When the area is too
   broad for practical conditional filtering, add its primary project to the fallback
-  table in the `targeted-test` skill.
+  table in the `run-tests` skill.
 - **Skips must point to a tracking issue URL** — `[Ignore("https://github.com/dotnet/sdk/issues/N")]`.
 - **Verify (approval) snapshots**: `*.verified.*` is checked in; the runner writes a
   `*.received.*` on mismatch — promote received → verified when you change output

--- a/test/ConditionalTests.props
+++ b/test/ConditionalTests.props
@@ -6,7 +6,7 @@
     This file defines which tests can be skipped on PRs that don't touch relevant source.
     See documentation/project-docs/pr-test-filtering.md for design details and usage guide.
 
-    The targeted-test agent skill reads these scopes directly. When changing them, also
+    The run-tests agent skill reads these scopes directly. When changing them, also
     reconcile its fallback table for common unscoped areas: remove entries now covered by
     a scope, and update entries when test-project ownership changes.
   -->

--- a/test/Microsoft.NET.Infrastructure.Tests/RunTestsScriptTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/RunTestsScriptTests.cs
@@ -117,7 +117,8 @@ public class RunTestsScriptTests : SdkTest
 
         Assert.AreNotEqual(0, result.ExitCode);
         Assert.Contains("Target framework 'net999.0' is not listed in TargetFrameworks", result.StdErr);
-        Assert.Contains(@"Rerun: .\.dotnet\dotnet.exe scripts\RunTests.cs", result.StdErr);
+        Assert.Contains("Rerun:", result.StdErr);
+        Assert.Contains(Path.Combine("scripts", "RunTests.cs"), result.StdErr);
         Assert.DoesNotContain(_repoRoot, result.StdErr);
     }
 

--- a/test/Microsoft.NET.Infrastructure.Tests/RunTestsScriptTests.cs
+++ b/test/Microsoft.NET.Infrastructure.Tests/RunTestsScriptTests.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.NET.Infrastructure.Tests;
+
+[TestClass]
+public class RunTestsScriptTests : SdkTest
+{
+    private string _dotnetPath = null!;
+    private string _repoRoot = null!;
+    private string _scriptPath = null!;
+
+    [TestInitialize]
+    public void TestInit()
+    {
+        _dotnetPath = SdkTestContext.Current.ToolsetUnderTest.DotNetHostPath;
+
+        string? repoRoot = SdkTestContext.Current.ToolsetUnderTest.RepoRoot
+            ?? SdkTestContext.GetRepoRoot();
+        if (repoRoot is null
+            || (!Directory.Exists(Path.Combine(repoRoot, ".git"))
+                && !File.Exists(Path.Combine(repoRoot, ".git"))))
+        {
+            Assert.Inconclusive("run-tests is a local-checkout tool and is not deployed to Helix.");
+            return;
+        }
+
+        _repoRoot = repoRoot;
+        _scriptPath = Path.Combine(
+            _repoRoot,
+            "scripts",
+            "RunTests.cs");
+
+        Assert.IsTrue(File.Exists(_scriptPath), $"Script not found: {_scriptPath}");
+    }
+
+    [TestMethod]
+    public async Task HelpDescribesTheConsolidatedRunner()
+    {
+        ScriptResult result = await RunScript("--help");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdErr);
+        Assert.Contains("Run one dotnet/sdk test project", result.StdOut);
+        Assert.Contains("--project", result.StdOut);
+        Assert.Contains("--filter", result.StdOut);
+        Assert.Contains("--framework", result.StdOut);
+        Assert.Contains("--skip-redist-check", result.StdOut);
+        Assert.DoesNotContain("--no-build", result.StdOut);
+    }
+
+    [TestMethod]
+    public async Task MissingProjectReturnsAClearError()
+    {
+        ScriptResult result = await RunScript("--project", "test/Missing.Tests.csproj");
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.Contains("Test project does not exist", result.StdErr);
+    }
+
+    [TestMethod]
+    public async Task UnsupportedConfigurationReturnsAParserError()
+    {
+        ScriptResult result = await RunScript(
+            "--project",
+            "test/Missing.Tests.csproj",
+            "--configuration",
+            "Checked");
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.Contains("Unsupported configuration 'Checked'. Use Debug or Release.", result.StdErr);
+    }
+
+    [TestMethod]
+    public async Task RunsSingleTargetMtpProjectWithDiagnostics()
+    {
+        ScriptResult result = await RunScript(
+            "--project",
+            "test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj",
+            "--filter",
+            "FullyQualifiedName~ArgumentEscaperTests.EscapesArgumentsForProcessStart",
+            "--skip-redist-check");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdOut + result.StdErr);
+        Assert.Contains($"Framework: {ToolsetInfo.CurrentTargetFramework}", result.StdOut);
+        Assert.Contains("TRX: artifacts", result.StdOut);
+        Assert.Contains("Binlog: artifacts", result.StdOut);
+    }
+
+    [TestMethod]
+    public async Task MultiTargetedProjectDefaultsToSdkTargetFramework()
+    {
+        ScriptResult result = await RunWorkloadManifestReaderTests();
+
+        Assert.AreEqual(0, result.ExitCode, result.StdOut + result.StdErr);
+        Assert.Contains($"Framework: {ToolsetInfo.CurrentTargetFramework}", result.StdOut);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public async Task MultiTargetedProjectRunsNetFrameworkExecutable()
+    {
+        ScriptResult result = await RunWorkloadManifestReaderTests("net472");
+
+        Assert.AreEqual(0, result.ExitCode, result.StdOut + result.StdErr);
+        Assert.Contains("Framework: net472", result.StdOut);
+        Assert.Contains(
+            @"Command: .\artifacts\bin\Microsoft.NET.Sdk.WorkloadManifestReader.Tests\Debug\net472\Microsoft.NET.Sdk.WorkloadManifestReader.Tests.exe",
+            result.StdOut);
+    }
+
+    [TestMethod]
+    public async Task InvalidFrameworkReturnsAProjectSpecificErrorAndPortableRerun()
+    {
+        ScriptResult result = await RunWorkloadManifestReaderTests("net999.0");
+
+        Assert.AreNotEqual(0, result.ExitCode);
+        Assert.Contains("Target framework 'net999.0' is not listed in TargetFrameworks", result.StdErr);
+        Assert.Contains(@"Rerun: .\.dotnet\dotnet.exe scripts\RunTests.cs", result.StdErr);
+        Assert.DoesNotContain(_repoRoot, result.StdErr);
+    }
+
+    private Task<ScriptResult> RunWorkloadManifestReaderTests(string? framework = null)
+    {
+        var arguments = new List<string>
+        {
+            "--project",
+            "test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj",
+            "--filter",
+            "FullyQualifiedName~ManifestReaderTests.SdkFeatureBandTests.ItParsesVersionsCorrectly",
+            "--skip-redist-check"
+        };
+        if (framework is not null)
+        {
+            arguments.Add("--framework");
+            arguments.Add(framework);
+        }
+
+        return RunScript([.. arguments]);
+    }
+
+    private async Task<ScriptResult> RunScript(params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo(_dotnetPath)
+        {
+            WorkingDirectory = _repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add(_scriptPath);
+        startInfo.ArgumentList.Add("--");
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        startInfo.Environment.Remove("MSBUILD_EXE_PATH");
+        startInfo.Environment.Remove("MSBuildSDKsPath");
+        startInfo.Environment.Remove("MSBuildExtensionsPath");
+
+        var output = await Process.RunAndCaptureTextAsync(startInfo);
+        return new ScriptResult(
+            output.ExitStatus.ExitCode,
+            output.StandardOutput,
+            output.StandardError);
+    }
+
+    private sealed record ScriptResult(int ExitCode, string StdOut, string StdErr);
+}


### PR DESCRIPTION
## Problem

Local test execution was documented through several different command shapes with different diagnostic guarantees. The developer guide used raw `dotnet test`, while specialized workflows directly invoked built Microsoft.Testing.Platform applications. The existing `targeted-test` workflow retained diagnostics, but it was framed as an agent-only targeted-test helper rather than the repository’s standard contributor entry point.

As a result, there was no single local testing contract that consistently built the selected test project, chose the appropriate framework and test-application launcher, and returned stable TRX and MSBuild binlog paths. The required Microsoft.Testing.Platform, multi-targeting, and .NET Framework behavior was implemented in other repository infrastructure but was not available through one reusable local command.

## Fix

This change replaces the narrow `targeted-test` workflow with a general `run-tests` entry point backed by `scripts/RunTests.cs`.

The runner evaluates the selected project rather than guessing its test platform. It selects the appropriate target framework, builds that framework incrementally with an MSBuild binlog, and invokes the resulting Microsoft.Testing.Platform application correctly. Multi-targeted projects default to the repository’s current SDK framework, while callers can explicitly select another framework, including .NET Framework on Windows.

Every run receives a unique diagnostics directory. The runner reports the build binlog and, when supported by the project, the TRX. Failures also include the failed test names and a portable command that reruns the same project, framework, configuration, and filter through `RunTests.cs`.

Repository instructions, specialized agent workflows, and contributor documentation now use this entry point instead of constructing test commands independently. Characterization tests cover single-target and multi-target execution, .NET Framework applications, argument validation, diagnostics, and portable reruns.