### PR TITLE
Parallelize dotnet-format tests by class

### DIFF
--- a/test/dotnet-format.IntegrationTests/FormatIntegrationTestBase.cs
+++ b/test/dotnet-format.IntegrationTests/FormatIntegrationTestBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -20,7 +21,7 @@ public abstract class FormatIntegrationTestBase : SdkTest
     // Keyed by concrete type so each derived class gets its own entry.
     // MSTest creates a new instance per test method, so clone+restore would otherwise
     // run once per test method rather than once per class per process.
-    private static readonly Dictionary<Type, string> s_initializedRepoPaths = new();
+    private static readonly ConcurrentDictionary<Type, string> s_initializedRepoPaths = new();
 
     private string? _repoPath;
 

--- a/test/dotnet-format.IntegrationTests/dotnet-format.IntegrationTests.csproj
+++ b/test/dotnet-format.IntegrationTests/dotnet-format.IntegrationTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- Tests are resource-intensive (git clones, restores) and must run serially. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Each test class owns a repository clone; inherited methods within a class share that clone. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-format.UnitTests/Analyzers/AnalyzerAssemblyGenerator.cs
+++ b/test/dotnet-format.UnitTests/Analyzers/AnalyzerAssemblyGenerator.cs
@@ -15,15 +15,12 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
 {
     public static class AnalyzerAssemblyGenerator
     {
-        private static IEnumerable<MetadataReference> s_references;
+        private static readonly Lazy<Task<IEnumerable<MetadataReference>>> s_references = new(ResolveReferencesAsync);
 
-        private static async Task<IEnumerable<MetadataReference>> GetReferencesAsync()
+        private static Task<IEnumerable<MetadataReference>> GetReferencesAsync() => s_references.Value;
+
+        private static async Task<IEnumerable<MetadataReference>> ResolveReferencesAsync()
         {
-            if (s_references is not null)
-            {
-                return s_references;
-            }
-
             var references = new List<MetadataReference>()
             {
                 MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location),
@@ -45,7 +42,6 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var netcoreMetadataReferences = await sdkTargetFrameworkReferenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
             references.AddRange(netcoreMetadataReferences.Where(reference => Path.GetFileName(reference.Display) != "System.Collections.Immutable.dll"));
 
-            s_references = references;
             return references;
         }
 

--- a/test/dotnet-format.UnitTests/CodeFormatterTests.cs
+++ b/test/dotnet-format.UnitTests/CodeFormatterTests.cs
@@ -723,10 +723,7 @@ Greeter.Greeter() -> void";
             bool noRestore = false,
             bool saveFormattedFiles = false)
         {
-            var currentDirectory = Environment.CurrentDirectory;
-            Environment.CurrentDirectory = TestProjectsPathHelper.GetProjectsDirectory();
-
-            var workspacePath = Path.GetFullPath(workspaceFilePath);
+            var workspacePath = Path.GetFullPath(workspaceFilePath, TestProjectsPathHelper.GetProjectsDirectory());
 
             WorkspaceType workspaceType;
             if (Directory.Exists(workspacePath))
@@ -761,7 +758,6 @@ Greeter.Greeter() -> void";
                 BinaryLogPath: null,
                 TargetFramework: null);
             var formatResult = await CodeFormatter.FormatWorkspaceAsync(formatOptions, logger, CancellationToken.None);
-            Environment.CurrentDirectory = currentDirectory;
 
             var log = logger.GetLog();
 

--- a/test/dotnet-format.UnitTests/Utilities/TestProjectsPathHelper.cs
+++ b/test/dotnet-format.UnitTests/Utilities/TestProjectsPathHelper.cs
@@ -7,23 +7,15 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Utilities
 {
     public static class TestProjectsPathHelper
     {
-        private static string s_projectsDirectory;
-
         public static string GetProjectsDirectory()
         {
-            if (s_projectsDirectory == null)
+            var assetsDirectory = Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "dotnet-format");
+            if (Directory.Exists(assetsDirectory))
             {
-                var assetsDirectory = Path.Combine(SdkTestContext.Current.TestAssetsDirectory, "dotnet-format");
-                if (Directory.Exists(assetsDirectory))
-                {
-                    s_projectsDirectory = assetsDirectory;
-                    return assetsDirectory;
-                }
-
-                throw new ArgumentException("Can't find the project assets directory");
+                return assetsDirectory;
             }
 
-            return s_projectsDirectory;
+            throw new ArgumentException("Can't find the project assets directory");
         }
     }
 }

--- a/test/dotnet-format.UnitTests/dotnet-format.UnitTests.csproj
+++ b/test/dotnet-format.UnitTests/dotnet-format.UnitTests.csproj
@@ -8,8 +8,8 @@
     <RollForward>LatestMajor</RollForward>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);binaries\**;projects\**</DefaultExcludesInProjectFolder>
-    <!-- Tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Test classes use disjoint workspaces; methods within a class may share test assets. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The dotnet-format unit and integration test projects currently force fully serial execution even though test classes use disjoint workspaces or repository clones. Enabling class-level parallelism can reduce wall-clock time while preserving method-level serialization where assets are shared.

This change:
- enables `ClassLevel` MSTest parallelization in both projects
- resolves unit-test workspace paths against the test-assets root instead of mutating the process current directory
- removes or makes thread-safe the remaining mutable static caches used during parallel execution
- keeps inherited integration-test methods serialized within each concrete repository class

No `ResourceLock` or `DoNotParallelize` annotations are needed after isolating the shared state. The full two-project static audit covered workspace and MSBuild state, environment variables, current directory, console state, static caches, and shared files.

Validation: local timing runs were intentionally deferred to the consolidated 10-run baseline/changed benchmark for the broader MSTest parallelization effort. That benchmark should also confirm that concurrently running the three resource-intensive integration classes is operationally acceptable.