### PR TITLE
Enable root shell completion in the Native AOT CLI

### DIFF
--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -199,9 +199,9 @@ and binary-size delta.
   built executable for a focused managed iteration or use `run-aot-tests.ps1` for native execution.
 - **Existing tests may assert exclusions.** Search before enabling a command; an intentional
   `DoesNotContain` can need a carefully justified inversion.
-- **Dynamic completion can cross the eligibility boundary.** Keep command-tree completion free of
-  managed-only project evaluation. Providers that require unavailable project state must remain AOT-safe
-  or conservatively return definition-backed results.
+- **Completion eligibility is cursor-context-sensitive.** Root command and option labels can come from
+  shared definitions. Once the input selects a command, fall back before producing output so managed
+  parser configuration owns template, project, package, and other command-specific providers.
 - **A Roslyn pragma is not native-publish evidence.** ILC can report the same trim/AOT warning during
   publish. Use **dotnet-aot-compat**, keep suppression scope narrow, and reference an existing tracking
   issue for temporary dependency warnings. Ask the user before creating a new issue.

--- a/.github/skills/add-dotnet-aot-command/SKILL.md
+++ b/.github/skills/add-dotnet-aot-command/SKILL.md
@@ -199,6 +199,9 @@ and binary-size delta.
   built executable for a focused managed iteration or use `run-aot-tests.ps1` for native execution.
 - **Existing tests may assert exclusions.** Search before enabling a command; an intentional
   `DoesNotContain` can need a carefully justified inversion.
+- **Dynamic completion can cross the eligibility boundary.** Keep command-tree completion free of
+  managed-only project evaluation. Providers that require unavailable project state must remain AOT-safe
+  or conservatively return definition-backed results.
 - **A Roslyn pragma is not native-publish evidence.** ILC can report the same trim/AOT warning during
   publish. Use **dotnet-aot-compat**, keep suppression scope narrow, and reference an existing tracking
   issue for temporary dependency warnings. Ask the user before creating a new issue.

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -210,6 +210,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Solution\Remove\SolutionRemoveCommand.cs" Link="Commands\Solution\Remove\SolutionRemoveCommand.cs" />
   </ItemGroup>
 
+  <!-- Dynamic shell completion over the shared command tree. -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Hidden\Complete\CompleteCommand.cs" Link="Commands\Hidden\Complete\CompleteCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Hidden\Complete\CompleteCommandParser.cs" Link="Commands\Hidden\Complete\CompleteCommandParser.cs" />
+  </ItemGroup>
+
   <!-- Project-backed command completions. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\CliCompletion.cs" Link="CliCompletion.cs" />

--- a/src/Cli/dotnet-aot/AotSourceFiles.props
+++ b/src/Cli/dotnet-aot/AotSourceFiles.props
@@ -210,7 +210,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Solution\Remove\SolutionRemoveCommand.cs" Link="Commands\Solution\Remove\SolutionRemoveCommand.cs" />
   </ItemGroup>
 
-  <!-- Dynamic shell completion over the shared command tree. -->
+  <!-- Root-level shell completion over the shared command tree. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Hidden\Complete\CompleteCommand.cs" Link="Commands\Hidden\Complete\CompleteCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet\Commands\Hidden\Complete\CompleteCommandParser.cs" Link="Commands\Hidden\Complete\CompleteCommandParser.cs" />

--- a/src/Cli/dotnet-aot/DESIGN.md
+++ b/src/Cli/dotnet-aot/DESIGN.md
@@ -121,8 +121,9 @@ the dual-path dispatch logic.
 bridge builds the
 **full** command tree (the same `DotNetCommandDefinition` used by the managed
 CLI) so that parsing and `--help` match the managed CLI exactly. Commands that
