### PR TITLE
Avoid duplicate TypeScript static web assets

### DIFF
--- a/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
+++ b/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.TypeScript.targets
@@ -63,6 +63,33 @@ Copyright (c) .NET Foundation. All rights reserved.
       <FileWrites Include="$(_TypeScriptSwaManifestPath)" />
     </ItemGroup>
 
+    <!--
+      TypeScript outputs can already be present in @(Content) when the project is evaluated,
+      causing ResolveProjectStaticWebAssets to register them before TypeScript compilation.
+      Remove those assets and their endpoints before re-registering them with fresh
+      post-compilation metadata.
+      StaticWebAsset Identity = full path, so Remove with the resolved full paths works.
+    -->
+    <ItemGroup Condition="'@(_TypeScriptWwwrootAssets)' != ''">
+      <_TypeScriptWwwrootFullPaths Include="@(_TypeScriptWwwrootAssets->'%(FullPath)')" />
+      <StaticWebAsset Remove="@(_TypeScriptWwwrootFullPaths)" />
+    </ItemGroup>
+
+    <!-- Remove endpoints that pointed to the stale assets. FilterStaticWebAssetEndpoints
+         matches endpoints whose AssetFile is in the Assets dictionary (keyed by Identity).
+         We pass the full paths as bare items; only Identity is needed for the lookup. -->
+    <FilterStaticWebAssetEndpoints
+      Condition="'@(_TypeScriptWwwrootFullPaths)' != '' And '@(StaticWebAssetEndpoint)' != ''"
+      Endpoints="@(StaticWebAssetEndpoint)"
+      Assets="@(_TypeScriptWwwrootFullPaths)"
+      Filters="">
+      <Output TaskParameter="FilteredEndpoints" ItemName="_StaleTypeScriptEndpoints" />
+    </FilterStaticWebAssetEndpoints>
+
+    <ItemGroup Condition="'@(_StaleTypeScriptEndpoints)' != ''">
+      <StaticWebAssetEndpoint Remove="@(_StaleTypeScriptEndpoints)" />
+    </ItemGroup>
+
     <DefineStaticWebAssets
       Condition="'@(_TypeScriptWwwrootAssets)' != ''"
       CandidateAssets="@(_TypeScriptWwwrootAssets)"

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/TypeScriptIntegrationTest.cs
@@ -233,6 +233,55 @@ public class TypeScriptIntegrationTest : IsolatedNuGetPackageFolderAspNetSdkBase
         new FileInfo(manifestPath).Should().NotExist();
     }
 
+    [TestMethod]
+    public void Build_AfterObjDeleteWithRetainedOutputs_DoesNotDuplicateAssets()
+    {
+        var testAsset = "RazorClassLibrary";
+        ProjectDirectory = CreateAspNetSdkTestAsset(testAsset);
+
+        SetupTypeScriptProject(ProjectDirectory);
+
+        ProjectDirectory.WithProjectChanges(document =>
+        {
+            var propertyGroup = document.Root.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "PropertyGroup");
+            propertyGroup?.Add(new XElement("CompressionEnabled", "true"));
+        });
+
+        var build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var jsFilePath = Path.Combine(ProjectDirectory.TestRoot, "wwwroot", "app.js");
+        new FileInfo(jsFilePath).Should().Exist();
+
+        Directory.Delete(Path.Combine(ProjectDirectory.TestRoot, "obj"), recursive: true);
+        Directory.Delete(Path.Combine(ProjectDirectory.TestRoot, "bin"), recursive: true);
+
+        new FileInfo(jsFilePath).Should().Exist();
+
+        build = CreateBuildCommand(ProjectDirectory);
+        ExecuteCommand(build).Should().Pass();
+
+        var intermediateOutputPath = build.GetIntermediateDirectory(DefaultTfm, "Debug").ToString();
+        var finalPath = Path.Combine(intermediateOutputPath, "staticwebassets.build.json");
+        var buildManifest = StaticWebAssetsManifest.FromJsonBytes(File.ReadAllBytes(finalPath));
+        buildManifest.Should().NotBeNull();
+
+        foreach (var relativePath in new[] { "app.js", "app.js.map" })
+        {
+            var asset = buildManifest.Assets.Should().ContainSingle(
+                candidate => candidate.RelativePath == relativePath &&
+                    candidate.AssetRole == StaticWebAsset.AssetRoles.Primary,
+                $"there should be exactly one primary asset for {relativePath}").Subject;
+
+            buildManifest.Endpoints.Should().ContainSingle(
+                endpoint => endpoint.Route == relativePath &&
+                    endpoint.AssetFile == asset.Identity &&
+                    endpoint.Selectors.Length == 0,
+                $"there should be exactly one default endpoint for {relativePath}");
+        }
+    }
+
     /// <summary>
     /// Sets up a test project with TypeScript configuration using the
     /// Microsoft.TypeScript.MSBuild NuGet package.


### PR DESCRIPTION
## Summary

- replace TypeScript outputs that were already discovered as static web assets before compilation
- remove their stale endpoints before registering the freshly generated outputs
- add regression coverage for retained generated outputs after `bin` and `obj` cleanup

Fixes #55945