### PR TITLE
Parallelize ApiDiff unit tests

### DIFF
--- a/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tests/Microsoft.DotNet.ApiDiff.Tests.csproj
+++ b/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tests/Microsoft.DotNet.ApiDiff.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`Microsoft.DotNet.ApiDiff.Tests` currently runs serially despite having isolated per-test state, which unnecessarily lengthens validation.

This opts the project into MSTest method-level parallelization after auditing all 19 test classes and 173 methods. Tests use per-instance state, unique temporary directories, read-only shared inputs, and stateless shared rewriters, so no resource locks are required.

Validation: the focused 173-test suite passed four consecutive runs with 32 method-level workers (170 passed, 3 existing skips, 0 failed).