### PR TITLE
Use versioned SDK directory for AOT forwarding apps

### DIFF
--- a/src/Cli/dotnet/Commands/Fsi/FsiForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/Fsi/FsiForwardingApp.cs
@@ -9,8 +9,9 @@ namespace Microsoft.DotNet.Cli.Commands.Fsi;
 
 public class FsiForwardingApp(string[] arguments) : ForwardingApp(GetFsiAppPath(), processArguments(arguments))
 {
-    private const string FsiDllName = @"FSharp/fsi.dll";
-    private const string FsiExeName = @"FSharp/fsi.exe";
+    private const string FsiDirectoryName = "FSharp";
+    private const string FsiDllName = "fsi.dll";
+    private const string FsiExeName = "fsi.exe";
 
     static string[] processArguments(string[] args)
     {
@@ -45,16 +46,16 @@ public class FsiForwardingApp(string[] arguments) : ForwardingApp(GetFsiAppPath(
      * So here we look for fsi.dll, if it's found then we will return the path to it, otherwise we return fsi.exe
      * the reason for using this bridging mechanism is to simplify the coordination between F#/VS and the dotnet sdk
     */
-    private static string GetFsiAppPath()
+    internal static string GetFsiAppPath()
     {
-        var dllPath = Path.Combine(AppContext.BaseDirectory, FsiDllName);
+        var dllPath = Path.Combine(SdkPaths.SdkDirectory, FsiDirectoryName, FsiDllName);
         if (exists(dllPath))
         {
             return dllPath;
         }
         else
         {
-            return Path.Combine(AppContext.BaseDirectory, FsiExeName);
+            return Path.Combine(SdkPaths.SdkDirectory, FsiDirectoryName, FsiExeName);
         }
     }
 }

--- a/src/Cli/dotnet/Commands/Test/VSTest/VSTestForwardingApp.cs
+++ b/src/Cli/dotnet/Commands/Test/VSTest/VSTestForwardingApp.cs
@@ -24,7 +24,7 @@ public class VSTestForwardingApp : ForwardingApp
         VSTestTrace.SafeWriteTrace(() => $"Forwarding to '{GetVSTestExePath()}' with args \"{string.Join(" | ", argsToForward ?? [])}\"");
     }
 
-    private static string GetVSTestExePath()
+    internal static string GetVSTestExePath()
     {
         // Provide custom path to vstest.console.dll or exe to be able to test it against any version of 
         // vstest.console. This is useful especially for our integration tests.
@@ -35,7 +35,7 @@ public class VSTestForwardingApp : ForwardingApp
             return vsTestConsolePath;
         }
 
-        return Path.Combine(AppContext.BaseDirectory, VstestAppName);
+        return Path.Combine(SdkPaths.SdkDirectory, VstestAppName);
     }
 
     internal static Dictionary<string, string> GetVSTestRootVariables()

--- a/src/Cli/dotnet/NuGetForwardingApp.cs
+++ b/src/Cli/dotnet/NuGetForwardingApp.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using Microsoft.DotNet.Cli.Utils;
+
 namespace Microsoft.DotNet.Cli;
 
 public class NuGetForwardingApp
@@ -35,10 +37,10 @@ public class NuGetForwardingApp
         return this;
     }
 
-    private static string GetNuGetExePath()
+    internal static string GetNuGetExePath()
     {
         return Path.Combine(
-            AppContext.BaseDirectory,
+            SdkPaths.SdkDirectory,
             s_nugetExeName);
     }
 }

--- a/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
+++ b/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Commands.Fsi;
+using Microsoft.DotNet.Cli.Commands.Test;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+[TestClass]
+public class SdkForwardingAppTests
+{
+    [TestMethod]
+    public void NuGetForwardingUsesVersionedSdkDirectory()
+    {
+        string sdkDirectory = CreateSdkDirectory();
+        using var _ = new SdkDirectoryScope(sdkDirectory);
+
+        Assert.AreEqual(
+            Path.Combine(sdkDirectory, "NuGet.CommandLine.XPlat.dll"),
+            NuGetForwardingApp.GetNuGetExePath());
+    }
+
+    [TestMethod]
+    public void FsiForwardingUsesVersionedSdkDirectory()
+    {
+        string sdkDirectory = CreateSdkDirectory();
+        using var _ = new SdkDirectoryScope(sdkDirectory);
+
+        Assert.AreEqual(
+            Path.Combine(sdkDirectory, "FSharp", "fsi.exe"),
+            FsiForwardingApp.GetFsiAppPath());
+    }
+
+    [TestMethod]
+    public void VSTestForwardingUsesVersionedSdkDirectory()
+    {
+        string sdkDirectory = CreateSdkDirectory();
+        using var _ = new SdkDirectoryScope(sdkDirectory);
+        string? previousVSTestConsolePath = Environment.GetEnvironmentVariable("VSTEST_CONSOLE_PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("VSTEST_CONSOLE_PATH", null);
+            Assert.AreEqual(
+                Path.Combine(sdkDirectory, "vstest.console.dll"),
+                VSTestForwardingApp.GetVSTestExePath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("VSTEST_CONSOLE_PATH", previousVSTestConsolePath);
+        }
+    }
+
+    private static string CreateSdkDirectory()
+        => Path.Combine(Path.GetTempPath(), "dotnet", "sdk", $"test-version-{Guid.NewGuid():N}");
+}


### PR DESCRIPTION
## Summary

- resolve NuGet, VSTest, and FSI forwarding assets from the versioned SDK directory
- preserve the VSTest path override and FSI DLL/EXE fallback behavior
- add NativeAOT regression tests for all three SDK-relative paths

## Testing

- `SdkForwardingAppTests`: 3 passed (managed and NativeAOT-published)
- `GivenDotnetVsTestForwardingApp`: 2 passed
- NativeAOT redist checks: `dotnet nuget --help`, `dotnet vstest --help`, and `dotnet fsi --help` passed in a separated muxer/SDK layout

Stacked on #55920.