### PR TITLE
dotnetup: Update documentation for access modes and add everywhere mode considerations

### DIFF
--- a/documentation/general/dotnetup/README.md
+++ b/documentation/general/dotnetup/README.md
@@ -10,9 +10,10 @@ using a system package manager.
 - A terminal.
 - Bash on macOS or Linux, or PowerShell on Windows, to run the download script.
 
-The default installation and all access modes use your user profile. They do
-not require administrator access. A custom installation path can require
-additional file permissions.
+On Windows, the default setup uses the `everywhere` access mode and requires
+elevation to update the system `PATH`. Choose `none` or `shell` to avoid this
+requirement. For details, see
+[dotnetup environment configuration](concepts/environment.md).
 
 ## Download dotnetup
 
@@ -83,9 +84,8 @@ Setup complete!
 The paths, progress display, and environment guidance depend on your system and
 the selected mode.
 
-The recommended mode is Everywhere Mode on Windows. On macOS and Linux, it is
-Terminal Mode when `dotnetup` detects a supported shell. It is Isolation Mode
-when shell detection is not available.
+The recommended access mode is `everywhere` on Windows. On macOS and Linux, it
+is `shell` when `dotnetup` detects a supported shell and `none` otherwise.
 
 Select **No, customize setup** to choose the SDK channel, access mode, and
 migration options.
@@ -111,43 +111,40 @@ Exact versions do not advance during updates. For all accepted forms, see
 
 ### Choose how to access .NET
 
-The access mode controls how terminals and applications find the managed
-`dotnet` command.
+The access mode controls how terminals and applications find the
+dotnetup-managed .NET installation.
 
-| Mode | Behavior |
+| Access mode | Behavior |
 | --- | --- |
-| Isolation Mode | Use `dotnetup dotnet <command>`. Existing .NET installations remain the default. |
-| Terminal Mode | Update the selected shell profile. Applications launched from that shell use the managed installation. |
-| Everywhere Mode | Update the Windows user environment and shell profile. New terminals and user applications use the managed installation. Windows only. |
+| `none` | Does not modify these environment variables. Run .NET with `dotnetup dotnet`. |
+| `shell` | Modifies the shell profile to set these environment variables. Processes started from that shell use the .NET SDKs and Runtimes installed by dotnetup. |
+| `everywhere` | Modifies the system `PATH` and sets the user-level `DOTNET_ROOT` environment variable. Only available on Windows. |
 
-Terminal Mode supports Bash, Z shell, Fish, PowerShell Core, and Windows
-PowerShell.
-
-For more information, see
+For more details and considerations for `everywhere` mode, see
 [dotnetup environment configuration](concepts/environment.md).
 
 ### Migrate existing installations
 
