### PR TITLE
Reuse the workload resolver across builds in the .NET SDK

### DIFF
--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using System.Collections.Immutable;
+using System.Security.Cryptography;
 
 namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
 {
@@ -25,8 +26,9 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
     //  For SDK or workload installation actions, we expect to be running under a new process since Visual Studio will have been restarted.
     //  For global.json changes, the Resolve method takes parameters for the dotnet root and the SDK version.  If those values have changed
     //  from the previous call, the cached state will be thrown out and recreated.
-    //  We don't currently handle the case where a global.json file is edited to change the workload version.  It may be necessary
-    //  to kill running MSBuild processes to get that change to take effect.
+    //  A caller that keeps an instance beyond a single build is responsible for the rest: see
+    //  WorkloadSdkResolver, which replaces its instance when the opt-out, the user profile
+    //  directory, or the contents of global.json change.
     class CachingWorkloadResolver
     {
         private sealed record CachedState
@@ -50,25 +52,86 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
 
 
         public CachingWorkloadResolver()
+            : this(IsEnabled())
+        {
+        }
+
+        public CachingWorkloadResolver(bool enabled)
+        {
+            _enabled = enabled;
+        }
+
+        //  A caller that caches a resolver must key on this, so sample it once and build the
+        //  resolver from the sampled value rather than reading it again.
+        public static bool IsEnabled()
         {
             // Support opt-out for workload resolution
-            _enabled = true;
             var envVar = Environment.GetEnvironmentVariable("MSBuildEnableWorkloadResolver");
-            if (envVar != null)
+            if (envVar != null && envVar.Equals("false", StringComparison.OrdinalIgnoreCase))
             {
-                if (envVar.Equals("false", StringComparison.OrdinalIgnoreCase))
-                {
-                    _enabled = false;
-                }
+                return false;
             }
 
-            if (_enabled)
+            string sentinelPath = Path.Combine(SdkPaths.SdkDirectory, "DisableWorkloadResolver.sentinel");
+            return !File.Exists(sentinelPath);
+        }
+
+        //  One resolver shared by every build in this process.
+        //
+        //  What a resolver reads is fixed for the life of the process: an SDK or a workload is not
+        //  installed underneath a running build server. Three things are not fixed, and they are
+        //  the key below:
+        //    - the opt-out, which MSBuild re-applies from the client environment on every build;
+        //    - the user profile directory, which selects user-local manifests and packs;
+        //    - global.json, which selects a workload version and can be edited in place.
+        //  Resolve already rebuilds the cached state when the dotnet root or the SDK version
+        //  changes, so those are not repeated here.
+        private static readonly object s_sharedLock = new();
+        private static CachingWorkloadResolver? s_shared;
+        private static (bool Enabled, string? UserProfileDir, string? GlobalJsonPath, string GlobalJson)? s_sharedKey;
+
+        /// <summary>
+        ///  The shared resolver for these settings, built anew when any of them has changed since
+        ///  the last call. Callers should ask once per build rather than once per SDK reference,
+        ///  and keep the returned instance for the whole build.
+        /// </summary>
+        public static CachingWorkloadResolver GetShared(bool enabled, string? userProfileDir, string? globalJsonPath)
+        {
+            //  Hashed outside the lock: it is file I/O and does not need to be serialized.
+            var key = (enabled, userProfileDir, globalJsonPath, DescribeGlobalJson(globalJsonPath));
+
+            lock (s_sharedLock)
             {
-                string sentinelPath = Path.Combine(SdkPaths.SdkDirectory, "DisableWorkloadResolver.sentinel");
-                if (File.Exists(sentinelPath))
+                if (s_shared is null || !key.Equals(s_sharedKey))
                 {
-                    _enabled = false;
+                    s_shared = new CachingWorkloadResolver(enabled);
+                    s_sharedKey = key;
                 }
+
+                return s_shared;
+            }
+        }
+
+        //  Contents, not a timestamp: editing global.json in place need not move its timestamp
+        //  and need not change its length.
+        private static string DescribeGlobalJson(string? globalJsonPath)
+        {
+            //  A stable value, so that the ordinary case of having no global.json still reuses.
+            if (globalJsonPath is null || !File.Exists(globalJsonPath))
+            {
+                return "none";
+            }
+
+            try
+            {
+                using var contents = File.OpenRead(globalJsonPath);
+                using var sha = SHA256.Create();
+                return Convert.ToBase64String(sha.ComputeHash(contents));
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                //  Unreadable: build a new resolver rather than trust a file we could not check.
+                return Guid.NewGuid().ToString();
             }
         }
 

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs
@@ -97,8 +97,8 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
         /// </summary>
         public static CachingWorkloadResolver GetShared(bool enabled, string? userProfileDir, string? globalJsonPath)
         {
-            //  Hashed outside the lock: it is file I/O and does not need to be serialized.
-            var key = (enabled, userProfileDir, globalJsonPath, DescribeGlobalJson(globalJsonPath));
+            //  Hashed outside the lock when enabled: it is file I/O and does not need to be serialized.
+            var key = (enabled, userProfileDir, globalJsonPath, enabled ? DescribeGlobalJson(globalJsonPath) : "disabled");
 
             lock (s_sharedLock)
             {

--- a/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
+++ b/src/Resolvers/Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/WorkloadSdkResolver.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Framework;
@@ -29,6 +29,8 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
 
             public string? GlobalJsonPath { get; init; }
 
+            public string? UserProfileDir { get; init; }
+
             public CachingWorkloadResolver? WorkloadResolver { get; init; }
         }
 
@@ -50,23 +52,26 @@ namespace Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver
                 var sdkVersion = Path.GetFileName(sdkDirectory);
 
                 var globalJsonPath = SdkDirectoryWorkloadManifestProvider.GetGlobalJsonPath(GetGlobalJsonStartDir(resolverContext));
+                var userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
 
                 cachedState = new CachedState()
                 {
                     DotnetRootPath = dotnetRootPath,
                     SdkVersion = sdkVersion,
                     GlobalJsonPath = globalJsonPath,
-                    WorkloadResolver = new CachingWorkloadResolver()
+                    UserProfileDir = userProfileDir,
+                    //  Asked once per submission, not once per SDK reference: MSBuild re-applies
+                    //  the client environment to a reused process on every build.
+                    WorkloadResolver = CachingWorkloadResolver.GetShared(CachingWorkloadResolver.IsEnabled(), userProfileDir, globalJsonPath)
                 };
 
                 resolverContext.State = cachedState;
             }
 
-            string? userProfileDir = new CliFolderPathCalculatorCore().GetDotnetUserProfileFolderPath();
             ResolutionResult? result = null;
             if (cachedState.DotnetRootPath is not null && cachedState.SdkVersion is not null)
             {
-                result = cachedState.WorkloadResolver?.Resolve(sdkReference.Name, cachedState.DotnetRootPath, cachedState.SdkVersion, userProfileDir, cachedState.GlobalJsonPath);
+                result = cachedState.WorkloadResolver?.Resolve(sdkReference.Name, cachedState.DotnetRootPath, cachedState.SdkVersion, cachedState.UserProfileDir, cachedState.GlobalJsonPath);
             }
 
             return result?.ToSdkResult(sdkReference, factory);

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenACachingWorkloadResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenACachingWorkloadResolver.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    /// <summary>
+    ///  The workload opt-out is sampled separately from constructing a resolver, so that a caller
+    ///  which caches resolvers can key on the same value it built the resolver from. These tests
+    ///  cover that split: sampling must follow the environment, and construction must follow the
+    ///  value it was given rather than sampling again.
+    /// </summary>
+    [TestClass]
+    public class GivenACachingWorkloadResolver : SdkTest
+    {
+        private const string OptOutVariable = "MSBuildEnableWorkloadResolver";
+
+        public GivenACachingWorkloadResolver() : base()
+        {
+        }
+
+        //  Runs an action with the opt-out variable set, then restores it.
+        private static void WithOptOut(string? value, Action action)
+        {
+            string? original = Environment.GetEnvironmentVariable(OptOutVariable);
+            Environment.SetEnvironmentVariable(OptOutVariable, value);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(OptOutVariable, original);
+            }
+        }
+
+        //  A minimal SDK layout: enough for a resolver to answer without finding any workload.
+        private (string DotnetRoot, string SdkVersion) CreateEmptySdk(string identifier)
+        {
+            string dotnetRoot = TestAssetsManager.CreateTestDirectory(identifier: identifier).Path;
+            string sdkVersion = "10.0.100";
+            Directory.CreateDirectory(Path.Combine(dotnetRoot, "sdk", sdkVersion));
+            Directory.CreateDirectory(Path.Combine(dotnetRoot, "sdk-manifests", sdkVersion));
+            return (dotnetRoot, sdkVersion);
+        }
+
+        private CachingWorkloadResolver.ResolutionResult ResolveAutoImports(CachingWorkloadResolver resolver, string dotnetRoot, string sdkVersion)
+            => resolver.Resolve(
+                "Microsoft.NET.SDK.WorkloadAutoImportPropsLocator",
+                dotnetRoot,
+                sdkVersion,
+                userProfileDir: null,
+                globalJsonPath: null);
+
+        [TestMethod]
+        public void ItSamplesTheOptOutAsDisabled()
+        {
+            WithOptOut("false", () => CachingWorkloadResolver.IsEnabled().Should().BeFalse());
+        }
+
+        [TestMethod]
+        public void ItSamplesTheOptOutCaseInsensitively()
+        {
+            WithOptOut("FALSE", () => CachingWorkloadResolver.IsEnabled().Should().BeFalse());
+        }
+
+        [TestMethod]
+        public void ItSamplesAnyOtherValueAsEnabled()
+        {
+            //  Only the exact word "false" opts out; anything else leaves resolution on.
+            WithOptOut("true", () => CachingWorkloadResolver.IsEnabled().Should().BeTrue());
+            WithOptOut("0", () => CachingWorkloadResolver.IsEnabled().Should().BeTrue());
+        }
+
+        [TestMethod]
+        public void ItResolvesNothingWhenConstructedDisabled()
+        {
+            //  A disabled resolver answers without touching the filesystem, so a path that does
+            //  not exist is enough here, and proves it never looked.
+            string missingRoot = Path.Combine(Path.GetTempPath(), "no-such-dotnet-root");
+
+            WithOptOut(null, () =>
+            {
+                var result = ResolveAutoImports(new CachingWorkloadResolver(enabled: false), missingRoot, "10.0.100");
+                result.Should().BeOfType<CachingWorkloadResolver.NullResolutionResult>();
+            });
+        }
+
+        [TestMethod]
+        public void ItDoesNotResampleTheOptOutWhenConstructedEnabled()
+        {
+            var (dotnetRoot, sdkVersion) = CreateEmptySdk("enabledResolver");
+
+            //  Constructed enabled while the environment says "false". If the constructor sampled
+            //  the environment again it would disagree with the value a caller keyed on.
+            WithOptOut("false", () =>
+            {
+                var result = ResolveAutoImports(new CachingWorkloadResolver(enabled: true), dotnetRoot, sdkVersion);
+                result.Should().BeOfType<CachingWorkloadResolver.MultiplePathResolutionResult>();
+            });
+        }
+
+        //  One test rather than several, because the shared slot is process-wide state and
+        //  separate test methods could run in parallel against it.
+        [TestMethod]
+        public void ItSharesOneResolverUntilTheKeyChanges()
+        {
+            var first = CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: "profile-one", globalJsonPath: null);
+
+            //  Same settings: the whole point of the change.
+            CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: "profile-one", globalJsonPath: null)
+                .Should().BeSameAs(first, "nothing changed, so the resolver must be reused");
+
+            //  A different user profile selects different user-local manifests and packs.
+            var otherProfile = CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: "profile-two", globalJsonPath: null);
+            otherProfile.Should().NotBeSameAs(first);
+
+            //  The opt-out is re-applied by MSBuild on every build, so it must not be frozen.
+            CachingWorkloadResolver.GetShared(enabled: false, userProfileDir: "profile-two", globalJsonPath: null)
+                .Should().NotBeSameAs(otherProfile);
+        }
+
+        [TestMethod]
+        public void ItReplacesTheSharedResolverWhenGlobalJsonIsEditedInPlace()
+        {
+            string directory = TestAssetsManager.CreateTestDirectory(identifier: "sharedGlobalJson").Path;
+            string globalJsonPath = Path.Combine(directory, "global.json");
+            File.WriteAllText(globalJsonPath, """{"sdk":{"version":"10.0.100"}}""");
+
+            var first = CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: null, globalJsonPath);
+
+            //  An unchanged global.json must still reuse, or the optimization is lost for every
+            //  build in a repository that has one.
+            CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: null, globalJsonPath)
+                .Should().BeSameAs(first, "the file has not changed");
+
+            //  Same path, same length, and the timestamp is put back: only the contents differ.
+            DateTime originalWriteTime = File.GetLastWriteTimeUtc(globalJsonPath);
+            File.WriteAllText(globalJsonPath, """{"sdk":{"version":"10.0.200"}}""");
+            File.SetLastWriteTimeUtc(globalJsonPath, originalWriteTime);
+
+            CachingWorkloadResolver.GetShared(enabled: true, userProfileDir: null, globalJsonPath)
+                .Should().NotBeSameAs(first, "the workload version global.json selects may have changed");
+        }
+    }
+}


