### PR TITLE
Package download: Validate paths on non-Windows platforms

### DIFF
--- a/src/Cli/dotnet/CliStrings.resx
+++ b/src/Cli/dotnet/CliStrings.resx
@@ -663,4 +663,7 @@ setx PATH "%PATH%;{0}"
   <data name="SdkRootDirectoryDoesNotExist" xml:space="preserve">
     <value>The SDK root directory '{0}' provided via the '{1}' setting does not exist.</value>
   </data>
+  <data name="ResolvedPathEscapesTargetDirectory" xml:space="preserve">
+    <value>The resolved path '{0}' escapes the target directory '{1}'.</value>
+  </data>
 </root>

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -353,7 +353,7 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
 
                     if (!fullPath.StartsWith(Path.GetFullPath(targetFolder.Value) + Path.DirectorySeparatorChar))
                     {
-                        throw new InvalidOperationException(string.Format(CliStrings.ResolvedPathEscapesTargetDirectory, fullPath, targetFolder.Value));
+                        throw new GracefulException(string.Format(CliStrings.ResolvedPathEscapesTargetDirectory, fullPath, targetFolder.Value));
                     }
 
                     _filePermissionSetter

--- a/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
+++ b/src/Cli/dotnet/NugetPackageDownloader/NuGetPackageDownloader.cs
@@ -4,11 +4,9 @@
 #nullable disable
 
 using System.Collections.Concurrent;
-using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.NugetPackageDownloader;
 using Microsoft.DotNet.Cli.ToolPackage;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -351,9 +349,16 @@ internal class NuGetPackageDownloader : INuGetPackageDownloader
                 var permissionList = FileList.Deserialize(workloadUnixFilePermissions);
                 foreach (var fileAndPermission in permissionList.File)
                 {
+                    string fullPath = Path.GetFullPath(Path.Combine(targetFolder.Value, fileAndPermission.Path));
+
+                    if (!fullPath.StartsWith(Path.GetFullPath(targetFolder.Value) + Path.DirectorySeparatorChar))
+                    {
+                        throw new InvalidOperationException(string.Format(CliStrings.ResolvedPathEscapesTargetDirectory, fullPath, targetFolder.Value));
+                    }
+
                     _filePermissionSetter
                         .SetPermission(
-                            Path.Combine(targetFolder.Value, fileAndPermission.Path),
+                            fullPath,
                             fileAndPermission.Permission);
                 }
             }

--- a/src/Cli/dotnet/xlf/CliStrings.cs.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.cs.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Požadovaný příkaz nebyl zadán.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: Řeší se specifikace příkazu commandspec z knihoven nástroje {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.de.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.de.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Der erforderliche Befehl wurde nicht bereitgestellt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: commandspec aus {1} Toolbibliotheken wird aufgelöst.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.es.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.es.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">No se proporcionó el comando requerido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: resolviendo commandspec desde las bibliotecas de herramientas de {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.fr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.fr.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">La commande nécessaire n'a pas été fournie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0} : résolution de la spécification de commande à partir des bibliothèques d'outils {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.it.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.it.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Il comando obbligatorio non è stato specificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: risoluzione di commandSpec dalle librerie degli strumenti di {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ja.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ja.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">必要なコマンドが指定されませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: {1} ツール ライブラリから commandspec を解決しています。</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ko.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ko.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">필수 명령을 제공하지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: {1} 도구 라이브러리에서 commandspec을 확인하는 중입니다.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.pl.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pl.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Nie podano wymaganego polecenia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: Rozpoznawanie elementu commandspec z bibliotek narzędzia {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.pt-BR.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">O comando necessário não foi fornecido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: resolvendo commandspec por meio das Bibliotecas de Ferramentas de {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.ru.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.ru.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Обязательная команда не указана.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: разрешение спецификации команды из библиотек средств {1}.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.tr.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.tr.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">Gerekli komut sağlanmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: {1} Araç Kitaplıklarından commandspec çözümleniyor.</target>

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hans.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">未提供必需的命令。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: 正在从 {1} 工具库解析 commandspec。</target>

--- a/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
+++ b/src/Cli/dotnet/xlf/CliStrings.zh-Hant.xlf
@@ -696,6 +696,11 @@ setx PATH "%PATH%;{0}"
         <target state="translated">未提供所需的命令。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvedPathEscapesTargetDirectory">
+        <source>The resolved path '{0}' escapes the target directory '{1}'.</source>
+        <target state="new">The resolved path '{0}' escapes the target directory '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolvingCommandSpec">
         <source>{0}: resolving commandspec from {1} Tool Libraries.</source>
         <target state="translated">{0}: 正在從 {1} 工具程式庫解析 commandspec。</target>


### PR DESCRIPTION
Verify paths on non-Windows platforms when extracting files from packages.