-can run entirely in AOT (`--version`, `--info`, the AOT-capable `sln`
-subcommands, and the narrow file-based run path described below) execute immediately and return.
+can run entirely in AOT (`--version`, `--info`, dynamic shell completion, the
+AOT-capable `sln` subcommands, and the narrow file-based run path described below)
+execute immediately and return.
 Other built-in command shapes are wired with a fallback action that throws
 `CommandNotAvailableInAotException`;
 the bridge catches it (and any unexpected parse-time failure) and transparently
@@ -250,7 +251,7 @@ In the shared files:
   isolated to small inline `#if CLI_AOT` regions: the managed build wires the
   real command handlers, while the AOT build attaches a managed-fallback handler
   to every command (overriding it with real implementations where AOT can run
-  the command, e.g. `sln` and the narrow cached `run` action). The help writer (`DotnetHelpBuilder`) has no
+  the command, e.g. dynamic `complete`, `sln`, and the narrow cached `run` action). The help writer (`DotnetHelpBuilder`) has no
   conditional compilation: help for the external-tool commands
   (msbuild/nuget/vstest/format/fsi) renders from AOT because those forwarding
   apps use AOT-friendly out-of-process codepaths under `#if CLI_AOT`.

--- a/src/Cli/dotnet-aot/DESIGN.md
+++ b/src/Cli/dotnet-aot/DESIGN.md
@@ -121,9 +121,11 @@ the dual-path dispatch logic.
 bridge builds the
 **full** command tree (the same `DotNetCommandDefinition` used by the managed
 CLI) so that parsing and `--help` match the managed CLI exactly. Commands that
-can run entirely in AOT (`--version`, `--info`, dynamic shell completion, the
-AOT-capable `sln` subcommands, and the narrow file-based run path described below)
-execute immediately and return.
+can run entirely in AOT (`--version`, `--info`, root command and option shell
+completion, the AOT-capable `sln` subcommands, and the narrow file-based run path
+described below) execute immediately and return. Shell completion falls back before
+producing output once its input selects a command, allowing the managed parser to
+supply template, project, package, and other command-specific providers.
 Other built-in command shapes are wired with a fallback action that throws
 `CommandNotAvailableInAotException`;
 the bridge catches it (and any unexpected parse-time failure) and transparently
@@ -251,8 +253,9 @@ In the shared files:
   isolated to small inline `#if CLI_AOT` regions: the managed build wires the
   real command handlers, while the AOT build attaches a managed-fallback handler
   to every command (overriding it with real implementations where AOT can run
-  the command, e.g. dynamic `complete`, `sln`, and the narrow cached `run` action). The help writer (`DotnetHelpBuilder`) has no
-  conditional compilation: help for the external-tool commands
+  the command, e.g. root-level `complete`, `sln`, and the narrow cached `run`
+  action). The help writer (`DotnetHelpBuilder`) has no conditional compilation:
+  help for the external-tool commands
   (msbuild/nuget/vstest/format/fsi) renders from AOT because those forwarding
   apps use AOT-friendly out-of-process codepaths under `#if CLI_AOT`.
 - **`ParserOptionActions.cs`** — The shared `--help`/`--version`/`--info` option

