### PR TITLE
Fix authentication for man-pages update

### DIFF
--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -44,6 +44,7 @@ jobs:
             branch=update-man-page-$date
             git checkout -b $branch
             git commit -m "$title"
+            gh auth setup-git
             git push -u origin $branch --force
             gh pr create --base release/10.0.1xx --head $branch --title "$title" --body "$body"
           fi


### PR DESCRIPTION
## Summary

- configure the GitHub CLI as Git's credential helper before pushing the generated man-pages branch
- retain `persist-credentials: false` on checkout

## Root cause

The workflow disabled checkout's persisted credentials but did not configure replacement authentication for `git push`. As a result, generation and commit succeeded, then the workflow failed with `fatal: could not read Username for 'https://github.com'`.

Fixes the failure in https://github.com/dotnet/sdk/actions/runs/31925513332/job/95112348172.