### PR TITLE
Reenable artifacts cleanup test

### DIFF
--- a/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
+++ b/test/Microsoft.NET.Build.Tests/ArtifactsOutputPathTests.cs
@@ -533,7 +533,6 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/50140")]
         public void PublishingRegistersWrittenFilesForProperCleanup()
         {
             var testProject = new TestProject()


### PR DESCRIPTION
## Summary

- reenable `PublishingRegistersWrittenFilesForProperCleanup`
- restore coverage that verifies a framework-dependent build removes stale self-contained publish artifacts
- follow up on the MSBuild cleanup support restored by dotnet/msbuild#12554

This is part of the weekly test issue cleanup effort to burn down the SDK's Test Debt and Known Build Error issues.

Closes #50140

## Validation

- `Microsoft.NET.Build.Tests.ArtifactsOutputPathTests.PublishingRegistersWrittenFilesForProperCleanup`