### PR TITLE
Parallelize additional MSTest unit suites

### DIFF
--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Microsoft.DotNet.ApiCompatibility.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompatibility.Tests/Rules/AssemblyIdentityMustMatchTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
     [TestClass]
     public class AssemblyIdentityMustMatchTests
     {
-        private static readonly SuppressibleTestLog s_log = new();
-        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(s_log, settings, context));
+        private const string EmitAssemblyFromSyntaxResource = nameof(SymbolFactory.EmitAssemblyFromSyntax);
+        private static readonly TestRuleFactory s_ruleFactory = new((settings, context) => new AssemblyIdentityMustMatch(new SuppressibleTestLog(), settings, context));
 
         private static readonly byte[] _publicKey = new byte[]
         {
@@ -185,6 +185,7 @@ namespace Microsoft.DotNet.ApiCompatibility.Rules.Tests
         [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
+        [ResourceLock(EmitAssemblyFromSyntaxResource)]
         public void RetargetableFlagSet(bool strictMode)
         {
             string syntax = @"
@@ -198,8 +199,9 @@ using System.Reflection;
             string leftAssembly = SymbolFactory.EmitAssemblyFromSyntax(syntax, publicKey: _publicKey);
             string rightAssembly = SymbolFactory.EmitAssemblyFromSyntax(syntax);
 
-            IAssemblySymbol leftSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(leftAssembly);
-            IAssemblySymbol rightSymbol = new AssemblySymbolLoader(s_log).LoadAssembly(rightAssembly);
+            SuppressibleTestLog log = new();
+            IAssemblySymbol leftSymbol = new AssemblySymbolLoader(log).LoadAssembly(leftAssembly);
+            IAssemblySymbol rightSymbol = new AssemblySymbolLoader(log).LoadAssembly(rightAssembly);
 
             Assert.IsTrue(leftSymbol.Identity.IsRetargetable);
             Assert.IsTrue(rightSymbol.Identity.IsRetargetable);

--- a/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tests/Microsoft.DotNet.ApiDiff.Tests.csproj
+++ b/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.Tests/Microsoft.DotNet.ApiDiff.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Preserve class isolation while allowing independent test classes to run concurrently. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public ChunkStreamReadTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1443,21 +1443,29 @@ There";
         [DataRow("zh-CHT", "Hello\r\n#if (2.5 < 25)\r\nvalue\r\n#endif\r\nThere", "Hello\r\nvalue\r\nThere")]
         public void VerifyIfElseEndifConditionUsesDouble(string culture, string value, string expected)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo currentCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
+
+                byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+                MemoryStream input = new MemoryStream(valueBytes);
+                MemoryStream output = new MemoryStream();
+
+                VariableCollection vc = new VariableCollection();
+                IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
+
+                //Changes should be made
+                bool changed = processor.Run(input, output, 28);
+                Verify(Encoding.UTF8, output, changed, value, expected);
             }
-
-            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
-            MemoryStream input = new MemoryStream(valueBytes);
-            MemoryStream output = new MemoryStream();
-
-            VariableCollection vc = new VariableCollection();
-            IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
-
-            //Changes should be made
-            bool changed = processor.Run(input, output, 28);
-            Verify(Encoding.UTF8, output, changed, value, expected);
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         internal ConditionalTests(EnvironmentSettingsHelper environmentSettingsHelper)
         {
-            _engineEnvironmentSettings = environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(environmentSettingsHelper, GetType().Name);
         }
 
         /// <summary>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public LookaroundTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <!-- Test classes have isolated fixtures, but methods within several classes share mutable
+         logger/environment helpers and variable collections. Run classes in parallel while
+         preserving method isolation within each class. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.TestHelper;
 namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     [TestClass]
-    public class OrchestratorTests
+    public class OrchestratorTests : TestBase
     {
         private static EnvironmentSettingsHelper s_environmentSettingsHelper = null!;
         private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public OrchestratorTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
             _logger = _engineEnvironmentSettings.Host.Logger;
         }
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public RegionTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public ReplacementTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
@@ -156,7 +156,7 @@ End";
 End";
 
             VariableCollection vc = new VariableCollection();
-            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            IEngineEnvironmentSettings environmentSettings = CreateEnvironment(_environmentSettingsHelper);
             EngineConfig engineConfig = new EngineConfig(environmentSettings.Host.Logger, vc);
 
             string on = "//+:cnd";
@@ -186,7 +186,7 @@ End";
 ";
 
             VariableCollection vc = new();
-            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            IEngineEnvironmentSettings environmentSettings = CreateEnvironment(_environmentSettingsHelper);
             EngineConfig engineConfig = new(environmentSettings.Host.Logger, vc);
 
             ConditionalTokens tokens = new()

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
@@ -1,13 +1,32 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public abstract class TestBase
     {
+        protected static IEngineEnvironmentSettings CreateEnvironment(
+            EnvironmentSettingsHelper environmentSettingsHelper,
+            [CallerMemberName] string hostIdentifier = "")
+        {
+            CultureInfo currentUICulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                return environmentSettingsHelper.CreateEnvironment(hostIdentifier: hostIdentifier, virtualize: true);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = currentUICulture;
+            }
+        }
+
         protected static void RunAndVerify(string originalValue, string expectedValue, IProcessor processor, int bufferSize, bool? changeOverride = null, bool emitBOM = false)
         {
             byte[] valueBytes = Encoding.UTF8.GetBytes(originalValue);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
         public VariablesTests()
         {
-            _engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+            _engineEnvironmentSettings = CreateEnvironment(s_environmentSettingsHelper, GetType().Name);
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Components;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Abstractions.Parameters;
-using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -93,8 +92,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             // Dependencies preparation and mounting
             //
 
-            Environment.SetEnvironmentVariable("MYENVVAR", "MyValue");
-            IEnvironment environment = new DefaultEnvironment();
+            IEnvironment environment = CreateEnvironment("MYENVVAR", "MyValue");
 
             IEngineEnvironmentSettings settings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: "TestHost", virtualize: true, environment: environment);
             ((TestHost)settings.Host).HostParamDefaults["HostIdentifier"] = "TestHost";
@@ -166,8 +164,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             // Dependencies preparation and mounting
             //
 
-            Environment.SetEnvironmentVariable("MYENVVAR", "MyValue");
-            IEnvironment environment = new DefaultEnvironment();
+            IEnvironment environment = CreateEnvironment("MYENVVAR", "MyValue");
 
             IEngineEnvironmentSettings settings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: "TestHost", virtualize: true, environment: environment);
             ((TestHost)settings.Host).HostParamDefaults["HostIdentifier"] = "TestHost";
@@ -502,8 +499,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             // Dependencies preparation and mounting
             //
 
-            Environment.SetEnvironmentVariable("MYENVVAR", "MyValue");
-            IEnvironment environment = new DefaultEnvironment();
+            IEnvironment environment = CreateEnvironment("MYENVVAR", "MyValue");
 
             IEngineEnvironmentSettings settings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: "TestHost", virtualize: true, environment: environment);
             ((TestHost)settings.Host).HostParamDefaults["HostIdentifier"] = "TestHost";
@@ -581,9 +577,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             // Dependencies preparation and mounting
             //
 
-            //int
-            Environment.SetEnvironmentVariable("MYENVVAR", "100");
-            IEnvironment environment = new DefaultEnvironment();
+            IEnvironment environment = CreateEnvironment("MYENVVAR", "100");
 
             IEngineEnvironmentSettings settings = s_environmentSettingsHelper.CreateEnvironment(hostIdentifier: "TestHost", virtualize: true, environment: environment);
             string sourceBasePath = settings.GetTempVirtualizedPath();
@@ -693,6 +687,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             (LogLevel, string Message) warningMessage = Assert.ContainsSingle(loggedMessages.Where(lm => lm.Level == LogLevel.Warning));
             Assert.AreEqual("Failed to evaluate bind symbol 'env2', it will be skipped.", warningMessage.Message);
             Assert.Contains("Failed to evaluate bind symbol 'env1', the returned value is null. The default value 'envDefault' is used instead.", loggedMessages.Select(lm => lm.Message));
+        }
+
+        private static IEnvironment CreateEnvironment(string variableName, string variableValue)
+        {
+            IEnvironment environment = A.Fake<IEnvironment>();
+            A.CallTo(() => environment.GetEnvironmentVariable(A<string>._))
+                .ReturnsLazily((string name) => Environment.GetEnvironmentVariable(name));
+            A.CallTo(() => environment.GetEnvironmentVariable(variableName)).Returns(variableValue);
+            return environment;
         }
 
         private class TestBindSymbolSource : IBindSymbolSource

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/BindSymbolTests.cs
@@ -9,6 +9,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Components;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Abstractions.Parameters;
+using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -691,9 +692,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 
         private static IEnvironment CreateEnvironment(string variableName, string variableValue)
         {
-            IEnvironment environment = A.Fake<IEnvironment>();
-            A.CallTo(() => environment.GetEnvironmentVariable(A<string>._))
-                .ReturnsLazily((string name) => Environment.GetEnvironmentVariable(name));
+            IEnvironment environment = A.Fake<IEnvironment>(options => options.Wrapping(new DefaultEnvironment()));
             A.CallTo(() => environment.GetEnvironmentVariable(variableName)).Returns(variableValue);
             return environment;
         }

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <!-- These tests share class-scoped EnvironmentSettingsHelper instances. Run classes in parallel
+         while preserving the original xUnit isolation between methods in the same class. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" />

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
@@ -18,14 +18,22 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [DataRow("İndigo", "İndigo", "tr-TR")]
         public void FirstLowerCaseInvariantWorksAsExpected(string input, string expected, string? culture)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
