### PR TITLE
Add incremental container archive publishing

### DIFF
--- a/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -52,6 +52,8 @@ internal sealed class ImageBuilder
     // For tests
     internal string ManifestConfigDigest => _manifest.Config.digest;
 
+    internal string BaseImageManifestDigest => _baseImageManifest.GetDigest();
+
     /// <summary>
     /// Builds the image configuration <see cref="BuiltImage"/> ready for further processing.
     /// </summary>

--- a/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Layer.cs
@@ -207,17 +207,6 @@ internal class Layer
                     entry.DataStream.Dispose();
                 }
 
-                static UnixFileMode DetermineFileMode(FileSystemInfo file)
-                {
-                    const UnixFileMode nonExecuteMode = UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                                                        UnixFileMode.GroupRead |
-                                                        UnixFileMode.OtherRead;
-                    const UnixFileMode executeMode = nonExecuteMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
-
-                    // On Unix, we can determine the x-bit based on the filesystem permission.
-                    // On Windows, we use executable permissions for all entries.
-                    return (OperatingSystem.IsWindows() || ((file.UnixFileMode | UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
-                }
             }
         }
 
@@ -247,6 +236,18 @@ internal class Layer
         File.Move(tempTarballPath, storedContent, overwrite: true);
 
         return new(storedContent, descriptor);
+    }
+
+    internal static UnixFileMode DetermineFileMode(FileSystemInfo file)
+    {
+        const UnixFileMode nonExecuteMode = UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                                            UnixFileMode.GroupRead |
+                                            UnixFileMode.OtherRead;
+        const UnixFileMode executeMode = nonExecuteMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+        // On Unix, we can determine the x-bit based on the filesystem permission.
+        // On Windows, we use executable permissions for all entries.
+        return (OperatingSystem.IsWindows() || ((file.UnixFileMode | UnixFileMode.UserExecute) != 0)) ? executeMode : nonExecuteMode;
     }
 
     internal virtual Stream OpenBackingFile() => File.OpenRead(BackingFile);

