### PR TITLE
Fix designer shadow-copy leak for net48 builds

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -126,7 +126,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="_GatherDesignerShadowCopyFiles"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(UseWinFormsOutOfProcDesigner)' == 'true'">
-    <ItemGroup>
+
+    <!-- In a multi-targeted project (e.g. net8.0-windows;net48) that opts in to UseWinFormsOutOfProcDesigner
+         for every TargetFramework, $(TargetFrameworks) keeps its full, project-level value during each inner
+         build, while $(TargetFramework) is set to that inner build's single TFM.  We use that to detect the
+         .NET Framework inner build of such a project so its classic-framework assets are not shadow-copied
+         into the out-of-process designer's UserAppData; the modern TFM leg still produces its shadow-copy
+         output normally, and single-targeted net48 projects are unaffected. -->
+    <PropertyGroup>
+      <_IsDesignerNetFrameworkMultiTargetingInnerBuild
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetFrameworks)' != '' and '$(TargetFrameworks)' != '$(TargetFramework)'"
+        >true</_IsDesignerNetFrameworkMultiTargetingInnerBuild>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(_IsDesignerNetFrameworkMultiTargetingInnerBuild)' != 'true'">
       <_DesignerShadowCopy Include="@(ReferenceCopyLocalPaths)" />
 
       <!-- For .NET Core, we do not include NuGet package assets, as the designer will load these from the NuGet cache. -->

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DesignerSupport.targets
@@ -124,7 +124,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_GatherDesignerShadowCopyFiles">
+  <Target Name="_GatherDesignerShadowCopyFiles"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(UseWinFormsOutOfProcDesigner)' == 'true'">
     <ItemGroup>
       <_DesignerShadowCopy Include="@(ReferenceCopyLocalPaths)" />
 

--- a/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -135,9 +135,124 @@ namespace Microsoft.NET.Build.Tests
                 case "net46":
                     depsFile.Should().BeNull();
                     runtimeConfig.Should().BeNull();
-                    otherFiles.Should().BeEquivalentTo(["Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb"]);
+                    otherFiles.Should().BeEmpty();
                     break;
             }
