### PR TITLE
Parallelize AOT size analysis artifact downloads

### DIFF
--- a/.github/workflows/aot-size-analysis.yml
+++ b/.github/workflows/aot-size-analysis.yml
@@ -193,54 +193,24 @@ jobs:
       has_report: ${{ steps.report.outputs.has_report }}
 
     steps:
+      - name: Check out workflow scripts
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: .github/workflows/aot-size-analysis/scripts
+
       - name: Find PR and baseline builds
         id: builds
-        run: |
-          set -euo pipefail
-
-          AZDO_API="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_apis"
-
-          get_latest_build_id() {
-            local branch="$1"
-            local source_sha="${2:-}"
-
-            curl --fail --silent --show-error --location --retry 3 --max-time 60 --get \
-              "${AZDO_API}/build/builds" \
-              --data-urlencode "definitions=${AZDO_PIPELINE_ID}" \
-              --data-urlencode "branchName=${branch}" \
-              --data-urlencode "statusFilter=completed" \
-              --data-urlencode "queryOrder=queueTimeDescending" \
-              --data-urlencode '$top=1' \
-              --data-urlencode "api-version=7.1" |
-              jq -r --arg source_sha "$source_sha" '
-                .value[0]
-                | select($source_sha == "" or .triggerInfo["pr.sourceSha"] == $source_sha)
-                | .id // empty'
-          }
-
-          # sourceVersion is the synthetic merge commit, so match the PR head through triggerInfo.
-          PR_BUILD_ID=$(get_latest_build_id "refs/pull/${PR_NUMBER}/merge" "$PR_HEAD_SHA")
-
-          if [ -z "$PR_BUILD_ID" ]; then
-            echo "::warning::No completed build found for PR commit ${PR_HEAD_SHA}. Ensure the AzDO pipeline has finished."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "PR build ID: $PR_BUILD_ID"
-
-          # Find the most recent baseline build on the base branch
-          BASE_BUILD_ID=$(get_latest_build_id "refs/heads/${BASE_BRANCH}")
-
-          if [ -z "$BASE_BUILD_ID" ]; then
-            echo "::warning::No completed baseline build found on ${BASE_BRANCH}."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Baseline build ID: $BASE_BUILD_ID"
-
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "pr_build_id=${PR_BUILD_ID}" >> "$GITHUB_OUTPUT"
-          echo "base_build_id=${BASE_BUILD_ID}" >> "$GITHUB_OUTPUT"
+        run: >-
+          bash ".github/workflows/aot-size-analysis/scripts/find-builds.sh"
+          --azdo-org "$AZDO_ORG"
+          --azdo-project "$AZDO_PROJECT"
+          --pipeline-id "$AZDO_PIPELINE_ID"
+          --pr-number "$PR_NUMBER"
+          --pr-head-sha "$PR_HEAD_SHA"
+          --base-branch "$BASE_BRANCH"
+          --output-file "$GITHUB_OUTPUT"
 
       - name: Download size analysis artifacts
         if: steps.builds.outputs.found == 'true'
@@ -248,106 +218,14 @@ jobs:
         env:
           PR_BUILD_ID: ${{ steps.builds.outputs.pr_build_id }}
           BASE_BUILD_ID: ${{ steps.builds.outputs.base_build_id }}
