### PR TITLE
[release/9.0.1xx] Disable network isolation on internal PR builds; enforce CFSClean3 on official

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -62,6 +62,15 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      settings:
+        networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+    ${{ else }}:
+      # Internal PR builds run under the 1ES Unofficial template. They restore from
+      # public feeds (nuget.org, npm, yarn), so network isolation is not applicable
+      # and is disabled to avoid spurious CFS clean violations.
+      settings:
+        networkIsolationMode: None
     containers:
       alpine322:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.22-amd64


### PR DESCRIPTION
🤖 Port of #55220 to `release/9.0.1xx`. The automatic flow did not bring this change forward.

Scopes the 1ES settings by `Build.Reason`:
- Official builds retain `networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3`.
- Internal PR/unofficial builds use `networkIsolationMode: None` because they restore from public feeds and otherwise produce spurious CFS clean violations.