-Setup can find SDKs and runtimes in the system-managed .NET directory. It can
-install matching native-architecture versions in the dotnetup-managed
-directory. This keeps existing projects working after you change the access
-mode.
+Setup can offer to migrate existing machine-wide .NET SDK and Runtime
+installations into the dotnetup-managed installation. See
+[Everywhere mode considerations](concepts/environment.md#everywhere-mode-considerations)
+for why migration is especially important with `everywhere` mode.
 
 ## Verify setup
 
 Open a new terminal after setup changes your environment.
 
-For Terminal Mode or Everywhere Mode, run:
+For `shell` or `everywhere` mode, run:
 
 ```dotnetcli
 dotnet --version
 dotnetup list
 ```
 
-For Isolation Mode, run:
+For `none` mode, run:
 
 ```dotnetcli
-dotnetup dotnet --version
+dotnetup dotnet -- --version
 dotnetup list
 ```
 

--- a/documentation/general/dotnetup/concepts/environment.md
+++ b/documentation/general/dotnetup/concepts/environment.md
@@ -7,12 +7,19 @@ ms.date: 08/11/2026
 
 # dotnetup environment configuration
 
-Dotnetup can configure the environment to make the .NET SDKs and Runtimes it installs available.  It does this by setting the following environment variables:
+Dotnetup can configure the environment to make the .NET SDKs and Runtimes it
+installs available.  It does this by setting the following environment
+variables:
 
-- **`PATH`**: Makes the `dotnet` command available on the command line.  Dev tools such as Visual Studio or C# Dev Kit also use the `PATH` to locate .NET SDKs and Runtimes.
-- **`DOTNET_ROOT`**: Tells framework-dependent application executables where to find a .NET installation and its shared runtimes.
+- **`PATH`**: Makes the `dotnet` command available on the command line.  Dev
+  tools such as Visual Studio or C# Dev Kit also use the `PATH` to locate .NET
+  SDKs and Runtimes.
+- **`DOTNET_ROOT`**: Tells framework-dependent application executables where to
+  find a .NET installation and its shared runtimes.
 
-Dotnetup supports different access modes which control where these environment variables are set.  You can choose an access mode in the initial dotnetup setup or later with the `dotnetup env` command.
+Dotnetup supports different access modes which control where these environment
+variables are set.  You can choose an access mode in the initial dotnetup setup
+or later with the `dotnetup env` command.
 
 | Access Mode | Behavior |
 | --- | --- |
@@ -20,21 +27,49 @@ Dotnetup supports different access modes which control where these environment v
 | `shell` | Modifies the shell profile to set these environment variables. Processes started from that shell use the .NET SDKs and Runtimes installed by dotnetup. |
 | `everywhere` | Modifies the system `PATH` and sets the user-level `DOTNET_ROOT` environment variable. Only available on Windows. |
 
-By default, dotnetup also adds itself to the `PATH`, regardless of the access mode setting.  This can be controlled with `dotnetup env set --dotnetup-on-path <true|false>`.
+By default, dotnetup also adds itself to the `PATH`, regardless of the access
+mode setting.  This can be controlled with
+`dotnetup env set --dotnetup-on-path <true|false>`.
 
 ## Everywhere mode considerations
 
-Everywhere mode is the default on Windows so that SDKs and runtimes installed by dotnetup will be available from dev tools and from terminals using `cmd` as the shell.  However, there are some things to be aware of, primarily around how it interacts with machine-wide installations of the .NET SDK and Runtime.
+Everywhere mode is the default on Windows so that SDKs and runtimes installed
+by dotnetup will be available from dev tools and from terminals using `cmd` as
+the shell.  However, there are some things to be aware of, primarily around how
+it interacts with machine-wide installations of the .NET SDK and Runtime.
 
-Machine-wide installations of .NET are located under the Program Files folder.  They can be installed with installers that can be downloaded from the .NET downloads page.  Visual Studio installs machine-wide installations of the .NET SDK and Runtime, and installers for framework-dependent applications may also install the .NET Runtime they depend on in the machine-wide location.
+Machine-wide installations of .NET are located under the Program Files folder.
+They can be installed with installers that can be downloaded from the .NET
+downloads page.  Visual Studio installs machine-wide installations of the .NET
+SDK and Runtime, and installers for framework-dependent applications may also
+install the .NET Runtime they depend on in the machine-wide location.
 
-In everywhere mode, the user-local dotnetup-managed .NET installation root will override the machine-wide .NET installation root.  This means that .NET SDKs and Runtimes installed in Program Files will not be available.  Projects that depend on those SDKs will fail to build if a matching SDK is not installed.  If a matching runtime is not installed, framework-dependent applications will fail to launch with an error that says "You must install or update .NET to run this application."
+In everywhere mode, the user-local dotnetup-managed .NET installation root will
+override the machine-wide .NET installation root.  This means that .NET SDKs
+and Runtimes installed in Program Files will not be available.  Projects that
+depend on those SDKs will fail to build if a matching SDK is not installed.  If
+a matching runtime is not installed, framework-dependent applications will fail
+to launch with an error that says "You must install or update .NET to run this
+application."
 
-To avoid these failures, the initial dotnetup setup offers the option to migrate existing system .NET SDK and Runtime installs.  You can also migrate them explicitly by running `dotnetup sdk install --migrate-from-system` for SDKs or `dotnetup runtime install --migrate-from-system` for runtimes.
+To avoid these failures, the initial dotnetup setup offers the option to
+migrate existing system .NET SDK and Runtime installs.  You can also migrate
+them explicitly by running `dotnetup sdk install --migrate-from-system` for
+SDKs or `dotnetup runtime install --migrate-from-system` for runtimes.
 
-Turning everywhere mode on or off requires modifying the system PATH, which requires elevation (i.e. a UAC prompt approval, or "Run as Administrator").  This is because the machine-wide installers for .NET add the Program Files .NET installation root to the system PATH, and the system PATH takes precedence over the user-level PATH when resolving commands.  So dotnetup needs to modify the system PATH to make the dotnetup .NET installation root take precedence.
+Turning everywhere mode on or off requires modifying the system PATH, which
+requires elevation (i.e. a UAC prompt approval, or "Run as Administrator").
+This is because the machine-wide installers for .NET add the Program Files .NET
+installation root to the system PATH, and the system PATH takes precedence over
+the user-level PATH when resolving commands.  So dotnetup needs to modify the
+system PATH to make the dotnetup .NET installation root take precedence.
 
-Because the system PATH applies to all users, these changes can impact other users.  The path that is added to the system PATH is by default under the user's local AppData folder.  This won't normally be accessible to other users so it wouldn't affect which version of `dotnet` is resolved.  However, elevated processes (i.e. running as Administrator) would be able to read the path, and could end up unexpectedly resolving .NET SDKs or Runtimes from another user.
+Because the system PATH applies to all users, these changes can impact other
+users.  The path that is added to the system PATH is by default under the
+user's local AppData folder.  This won't normally be accessible to other users
+so it wouldn't affect which version of `dotnet` is resolved.  However, elevated
+processes (i.e. running as Administrator) would be able to read the path, and
+could end up unexpectedly resolving .NET SDKs or Runtimes from another user.
 
 ## Supported shells
 

--- a/documentation/general/dotnetup/concepts/environment.md
+++ b/documentation/general/dotnetup/concepts/environment.md
@@ -2,25 +2,39 @@
 title: dotnetup environment configuration
 description: Learn how dotnetup configures PATH and DOTNET_ROOT for managed .NET installations.
 ms.topic: conceptual
-ms.date: 08/07/2026
+ms.date: 08/11/2026
 ---
 
 # dotnetup environment configuration
 
-Installing .NET and making the managed `dotnet` command available are
-separate operations. The `dotnetup env` commands control `PATH` and
-`DOTNET_ROOT` configuration.
+Dotnetup can configure the environment to make the .NET SDKs and Runtimes it installs available.  It does this by setting the following environment variables:
 
-## .NET access modes
+- **`PATH`**: Makes the `dotnet` command available on the command line.  Dev tools such as Visual Studio or C# Dev Kit also use the `PATH` to locate .NET SDKs and Runtimes.
+- **`DOTNET_ROOT`**: Tells framework-dependent application executables where to find a .NET installation and its shared runtimes.
 
-| Mode | Behavior |
+Dotnetup supports different access modes which control where these environment variables are set.  You can choose an access mode in the initial dotnetup setup or later with the `dotnetup env` command.
+
+| Access Mode | Behavior |
 | --- | --- |
-| `none` | Does not add the managed `dotnet` to `PATH` or set `DOTNET_ROOT`. Run .NET with `dotnetup dotnet`. |
-| `shell` | Writes a managed block to the selected shell profile. Processes started from that shell use the managed `dotnet`. |
-| `everywhere` | Configures the Windows user environment and the shell profile so terminals and other user applications use the managed `dotnet`. Windows only. |
+| `none` | Does not modify these environment variables. Run .NET with `dotnetup dotnet`. |
+| `shell` | Modifies the shell profile to set these environment variables. Processes started from that shell use the .NET SDKs and Runtimes installed by dotnetup. |
+| `everywhere` | Modifies the system `PATH` and sets the user-level `DOTNET_ROOT` environment variable. Only available on Windows. |
 
-The `dotnetup` executable has a separate `PATH` setting. For example, you can
-choose `none` for .NET access but keep `dotnetup` on `PATH`.
+By default, dotnetup also adds itself to the `PATH`, regardless of the access mode setting.  This can be controlled with `dotnetup env set --dotnetup-on-path <true|false>`.
+
+## Everywhere mode considerations
+
+Everywhere mode is the default on Windows so that SDKs and runtimes installed by dotnetup will be available from dev tools and from terminals using `cmd` as the shell.  However, there are some things to be aware of, primarily around how it interacts with machine-wide installations of the .NET SDK and Runtime.
+
+Machine-wide installations of .NET are located under the Program Files folder.  They can be installed with installers that can be downloaded from the .NET downloads page.  Visual Studio installs machine-wide installations of the .NET SDK and Runtime, and installers for framework-dependent applications may also install the .NET Runtime they depend on in the machine-wide location.
+
+In everywhere mode, the user-local dotnetup-managed .NET installation root will override the machine-wide .NET installation root.  This means that .NET SDKs and Runtimes installed in Program Files will not be available.  Projects that depend on those SDKs will fail to build if a matching SDK is not installed.  If a matching runtime is not installed, framework-dependent applications will fail to launch with an error that says "You must install or update .NET to run this application."
+
+To avoid these failures, the initial dotnetup setup offers the option to migrate existing system .NET SDK and Runtime installs.  You can also migrate them explicitly by running `dotnetup sdk install --migrate-from-system` for SDKs or `dotnetup runtime install --migrate-from-system` for runtimes.
+
+Turning everywhere mode on or off requires modifying the system PATH, which requires elevation (i.e. a UAC prompt approval, or "Run as Administrator").  This is because the machine-wide installers for .NET add the Program Files .NET installation root to the system PATH, and the system PATH takes precedence over the user-level PATH when resolving commands.  So dotnetup needs to modify the system PATH to make the dotnetup .NET installation root take precedence.
+
+Because the system PATH applies to all users, these changes can impact other users.  The path that is added to the system PATH is by default under the user's local AppData folder.  This won't normally be accessible to other users so it wouldn't affect which version of `dotnet` is resolved.  However, elevated processes (i.e. running as Administrator) would be able to read the path, and could end up unexpectedly resolving .NET SDKs or Runtimes from another user.
 
 ## Supported shells
 

--- a/documentation/general/dotnetup/designs/dotnetup-env.md
+++ b/documentation/general/dotnetup/designs/dotnetup-env.md
@@ -63,8 +63,9 @@ Modes:
 - `none` — Don't modify your environment; use `dotnetup dotnet` to invoke.
 - `shell` — Wire dotnetup into your shell's profile file (only shells that load
   profiles see the user dotnet).