-        run: |
-          set -euo pipefail
-
-          AZDO_API="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_apis"
-          PR_ARTIFACTS_FILE="${RUNNER_TEMP}/pr-artifacts.json"
-          BASE_ARTIFACTS_FILE="${RUNNER_TEMP}/base-artifacts.json"
-
-          curl --fail --silent --show-error --location --retry 3 --max-time 60 \
-            "${AZDO_API}/build/builds/${PR_BUILD_ID}/artifacts?api-version=7.1" \
-            --output "$PR_ARTIFACTS_FILE"
-          curl --fail --silent --show-error --location --retry 3 --max-time 60 \
-            "${AZDO_API}/build/builds/${BASE_BUILD_ID}/artifacts?api-version=7.1" \
-            --output "$BASE_ARTIFACTS_FILE"
-
-          # List artifacts from PR build that match _AotSizeAnalysis
-          mapfile -t ARTIFACT_NAMES < <(
-            jq -r '.value[] | select(.name | endswith("_AotSizeAnalysis")) | .name' "$PR_ARTIFACTS_FILE"
-          )
-
-          if [ "${#ARTIFACT_NAMES[@]}" -eq 0 ]; then
-            echo "::warning::No _AotSizeAnalysis artifacts found in PR build ${PR_BUILD_ID}."
-            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Found artifacts: ${ARTIFACT_NAMES[*]}"
-          PLATFORMS=""
-
-          download_artifact() {
-            local artifacts_file="$1"
-            local artifact_name="$2"
-            local destination="$3"
-            local download_url
-            local archive
-
-            download_url=$(jq -r --arg name "$artifact_name" \
-              '[.value[] | select(.name == $name) | .resource.downloadUrl][0] // empty' \
-              "$artifacts_file")
-            if [ -z "$download_url" ]; then
-              return 1
-            fi
-
-            archive=$(mktemp "${RUNNER_TEMP}/aot-size-artifact.XXXXXX.zip")
-            if ! curl --fail --silent --show-error --location --retry 3 --max-time 300 \
-                "$download_url" --output "$archive"; then
-              rm -f "$archive"
-              return 1
-            fi
-
-            if ! unzip -q "$archive" -d "$destination"; then
-              rm -f "$archive"
-              return 1
-            fi
-
-            rm -f "$archive"
-          }
-
-          for ARTIFACT_NAME in "${ARTIFACT_NAMES[@]}"; do
-            PLATFORM="${ARTIFACT_NAME%_AotSizeAnalysis}"
-            echo "::group::Downloading ${PLATFORM}"
-
-            PR_DIR="${RUNNER_TEMP}/pr/${PLATFORM}"
-            BASE_DIR="${RUNNER_TEMP}/base/${PLATFORM}"
-            mkdir -p "$PR_DIR" "$BASE_DIR"
-
-            # Download PR artifact
-            if ! download_artifact "$PR_ARTIFACTS_FILE" "$ARTIFACT_NAME" "$PR_DIR"; then
-              echo "::warning::Failed to download ${ARTIFACT_NAME} from PR build, skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # Download baseline artifact (same name)
-            if ! download_artifact "$BASE_ARTIFACTS_FILE" "$ARTIFACT_NAME" "$BASE_DIR"; then
-              echo "Baseline build does not have artifact ${ARTIFACT_NAME}, skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # Verify .mstat files exist in both
-            PR_MSTAT=$(find "$PR_DIR" -name "dotnet-aot.mstat" -type f | head -1)
-            BASE_MSTAT=$(find "$BASE_DIR" -name "dotnet-aot.mstat" -type f | head -1)
-
-            if [ -n "$PR_MSTAT" ] && [ -n "$BASE_MSTAT" ]; then
-              PLATFORMS="${PLATFORMS:+${PLATFORMS} }${PLATFORM}"
-            else
-              echo "Could not find .mstat files for ${PLATFORM}, skipping."
-            fi
-
-            echo "::endgroup::"
-          done
-
-          if [ -z "$PLATFORMS" ]; then
-            echo "::warning::No matching .mstat file pairs found."
-            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
-          echo "platforms=$(echo "$PLATFORMS" | tr ' ' '\n' | sort | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+        run: >-
+          bash ".github/workflows/aot-size-analysis/scripts/download-artifacts.sh"
+          --azdo-org "$AZDO_ORG"
+          --azdo-project "$AZDO_PROJECT"
+          --pr-build-id "$PR_BUILD_ID"
+          --base-build-id "$BASE_BUILD_ID"
+          --temp-dir "$RUNNER_TEMP"
+          --output-file "$GITHUB_OUTPUT"
 
       - name: Install sizoscope-cli
         if: steps.download.outputs.has_artifacts == 'true'
@@ -360,79 +238,17 @@ jobs:
           PLATFORMS: ${{ steps.download.outputs.platforms }}
           PR_BUILD_ID: ${{ steps.builds.outputs.pr_build_id }}
           BASE_BUILD_ID: ${{ steps.builds.outputs.base_build_id }}
-        run: |
-          set -euo pipefail
-
-          REPORT_FILE="${RUNNER_TEMP}/size-report.md"
-          DETAILS_FILE="${RUNNER_TEMP}/size-details.md"
-          AZDO_BUILD_URL="https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_build/results?buildId="
-
-          # Pass 1: run sizoscope-cli for each platform, collect summary data
-          declare -A PLATFORM_TOTALS
-          HAS_ANY_DIFF=false
-
-          for PLATFORM in $PLATFORMS; do
-            echo "::group::Analyzing ${PLATFORM}"
-
-            PR_MSTAT=$(find "${RUNNER_TEMP}/pr/${PLATFORM}" -name "dotnet-aot.mstat" -type f | head -1)
-            BASE_MSTAT=$(find "${RUNNER_TEMP}/base/${PLATFORM}" -name "dotnet-aot.mstat" -type f | head -1)
-
-            DIFF_FILE="${RUNNER_TEMP}/${PLATFORM}-diff.md"
-            if sizoscope-cli "$BASE_MSTAT" "$PR_MSTAT" --output "$DIFF_FILE"; then
-              HAS_ANY_DIFF=true
-
-              # Extract the total size difference from the first line
-              TOTAL_LINE=$(head -1 "$DIFF_FILE")
-              # Expected format: "Total accounted size difference: 781.8 kB"
-              TOTAL_SIZE=$(echo "$TOTAL_LINE" | sed -n 's/^Total accounted size difference: *//p')
-              PLATFORM_TOTALS["$PLATFORM"]="${TOTAL_SIZE:-unknown}"
-
-              # Accumulate per-platform details
-              {
-                echo "### ${PLATFORM}"
-                echo ""
-                echo "<details>"
-                echo "<summary>Size diff details</summary>"
-                echo ""
-                echo '```'
-                cat "$DIFF_FILE"
-                echo '```'
-                echo ""
-                echo "</details>"
-                echo ""
-              } >> "$DETAILS_FILE"
-            else
-              echo "::warning::sizoscope-cli failed for ${PLATFORM}."
-            fi
-
-            echo "::endgroup::"
-          done
-
-          if [ "$HAS_ANY_DIFF" = false ]; then
-            echo "::notice::No size diffs were generated across any platform."
-            echo "has_report=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Pass 2: assemble the final report with summary table first
-          {
-            echo "## 📊 NativeAOT Size Analysis"
-            echo ""
-            echo "Comparing PR build [\`${PR_HEAD_SHA:0:8}\`](${AZDO_BUILD_URL}${PR_BUILD_ID}) against baseline on \`${BASE_BRANCH}\` ([build](${AZDO_BUILD_URL}${BASE_BUILD_ID}))."
-            echo ""
-            echo "| Platform | Size Difference |"
-            echo "|----------|-----------------|"
-            for PLATFORM in $PLATFORMS; do
-              if [ -n "${PLATFORM_TOTALS[$PLATFORM]+x}" ]; then
-                echo "| ${PLATFORM} | ${PLATFORM_TOTALS[$PLATFORM]} |"
-              fi
-            done
-            echo ""
-            cat "$DETAILS_FILE"
-          } > "$REPORT_FILE"
-
-          echo "has_report=true" >> "$GITHUB_OUTPUT"
-          echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
+        run: >-
+          bash ".github/workflows/aot-size-analysis/scripts/generate-report.sh"
+          --azdo-org "$AZDO_ORG"
+          --azdo-project "$AZDO_PROJECT"
+          --platforms "$PLATFORMS"
+          --pr-build-id "$PR_BUILD_ID"
+          --base-build-id "$BASE_BUILD_ID"
+          --pr-head-sha "$PR_HEAD_SHA"
+          --base-branch "$BASE_BRANCH"
+          --temp-dir "$RUNNER_TEMP"
+          --output-file "$GITHUB_OUTPUT"
 
       - name: Upload size report
         if: steps.report.outputs.has_report == 'true'

