### PR TITLE
Remove legacy formatter serialization from custom exceptions

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.JsonReader.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadManifestReader/SdkDirectoryWorkloadManifestProvider.JsonReader.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.Serialization;
 using System.Text.Json;
 using Microsoft.NET.Sdk.Localization;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadManifestReader;
@@ -80,18 +79,12 @@ namespace Microsoft.NET.Sdk.WorkloadManifestReader
             }
         }
 
-        [Serializable]
         public class JsonFormatException : Exception
         {
             public JsonFormatException() { }
             public JsonFormatException(string messageFormat, params object?[] args) : base(string.Format(messageFormat, args)) { }
             public JsonFormatException(string message) : base(message) { }
             public JsonFormatException(string message, Exception inner) : base(message, inner) { }
-#if NET8_0_OR_GREATER
-            [Obsolete(DiagnosticId = "SYSLIB0051")] // add this attribute to the serialization ctor
-#endif
-            protected JsonFormatException(SerializationInfo info, StreamingContext context) : base(info, context) { }
         }
     }
 }
-

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/PublicAPI.Unshipped.txt
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/PublicAPI.Unshipped.txt
@@ -24,7 +24,6 @@ Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationExceptio
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationException.TemplateVerificationErrorCode.init -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationException.TemplateVerificationException(string! message, Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode templateVerificationErrorCode) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationException.TemplateVerificationException(string! message, Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationErrorCode templateVerificationErrorCode, System.Exception! inner) -> void
-Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerificationException.TemplateVerificationException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerifierOptions
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerifierOptions.CustomDirectoryVerifier.get -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.VerifyDirectory?
 Microsoft.TemplateEngine.Authoring.TemplateVerifier.TemplateVerifierOptions.CustomInstatiation.get -> Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands.RunInstantiation?

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/TemplateVerificationException.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/TemplateVerificationException.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.Serialization;
-
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
 {
-    [Serializable]
     public class TemplateVerificationException : Exception
     {
         public TemplateVerificationException(string message, TemplateVerificationErrorCode templateVerificationErrorCode) : base(message)
@@ -16,13 +13,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
         public TemplateVerificationException(string message, TemplateVerificationErrorCode templateVerificationErrorCode, Exception inner) : base(message, inner)
         {
             TemplateVerificationErrorCode = templateVerificationErrorCode;
-        }
-
-        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
-        protected TemplateVerificationException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
         }
 
         public TemplateVerificationErrorCode TemplateVerificationErrorCode { get; init; }


### PR DESCRIPTION
## Summary

Remove legacy formatter-based serialization support from:

- `TemplateVerificationException`
- `SdkDirectoryWorkloadManifestProvider.JsonFormatException`

This removes `[Serializable]`, the protected `SerializationInfo` constructors, and the now-unused serialization imports. The template verifier's unshipped public API baseline is updated accordingly.

## Rationale

A security scanner flagged these automatically invoked deserialization constructors and recommended validating input before calling dangerous methods. Validation in the constructor cannot mitigate unsafe formatter deserialization: the formatter reconstructs the object graph and invokes the base `Exception(SerializationInfo, StreamingContext)` constructor before the derived constructor body can validate anything. Neither constructor is involved in normal template verification or `global.json` parsing.

The serialization support only enabled obsolete formatter scenarios such as `BinaryFormatter`, remoting, or cross-AppDomain exception transport. Normal construction, throwing, and catching are unchanged.

## Compatibility assessment

We checked public GitHub code search and the internal DevDiv and dnceng Azure DevOps code indexes for both exception names, their qualified names, and serialization-constructor usage.

- `TemplateVerificationException` results were limited to `dotnet/sdk`, the `dotnet/dotnet` VMR mirror, and repositories containing copied/forked SDK sources.
- Qualified searches for `SdkDirectoryWorkloadManifestProvider.JsonFormatException` found no external GitHub consumers.
- dnceng results were limited to `dotnet-sdk` and its `dotnet-dotnet` mirror: definitions, normal throw/catch sites, and tests.
- DevDiv returned no results for either exception.
- No external subclasses or calls to either serialization constructor were found.

This cannot prove the absence of closed-source or reflection-based consumers, but it provides strong evidence that removing these obsolete hooks is an acceptable compatibility risk.

## Validation

- Full Debug repository build
- `SdkDirectoryWorkloadManifestProviderTests.ItFailsIfGlobalJsonIsMalformed`
- `VerificationEngineTests.ExecuteFailsOnInstantiationFailure`