### PR TITLE
Enable safe Template authoring test parallelization

### DIFF
--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
@@ -10,6 +10,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
     [TestClass]
     public class ExportCommandFailureTests : IDisposable
     {
+        private readonly CultureInfo _originalCurrentCulture;
+        private readonly CultureInfo _originalCurrentUICulture;
         private readonly string _workingDirectory;
 
         public TestContext TestContext { get; set; } = null!;
@@ -18,6 +20,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public ExportCommandFailureTests()
         {
+            _originalCurrentCulture = CultureInfo.CurrentCulture;
+            _originalCurrentUICulture = CultureInfo.CurrentUICulture;
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
@@ -27,7 +31,15 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public void Dispose()
         {
-            Directory.Delete(_workingDirectory, true);
+            try
+            {
+                Directory.Delete(_workingDirectory, true);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = _originalCurrentCulture;
+                CultureInfo.CurrentUICulture = _originalCurrentUICulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Several Template authoring test projects inherit the repository-wide disabled MSTest parallelization setting even though their mutable resources are isolated. This change opts the audited suites into parallel execution to reduce test latency without broadening shared-state risk.

## Summary

- Enable class-level parallelism for the CLI integration, CLI unit, authoring tasks integration, and TemplateVerifier integration suites.
- Enable method-level parallelism for the single-class authoring templates integration and TemplateVerifier unit suites, where class-level parallelism would have no effect.
- Preserve and restore `CurrentCulture` and `CurrentUICulture` around the CLI integration tests that require invariant culture.
- Keep intentional shared Verify snapshots serialized within their existing test class; no `ResourceLock` or `DoNotParallelize` annotations are needed.

## Testing

Consolidated 10-run baseline and changed-branch benchmarks are being run separately across the full parallelization fleet.