### PR TITLE
Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26421.110",
+      "version": "11.0.0-beta.26427.10",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -55,7 +55,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetHelixJobMonitorPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetSignToolPackageVersion>11.0.0-beta.26421.110</MicrosoftDotNetSignToolPackageVersion>
     <MicrosoftDotNetWebItemTemplates110PackageVersion>11.0.0-rc.1.26421.110</MicrosoftDotNetWebItemTemplates110PackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -521,9 +521,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>25c0025e42e3857ccc7b946adff9fadea9fe35a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26421.110">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>25c0025e42e3857ccc7b946adff9fadea9fe35a4</Sha>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.SignTool" Version="11.0.0-beta.26421.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>


### PR DESCRIPTION
Updates the Helix Job Monitor tool plus dependency metadata to the fixed build, `Microsoft.DotNet.Helix.JobMonitor` 11.0.0-beta.26427.10.

Azure build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358