### PR TITLE
Re-enable dotnet new solution tests on Linux

### DIFF
--- a/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/DotnetSlnPostActionTests.cs
@@ -32,13 +32,9 @@ namespace Microsoft.DotNet.Cli.New.Tests
         }
 
         [TestMethod]
-        [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/49923
         public void AddProjectToSolutionPostActionFindSlnxFileAtOutputPath()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
-            _engineEnvironmentSettings.Host.VirtualizeDirectory(targetBasePath);
-            EnsureParentDirectoriesExist(targetBasePath);
-            
             string solutionFileFullPath = Path.Combine(targetBasePath, "MySln.slnx");
             _engineEnvironmentSettings.Host.FileSystem.WriteAllText(solutionFileFullPath, string.Empty);
 
@@ -51,9 +47,6 @@ namespace Microsoft.DotNet.Cli.New.Tests
         public void AddProjectToSolutionPostActionPrefersSlnOverSlnx()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
-            _engineEnvironmentSettings.Host.VirtualizeDirectory(targetBasePath);
-            EnsureParentDirectoriesExist(targetBasePath);
-            
             string slnFileFullPath = Path.Combine(targetBasePath, "MySln.sln");
             string slnxFileFullPath = Path.Combine(targetBasePath, "MySln.slnx");
             _engineEnvironmentSettings.Host.FileSystem.WriteAllText(slnFileFullPath, string.Empty);
@@ -65,12 +58,9 @@ namespace Microsoft.DotNet.Cli.New.Tests
         }
 
         [TestMethod]
-        [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/49923
         public void AddProjectToSolutionPostActionPrefersNearbySlnxOverDistantSln()
         {
             string targetBasePath = _engineEnvironmentSettings.GetTempVirtualizedPath();
-            _engineEnvironmentSettings.Host.VirtualizeDirectory(targetBasePath);
-            EnsureParentDirectoriesExist(targetBasePath);
 
             // Place a .sln in targetBasePath (acts as "parent" directory)
             string parentSlnPath = Path.Combine(targetBasePath, "Parent.sln");
@@ -369,20 +359,6 @@ namespace Microsoft.DotNet.Cli.New.Tests
                 targetBasePath);
 
             Assert.IsFalse(result);
-        }
-
-        private void EnsureParentDirectoriesExist(string targetBasePath)
-        {
-            // Ensure parent directories exist to avoid DirectoryNotFoundException during traversal
-            string? currentPath = targetBasePath;
-            while (!string.IsNullOrEmpty(currentPath) && currentPath != Path.GetPathRoot(currentPath))
-            {
-                if (!_engineEnvironmentSettings.Host.FileSystem.DirectoryExists(currentPath))
-                {
-                    _engineEnvironmentSettings.Host.FileSystem.CreateDirectory(currentPath);
-                }
-                currentPath = Path.GetDirectoryName(currentPath);
-            }
         }
 
         private class MockAddProjectToSolutionCallback


### PR DESCRIPTION
## Summary

- re-enable the `.slnx` solution discovery tests on Linux
- remove redundant filesystem virtualization and parent-directory setup left over from the old traversal behavior
- rely on the level-by-level `.sln`/`.slnx` search introduced in #55048, which avoids the host filesystem access that caused the original Helix failure

This is part of the weekly test issue cleanup effort.

Closes #49923

## Testing

- `DotnetSlnPostActionTests`: 14 passed, 0 failed, 0 skipped