### PR TITLE
Allow passing per-client updates

### DIFF
--- a/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
@@ -129,11 +129,18 @@ internal sealed class HotReloadClients(
         return [.. results.SelectMany(r => r).Distinct(StringComparer.Ordinal).OrderBy(c => c)];
     }
 
+    /// <summary>
+    /// Applies managed code updates to all clients.
+    /// </summary>
+    /// <param name="updates">Updates for each client. Must be of the same length as <see cref="Clients"/>.</param>
+    /// <param name="applyOperationCancellationToken">Cancellation token for the apply operation that starts but not necessarily completes when this method returns.</param>
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
-    public async Task<Task> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
+    /// <returns></returns>
+    public async Task<Task> ApplyManagedCodeUpdatesAsync(ImmutableArray<ImmutableArray<HotReloadManagedCodeUpdate>> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
     {
         // shouldn't be called if there are no clients
         Debug.Assert(IsManagedAgentSupported);
+        Debug.Assert(updates.Length == clients.Length);
 
         // Apply to all processes.
         // The module the change is for does not need to be loaded to any of the processes, yet we still consider it successful if the application does not fail.
@@ -141,7 +148,8 @@ internal sealed class HotReloadClients(
         // An error is only reported if the delta application fails, which would be a bug either in the runtime (applying valid delta incorrectly),
         // the compiler (producing wrong delta), or rude edit detection (the change shouldn't have been allowed).
 
-        var applyTasks = await Task.WhenAll(clients.Select(c => c.ApplyManagedCodeUpdatesAsync(updates, applyOperationCancellationToken, cancellationToken)));
+        var applyTasks = await Task.WhenAll(
+            clients.Zip(updates, (client, clientUpdates) => client.ApplyManagedCodeUpdatesAsync(clientUpdates, applyOperationCancellationToken, cancellationToken)));
 
         return CompleteApplyOperationAsync();
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -265,7 +265,7 @@ internal abstract class AbstractBrowserRefreshServer(
         await SendAndReceiveAsync<ReadOnlyMemory<byte>, None>(request: _ => messageBytes, response: null, cancellationToken);
     }
 
-    protected virtual async ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
+    internal virtual async ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
         Func<string?, TRequest>? request,
         ResponseFunc<TResult>? response,
         CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -265,7 +265,7 @@ internal abstract class AbstractBrowserRefreshServer(
         await SendAndReceiveAsync<ReadOnlyMemory<byte>, None>(request: _ => messageBytes, response: null, cancellationToken);
     }
 
-    public async ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
+    protected virtual async ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
         Func<string?, TRequest>? request,
         ResponseFunc<TResult>? response,
         CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
@@ -149,7 +149,7 @@ internal sealed class RunningProjectsManager(ProcessRunner processRunner, ILogge
                 if (updatesToApply.Any() && clients.IsManagedAgentSupported)
                 {
                     await await clients.ApplyManagedCodeUpdatesAsync(
-                        ToManagedCodeUpdates(updatesToApply),
+                        ToManagedCodeUpdates(clients, updatesToApply),
                         applyOperationCancellationToken: processExitedSource.Token,
                         cancellationToken: processCommunicationCancellationToken);
                 }
@@ -304,7 +304,7 @@ internal sealed class RunningProjectsManager(ProcessRunner processRunner, ILogge
 
                     // Only cancel applying updates when the process exits. Canceling disables further updates since the state of the runtime becomes unknown.
                     var applyTask = await runningProject.Clients.ApplyManagedCodeUpdatesAsync(
-                        ToManagedCodeUpdates(builder.ManagedCodeUpdates),
+                        ToManagedCodeUpdates(runningProject.Clients, builder.ManagedCodeUpdates),
                         applyOperationCancellationToken: runningProject.Process.ExitedCancellationToken,
                         cancellationToken);
 
@@ -474,6 +474,11 @@ internal sealed class RunningProjectsManager(ProcessRunner processRunner, ILogge
         return relaunchOperations;
     }
 
-    private static ImmutableArray<HotReloadManagedCodeUpdate> ToManagedCodeUpdates(IEnumerable<HotReloadService.Update> updates)
-        => [.. updates.Select(update => new HotReloadManagedCodeUpdate(update.ModuleId, update.MetadataDelta, update.ILDelta, update.PdbDelta, update.UpdatedTypes, update.RequiredCapabilities))];
+    private static ImmutableArray<ImmutableArray<HotReloadManagedCodeUpdate>> ToManagedCodeUpdates(HotReloadClients clients, IEnumerable<HotReloadService.Update> updates)
+    {
+        var updatesForClient = updates.Select(update => new HotReloadManagedCodeUpdate(update.ModuleId, update.MetadataDelta, update.ILDelta, update.PdbDelta, update.UpdatedTypes, update.RequiredCapabilities));
+
+        // The updates are the same for all clients since the debugger isn't attached:
+        return [.. Enumerable.Repeat(updatesForClient.ToImmutableArray(), clients.Clients.Length)];
+    }
 }

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
-using Microsoft.DotNet.HotReload;
 using Moq;
 
-namespace Microsoft.DotNet.Watch.UnitTests
+namespace Microsoft.DotNet.HotReload.UnitTests
 {
     [TestClass]
     public class HotReloadAgentTest

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.HotReload;
 using Microsoft.DotNet.Test.MSTest.Utilities;
 
-namespace Microsoft.DotNet.Watch.UnitTests;
+namespace Microsoft.DotNet.HotReload.UnitTests;
 
 [TestClass]
 public class HotReloadClientTests

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientsTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientsTests.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.HotReload.UnitTests;
+
+[TestClass]
+public class HotReloadClientsTests
+{
+    [TestMethod]
+    public async Task ApplyManagedCodeUpdates()
+    {
+        var client1Apply = new TaskCompletionSource<bool>();
+        var client2Apply = new TaskCompletionSource<bool>();
+
+        var client1 = new TestHotReloadClient { ApplyImpl = _ => client1Apply.Task };
+        var client2 = new TestHotReloadClient { ApplyImpl = _ => client2Apply.Task };
+        using var refreshServer = new TestBrowserRefreshServer();
+
+        using var clients = new HotReloadClients([client1, client2], refreshServer, useRefreshServerToApplyStaticAssets: false);
+
+        var update1 = CreateUpdate();
+        var update2 = CreateUpdate();
+
+        var applyTask = await clients.ApplyManagedCodeUpdatesAsync([[update1], [update2]], CancellationToken.None, CancellationToken.None);
+
+        Assert.HasCount(1, client1.ReceivedUpdates);
+        Assert.AreEqual(update1.ModuleId, client1.ReceivedUpdates[0].ModuleId);
+        Assert.HasCount(1, client2.ReceivedUpdates);
+        Assert.AreEqual(update2.ModuleId, client2.ReceivedUpdates[0].ModuleId);
+        Assert.IsFalse(applyTask.IsCompleted);
+        Assert.IsEmpty(refreshServer.SentMessages);
+
+        client1Apply.SetResult(true);
+        Assert.IsEmpty(refreshServer.SentMessages);
+
+        client2Apply.SetResult(true);
+        await applyTask;
+
+        Assert.HasCount(1, refreshServer.SentMessages);
+        Assert.Contains("RefreshBrowser", refreshServer.SentMessages[0]);
+    }
+
+    private static HotReloadManagedCodeUpdate CreateUpdate()
+        => new(
+            moduleId: Guid.NewGuid(),
+            metadataDelta: [1],
+            ilDelta: [],
+            pdbDelta: [],
+            updatedTypes: [],
+            requiredCapabilities: ["Baseline"]);
+}

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/ManagedCodeUpdateRequestTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/ManagedCodeUpdateRequestTests.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.HotReload;
-
-namespace Microsoft.DotNet.Watch.UnitTests;
+namespace Microsoft.DotNet.HotReload.UnitTests;
 
 [TestClass]
 public class ManagedCodeUpdateRequestTests

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestBrowserRefreshServer.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestBrowserRefreshServer.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.DotNet.HotReload;
+using Microsoft.DotNet.Test.MSTest.Utilities;
+
+namespace Microsoft.DotNet.HotReload.UnitTests;
+
+internal sealed class TestBrowserRefreshServer()
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath: "", new TestLogger(), _ => new TestLogger(), _ => new TestLogger())
+{
+    public List<string> SentMessages { get; } = [];
+
+    protected override ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
+        Func<string?, TRequest>? request,
+        ResponseFunc<TResult>? response,
+        CancellationToken cancellationToken)
+        where TResult : struct
+    {
+        if (request != null)
+        {
+            var requestValue = request(null);
+            var requestBytes = requestValue is ReadOnlyMemory<byte> bytes ? bytes : SerializeJson(requestValue);
+            SentMessages.Add(Encoding.UTF8.GetString(requestBytes.Span));
+        }
+
+        return ValueTask.FromResult<TResult?>(null);
+    }
+
+    protected override ValueTask<WebServerHost> CreateAndStartHostAsync(CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    protected override bool SuppressTimeouts => true;
+}

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestBrowserRefreshServer.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestBrowserRefreshServer.cs
@@ -12,7 +12,7 @@ internal sealed class TestBrowserRefreshServer()
 {
     public List<string> SentMessages { get; } = [];
 
-    protected override ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
+    internal override ValueTask<TResult?> SendAndReceiveAsync<TRequest, TResult>(
         Func<string?, TRequest>? request,
         ResponseFunc<TResult>? response,
         CancellationToken cancellationToken)

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadAgent.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadAgent.cs
@@ -1,12 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.DotNet.HotReload;
-
-namespace Microsoft.DotNet.Watch.UnitTests;
+namespace Microsoft.DotNet.HotReload.UnitTests;
 
 internal class TestHotReloadAgent : IHotReloadAgent
 {

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.DotNet.Test.MSTest.Utilities;
+
+namespace Microsoft.DotNet.HotReload.UnitTests;
+
+internal sealed class TestHotReloadClient() : HotReloadClient(new TestLogger(), new TestLogger())
+{
+    public ImmutableArray<HotReloadManagedCodeUpdate> ReceivedUpdates { get; private set; }
+    public Func<ImmutableArray<HotReloadManagedCodeUpdate>, Task<bool>> ApplyImpl { get; init; } = _ => Task.FromResult(true);
+
+    public override void ConfigureLaunchEnvironment(IDictionary<string, string> environmentBuilder)
+    {
+    }
+
+    public override void InitiateConnection(CancellationToken cancellationToken)
+    {
+    }
+
+    public override Task WaitForConnectionEstablishedAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    public override Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
+        => Task.FromResult(ImmutableArray<string>.Empty);
+
+    public override Task<Task<bool>> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
+    {
+        ReceivedUpdates = updates;
+        return Task.FromResult(ApplyImpl(updates));
+    }
+
+    public override Task<Task<bool>> ApplyStaticAssetUpdatesAsync(ImmutableArray<HotReloadStaticAssetUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
+        => Task.FromResult(Task.FromResult(true));
+
+    public override Task InitialUpdatesAppliedAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    public override void Dispose()
+    {
+    }
+}

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StaticAssetUpdateRequestTests.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.HotReload;
-
-namespace Microsoft.DotNet.Watch.UnitTests;
+namespace Microsoft.DotNet.HotReload.UnitTests;
 
 [TestClass]
 public class StaticAssetUpdateRequestTests

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Combinatorial.MSTest;
-using Microsoft.DotNet.HotReload;
 
-namespace Microsoft.DotNet.Watch.UnitTests;
+namespace Microsoft.DotNet.HotReload.UnitTests;
 
 [TestClass]
 public class StreamExtensionsTests


### PR DESCRIPTION
When applying changes with a debugger attached to a strict subset of the clients we need to send empty changes to debugger-attached clients and full changes to the other clients.
