### PR TITLE
Remove dotnethome

### DIFF
--- a/src/Layout/pkg/windows/bundles/sdk/LCID/1033/bundle.wxl
+++ b/src/Layout/pkg/windows/bundles/sdk/LCID/1033/bundle.wxl
@@ -80,7 +80,4 @@ This product collects usage data
   <!--_locComment="{Locked='Visual Studio'}"-->
   <String Id="VisualStudioWarning" Value="If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2026 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;." />
   <String Id="LicenseAssent" Value="By clicking Install, you agree to the following terms:" />
-  <String Id="InstallPathx64x86" Value="The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;" />
-  <String Id="InstallPathARM64x86" Value="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;" />
-  <String Id="InstallPathARM64x64" Value="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot;" />
 </WixLocalization>

--- a/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
+++ b/src/Layout/pkg/windows/bundles/sdk/bundle.wxs
@@ -3,13 +3,6 @@
   <Bundle Name="$(ProductName)" Manufacturer="$(Manufacturer)" Version="$(BundleVersion)" UpgradeCode="$(UpgradeCode)" AboutUrl="https://aka.ms/netcorehelp/"
           Compressed="yes">
 
-    <bal:Condition Message="#(loc.InstallPathx64x86)" Condition="WixBundleInstalled OR (NOT DOTNETHOME_X64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE" />
-
-    <bal:Condition Message="#(loc.InstallPathARM64x86)" Condition="WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE" />
-
-    <!-- Permit same path on non-ARM64 machines since past SDKs always wrote this value -->
-    <bal:Condition Message="#(loc.InstallPathARM64x64)" Condition="WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X64) OR (NOT NativeMachine=&quot;$(NativeMachine_arm64)&quot;) OR DOTNETHOMESIMILARITYCHECKOVERRIDE" />
-
     <BootstrapperApplication>
       <bal:WixStandardBootstrapperApplication LicenseFile="..\..\dummyeula.rtf"
                                               LocalizationFile="LCID\1033\bundle.wxl"
@@ -40,124 +33,11 @@
     <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
     <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
 
