### PR TITLE
Add code coverage artifact post-processing test

### DIFF
--- a/documentation/general/dotnet-test-artifact-post-processing.md
+++ b/documentation/general/dotnet-test-artifact-post-processing.md
@@ -143,12 +143,15 @@ per-module inputs and double-count tests.
 
 ## What currently merges
 
-Today only **TRX** consolidates: the only shipping post-processor is the one in the
-`Microsoft.Testing.Extensions.TrxReport` package. Code coverage and other formats will only be
-merged once a post-processor ships in the extension that produces them; until then those
-artifacts are listed individually, exactly as before. This is a capability question, not a
-configuration one — the SDK merges whatever the installed extensions advertise. The contract for
-adding a format is public; see [Extending it to another artifact format](#extending-it-to-another-artifact-format).
+Shipping Microsoft.Testing.Platform extensions provide post-processors for **TRX, Microsoft code
+coverage, JUnit, CTRF, and HTML reports**, as well as aggregated GitHub Actions and Azure DevOps
+summaries. The formats available to a run still depend on which extensions its test applications
+reference and enable; the SDK does not install a processor or infer mergeability from a file name.
+It merges whatever the installed extensions advertise.
+
+Other formats continue to be listed individually until their producing extension ships a
+post-processor. The contract for adding one is public; see
+[Extending it to another artifact format](#extending-it-to-another-artifact-format).
 
 ## Extending it to another artifact format
 

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -138,10 +138,10 @@ This file should be imported by eng/Versions.props
     <SystemTextJsonPackageVersion>11.0.0-rc.1.26410.101</SystemTextJsonPackageVersion>
     <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26410.101</SystemWindowsExtensionsPackageVersion>
     <!-- microsoft-testfx dependencies -->
-    <MicrosoftTestingPlatformPackageVersion>2.4.0-preview.26418.7</MicrosoftTestingPlatformPackageVersion>
+    <MicrosoftTestingPlatformPackageVersion>2.4.0-preview.26426.8</MicrosoftTestingPlatformPackageVersion>
     <MicrosoftTestingPlatformInternalDotnetTestPackageVersion>2.3.0-preview.26330.8</MicrosoftTestingPlatformInternalDotnetTestPackageVersion>
-    <MSTestPackageVersion>4.4.0-preview.26418.7</MSTestPackageVersion>
-    <MSTestSdkPackageVersion>4.4.0-preview.26418.7</MSTestSdkPackageVersion>
+    <MSTestPackageVersion>4.4.0-preview.26426.8</MSTestPackageVersion>
+    <MSTestSdkPackageVersion>4.4.0-preview.26426.8</MSTestSdkPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -544,18 +544,18 @@
     <!-- KEEP IN SYNC: the following testfx packages (Microsoft.Testing.Platform, MSTest, MSTest.Sdk) must
          stay on the SAME testfx build/Sha. The MSTest.Sdk source generator emits registrations against the
          MSTest.TestFramework runtime, so a version skew breaks the NativeAOT CLI test build. See #55302. -->
-    <Dependency Name="Microsoft.Testing.Platform" Version="2.4.0-preview.26418.7">
+    <Dependency Name="Microsoft.Testing.Platform" Version="2.4.0-preview.26426.8">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>466d76410b8daf0077502784a583ac7a9e4d97ad</Sha>
+      <Sha>7d67f3ca4ede878ef631ffc529e75e6af12c78bc</Sha>
     </Dependency>
-    <Dependency Name="MSTest" Version="4.4.0-preview.26418.7">
+    <Dependency Name="MSTest" Version="4.4.0-preview.26426.8">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>466d76410b8daf0077502784a583ac7a9e4d97ad</Sha>
+      <Sha>7d67f3ca4ede878ef631ffc529e75e6af12c78bc</Sha>
     </Dependency>
     <!-- MSTest.Sdk is consumed from global.json's msbuild-sdks (not as a PackageReference). -->
-    <Dependency Name="MSTest.Sdk" Version="4.4.0-preview.26418.7">
+    <Dependency Name="MSTest.Sdk" Version="4.4.0-preview.26426.8">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>466d76410b8daf0077502784a583ac7a9e4d97ad</Sha>
+      <Sha>7d67f3ca4ede878ef631ffc529e75e6af12c78bc</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-rc.1.26410.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/global.json
+++ b/global.json
@@ -32,6 +32,6 @@
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Build.Traversal": "4.1.82",
     "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6",
-    "MSTest.Sdk": "4.4.0-preview.26418.7"
+    "MSTest.Sdk": "4.4.0-preview.26426.8"
   }
 }

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.cs
@@ -46,6 +46,39 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
     }
 
     [TestMethod]
