### PR TITLE
Change CODEOWNERS for Microsoft.NET.ClickOnce.targets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -106,7 +106,7 @@
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink @dotnet/dotnet-cli
 
 # Area-ClickOnce
-/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @sujitnayak
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @msbuild-clickonce
 
 # Area-Watch
 /test/TestAssets/TestProjects/Watch*/ @tmat @dotnet/roslyn-ide

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -106,7 +106,7 @@
 /src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets @dotnet/illink @dotnet/dotnet-cli
 
 # Area-ClickOnce
-/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @msbuild-clickonce
+/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ClickOnce.targets @dotnet/msbuild-clickonce
 
 # Area-Watch
 /test/TestAssets/TestProjects/Watch*/ @tmat @dotnet/roslyn-ide


### PR DESCRIPTION
Updated CODEOWNERS to change ownership for ClickOnce targets.