-    <!-- MSI installers always write search keys to the 32-bit hive. -->
-    <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
-                         Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86"
-                         Result="exists"
-                         Root="HKLM"
-                         Value="InstallLocation"
-                         Variable="DotnetInstallLocationExists_x86" />
-
-    <util:RegistrySearch After="CheckDotnetInstallLocation_x86"
-                         Condition="DotnetInstallLocationExists_x86"
-                         Id="DotnetInstallLocation_x86"
-                         Variable="DOTNETHOME_X86"
-                         Result="value"
-                         Root="HKLM"
-                         Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86"
-                         Value="InstallLocation" />
-
-    <util:FileSearch Id="DotnetExeSearch_x86"
-                     After="DotnetInstallLocation_x86"
-                     Variable="DotnetExeExists_x86"
-                     Condition="NOT DotnetInstallLocationExists_x86"
-                     Result="exists"
-                     Path="[ProgramFilesFolder]dotnet\dotnet.exe"/>
-    <util:DirectorySearch Id="DotnetExeLocation_x86"
-                          After="DotnetExeSearch_x86"
-                          Condition="DotnetExeExists_x86"
-                          Variable="DOTNETHOME_X86"
-                          Path="[ProgramFilesFolder]dotnet"/>
-
-    <?if $(TargetArchitecture)!=x86?>
-    <util:RegistrySearch Id="CheckDotnetInstallLocation_x64"
-              Variable="DotnetInstallLocationExists_x64"
-              Result="exists"
-              Root="HKLM"
-              Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64"
-              Value="InstallLocation" />
-    <util:RegistrySearch Id="DotnetInstallLocation_x64"
-              After="CheckDotnetInstallLocation_x64"
-              Condition="DotnetInstallLocationExists_x64"
-              Variable="DOTNETHOME_X64"
-              Result="value"
-              Root="HKLM"
-              Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64"
-              Value="InstallLocation" />
-
-    <!-- Check default location when on x64 OS-->
-    <util:FileSearch Id="DotnetExeSearch_x64"
-              After="DotnetInstallLocation_x64"
-              Variable="DotnetExeExists_x64"
-              Condition="NOT DotnetInstallLocationExists_x64 AND (NOT NativeMachine OR NativeMachine=&quot;$(NativeMachine_x64)&quot;)"
-              Result="exists"
-              Path="[ProgramFiles64Folder]dotnet\dotnet.exe"/>
-    <util:DirectorySearch Id="DotnetExeLocation_x64"
-              After="DotnetExeSearch_x64"
-              Condition="DotnetExeExists_x64"
-              Variable="DOTNETHOME_X64"
-              Path="[ProgramFiles64Folder]dotnet"/>
-
-    <!-- Check alternate location on non-x64 OS -->
-    <util:FileSearch Id="DotnetExeSearch_alt_x64"
-              After="DotnetInstallLocation_x64"
-              Variable="DotnetExeExists_alt_x64"
-              Condition="NOT DotnetInstallLocationExists_x64 AND NOT NativeMachine=&quot;$(NativeMachine_x64)&quot;"
-              Result="exists"
-              Path="[ProgramFiles64Folder]dotnet\x64\dotnet.exe"/>
-    <util:DirectorySearch Id="DotnetExeLocation_alt_x64"
-              After="DotnetExeSearch_alt_x64"
-              Condition="DotnetExeExists_alt_x64"
-              Variable="DOTNETHOME_X64"
-              Path="[ProgramFiles64Folder]dotnet\x64"/>
-    <?endif?>
-    <?if $(TargetArchitecture)=arm64?>
-    <util:RegistrySearch Id="CheckDotnetInstallLocation_arm64"
-              Variable="DotnetInstallLocationExists_arm64"
-              Result="exists"
-              Root="HKLM"
-              Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64"
-              Value="InstallLocation" />
-    <util:RegistrySearch Id="DotnetInstallLocation_arm64"
-              After="CheckDotnetInstallLocation_arm64"
-              Condition="DotnetInstallLocationExists_arm64"
-              Variable="DOTNETHOME_ARM64"
-              Result="value"
-              Root="HKLM"
-              Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64"
-              Value="InstallLocation" />
-
-    <util:FileSearch Id="DotnetExeSearch_arm64"
-              After="DotnetInstallLocation_arm64"
-              Variable="DotnetExeExists_arm64"
-              Condition="NOT DotnetInstallLocationExists_arm64"
-              Result="exists"
-              Path="[ProgramFiles64Folder]dotnet\dotnet.exe"/>
-    <util:DirectorySearch Id="DotnetExeLocation_arm64"
-              After="DotnetExeSearch_arm64"
-              Condition="DotnetExeExists_arm64"
-              Variable="DOTNETHOME_ARM64"
-              Path="[ProgramFiles64Folder]dotnet"/>
-    <?endif?>
-
-    <!--
-        When installing the SDK bundle to a custom location using the commandline parameters, it is intended, not mandatory, that
-        both "DOTNETHOME_X86" and "DOTNETHOME_X64" should be used on the commandline and should take this convention:
-            DOTNETHOME_X86=<InstallFolder>\x86
-            DOTNETHOME_X64=<InstallFolder>\x64
-        Example:
-            dotnet-sdk-3.0.100-alpha1-009719-win-x64.exe /install DOTNETHOME_X64="D:\dotnet\x64" DOTNETHOME_X86="D:\dotnet\x86" /log "installation.log" /quiet /norestart
-    -->
-    <Variable Name="DOTNETHOME_X86" bal:Overridable="yes" />
-    <Variable Name="DOTNETHOME_X64" bal:Overridable="yes" />
-    <Variable Name="DOTNETHOME_ARM64" bal:Overridable="yes" />
-    <Variable Name="DOTNETHOME" Type="formatted" Value="[DOTNETHOME_$(PlatformToken)]" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(SdkBrandName)" bal:Overridable="no" />
     <Variable Name="DOTNETSDKVERSION" Type="string" Value="$(Version)" bal:Overridable="no" />
     <Variable Name="DOTNETRUNTIMEVERSION" Type="string" Value="$(DotNetRuntimeVersion)" bal:Overridable="no" />
     <Variable Name="ASPNETCOREVERSION" Type="string" Value="$(AspNetCoreVersion)" bal:Overridable="no" />
     <Variable Name="WINFORMSANDWPFVERSION" Type="string" Value="$(WinFormsAndWpfVersion)" bal:Overridable="no" />
-    <Variable Name="DOTNETHOMESIMILARITYCHECKOVERRIDE" Type="string" Value="" bal:Overridable="yes" />
     <Variable Name="VERSIONMAJOR" Type="string" Value="$(MajorVersion)" bal:Overridable="no" />
     <Variable Name="VERSIONMINOR" Type="string" Value="$(MinorVersion)" bal:Overridable="no" />
     <Variable Name="MINIMUMVSVERSION" Type="string" Value="$(MinimumVSVersion)" bal:Overridable="no" />
@@ -192,12 +72,10 @@
       <PackageGroupRef Id="PG_DotNet"/>
 
       <MsiPackage SourceFile="$(TemplatesMsiSourceFile)">
-        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>
 
       <MsiPackage SourceFile="$(SdkMsiSourceFile)">
-        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>

--- a/src/Layout/redist/targets/GenerateMSIs.targets
+++ b/src/Layout/redist/targets/GenerateMSIs.targets
@@ -197,7 +197,6 @@
     <Fragment>
         <PackageGroup Id="PG_WorkloadManifests">
             @(_Manifests->'<MsiPackage SourceFile="%(MsiPath)">
-                <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
             </MsiPackage>', '
             ')
         </PackageGroup>
@@ -271,7 +270,6 @@
     <Fragment>
         <PackageGroup Id="PG_DotNet">
             @(_DotNetMsiPackages->'<MsiPackage SourceFile="%(FullPath)">
-                <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
             </MsiPackage>', '
             ')
         </PackageGroup>


### PR DESCRIPTION
Removing DOTNETHOME properties from the Windows installers. These were originally added as part of .NET Core 3.0 to support customization, but never worked well. Visual Studio also do not use these and with arm64/x64 support, we introduced additional rules that require a more strict pattern under Program Files.