### PR TITLE
Do not set DotNetWatchBuild in design-time build in Hot Reload mode

### DIFF
--- a/src/Dotnet.Watch/Watch/Build/BuildNames.cs
+++ b/src/Dotnet.Watch/Watch/Build/BuildNames.cs
@@ -18,7 +18,6 @@ internal static class PropertyNames
     public const string HotReloadAutoRestart = nameof(HotReloadAutoRestart);
     public const string DefaultItemExcludes = nameof(DefaultItemExcludes);
     public const string CustomCollectWatchItems = nameof(CustomCollectWatchItems);
-    public const string DotNetWatchBuild = nameof(DotNetWatchBuild);
     public const string DesignTimeBuild = nameof(DesignTimeBuild);
     public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
     public const string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);

--- a/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
+++ b/src/Dotnet.Watch/Watch/Build/EvaluationResult.cs
@@ -44,7 +44,6 @@ internal sealed class EvaluationResult(
 
         return BuildUtilities.ParseBuildProperties(buildArguments)
             .ToImmutableDictionary(keySelector: arg => arg.key, elementSelector: arg => arg.value)
-            .SetItem(PropertyNames.DotNetWatchBuild, "true")
             .SetItem(PropertyNames.DesignTimeBuild, "true")
             .SetItem(PropertyNames.SkipCompilerExecution, "true")
             .SetItem(PropertyNames.ProvideCommandLineArgs, "true")


### PR DESCRIPTION
Design-time build outputs need to match regular dotnet build to allow Hot Reload to determine correct updates to the baseline.
In future we might also integrate design-time build with regular build to improve performance.

The property is still set when Hot Reload is disabled (`--no-hot-reload`).