--- a/.github/workflows/aot-size-analysis.yml
+++ b/.github/workflows/aot-size-analysis.yml
@@ -198,8 +198,9 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
-          sparse-checkout: .github/workflows/aot-size-analysis/scripts
-
+          sparse-checkout: |
+            .github/workflows/aot-size-analysis/scripts
+            NuGet.config
       - name: Find PR and baseline builds
         id: builds
         run: >-

--- a/.github/workflows/aot-size-analysis.yml
+++ b/.github/workflows/aot-size-analysis.yml
@@ -240,13 +240,9 @@ jobs:
           BASE_BUILD_ID: ${{ steps.builds.outputs.base_build_id }}
         run: >-
           bash ".github/workflows/aot-size-analysis/scripts/generate-report.sh"
-          --azdo-org "$AZDO_ORG"
-          --azdo-project "$AZDO_PROJECT"
           --platforms "$PLATFORMS"
-          --pr-build-id "$PR_BUILD_ID"
-          --base-build-id "$BASE_BUILD_ID"
-          --pr-head-sha "$PR_HEAD_SHA"
-          --base-branch "$BASE_BRANCH"
+          --pr-build-url "https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_build/results?buildId=${PR_BUILD_ID}"
+          --baseline-build-url "https://dev.azure.com/${AZDO_ORG}/${AZDO_PROJECT}/_build/results?buildId=${BASE_BUILD_ID}"
           --temp-dir "$RUNNER_TEMP"
           --output-file "$GITHUB_OUTPUT"
 

