### PR TITLE
Enable safe parallelization for installer-related tests

### DIFF
--- a/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
@@ -5,6 +5,8 @@
     <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <!-- Tests only parse messages or query Windows Installer with invalid and unknown product codes. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\dotnet-MsiInstallation.Tests.runsettings</RunSettingsFilePath>
+    <!-- Every test class shares one Hyper-V VM and persisted snapshot graph, so class-level locking would still serialize the assembly. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/trustedroots.Tests/AssemblySetup.cs
+++ b/test/trustedroots.Tests/AssemblySetup.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Tests;
+
+[TestClass]
+public class AssemblySetup
+{
+    [AssemblyInitialize]
+    public static void Initialize(TestContext _)
+    {
+        _ = SdkTestContext.Current;
+    }
+}

--- a/test/trustedroots.Tests/AssemblySetup.cs
+++ b/test/trustedroots.Tests/AssemblySetup.cs
@@ -4,10 +4,10 @@
 namespace Microsoft.DotNet.Tests;
 
 [TestClass]
-public class AssemblySetup
+public static class AssemblySetup
 {
     [AssemblyInitialize]
-    public static void Initialize(TestContext _)
+    public static void Initialize(TestContext testContext)
     {
         _ = SdkTestContext.Current;
     }

--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <CanRunTestAsTool>false</CanRunTestAsTool>
     <OutputPath>$(TestHostFolder)</OutputPath>
+    <!-- Tests only read immutable SDK files; shared certificate sets use thread-safe lazy initialization. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These test projects currently inherit assembly-wide serialization, even when their tests only perform immutable reads or read-only API queries. This opts the safe suites into method-level execution while preserving serialization where tests share machine-wide state.

- Enable method-level parallelism for trusted-root bundle checks, whose shared certificate data is initialized thread-safely.
- Enable method-level parallelism for Windows Installer parsing and read-only unknown-product queries.
- Keep the VM-based MSI installation suite serial because every test class shares one Hyper-V VM, snapshot graph, and fixed machine paths. Class-level locking would still serialize the entire assembly and provide no parallel work.

Validation is limited to the static resource audit in this change. The consolidated 10-run baseline and changed benchmark will be run after integration.