### PR TITLE
Parallelize ApiCompat unit tests

### DIFF
--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
     [TestClass]
     public class AssemblyIdentityMustMatchTests
     {
-        private static readonly SuppressibleTestLog s_log = new();
-        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(s_log, settings, context));
+        private const string EmitAssemblyFromSyntaxResource = nameof(SymbolFactory.EmitAssemblyFromSyntax);
+        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(new SuppressibleTestLog(), settings, context));
 
         private static readonly byte[] _publicKey = new byte[]
         {
@@ -185,6 +185,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
+        [ResourceLock(EmitAssemblyFromSyntaxResource)]
         public void RetargetableFlagSet(bool strictMode)
         {
             string syntax = @"
@@ -198,8 +199,9 @@ using System.Reflection;
             string leftAssembly = SymbolFactory.EmitAssemblyFromSyntax(syntax, publicKey: _publicKey);
             string rightAssembly = SymbolFactory.EmitAssemblyFromSyntax(syntax);
 
-            IAssemblySymbol leftSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(leftAssembly);
-            IAssemblySymbol rightSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(rightAssembly);
+            SuppressibleTestLog log = new();
+            IAssemblySymbol leftSymbol = new AssemblySymbolLoader(log).LoadAssembly(leftAssembly);
+            IAssemblySymbol rightSymbol = new AssemblySymbolLoader(log).LoadAssembly(rightAssembly);
 
             Assert.IsTrue(leftSymbol.Identity.IsRetargetable);
             Assert.IsTrue(rightSymbol.Identity.IsRetargetable);


### PR DESCRIPTION
The SDK test suite disables MSTest parallelization by default because unaudited projects can interfere through shared process or filesystem state. This project is isolated enough to run concurrently, reducing its test execution time without broadening parallelism elsewhere.

This change enables MethodLevel parallelism for `Microsoft.DotNet.ApiCompatibility.Tests`. The concurrency audit found one shared mutable test log, which is now created per rule/test, and one linked helper that emits caller-named assemblies to temporary paths. The affected data-driven test uses a narrow resource lock so those emissions cannot overlap.

Validation:
- Focused project build completed with 0 warnings and 0 errors.
- All 246 tests passed once with the build and five additional parallel repetitions at 32 workers.
- 1,476 total test executions completed with 0 failures or skips.