--- a/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
+++ b/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Usage: download-artifacts.sh [options]
+
+Options:
+  --azdo-org <name>        Azure DevOps organization
+  --azdo-project <name>    Azure DevOps project
+  --pr-build-id <id>       Pull request build ID
+  --base-build-id <id>     Baseline build ID
+  --temp-dir <path>        Directory for downloads and extracted artifacts
+  --output-file <path>     File that receives step outputs
+  -h, --help               Show this help
+
+Example:
+  download-artifacts.sh \
+    --azdo-org dnceng-public \
+    --azdo-project public \
+    --pr-build-id 1569498 \
+    --base-build-id 1569822 \
+    --temp-dir /tmp/aot-size-analysis \
+    --output-file /tmp/download-artifacts.out
+EOF
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+    echo "Missing value for $1." >&2
+    print_usage >&2
+    exit 2
+  fi
+}
+
+emit_warning() {
+  printf '::warning::%s\n' "$1"
+}
+
+emit_output_value() {
+  printf '%s=%s\n' "$1" "$2" >> "$output_file"
+}
+
+start_group() {
+  printf '::group::%s\n' "$1"
+}
+
+end_group() {
+  printf '::endgroup::\n'
+}
+
+azdo_org=""
+azdo_project=""
+pr_build_id=""
+base_build_id=""
+temp_dir=""
+output_file=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --azdo-org)
+      require_value "$@"
+      azdo_org="$2"
+      shift 2
+      ;;
+    --azdo-project)
+      require_value "$@"
+      azdo_project="$2"
+      shift 2
+      ;;
+    --pr-build-id)
+      require_value "$@"
+      pr_build_id="$2"
+      shift 2
+      ;;
+    --base-build-id)
+      require_value "$@"
+      base_build_id="$2"
+      shift 2
+      ;;
+    --temp-dir)
+      require_value "$@"
+      temp_dir="$2"
+      shift 2
+      ;;
+    --output-file)
+      require_value "$@"
+      output_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$azdo_org" ] || [ -z "$azdo_project" ] || [ -z "$pr_build_id" ] ||
+    [ -z "$base_build_id" ] || [ -z "$temp_dir" ] || [ -z "$output_file" ]; then
+  echo "All options except --help are required." >&2
+  print_usage >&2
+  exit 2
+fi
+
+azdo_api="https://dev.azure.com/${azdo_org}/${azdo_project}/_apis"
+pr_artifacts_file="${temp_dir}/pr-artifacts.json"
+base_artifacts_file="${temp_dir}/base-artifacts.json"
+
+curl --fail --silent --show-error --location --retry 3 --max-time 60 \
+  "${azdo_api}/build/builds/${pr_build_id}/artifacts?api-version=7.1" \
+  --output "$pr_artifacts_file"
+curl --fail --silent --show-error --location --retry 3 --max-time 60 \
+  "${azdo_api}/build/builds/${base_build_id}/artifacts?api-version=7.1" \
+  --output "$base_artifacts_file"
+
+# List artifacts from PR build that match _AotSizeAnalysis
+mapfile -t artifact_names < <(
+  jq -r '.value[] | select(.name | endswith("_AotSizeAnalysis")) | .name' "$pr_artifacts_file"
+)
+
+if [ "${#artifact_names[@]}" -eq 0 ]; then
+  emit_warning "No _AotSizeAnalysis artifacts found in PR build ${pr_build_id}."
+  emit_output_value "has_artifacts" "false"
+  exit 0
+fi
+
+echo "Found artifacts: ${artifact_names[*]}"
+platforms=""
+
+download_artifact() {
+  local artifacts_file="$1"
+  local artifact_name="$2"
+  local destination="$3"
+  local download_url
+  local archive
+
+  download_url=$(jq -r --arg name "$artifact_name" \
+    '[.value[] | select(.name == $name) | .resource.downloadUrl][0] // empty' \
+    "$artifacts_file")
+  if [ -z "$download_url" ]; then
+    return 1
+  fi
+
+  archive=$(mktemp "${temp_dir}/aot-size-artifact.XXXXXX.zip")
+  if ! curl --fail --silent --show-error --location --retry 3 --max-time 300 \
+      "$download_url" --output "$archive"; then
+    rm -f "$archive"
+    return 1
+  fi
+
+  if ! unzip -q "$archive" -d "$destination"; then
+    rm -f "$archive"
+    return 1
+  fi
+
+  rm -f "$archive"
+}
+
+for artifact_name in "${artifact_names[@]}"; do
+  platform="${artifact_name%_AotSizeAnalysis}"
+  start_group "Downloading ${platform}"
+
+  pr_dir="${temp_dir}/pr/${platform}"
+  base_dir="${temp_dir}/base/${platform}"
+  mkdir -p "$pr_dir" "$base_dir"
+
+  if ! download_artifact "$pr_artifacts_file" "$artifact_name" "$pr_dir"; then
+    emit_warning "Failed to download ${artifact_name} from PR build, skipping."
+    end_group
+    continue
+  fi
+
+  if ! download_artifact "$base_artifacts_file" "$artifact_name" "$base_dir"; then
+    echo "Baseline build does not have artifact ${artifact_name}, skipping."
+    end_group
+    continue
+  fi
+
+  pr_mstat=$(find "$pr_dir" -name "dotnet-aot.mstat" -type f -print -quit)
+  base_mstat=$(find "$base_dir" -name "dotnet-aot.mstat" -type f -print -quit)
+
+  if [ -n "$pr_mstat" ] && [ -n "$base_mstat" ]; then
+    platforms="${platforms:+${platforms} }${platform}"
+  else
+    echo "Could not find .mstat files for ${platform}, skipping."
+  fi
+
+  end_group
+done
+
+if [ -z "$platforms" ]; then
+  emit_warning "No matching .mstat file pairs found."
+  emit_output_value "has_artifacts" "false"
+  exit 0
+fi
+
+emit_output_value "has_artifacts" "true"
+emit_output_value "platforms" "$(echo "$platforms" | tr ' ' '\n' | sort | tr '\n' ' ')"

--- a/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
+++ b/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
@@ -132,63 +132,93 @@ fi
 
 echo "Found artifacts: ${artifact_names[*]}"
 platforms=""
+zip_dir=$(mktemp -d "${temp_dir}/aot-size-zips.XXXXXX")
+trap 'rm -rf "$zip_dir"' EXIT
+declare -a pair_platforms pr_archives base_archives curl_args
 
-download_artifact() {
-  local artifacts_file="$1"
-  local artifact_name="$2"
-  local destination="$3"
-  local download_url
-  local archive
-
-  download_url=$(jq -r --arg name "$artifact_name" \
-    '[.value[] | select(.name == $name) | .resource.downloadUrl][0] // empty' \
-    "$artifacts_file")
-  if [ -z "$download_url" ]; then
-    return 1
-  fi
-
-  archive=$(mktemp "${temp_dir}/aot-size-artifact.XXXXXX.zip")
-  if ! curl --fail --silent --show-error --location --retry 3 --max-time 300 \
-      "$download_url" --output "$archive"; then
-    rm -f "$archive"
-    return 1
-  fi
-
-  if ! unzip -q "$archive" -d "$destination"; then
-    rm -f "$archive"
-    return 1
-  fi
-
-  rm -f "$archive"
-}
-
+# Build one curl invocation containing every complete PR/baseline artifact pair.
 for artifact_name in "${artifact_names[@]}"; do
   platform="${artifact_name%_AotSizeAnalysis}"
-  start_group "Downloading ${platform}"
+  pr_download_url=$(jq -r --arg name "$artifact_name" \
+    '[.value[] | select(.name == $name) | .resource.downloadUrl][0] // empty' \
+    "$pr_artifacts_file")
+  base_download_url=$(jq -r --arg name "$artifact_name" \
+    '[.value[] | select(.name == $name) | .resource.downloadUrl][0] // empty' \
+    "$base_artifacts_file")
 