### PR DESCRIPTION
Related to dotnet/msbuild#14704

### Context

`WorkloadSdkResolver` created a `CachingWorkloadResolver` per build and stored it in `SdkResolverContext.State`, which MSBuild clears when the submission ends, so workload manifests were re-read on every build even in a reused process. `MSBuildSdkResolver` already keeps a static instance, but only when `context.IsRunningInVisualStudio` — so the .NET SDK CLI paid a cost Visual Studio does not.

Everything the workload resolver reads is fixed for the life of the process: an SDK or workload is not installed underneath a running build server. Three inputs are not fixed, and they form the cache key.

### Changes Made

- Added `CachingWorkloadResolver.GetShared(bool, string?, string?)`, a lock-guarded process-wide slot holding one resolver, replaced whenever its key changes. The key is a tuple of the sampled opt-out, the user profile directory, the `global.json` path, and a SHA-256 of the `global.json` contents.
- Split `CachingWorkloadResolver.IsEnabled()` out of the constructor and added `CachingWorkloadResolver(bool enabled)`, so the value a caller keys on is the value the resolver is built from. `MSBuildEnableWorkloadResolver` and `DisableWorkloadResolver.sentinel` are re-sampled every build, because MSBuild re-applies the client environment to a reused process.
- Changed `WorkloadSdkResolver.Resolve` to obtain the shared resolver once per submission rather than constructing one, and to sample `userProfileDir` once per submission rather than once per SDK reference. The same sampled value is now used for the key and passed to `Resolve`.
- Left the dotnet root, the SDK version, and the `global.json` path out of the shared key: `CachingWorkloadResolver.Resolve` already rebuilds its own cached state when those change.
- Updated the `CachingWorkloadResolver` comment that stated an in-place `global.json` edit "may [require] kill[ing] running MSBuild processes", which this change handles.

