### PR TITLE
Use MTP artifact input provenance

### DIFF
--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -100,9 +100,12 @@ and manifest option are defined in
 The SDK writes a JSON manifest listing the input artifacts (path, kind, producing module,
 target framework, architecture, execution id) and the output directory, then hands it to the
 relaunched tool. The merged artifacts flow **back over the same pipe** as ordinary
-file-artifact messages, so they re-enter the normal reporter path. In the summary, the SDK
-[removes the inputs it consumed and adds the merged output](../../src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs)
-in their place.
+file-artifact messages, together with the exact manifest input paths represented by each output,
+so they re-enter the normal reporter path. In the summary, the SDK
+[removes only those consumed inputs and adds the merged output](../../src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs)
+in their place. This provenance keeps an unrelated artifact listed even when it happens to share
+the merged output's file extension. Older merge hosts that do not report provenance retain the
+previous kind-and-extension inference for compatibility.
 
 The original per-module artifacts are **never deleted from disk** — only the run summary
 changes. If you need the individual files (for example a per-module TRX), they are still where
@@ -201,8 +204,9 @@ What `dotnet test` expects of a processor:
   a binary format cannot safely combine).
 - **Treat inputs as read-only** and write under the supplied `outputDirectory`. Never return one of
   the inputs as your output, and never delete a source file.
-- **Set `Kind` on the artifact you return.** That is what the SDK uses to decide which originals the
-  merged artifact replaced in the run summary.
+- **Set `Kind` on the artifact you return.** The MTP dispatcher pairs the result with the exact
+  inputs supplied to that processor, and the SDK uses that provenance to replace only those
+  originals in the run summary.
 - **Be deterministic**: the same set of inputs should produce the same output path.
 
 Two SDK behaviors are worth knowing about. The SDK relaunches the *fewest* test applications that

--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -10,8 +10,8 @@
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs",
-          "baseline_ref_sha": "dba319b212caae2a325800de8a5570ebe787b06d",
-          "baseline_blob_sha": "9abf6c1c70ab832033cfca805078df74ee87cc9b",
+          "baseline_ref_sha": "466d76410b8daf0077502784a583ac7a9e4d97ad",
+          "baseline_blob_sha": "7fb6c55c6d73599069a75cf28de9c043de5fc775",
           "scope": "entire file; ids must match exactly"
         }
       ]

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
@@ -352,22 +352,34 @@ internal sealed class ArtifactPostProcessingManager
     {
         foreach (ArtifactPostProcessingArtifact processedArtifact in processedArtifacts)
         {
-            string outputExtension = Path.GetExtension(processedArtifact.Path).ToLowerInvariant();
-            // The dispatcher gives one processor both its kind-tagged inputs and matching legacy
-            // extension inputs, so the returned output consumes both groups.
-            ArtifactPostProcessingGroup[] consumedGroups =
-            [
-                .. job.Groups.Where(group =>
-                    group.IsKind
-                        ? string.Equals(group.Key, processedArtifact.Kind, StringComparison.Ordinal)
-                        : string.Equals(group.Key, outputExtension, StringComparison.Ordinal))
-            ];
-
-            if (consumedGroups.Length > 0)
+            HashSet<string> consumedPaths;
+            if (processedArtifact.InputArtifactPaths is not null)
             {
-                var consumedPaths = new HashSet<string>(
-                    consumedGroups.SelectMany(group => group.Artifacts).Select(artifact => artifact.Path),
+                var jobInputPaths = new HashSet<string>(
+                    job.Groups.SelectMany(group => group.Artifacts).Select(artifact => artifact.Path),
                     FileUtilities.PathComparer);
+                consumedPaths = new HashSet<string>(
+                    processedArtifact.InputArtifactPaths.Where(jobInputPaths.Contains),
+                    FileUtilities.PathComparer);
+            }
+            else
+            {
+                // Older dispatchers do not report input provenance. Preserve their behavior by
+                // inferring consumed groups from the output kind and extension.
+                string outputExtension = Path.GetExtension(processedArtifact.Path).ToLowerInvariant();
+                consumedPaths = new HashSet<string>(
+                    job.Groups
+                        .Where(group =>
+                            group.IsKind
+                                ? string.Equals(group.Key, processedArtifact.Kind, StringComparison.Ordinal)
+                                : string.Equals(group.Key, outputExtension, StringComparison.Ordinal))
+                        .SelectMany(group => group.Artifacts)
+                        .Select(artifact => artifact.Path),
+                    FileUtilities.PathComparer);
+            }
+
+            if (consumedPaths.Count > 0)
+            {
                 output.RemoveArtifacts(consumedPaths);
             }
 
@@ -434,7 +446,8 @@ internal sealed class ArtifactPostProcessingInvocation(string manifestPath)
                 module.TargetPath,
                 targetFramework,
                 architecture,
-                executionId));
+                executionId,
+                artifact.InputArtifactPaths));
         }
     }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingManager.cs