+  if [ -z "$pr_download_url" ]; then
+    emit_warning "PR build does not have a download URL for ${artifact_name}, skipping."
+    continue
+  fi
+  if [ -z "$base_download_url" ]; then
+    emit_warning "Baseline build does not have artifact ${artifact_name}, skipping."
+    continue
+  fi
+
+  pair_index="${#pair_platforms[@]}"
+  pr_archive="${zip_dir}/${pair_index}-pr.zip"
+  base_archive="${zip_dir}/${pair_index}-base.zip"
+  pair_platforms+=("$platform")
+  pr_archives+=("$pr_archive")
+  base_archives+=("$base_archive")
+  curl_args+=(--url "$pr_download_url" --output "$pr_archive")
+  curl_args+=(--url "$base_download_url" --output "$base_archive")
+done
+
+if [ "${#pair_platforms[@]}" -eq 0 ]; then
+  emit_warning "No matching PR and baseline artifact pairs found."
+  emit_output_value "has_artifacts" "false"
+  exit 0
+fi
+
+start_group "Downloading AOT artifact ZIPs"
+set +e
+curl --fail --show-error --location --retry 3 --max-time 300 \
+  --parallel --parallel-immediate --parallel-max 4 --progress-bar --remove-on-error \
+  --write-out 'Downloaded %{filename_effective}: %{size_download} bytes in %{time_total}s at %{speed_download} B/s (exit %{exitcode})\n' \
+  "${curl_args[@]}"
+curl_exit=$?
+set -e
+end_group
+
+if [ "$curl_exit" -ne 0 ]; then
+  emit_warning "One or more artifact downloads failed; continuing with successful pairs."
+fi
+
+for pair_index in "${!pair_platforms[@]}"; do
+  platform="${pair_platforms[$pair_index]}"
+  pr_archive="${pr_archives[$pair_index]}"
+  base_archive="${base_archives[$pair_index]}"
+  start_group "Extracting ${platform}"
   pr_dir="${temp_dir}/pr/${platform}"
   base_dir="${temp_dir}/base/${platform}"
   mkdir -p "$pr_dir" "$base_dir"
 
-  if ! download_artifact "$pr_artifacts_file" "$artifact_name" "$pr_dir"; then
-    emit_warning "Failed to download ${artifact_name} from PR build, skipping."
-    end_group
-    continue
+  pair_valid=true
+  if [ ! -s "$pr_archive" ]; then
+    emit_warning "PR artifact download for ${platform} is missing or empty."
+    pair_valid=false
+  elif ! unzip -q "$pr_archive" -d "$pr_dir"; then
+    emit_warning "Failed to extract PR artifact for ${platform}."
+    pair_valid=false
   fi
 
-  if ! download_artifact "$base_artifacts_file" "$artifact_name" "$base_dir"; then
-    echo "Baseline build does not have artifact ${artifact_name}, skipping."
-    end_group
-    continue
+  if [ ! -s "$base_archive" ]; then
+    emit_warning "Baseline artifact download for ${platform} is missing or empty."
+    pair_valid=false
+  elif ! unzip -q "$base_archive" -d "$base_dir"; then
+    emit_warning "Failed to extract baseline artifact for ${platform}."
+    pair_valid=false
   fi
+  rm -f "$pr_archive" "$base_archive"
 
   pr_mstat=$(find "$pr_dir" -name "dotnet-aot.mstat" -type f -print -quit)
   base_mstat=$(find "$base_dir" -name "dotnet-aot.mstat" -type f -print -quit)
 
-  if [ -n "$pr_mstat" ] && [ -n "$base_mstat" ]; then
+  if [ "$pair_valid" = true ] && [ -n "$pr_mstat" ] && [ -n "$base_mstat" ]; then
     platforms="${platforms:+${platforms} }${platform}"
   else
-    echo "Could not find .mstat files for ${platform}, skipping."
+    emit_warning "Could not validate an .mstat pair for ${platform}, skipping."
   fi
 
   end_group

--- a/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
+++ b/.github/workflows/aot-size-analysis/scripts/download-artifacts.sh
@@ -134,7 +134,7 @@ echo "Found artifacts: ${artifact_names[*]}"
 platforms=""
 zip_dir=$(mktemp -d "${temp_dir}/aot-size-zips.XXXXXX")
 trap 'rm -rf "$zip_dir"' EXIT
-declare -a pair_platforms pr_archives base_archives curl_args
+declare -a pair_platforms=() pr_archives=() base_archives=() curl_args=()
 
 # Build one curl invocation containing every complete PR/baseline artifact pair.
 for artifact_name in "${artifact_names[@]}"; do

