### PR TITLE
Parallelize additional MSTest integration suites

### DIFF
--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.IntegrationTests/Microsoft.DotNet.ApiCompat.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd.Tests/EndToEnd.Tests.csproj
+++ b/test/EndToEnd.Tests/EndToEnd.Tests.csproj
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- These tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- End-to-end scenarios use isolated test asset directories and virtual template hives. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd.Tests/GivenDotNetUsesMSBuild.cs
@@ -12,7 +12,7 @@ namespace EndToEnd.Tests
         [RequiresMSBuildVersion("17.0.0.32901")]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
-            string projectDirectory = TestAssetsManager.CreateTestDirectory().Path;
+            string projectDirectory = TestAssetsManager.CreateTestDirectory(identifier: nameof(GivenDotNetUsesMSBuild)).Path;
 
             string[] newArgs = ["console", "--no-restore"];
             new DotnetNewCommand(Log)

--- a/test/EndToEnd.Tests/GivenWindowsApp.cs
+++ b/test/EndToEnd.Tests/GivenWindowsApp.cs
@@ -24,7 +24,7 @@ namespace EndToEnd.Tests
         public void ItCanBuildAndRun(string targetPlatformVersion, string packageVersion = "")
         {
             var testInstance = TestAssetsManager
-                .CopyTestAsset("UseCswinrt", identifier: targetPlatformVersion)
+                .CopyTestAsset("UseCswinrt", identifier: targetPlatformVersion + packageVersion)
                 .WithSource();
 
             var projectPath = Path.Combine(testInstance.Path, "consolecswinrt.csproj");

--- a/test/EndToEnd.Tests/ProjectBuildTests.cs
+++ b/test/EndToEnd.Tests/ProjectBuildTests.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Runtime.CompilerServices;
 using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests
@@ -13,7 +14,7 @@ namespace EndToEnd.Tests
         [TestMethod]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
-            var directory = TestAssetsManager.CreateTestDirectory();
+            var directory = TestAssetsManager.CreateTestDirectory(identifier: nameof(ProjectBuildTests));
             string projectDirectory = directory.Path;
 
             new DotnetNewCommand(Log, "console", "--no-restore")
@@ -55,7 +56,7 @@ namespace EndToEnd.Tests
         [TestMethod]
         public void ItCanRunAnAppUsingTheWebSdk()
         {
-            var directory = TestAssetsManager.CreateTestDirectory();
+            var directory = TestAssetsManager.CreateTestDirectory(identifier: nameof(ProjectBuildTests));
             string projectDirectory = directory.Path;
 
             new DotnetNewCommand(Log, "console", "--no-restore")
@@ -87,7 +88,7 @@ namespace EndToEnd.Tests
         [DataRow("current", false)]
         public void ItCanPublishArm64Winforms(string targetFramework, bool selfContained)
         {
-            var directory = TestAssetsManager.CreateTestDirectory();
+            var directory = TestAssetsManager.CreateTestDirectory(identifier: $"{targetFramework}-{selfContained}");
             string projectDirectory = directory.Path;
 
             string[] newArgs = [
@@ -127,7 +128,7 @@ namespace EndToEnd.Tests
         [DataRow("current", false)]
         public void ItCanPublishArm64Wpf(string targetFramework, bool selfContained)
         {
-            var directory = TestAssetsManager.CreateTestDirectory();
+            var directory = TestAssetsManager.CreateTestDirectory(identifier: $"{targetFramework}-{selfContained}");
             string projectDirectory = directory.Path;
 
             string[] newArgs = [
@@ -416,9 +417,16 @@ namespace EndToEnd.Tests
             throw new Exception("Unsupported version of SDK");
         }
 
-        private void TestTemplateCreateAndBuild(string templateName, bool build = true, bool selfContained = false, string language = "", string framework = "", bool deleteTestDirectory = false)
+        private void TestTemplateCreateAndBuild(
+            string templateName,
+            bool build = true,
+            bool selfContained = false,
+            string language = "",
+            string framework = "",
+            bool deleteTestDirectory = false,
+            [CallerMemberName] string testName = "")
         {
-            var directory = InstantiateProjectTemplate(templateName, language);
+            var directory = InstantiateProjectTemplate(templateName, language, testName: testName);
             string projectDirectory = directory.Path;
 
             XDocument GetProjectXml()
@@ -485,7 +493,12 @@ namespace EndToEnd.Tests
             }
         }
 
-        private TestDirectory InstantiateProjectTemplate(string templateName, string language = "", bool withNoRestore = true, string itemName = "")
+        private TestDirectory InstantiateProjectTemplate(
+            string templateName,
+            string language = "",
+            bool withNoRestore = true,
+            string itemName = "",
+            [CallerMemberName] string testName = "")
         {
             var identifier = templateName;
             if (!string.IsNullOrWhiteSpace(language))
@@ -496,7 +509,7 @@ namespace EndToEnd.Tests
             {
                 identifier += $"({itemName})";
             }
-            var directory = TestAssetsManager.CreateTestDirectory(identifier: identifier);
+            var directory = TestAssetsManager.CreateTestDirectory(testName, identifier);
             string projectDirectory = directory.Path;
 
             string[] newArgs = [

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishASingleFileApp.cs
@@ -884,7 +884,7 @@ class C
 
 
             var testAsset = TestAssetsManager.CreateTestProject(testProject, identifier: cetCompat.HasValue ? cetCompat.Value.ToString() : "default");
-            var publishCommand = new PublishCommand(testAsset);
+            var publishCommand = new PublishCommand(testAsset).WithWorkingDirectory(testAsset.Path) as PublishCommand;
             publishCommand.Execute(PublishSingleFile, "/bl:" + binlogDestPath)
                 .Should()
                 .Pass();

--- a/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
+++ b/test/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishIncrementally.cs
@@ -64,7 +64,7 @@ namespace Microsoft.NET.Publish.Tests
                 "./msbuild.binlog";
 
             // Publish as a single file
-            var publishCommand = new PublishCommand(testAsset);
+            var publishCommand = new PublishCommand(testAsset).WithWorkingDirectory(testAsset.Path) as PublishCommand;
             publishCommand
                 .Execute(@"/p:PublishSingleFile=true", $"-bl:{binlogDestPath}")
                 .Should()

--- a/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
+++ b/test/Microsoft.NET.Publish.Tests/Microsoft.NET.Publish.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <!-- Test asset paths are isolated across classes, but data-driven methods within a class can share paths. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
@@ -11,30 +11,34 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     public class VerifySettingsFixture
     {
+        private static readonly object s_initializationLock = new();
         private static bool s_called;
 
         public VerifySettingsFixture()
         {
-            if (s_called)
+            lock (s_initializationLock)
             {
-                return;
-            }
-            s_called = true;
+                if (s_called)
+                {
+                    return;
+                }
 
-            VerifyMSTest.Verifier.DerivePathInfo(
-                (_, _, type, method) => new(
-                    directory: TestBase.ApprovalsDirectory,
-                    typeName: type.Name,
-                    methodName: method.Name));
+                VerifyMSTest.Verifier.DerivePathInfo(
+                    (_, _, type, method) => new(
+                        directory: TestBase.ApprovalsDirectory,
+                        typeName: type.Name,
+                        methodName: method.Name));
 
-            // Customize diff output of verifier
-            VerifyDiffPlex.Initialize(OutputType.Compact);
+                // Customize diff output of verifier
+                VerifyDiffPlex.Initialize(OutputType.Compact);
 
 #if NET
-            // The shared TemplateVerifier engine is compiled against the xUnit Verify adapter; route its directory
-            // verification to the MSTest adapter so the ambient MSTest test context is used under MTP.
-            VerificationEngine.DirectoryVerifier = VerifyMSTest.Verifier.VerifyDirectory;
+                // The shared TemplateVerifier engine is compiled against the xUnit Verify adapter; route its directory
+                // verification to the MSTest adapter so the ambient MSTest test context is used under MTP.
+                VerificationEngine.DirectoryVerifier = VerifyMSTest.Verifier.VerifyDirectory;
 #endif
+                s_called = true;
+            }
         }
     }
 }

--- a/test/dotnet-new.IntegrationTests/DotnetNewInstallTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewInstallTests.cs
@@ -47,7 +47,10 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             }
             finally
             {
-                Directory.Delete(testRoot, recursive: true);
+                if (!PathUtility.TryDeleteDirectory(testRoot))
+                {
+                    _log.WriteLine($"Failed to delete temporary directory '{testRoot}'.");
+                }
             }
         }
 

--- a/test/dotnet-new.IntegrationTests/DotnetNewInstallTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewInstallTests.cs
@@ -36,7 +36,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         [TestMethod]
         public void CanInstallToPathWithAt()
         {
-            string path = Path.Combine(Path.GetTempPath(), "repro@4");
+            string testRoot = CreateTemporaryFolder();
+            string path = Path.Combine(testRoot, "repro@4");
             try
             {
                 Directory.CreateDirectory(path);
@@ -46,7 +47,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             }
             finally
             {
-                Directory.Delete(path, recursive: true);
+                Directory.Delete(testRoot, recursive: true);
             }
         }
 

--- a/test/dotnet-new.IntegrationTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new.IntegrationTests/DotnetNewLocaleTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.TestHelper;
@@ -21,8 +20,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         [TestMethod]
         public void TestDefaultLocale()
         {
-            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
-
             string home = CreateTemporaryFolder(folderName: "Home");
             string? thisDir = Path.GetDirectoryName(typeof(DotnetNewLocaleTests).Assembly.Location);
             string testTemplatesFolder = GetTestTemplateLocation("TemplateWithLocalization");

--- a/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
+++ b/test/dotnet-new.IntegrationTests/ModuleInitializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using EmptyFiles;
 using VerifyTests.DiffPlex;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
@@ -32,6 +33,8 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
                        directory: BaseIntegrationTest.ApprovalsDirectory,
                        typeName: type.Name,
                        methodName: method.Name));
+
+            FileExtensions.AddTextExtension(".cshtml");
 
             // Customize diff output of verifier
             VerifyDiffPlex.Initialize(OutputType.Compact);

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Cli.New.IntegrationTests
 {
@@ -53,7 +54,10 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         public void Dispose()
         {
-            Directory.Delete(dotnetNewTestExecutionDir, recursive: true);
+            if (!PathUtility.TryDeleteDirectory(dotnetNewTestExecutionDir))
+            {
+                testOutputHelper.WriteLine($"Failed to delete temporary directory '{dotnetNewTestExecutionDir}'.");
+            }
         }
     }
 }

