### PR TITLE
Update Helix Job Monitor to 11.0.0-beta.26424.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26414.2",
+      "version": "11.0.0-beta.26424.2",
       "commands": [
         "dotnet-helix-job-monitor"
       ]


### PR DESCRIPTION
## Summary
- update `Microsoft.DotNet.Helix.JobMonitor` to `11.0.0-beta.26424.2` from Arcade build `20260824.2`
- pick up the scalable result-processing rewrite from dotnet/arcade#17331, including build-scoped discovery, parallel incremental result uploads, retry-aware state, rate-limit handling, and final drain/status reporting
- remove the temporary `general-testing` package source now that the package is promoted