--- a/.github/workflows/aot-size-analysis/scripts/find-builds.sh
+++ b/.github/workflows/aot-size-analysis/scripts/find-builds.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Usage: find-builds.sh [options]
+
+Options:
+  --azdo-org <name>       Azure DevOps organization
+  --azdo-project <name>   Azure DevOps project
+  --pipeline-id <id>      Azure DevOps pipeline definition ID
+  --pr-number <number>    GitHub pull request number
+  --pr-head-sha <sha>     GitHub pull request head commit
+  --base-branch <name>    GitHub pull request base branch
+  --output-file <path>    File that receives step outputs
+  -h, --help              Show this help
+
+Example:
+  find-builds.sh \
+    --azdo-org dnceng-public \
+    --azdo-project public \
+    --pipeline-id 101 \
+    --pr-number 55938 \
+    --pr-head-sha 0123456789abcdef \
+    --base-branch main \
+    --output-file /tmp/find-builds.out
+EOF
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+    echo "Missing value for $1." >&2
+    print_usage >&2
+    exit 2
+  fi
+}
+
+emit_warning() {
+  printf '::warning::%s\n' "$1"
+}
+
+emit_output_value() {
+  printf '%s=%s\n' "$1" "$2" >> "$output_file"
+}
+
+azdo_org=""
+azdo_project=""
+pipeline_id=""
+pr_number=""
+pr_head_sha=""
+base_branch=""
+output_file=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --azdo-org)
+      require_value "$@"
+      azdo_org="$2"
+      shift 2
+      ;;
+    --azdo-project)
+      require_value "$@"
+      azdo_project="$2"
+      shift 2
+      ;;
+    --pipeline-id)
+      require_value "$@"
+      pipeline_id="$2"
+      shift 2
+      ;;
+    --pr-number)
+      require_value "$@"
+      pr_number="$2"
+      shift 2
+      ;;
+    --pr-head-sha)
+      require_value "$@"
+      pr_head_sha="$2"
+      shift 2
+      ;;
+    --base-branch)
+      require_value "$@"
+      base_branch="$2"
+      shift 2
+      ;;
+    --output-file)
+      require_value "$@"
+      output_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$azdo_org" ] || [ -z "$azdo_project" ] || [ -z "$pipeline_id" ] ||
+    [ -z "$pr_number" ] || [ -z "$pr_head_sha" ] || [ -z "$base_branch" ] ||
+    [ -z "$output_file" ]; then
+  echo "All options except --help are required." >&2
+  print_usage >&2
+  exit 2
+fi
+
+azdo_api="https://dev.azure.com/${azdo_org}/${azdo_project}/_apis"
+
+get_latest_build_id() {
+  local branch="$1"
+  local source_sha="${2:-}"
+
+  # Do not filter by result: failed and canceled builds can still contain useful artifacts.
+  curl --fail --silent --show-error --location --retry 3 --max-time 60 --get \
+    "${azdo_api}/build/builds" \
+    --data-urlencode "definitions=${pipeline_id}" \
+    --data-urlencode "branchName=${branch}" \
+    --data-urlencode "statusFilter=completed" \
+    --data-urlencode "queryOrder=queueTimeDescending" \
+    --data-urlencode '$top=1' \
+    --data-urlencode "api-version=7.1" |
+    jq -r --arg source_sha "$source_sha" '
+      .value[0]
+      | select($source_sha == "" or .triggerInfo["pr.sourceSha"] == $source_sha)
+      | .id // empty'
+}
+
+# sourceVersion is the synthetic merge commit, so match the PR head through triggerInfo.
+pr_build_id=$(get_latest_build_id "refs/pull/${pr_number}/merge" "$pr_head_sha")
+
+if [ -z "$pr_build_id" ]; then
+  emit_warning "No completed build found for PR commit ${pr_head_sha}. Ensure the AzDO pipeline has finished."
+  emit_output_value "found" "false"
+  exit 0
+fi
+echo "PR build ID: $pr_build_id"
+
+# Find the most recent baseline build on the base branch
+base_build_id=$(get_latest_build_id "refs/heads/${base_branch}")
+
+if [ -z "$base_build_id" ]; then
+  emit_warning "No completed baseline build found on ${base_branch}."
+  emit_output_value "found" "false"
+  exit 0
+fi
+echo "Baseline build ID: $base_build_id"
+
+emit_output_value "found" "true"
+emit_output_value "pr_build_id" "$pr_build_id"
+emit_output_value "base_build_id" "$base_build_id"