-- `everywhere` — Wire dotnetup into your shell profile **and** your user-level
-  PATH/DOTNET_ROOT so cmd.exe, IDEs, and shortcuts also see it.
+- `everywhere` — Wire dotnetup into your shell profile, put the managed dotnet on the
+  Windows system `PATH`, and set user-level `DOTNET_ROOT` so cmd.exe, IDEs, shortcuts,
+  and framework-dependent apphosts also see it.
 
 `DotnetAccessMode` enum renames 1:1: `None` / `Shell` / `Everywhere`. JSON serialization
 follows.
@@ -96,17 +97,16 @@ system/user env-var `PATH` says, which on a typical box is the admin-installed
 `C:\Program Files\dotnet\`.
 
 To make `cmd.exe` (and GUI apps, IDE shortcuts launched from Start menu, etc.) see
-the user dotnet, the user picks `Everywhere` mode. That mode prepends the user dotnet path
-to the Windows env-var `PATH` (registry-level, user scope) and removes the Program
-Files dotnet path from the system PATH, **in addition to** writing the shell profile.
+the user dotnet, the user picks `Everywhere` mode. That mode inserts the user dotnet path
+in the Windows system `PATH` immediately before the Program Files dotnet path and sets
+user-level `DOTNET_ROOT`, **in addition to** writing the shell profile.
 
 Later, a system .NET SDK or runtime installer runs (for example, via a Visual Studio
-update). Its installer adds the Program Files dotnet path back to the system PATH,
-which means the effective PATH will list the Program Files dotnet path, and it will
-take precedence over the user dotnet install.
+update). If its installer rewrites the system `PATH` and removes or reorders dotnetup's
+entry, the Program Files dotnet path can take precedence again.
 
-The fix: rerun `dotnetup env set everywhere`.  This will once again remove the Program Files
-dotnet path from the system PATH. Because `env set` is idempotent, this works whether
+The fix: rerun `dotnetup env set everywhere`. This restores the dotnetup entry immediately
+before the Program Files dotnet entry. Because `env set` is idempotent, this works whether
 the mode was already applied or not.
 
 The mode the user picked is stored in `dotnetup.config.json` and is shown by
@@ -122,7 +122,7 @@ writes `DOTNET_ROOT` and (in the "everywhere" mode) edits the Windows env-var re
 ```
 DotnetAccessMode.None       // dotnetup doesn't wire anything; user invokes via `dotnetup dotnet`
 DotnetAccessMode.Shell      // write to the shell's profile file only
