### PR TITLE
Treat typed task diagnostics as suggestions 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -286,9 +286,9 @@ dotnet_diagnostic.IDE0082.severity = warning
 dotnet_diagnostic.IDE0200.severity = none
 # Remove redundant nullable directive
 dotnet_diagnostic.IDE0240.severity = warning
-# MSBuildTask0001-0005 (Microsoft.Build.TaskAuthoring.Analyzer). MSBuildTask0001 is Error severity by
-# default; the rest are warnings. All are downgraded to 'suggestion' here for report-only onboarding while
-# task migration to the multithreaded model (IMultiThreadableTask / TaskEnvironment) is pending. At
+# MSBuildTask0001-0008 (Microsoft.Build.TaskAuthoring.Analyzer). All are downgraded to 'suggestion' here
+# for report-only onboarding while task migration to the multithreaded model
+# (IMultiThreadableTask / TaskEnvironment) is pending. At
 # suggestion level they are info diagnostics, so they never fail the build (not even under Arcade's
 # MSBuild-engine warn-as-error) without needing any WarningsNotAsErrors exemptions.
 #
@@ -303,6 +303,9 @@ dotnet_diagnostic.MSBuildTask0002.severity = suggestion
 dotnet_diagnostic.MSBuildTask0003.severity = suggestion
 dotnet_diagnostic.MSBuildTask0004.severity = suggestion
 dotnet_diagnostic.MSBuildTask0005.severity = suggestion
+dotnet_diagnostic.MSBuildTask0006.severity = suggestion
+dotnet_diagnostic.MSBuildTask0007.severity = suggestion
+dotnet_diagnostic.MSBuildTask0008.severity = suggestion
 
 # Additional rules for template engine source code
 

--- a/eng/MSBuildTaskAuthoringAnalyzer.props
+++ b/eng/MSBuildTaskAuthoringAnalyzer.props
@@ -7,10 +7,9 @@
   This file is imported from the repo-root Directory.Build.targets so the opt-in property set in the
   project body is visible.
 
-  Report-only onboarding: MSBuildTask0001-0005 are downgraded to 'suggestion' in the root .editorconfig.
-  MSBuildTask0006-0008 remain warnings so they are visible in build output, but are excluded from warn-as-error
-  below while existing task implementations are migrated. Severity is re-raised incrementally per rule or per
-  task directory via .editorconfig as the multithreaded-task migration proceeds.
+  Report-only onboarding: MSBuildTask0001-0008 are downgraded to 'suggestion' in the root .editorconfig,
+  which keeps the build green while task migration to the multithreaded model proceeds. Severity is
+  re-raised incrementally per rule or per task directory via .editorconfig.
 
   The analyzer package is produced by the msbuild repo and flows to this repo via eng/Version.Details.xml
   (dotnet/dotnet). It is report-only and analyzers do not affect build output, so it is excluded from
@@ -26,9 +25,5 @@
   <ItemGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">
     <PackageReference Include="Microsoft.Build.TaskAuthoring.Analyzer" PrivateAssets="all" IncludeAssets="analyzers" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);MSBuildTask0006;MSBuildTask0007;MSBuildTask0008</WarningsNotAsErrors>
-  </PropertyGroup>
 
 </Project>

--- a/eng/MSBuildTaskAuthoringAnalyzer.props
+++ b/eng/MSBuildTaskAuthoringAnalyzer.props
@@ -7,11 +7,10 @@
   This file is imported from the repo-root Directory.Build.targets so the opt-in property set in the
   project body is visible.
 
-  Report-only onboarding: the analyzer emits MSBuildTask0001 at Error severity and MSBuildTask0002-0005 at
-  Warning severity by default. All five are downgraded to 'suggestion' in the root .editorconfig, which
-  keeps the build green (info-level diagnostics are never promoted by warn-as-error) without any
-  WarningsNotAsErrors exemptions here. Severity is re-raised incrementally per rule or per task directory
-  via .editorconfig as the multithreaded-task migration (IMultiThreadableTask / TaskEnvironment) proceeds.
+  Report-only onboarding: MSBuildTask0001-0005 are downgraded to 'suggestion' in the root .editorconfig.
+  MSBuildTask0006-0008 remain warnings so they are visible in build output, but are excluded from warn-as-error
+  below while existing task implementations are migrated. Severity is re-raised incrementally per rule or per
+  task directory via .editorconfig as the multithreaded-task migration proceeds.
 
   The analyzer package is produced by the msbuild repo and flows to this repo via eng/Version.Details.xml
   (dotnet/dotnet). It is report-only and analyzers do not affect build output, so it is excluded from
@@ -27,5 +26,9 @@
   <ItemGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">
     <PackageReference Include="Microsoft.Build.TaskAuthoring.Analyzer" PrivateAssets="all" IncludeAssets="analyzers" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(_UseMSBuildTaskAuthoringAnalyzer)' == 'true'">
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);MSBuildTask0006;MSBuildTask0007;MSBuildTask0008</WarningsNotAsErrors>
+  </PropertyGroup>
 
 </Project>

--- a/src/StaticWebAssetsSdk/.editorconfig
+++ b/src/StaticWebAssetsSdk/.editorconfig
@@ -94,7 +94,7 @@ charset = utf-8-bom
 
 [*.{cs,vb}]
 
-# MSBuildTask0001-0005 (Microsoft.Build.TaskAuthoring.Analyzer) downgraded to 'suggestion' for report-only
+# MSBuildTask0001-0008 (Microsoft.Build.TaskAuthoring.Analyzer) downgraded to 'suggestion' for report-only
 # onboarding while task migration to the multithreaded model (IMultiThreadableTask / TaskEnvironment) is
 # pending. This must be duplicated from the repo-root .editorconfig because this file sets `root = true`,
 # which severs inheritance from the root. Raise these to 'warning'/'error' (here or in a more specific
@@ -104,6 +104,9 @@ dotnet_diagnostic.MSBuildTask0002.severity = suggestion
 dotnet_diagnostic.MSBuildTask0003.severity = suggestion
 dotnet_diagnostic.MSBuildTask0004.severity = suggestion
 dotnet_diagnostic.MSBuildTask0005.severity = suggestion
+dotnet_diagnostic.MSBuildTask0006.severity = suggestion
+dotnet_diagnostic.MSBuildTask0007.severity = suggestion
+dotnet_diagnostic.MSBuildTask0008.severity = suggestion
 
 # SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 dotnet_diagnostic.SYSLIB1054.severity = warning


### PR DESCRIPTION
### Summary

Adds MSBuildTask0006-MSBuildTask0008 to the existing report-only analyzer configuration, unblocking dotnet/dotnet#8367.

### Testing

Verified WarnAsError fails without the overrides and succeeds under both SDK editorconfig scopes.