--- a/.github/workflows/aot-size-analysis/scripts/generate-report.sh
+++ b/.github/workflows/aot-size-analysis/scripts/generate-report.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Usage: generate-report.sh [options]
+
+Options:
+  --azdo-org <name>        Azure DevOps organization
+  --azdo-project <name>    Azure DevOps project
+  --platforms <list>       Space-separated platforms to analyze
+  --pr-build-id <id>       Pull request build ID
+  --base-build-id <id>     Baseline build ID
+  --pr-head-sha <sha>      GitHub pull request head commit
+  --base-branch <name>     GitHub pull request base branch
+  --temp-dir <path>        Directory containing extracted artifacts
+  --output-file <path>     File that receives step outputs
+  -h, --help               Show this help
+
+Example:
+  generate-report.sh \
+    --azdo-org dnceng-public \
+    --azdo-project public \
+    --platforms "Linux_x64_AOT Windows_x64_AOT" \
+    --pr-build-id 1569498 \
+    --base-build-id 1569822 \
+    --pr-head-sha 0123456789abcdef \
+    --base-branch main \
+    --temp-dir /tmp/aot-size-analysis \
+    --output-file /tmp/generate-report.out
+EOF
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+    echo "Missing value for $1." >&2
+    print_usage >&2
+    exit 2
+  fi
+}
+
+emit_warning() {
+  printf '::warning::%s\n' "$1"
+}
+
+emit_output_value() {
+  printf '%s=%s\n' "$1" "$2" >> "$output_file"
+}
+
+start_group() {
+  printf '::group::%s\n' "$1"
+}
+
+end_group() {
+  printf '::endgroup::\n'
+}
+
+azdo_org=""
+azdo_project=""
+platforms=""
+pr_build_id=""
+base_build_id=""
+pr_head_sha=""
+base_branch=""
+temp_dir=""
+output_file=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --azdo-org)
+      require_value "$@"
+      azdo_org="$2"
+      shift 2
+      ;;
+    --azdo-project)
+      require_value "$@"
+      azdo_project="$2"
+      shift 2
+      ;;
+    --platforms)
+      require_value "$@"
+      platforms="$2"
+      shift 2
+      ;;
+    --pr-build-id)
+      require_value "$@"
+      pr_build_id="$2"
+      shift 2
+      ;;
+    --base-build-id)
+      require_value "$@"
+      base_build_id="$2"
+      shift 2
+      ;;
+    --pr-head-sha)
+      require_value "$@"
+      pr_head_sha="$2"
+      shift 2
+      ;;
+    --base-branch)
+      require_value "$@"
+      base_branch="$2"
+      shift 2
+      ;;
+    --temp-dir)
+      require_value "$@"
+      temp_dir="$2"
+      shift 2
+      ;;
+    --output-file)
+      require_value "$@"
+      output_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$azdo_org" ] || [ -z "$azdo_project" ] || [ -z "$platforms" ] ||
+    [ -z "$pr_build_id" ] || [ -z "$base_build_id" ] || [ -z "$pr_head_sha" ] ||
+    [ -z "$base_branch" ] || [ -z "$temp_dir" ] || [ -z "$output_file" ]; then
+  echo "All options except --help are required." >&2
+  print_usage >&2
+  exit 2
+fi
+
+report_file="${temp_dir}/size-report.md"
+details_file="${temp_dir}/size-details.md"
+azdo_build_url="https://dev.azure.com/${azdo_org}/${azdo_project}/_build/results?buildId="
+
+# Pass 1: run sizoscope-cli for each platform, collect summary data
+declare -A platform_totals
+has_any_diff=false
+
+for platform in $platforms; do
+  start_group "Analyzing ${platform}"
+
+  pr_mstat=$(find "${temp_dir}/pr/${platform}" -name "dotnet-aot.mstat" -type f -print -quit)
+  base_mstat=$(find "${temp_dir}/base/${platform}" -name "dotnet-aot.mstat" -type f -print -quit)
+
+  diff_file="${temp_dir}/${platform}-diff.md"
+  if sizoscope-cli "$base_mstat" "$pr_mstat" --output "$diff_file"; then
+    has_any_diff=true
+
+    # Extract the total size difference from the first line
+    total_line=$(head -1 "$diff_file")
+    # Expected format: "Total accounted size difference: 781.8 kB"
+    total_size=$(echo "$total_line" | sed -n 's/^Total accounted size difference: *//p')
+    platform_totals["$platform"]="${total_size:-unknown}"
+
+    # Accumulate per-platform details
+    {
+      echo "### ${platform}"
+      echo ""
+      echo "<details>"
+      echo "<summary>Size diff details</summary>"
+      echo ""
+      echo '```'
+      cat "$diff_file"
+      echo '```'
+      echo ""
+      echo "</details>"
+      echo ""
+    } >> "$details_file"
+  else
+    emit_warning "sizoscope-cli failed for ${platform}."
+  fi
+
+  end_group
+done
+
+if [ "$has_any_diff" = false ]; then
+  echo "::notice::No size diffs were generated across any platform."
+  emit_output_value "has_report" "false"
+  exit 0
+fi
+
+# Pass 2: assemble the final report with summary table first
+{
+  echo "## 📊 NativeAOT Size Analysis"
+  echo ""
+  echo "Comparing PR build [\`${pr_head_sha:0:8}\`](${azdo_build_url}${pr_build_id}) against baseline on \`${base_branch}\` ([build](${azdo_build_url}${base_build_id}))."
+  echo ""
+  echo "| Platform | Size Difference |"
+  echo "|----------|-----------------|"
+  for platform in $platforms; do
+    if [ -n "${platform_totals[$platform]+x}" ]; then
+      echo "| ${platform} | ${platform_totals[$platform]} |"
+    fi
+  done
+  echo ""
+  cat "$details_file"
+} > "$report_file"
+
+emit_output_value "has_report" "true"
+emit_output_value "report_file" "$report_file"

--- a/.github/workflows/aot-size-analysis/scripts/generate-report.sh
+++ b/.github/workflows/aot-size-analysis/scripts/generate-report.sh
@@ -7,26 +7,18 @@ print_usage() {
 Usage: generate-report.sh [options]
 
 Options:
-  --azdo-org <name>        Azure DevOps organization
-  --azdo-project <name>    Azure DevOps project
-  --platforms <list>       Space-separated platforms to analyze
-  --pr-build-id <id>       Pull request build ID
-  --base-build-id <id>     Baseline build ID
-  --pr-head-sha <sha>      GitHub pull request head commit
-  --base-branch <name>     GitHub pull request base branch
-  --temp-dir <path>        Directory containing extracted artifacts
-  --output-file <path>     File that receives step outputs
-  -h, --help               Show this help
+  --platforms <list>           Space-separated platforms to analyze
+  --pr-build-url <url>         Pull request build link
+  --baseline-build-url <url>   Baseline build link
+  --temp-dir <path>            Directory containing extracted artifacts
+  --output-file <path>         File that receives step outputs
+  -h, --help                   Show this help
 
 Example:
   generate-report.sh \
-    --azdo-org dnceng-public \
-    --azdo-project public \
     --platforms "Linux_x64_AOT Windows_x64_AOT" \
-    --pr-build-id 1569498 \
-    --base-build-id 1569822 \
-    --pr-head-sha 0123456789abcdef \
-    --base-branch main \
+    --pr-build-url "https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569498" \
+    --baseline-build-url "https://dev.azure.com/dnceng-public/public/_build/results?buildId=1569822" \
     --temp-dir /tmp/aot-size-analysis \
     --output-file /tmp/generate-report.out
 EOF
@@ -56,51 +48,27 @@ end_group() {
   printf '::endgroup::\n'
 }
 
-azdo_org=""
-azdo_project=""
 platforms=""
-pr_build_id=""
-base_build_id=""
-pr_head_sha=""
-base_branch=""
+pr_build_url=""
+baseline_build_url=""
 temp_dir=""
 output_file=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --azdo-org)
