### PR TITLE
Enable parallelism in Watch unit tests

### DIFF
--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore.Watch.BrowserRefresh</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/Microsoft.DotNet.HotReload.Client.Tests.csproj
@@ -10,6 +10,7 @@
     <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
     <RootNamespace>Microsoft.DotNet.HotReload.UnitTests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/Microsoft.DotNet.HotReload.Watch.Aspire.Tests.csproj
+++ b/test/Microsoft.DotNet.HotReload.Watch.Aspire.Tests/Microsoft.DotNet.HotReload.Watch.Aspire.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.DotNet.Watch.Aspire.UnitTests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These three Watch unit test projects currently inherit repository-wide serial execution even though their tests do not share mutable process resources. Running independent methods concurrently should reduce test latency without introducing cross-test interference.

## Summary

- Enable MSTest `MethodLevel` parallelization for Browser Refresh, Hot Reload Client, and Watch Aspire unit tests.
- Keep all tests parallel rather than adding `ResourceLock` or `DoNotParallelize`, based on an audit of ports, pipes, processes, static state, environment variables, current directory, console access, and file writes.
- Limit the change to the three project files.

## Validation

- Completed a static full-project parallel-safety audit.
- Consolidated 10-run baseline and changed benchmarks are being run separately across the full parallelization change set.