@@ -350,12 +350,13 @@ internal sealed class ArtifactPostProcessingManager
         ArtifactPostProcessingJob job,
         IReadOnlyList<ArtifactPostProcessingArtifact> processedArtifacts)
     {
+        HashSet<string>? jobInputPaths = null;
         foreach (ArtifactPostProcessingArtifact processedArtifact in processedArtifacts)
         {
             HashSet<string> consumedPaths;
             if (processedArtifact.InputArtifactPaths is not null)
             {
-                var jobInputPaths = new HashSet<string>(
+                jobInputPaths ??= new HashSet<string>(
                     job.Groups.SelectMany(group => group.Artifacts).Select(artifact => artifact.Path),
                     FileUtilities.PathComparer);
                 consumedPaths = new HashSet<string>(

--- a/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingPlanner.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/ArtifactPostProcessingPlanner.cs
@@ -19,7 +19,8 @@ internal sealed record ArtifactPostProcessingArtifact(
     string ProducingTestModule,
     string? TargetFramework,
     string? Architecture,
-    string ExecutionId);
+    string ExecutionId,
+    IReadOnlyList<string>? InputArtifactPaths = null);
 
 internal sealed record ArtifactPostProcessingGroup(
     string Key,

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/FileArtifactMessages.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Models/FileArtifactMessages.cs
@@ -3,6 +3,14 @@
 
 namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 
-internal sealed record FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid, string? Kind);
+internal sealed record FileArtifactMessage(
+    string? FullPath,
+    string? DisplayName,
+    string? Description,
+    string? TestUid,
+    string? TestDisplayName,
+    string? SessionUid,
+    string? Kind,
+    string[]? InputArtifactPaths = null);
 
 internal sealed record FileArtifactMessages(string? ExecutionId, string? InstanceId, FileArtifactMessage[] FileArtifacts) : IRequest;

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/ObjectFieldIds.cs
@@ -140,6 +140,7 @@ internal static class FileArtifactMessageFieldsId
     public const ushort TestDisplayName = 5;
     public const ushort SessionUid = 6;
     public const ushort Kind = 7;
+    public const ushort InputArtifactPaths = 8;
 }
 
 internal static class TestSessionEventFieldsId

--- a/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -51,6 +51,13 @@ namespace Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
     |---FileArtifactMessageList[0].Kind Id---| (2 bytes)
     |---FileArtifactMessageList[0].Kind Size---| (4 bytes)
     |---FileArtifactMessageList[0].Kind Value---| (n bytes)
+
+    |---FileArtifactMessageList[0].InputArtifactPaths Id---| (2 bytes)
+    |---FileArtifactMessageList[0].InputArtifactPaths Size---| (4 bytes)
+    |---FileArtifactMessageList[0].InputArtifactPaths Value---| (n bytes)
+        |---InputArtifactPaths Length---| (4 bytes)
+        |---InputArtifactPaths[0] Size---| (4 bytes)
+        |---InputArtifactPaths[0] Value---| (n bytes)
 */
 
 internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPipeSerializer
@@ -102,6 +109,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         for (int i = 0; i < length; i++)
         {
             string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null, kind = null;
+            string[]? inputArtifactPaths = null;
 
             int fieldCount = ReadUShort(stream);
 
@@ -140,16 +148,40 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
                         kind = ReadStringValue(stream, fieldSize);
                         break;
 
+                    case FileArtifactMessageFieldsId.InputArtifactPaths:
+                        inputArtifactPaths = ReadInputArtifactPathsPayload(stream);
+                        break;
+
                     default:
                         SetPosition(stream, stream.Position + fieldSize);
                         break;
                 }
             }
 
-            fileArtifactMessages.Add(new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid, kind));
+            fileArtifactMessages.Add(new FileArtifactMessage(
+                fullPath,
+                displayName,
+                description,
+                testUid,
+                testDisplayName,
+                sessionUid,
+                kind,
+                inputArtifactPaths));
         }
 
         return fileArtifactMessages;
+    }
+
+    private static string[] ReadInputArtifactPathsPayload(Stream stream)
+    {
+        int length = ReadInt(stream);
+        string[] inputArtifactPaths = new string[length];
+        for (int i = 0; i < length; i++)
+        {
+            inputArtifactPaths[i] = ReadString(stream);
+        }
+
+        return inputArtifactPaths;
     }
 
     public void Serialize(object objectToSerialize, Stream stream)
