### PR TITLE
Enable safe parallelization for task test projects

### DIFF
--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGetDependsOnNETStandardMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGetDependsOnNETStandardMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenADependencyContextBuilder.cs
@@ -72,7 +72,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
                 .Build();
 
             JObject result = Save(dependencyContext);
-            JObject baseline = ReadJson($"{baselineFileName}.deps.json");
+            JObject baseline = ReadJson(Path.Combine(AppContext.BaseDirectory, $"{baselineFileName}.deps.json"));
 
             try
             {
@@ -84,7 +84,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             {
                 // write the result file out on failure for easy comparison
 
-                using (JsonTextWriter writer = new(File.CreateText($"result-{baselineFileName}.deps.json")))
+                using (JsonTextWriter writer = new(File.CreateText(Path.Combine(AppContext.BaseDirectory, $"result-{baselineFileName}.deps.json"))))
                 {
                     JsonSerializer serializer = new()
                     {

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -23,6 +23,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateClsidMapMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateClsidMapMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -14,6 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// current working directory differs from the project directory.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGetPackagesToPrune
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// current working directory differs from the project directory.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGetPackagesToPrune
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphContent = @"{

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphContent = @"{

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -19,6 +19,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// and that output metadata preserves the original path form.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {
         internal const string CollectionName = "ResolveAppHosts current directory tests";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// and that output metadata preserves the original path form.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {
         internal const string CollectionName = "ResolveAppHosts current directory tests";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolvePackageAssetsMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolvePackageAssetsMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -8,6 +8,7 @@ using Microsoft.NET.Build.Tasks.ConflictResolution;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
 [TestClass]
+[ResourceLock(WellKnownResources.CurrentDirectory)]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {
     private readonly string _originalCwd = Directory.GetCurrentDirectory();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -8,7 +8,7 @@ using Microsoft.NET.Build.Tasks.ConflictResolution;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
 [TestClass]
-[ResourceLock(WellKnownResources.CurrentDirectory)]
+[DoNotParallelize]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {
     private readonly string _originalCwd = Directory.GetCurrentDirectory();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -20,6 +20,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenATaskEnvironmentDefault
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenATaskEnvironmentDefault
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAWriteAppConfigWithSupportedRuntimeMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAWriteAppConfigWithSupportedRuntimeMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
 [TestClass]
+[ResourceLock(WellKnownResources.CurrentDirectory)]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
 [TestClass]
-[ResourceLock(WellKnownResources.CurrentDirectory)]
+[DoNotParallelize]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- CWD-mutating tests must run serially; emits [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- CWD-mutating test classes use a shared resource lock. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- CWD-mutating test classes use a shared resource lock. -->
+    <!-- CWD-mutating classes run in the serial tail so they cannot affect unannotated relative-path readers. -->
     <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class EnvironmentHelperTests
     {
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
@@ -22,17 +23,20 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         {
             // Arrange
             string originalValue = Environment.GetEnvironmentVariable(TelemetryOptout);
-            Environment.SetEnvironmentVariable(TelemetryOptout, value);
+            try
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, value);
 
-            // Act
-            bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
+                // Act
+                bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
 
-
-            // Assert
-            Assert.AreEqual<bool>(expectedOutput, actualOutput);
-
-            // reset the value back to the original value
-            Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+                // Assert
+                Assert.AreEqual<bool>(expectedOutput, actualOutput);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+            }
         }
     }
 }

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
@@ -9,6 +9,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(SdkTargetFramework)</TargetFrameworks>
 
     <AssemblyName>Microsoft.NET.Sdk.Publish.Tasks.Tests</AssemblyName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <EndToEndTestsDisabled>true</EndToEndTestsDisabled>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>

--- a/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
+++ b/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
 


### PR DESCRIPTION
These task-focused MSTest projects currently run serially even though most test classes do not share mutable state. Enabling conservative class-level parallelism should reduce execution time while preserving isolation for process-global resources.

## Changes

- Enable `ClassLevel` parallelization in four task test projects.
- Run classes that change the process current directory in MSTest's serial tail with `[DoNotParallelize]`, preventing them from affecting unannotated tests that read relative paths.
- Resolve dependency-context test baselines from the test assembly directory instead of the process current directory.
- Serialize the publish environment-variable test with `WellKnownResources.EnvironmentVariables` and restore its original value from a `finally` block.
- Keep tests within each class sequential, avoiding races in class-private fixtures and static test data.

## Testing

- `Microsoft.NET.Build.Tasks.Tests`: 355 passed, 0 failed with 32 class-level workers.
- Focused `GivenADependencyContextBuilder` and `GivenAGenerateDepsFilePathResolution` run: 27 passed, 0 failed.

## Local before/after benchmark

Partial local gain confirmed on Windows using the SDK repository test runner. Comparable clean total: **1m 22.3s before -> 49.682s after** (**32.578s saved, 39.6%**).