+    public void MultiProjectRun_MergesCodeCoverageArtifacts()
+    {
+        TestAsset testInstance = TestAssetsManager
+            .CopyTestAsset("TestProjectSolutionWithCodeCoverage", Guid.NewGuid().ToString())
+            .WithSource();
+        string solutionPath = CreateMultiProjectCoverageSolution(testInstance);
+
+        string unmergedResultsDirectory = Path.Combine(testInstance.Path, "UnmergedTestResults");
+        CommandResult unmergedResult = RunCoverage(
+            testInstance.Path,
+            solutionPath,
+            unmergedResultsDirectory,
+            "--no-artifact-post-processing");
+
+        AssertTestFailures(unmergedResult);
+        string[] unmergedCoveragePaths =
+            Directory.GetFiles(unmergedResultsDirectory, "*.coverage", SearchOption.AllDirectories);
+        unmergedCoveragePaths.Should().HaveCount(2, "each test application keeps its own coverage artifact");
+        GetReportedCoveragePaths(unmergedResult).Should().BeEquivalentTo(unmergedCoveragePaths);
+
+        string mergedResultsDirectory = Path.Combine(testInstance.Path, "MergedTestResults");
+        CommandResult mergedResult = RunCoverage(testInstance.Path, solutionPath, mergedResultsDirectory);
+
+        AssertTestFailures(mergedResult);
+        string mergedCoveragePath = GetReportedCoveragePaths(mergedResult).Should().ContainSingle().Subject;
+        File.Exists(mergedCoveragePath).Should().BeTrue();
+        string[] mergedCoveragePaths =
+            Directory.GetFiles(mergedResultsDirectory, "*.coverage", SearchOption.AllDirectories);
+        mergedCoveragePaths.Should().HaveCount(3, "the two original reports remain on disk beside the merged report");
+        mergedCoveragePaths.Should().Contain(mergedCoveragePath);
+    }
+
+    [TestMethod]
     public void MultiProjectRun_WithNoArtifactPostProcessing_KeepsOneReportPerTestApplication()
     {
         TestAsset testInstance = TestAssetsManager
@@ -186,6 +219,79 @@ public class GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP : SdkTest
 
         return command.Execute(arguments);
     }