@@ -191,10 +223,31 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
             WriteField(stream, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
             WriteField(stream, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
             WriteField(stream, FileArtifactMessageFieldsId.Kind, fileArtifactMessage.Kind);
+            WriteInputArtifactPathsPayload(stream, fileArtifactMessage.InputArtifactPaths);
         }
 
         // NOTE: We are able to seek only if we are using a MemoryStream
         // thus, the seek operation is fast as we are only changing the value of a property
+        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
+    }
+
+    private static void WriteInputArtifactPathsPayload(Stream stream, string[]? inputArtifactPaths)
+    {
+        if (inputArtifactPaths is null || inputArtifactPaths.Length == 0)
+        {
+            return;
+        }
+
+        WriteUShort(stream, FileArtifactMessageFieldsId.InputArtifactPaths);
+        WriteInt(stream, 0);
+
+        long before = stream.Position;
+        WriteInt(stream, inputArtifactPaths.Length);
+        foreach (string inputArtifactPath in inputArtifactPaths)
+        {
+            WriteString(stream, inputArtifactPath);
+        }
+
         WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
     }
 
@@ -210,5 +263,6 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         (fileArtifactMessage.TestUid is null ? 0 : 1) +
         (fileArtifactMessage.TestDisplayName is null ? 0 : 1) +
         (fileArtifactMessage.SessionUid is null ? 0 : 1) +
-        (fileArtifactMessage.Kind is null ? 0 : 1));
+        (fileArtifactMessage.Kind is null ? 0 : 1) +
+        (IsNullOrEmpty(fileArtifactMessage.InputArtifactPaths) ? 0 : 1));
 }

--- a/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/ArtifactPostProcessingManagerTests.cs
@@ -109,6 +109,87 @@ public class ArtifactPostProcessingManagerTests
     }
 
     [TestMethod]
+    public void ApplyOutputs_WithInputProvenance_PreservesUnconsumedArtifactsSharingOutputExtension()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        ArtifactPostProcessingArtifact taggedFirst = CreateArtifact("tagged-first.xml", "example.junit");
+        ArtifactPostProcessingArtifact taggedSecond = CreateArtifact("tagged-second.xml", "example.junit");
+        ArtifactPostProcessingArtifact unrelated = CreateArtifact("unrelated.xml", kind: null);
+        ArtifactPostProcessingApplication application = CreateApplication();
+        var taggedGroup = new ArtifactPostProcessingGroup(
+            "example.junit",
+            IsKind: true,
+            [taggedFirst, taggedSecond],
+            [application]);
+        var fallbackGroup = new ArtifactPostProcessingGroup(
+            ".xml",
+            IsKind: false,
+            [unrelated],
+            [application]);
+        var job = new ArtifactPostProcessingJob(application, [taggedGroup, fallbackGroup]);
+        foreach (ArtifactPostProcessingArtifact artifact in taggedGroup.Artifacts.Concat(fallbackGroup.Artifacts))
+        {
+            reporter.ArtifactAdded(false, "A.dll", "net10.0", "x64", artifact.ExecutionId, null, artifact.Path);
+        }
+
+        ArtifactPostProcessingManager.ApplyOutputs(
+            reporter,
+            job,
+            [
+                CreateArtifact("merged.xml", "example.junit") with
+                {
+                    InputArtifactPaths = [taggedFirst.Path, taggedSecond.Path],
+                },
+            ]);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, TestExitCode.Success);
+
+        string output = console.GetOutput();
+        output.Should().Contain("merged.xml");
+        output.Should().NotContain("tagged-first.xml");
+        output.Should().NotContain("tagged-second.xml");
+        output.Should().Contain("unrelated.xml");
+    }
+
+    [TestMethod]
+    public void ApplyOutputs_WithInputProvenance_CannotRemoveArtifactsOutsideJob()
+    {
+        var console = new CapturingConsole();
+        using var reporter = CreateReporter(console);
+        ArtifactPostProcessingArtifact first = CreateArtifact("first.trx", "microsoft.testing.trx");
+        ArtifactPostProcessingArtifact second = CreateArtifact("second.trx", "microsoft.testing.trx");
+        ArtifactPostProcessingArtifact outsideJob = CreateArtifact("outside-job.trx", "microsoft.testing.trx");
+        ArtifactPostProcessingApplication application = CreateApplication();
+        var group = new ArtifactPostProcessingGroup(
+            "microsoft.testing.trx",
+            IsKind: true,
+            [first, second],
+            [application]);
+        var job = new ArtifactPostProcessingJob(application, [group]);
+        foreach (ArtifactPostProcessingArtifact artifact in group.Artifacts.Append(outsideJob))
+        {
+            reporter.ArtifactAdded(false, "A.dll", "net10.0", "x64", artifact.ExecutionId, null, artifact.Path);
+        }
+
+        ArtifactPostProcessingManager.ApplyOutputs(
+            reporter,
+            job,
+            [
+                CreateArtifact("merged.trx", "microsoft.testing.trx") with
+                {
+                    InputArtifactPaths = [first.Path, second.Path, outsideJob.Path],
+                },
+            ]);
+        reporter.TestExecutionCompleted(DateTimeOffset.UtcNow, TestExitCode.Success);
+
+        string output = console.GetOutput();
+        output.Should().Contain("merged.trx");
+        output.Should().NotContain("first.trx");
+        output.Should().NotContain("second.trx");
+        output.Should().Contain("outside-job.trx");
+    }
+
+    [TestMethod]
     public void GetArtifactPostProcessingLaunchArguments_DotnetCommand_UsesOnlyExecAndTargetPath()
     {
         ArtifactPostProcessingApplication application = CreateApplication();

--- a/test/dotnet.Tests/CommandTests/Test/FileArtifactMessagesSerializerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/FileArtifactMessagesSerializerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using Microsoft.DotNet.Cli.Commands.Test.IPC;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Models;
 using Microsoft.DotNet.Cli.Commands.Test.IPC.Serializers;
 
@@ -11,7 +12,13 @@ namespace dotnet.Tests.CommandTests.Test;
 public class FileArtifactMessagesSerializerTests
 {
     [TestMethod]
-    public void RoundTrip_PreservesArtifactKind()
+    public void InputArtifactPathsFieldId_MatchesProtocolContract()
+    {
+        FileArtifactMessageFieldsId.InputArtifactPaths.Should().Be(8);
+    }
+
+    [TestMethod]
+    public void RoundTrip_PreservesArtifactKindAndInputPaths()
     {
         var original = new FileArtifactMessages(
             ExecutionId: "exec-1",
@@ -25,7 +32,8 @@ public class FileArtifactMessagesSerializerTests
                     TestUid: null,
                     TestDisplayName: null,
                     SessionUid: "session-1",
-                    Kind: "trx"),
+                    Kind: "trx",
+                    InputArtifactPaths: ["/repo/TestResults/first.trx", "/repo/TestResults/second.trx"]),
             ]);
 
         var serializer = new FileArtifactMessagesSerializer();