-      require_value "$@"
-      azdo_org="$2"
-      shift 2
-      ;;
-    --azdo-project)
-      require_value "$@"
-      azdo_project="$2"
-      shift 2
-      ;;
     --platforms)
       require_value "$@"
       platforms="$2"
       shift 2
       ;;
-    --pr-build-id)
+    --pr-build-url)
       require_value "$@"
-      pr_build_id="$2"
+      pr_build_url="$2"
       shift 2
       ;;
-    --base-build-id)
+    --baseline-build-url)
       require_value "$@"
-      base_build_id="$2"
-      shift 2
-      ;;
-    --pr-head-sha)
-      require_value "$@"
-      pr_head_sha="$2"
-      shift 2
-      ;;
-    --base-branch)
-      require_value "$@"
-      base_branch="$2"
+      baseline_build_url="$2"
       shift 2
       ;;
     --temp-dir)
@@ -125,9 +93,8 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ -z "$azdo_org" ] || [ -z "$azdo_project" ] || [ -z "$platforms" ] ||
-    [ -z "$pr_build_id" ] || [ -z "$base_build_id" ] || [ -z "$pr_head_sha" ] ||
-    [ -z "$base_branch" ] || [ -z "$temp_dir" ] || [ -z "$output_file" ]; then
+if [ -z "$platforms" ] || [ -z "$pr_build_url" ] || [ -z "$baseline_build_url" ] ||
+    [ -z "$temp_dir" ] || [ -z "$output_file" ]; then
   echo "All options except --help are required." >&2
   print_usage >&2
   exit 2
@@ -135,7 +102,6 @@ fi
 
 report_file="${temp_dir}/size-report.md"
 details_file="${temp_dir}/size-details.md"
-azdo_build_url="https://dev.azure.com/${azdo_org}/${azdo_project}/_build/results?buildId="
 
 # Pass 1: run sizoscope-cli for each platform, collect summary data
 declare -A platform_totals
@@ -147,7 +113,13 @@ for platform in $platforms; do
   pr_mstat=$(find "${temp_dir}/pr/${platform}" -name "dotnet-aot.mstat" -type f -print -quit)
   base_mstat=$(find "${temp_dir}/base/${platform}" -name "dotnet-aot.mstat" -type f -print -quit)
 
+  pr_mstat_size=$(stat --format='%s' "$pr_mstat")
+  base_mstat_size=$(stat --format='%s' "$base_mstat")
+  echo "Baseline MSTAT: ${base_mstat_size} bytes"
+  echo "PR MSTAT: ${pr_mstat_size} bytes"
+
   diff_file="${temp_dir}/${platform}-diff.md"
+  start_time=$(date +%s%N)
   if sizoscope-cli "$base_mstat" "$pr_mstat" --output "$diff_file"; then
     has_any_diff=true
 
@@ -156,6 +128,11 @@ for platform in $platforms; do
     # Expected format: "Total accounted size difference: 781.8 kB"
     total_size=$(echo "$total_line" | sed -n 's/^Total accounted size difference: *//p')
     platform_totals["$platform"]="${total_size:-unknown}"
+    elapsed_ns=$(($(date +%s%N) - start_time))
+    detail_line_count=$(tail -n +2 "$diff_file" | grep -cve '^[[:space:]]*$' || true)
+    printf 'Completed in %d.%03d seconds; total accounted size difference: %s; detail lines: %d\n' \
+      "$((elapsed_ns / 1000000000))" "$(((elapsed_ns / 1000000) % 1000))" \
+      "${total_size:-unknown}" "$detail_line_count"
 
     # Accumulate per-platform details
     {
@@ -188,7 +165,7 @@ fi
 {
   echo "## 📊 NativeAOT Size Analysis"
   echo ""
-  echo "Comparing PR build [\`${pr_head_sha:0:8}\`](${azdo_build_url}${pr_build_id}) against baseline on \`${base_branch}\` ([build](${azdo_build_url}${base_build_id}))."
+  echo "Comparing [PR build](${pr_build_url}) against [baseline build](${baseline_build_url})."
   echo ""
   echo "| Platform | Size Difference |"
   echo "|----------|-----------------|"


### PR DESCRIPTION
## Summary

- Move the AOT size analysis Bash logic into focused scripts under `.github/workflows/aot-size-analysis/scripts`.
- Download matching PR and baseline artifact ZIPs in parallel with bounded curl concurrency, aggregate progress, and per-transfer statistics.

## Validation

- Bash syntax and ShellCheck
- Workflow YAML parsing and zizmor
- Parallel download smoke test with public AOT artifacts