### PR TITLE
Restore OneLocBuild check-in CI for release/11.0.1xx

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -112,6 +112,20 @@ extends:
         ignoreDirectories: artifacts, .packages
 
     stages:
+    ############### ONELOCBUILD STAGE ###############
+    - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['Build.SourceBranch'], 'refs/heads/release/11.0.1xx')) }}:
+      - stage: onelocbuild
+        displayName: OneLocBuild
+        dependsOn: []
+        jobs:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            CreatePr: true
+            LclSource: lclFilesfromPackage
+            LclPackageId: LCL-JUNO-PROD-DOTNETSDK
+            MirrorBranch: release/11.0.1xx
+            MirrorRepo: sdk
+
     ############### BUILD STAGE ###############
     # Run build jobs for non-check-in runs.
     - ${{ if and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'BatchedCI')) }}:
@@ -139,7 +153,6 @@ extends:
             runTests: ${{ eq(variables['runInTestMode'], 'true') }}
             populateInternalRuntimeVariables: true
             runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-            locBranch: release/10.0.3xx
             # WORKAROUND: BinSkim requires the folder exist prior to scanning.
             preSteps:
             - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force

--- a/documentation/project-docs/Localization.md
+++ b/documentation/project-docs/Localization.md
@@ -33,7 +33,7 @@ https://github.com/dotnet/sdk/pulls?q=is%3Apr+author%3Adotnet-bot+onelocbuild
 ### Loc Builds
 We typically only localize the primary development branch. We move to vNext once we get to RC1 and only then, localize all new strings introduced in that release. That way we can continue to add messages in the 4xx release of an SDK.
 
-This is controlled https://github.com/dotnet/sdk/blob/main/eng/pipelines/templates/jobs/sdk-job-matrix.yml#L86 and requires a change both here and in the loc system to align branches.
+This is controlled by the OneLocBuild stage in [`.vsts-ci.yml`](../../.vsts-ci.yml) and requires a change both there and in the loc system to align branches.
 
 ### Translation directives
 There are a ton of translations directives our localization system understands. Here are some of the most common in this repo:


### PR DESCRIPTION
🤖 Check-in CI stopped running OneLocBuild when the build stage was disabled for `IndividualCI` and `BatchedCI`, because localization was instantiated through the Windows build matrix.

This adds a standalone OneLocBuild stage for check-in runs on `refs/heads/release/11.0.1xx` without restoring any build legs. It also removes the stale `release/10.0.3xx` localization hook from the Windows matrix and updates the localization documentation to identify `.vsts-ci.yml` as the control point.

Validation: `git diff --check`