-            }
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
 
-            IValueForm model = new FirstLowerCaseInvariantValueFormFactory().Create("test");
-            string actual = model.Process(input, new Dictionary<string, IValueForm>());
-            Assert.AreEqual(expected, actual);
+                IValueForm model = new FirstLowerCaseInvariantValueFormFactory().Create("test");
+                string actual = model.Process(input, new Dictionary<string, IValueForm>());
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
@@ -18,14 +18,22 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [DataRow("Indigo", "ındigo", "tr-TR")]
         public void FirstLowerCaseWorksAsExpected(string input, string expected, string? culture)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
-            }
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
 
-            IValueForm model = new FirstLowerCaseValueFormFactory().Create("test");
-            string actual = model.Process(input, new Dictionary<string, IValueForm>());
-            Assert.AreEqual(expected, actual);
+                IValueForm model = new FirstLowerCaseValueFormFactory().Create("test");
+                string actual = model.Process(input, new Dictionary<string, IValueForm>());
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
@@ -18,13 +18,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [DataRow("ındigo", "ındigo", "tr-TR")]
         public void FirstUpperCaseInvariantWorksAsExpected(string input, string expected, string? culture)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
+                IValueForm model = new FirstUpperCaseInvariantValueFormFactory().Create("test");
+                string actual = model.Process(input, new Dictionary<string, IValueForm>());
+                Assert.AreEqual(expected, actual);
             }
