### PR TITLE
Run dn integration tests in the Native AOT test runner

### DIFF
--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -308,8 +308,10 @@ on each affected OS rather than cross-publishing and assuming native execution.
 .\test\dotnet-aot.Tests\run-aot-tests.ps1 -Trx
 ```
 
-The script publishes the MTP test application with Native AOT, verifies the executable exists, supplies
-the SDK/host paths, runs it, and can emit a TRX. Report executed, passed, failed, and skipped counts.
+The script publishes the MTP test application, product `dotnet-aot` library, and `dn` host with Native
+AOT. It loads the test-built library while using a complete installed SDK for SDK-relative assets and
+managed fallback, then runs the suite and can emit a TRX. Report executed, passed, failed, and skipped
+counts; required `dn` integration tests must not be skipped.
 
 ### 5. Real `dn` integration and parity
 

--- a/src/Cli/dn/Program.cs
+++ b/src/Cli/dn/Program.cs
@@ -119,9 +119,9 @@ partial class Program
     }
 
     /// <summary>
-    ///  Resolves the directory dotnet-aot is loaded from (and passed as sdk_dir). Honors the
+    ///  Resolves the directory passed to dotnet-aot as <c>sdk_dir</c>. Honors the
     ///  DOTNET_AOT_SDK_DIR override for emulating the deployed non-flat layout; otherwise defaults
-    ///  to dn's own directory.
+    ///  to dn's own directory. The native-library load directory is resolved separately.
     /// </summary>
     private static string ResolveAotSdkDir(string baseDir)
     {

--- a/src/Cli/dn/Program.cs
+++ b/src/Cli/dn/Program.cs
@@ -22,17 +22,16 @@ partial class Program
         string baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
         string dotnetRoot = ResolveDotnetRoot();
 
-        // The muxer loads dotnet-aot from the resolved SDK directory. For local testing, allow the
-        // harness to emulate the deployed (non-flat) layout - where dotnet-aot lives in sdk\<version>\
-        // while dn stays in the parent - via DOTNET_AOT_SDK_DIR, which overrides both where the
-        // library is loaded from and the sdk_dir passed to dotnet_execute. Defaults to dn's own
-        // directory (the flat layout).
+        // The muxer loads dotnet-aot from the resolved SDK directory. The harness can override the
+        // SDK and native-library directories independently so it can use a complete installed SDK
+        // without modifying it.
         string sdkDir = ResolveAotSdkDir(baseDir);
-        if (!string.Equals(sdkDir, baseDir, StringComparison.OrdinalIgnoreCase))
+        string aotLibraryDir = ResolveAotLibraryDir(sdkDir);
+        if (!string.Equals(aotLibraryDir, baseDir, StringComparison.OrdinalIgnoreCase))
         {
             NativeLibrary.SetDllImportResolver(typeof(Program).Assembly, (name, assembly, searchPath) =>
                 string.Equals(name, "dotnet-aot", StringComparison.Ordinal)
-                    && NativeLibrary.TryLoad(Path.Combine(sdkDir, AotLibraryFileName), out nint handle)
+                    && NativeLibrary.TryLoad(Path.Combine(aotLibraryDir, AotLibraryFileName), out nint handle)
                         ? handle
                         : nint.Zero);
         }
@@ -130,6 +129,19 @@ partial class Program
         return !string.IsNullOrEmpty(overrideDir) && Directory.Exists(overrideDir)
             ? Path.TrimEndingDirectorySeparator(Path.GetFullPath(overrideDir))
             : baseDir;
+    }
+
+    /// <summary>
+    ///  Resolves the directory from which the test harness loads dotnet-aot. By default this is the
+    ///  resolved SDK directory, matching the muxer; DOTNET_AOT_LIBRARY_DIR lets tests keep native
+    ///  artifacts separate from an installed SDK.
+    /// </summary>
+    private static string ResolveAotLibraryDir(string sdkDir)
+    {
+        string? overrideDir = Environment.GetEnvironmentVariable("DOTNET_AOT_LIBRARY_DIR");
+        return !string.IsNullOrEmpty(overrideDir) && Directory.Exists(overrideDir)
+            ? Path.TrimEndingDirectorySeparator(Path.GetFullPath(overrideDir))
+            : sdkDir;
     }
 
     /// <summary>

--- a/src/Cli/dn/run-dn.ps1
+++ b/src/Cli/dn/run-dn.ps1
@@ -139,6 +139,7 @@ $environmentVariableNames = @(
     "DOTNET_ROOT",
     "DOTNET_CLI_TELEMETRY_OPTOUT",
     "DOTNET_AOT_SDK_DIR",
+    "DOTNET_AOT_LIBRARY_DIR",
     "DOTNET_AOT_BLANK_SDKDIR",
     "DOTNET_CLI_ENABLEAOT"
 )
@@ -154,6 +155,7 @@ foreach ($variableName in $environmentVariableNames) {
 try {
     $env:DOTNET_ROOT = (Join-Path $repoRoot ".dotnet")
     $env:DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+    Remove-Item Env:\DOTNET_AOT_LIBRARY_DIR -ErrorAction SilentlyContinue
 
     # Emulate the deployed non-flat layout: tell dn to load dotnet-aot from (and pass as sdk_dir) the
     # versioned SDK subfolder, optionally forcing the self-locate fallback by blanking sdk_dir.

--- a/test/Microsoft.NET.TestFramework/Utilities/TestPathUtility.cs
+++ b/test/Microsoft.NET.TestFramework/Utilities/TestPathUtility.cs
@@ -7,18 +7,22 @@ public static class TestPathUtility
 {
 #if NET
     /// <summary>
-    /// For path like <c>/tmp/something</c>, returns <c>/private/tmp/something</c> on macOS.
+    /// Resolves symlinked macOS temporary-directory prefixes, such as <c>/tmp</c> and <c>/var</c>.
     /// </summary>
     public static string ResolveTempPrefixLink(string path)
     {
-        // SDK tests use /tmp for test assets. On macOS, it is a symlink - the app will print the resolved path
         if (OperatingSystem.IsMacOS())
         {
-            string tmpPath = "/tmp/";
-            var tmp = new DirectoryInfo(tmpPath[..^1]); // No trailing slash in order to properly check the link target
-            if (tmp.LinkTarget != null && path.StartsWith(tmpPath) && tmp.ResolveLinkTarget(true) is { } linkTarget)
+            string[] tempPaths = ["/tmp/", "/var/"];
+            foreach (string tempPath in tempPaths)
             {
-                return Path.Combine(linkTarget.FullName, path[tmpPath.Length..]);
+                var tempRoot = new DirectoryInfo(tempPath[..^1]);
+                if (path.StartsWith(tempPath, StringComparison.Ordinal)
+                    && tempRoot.LinkTarget != null
+                    && tempRoot.ResolveLinkTarget(true) is { } linkTarget)
+                {
+                    return Path.Combine(linkTarget.FullName, path[tempPath.Length..]);
+                }
             }
         }
 

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
+using Microsoft.NET.TestFramework.Utilities;
 
 namespace Microsoft.DotNet.Cli.Tests;
 
@@ -328,7 +329,8 @@ public partial class AotIntegrationTests
     {
         SkipIfDnUnavailable();
 
-        string testDirectory = Path.Join(Path.GetTempPath(), $"dotnet-aot-run-file-{Guid.NewGuid():N}");
+        string testDirectory = TestPathUtility.ResolveTempPrefixLink(
+            Path.Join(Path.GetTempPath(), $"dotnet-aot-run-file-{Guid.NewGuid():N}"));
         Directory.CreateDirectory(testDirectory);
         string entryPointPath = Path.Join(testDirectory, "Program.cs");
         File.WriteAllText(entryPointPath, """

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -239,10 +239,11 @@ public partial class AotIntegrationTests
         string aotLib = OperatingSystem.IsWindows() ? "dotnet-aot.dll"
             : OperatingSystem.IsMacOS() ? "libdotnet-aot.dylib"
             : "libdotnet-aot.so";
-        string aotSource = Path.Combine(sdkLayoutDir, aotLib);
+        string aotLibraryDir = Environment.GetEnvironmentVariable("DOTNET_AOT_LIBRARY_DIR") ?? sdkLayoutDir;
+        string aotSource = Path.Combine(aotLibraryDir, aotLib);
         if (!File.Exists(aotSource))
         {
-            Assert.Inconclusive($"{aotLib} not found next to dn; build with NativeAOT to enable this test.");
+            Assert.Inconclusive($"{aotLib} not found; build with NativeAOT to enable this test.");
         }
 
         string sdkSubDir = Path.Combine(Path.GetTempPath(), "aot-sep-" + Guid.NewGuid().ToString("N"));
@@ -256,7 +257,11 @@ public partial class AotIntegrationTests
                 Path.Combine(sdkSubDir, ".version"),
                 ["0123456789abcdef", expectedVersion]);
 
-            var env = new Dictionary<string, string> { ["DOTNET_AOT_SDK_DIR"] = sdkSubDir };
+            var env = new Dictionary<string, string>
+            {
+                ["DOTNET_AOT_SDK_DIR"] = sdkSubDir,
+                ["DOTNET_AOT_LIBRARY_DIR"] = sdkSubDir,
+            };
             if (selfLocate)
             {
                 env["DOTNET_AOT_BLANK_SDKDIR"] = "1";
@@ -553,9 +558,25 @@ public partial class AotIntegrationTests
             Assert.Contains("AOT run tier: LaunchOnly (NoBuildSyntheticCache).", projectShorthandStderr);
             File.Delete(projectPath);
 
-            byte[] successCacheBeforeFallback = File.ReadAllBytes(successCachePath);
             File.AppendAllText(entryPointPath, $"{Environment.NewLine}// #: conservative fallback");
+            RunFileBuildCacheEntry? fallbackCacheEntry;
+            using (FileStream stream = File.OpenRead(successCachePath))
+            {
+                fallbackCacheEntry = JsonSerializer.Deserialize(
+                    stream,
+                    RunFileBuildCacheJsonSerializerContext.Default.RunFileBuildCacheEntry);
+            }
+            Assert.IsNotNull(fallbackCacheEntry);
+            fallbackCacheEntry.CscArguments = ["/nologo"];
+            using (FileStream stream = File.Create(successCachePath))
+            {
+                JsonSerializer.Serialize(
+                    stream,
+                    fallbackCacheEntry,
+                    RunFileBuildCacheJsonSerializerContext.Default.RunFileBuildCacheEntry);
+            }
             File.SetLastWriteTimeUtc(entryPointPath, File.GetLastWriteTimeUtc(successCachePath).AddSeconds(2));
+            byte[] successCacheBeforeFallback = File.ReadAllBytes(successCachePath);
 
             var (fallbackExitCode, fallbackStdout, fallbackStderr) = RunDn(
                 [

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -378,6 +378,27 @@ public partial class AotIntegrationTests
             Assert.AreEqual(0, setupExitCode, setupOutput + setupError);
             Assert.AreEqual("AOT_RUN_FILE::", setupOutput.Trim());
 
+            string successCachePath = Path.Join(artifactsPath, FileBasedAppRunPlan.BuildSuccessCacheFileName);
+            RunFileBuildCacheEntry? syntheticCacheEntry;
+            using (FileStream stream = File.OpenRead(successCachePath))
+            {
+                syntheticCacheEntry = JsonSerializer.Deserialize(
+                    stream,
+                    RunFileBuildCacheJsonSerializerContext.Default.RunFileBuildCacheEntry);
+            }
+            Assert.IsNotNull(syntheticCacheEntry);
+            syntheticCacheEntry.BuildLevel = BuildLevel.Csc;
+            syntheticCacheEntry.Run = null;
+            syntheticCacheEntry.BuildResultFile = null;
+            syntheticCacheEntry.CscArguments = [];
+            using (FileStream stream = File.Create(successCachePath))
+            {
+                JsonSerializer.Serialize(
+                    stream,
+                    syntheticCacheEntry,
+                    RunFileBuildCacheJsonSerializerContext.Default.RunFileBuildCacheEntry);
+            }
+
             environment["DOTNET_CLI_CONTEXT_VERBOSE"] = bool.TrueString;
             environment["DOTNET_CLI_CONTEXT_VERBOSE_TO_STDERR"] = bool.TrueString;
             var (exitCode, stdout, stderr) = RunDn(
@@ -474,7 +495,6 @@ public partial class AotIntegrationTests
             Assert.AreEqual(projectProfileStdout.Trim(), shorthandProfileStdout.Trim());
             Assert.Contains("AOT run tier: LaunchOnly (NoBuildSyntheticCache).", shorthandProfileStderr);
 
-            string successCachePath = Path.Join(artifactsPath, FileBasedAppRunPlan.BuildSuccessCacheFileName);
             byte[] successCacheBeforeExecutableProfile = File.ReadAllBytes(successCachePath);
             File.Delete(successCachePath);
             DateTime artifactsTimeBeforeExecutableProfile = Directory.GetLastWriteTimeUtc(artifactsPath);

--- a/test/dotnet-aot.Tests/run-aot-tests.ps1
+++ b/test/dotnet-aot.Tests/run-aot-tests.ps1
@@ -7,13 +7,10 @@
     Publishes and runs the dotnet-aot tests as a NativeAOT binary.
 
 .DESCRIPTION
-    This script publishes the dotnet-aot.Tests project as a NativeAOT executable
-    and runs the resulting native binary. This verifies that the AOT CLI code
-    (Parser, DotnetRootResolver, NativeEntryPoint) works correctly when compiled
-    ahead-of-time.
-
-    The test project uses xUnit v3 AOT packages (xunit.v3.core.aot) which use
-    source generators for test discovery, replacing runtime reflection.
+    This script publishes the dotnet-aot.Tests project as a NativeAOT executable,
+    publishes the dotnet-aot library and dn host, and runs the resulting native
+    test binary. This verifies both the Native AOT test closure and end-to-end dn
+    integration against a complete SDK installation.
 
 .PARAMETER Configuration
     Build configuration (Debug or Release). Default: Debug.
@@ -49,8 +46,11 @@ $ErrorActionPreference = "Stop"
 
 # Resolve paths
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..") | Select-Object -ExpandProperty Path
-$dotnet = [System.IO.Path]::Combine($repoRoot, ".dotnet", "dotnet")
+$dotnetName = if ($IsWindows -or $env:OS -eq "Windows_NT") { "dotnet.exe" } else { "dotnet" }
+$dotnet = [System.IO.Path]::Combine($repoRoot, ".dotnet", $dotnetName)
 $testProject = Join-Path $PSScriptRoot "dotnet-aot.Tests.csproj"
+$productProject = [System.IO.Path]::Combine($repoRoot, "src", "Cli", "dotnet-aot", "dotnet-aot.csproj")
+$dnProject = [System.IO.Path]::Combine($repoRoot, "src", "Cli", "dn", "dn.csproj")
 
 # Auto-detect RID
 if (-not $RuntimeIdentifier) {
@@ -69,8 +69,16 @@ if (-not $RuntimeIdentifier) {
 }
 
 $publishDir = [System.IO.Path]::Combine($PSScriptRoot, "artifacts", "aot-tests", $Configuration, $RuntimeIdentifier)
+$aotPublishDir = [System.IO.Path]::Combine($PSScriptRoot, "artifacts", "dotnet-aot", $Configuration, $RuntimeIdentifier)
+$dnPublishDir = [System.IO.Path]::Combine($PSScriptRoot, "artifacts", "dn", $Configuration, $RuntimeIdentifier)
 $exeName = if ($RuntimeIdentifier.StartsWith("win")) { "dotnet-aot.Tests.exe" } else { "dotnet-aot.Tests" }
+$aotLibraryName = if ($RuntimeIdentifier.StartsWith("win")) { "dotnet-aot.dll" }
+                  elseif ($RuntimeIdentifier.StartsWith("osx")) { "libdotnet-aot.dylib" }
+                  else { "libdotnet-aot.so" }
+$dnName = if ($RuntimeIdentifier.StartsWith("win")) { "dn.exe" } else { "dn" }
 $exePath = Join-Path $publishDir $exeName
+$aotLibraryPath = Join-Path $aotPublishDir $aotLibraryName
+$dnPath = Join-Path $dnPublishDir $dnName
 
 Write-Host "=== dotnet-aot NativeAOT Test Runner ===" -ForegroundColor Cyan
 Write-Host "  Configuration: $Configuration"
@@ -93,6 +101,26 @@ if (-not $NoBuild) {
         exit $LASTEXITCODE
     }
 
+    & $dotnet publish $productProject `
+        -c $Configuration `
+        -r $RuntimeIdentifier `
+        -p:PublishDir=$aotPublishDir
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: dotnet-aot publish failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    & $dotnet publish $dnProject `
+        -c $Configuration `
+        -r $RuntimeIdentifier `
+        -p:PublishDir=$dnPublishDir
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: dn publish failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
     Write-Host ""
     Write-Host "Published: $exePath" -ForegroundColor Green
     $size = (Get-Item $exePath -ErrorAction SilentlyContinue).Length
@@ -106,6 +134,14 @@ if (-not $NoBuild) {
 if (-not (Test-Path $exePath)) {
     Write-Host "ERROR: Published binary not found at $exePath" -ForegroundColor Red
     Write-Host "Run without -NoBuild to publish first." -ForegroundColor Yellow
+    exit 1
+}
+if (-not (Test-Path $aotLibraryPath)) {
+    Write-Host "ERROR: Published native library not found at $aotLibraryPath" -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $dnPath)) {
+    Write-Host "ERROR: Published dn host not found at $dnPath" -ForegroundColor Red
     exit 1
 }
 
@@ -123,10 +159,19 @@ if (-not $sdkDirectory) {
     exit 1
 }
 
-$previousTestSdkDirectory = $env:DOTNET_AOT_TEST_SDK_DIRECTORY
-$previousDotnetHostPath = $env:DOTNET_HOST_PATH
-$env:DOTNET_AOT_TEST_SDK_DIRECTORY = $sdkDirectory
-$env:DOTNET_HOST_PATH = $dotnet
+$environment = @{
+    DOTNET_AOT_LIBRARY_DIR = $aotPublishDir
+    DOTNET_AOT_SDK_DIR = $sdkDirectory
+    DOTNET_AOT_TEST_DN_PATH = $dnPath
+    DOTNET_AOT_TEST_SDK_DIRECTORY = $sdkDirectory
+    DOTNET_HOST_PATH = $dotnet
+    DOTNET_ROOT = [System.IO.Path]::Combine($repoRoot, ".dotnet")
+}
+$previousEnvironment = @{}
+foreach ($entry in $environment.GetEnumerator()) {
+    $previousEnvironment[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key)
+    [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+}
 
 # When -Trx is set, emit a TRX report (the AOT test binary is a Microsoft.Testing.Platform
 # app, so it accepts the --report-trx options) so CI can publish the results.
@@ -144,8 +189,9 @@ try {
     $testExitCode = $LASTEXITCODE
 }
 finally {
-    $env:DOTNET_AOT_TEST_SDK_DIRECTORY = $previousTestSdkDirectory
-    $env:DOTNET_HOST_PATH = $previousDotnetHostPath
+    foreach ($entry in $previousEnvironment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+    }
 }
 
 Write-Host ""

--- a/test/dotnet-aot.Tests/run-aot-tests.sh
+++ b/test/dotnet-aot.Tests/run-aot-tests.sh
@@ -2,8 +2,8 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-# Publishes and runs the dotnet-aot tests as a NativeAOT binary.
-# Uses xUnit v3 AOT packages (source-generator-based test discovery).
+# Publishes the NativeAOT test binary, dotnet-aot library, and dn host, then runs
+# the full test suite including end-to-end dn integration.
 # See run-aot-tests.ps1 for detailed documentation.
 #
 # Usage:
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DOTNET="$REPO_ROOT/.dotnet/dotnet"
 TEST_PROJECT="$SCRIPT_DIR/dotnet-aot.Tests.csproj"
+PRODUCT_PROJECT="$REPO_ROOT/src/Cli/dotnet-aot/dotnet-aot.csproj"
+DN_PROJECT="$REPO_ROOT/src/Cli/dn/dn.csproj"
 
 CONFIGURATION="Debug"
 RID=""
@@ -55,6 +57,15 @@ fi
 
 PUBLISH_DIR="$SCRIPT_DIR/artifacts/aot-tests/$CONFIGURATION/$RID"
 EXE_PATH="$PUBLISH_DIR/dotnet-aot.Tests"
+AOT_PUBLISH_DIR="$SCRIPT_DIR/artifacts/dotnet-aot/$CONFIGURATION/$RID"
+DN_PUBLISH_DIR="$SCRIPT_DIR/artifacts/dn/$CONFIGURATION/$RID"
+case "$RID" in
+    win-*) AOT_LIBRARY_NAME="dotnet-aot.dll"; DN_NAME="dn.exe" ;;
+    osx-*) AOT_LIBRARY_NAME="libdotnet-aot.dylib"; DN_NAME="dn" ;;
+    *) AOT_LIBRARY_NAME="libdotnet-aot.so"; DN_NAME="dn" ;;
+esac
+AOT_LIBRARY_PATH="$AOT_PUBLISH_DIR/$AOT_LIBRARY_NAME"
+DN_PATH="$DN_PUBLISH_DIR/$DN_NAME"
 
 echo "=== dotnet-aot NativeAOT Test Runner ==="
 echo "  Configuration: $CONFIGURATION"
@@ -72,6 +83,16 @@ if [[ "$NO_BUILD" == false ]]; then
         -p:PublishAotTests=true \
         -p:PublishDir="$PUBLISH_DIR"
 
+    "$DOTNET" publish "$PRODUCT_PROJECT" \
+        -c "$CONFIGURATION" \
+        -r "$RID" \
+        -p:PublishDir="$AOT_PUBLISH_DIR"
+
+    "$DOTNET" publish "$DN_PROJECT" \
+        -c "$CONFIGURATION" \
+        -r "$RID" \
+        -p:PublishDir="$DN_PUBLISH_DIR"
+
     echo ""
     echo "Published: $EXE_PATH"
     if [[ -f "$EXE_PATH" ]]; then
@@ -85,6 +106,14 @@ fi
 if [[ ! -f "$EXE_PATH" ]]; then
     echo "ERROR: Published binary not found at $EXE_PATH"
     echo "Run without --no-build to publish first."
+    exit 1
+fi
+if [[ ! -f "$AOT_LIBRARY_PATH" ]]; then
+    echo "ERROR: Published native library not found at $AOT_LIBRARY_PATH"
+    exit 1
+fi
+if [[ ! -f "$DN_PATH" ]]; then
+    echo "ERROR: Published dn host not found at $DN_PATH"
     exit 1
 fi
 
@@ -104,9 +133,14 @@ if [[ -z "$SDK_DIRECTORY" ]]; then
 fi
 
 export DOTNET_AOT_TEST_SDK_DIRECTORY="$SDK_DIRECTORY"
+export DOTNET_AOT_TEST_DN_PATH="$DN_PATH"
+export DOTNET_AOT_SDK_DIR="$SDK_DIRECTORY"
+export DOTNET_AOT_LIBRARY_DIR="$AOT_PUBLISH_DIR"
 export DOTNET_HOST_PATH="$DOTNET"
+export DOTNET_ROOT="$REPO_ROOT/.dotnet"
 
 chmod +x "$EXE_PATH"
+chmod +x "$DN_PATH"
 
 # When --trx is set, emit a TRX report (the AOT test binary is a Microsoft.Testing.Platform
 # app, so it accepts the --report-trx options) so CI can publish the results.


### PR DESCRIPTION
## Summary

The Native AOT CLI test runner currently publishes only the `dotnet-aot.Tests` executable. `AotIntegrationTests` launches the separate `dn` host, so those tests report inconclusive when the host is absent and CI can pass without exercising the real native host/library boundary.

This change makes the runner:

- publish `dotnet-aot.Tests`, the product `dotnet-aot` native library, and `dn` for the host RID
- run `dn` against a complete installed SDK while loading the freshly published native library from a separate directory
- provide the host, SDK, and library paths required by end-to-end and separated-layout tests
- fail preflight when any required native artifact is missing
- keep the AOT workflow guidance aligned with the runner contract

## History

#54297 introduced the Native AOT test project and the `dn` integration tests. Its validation explicitly reported `38 passed, 6 skipped`; the integration tests were designed to skip when `dn` had not been built.

#54719 added the native test runner to Windows, Linux, and macOS CI. Its validation reported `0 failed, 52 passed, 9 skipped`, including the six `dn` integration tests. The CI runner still published only the test executable, so this was a deliberate incremental scope boundary rather than a platform restriction.

As a result, CI proved that the test closure could compile and execute under Native AOT, but it did not prove that the separately published `dn` host could load the product library, use a complete SDK layout, or transition to managed fallback.

## Implementation notes

`DOTNET_AOT_SDK_DIR` continues to identify the complete versioned SDK directory passed to `dotnet_execute`. A separate `DOTNET_AOT_LIBRARY_DIR` test hook identifies the directory containing the freshly published product library. Keeping these paths separate avoids modifying the bootstrap SDK while preserving realistic SDK-relative lookup for `Roslyn`, `Sdks`, `Current`, and install-root `packs`.

The no-build fallback integration fixture also now creates a cache shape that the native path intentionally rejects. A source timestamp change alone is valid with managed `--no-build` semantics and therefore could not reach the asserted fallback branch.

## Validation

Windows `win-x64`, Release Native AOT run:

```powershell
.\test\dotnet-aot.Tests\run-aot-tests.ps1 `
  -Configuration Release `
  -Trx `
  -ResultsDirectory .\artifacts\TestResults\Release
```

Result: `159` discovered, `159` executed, `159` passed, `0` failed, `0` skipped.

The assembled artifacts were rerun with `-NoBuild` with the same result. `bash -n test/dotnet-aot.Tests/run-aot-tests.sh`, diagnostics, and `git diff --check` also pass. Linux and macOS native execution are left to the existing CI matrix.