### PR TITLE
Enable parallelism in selected MSTest projects

### DIFF
--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <!-- Test classes either use immutable inputs or isolated TestAssetsManager directories. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests
          we need to -->

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
+    <!-- Keep server tests serial within their class because port discovery and Kestrel binding are not atomic. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
+++ b/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <!-- Each test uses a caller- and data-row-specific asset directory and only mutates child-process state. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These test projects currently inherit assembly-wide serialization even though their shared-state boundaries permit narrower parallel execution.

## Approach

- Enable class-level parallelism for WorkloadManifestReader tests, whose writable test data is isolated per class/test and whose shared SDK inputs are read-only.
- Enable class-level parallelism for AspireService tests, keeping server methods serial because free-port discovery and Kestrel binding are not atomic.
- Enable method-level parallelism for MSBuild integration tests, which use caller- and data-row-specific asset directories and child-process-local environment changes.

No `ResourceLock` or `DoNotParallelize` annotations are needed because these scopes preserve the identified serialization boundaries.

## Validation

Project files were XML-validated and reviewed for shared workload/cache, MSBuild, port, process, global, and path state. Consolidated 10x baseline and changed-fleet benchmarking is handled separately after integration.