### PR TITLE
Enable parallel TemplateEngine core unit tests

### DIFF
--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public ChunkStreamReadTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1443,21 +1443,29 @@ There";
         [DataRow("zh-CHT", "Hello\r\n#if (2.5 < 25)\r\nvalue\r\n#endif\r\nThere", "Hello\r\nvalue\r\nThere")]
         public void VerifyIfElseEndifConditionUsesDouble(string culture, string value, string expected)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
+
+                byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+                MemoryStream input = new MemoryStream(valueBytes);
+                MemoryStream output = new MemoryStream();
+
+                VariableCollection vc = new VariableCollection();
+                IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
+
+                //Changes should be made
+                bool changed = processor.Run(input, output, 28);
+                Verify(Encoding.UTF8, output, changed, value, expected);
             }
-
-            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
-            MemoryStream input = new MemoryStream(valueBytes);
-            MemoryStream output = new MemoryStream();
-
-            VariableCollection vc = new VariableCollection();
-            IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
-
-            //Changes should be made
-            bool changed = processor.Run(input, output, 28);
-            Verify(Encoding.UTF8, output, changed, value, expected);
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         internal ConditionalTests(EnvironmentSettingsHelper environmentSettingsHelper)
         {
-            _engineEnvironmentSettings = environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(environmentSettingsHelper, GetType().Name);
         }
 
         /// <summary>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public LookaroundTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <!-- Test classes have isolated fixtures, but methods within several classes share mutable
+         logger/environment helpers and variable collections. Run classes in parallel while
+         preserving method isolation within each class. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     [TestClass]
-    public class OrchestratorTests
+    public class OrchestratorTests : TestBase
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;
         private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public OrchestratorTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
             _logger = _engineEnvironmentSettings.Host.Logger;
         }
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public RegionTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public ReplacementTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
@@ -156,7 +156,7 @@ End";
 End";
 
             VariableCollection vc = new VariableCollection();
-            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            IEngineEnvironmentSettings environmentSettings = CreateEnvironment(_environmentSettingsHelper);
             EngineConfig engineConfig = new EngineConfig(environmentSettings.Host.Logger, vc);
 
             string on = "//+:cnd";
@@ -186,7 +186,7 @@ End";
 ";
 
             VariableCollection vc = new();
-            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            IEngineEnvironmentSettings environmentSettings = CreateEnvironment(_environmentSettingsHelper);
             EngineConfig engineConfig = new(environmentSettings.Host.Logger, vc);
 
             ConditionalTokens tokens = new()

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
@@ -1,13 +1,32 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public abstract class TestBase
     {
+        protected static IEngineEnvironmentSettings CreateEnvironment(
+            EnvironmentSettingsHelper environmentSettingsHelper,
+            [CallerMemberName] string hostIdentifier = "")
+        {
+            CultureInfo currentUICulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                return environmentSettingsHelper.CreateEnvironment(hostIdentifier: hostIdentifier, virtualize: true);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = currentUICulture;
+            }
+        }
+
         protected static void RunAndVerify(string originalValue, string expectedValue, IProcessor processor, int bufferSize, bool? changeOverride = null, bool emitBOM = false)
         {
             byte[] valueBytes = Encoding.UTF8.GetBytes(originalValue);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public VariablesTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]


### PR DESCRIPTION
The TemplateEngine Core unit tests currently run serially even though their test classes use isolated fixtures. This enables safe parallel execution to reduce test time while preserving the method-level isolation required by shared class fixtures.

- Configure MSTest to use `ClassLevel` parallelization. `MethodLevel` remains unsafe because several classes share mutable logger/environment helpers and variable collections.
- Restore `CurrentUICulture` after creating test environments and restore `CurrentCulture` after the culture-sensitive conditional test.
- Avoid resource locks because the audit found no process-global resource shared across test classes.

Validation:
- Full repository build passed.
- Focused project build passed with 0 warnings and 0 errors.
- `net11.0`: 6 parallel runs, each 363 total / 362 passed / 1 tracked skip / 0 failed.
- `net481`: 6 parallel runs, each 363 total / 362 passed / 1 tracked skip / 0 failed.