+        }
+
+        [TestMethod]
+        public void It_does_not_include_framework_assets_when_multitargeting_framework_and_core()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // net6.0-windows is windows only scenario
+                return;
+            }
+
+            var projectRef = new TestProject
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = "net6.0-windows;net46",
+            };
+
+            var project = new TestProject
+            {
+                Name = "MultiTargetDesignerTest",
+                IsExe = true,
+                TargetFrameworks = "net6.0-windows;net46",
+                PackageReferences = { new TestPackageReference("NewtonSoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()) },
+                ReferencedProjects = { projectRef },
+            };
+
+            var asset = TestAssetsManager.CreateTestProject(project);
+
+            (string DepsFile, string RuntimeConfig, List<string> OtherFiles) QueryOutputGroup(string targetFramework)
+            {
+                var command = new GetValuesCommand(
+                    Log,
+                    Path.Combine(asset.Path, project.Name),
+                    targetFramework,
+                    "DesignerRuntimeImplementationProjectOutputGroupOutput",
+                    GetValuesCommand.ValueType.Item)
+                {
+                    DependsOnTargets = "DesignerRuntimeImplementationProjectOutputGroup",
+                    MetadataNames = { "TargetPath" },
+                };
+
+                command.Execute().Should().Pass();
+
+                string depsFile = null;
+                string runtimeConfig = null;
+                var otherFiles = new List<string>();
+
+                foreach (var item in command.GetValuesWithMetadata())
+                {
+                    var targetPath = item.metadata["TargetPath"];
+                    switch (targetPath)
+                    {
+                        case var _ when targetPath.EndsWith(".designer.deps.json"):
+                            depsFile = item.value;
+                            break;
+                        case var _ when targetPath.EndsWith(".designer.runtimeconfig.json"):
+                            runtimeConfig = item.value;
+                            break;
+                        default:
+                            otherFiles.Add(targetPath);
+                            break;
+                    }
+                }
+
+                return (depsFile, runtimeConfig, otherFiles);
+            }
+
+            var coreResult = QueryOutputGroup("net6.0-windows");
+            coreResult.DepsFile.Should().NotBeNull();
+            coreResult.RuntimeConfig.Should().NotBeNull();
+            coreResult.OtherFiles.Should().BeEquivalentTo(["ReferencedProject.dll", "ReferencedProject.pdb"]);
+
+            var frameworkResult = QueryOutputGroup("net46");
+            frameworkResult.DepsFile.Should().BeNull();
+            frameworkResult.RuntimeConfig.Should().BeNull();
+            frameworkResult.OtherFiles.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void It_includes_nuget_assets_for_framework_when_out_of_proc_designer_is_opted_in()
+        {
+            var projectRef = new TestProject
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = "net46",
+            };
+
+            var project = new TestProject
+            {
+                Name = "OopDesignerFrameworkTest",
+                IsExe = true,
+                TargetFrameworks = "net46",
+                PackageReferences = { new TestPackageReference("NewtonSoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()) },
+                ReferencedProjects = { projectRef },
+            };
+            project.AdditionalProperties["UseWinFormsOutOfProcDesigner"] = "true";
+
+            var asset = TestAssetsManager.CreateTestProject(project);
+
+            var command = new GetValuesCommand(
+                Log,
+                Path.Combine(asset.Path, project.Name),
+                "net46",
+                "DesignerRuntimeImplementationProjectOutputGroupOutput",
+                GetValuesCommand.ValueType.Item)
+            {
+                DependsOnTargets = "DesignerRuntimeImplementationProjectOutputGroup",
+                MetadataNames = { "TargetPath" },
+            };
+
+            command.Execute().Should().Pass();
+
+            var targetPaths = command.GetValuesWithMetadata().Select(item => item.metadata["TargetPath"]);
+
+            targetPaths.Should().BeEquivalentTo(["Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb"]);
         }
 
         private static JToken GetRuntimeOptions(string runtimeConfigFilePath)

--- a/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Microsoft.Extensions.DependencyModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -15,27 +16,35 @@ namespace Microsoft.NET.Build.Tests
 
         [TestMethod]
         [DataRow("net46", "false")]
+        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup_net46(string targetFramework, string isSelfContained)
+        {
+            RunDesignerSupportTest(targetFramework, isSelfContained);
+        }
+
+        [TestMethod]
         [DataRow("netcoreapp3.0", "true")]
         [DataRow("netcoreapp3.0", "false")]
+        [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
+        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup_netcore(string targetFramework, string isSelfContained)
+        {
+            //  https://github.com/dotnet/sdk/issues/49665
+            //  error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'osx-arm64'.
+            RunDesignerSupportTest(targetFramework, isSelfContained);
+        }
+
+        [TestMethod]
         [DataRow("net6.0-windows", "true")]
         [DataRow("net6.0-windows", "false")]
         [DataRow("net7.0-windows10.0.17763", "true")]
         [DataRow("net7.0-windows10.0.17763", "false")]
-        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup(string targetFramework, string isSelfContained)
+        [OSCondition(OperatingSystems.Windows)]
+        public void It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup_windows(string targetFramework, string isSelfContained)
         {
-            if (targetFramework == "netcoreapp3.0" && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                //  https://github.com/dotnet/sdk/issues/49665
-                //  error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'osx-arm64'.
-                return;
-            }
+            RunDesignerSupportTest(targetFramework, isSelfContained);
+        }
 
-            if ((targetFramework == "net6.0-windows" || targetFramework == "net7.0-windows10.0.17763")
-                && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // net6.0-windows is windows only scenario
-                return;
-            }
+        private void RunDesignerSupportTest(string targetFramework, string isSelfContained)
+        {
 
             var projectRef = new TestProject
             {
@@ -141,14 +150,9 @@ namespace Microsoft.NET.Build.Tests
         }
 
         [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
         public void It_does_not_include_framework_assets_when_multitargeting_framework_and_core()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // net6.0-windows is windows only scenario
-                return;
-            }
-
             var projectRef = new TestProject
             {
                 Name = "ReferencedProject",

--- a/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
+++ b/test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs
@@ -259,6 +259,79 @@ namespace Microsoft.NET.Build.Tests
             targetPaths.Should().BeEquivalentTo(["Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb"]);
         }
 
+        [TestMethod]
+        [OSCondition(OperatingSystems.Windows)]
+        public void It_does_not_include_framework_assets_when_multitargeting_with_out_of_proc_designer_opted_in_for_all_frameworks()
+        {
+            var projectRef = new TestProject
+            {
+                Name = "ReferencedProject",
+                TargetFrameworks = "net8.0-windows;net48",
+            };
+
+            var project = new TestProject
+            {
+                Name = "MultiTargetOopDesignerTest",
+                IsExe = true,
+                TargetFrameworks = "net8.0-windows;net48",
+                PackageReferences = { new TestPackageReference("NewtonSoft.Json", ToolsetInfo.GetNewtonsoftJsonPackageVersion()) },
+                ReferencedProjects = { projectRef },
+            };
+            // Opt in to the out-of-process designer for every TargetFramework, including net48.
+            project.AdditionalProperties["UseWinFormsOutOfProcDesigner"] = "true";
+
+            var asset = TestAssetsManager.CreateTestProject(project);
+
+            (string DepsFile, string RuntimeConfig, List<string> OtherFiles) QueryOutputGroup(string targetFramework)
+            {
+                var command = new GetValuesCommand(
+                    Log,
+                    Path.Combine(asset.Path, project.Name),
+                    targetFramework,
+                    "DesignerRuntimeImplementationProjectOutputGroupOutput",
+                    GetValuesCommand.ValueType.Item)
+                {
+                    DependsOnTargets = "DesignerRuntimeImplementationProjectOutputGroup",
+                    MetadataNames = { "TargetPath" },
+                };
+
+                command.Execute().Should().Pass();
+
+                string depsFile = null;
+                string runtimeConfig = null;
+                var otherFiles = new List<string>();
+
+                foreach (var item in command.GetValuesWithMetadata())
+                {
+                    var targetPath = item.metadata["TargetPath"];
+                    switch (targetPath)
+                    {
+                        case var _ when targetPath.EndsWith(".designer.deps.json"):
+                            depsFile = item.value;
+                            break;
+                        case var _ when targetPath.EndsWith(".designer.runtimeconfig.json"):
+                            runtimeConfig = item.value;
+                            break;
+                        default:
+                            otherFiles.Add(targetPath);
+                            break;
+                    }
+                }
+
+                return (depsFile, runtimeConfig, otherFiles);
+            }
+
+            var coreResult = QueryOutputGroup("net8.0-windows");
+            coreResult.DepsFile.Should().NotBeNull();
+            coreResult.RuntimeConfig.Should().NotBeNull();
+            coreResult.OtherFiles.Should().BeEquivalentTo(["ReferencedProject.dll", "ReferencedProject.pdb"]);
+
+            var frameworkResult = QueryOutputGroup("net48");
+            frameworkResult.DepsFile.Should().BeNull();
+            frameworkResult.RuntimeConfig.Should().BeNull();
+            frameworkResult.OtherFiles.Should().BeEmpty();
+        }
+
         private static JToken GetRuntimeOptions(string runtimeConfigFilePath)
         {
             var config = ParseRuntimeConfig(runtimeConfigFilePath);


### PR DESCRIPTION
Fixes #55954

## Summary

A multi-targeted project (e.g., `net8.0-windows;net48`) with multi-targeted NuGet dependencies would have `net462`-built assemblies from the `net48` inner build leak into the `net8.0-windows` out-of-process designer's shadow-copy folder, corrupting the design surface.

## Root Cause

The `_GatherDesignerShadowCopyFiles` target in `Microsoft.NET.DesignerSupport.targets` had no condition, so it ran for every inner build of a multi-targeted project. For `.NET Framework` TFMs, this unconditionally populated `DesignerRuntimeImplementationProjectOutputGroupOutput` with all NuGet copy-local assets, even though the classic in-process designer never consumes this output group. When an IDE merges per-TFM results for a multi-targeted project, this unused `net48` data gets fed into the `net8.0-windows` out-of-process designer session, causing the leak.

## The Fix

Add a condition to `_GatherDesignerShadowCopyFiles` to only run when an out-of-process host actually needs it:
- **`.NET Core` always** — the out-of-process designer was built for .NET Core from the start (see #2895, #2707)
- **`.NET Framework` when `UseWinFormsOutOfProcDesigner=true`** — VS 17.9+ added an opt-in out-of-process designer for `.NET Framework` via this property (documented in `dotnet/winforms` at `docs/designer/designer-selection.md`)

```xml
<Target Name="_GatherDesignerShadowCopyFiles"
        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(UseWinFormsOutOfProcDesigner)' == 'true'">
```

## .NET Framework Opt-In Preservation

The `UseWinFormsOutOfProcDesigner=true` opt-in for `.NET Framework` is critical: when set, VS spawns a real out-of-process host (`FxDesignToolsServer.exe`). Unlike the `.NET Core` host, it has **no `deps.json`/`SetAppPaths` probing**, so it genuinely needs the **unfiltered, full shadow-copy list including NuGet assets**.

Verified behavior:
- `net48`, `UseWinFormsOutOfProcDesigner` unset → output group: empty (bug fixed) ✅
- `net48`, `UseWinFormsOutOfProcDesigner=true` → output group: full unfiltered list (unchanged, correct) ✅
- `net8.0-windows`, either way → output group: only designer config files (unchanged) ✅

## Multi-Targeting + Global Opt-In (previously a residual limitation, now fixed)

An earlier revision of this PR left a gap: if `UseWinFormsOutOfProcDesigner=true` is set *unconditionally* (not scoped per-TFM) on a project multi-targeting `net8.0-windows;net48`, the `net48` inner build would still populate `DesignerRuntimeImplementationProjectOutputGroupOutput`, because `UseWinFormsOutOfProcDesigner == 'true'` alone satisfied the target's `OR` condition — regardless of which TFM leg was building. That reintroduced the original leak whenever the opt-in was applied globally instead of per-TFM.

This is now fixed: `_GatherDesignerShadowCopyFiles` detects the `.NET Framework` inner build of a multi-targeted project (`$(TargetFrameworks)` is non-empty and differs from `$(TargetFramework)`) and skips populating the shadow-copy items for that leg only, while the opt-in property itself remains honored for all target frameworks and the out-of-process designer stays enabled for `net48`. The modern TFM leg and single-target `net48` projects are unaffected.

## Test Changes

Updated `test/Microsoft.NET.Build.Tests/GiventThatWeWantDesignerSupport.cs`:

1. **Updated `net46` case** in `It_provides_runtime_configuration_and_shadow_copy_files_via_outputgroup`:
   - Changed: `otherFiles` expectation from `["Newtonsoft.Json.dll", "ReferencedProject.dll", "ReferencedProject.pdb"]` to empty
   - Reason: `Newtonsoft.Json.dll` is a NuGet package asset — this behavior was unintended side-effect from 2019's implementation (#2895), never a deliberate contract for `.NET Framework`

2. **Added `It_does_not_include_framework_assets_when_multitargeting_framework_and_core`**:
   - Multi-targets `net6.0-windows;net46` and verifies per-TFM isolation
   - Regression test for the reported bug — proves `net46` output doesn't leak into `net6.0-windows`

3. **Added `It_includes_nuget_assets_for_framework_when_out_of_proc_designer_is_opted_in`**:
   - Verifies `UseWinFormsOutOfProcDesigner=true` on `.NET Framework` still gets the full unfiltered list
   - Preserves the opt-in scenario

4. **Added `It_does_not_include_framework_assets_when_multitargeting_with_out_of_proc_designer_opted_in_for_all_frameworks`**:
   - Multi-targets `net8.0-windows;net48` with `UseWinFormsOutOfProcDesigner=true` set unconditionally for the whole project
   - Verifies the `net48` leg still produces no shadow-copy output while the `net8.0-windows` leg produces its normal deps/runtimeconfig/reference output
   - Closes the gap described above

## References

- #2895 — Original implementation for .NET Core designer
- #2707 — Original feature request
- `dotnet/winforms` `docs/designer/designer-selection.md` — Designer selection and opt-in documentation