### Testing

- Built `Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver` and `Microsoft.DotNet.MSBuildSdkResolver.Tests` — 0 warnings, 0 errors.
- Added `GivenACachingWorkloadResolver` in `Microsoft.DotNet.MSBuildSdkResolver.Tests`:
  - `ItSamplesTheOptOutAsDisabled` — `MSBuildEnableWorkloadResolver=false` disables resolution.
  - `ItSamplesTheOptOutCaseInsensitively` — `FALSE` also disables it.
  - `ItSamplesAnyOtherValueAsEnabled` — only the word `false` opts out.
  - `ItResolvesNothingWhenConstructedDisabled` — a disabled resolver answers without touching the filesystem (it is given a path that does not exist).
  - `ItSharesOneResolverUntilTheKeyChanges` — the same settings reuse one instance; a user-profile change and an enablement change each replace it.
  - `ItDoesNotResampleTheOptOutWhenConstructedEnabled` — the constructor uses the value supplied rather than re-reading the environment.
  - `ItReplacesTheSharedResolverWhenGlobalJsonIsEditedInPlace` — an unchanged file reuses; a same-length edit with the original timestamp restored replaces.
  - Result: 5 passed, 2 not executed locally (see Notes).

### Measured savings

Warm Orchard Core build (`OrchardCore.slnx`, 704 workload SDK requests per build), three counterbalanced pairs, `MSBUILDFORCEMULTITHREADED=1` with a reused server. The two SDK layouts were verified to differ in exactly one file, `Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.dll`.

