### PR TITLE
Exclude GitHub Actions workflows from public CI

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -28,6 +28,7 @@ pr:
     - '*.targets'
     - global.json
     exclude:
+    - .github/workflows/**
     - .github/ISSUE_TEMPLATE/*
     - documentation/*
     - README.md

--- a/eng/pipelines/report-green.yml
+++ b/eng/pipelines/report-green.yml
@@ -14,6 +14,7 @@ pr:
     include:
     - .devcontainer/*
     - .github/*
+    - .github/workflows/**
     - .vscode/*
     - documentation/*
     - '**/*.md'


### PR DESCRIPTION
## Summary
- exclude `.github/workflows/**` from the Azure DevOps `dotnet-sdk-public-ci` PR trigger
- include the same recursive path in `report-green.yml` so workflow-only PRs still receive a successful check
- preserve public CI for mixed product/build changes and root pipeline YAML changes such as `.vsts-pr.yml`

## Validation
- parsed both edited YAML files with PyYAML
- verified path-filter scenarios for workflow-only, nested workflow, mixed product, and root pipeline YAML changes
- ran `git diff --check`