--- a/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateDiscoveryTool.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
         {
             testOutputHelper = log;
             string home = Utilities.CreateTemporaryFolder("home");
-            dotnetNewTestExecutionDir = Utilities.GetTestExecutionTempFolder();
+            dotnetNewTestExecutionDir = Utilities.CreateTemporaryFolder(nameof(TemplateDiscoveryTool));
             string toolManifestPath = Path.Combine(dotnetNewTestExecutionDir, "dotnet-tools.json");
             if (!File.Exists(toolManifestPath))
             {
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
 
         public void Dispose()
         {
+            Directory.Delete(dotnetNewTestExecutionDir, recursive: true);
         }
     }
 }

--- a/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/dotnet-new.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using EmptyFiles;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 
@@ -52,7 +51,6 @@ namespace Microsoft.DotNet.Cli.New.IntegrationTests
             _log.LogInformation($"Template with {caseDescription}");
             Dictionary<string, string?> environmentUnderTest = new() { ["DOTNET_NOLOGO"] = false.ToString() };
             SdkTestContext.Current.AddTestEnvironmentVariables(environmentUnderTest);
-            FileExtensions.AddTextExtension(".cshtml");
 
             TemplateVerifierOptions options = new TemplateVerifierOptions(templateName: shortName)
             {

--- a/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
+++ b/test/dotnet-new.IntegrationTests/dotnet-new.IntegrationTests.csproj
@@ -6,6 +6,8 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <IsUnitTestProject>true</IsUnitTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Several classes intentionally share a custom hive or output root through class fixtures. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Enable method-level parallelism for EndToEnd and ApiCompat integration tests.
- Enable class-level parallelism for dotnet-new, Publish, and TemplateEngine IDE integration tests.
- Isolate test asset paths, temporary roots, working directories, and one-time global initialization so parallel workers do not contend over shared state.

## Validation

- EndToEnd: 146 runnable cases passed twice; duration improved from 61 minutes to 4m13s and 3m30s.
- ApiCompat: both `net11` and `net472` passed all 16 tests.
- TemplateEngine IDE: `net11` completed 138 tests (137 passed, 1 skipped); `net481` completed 105 tests (104 passed, 1 skipped).
- Publish: the full 444-test run completed with 416 passed and 26 skipped; the only two failures require unavailable ARM64 NativeAOT prerequisites. All 89 changed-class cases passed.
- dotnet-new: the changed set completed with 76 passed and 2 skipped; the remaining prerequisite is a missing local TemplateDiscovery package.