| Metric | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Elapsed time with a workload SDK request outstanding, mean | 57.54 ms | 26.84 ms | 30.69 ms |
| Same, median | 54.67 ms | 28.34 ms | 26.33 ms |
| Workload resolver execution, mean | 52.02 ms | 0.69 ms | 51.33 ms |

Per pair, before 73.59 / 44.35 / 54.67 ms against after 28.34 / 29.24 / 22.95 ms. Every run after beat every run before.

Four builds in one reused process, workload resolver execution:

| Build | Change made first | Resolver work |
| --- | --- | ---: |
| 1 | none, cold server | 187.02 ms |
| 2 | none | 0.49 ms |
| 3 | `global.json` edited in place | 41.12 ms |
| 4 | `global.json` restored | 29.46 ms |

Build 3 preserved the file length and restored the original `LastWriteTimeUtc`, so only the contents differed; the resolver is replaced because the key hashes contents.

The elapsed figure is the union of the request intervals, not their sum — under multithreaded MSBuild the requests overlap, and the sum for the same runs was 318.37 ms.

### When this applies

The resolver is a static, so it only helps when the process performing SDK resolution — the MSBuild entry process — survives to the next build. Two consecutive builds per configuration, reporting the entry process id and workload resolver execution:

| Configuration | Entry process, build 1 -> 2 | Resolver work, build 1 -> 2 | Reused |
| --- | --- | ---: | --- |
| Server + multithreaded | 57612 -> 57612 | 111.08 -> 1.66 ms | yes |
| Server, not multithreaded | 114396 -> 114396 | 85.69 -> 1.69 ms | yes |
| Multithreaded, no server | 98856 -> 44612 | 122.31 -> 117.93 ms | no |
| Neither | 108808 -> 111192 | 63.92 -> 55.27 ms | no |

