### PR TITLE
Parallelize Native AOT tests by class

### DIFF
--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(WellKnownResources.Console)]
 public partial class AotParserTests
 {
     private static Exception? RecordException(Action action)

--- a/test/dotnet-aot.Tests/AotRunCommandTests.cs
+++ b/test/dotnet-aot.Tests/AotRunCommandTests.cs
@@ -16,6 +16,9 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// Tests Native AOT file-based run planning and launch invocation construction.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(NativeEntryPoint))]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class AotRunCommandTests
 {
     /// <summary>Verifies that an explicit no-build invocation reaches the launcher without prevalidating output.</summary>

--- a/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
+++ b/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class EnvironmentProviderTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/FileBasedAppRunPlanTests.cs
+++ b/test/dotnet-aot.Tests/FileBasedAppRunPlanTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// Tests shared file-based application build and launch planning.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(Reporter))]
 public class FileBasedAppRunPlanTests
 {
     /// <summary>Verifies that a fresh simple application selects direct compilation.</summary>

--- a/test/dotnet-aot.Tests/FormatForwardingAppTests.cs
+++ b/test/dotnet-aot.Tests/FormatForwardingAppTests.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Cli.Commands.Format;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class FormatForwardingAppTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
+++ b/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class MSBuildEvaluationTests
 {
     public TestContext TestContext { get; set; } = null!;

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -15,6 +15,11 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  "managed fallback not found" error because test env doesn't have dotnet.dll in sdkDir.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(NativeEntryPoint))]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(nameof(SdkDirectoryScope))]
+[ResourceLock(WellKnownResources.Console)]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public partial class NativeEntryPointTests
 {
     /// <summary>
@@ -30,6 +35,8 @@ public partial class NativeEntryPointTests
         string? originalTraceState = Environment.GetEnvironmentVariable(Activities.TRACESTATE);
         string? originalTelemetryOptout = Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT");
         object? originalSdkRoot = AppContext.GetData(SdkPaths.DataName);
+        string? originalDotnetRoot = NativeEntryPoint.DotnetRoot;
+        string? originalSdkDirectory = NativeEntryPoint.SdkDirectory;
         try
         {
             action();
@@ -42,6 +49,9 @@ public partial class NativeEntryPointTests
             Environment.SetEnvironmentVariable(Activities.TRACESTATE, originalTraceState);
             Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", originalTelemetryOptout);
             AppContext.SetData(SdkPaths.DataName, originalSdkRoot);
+            NativeEntryPoint.DotnetRoot = originalDotnetRoot;
+            NativeEntryPoint.SdkDirectory = originalSdkDirectory;
+            SdkPaths.ClearSdkDirectoryCacheForTests();
         }
     }
 

--- a/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
+++ b/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
@@ -7,6 +7,8 @@ using Microsoft.DotNet.Cli.Commands.Test;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class SdkForwardingAppTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -6,8 +6,9 @@
     <DefineConstants>$(DefineConstants);CLI_AOT</DefineConstants>
     <RootNamespace>Microsoft.DotNet.Cli.Tests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <!-- Tests modify process-global state; run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Methods within a class share fixtures and process state. Audited classes use
+         ResourceLock for the process-global resources they share with other classes. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- Strong naming deprecated on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>


### PR DESCRIPTION
## Summary

`dotnet-aot.Tests` currently runs entirely serially even though most test classes use isolated temporary paths or child-process environments. This enables safe class-level parallelism while retaining serialization around the process-global resources that cannot be isolated.

- switch the project from `None` to `ClassLevel` parallelization
- add targeted resource locks for CLI reporters, console streams, environment variables, SDK directory/cache state, and native entry-point statics
- restore native entry-point static fields and clear the SDK path cache after each guarded test
- keep all tests eligible for parallel scheduling without `DoNotParallelize`

## Testing

Local benchmark and test execution was intentionally deferred to the coordinated, exclusive 10-run baseline and 10-run changed benchmark for the parallelization fleet.