### PR TITLE
Update VersionFeature 8/9/10 for the next release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,9 +34,9 @@
     <VersionFeature60>36</VersionFeature60>
     <VersionFeature70>20</VersionFeature70>
     <!-- This version should be N-1 (ie the currently released version) in the preview branch but N-2 in main so that workloads stay behind the unreleased version -->
-    <VersionFeature80>28</VersionFeature80>
-    <VersionFeature90>17</VersionFeature90>
-    <VersionFeature100>9</VersionFeature100>
+    <VersionFeature80>31</VersionFeature80>
+    <VersionFeature90>20</VersionFeature90>
+    <VersionFeature100>12</VersionFeature100>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
Bump VersionFeature properties to released+1 for the upcoming prerelease:

- `VersionFeature80`: 28 → 31 (targeting 8.0.31)
- `VersionFeature90`: 17 → 20 (targeting 9.0.20)
- `VersionFeature100`: 9 → 12 (targeting 10.0.12)

The `VersionFeatureXXForWorkloads` properties reference these via `$(VersionFeatureXX)` and require no separate changes.