The MSBuild server is the requirement; multithreaded mode is not. Where the server is not reused the change is inert, neither faster nor slower.

`DOTNET_CLI_USE_MSBUILD_SERVER` defaults to `true` in `MSBuildForwardingAppWithoutLogging`, so this is the default `dotnet build` path rather than an opt-in configuration. It does not apply when the server is disabled explicitly, or when the CLI turns it off itself — for example when an environment variable has an empty value and MSBuild is forwarded out of process.

### Notes

- This does not speed up a cold build. It removes repeated work in a reused process; a first build in a fresh process is unaffected, and so is any build where the MSBuild server is not reused (see "When this applies").
- 30 ms on a build of this size is below wall-clock noise. The claim is a reproducible reduction in resolver work, not a measurable reduction in build time. This was measured rather than assumed: six counterbalanced pairs timing the whole warm build gave a paired standard deviation of 2,139 ms, roughly 70x the effect being sought, so the comparison cannot resolve it (paired mean difference 1,240 ms, t = 1.42, 95% CI -1,004 to +3,484 ms — the naive mean is far larger than the change can possibly account for, which is what noise at this scale looks like). Detecting a 30 ms effect against that variance would need on the order of 38,000 paired runs.
- **Known behaviour change, needs a decision before this leaves draft.** A workload install, uninstall, workload-set change, install-state change, or in-place manifest edit is not detected. Only `global.json` contents, the opt-out, and the user profile directory are tracked. Before this change the resolver was rebuilt on every build, so a workload installed while a build server was running *was* picked up by the next build. Now it is not, until the server is restarted or the key changes.

  Measured — a simulated workload install (new manifest directory plus its pack) between two warm builds in one server process, workload resolver execution:

  | Build | Before this change | After this change |
  | --- | ---: | ---: |
  | 1, cold | 136.79 ms | 131.71 ms |
  | 2, warm | 21.02 ms | 0.52 ms |
  | 3, after the install | **36.54 ms** (re-read, install seen) | **0.49 ms** (reused, install not seen) |

  The affected sequence is the common one: `dotnet build` reports a missing workload, the user runs `dotnet workload install`, and builds again in the same server process. `dotnet workload install` does not shut the build server down.
- `ItDoesNotResampleTheOptOutWhenConstructedEnabled` and `ItReplacesTheSharedResolverWhenGlobalJsonIsEditedInPlace` were not executed locally: they use `TestAssetsManager`, which requires `artifacts/bin/redist/.../dotnet.exe`, and `redist.csproj` does not build in my environment for unrelated reasons. They follow `test/AGENTS.md` conventions and should run in CI.