@@ -37,5 +45,8 @@ public class FileArtifactMessagesSerializerTests
 
         roundTripped.FileArtifacts.Should().ContainSingle();
         roundTripped.FileArtifacts[0].Kind.Should().Be("trx");
+        roundTripped.FileArtifacts[0].InputArtifactPaths.Should().Equal(
+            "/repo/TestResults/first.trx",
+            "/repo/TestResults/second.trx");
     }
 }

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -206,6 +206,33 @@ public class TestApplicationHandlerTests : IDisposable
     }
 
     [TestMethod]
+    public void OnFileArtifactsReceived_DuringArtifactPostProcessing_RecordsInputProvenance()
+    {
+        var invocation = new ArtifactPostProcessingInvocation("manifest.json");
+        (TestApplicationHandler handler, _, _) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            artifactPostProcessingInvocation: invocation);
+        handler.OnHandshakeReceived(
+            BuildHandshake(
+                HandshakeMessageExecutionModes.Tool,
+                hostType: HandshakeMessageHostTypes.ArtifactPostProcessor,
+                includeInstanceId: false),
+            gotSupportedVersion: true).Should().BeTrue();
+        string outputPath = Path.GetFullPath("merged.trx");
+        string[] inputPaths = [Path.GetFullPath("first.trx"), Path.GetFullPath("second.trx")];
+
+        handler.OnFileArtifactsReceived(new FileArtifactMessages(
+            "exec-1",
+            "inst-1",
+            [new FileArtifactMessage(outputPath, "Merged TRX", null, null, null, null, "microsoft.testing.trx", inputPaths)]));
+
+        ArtifactPostProcessingArtifact output = invocation.SnapshotOutputs().Should().ContainSingle().Subject;
+        output.Path.Should().Be(outputPath);
+        output.InputArtifactPaths.Should().Equal(inputPaths);
+    }
+
+    [TestMethod]
     public void OnHandshakeReceived_WhenArtifactPostProcessorHandshakeFails_DoesNotFailTestRun()
     {
         var invocation = new ArtifactPostProcessingInvocation("manifest.json");


### PR DESCRIPTION
Fixes #55555

## Summary

- adopt the additive `FileArtifactMessage.InputArtifactPaths` wire field added by microsoft/testfx#10463
- remove only manifest inputs explicitly represented by each merged output, intersected with the dispatched job
- retain kind-and-extension inference for older Microsoft.Testing.Platform hosts that omit provenance
- sync the vendored wire-contract baseline and update artifact post-processing documentation

## Validation

- `build.cmd -c Debug`
- 63 focused `dotnet.Tests` covering serializer compatibility, protocol ID alignment, handler propagation, legacy fallback, generic-extension collisions, and cross-job isolation
- `python .github/scripts/check_vendored_files.py validate`