### PR TITLE
Declare Microsoft.Css.Parser in the static web assets test project

### DIFF
--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Css.Parser" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #55885.

`RewriteCssTest` currently fails all 19 of its tests locally with a `FileNotFoundException` for `Microsoft.Css.Parser`, an assembly that is sitting in the test output directory. The file being present does not help, because it is not declared in `Microsoft.NET.Sdk.StaticWebAssets.Tests.deps.json` and the host will not load an assembly that is not in the dependency graph.

The reference does not reach the test project because `Microsoft.NET.Sdk.StaticWebAssets.Tasks.csproj` marks every package reference private through an `ItemDefinitionGroup`, so nothing flows through the project reference, while a separate copy step still places the file next to the tests.

This declares the package in the test project. The version is already centrally managed in `Directory.Packages.props`, so no version is specified.

I considered narrowing the blanket `PrivateAssets=All` in the tasks project instead, but that changes what flows to consumers of the produced package, so referencing it from the test project looked like the smaller and safer change. Happy to go the other way if you'd prefer.

### Verification

macOS arm64, SDK `11.0.100-preview.6.26359.118`, branched from `7053edd`.

Before:

```
dotnet test --filter "FullyQualifiedName~RewriteCssTest"
  total: 19, failed: 19, succeeded: 0
```

After:

```
dotnet test --filter "FullyQualifiedName~RewriteCssTest"
  total: 19, failed: 0, succeeded: 19
```

Full project suite after the change (requires `redist.csproj` built so the integration tests can find the composed SDK host):

```
  total: 882, failed: 0, succeeded: 876, skipped: 6
```

The 6 skips are Windows-only tests.

### Note

I could not confirm whether CI is affected. `./build.sh --test` does not work for this project — it fails with `MSB4057: The target "RunTests" does not exist in the project`, since these tests moved to `MSTest.Sdk` / Microsoft.Testing.Platform — so I could not reproduce the CI invocation to compare against. If CI's build already produces a `deps.json` containing the assembly then this only fixes local runs, which still seems worth having.