--- a/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/LocalDaemons/ArchiveFileRegistry.cs
@@ -21,7 +21,36 @@ internal class ArchiveFileRegistry : ILocalRegistry
         DestinationImageReference destinationReference, CancellationToken cancellationToken,
         Func<T, SourceImageReference, DestinationImageReference, Stream, CancellationToken, Task> writeStreamFunc)
     {
-        var fullPath = Path.GetFullPath(ArchiveOutputPath);
+        var fullPath = GetArchiveOutputPath(ArchiveOutputPath, destinationReference.Repository);
+
+        // create parent directory if required.
+        var parentDirectory = Path.GetDirectoryName(fullPath);
+        if (parentDirectory != null && !Directory.Exists(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
+
+        ArchiveOutputPath = fullPath;
+        string temporaryPath = $"{fullPath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await using (var fileStream = File.Create(temporaryPath))
+            {
+                // Call the delegate to write the image to the stream
+                await writeStreamFunc(image, sourceReference, destinationReference, fileStream, cancellationToken).ConfigureAwait(false);
+            }
+
+            File.Move(temporaryPath, fullPath, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+    }
+
+    internal static string GetArchiveOutputPath(string archiveOutputPath, string repository)
+    {
+        var fullPath = Path.GetFullPath(archiveOutputPath);
 
         var directorySeparatorChar = Path.DirectorySeparatorChar;
 
@@ -34,21 +63,10 @@ internal class ArchiveFileRegistry : ILocalRegistry
         // pointing to a directory? -> append default name
         if (fullPath.EndsWith(directorySeparatorChar))
         {
-            fullPath = Path.Combine(fullPath, destinationReference.Repository + ".tar.gz");
+            fullPath = Path.Combine(fullPath, repository + ".tar.gz");
         }
 
-        // create parent directory if required.
-        var parentDirectory = Path.GetDirectoryName(fullPath);
-        if (parentDirectory != null && !Directory.Exists(parentDirectory))
-        {
-            Directory.CreateDirectory(parentDirectory);
-        }
-
-        ArchiveOutputPath = fullPath;
-        await using var fileStream = File.Create(fullPath);
-
-        // Call the delegate to write the image to the stream
-        await writeStreamFunc(image, sourceReference, destinationReference, fileStream, cancellationToken).ConfigureAwait(false);
+        return fullPath;
     }
 
     /// <inheritdoc />

--- a/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Containers/Microsoft.NET.Build.Containers/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -188,6 +188,8 @@ Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFramewor
 Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.TargetFrameworkVersion.set -> void
 override Microsoft.NET.Build.Containers.Tasks.ComputeDotnetBaseImageAndTag.Execute() -> bool
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveIncrementalCachePath.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ArchiveIncrementalCachePath.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageName.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.BaseImageTag.get -> string!
@@ -211,6 +213,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.EntrypointArgs.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.EntrypointArgs.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.EnableArchiveIncrementalCache.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.EnableArchiveIncrementalCache.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.DefaultArgs.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.DefaultArgs.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.AppCommand.get -> Microsoft.Build.Framework.ITaskItem![]!

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/ContainerArchiveCache.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/ContainerArchiveCache.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.NET.Build.Containers.LocalDaemons;
+
+namespace Microsoft.NET.Build.Containers.Tasks;
+
+internal static class ContainerArchiveCache
+{
+    private const int FormatVersion = 1;
+
+    public static string ComputeFingerprint(
+        CreateNewImage task,
+        string baseImageManifestDigest,
+        bool baseImageIsResolved,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        Append(hash, FormatVersion.ToString());
+        Append(hash, Constants.Version);
+        Append(hash, baseImageManifestDigest);
+        Append(hash, task.Repository);
+        Append(hash, task.WorkingDirectory);
+        Append(hash, task.ContainerUser);
+        Append(hash, task.ImageFormat);
+        Append(hash, task.AppCommandInstruction);
+        Append(hash, task.SourceDateEpoch);
+        Append(hash, task.GenerateLabels.ToString());
+        if (task.GenerateLabels)
+        {
+            Append(hash, task.GenerateCreatedLabels.ToString());
+            Append(hash, task.GenerateDigestLabel.ToString());
+            AppendLabels(hash, task.Labels);
+        }
+        Append(hash, task.SkipPublishing.ToString());
+        Append(hash, "ImageTags", task.ImageTags);
+        Append(hash, "Entrypoint", task.Entrypoint);
+        Append(hash, "EntrypointArgs", task.EntrypointArgs);
+        Append(hash, "DefaultArgs", task.DefaultArgs);
+        Append(hash, "AppCommand", task.AppCommand);
+        Append(hash, "AppCommandArgs", task.AppCommandArgs);
+        Append(hash, "ExposedPorts", task.ExposedPorts, "Type");
+        Append(hash, "EnvironmentVariables", task.ContainerEnvironmentVariables, "Value");
+        if (!baseImageIsResolved)
+        {
+            Append(hash, task.ContainerRuntimeIdentifier);
+            AppendFile(hash, task.RuntimeIdentifierGraphPath, "RuntimeIdentifierGraph", includeMode: false, cancellationToken);
+        }
+
+        string publishDirectory = Path.GetFullPath(task.PublishDirectory);
+        AppendFile(hash, publishDirectory, ".", includeMode: true, cancellationToken);
+        foreach (string path in Directory.EnumerateFileSystemEntries(publishDirectory, "*", SearchOption.AllDirectories)
+            .OrderBy(path => Path.GetRelativePath(publishDirectory, path), StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string relativePath = Path.GetRelativePath(publishDirectory, path).Replace('\\', '/');
+            AppendFile(hash, path, relativePath, includeMode: true, cancellationToken);
+        }
+
+        return Convert.ToHexStringLower(hash.GetHashAndReset());
+    }
+
+    public static bool TryRestore(CreateNewImage task, string fingerprint)
+    {
+        if (string.IsNullOrEmpty(task.ArchiveOutputPath)
+            || string.IsNullOrEmpty(task.ArchiveIncrementalCachePath)
+            || !File.Exists(GetArchiveOutputPath(task))
+            || !File.Exists(task.ArchiveIncrementalCachePath))
+        {
+            return false;
+        }
+
+        ArchiveCacheEntry? entry;
+        try
+        {
+            entry = JsonSerializer.Deserialize<ArchiveCacheEntry>(File.ReadAllText(task.ArchiveIncrementalCachePath));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+
+        if (entry is null || entry.FormatVersion != FormatVersion || entry.Fingerprint != fingerprint)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (entry.ArchiveDigest != ComputeFileDigest(GetArchiveOutputPath(task)))
+            {
+                return false;
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+
+        task.GeneratedContainerManifest = entry.Manifest;
+        task.GeneratedContainerConfiguration = entry.Configuration;
+        task.GeneratedContainerDigest = entry.ManifestDigest;
+        task.GeneratedArchiveOutputPath = task.ArchiveOutputPath;
+        task.GeneratedContainerMediaType = entry.ManifestMediaType;
+        task.GeneratedContainerNames = entry.ContainerNames.Select(name => new TaskItem(name)).ToArray();
+        if (entry.DigestLabel is not null)
+        {
+            TaskItem label = new(entry.DigestLabel.Name);
+            label.SetMetadata("Value", entry.DigestLabel.Value);
+            task.GeneratedDigestLabel = label;
+        }
+
+        return true;
+    }
+
+    public static void Save(CreateNewImage task, string fingerprint)
+    {
+        if (string.IsNullOrEmpty(task.ArchiveOutputPath)
+            || string.IsNullOrEmpty(task.ArchiveIncrementalCachePath)
+            || !File.Exists(GetArchiveOutputPath(task)))
+        {
+            return;
+        }
+
+        string? cacheDirectory = Path.GetDirectoryName(task.ArchiveIncrementalCachePath);
+        if (!string.IsNullOrEmpty(cacheDirectory))
+        {
+            Directory.CreateDirectory(cacheDirectory);
+        }
+
+        DigestLabel? digestLabel = task.GeneratedDigestLabel is null
+            ? null
+            : new(task.GeneratedDigestLabel.ItemSpec, task.GeneratedDigestLabel.GetMetadata("Value"));
+        ArchiveCacheEntry entry = new(
+            FormatVersion,
+            fingerprint,
+            ComputeFileDigest(GetArchiveOutputPath(task)),
+            task.GeneratedContainerManifest,
+            task.GeneratedContainerConfiguration,
+            task.GeneratedContainerDigest,
+            task.GeneratedContainerMediaType,
+            task.GeneratedContainerNames.Select(item => item.ItemSpec).ToArray(),
+            digestLabel);
+        string temporaryPath = $"{task.ArchiveIncrementalCachePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(temporaryPath, JsonSerializer.Serialize(entry));
+            File.Move(temporaryPath, task.ArchiveIncrementalCachePath, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporaryPath);
+        }
+    }
+
+    private static string GetArchiveOutputPath(CreateNewImage task)
+        => ArchiveFileRegistry.GetArchiveOutputPath(task.ArchiveOutputPath, task.Repository);
+
+    private static void AppendLabels(IncrementalHash hash, IEnumerable<ITaskItem> labels)
+    {
+        ITaskItem[] labelArray = labels.ToArray();
+        Append(hash, "Labels");
+        Append(hash, labelArray.Length.ToString());
+        foreach (ITaskItem label in labelArray)
+        {
+            Append(hash, label.ItemSpec);
+            Append(hash, label.GetMetadata("Value"));
+        }
+    }
+
+    private static void Append(IncrementalHash hash, string name, IEnumerable<ITaskItem> items, string? metadataName = null)
+    {
+        ITaskItem[] itemArray = items.ToArray();
+        Append(hash, name);
+        Append(hash, itemArray.Length.ToString());
+        foreach (ITaskItem item in itemArray)
+        {
+            Append(hash, item.ItemSpec);
+            if (metadataName is not null)
+            {
+                Append(hash, item.GetMetadata(metadataName));
+            }
+        }
+    }
+
+    private static void Append(IncrementalHash hash, string name, IEnumerable<string> values)
+    {
+        string[] valueArray = values.ToArray();
+        Append(hash, name);
+        Append(hash, valueArray.Length.ToString());
+        foreach (string value in valueArray)
+        {
+            Append(hash, value);
+        }
+    }
+
+    private static void AppendFile(
+        IncrementalHash hash,
+        string path,
+        string identity,
+        bool includeMode,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Append(hash, identity);
+        FileSystemInfo info = Directory.Exists(path) ? new DirectoryInfo(path) : new FileInfo(path);
+        Append(hash, info is DirectoryInfo ? "directory" : "file");
+        if (includeMode)
+        {
+            Append(hash, ((int)Layer.DetermineFileMode(info)).ToString());
+        }
+
+        if (info is FileInfo)
+        {
+            using FileStream stream = File.OpenRead(path);
+            Append(hash, stream.Length.ToString());
+            byte[] buffer = new byte[81920];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) != 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                hash.AppendData(buffer, 0, read);
+            }
+        }
+    }
+
+    private static void Append(IncrementalHash hash, string? value)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(value ?? "");
+        Span<byte> length = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32LittleEndian(length, bytes.Length);
+        hash.AppendData(length);
+        hash.AppendData(bytes);
+    }
+
+    private static string ComputeFileDigest(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        return Convert.ToHexStringLower(SHA256.HashData(stream));
+    }
+
+    private sealed record ArchiveCacheEntry(
+        int FormatVersion,
+        string Fingerprint,
+        string ArchiveDigest,
+        string Manifest,
+        string Configuration,
+        string ManifestDigest,
+        string ManifestMediaType,
+        string[] ContainerNames,
+        DigestLabel? DigestLabel);
+
+    private sealed record DigestLabel(string Name, string Value);
+}

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -182,6 +182,17 @@ partial class CreateNewImage
     /// </summary>
     public bool NoCache { get; set; }
 
+    /// <summary>
+    /// If true, an unchanged single-platform archive can be reused without rebuilding the image.
+    /// Mutable base image tags are resolved before cache lookup; digest-pinned base images can be reused without registry access.
+    /// </summary>
+    public bool EnableArchiveIncrementalCache { get; set; }
+
+    /// <summary>
+    /// The file used to persist the incremental archive fingerprint and generated task outputs.
+    /// </summary>
+    public string ArchiveIncrementalCachePath { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 
@@ -229,6 +240,7 @@ partial class CreateNewImage
         LocalRegistry = "";
         ContainerUser = "";
         SourceDateEpoch = "";
+        ArchiveIncrementalCachePath = "";
 
         GeneratedContainerConfiguration = "";
         GeneratedContainerManifest = "";

--- a/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/src/Containers/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -66,6 +66,21 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
             return !Log.HasLoggedErrors;
         }
 
+        string? archiveIncrementalFingerprint = null;
+        if (EnableArchiveIncrementalCache && !string.IsNullOrEmpty(BaseImageDigest))
+        {
+            archiveIncrementalFingerprint = ContainerArchiveCache.ComputeFingerprint(
+                this,
+                BaseImageDigest,
+                baseImageIsResolved: false,
+                cancellationToken);
+            if (ContainerArchiveCache.TryRestore(this, archiveIncrementalFingerprint))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return true;
+            }
+        }
+
         bool credentialsSet = false;
         VSHostObject hostObj = new(HostObject, Log);
         if (hostObj.TryGetCredentials() is (string userName, string pass))
@@ -83,7 +98,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         try
         {
-            return await ExecuteAsyncCore(logger, msbuildLoggerFactory, cancellationToken).ConfigureAwait(false);
+            return await ExecuteAsyncCore(logger, msbuildLoggerFactory, archiveIncrementalFingerprint, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -96,7 +111,11 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         }
     }
 
-    private async Task<bool> ExecuteAsyncCore(ILogger logger, ILoggerFactory msbuildLoggerFactory, CancellationToken cancellationToken)
+    private async Task<bool> ExecuteAsyncCore(
+        ILogger logger,
+        ILoggerFactory msbuildLoggerFactory,
+        string? archiveIncrementalFingerprint,
+        CancellationToken cancellationToken)
     {
         RegistryMode sourceRegistryMode = BaseRegistry.Equals(OutputRegistry, StringComparison.InvariantCultureIgnoreCase) ? RegistryMode.PullFromOutput : RegistryMode.Pull;
         Registry? sourceRegistry = IsLocalPull ? null : new Registry(BaseRegistry, logger, sourceRegistryMode);
@@ -158,6 +177,20 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         {
             Log.LogErrorWithCodeFromResources(nameof(Strings.BaseImageNotFound), sourceImageReference, ContainerRuntimeIdentifier);
             return !Log.HasLoggedErrors;
+        }
+
+        if (EnableArchiveIncrementalCache && archiveIncrementalFingerprint is null)
+        {
+            archiveIncrementalFingerprint = ContainerArchiveCache.ComputeFingerprint(
+                this,
+                imageBuilder.BaseImageManifestDigest,
+                baseImageIsResolved: true,
+                cancellationToken);
+            if (ContainerArchiveCache.TryRestore(this, archiveIncrementalFingerprint))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return true;
+            }
         }
 
         (string message, object[] parameters) = SkipPublishing ?
@@ -261,6 +294,11 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         {
             await ImagePublisher.PublishImageAsync(builtImage, sourceImageReference, destinationImageReference, NoCache, Log, telemetry, cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        if (archiveIncrementalFingerprint is not null && !Log.HasLoggedErrors)
+        {
+            ContainerArchiveCache.Save(this, archiveIncrementalFingerprint);
         }
 
         return !Log.HasLoggedErrors;

--- a/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/src/Containers/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -101,6 +101,7 @@
       <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">latest</ContainerImageTag>
       <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true' and '$(ContainerImageTags)' == ''">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
       <ContainerPushNoCache Condition="'$(ContainerPushNoCache)' == ''">false</ContainerPushNoCache>
+      <ContainerArchiveNoIncremental Condition="'$(ContainerArchiveNoIncremental)' == ''">false</ContainerArchiveNoIncremental>
     </PropertyGroup>
 
     <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
@@ -252,6 +253,11 @@
   <!-- There is an implicit dependency here in that both of ComputeContainerConfig and _ComputeContainerExecutionArgs must have been run, but because we call this Target
        in a few different ways we can't express that dependency directly here. -->
   <Target Name="_PublishSingleContainer" Returns="@(GeneratedContainer)">
+    <PropertyGroup>
+      <_ContainerArchiveIncrementalCacheEnabled Condition="'$(ContainerArchiveNoIncremental)' == 'false' and '$(ContainerArchiveOutputPath)' != '' and '$(_IsSingleRIDBuild)' == 'true' and '$(_IsMultiRIDInnerBuild)' != 'true'">true</_ContainerArchiveIncrementalCacheEnabled>
+      <_ContainerArchiveIncrementalCachePath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'container', 'publish.cache.json'))</_ContainerArchiveIncrementalCachePath>
+    </PropertyGroup>
+
     <CreateNewImage BaseRegistry="$(ContainerBaseRegistry)"
                     BaseImageName="$(ContainerBaseName)"
                     BaseImageTag="$(ContainerBaseTag)"
@@ -281,7 +287,9 @@
                     NoCache="$(ContainerPushNoCache)"
                     GenerateLabels="$(ContainerGenerateLabels)"
                     GenerateCreatedLabels="$(ContainerGenerateLabelsImageCreated)"
-                    GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"> <!-- The RID graph path is provided as a property by the SDK. -->
+                    GenerateDigestLabel="$(ContainerGenerateLabelsImageBaseDigest)"
+                    EnableArchiveIncrementalCache="$(_ContainerArchiveIncrementalCacheEnabled)"
+                    ArchiveIncrementalCachePath="$(_ContainerArchiveIncrementalCachePath)"> <!-- The RID graph path is provided as a property by the SDK. -->
 
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
@@ -342,6 +350,7 @@
           ContainerImageFormat=$(_SingleImageContainerFormat);
           _IsMultiRIDBuild=false;
           _IsSingleRIDBuild=true;
+          _IsMultiRIDInnerBuild=true;
           _InitialContainerBaseImage=$(_InitialContainerBaseImage)
         "/>
       <_rids Remove ="$(_rids)" />

--- a/test/Microsoft.NET.Build.Containers.UnitTests/ContainerArchiveTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/ContainerArchiveTests.cs
@@ -11,6 +11,39 @@ namespace Microsoft.NET.Build.Containers.UnitTests;
 public class ContainerArchiveTests
 {
     [TestMethod]
+    public async Task Failed_archive_write_preserves_existing_archive()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(directory);
+        string archivePath = Path.Combine(directory, "image.tar.gz");
+        await File.WriteAllTextAsync(archivePath, "existing", TestContext.CancellationToken);
+        ArchiveFileRegistry registry = new(archivePath);
+        DestinationImageReference destination = new(registry, "repository", ["tag"]);
+
+        try
+        {
+            await Assert.ThrowsExactlyAsync<IOException>(
+                () => registry.LoadAsync(
+                    new object(),
+                    default,
+                    destination,
+                    TestContext.CancellationToken,
+                    async (_, _, _, stream, cancellationToken) =>
+                    {
+                        await stream.WriteAsync("partial"u8.ToArray(), cancellationToken);
+                        throw new IOException("write interrupted");
+                    }));
+
+            Assert.AreEqual("existing", await File.ReadAllTextAsync(archivePath, TestContext.CancellationToken));
+            Assert.HasCount(1, Directory.GetFiles(directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public async Task Rejects_unsupported_manifest_media_type()
     {
         BuiltImage image = new()

--- a/test/Microsoft.NET.Build.Containers.UnitTests/CreateNewImageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.UnitTests/CreateNewImageTests.cs
@@ -11,6 +11,250 @@ namespace Microsoft.NET.Build.Containers.UnitTests;
 [TestClass]
 public class CreateNewImageTests
 {
+    private const string BaseManifestDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+    public TestContext TestContext { get; set; } = default!;
+
+    [TestMethod]
+    public void ArchiveIncrementalFingerprintTracksInputs()
+    {
+        string publishDirectory = CreateTempDirectory();
+        try
+        {
+            string publishedFile = Path.Combine(publishDirectory, "app.dll");
+            File.WriteAllText(publishedFile, "first");
+
+            CreateNewImage task = CreateIncrementalTask(publishDirectory);
+            string initial = ComputeResolvedFingerprint(task);
+
+            File.WriteAllText(publishedFile, "second");
+            string contentChanged = ComputeResolvedFingerprint(task);
+            Assert.AreNotEqual(initial, contentChanged);
+
+            File.WriteAllText(publishedFile, "first");
+            task.WorkingDirectory = "/changed";
+            string configurationChanged = ComputeResolvedFingerprint(task);
+            Assert.AreNotEqual(initial, configurationChanged);
+
+            task.WorkingDirectory = "/app";
+            const string changedBaseManifestDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+            string baseImageChanged = ContainerArchiveCache.ComputeFingerprint(
+                task,
+                changedBaseManifestDigest,
+                baseImageIsResolved: true,
+                TestContext.CancellationToken);
+            Assert.AreNotEqual(initial, baseImageChanged);
+        }
+        finally
+        {
+            Directory.Delete(publishDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ArchiveIncrementalFingerprintTracksLabels()
+    {
+        string publishDirectory = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(publishDirectory, "app.dll"), "content");
+            CreateNewImage task = CreateIncrementalTask(publishDirectory);
+            task.GenerateLabels = true;
+            TaskItem createdLabel = new("org.opencontainers.image.created");
+            createdLabel.SetMetadata("Value", "first");
+            task.Labels = [createdLabel];
+
+            string initial = ComputeResolvedFingerprint(task);
+            createdLabel.SetMetadata("Value", "second");
+
+            Assert.AreNotEqual(
+                initial,
+                ComputeResolvedFingerprint(task));
+        }
+        finally
+        {
+            Directory.Delete(publishDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ArchiveIncrementalFingerprintIgnoresDisabledLabels()
+    {
+        string publishDirectory = CreateTempDirectory();
+        try
+        {
+            CreateNewImage task = CreateIncrementalTask(publishDirectory);
+            task.GenerateLabels = false;
+            task.GenerateCreatedLabels = true;
+            task.GenerateDigestLabel = true;
+            TaskItem label = new("label");
+            label.SetMetadata("Value", "first");
+            task.Labels = [label];
+            string initial = ComputeResolvedFingerprint(task);
+
+            task.GenerateCreatedLabels = false;
+            task.GenerateDigestLabel = false;
+            label.SetMetadata("Value", "second");
+
+            Assert.AreEqual(initial, ComputeResolvedFingerprint(task));
+        }
+        finally
+        {
+            Directory.Delete(publishDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolvedBaseFingerprintIgnoresReferenceSelectors()
+    {
+        string rootDirectory = CreateTempDirectory();
+        try
+        {
+            string publishDirectory = Path.Combine(rootDirectory, "publish");
+            string runtimeIdentifierGraph = Path.Combine(rootDirectory, "runtime.json");
+            Directory.CreateDirectory(publishDirectory);
+            File.WriteAllText(runtimeIdentifierGraph, "{}");
+            CreateNewImage task = CreateIncrementalTask(publishDirectory, runtimeIdentifierGraph);
+            string initial = ComputeResolvedFingerprint(task);
+
+            task.BaseRegistry = "example.invalid";
+            task.BaseImageName = "different/image";
+            task.BaseImageTag = "different";
+            task.BaseImageDigest = "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+            task.ContainerRuntimeIdentifier = "linux-arm64";
+            File.WriteAllText(task.RuntimeIdentifierGraphPath, """{"different":true}""");
+
+            Assert.AreEqual(initial, ComputeResolvedFingerprint(task));
+        }
+        finally
+        {
+            Directory.Delete(rootDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ArchiveIncrementalFingerprintIsStableAcrossDirectories()
+    {
+        string rootDirectory = CreateTempDirectory();
+        try
+        {
+            string firstPublishDirectory = Path.Combine(rootDirectory, "first", "publish");
+            string secondPublishDirectory = Path.Combine(rootDirectory, "second", "publish");
+            string firstGraph = Path.Combine(rootDirectory, "first", "runtime.json");
+            string secondGraph = Path.Combine(rootDirectory, "second", "runtime.json");
+            Directory.CreateDirectory(firstPublishDirectory);
+            Directory.CreateDirectory(secondPublishDirectory);
+            File.WriteAllText(Path.Combine(firstPublishDirectory, "app.dll"), "content");
+            File.WriteAllText(Path.Combine(secondPublishDirectory, "app.dll"), "content");
+            File.WriteAllText(firstGraph, "{}");
+            File.WriteAllText(secondGraph, "{}");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(firstGraph, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                File.SetUnixFileMode(secondGraph, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+            }
+            CreateNewImage firstTask = CreateIncrementalTask(firstPublishDirectory, firstGraph);
+            CreateNewImage secondTask = CreateIncrementalTask(secondPublishDirectory, secondGraph);
+
+            string first = ContainerArchiveCache.ComputeFingerprint(
+                firstTask,
+                BaseManifestDigest,
+                baseImageIsResolved: false,
+                TestContext.CancellationToken);
+            string second = ContainerArchiveCache.ComputeFingerprint(
+                secondTask,
+                BaseManifestDigest,
+                baseImageIsResolved: false,
+                TestContext.CancellationToken);
+
+            Assert.AreEqual(first, second);
+        }
+        finally
+        {
+            Directory.Delete(rootDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ArchiveIncrementalFingerprintHonorsCancellation()
+    {
+        string publishDirectory = CreateTempDirectory();
+        try
+        {
+            CreateNewImage task = CreateIncrementalTask(publishDirectory);
+            using CancellationTokenSource cancellation = new();
+            cancellation.Cancel();
+
+            Assert.ThrowsExactly<OperationCanceledException>(
+                () => ContainerArchiveCache.ComputeFingerprint(
+                    task,
+                    BaseManifestDigest,
+                    baseImageIsResolved: true,
+                    cancellation.Token));
+        }
+        finally
+        {
+            Directory.Delete(publishDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async System.Threading.Tasks.Task ArchiveIncrementalCacheRestoresOutputsBeforeResolvingBaseImage()
+    {
+        string tempDirectory = CreateTempDirectory();
+        try
+        {
+            string publishDirectory = Path.Combine(tempDirectory, "publish");
+            Directory.CreateDirectory(publishDirectory);
+            File.WriteAllText(Path.Combine(publishDirectory, "app.dll"), "content");
+            string archivePath = Path.Combine(tempDirectory, "archives");
+            string resolvedArchivePath = Path.Combine(archivePath, "test.tar.gz");
+            string cachePath = Path.Combine(tempDirectory, "obj", "publish.cache.json");
+            Directory.CreateDirectory(archivePath);
+            File.WriteAllText(resolvedArchivePath, "archive");
+
+            CreateNewImage original = CreateIncrementalTask(publishDirectory);
+            original.BaseRegistry = "invalid.example";
+            original.BaseImageDigest = BaseManifestDigest;
+            original.ArchiveOutputPath = archivePath;
+            original.ArchiveIncrementalCachePath = cachePath;
+            original.GeneratedContainerManifest = "manifest";
+            original.GeneratedContainerConfiguration = "configuration";
+            original.GeneratedContainerDigest = "sha256:digest";
+            original.GeneratedContainerMediaType = "application/vnd.oci.image.manifest.v1+json";
+            original.GeneratedContainerNames = [new TaskItem("test:latest")];
+            string fingerprint = ContainerArchiveCache.ComputeFingerprint(
+                original,
+                BaseManifestDigest,
+                baseImageIsResolved: false,
+                TestContext.CancellationToken);
+            ContainerArchiveCache.Save(original, fingerprint);
+            DateTime archiveWriteTime = File.GetLastWriteTimeUtc(resolvedArchivePath);
+
+            CreateNewImage cached = CreateIncrementalTask(publishDirectory);
+            cached.BaseRegistry = "invalid.example";
+            cached.BaseImageDigest = BaseManifestDigest;
+            cached.ArchiveOutputPath = archivePath;
+            cached.ArchiveIncrementalCachePath = cachePath;
+            cached.EnableArchiveIncrementalCache = true;
+            cached.BuildEngine = new Mock<IBuildEngine>().Object;
+
+            Assert.IsTrue(await cached.ExecuteAsync(CancellationToken.None));
+            Assert.AreEqual("manifest", cached.GeneratedContainerManifest);
+            Assert.AreEqual("configuration", cached.GeneratedContainerConfiguration);
+            Assert.AreEqual("sha256:digest", cached.GeneratedContainerDigest);
+            Assert.AreEqual("test:latest", cached.GeneratedContainerNames.Single().ItemSpec);
+            Assert.AreEqual(archiveWriteTime, File.GetLastWriteTimeUtc(resolvedArchivePath));
+
+            File.WriteAllText(resolvedArchivePath, "different archive");
+            Assert.IsFalse(ContainerArchiveCache.TryRestore(cached, fingerprint));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
     [TestMethod]
     [DataRow("0", 0L)]
     [DataRow("1636374896", 1636374896L)]
@@ -123,5 +367,40 @@ public class CreateNewImageTests
 
         static ITaskItem[] CreateTaskItems(string value)
             => value.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(s => new TaskItem(s)).ToArray();
+    }
+
+    private string ComputeResolvedFingerprint(CreateNewImage task)
+        => ContainerArchiveCache.ComputeFingerprint(
+            task,
+            BaseManifestDigest,
+            baseImageIsResolved: true,
+            TestContext.CancellationToken);
+
+    private static CreateNewImage CreateIncrementalTask(string publishDirectory, string? runtimeIdentifierGraph = null)
+    {
+        runtimeIdentifierGraph ??= Path.Combine(publishDirectory, "runtime.json");
+        if (!File.Exists(runtimeIdentifierGraph))
+        {
+            File.WriteAllText(runtimeIdentifierGraph, "{}");
+        }
+        return new CreateNewImage
+        {
+            BaseRegistry = "mcr.microsoft.com",
+            BaseImageName = "dotnet/runtime",
+            BaseImageTag = "latest",
+            Repository = "test",
+            ImageTags = ["latest"],
+            PublishDirectory = publishDirectory,
+            WorkingDirectory = "/app",
+            ContainerRuntimeIdentifier = "linux-x64",
+            RuntimeIdentifierGraphPath = runtimeIdentifierGraph,
+        };
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
     }
 }


### PR DESCRIPTION
Container archive publishing currently resolves the base image, rebuilds the application layer, and rewrites the archive on every invocation, even when neither the published application nor its container configuration changed. This makes archive-based inner-loop and orchestration scenarios pay avoidable registry and compression costs.

Add opt-out incremental build support for single-platform archives. CreateNewImage computes a stable fingerprint over published files, relevant container settings and metadata, and the RID graph. Generated creation timestamps are excluded so they do not invalidate otherwise identical inputs. The cache persists both the fingerprint and generated task outputs under the intermediate directory, allowing a hit to restore the normal MSBuild outputs before credentials or registry access.

On a miss, publishing follows the existing path and records the cache only after an error-free archive write. ArchiveFileRegistry now writes beside the destination and atomically replaces the final archive, preserving a previously valid artifact if writing is interrupted. Fingerprinting observes cancellation, and multi-RID inner builds remain on the existing image-index path because their archive lifecycle differs from standalone images.

This should be safe to have as opt-out because the task hash is extensive and includes the image hash. Callers that require every invocation to observe a moved tag can retain the existing non-incremental behavior by specifying ContainerArchiveNoIncremental as false in their project file.