--- a/src/Cli/dotnet/Commands/Hidden/Complete/CompleteCommand.cs
+++ b/src/Cli/dotnet/Commands/Hidden/Complete/CompleteCommand.cs
@@ -32,7 +32,9 @@ public class CompleteCommand
 
         try
         {
+#if !CLI_AOT
             result.HandleDebugSwitch();
+#endif
 
             var completions = Completions(result);
 

--- a/src/Cli/dotnet/Commands/Hidden/Complete/CompleteCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Hidden/Complete/CompleteCommandParser.cs
@@ -9,6 +9,23 @@ internal static class CompleteCommandParser
 {
     public static void ConfigureCommand(CompleteCommandDefinition command)
     {
+#if CLI_AOT
+        command.SetAction(parseResult =>
+        {
+            string input = parseResult.GetValue(command.PathArgument) ?? string.Empty;
+
+            // Managed command parsers can add template, project, and package-backed providers to
+            // command subtrees. Keep only root command/option labels in AOT; defer after a command
+            // is selected so the managed CLI can supply every command-specific provider.
+            if (!ReferenceEquals(Parser.Parse(input).CommandResult.Command, Parser.RootCommand))
+            {
+                throw new CommandNotAvailableInAotException();
+            }
+
+            return CompleteCommand.Run(parseResult);
+        });
+#else
         command.SetAction(CompleteCommand.Run);
+#endif
     }
 }

--- a/src/Cli/dotnet/FirstRunExperience.cs
+++ b/src/Cli/dotnet/FirstRunExperience.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+#if CLI_AOT
+using Microsoft.DotNet.Cli.Commands.Hidden.Complete;
+#endif
 using Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
 using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.ShellShim;
@@ -57,6 +60,15 @@ internal static class FirstRunExperience
         {
             return true;
         }
+
+#if CLI_AOT
+        // Native completion must remain free of first-use output and mutations. Command-specific
+        // completion falls back before producing output so the managed CLI owns its first-run work.
+        if (parseResult.CommandResult.Command is CompleteCommandDefinition)
+        {
+            return true;
+        }
+#endif
 
         using var activity = Activities.Source.StartActivity("first-time-use");
         IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel = new FirstTimeUseNoticeSentinel();

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -228,7 +228,8 @@ public static class Parser
         // reuse a synthetic CSC cache or a validated cached run contract. Other shapes fall back.
         AotRunCommand.ConfigureCommand(rootCommand.RunCommand);
 
-        // Dynamic shell completion only walks the shared command tree and writes candidate labels.
+        // Root command and option labels come from the shared command tree. Once the completion
+        // input selects a command, defer so managed parser configuration supplies its providers.
         CompleteCommandParser.ConfigureCommand(rootCommand.CompleteCommand);
 
         rootCommand.VersionOption.Action = new PrintVersionAction(rootCommand.VersionOption);

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.Cli.Commands.Format;
 using Microsoft.DotNet.Cli.Commands.Fsi;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add.Package;
+using Microsoft.DotNet.Cli.Commands.Hidden.Complete;
 using Microsoft.DotNet.Cli.Commands.Hidden.List;
 using Microsoft.DotNet.Cli.Commands.Hidden.List.Reference;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
@@ -38,7 +39,6 @@ using Microsoft.DotNet.Cli.Commands.BuildServer;
 using Microsoft.DotNet.Cli.Commands.Clean;
 using Microsoft.DotNet.Cli.Commands.Dnx;
 using Microsoft.DotNet.Cli.Commands.Help;
-using Microsoft.DotNet.Cli.Commands.Hidden.Complete;
 using Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
 using Microsoft.DotNet.Cli.Commands.Hidden.Parse;
 using Microsoft.DotNet.Cli.Commands.Hidden.Remove;
@@ -227,6 +227,9 @@ public static class Parser
         // Narrow file-based run fast path: explicit, positional, and shorthand invocations can
         // reuse a synthetic CSC cache or a validated cached run contract. Other shapes fall back.
         AotRunCommand.ConfigureCommand(rootCommand.RunCommand);
+
+        // Dynamic shell completion only walks the shared command tree and writes candidate labels.
+        CompleteCommandParser.ConfigureCommand(rootCommand.CompleteCommand);
 
         rootCommand.VersionOption.Action = new PrintVersionAction(rootCommand.VersionOption);
         rootCommand.InfoOption.Action = new PrintInfoAction(rootCommand.InfoOption);

--- a/test/dotnet-aot.Tests/AotIntegrationTests.cs
+++ b/test/dotnet-aot.Tests/AotIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
 using Microsoft.NET.TestFramework.Utilities;
@@ -319,6 +320,112 @@ public partial class AotIntegrationTests
 
         Assert.AreEqual(0, exitCode);
         stdout.Should().Contain("Usage:");
+    }
+
+    [TestMethod]
+    public void AotComplete_RootLabels_RunWithoutManagedFallbackOrFirstRunSideEffects()
+    {
+        SkipIfDnUnavailable();
+
+        string testDirectory = Path.Combine(Path.GetTempPath(), $"dotnet-aot-complete-{Guid.NewGuid():N}");
+        string sdkDirectory = Path.Combine(testDirectory, "sdk");
+        string cliHome = Path.Combine(testDirectory, "home");
+        Directory.CreateDirectory(sdkDirectory);
+        Directory.CreateDirectory(cliHome);
+
+        string dnPath = FindDnPath()!;
+        string aotLibraryDirectory = Environment.GetEnvironmentVariable("DOTNET_AOT_LIBRARY_DIR")
+            ?? Path.GetDirectoryName(dnPath)!;
+        string aotLibraryFileName = OperatingSystem.IsWindows() ? "dotnet-aot.dll"
+            : OperatingSystem.IsMacOS() ? "libdotnet-aot.dylib"
+            : "libdotnet-aot.so";
+        File.Copy(
+            Path.Combine(aotLibraryDirectory, aotLibraryFileName),
+            Path.Combine(sdkDirectory, aotLibraryFileName));
+        var environment = new Dictionary<string, string>
+        {
+            ["DOTNET_AOT_SDK_DIR"] = sdkDirectory,
+            ["DOTNET_AOT_LIBRARY_DIR"] = sdkDirectory,
+            ["DOTNET_CLI_HOME"] = cliHome,
+            ["DOTNET_CLI_TELEMETRY_OPTOUT"] = bool.TrueString,
+            ["DOTNET_GENERATE_ASPNET_CERTIFICATE"] = bool.FalseString,
+            ["DOTNET_ADD_GLOBAL_TOOLS_TO_PATH"] = bool.FalseString,
+            ["DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK"] = bool.TrueString,
+            ["DOTNET_NOLOGO"] = bool.FalseString,
+        };
+
+        try
+        {
+            var (exitCode, stdout, stderr) = RunDn(
+                ["complete", "--position", "9", "dotnet bu"],
+                enableAot: true,
+                extraEnv: environment);
+
+            Assert.AreEqual(0, exitCode, stderr);
+            Assert.IsTrue(string.IsNullOrEmpty(stderr), stderr);
+            Assert.AreSequenceEqual(
+                ["build", "build-server", "msbuild"],
+                stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+            Assert.IsFalse(File.Exists(Path.Combine(
+                cliHome,
+                ".dotnet",
+                FirstTimeUseNoticeSentinel.SENTINEL)));
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void AotComplete_CommandSpecificProviders_FallBackToManaged()
+    {
+        SkipIfDnUnavailable();
+
+        string testDirectory = Path.Combine(Path.GetTempPath(), $"dotnet-aot-complete-fallback-{Guid.NewGuid():N}");
+        string cliHome = Path.Combine(testDirectory, "home");
+        string customHive = Path.Combine(testDirectory, "hive");
+        Directory.CreateDirectory(cliHome);
+
+        var environment = new Dictionary<string, string>
+        {
+            ["DOTNET_CLI_HOME"] = cliHome,
+            ["DOTNET_CLI_TELEMETRY_OPTOUT"] = bool.TrueString,
+            ["DOTNET_GENERATE_ASPNET_CERTIFICATE"] = bool.FalseString,
+            ["DOTNET_ADD_GLOBAL_TOOLS_TO_PATH"] = bool.FalseString,
+            ["DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK"] = bool.TrueString,
+            ["DOTNET_NOLOGO"] = bool.TrueString,
+        };
+        string completionInput = $"new --debug:custom-hive {customHive} ";
+
+        try
+        {
+            var (warmupExitCode, _, warmupError) = RunDn(
+                ["complete", completionInput],
+                enableAot: true,
+                extraEnv: environment);
+            Assert.AreEqual(0, warmupExitCode, warmupError);
+
+            var (aotExitCode, aotOutput, aotError) = RunDn(
+                ["complete", completionInput],
+                enableAot: true,
+                extraEnv: environment);
+            var (managedExitCode, managedOutput, managedError) = RunDn(
+                ["complete", completionInput],
+                enableAot: false,
+                extraEnv: environment);
+
+            Assert.AreEqual(0, aotExitCode, aotError);
+            Assert.AreEqual(0, managedExitCode, managedError);
+            Assert.IsTrue(string.IsNullOrEmpty(aotError), aotError);
+            Assert.IsTrue(string.IsNullOrEmpty(managedError), managedError);
+            aotOutput.Should().Contain("console");
+            Assert.AreEqual(managedOutput, aotOutput);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
     }
 
     /// <summary>

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DotNet.Cli.Tests;
 
 /// <summary>
 ///  Tests for the AOT-compiled CLI parser (the #if CLI_AOT path in Parser.cs).
-///  Validates that --version, --info, --help, and default usage are served entirely
-///  from AOT, that the full command surface now parses (matching the managed CLI),
+///  Validates that --version, --info, --help, dynamic completion, and default usage are served
+///  entirely from AOT, that the full command surface now parses (matching the managed CLI),
 ///  and that commands which require the managed CLI report this via
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
 /// </summary>
@@ -332,6 +332,22 @@ public partial class AotParserTests
         stdout.Should().Contain($"\"version\": \"{Product.Version}\"");
         stdout.Should().Contain("\"subcommands\"");
         stdout.Should().Contain("\"build\"");
+    }
+
+    [TestMethod]
+    public void InvokeComplete_RendersCompletionsFromAot()
+    {
+        var (exitCode, stdout, stderr) = InvokeWithCapture([
+            "complete",
+            "--position", "9",
+            "dotnet bu",
+        ]);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.IsTrue(string.IsNullOrEmpty(stderr));
+        Assert.AreSequenceEqual(
+            ["build", "build-server", "msbuild"],
+            stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
     }
 
     [TestMethod]

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 
 /// <summary>
 ///  Tests for the AOT-compiled CLI parser (the #if CLI_AOT path in Parser.cs).
-///  Validates that --version, --info, --help, dynamic completion, and default usage are served
+///  Validates that --version, --info, --help, root completion, and default usage are served
 ///  entirely from AOT, that the full command surface now parses (matching the managed CLI),
 ///  and that commands which require the managed CLI report this via
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
@@ -348,6 +348,17 @@ public partial class AotParserTests
         Assert.AreSequenceEqual(
             ["build", "build-server", "msbuild"],
             stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    [TestMethod]
+    [DataRow("dotnet new ")]
+    [DataRow("dotnet build --framework ")]
+    [DataRow("dotnet add package ")]
+    public void InvokeComplete_CommandSpecificCompletionsFallBackToManaged(string input)
+    {
+        var result = Parser.Parse(["complete", input]);
+
+        Assert.ThrowsExactly<CommandNotAvailableInAotException>(() => Parser.Invoke(result));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- link the existing hidden `complete` command implementation into the Native AOT CLI
- serve root command and option labels in-process from the shared command definitions
- fall back before producing output once completion input selects a command, preserving managed template, project, package, and other command-specific providers
- skip Native AOT first-run setup for completion and cover fresh-profile execution plus managed fallback through the published `dn` host

## Validation

- focused AOT parser completion tests: 4 passed, 0 failed, 0 skipped
- focused published-host completion tests: 2 passed, 0 failed, 0 skipped
- managed `dotnet` build: passed
- `win-x64` Native AOT product publish: passed with no warnings
- `win-x64` Native AOT test publish: passed with 6 test/dependency warnings
- focused completion tests in the published Native AOT test executable: 6 passed, 0 failed, 0 skipped
- Debug `win-x64` `dotnet-aot.dll`: 33,241,088 -> 33,246,208 bytes (+5,120 bytes, +0.0154%) against the exact rebased `main` parent

The full Native AOT test suite was not run locally; CI will provide the remaining platform and suite coverage.