+
+    private CommandResult RunCoverage(
+        string workingDirectory,
+        string solutionPath,
+        string resultsDirectory,
+        params string[] additionalArguments)
+    {
+        string[] arguments =
+        [
+            "--solution", solutionPath,
+            "--coverage",
+            "--results-directory", resultsDirectory,
+            "--configuration", TestingConstants.Debug,
+            .. additionalArguments
+        ];
+
+        Microsoft.NET.TestFramework.Commands.TestCommand command = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(workingDirectory);
+        command.EnvironmentToRemove.Add("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID");
+
+        return command.Execute(arguments);
+    }
+
+    private static string CreateMultiProjectCoverageSolution(TestAsset testInstance)
+    {
+        string firstProjectDirectory = Path.Combine(testInstance.Path, "TestProject");
+        string secondProjectDirectory = Path.Combine(testInstance.Path, "OtherTestProject");
+        Directory.CreateDirectory(secondProjectDirectory);
+
+        foreach (string fileName in new[] { "Program.cs", "Test1.cs" })
+        {
+            string source = File.ReadAllText(Path.Combine(firstProjectDirectory, fileName))
+                .Replace("namespace TestProject", "namespace OtherTestProject", StringComparison.Ordinal);
+            File.WriteAllText(Path.Combine(secondProjectDirectory, fileName), source);
+        }
+
+        string firstProjectPath = Path.Combine(firstProjectDirectory, "TestProject.csproj");
+        string secondProjectPath = Path.Combine(secondProjectDirectory, "OtherTestProject.csproj");
+        File.Copy(firstProjectPath, secondProjectPath);
+
+        string versionsRoot = SdkTestContext.Current.ToolsetUnderTest.RepoRoot
+            ?? SdkTestContext.Current.TestExecutionDirectory;
+        string versionsPropsPath = Path.Combine(versionsRoot, "eng", "Version.Details.props");
+        string mstestVersion = testInstance.ReadMSTestPackageVersionFromProps(versionsPropsPath);
+        testInstance.UpdateProjectFileWithMSTestPackageVersion(firstProjectPath, mstestVersion);
+        testInstance.UpdateProjectFileWithMSTestPackageVersion(secondProjectPath, mstestVersion);
+
+        string solutionPath = Path.Combine(testInstance.Path, "CoverageTests.slnx");
+        File.WriteAllText(
+            solutionPath,
+            """
+            <Solution>
+              <Project Path="OtherTestProject/OtherTestProject.csproj" />
+              <Project Path="TestProject/TestProject.csproj" />
+            </Solution>
+            """);
+        return solutionPath;
+    }
+
+    private static void AssertTestFailures(CommandResult result)
+        => result.ExitCode.Should().Be(
+            ExitCodes.AtLeastOneTestFailed,
+            $"the test output was:{Environment.NewLine}{result.StdOut}{Environment.NewLine}{result.StdErr}");
+
+    private static string[] GetReportedCoveragePaths(CommandResult result)
+        =>
+        [
+            .. Regex.Matches(
+                    result.StdOut ?? string.Empty,
+                    @"(?m)^\s*-\s+(?<path>.*\.coverage)\s*$",
+                    RegexOptions.CultureInvariant)
+                .Select(match => match.Groups["path"].Value)
+        ];
 
     private static string GetMergedTrxPath(CommandResult result)
     {

--- a/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
+++ b/test/dotnet.Tests/CommandTests/Test/snapshots/MTPHelpSnapshotTests.VerifyMTPHelpOutput.verified.txt
@@ -61,8 +61,8 @@ Platform Options:
                                   When both --ansi and --no-ansi are provided, --ansi wins.
   --debug                         Allows to pause execution in order to attach to the process for debug purposes.
   --diagnostic                    Enable the diagnostic logging. The default log level is 'Trace'.
-                                  The file will be written in the output directory with the name log_[yyMMddHHmmssfff].diag
-  --diagnostic-file-prefix        Prefix for the log file name that will replace '[log]_.'
+                                  The file will be written in the output directory with the name log_[yyMMddHHmmssfff].diag.
+  --diagnostic-file-prefix        Replace '[log]_.' with the specified log file name prefix.
   --diagnostic-synchronous-write  Force the built-in file logger to write the log synchronously.
                                   Useful for scenario where you don't want to lose any log (i.e. in case of crash).
                                   Note that this is slowing down the test execution.
@@ -88,11 +88,14 @@ Platform Options:
                                   Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an LLM/AI agent environment is detected).
   --show-stdout                   Determines when to show captured standard output of a test.
                                   Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an LLM/AI agent environment is detected).
+  --show-test-results             Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
+                                  Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
+                                  Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.
   --zero-tests-policy             Specifies how a run that executed no tests is treated.
                                   Valid values are 'allow-skipped' (the default) which counts skipped tests as run, so only a run where no test was found at all fails with exit code 8, and 'strict' which treats skipped tests as not run, so a run where every test was skipped (or no test was found) fails with exit code 8.
 
 Extension Options:
-  --report-trx           Enable generating TRX report
+  --report-trx           Enable generating TRX report.
   --report-trx-filename  The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
                          Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
-                         Example: MyReport_{tfm}.trx
+                         Example: 'MyReport_{tfm}.trx'.


### PR DESCRIPTION
Closes #47613

## Summary

- add an end-to-end `dotnet test` scenario proving Microsoft code coverage artifacts are consolidated across two MTP test applications
- verify `--no-artifact-post-processing` continues to report the two original coverage artifacts
- verify successful post-processing reports one merged artifact while preserving both originals on disk
- update the artifact post-processing documentation with the currently shipping first-party processors
- update the MTP help snapshot for the option text shipped by the flowed TestFX build

## Dependency

Depends on #55936, which flows the TestFX build containing `Microsoft.Testing.Extensions.CodeCoverage` 18.11.0-preview.26425.2 into SDK main.

## Validation

- `build.cmd -c Debug`
- `RunTargetedTests.cs --project test\dotnet.Tests\dotnet.Tests.csproj --filter "FullyQualifiedName~GivenDotnetTestBuildsAndRunsArtifactPostProcessingMTP.MultiProjectRun_MergesCodeCoverageArtifacts"`
- `RunTargetedTests.cs --project test\dotnet.Tests\dotnet.Tests.csproj --filter "FullyQualifiedName~MTPHelpSnapshotTests.VerifyMTPHelpOutput"`