-DotnetAccessMode.Everywhere // shell profile + Windows user env-var PATH/DOTNET_ROOT
+DotnetAccessMode.Everywhere // shell profile + Windows system PATH + user DOTNET_ROOT
 ```
 
 Why these names:
@@ -143,8 +143,8 @@ Help text writes itself:
 
 - `none` — Don't modify your environment; use `dotnetup dotnet` to invoke.
 - `shell` — Wire dotnetup into your shell's profile file.
-- `everywhere` — Wire dotnetup into your shell profile **and** your user-level
-  PATH/DOTNET_ROOT so cmd.exe, IDEs, and shortcuts also see it.
+- `everywhere` — Wire dotnetup into your shell profile, put the managed dotnet on the
+  Windows system `PATH`, and set user-level `DOTNET_ROOT`.
 
 ### Renamed `DotnetAccessMode` enum
 
@@ -354,19 +354,20 @@ the parts you list."*
 
 ### Composition table (what actually gets written)
 
-| `env` | `dotnetupOnPath` | Unix profile (`env script` wires) | Windows user `PATH` | Windows profile (`env script` wires) |
-| --- | --- | --- | --- | --- |
-| none | true | dotnetup only | dotnetup | dotnetup only |
-| none | false | (block removed) | — | (block removed) |
-| shell | true | dotnetup + dotnet | dotnetup | dotnetup + dotnet |
-| shell | false | dotnet only | — | dotnet only |
-| everywhere | true | dotnetup + dotnet | dotnetup + dotnet env vars | dotnetup + dotnet |
-| everywhere | false | n/a (`everywhere` is Windows-only) | dotnet env vars | dotnet only |
+| `env` | `dotnetupOnPath` | Unix profile (`env script` wires) | Windows user `PATH` | Windows system `PATH` / user `DOTNET_ROOT` | Windows profile (`env script` wires) |
+| --- | --- | --- | --- | --- | --- |
+| none | true | dotnetup only | dotnetup | — | dotnetup only |
+| none | false | (block removed) | — | — | (block removed) |
+| shell | true | dotnetup + dotnet | dotnetup | — | dotnetup + dotnet |
+| shell | false | dotnet only | — | — | dotnet only |
+| everywhere | true | n/a (`everywhere` is Windows-only) | dotnetup | managed dotnet / managed root | dotnetup + dotnet |
+| everywhere | false | n/a (`everywhere` is Windows-only) | — | managed dotnet / managed root | dotnet only |
 
 The Unix and Windows profile columns are driven by the same `env script` arguments
 (identical wherever both platforms support the mode; `everywhere` is Windows-only). The Windows
-user `PATH` column is the extra Windows-only piece (and, for `everywhere`, is also where the
-dotnet env-var wiring lives).
+user `PATH` column controls whether dotnetup itself is discoverable. In `everywhere`, the
+managed dotnet is instead inserted into the system `PATH`, while `DOTNET_ROOT` is set at
+user scope.
 
 ### Open questions
 
@@ -413,4 +414,3 @@ Alternative command shapes considered and rejected:
 | `dotnetup config set env <mode>` / `dotnetup config apply`      | git-style; lower-level feel; not the dotnetup CLI's style.         |
 | `dotnetup enable <mode>` / `disable` / `refresh` / `status`     | `enable`/`disable` overload heavily with channel install verbs.    |
 | `dotnetup path set <mode>` / `path show`                        | `path` is narrower than what we do (DOTNET_ROOT, profile script).  |
-

--- a/documentation/general/dotnetup/reference/dotnetup-env-clear.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-clear.md
@@ -28,6 +28,9 @@ dotnetup env set none --dotnetup-on-path false
 
 It does not uninstall .NET.
 
+For more information about access modes, see
+[dotnetup environment configuration](../concepts/environment.md).
+
 ## Options
 
 | Option | Description |

--- a/documentation/general/dotnetup/reference/dotnetup-env-set.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-set.md
@@ -2,7 +2,7 @@
 title: dotnetup env set command
 description: Command reference for applying dotnetup environment settings.
 ms.topic: reference
-ms.date: 08/07/2026
+ms.date: 08/11/2026
 ---
 
 # dotnetup env set command
@@ -23,11 +23,14 @@ dotnetup env set [<MODE>] [options]
 
 The optional .NET access mode:
 
-| Value | Behavior |
+| Access mode | Behavior |
 | --- | --- |
-| `none` | Do not wire the managed `dotnet`. |
-| `shell` | Wire the managed `dotnet` through a shell profile. |
-| `everywhere` | Wire the managed `dotnet` through the Windows user environment and shell profile. Windows only. |
+| `none` | Does not modify these environment variables. Run .NET with `dotnetup dotnet`. |
+| `shell` | Modifies the shell profile to set these environment variables. Processes started from that shell use the .NET SDKs and Runtimes installed by dotnetup. |
+| `everywhere` | Modifies the system `PATH` and sets the user-level `DOTNET_ROOT` environment variable. Only available on Windows. |
+
+For details about each mode and considerations for `everywhere`, see
+[dotnetup environment configuration](../concepts/environment.md).
 
 When you omit `MODE`, the command reapplies the stored mode. The command
 fails if no readable configuration exists.

--- a/documentation/general/dotnetup/reference/dotnetup-env-show.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-show.md
@@ -26,6 +26,9 @@ the requested settings.
 
 If the configuration has drifted, run `dotnetup env set` to reapply it.
 
+For more information about access modes, see
+[dotnetup environment configuration](../concepts/environment.md).
+
 ## Options
 
 | Option | Description |

--- a/documentation/general/dotnetup/reference/dotnetup-init.md
+++ b/documentation/general/dotnetup/reference/dotnetup-init.md
@@ -23,7 +23,8 @@ dotnetup init [options]
 The setup flow presents the effective install path and starter SDK channel.
 It lets you select an access mode and whether the `dotnetup` executable is on
 `PATH`. It can also offer to migrate matching native-architecture
-system-managed installations.
+system-managed installations. For descriptions of the access modes, see
+[dotnetup environment configuration](../concepts/environment.md).
 
 Run this command again to reconfigure dotnetup.
 

--- a/documentation/general/dotnetup/usecases/manage-environment.md
+++ b/documentation/general/dotnetup/usecases/manage-environment.md
@@ -2,13 +2,15 @@
 title: Configure access to dotnetup-managed .NET
 description: Configure shell profiles, user environment variables, or command forwarding.
 ms.topic: how-to
-ms.date: 08/07/2026
+ms.date: 08/11/2026
 ---
 
 # Configure access to dotnetup-managed .NET
 
 Installation and environment configuration are separate operations. Select
-the access mode that fits your workflow.
+the access mode that fits your workflow. For descriptions of the available
+modes, see
+[dotnetup environment configuration](../concepts/environment.md).
 
 ## Use command forwarding
 
@@ -38,16 +40,22 @@ Open a new shell after the command finishes, or activate the current shell to ap
 dotnetup env script --shell pwsh | Invoke-Expression
 ```
 
