### PR TITLE
Fix Include Symbols when using dotnet pack with nuspec file (#55252)

### DIFF
--- a/src/Cli/dotnet/Commands/Pack/PackCommand.cs
+++ b/src/Cli/dotnet/Commands/Pack/PackCommand.cs
@@ -121,6 +121,9 @@ public class PackCommand(
         if (version != null)
             packArgs.Version = version.ToNormalizedString();
 
+        if (parseResult.GetValue(definition.IncludeSymbolsOption))
+            packArgs.Symbols = true;
+
         var configuration = parseResult.GetValue(definition.ConfigurationOption) ?? "Debug";
         packArgs.Properties["configuration"] = configuration;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/55252
Related: https://github.com/NuGet/Home/issues/14903

This is one liner fix. If you want I can continue in this PR or open another, where I also add new argument that can pass symbol format to dotnet pack command