### PR TITLE
[release/11.0.1xx] Use SDK directory for environment command search

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -39,7 +39,7 @@ public class EnvironmentProvider(
         {
             if (_searchPaths == null)
             {
-                var searchPaths = new List<string> { AppContext.BaseDirectory };
+                var searchPaths = new List<string> { SdkPaths.SdkDirectory };
 
                 searchPaths.AddRange(Environment
                     .GetEnvironmentVariable("PATH")?

--- a/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
+++ b/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Cli.Tests;
+
+[TestClass]
+public class EnvironmentProviderTests
+{
+    [TestMethod]
+    public void CommandSearchStartsInVersionedSdkDirectory()
+    {
+        string sdkDirectory = Path.Combine(Path.GetTempPath(), "dotnet", "sdk", $"test-version-{Guid.NewGuid():N}");
+        string commandName = $"sdk-command-{Guid.NewGuid():N}";
+        string commandPath = Path.Combine(sdkDirectory, commandName);
+        Directory.CreateDirectory(sdkDirectory);
+        File.WriteAllText(commandPath, string.Empty);
+
+        try
+        {
+            using var _ = new SdkDirectoryScope(sdkDirectory);
+
+            Assert.AreEqual(
+                commandPath,
+                new EnvironmentProvider().GetCommandPath(commandName, string.Empty));
+        }
+        finally
+        {
+            Directory.Delete(sdkDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Backport of #55925 to release/11.0.1xx.

Part 3 of the three-PR backport stack. Stacked on #55989; merge that PR first.