-## Configure the Windows user environment
+## Configure all Windows user applications
 
-On Windows, the `everywhere` mode updates the persistent user environment
-and the selected shell profile:
+On Windows, use `everywhere` mode to make the managed installation available
+to terminals and other user applications:
 
 ```dotnetcli
 dotnetup env set everywhere --shell pwsh
 ```
 
 This mode is not available on Linux or macOS.
+
+> [!IMPORTANT]
+> Before enabling `everywhere`, review
+> [Everywhere mode considerations](../concepts/environment.md#everywhere-mode-considerations),
+> including how the mode interacts with machine-wide installations and
+> framework-dependent applications.
 
 ## Inspect and correct drift
 

--- a/src/Installer/dotnetup.Library/DotnetupConfig.cs
+++ b/src/Installer/dotnetup.Library/DotnetupConfig.cs
@@ -23,7 +23,7 @@ internal enum DotnetAccessMode
     /// <summary>Add dotnetup-managed dotnet to a shell profile file.</summary>
     Shell = 2,
 
-    /// <summary>Shell profile plus user-level env-var PATH/DOTNET_ROOT (so cmd.exe and GUI apps see the user dotnet too).</summary>
+    /// <summary>Shell profile plus system PATH and user-level DOTNET_ROOT (so cmd.exe and GUI apps see the user dotnet too).</summary>
     Everywhere = 3,
 }
 


### PR DESCRIPTION
- Update environment documentation with details about everywhere mode and considerations when using that mode
- Updates some of the documentation that was still outdated with respect to access mode
- Point to the environment / access mode documentation from related commands.