### PR TITLE
Re-enable target framework display name test

### DIFF
--- a/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
+++ b/test/Microsoft.NET.Build.Tests/GivenThatWeWantToControlGeneratedAssemblyInfo.cs
@@ -814,7 +814,6 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/45148")]
         [DataRow("netcoreapp3.1", ".NET Core 3.1")]
         [DataRow("netcoreapp2.1", ".NET Core 2.1")]
         [DataRow("netstandard2.1", ".NET Standard 2.1")]


### PR DESCRIPTION
🤖 This change is part of the weekly test issue cleanup effort.

`CheckTargetFrameworkDisplayName` was disabled because terminal logger progress indicators could contaminate redirected stdout. The test now executes the built assembly directly with `dotnet exec`, so that failure mode no longer applies. Re-enable the existing four data rows without changing test behavior.

Validation: `CheckTargetFrameworkDisplayName` (4 passed, 0 failed, 0 skipped).

Closes #45148