-            IValueForm model = new FirstUpperCaseInvariantValueFormFactory().Create("test");
-            string actual = model.Process(input, new Dictionary<string, IValueForm>());
-            Assert.AreEqual(expected, actual);
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
@@ -18,14 +18,22 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [DataRow("ındigo", "Indigo", "tr-TR")]
         public void FirstUpperCaseWorksAsExpected(string input, string expected, string? culture)
         {
-            if (!string.IsNullOrEmpty(culture))
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
             {
-                CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
-            }
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    CultureInfo.CurrentCulture = culture == "invariant" ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
 
-            IValueForm model = new FirstUpperCaseValueFormFactory().Create("test");
-            string actual = model.Process(input, new Dictionary<string, IValueForm>());
-            Assert.AreEqual(expected, actual);
+                IValueForm model = new FirstUpperCaseValueFormFactory().Create("test");
+                string actual = model.Process(input, new Dictionary<string, IValueForm>());
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

- Enable MSTest method-level parallelization for the ApiDiff and ApiCompatibility unit test projects.
- Enable MSTest class-level parallelization for Microsoft.DotNet.Cli.Utils.Tests, TemplateEngine Core unit tests, and TemplateEngine Orchestrator RunnableProjects unit tests, preserving isolation between methods that share class-scoped state.
- Harden test isolation by removing shared log state, protecting assembly emission with `ResourceLock`, restoring ambient cultures, virtualizing environment-variable access, and isolating Template Engine host identifiers.

## Test evidence

Validated on the creator branch before extracting this reviewable tranche:

| Project | Result |
| --- | --- |
| Microsoft.DotNet.Cli.Utils.Tests | 236 cases passed repeatedly; warm runtime improved from 69.5s to 46.6s |
| ApiDiff | 173 total: 170 passed, 3 skipped |
| ApiCompatibility | 246 passed |
| TemplateEngine Core | Both target frameworks: 363 total, 362 passed, 1 skipped |
| TemplateEngine Orchestrator RunnableProjects | net11.0: 511 total, 509 passed, 2 skipped; net481: 500 total, 498 passed, 2 skipped |
