### PR TITLE
[Wasm] Prototype middleware-free standalone hot reload

### DIFF
--- a/src/Dotnet.Watch/AGENTS.md
+++ b/src/Dotnet.Watch/AGENTS.md
@@ -10,7 +10,7 @@ Reload).
 | `dotnet-watch` | The tool executable and CLI surface. Its command/options are defined in `CommandLine/DotnetWatchCommandDefinition.cs`. |
 | `Watch` (`Microsoft.DotNet.HotReload.Watch`) | Core watcher library: file-set computation, process launching, Hot Reload, app models. |
 | `DotNetWatchTasks` | MSBuild task bundled into the tool for design-time file collection. |
-| `DotNetDeltaApplier`, `Web.Middleware`, `BrowserRefresh` | Assemblies **injected into the running app** via `DOTNET_STARTUP_HOOKS`. |
+| `DotNetDeltaApplier`, `Web.Middleware`, `BrowserRefresh` | Assemblies injected into supported running apps via `DOTNET_STARTUP_HOOKS`; modern standalone Blazor WebAssembly uses the browser initializer instead. |
 | `HotReloadAgent.*`, `HotReloadClient`, `AspireService` | Shared code consumed via `.projitems`.|
 
 ## Conventions & gotchas
@@ -26,6 +26,13 @@ Reload).
   named-pipe protocol; Blazor WASM uses JSON over WebSocket. Each protocol has its
   own `HotReloadClient` subclass (e.g. `DefaultHotReloadClient`,
   `WebAssemblyHotReloadClient`); a new app model may need its own implementation.
+- **Standalone Blazor WebAssembly bootstrap differs by TFM.** .NET 11+ receives the
+  browser-refresh WebSocket endpoints and public key in a launch URL fragment. The
+  `Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js` initializer consumes
+  and removes that fragment and retains applied deltas in watcher-scoped session storage
+  for page reloads. Older, hosted, initializer-disabled, and non-automatically-launched
+  apps retain the injected middleware path. Never place the browser-generated shared
+  secret in the launch URL.
 - **`CompilationHandler` drives Roslyn** via
   `Microsoft.CodeAnalysis.ExternalAccess.HotReload`; unsupported edits fall
   back to a full rebuild + restart.

--- a/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/WebAssemblyHotReload.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/WebAssemblyHotReload.cs
@@ -62,7 +62,7 @@ internal static partial class WebAssemblyHotReload
 
     [JSExport]
     [SupportedOSPlatform("browser")]
-    public static async Task InitializeAsync(string baseUri)
+    public static async Task InitializeAsync(string baseUri, bool applyPreviousUpdates)
     {
         if (MetadataUpdater.IsSupported && Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") == "true" &&
             OperatingSystem.IsBrowser())
@@ -78,7 +78,10 @@ internal static partial class WebAssemblyHotReload
                 throw new InvalidOperationException("Hot Reload agent already initialized");
             }
 
-            await ApplyPreviousDeltasAsync(agent, baseUri);
+            if (applyPreviousUpdates)
+            {
+                await ApplyPreviousDeltasAsync(agent, baseUri);
+            }
         }
     }
 

--- a/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
+++ b/src/Dotnet.Watch/HotReloadAgent.WebAssembly.Browser/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
@@ -1,8 +1,22 @@
 let isHotReloadEnabled = false;
+let refreshConfig = null;
+
+const hotReloadActiveKey = '_dotnet_watch_hot_reload_active';
+const launchUrlConfigParameter = '__dotnet_watch';
+const launchUrlConfigStorageKeyPrefix = '__dotnet_watch_browser_refresh_config:';
+const managedCodeUpdatesStorageKeyPrefix = '__dotnet_watch_managed_code_updates:';
+const scriptInjectedSentinel = '_dotnet_watch_ws_injected';
 
 export async function onRuntimeConfigLoaded(config) {
-    // If we have 'aspnetcore-browser-refresh', configure mono runtime for HotReload.
-    if (config.debugLevel !== 0 && globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']")) {
+    refreshConfig = readBrowserRefreshConfig();
+
+    const hasInjectedScript = globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']");
+    if (refreshConfig && hasInjectedScript) {
+        clearBrowserRefreshConfig();
+        refreshConfig = null;
+    }
+
+    if (config.debugLevel !== 0 && (refreshConfig || hasInjectedScript)) {
         isHotReloadEnabled = true;
 
         if (!config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]) {
@@ -13,7 +27,7 @@ export async function onRuntimeConfigLoaded(config) {
         }
     }
 
-    // Disable HotReload built-into the Blazor WebAssembly runtime
+    // Disable Hot Reload built into the Blazor WebAssembly runtime.
     config.environmentVariables["__BLAZOR_WEBASSEMBLY_LEGACY_HOTRELOAD"] = "false";
 }
 
@@ -21,16 +35,17 @@ export async function onRuntimeReady({ getAssemblyExports }) {
     if (!isHotReloadEnabled) {
         return;
     }
-    
+
     const exports = await getAssemblyExports("Microsoft.DotNet.HotReload.WebAssembly.Browser");
-    await exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.InitializeAsync(document.baseURI);
+    await exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.InitializeAsync(
+        document.baseURI,
+        refreshConfig === null);
 
     if (!window.Blazor) {
         window.Blazor = {};
-
-        if (!window.Blazor._internal) {
-            window.Blazor._internal = {};
-        }
+    }
+    if (!window.Blazor._internal) {
+        window.Blazor._internal = {};
     }
 
     window.Blazor._internal.applyHotReloadDeltas = (deltas, loggingLevel) => {
@@ -41,4 +56,457 @@ export async function onRuntimeReady({ getAssemblyExports }) {
     window.Blazor._internal.getApplyUpdateCapabilities = () => {
         return exports.Microsoft.DotNet.HotReload.WebAssembly.Browser.WebAssemblyHotReload.GetApplyUpdateCapabilities() ?? '';
     };
+
+    if (refreshConfig) {
+        try {
+            applyPreviousManagedCodeUpdates();
+        } catch (error) {
+            console.debug('Unable to apply previous dotnet-watch managed code updates.', error);
+        }
+
+        try {
+            await initializeBrowserRefreshConnection();
+        } catch (error) {
+            clearBrowserRefreshConfig();
+            delete window[scriptInjectedSentinel];
+            console.debug('Unable to initialize the dotnet-watch browser refresh connection.', error);
+        }
+    }
+}
+
+function readBrowserRefreshConfig() {
+    if (!globalThis.window?.location) {
+        return null;
+    }
+
+    const fragmentParts = window.location.hash.substring(1).split('&');
+    const configPartIndex = fragmentParts.findIndex(part => part.startsWith(`${launchUrlConfigParameter}=`));
+
+    if (configPartIndex >= 0) {
+        try {
+            const config = parseBrowserRefreshConfig(fragmentParts[configPartIndex].substring(launchUrlConfigParameter.length + 1));
+
+            try {
+                window.sessionStorage.setItem(getBrowserRefreshConfigStorageKey(), JSON.stringify(config));
+                fragmentParts.splice(configPartIndex, 1);
+
+                const fragment = fragmentParts.join('&');
+                const cleanUrl = `${window.location.pathname}${window.location.search}${fragment ? `#${fragment}` : ''}`;
+                window.history.replaceState(window.history.state, '', cleanUrl);
+            } catch {
+                // Keep the configuration in the fragment when session storage is unavailable.
+            }
+
+            return config;
+        } catch (error) {
+            console.debug('Ignoring invalid dotnet-watch browser refresh configuration.', error);
+            return null;
+        }
+    }
+
+    try {
+        const storedConfig = window.sessionStorage.getItem(getBrowserRefreshConfigStorageKey());
+        return storedConfig ? parseBrowserRefreshConfig(encodeURIComponent(storedConfig)) : null;
+    } catch {
+        return null;
+    }
+}
+
+function parseBrowserRefreshConfig(encodedConfig) {
+    const config = JSON.parse(decodeURIComponent(encodedConfig));
+    if (typeof config?.webSocketUrls !== 'string' || !config.webSocketUrls ||
+        typeof config?.serverKey !== 'string' || !config.serverKey) {
+        throw new Error('Invalid browser refresh configuration.');
+    }
+
+    for (const endpoint of config.webSocketUrls.split(',')) {
+        const endpointUrl = new URL(endpoint);
+        if ((endpointUrl.protocol !== 'ws:' && endpointUrl.protocol !== 'wss:') ||
+            !isTrustedBrowserRefreshHost(endpointUrl.hostname, window.location.hostname)) {
+            throw new Error(`Untrusted browser refresh endpoint '${endpoint}'.`);
+        }
+    }
+
+    return config;
+}
+
+function isTrustedBrowserRefreshHost(endpointHost, applicationHost) {
+    return endpointHost === applicationHost ||
+        (isLoopbackHost(endpointHost) && isLoopbackHost(applicationHost));
+}
+
+function isLoopbackHost(host) {
+    return host === 'localhost' || host === '::1' || host === '[::1]' ||
+        /^127\.(?:\d{1,3}\.){2}\d{1,3}$/.test(host);
+}
+
+function getBrowserRefreshConfigStorageKey() {
+    return launchUrlConfigStorageKeyPrefix + document.baseURI;
+}
+
+function clearBrowserRefreshConfig() {
+    try {
+        window.sessionStorage.removeItem(getBrowserRefreshConfigStorageKey());
+        clearManagedCodeUpdates();
+    } catch {
+    }
+}
+
+function getManagedCodeUpdatesStorageKey() {
+    return managedCodeUpdatesStorageKeyPrefix + document.baseURI + refreshConfig.serverKey;
+}
+
+function readManagedCodeUpdates() {
+    try {
+        const value = window.sessionStorage.getItem(getManagedCodeUpdatesStorageKey());
+        return value ? JSON.parse(value) : [];
+    } catch (error) {
+        console.debug('Unable to read previous dotnet-watch managed code updates.', error);
+        clearManagedCodeUpdates();
+        return [];
+    }
+}
+
+function rememberManagedCodeUpdate(update) {
+    try {
+        const updates = readManagedCodeUpdates();
+        if (!updates.some(previousUpdate => previousUpdate.id === update.id)) {
+            updates.push(update);
+            window.sessionStorage.setItem(getManagedCodeUpdatesStorageKey(), JSON.stringify(updates));
+        }
+    } catch (error) {
+        console.debug('Unable to remember the dotnet-watch managed code update.', error);
+    }
+}
+
+function clearManagedCodeUpdates() {
+    try {
+        window.sessionStorage.removeItem(getManagedCodeUpdatesStorageKey());
+    } catch (error) {
+        console.debug('Unable to clear previous dotnet-watch managed code updates.', error);
+    }
+}
+
+function applyPreviousManagedCodeUpdates() {
+    for (const update of readManagedCodeUpdates()) {
+        const { applyError } = applyManagedCodeDeltas(update.deltas, update.responseLoggingLevel);
+        if (applyError) {
+            clearManagedCodeUpdates();
+            throw applyError;
+        }
+    }
+}
+
+async function initializeBrowserRefreshConnection() {
+    if (window.hasOwnProperty(scriptInjectedSentinel)) {
+        return;
+    }
+
+    window[scriptInjectedSentinel] = true;
+
+    const webSocketUrls = refreshConfig.webSocketUrls.split(',');
+    const sharedSecret = await getSecret(refreshConfig.serverKey);
+    let connection;
+    for (const url of webSocketUrls) {
+        try {
+            connection = await getWebSocket(url, sharedSecret);
+            break;
+        } catch (error) {
+            console.debug(error);
+        }
+    }
+
+    if (!connection) {
+        throw new Error('Unable to establish a connection to the browser refresh server.');
+    }
+
+    let waiting = false;
+
+    connection.onmessage = function (message) {
+        const payload = JSON.parse(message.data);
+        const action = {
+            'Reload': () => reload(),
+            'Wait': () => wait(),
+            'UpdateStaticFile': () => updateStaticFile(payload.path),
+            'ApplyManagedCodeUpdates': () => applyManagedCodeUpdates(connection, sharedSecret, payload.sharedSecret, payload.updateId, payload.deltas, payload.responseLoggingLevel),
+            'ReportDiagnostics': () => reportDiagnostics(payload.diagnostics),
+            'GetApplyUpdateCapabilities': () => getApplyUpdateCapabilities(connection),
+            'RefreshBrowser': () => refreshBrowser()
+        };
+
+        if (payload.type && action.hasOwnProperty(payload.type)) {
+            action[payload.type]();
+        } else {
+            console.error('Unknown payload:', message.data);
+        }
+    };
+
+    connection.onerror = function (event) { console.debug('dotnet-watch reload socket error.', event); };
+    connection.onclose = function () { console.debug('dotnet-watch reload socket closed.'); };
+    console.debug('dotnet-watch reload socket connected.');
+
+    function wait() {
+        console.debug('Waiting for application to rebuild.');
+        if (waiting) {
+            return;
+        }
+
+        waiting = true;
+        const glyphs = ['.', '..', '...'];
+        const title = document.title;
+        let i = 0;
+        setInterval(function () { document.title = glyphs[i++ % glyphs.length] + ' ' + title; }, 240);
+    }
+}
+
+function updateStaticFile(path) {
+    if (path && path.endsWith('.css')) {
+        updateCssByPath(path);
+    } else {
+        console.debug(`File change detected to file ${path}. Reloading page...`);
+        location.reload();
+    }
+}
+
+function updateCssByPath(path) {
+    const styleElement = document.querySelector(`link[href^="${path}"]`) ||
+        document.querySelector(`link[href^="${document.baseURI}${path}"]`);
+
+    if (!styleElement || !styleElement.parentNode) {
+        console.debug('Unable to find a stylesheet to update. Updating all local css files.');
+        updateAllLocalCss();
+    }
+
+    updateCssElement(styleElement);
+}
+
+function updateAllLocalCss() {
+    [...document.querySelectorAll('link')]
+        .filter(link => link.baseURI === document.baseURI)
+        .forEach(element => updateCssElement(element));
+}
+
+function updateCssElement(styleElement) {
+    if (!styleElement || styleElement.loading) {
+        return;
+    }
+
+    const newElement = styleElement.cloneNode();
+    const href = styleElement.href;
+    newElement.href = href.split('?', 1)[0] + `?nonce=${Date.now()}`;
+
+    styleElement.loading = true;
+    newElement.loading = true;
+    newElement.addEventListener('load', function () {
+        newElement.loading = false;
+        styleElement.remove();
+    });
+
+    styleElement.parentNode.insertBefore(newElement, styleElement.nextSibling);
+}
+
+function getMessageAndStack(error) {
+    const message = error.message || '<unknown error>';
+    let messageAndStack = error.stack || message;
+    if (!messageAndStack.includes(message)) {
+        messageAndStack = message + "\n" + messageAndStack;
+    }
+
+    return messageAndStack;
+}
+
+function getApplyUpdateCapabilities(connection) {
+    let applyUpdateCapabilities;
+    try {
+        applyUpdateCapabilities = window.Blazor._internal.getApplyUpdateCapabilities();
+    } catch (error) {
+        applyUpdateCapabilities = "!" + getMessageAndStack(error);
+    }
+
+    connection.send(applyUpdateCapabilities);
+}
+
+function applyDeltasLegacy(deltas) {
+    const apply = window.Blazor?._internal?.applyHotReload;
+    if (apply) {
+        deltas.forEach(delta => {
+            if (apply.length === 5) {
+                apply(delta.moduleId, delta.metadataDelta, delta.ilDelta, delta.pdbDelta, delta.updatedTypes);
+            } else {
+                apply(delta.moduleId, delta.metadataDelta, delta.ilDelta, delta.pdbDelta);
+            }
+        });
+    }
+}
+
+function applyManagedCodeUpdates(connection, sharedSecret, serverSecret, updateId, deltas, responseLoggingLevel) {
+    if (sharedSecret && serverSecret !== sharedSecret.encodedSharedSecret) {
+        throw new Error('Unable to validate the server. Rejecting apply-update payload.');
+    }
+
+    console.debug('Applying managed code updates.');
+
+    const { applyError, log } = applyManagedCodeDeltas(deltas, responseLoggingLevel);
+    if (!applyError) {
+        rememberManagedCodeUpdate({ "id": updateId, "deltas": deltas, "responseLoggingLevel": responseLoggingLevel });
+    }
+
+    connection.send(JSON.stringify({ "success": !applyError, "log": log }));
+
+    if (!applyError) {
+        displayChangesAppliedToast();
+    }
+}
+
+function applyManagedCodeDeltas(deltas, responseLoggingLevel) {
+    const agentMessageSeverityError = 2;
+    let applyError;
+    let log = [];
+
+    try {
+        const applyDeltas = window.Blazor?._internal?.applyHotReloadDeltas;
+        if (applyDeltas) {
+            const wasmDeltas = deltas.map(delta => ({
+                "moduleId": delta.moduleId,
+                "metadataDelta": delta.metadataDelta,
+                "ilDelta": delta.ilDelta,
+                "pdbDelta": delta.pdbDelta,
+                "updatedTypes": delta.updatedTypes,
+            }));
+            log = applyDeltas(wasmDeltas, responseLoggingLevel);
+        } else {
+            applyDeltasLegacy(deltas);
+        }
+    } catch (error) {
+        console.warn(error);
+        applyError = error;
+        log.push({ "message": getMessageAndStack(error), "severity": agentMessageSeverityError });
+    }
+
+    return { applyError, log };
+}
+
+function reportDiagnostics(diagnostics) {
+    console.debug('Reporting Hot Reload diagnostics.');
+
+    document.querySelectorAll('#dotnet-compile-error').forEach(element => element.remove());
+
+    if (diagnostics.length === 0) {
+        return;
+    }
+
+    const element = document.body.appendChild(document.createElement('div'));
+    element.id = 'dotnet-compile-error';
+    element.setAttribute('style', 'z-index:1000000; position:fixed; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0,0,0,0.5); color:black; overflow: scroll;');
+    diagnostics.forEach(error => {
+        const item = element.appendChild(document.createElement('div'));
+        item.setAttribute('style', 'border: 2px solid red; padding: 8px; background-color: #faa;');
+        const message = item.appendChild(document.createElement('div'));
+        message.setAttribute('style', 'font-weight: bold');
+        message.textContent = error.Message;
+        item.appendChild(document.createElement('div')).textContent = error;
+    });
+}
+
+function displayChangesAppliedToast() {
+    document.querySelectorAll('#dotnet-compile-error').forEach(element => element.remove());
+    if (document.querySelector('#dotnet-hotreload-toast') || !window[hotReloadActiveKey]) {
+        return;
+    }
+
+    const element = document.createElement('div');
+    element.id = 'dotnet-hotreload-toast';
+    element.innerHTML = "<svg style=\"filter: drop-shadow(0px 2px 1px rgb(0 0 0 / 0.4));\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 500 500\"><style><![CDATA[#hotreloaded-ellipse1 {animation: hotreloaded-ellipse1_c_o 1800ms linear 1 normal forwards}@keyframes hotreloaded-ellipse1_c_o { 0% {opacity: 0} 16.666667% {opacity: 1} 72.222222% {opacity: 1} 90% {opacity: 0} 100% {opacity: 0}} #hotreloaded-path1 {animation-name: hotreloaded-path1__m, hotreloaded-path1_c_o;animation-duration: 1800ms;animation-delay:100ms;animation-fill-mode: forwards;animation-timing-function: linear;animation-direction: normal;animation-iteration-count: 1;}@keyframes hotreloaded-path1__m { 0% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')} 16.666667% {d: path('M126.151214,288.396852L126.151214,288.396852L126.151214,288.396852')} 22.222222% {d: path('M126.151214,288.396852L196.625037,350.661591L196.625037,350.661591');animation-timing-function: cubic-bezier(0.42,0,0.58,1)} 33.333333% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')} 100% {d: path('M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242')}}@keyframes hotreloaded-path1_c_o { 0% {opacity: 0} 16.666667% {opacity: 0} 22.222222% {opacity: 1} 72.222222% {opacity: 1} 90% {opacity: 0} 100% {opacity: 0}}]]></style><ellipse id=\"hotreloaded-ellipse1\" rx=\"212.808853\" ry=\"205.404598\" transform=\"matrix(0.982102 0 0 1.017504 251 238)\" opacity=\"0\" fill=\"rgb(120,120,120)\"/><path id=\"hotreloaded-path1\" d=\"M126.151214,288.396852L196.625037,350.661591L320.793323,178.518242\" transform=\"matrix(1 0 0 1 27.527732 -26.589916)\" opacity=\"0\" fill=\"none\" stroke=\"rgb(255,255,255)\" stroke-width=\"40\" stroke-linecap=\"round\"/></svg>";
+    element.setAttribute('style', 'z-index: 1000000; width: 48px; height: 48px; position:fixed; top:5px; left: 5px');
+    document.body.appendChild(element);
+    window[hotReloadActiveKey] = false;
+    setTimeout(() => element.remove(), 2000);
+}
+
+function refreshBrowser() {
+    if (window.Blazor) {
+        window[hotReloadActiveKey] = true;
+        if (window.Blazor?._internal?.hotReloadApplied) {
+            console.debug('Refreshing browser: WASM.');
+            window.Blazor._internal.hotReloadApplied();
+        } else {
+            console.debug('Refreshing browser.');
+            displayChangesAppliedToast();
+        }
+    } else {
+        console.debug('Refreshing browser: Reloading.');
+        location.reload();
+    }
+}
+
+function reload() {
+    console.debug('Reloading.');
+    clearManagedCodeUpdates();
+    location.reload();
+}
+
+async function getSecret(serverKeyString) {
+    if (!serverKeyString || !window.crypto || !window.crypto.subtle) {
+        throw new Error('Browser refresh requires WebCrypto and a server public key.');
+    }
+
+    const secretBytes = window.crypto.getRandomValues(new Uint8Array(32));
+    const binaryServerKey = stringToArrayBuffer(atob(serverKeyString));
+    const serverKey = await window.crypto.subtle.importKey('spki', binaryServerKey, { name: "RSA-OAEP", hash: "SHA-256" }, false, ['encrypt']);
+    const encrypted = await window.crypto.subtle.encrypt({ name: 'RSA-OAEP' }, serverKey, secretBytes);
+    return {
+        encryptedSharedSecret: btoa(String.fromCharCode(...new Uint8Array(encrypted))),
+        encodedSharedSecret: btoa(String.fromCharCode(...secretBytes)),
+    };
+}
+
+function stringToArrayBuffer(value) {
+    const buffer = new ArrayBuffer(value.length);
+    const bufferView = new Uint8Array(buffer);
+    for (let i = 0; i < value.length; i++) {
+        bufferView[i] = value.charCodeAt(i);
+    }
+
+    return buffer;
+}
+
+function getWebSocket(url, sharedSecret) {
+    return new Promise((resolve, reject) => {
+        const encryptedSecret = sharedSecret && sharedSecret.encryptedSharedSecret;
+        const protocol = encryptedSecret ? encodeURIComponent(encryptedSecret) : [];
+        const webSocket = new WebSocket(url, protocol);
+        let opened = false;
+
+        function onOpen() {
+            opened = true;
+            clearEventListeners();
+            resolve(webSocket);
+        }
+
+        function onClose(event) {
+            if (opened) {
+                return;
+            }
+
+            let error = 'WebSocket failed to connect.';
+            if (event instanceof ErrorEvent) {
+                error = event.error;
+            }
+
+            clearEventListeners();
+            reject(error);
+        }
+
+        function clearEventListeners() {
+            webSocket.removeEventListener('open', onOpen);
+            webSocket.removeEventListener('close', onClose);
+        }
+
+        webSocket.addEventListener('open', onOpen);
+        webSocket.addEventListener('close', onClose);
+        if (window.Blazor?.removeEventListener && window.Blazor?.addEventListener) {
+            webSocket.addEventListener('close', () => window.Blazor?.removeEventListener('enhancedload', displayChangesAppliedToast));
+            window.Blazor?.addEventListener('enhancedload', displayChangesAppliedToast);
+        }
+    });
 }

--- a/src/Dotnet.Watch/HotReloadClient/Utilities/EnvironmentUtilities.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Utilities/EnvironmentUtilities.cs
@@ -21,4 +21,25 @@ internal static class EnvironmentUtilities
             environment[key] = value + separator + existingValue;
         }
     }
+
+    public static void RemoveListItem(this IDictionary<string, string> environment, string key, string value, char separator)
+    {
+        if (!environment.TryGetValue(key, out var existingValue))
+        {
+            return;
+        }
+
+        var remainingValue = string.Join(
+            separator.ToString(),
+            Array.FindAll(existingValue.Split(separator), item => item != value));
+
+        if (remainingValue.Length == 0)
+        {
+            environment.Remove(key);
+        }
+        else
+        {
+            environment[key] = remainingValue;
+        }
+    }
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -26,12 +26,16 @@ internal abstract class AbstractBrowserRefreshServer(
     string middlewareAssemblyPath,
     ILogger logger,
     Func<int, ILogger> connectionServerLoggerFactory,
-    Func<int, ILogger> connectionAgentLoggerFactory) : IDisposable
+    Func<int, ILogger> connectionAgentLoggerFactory,
+    bool useLaunchUrlBootstrap = false) : IDisposable
 {
+    private const string LaunchUrlConfigParameter = "__dotnet_watch";
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
     private static int s_lastConnectionId;
 
+    private readonly bool _supportsLaunchUrlBootstrap = useLaunchUrlBootstrap;
+    private bool _useLaunchUrlBootstrap = useLaunchUrlBootstrap;
     private readonly List<BrowserConnection> _activeConnections = [];
     private readonly TaskCompletionSource<None> _browserConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -64,6 +68,15 @@ internal abstract class AbstractBrowserRefreshServer(
     public ILogger Logger
         => logger;
 
+    internal bool UsesLaunchUrlBootstrap
+        => _useLaunchUrlBootstrap;
+
+    internal bool SupportsLaunchUrlBootstrap
+        => _supportsLaunchUrlBootstrap;
+
+    internal void ConfigureLaunchUrlBootstrap(bool browserWillBeLaunched)
+        => _useLaunchUrlBootstrap = _supportsLaunchUrlBootstrap && browserWillBeLaunched;
+
     public async ValueTask StartAsync(CancellationToken cancellationToken)
     {
         if (_lazyHost != null)
@@ -80,6 +93,20 @@ internal abstract class AbstractBrowserRefreshServer(
         if (_lazyHost == null)
         {
             throw new InvalidOperationException("Server not started");
+        }
+
+        if (_useLaunchUrlBootstrap)
+        {
+            builder.Remove(MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint);
+            builder.Remove(MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSKey);
+            builder.Remove(MiddlewareEnvironmentVariables.AspNetCoreAutoReloadVirtualDirectory);
+            builder.Remove(MiddlewareEnvironmentVariables.LoggingLevel);
+            builder.RemoveListItem(MiddlewareEnvironmentVariables.DotNetStartupHooks, middlewareAssemblyPath, Path.PathSeparator);
+            builder.RemoveListItem(
+                MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies,
+                Path.GetFileNameWithoutExtension(middlewareAssemblyPath),
+                MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssembliesSeparator);
+            return;
         }
 
         builder[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint] = string.Join(",", _lazyHost.EndPoints);
@@ -104,6 +131,30 @@ internal abstract class AbstractBrowserRefreshServer(
             // enable debug logging from middleware:
             builder[MiddlewareEnvironmentVariables.LoggingLevel] = "Debug";
         }
+    }
+
+    public string AddLaunchUrlBootstrap(string launchUrl)
+    {
+        if (!_useLaunchUrlBootstrap)
+        {
+            return launchUrl;
+        }
+
+        if (_lazyHost == null)
+        {
+            throw new InvalidOperationException("Server not started");
+        }
+
+        var config = JsonSerializer.Serialize(
+            new BrowserRefreshConfig
+            {
+                WebSocketUrls = string.Join(",", _lazyHost.EndPoints),
+                ServerKey = _sharedSecretProvider.GetPublicKey(),
+            },
+            s_jsonSerializerOptions);
+
+        var separator = launchUrl.Contains('#') ? '&' : '#';
+        return $"{launchUrl}{separator}{LaunchUrlConfigParameter}={Uri.EscapeDataString(config)}";
     }
 
     /// <summary>
@@ -361,5 +412,11 @@ internal abstract class AbstractBrowserRefreshServer(
     {
         public string Type => "UpdateStaticFile";
         public string Path { get; init; }
+    }
+
+    private readonly struct BrowserRefreshConfig
+    {
+        public string WebSocketUrls { get; init; }
+        public string ServerKey { get; init; }
     }
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
@@ -28,8 +28,9 @@ internal sealed class BrowserRefreshServer(
     string middlewareAssemblyPath,
     string dotnetPath,
     WebSocketConfig webSocketConfig,
-    bool suppressTimeouts)
-    : AbstractBrowserRefreshServer(middlewareAssemblyPath, logger, connectionServerLoggerFactory, connectionAgentLoggerFactory)
+    bool suppressTimeouts,
+    bool useLaunchUrlBootstrap)
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath, logger, connectionServerLoggerFactory, connectionAgentLoggerFactory, useLaunchUrlBootstrap)
 {
     protected override bool SuppressTimeouts
         => suppressTimeouts;

--- a/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyAppModel.cs
@@ -17,11 +17,26 @@ internal sealed class BlazorWebAssemblyAppModel(DotNetWatchContext context, Proj
 {
     public override ProjectGraphNode LaunchingProject => clientProject;
 
+    internal override bool UseLaunchUrlBootstrap
+        => clientProject.GetTargetFrameworkVersion() is { Major: >= 11 } &&
+           IsBrowserHotReloadInitializerEnabled();
+
     public override bool ManagedHotReloadRequiresBrowserRefresh => true;
 
     protected override ImmutableArray<HotReloadClient> CreateManagedClients(ILogger clientLogger, ILogger agentLogger, BrowserRefreshServer? browserRefreshServer)
     {
         Debug.Assert(browserRefreshServer != null);
         return [CreateWebAssemblyClient(clientLogger, agentLogger, browserRefreshServer, clientProject)];
+    }
+
+    private bool IsBrowserHotReloadInitializerEnabled()
+    {
+        var configuredValue = clientProject.ProjectInstance.GetPropertyValue(PropertyNames.WasmEnableHotReload);
+        return bool.TryParse(configuredValue, out var isEnabled)
+            ? isEnabled
+            : string.Equals(
+                clientProject.ProjectInstance.GetPropertyValue(PropertyNames.Configuration),
+                "Debug",
+                StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
@@ -27,6 +27,8 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
     /// </summary>
     public abstract ProjectGraphNode LaunchingProject { get; }
 
+    internal virtual bool UseLaunchUrlBootstrap => false;
+
     protected abstract ImmutableArray<HotReloadClient> CreateManagedClients(ILogger clientLogger, ILogger agentLogger, BrowserRefreshServer? browserRefreshServer);
 
     public async sealed override ValueTask<HotReloadClients> CreateClientsAsync(ILogger clientLogger, ILogger agentLogger, CancellationToken cancellationToken)
@@ -64,7 +66,8 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
                 middlewareAssemblyPath: GetMiddlewareAssemblyPath(),
                 dotnetPath: context.EnvironmentOptions.GetMuxerPath(),
                 webSocketConfig: context.EnvironmentOptions.BrowserWebSocketConfig,
-                suppressTimeouts: context.EnvironmentOptions.TestFlags != TestFlags.None);
+                suppressTimeouts: context.EnvironmentOptions.TestFlags != TestFlags.None,
+                useLaunchUrlBootstrap: UseLaunchUrlBootstrap);
         }
 
         return null;
@@ -103,7 +106,15 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
             return false;
         }
 
-        logger.Log(MessageDescriptor.UsingBrowserRefreshMiddleware);
+        if (UseLaunchUrlBootstrap)
+        {
+            logger.LogDebug("Using browser refresh launch URL bootstrap.");
+        }
+        else
+        {
+            logger.Log(MessageDescriptor.UsingBrowserRefreshMiddleware);
+        }
+
         return true;
     }
 }

--- a/src/Dotnet.Watch/Watch/Browser/BrowserLauncher.cs
+++ b/src/Dotnet.Watch/Watch/Browser/BrowserLauncher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Watch;
 internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter processOutputReporter, EnvironmentOptions environmentOptions)
 {
     // interlocked
-    private ImmutableHashSet<ProjectInstanceId> _browserLaunchAttempted = [];
+    private ImmutableHashSet<(ProjectInstanceId Project, bool UsesLaunchUrlBootstrap)> _browserLaunchAttempted = [];
 
     /// <summary>
     /// Returns an output observing action that triggers the launch of the browser, or null if the browser should not be launched.
@@ -24,7 +24,10 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
         AbstractBrowserRefreshServer? server,
         CancellationToken cancellationToken)
     {
-        if (!CanLaunchBrowser(projectOptions, out var launchProfile))
+        var canLaunchBrowser = CanLaunchBrowser(projectOptions, out var launchProfile);
+        server?.ConfigureLaunchUrlBootstrap(canLaunchBrowser);
+
+        if (!canLaunchBrowser)
         {
             if (environmentOptions.TestFlags.HasFlag(TestFlags.MockBrowser))
             {
@@ -34,13 +37,18 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
             return null;
         }
 
+        Debug.Assert(launchProfile != null);
         return WebServerProcessStateObserver.GetObserver(projectNode, url =>
         {
             if (projectOptions.IsMainProject &&
-                ImmutableInterlocked.Update(ref _browserLaunchAttempted, static (set, key) => set.Add(key), projectNode.ProjectInstance.GetId()))
+                ImmutableInterlocked.Update(
+                    ref _browserLaunchAttempted,
+                    static (set, key) => set.Add(key),
+                    (projectNode.ProjectInstance.GetId(), server?.UsesLaunchUrlBootstrap == true)))
             {
                 // first build iteration of a root project:
                 var launchUrl = GetLaunchUrl(launchProfile.LaunchUrl, url);
+                launchUrl = server?.AddLaunchUrlBootstrap(launchUrl) ?? launchUrl;
                 LaunchBrowser(launchUrl, server);
             }
             else if (server != null)

--- a/src/Dotnet.Watch/Watch/Browser/BrowserRefreshServerFactory.cs
+++ b/src/Dotnet.Watch/Watch/Browser/BrowserRefreshServerFactory.cs
@@ -42,6 +42,7 @@ internal sealed class BrowserRefreshServerFactory : IDisposable
     public async ValueTask<BrowserRefreshServer?> GetOrCreateBrowserRefreshServerAsync(ProjectGraphNode projectNode, WebApplicationAppModel appModel, CancellationToken cancellationToken)
     {
         BrowserRefreshServer? server;
+        BrowserRefreshServer? serverToDispose = null;
         bool hasExistingServer;
 
         var key = projectNode.ProjectInstance.GetId();
@@ -49,12 +50,21 @@ internal sealed class BrowserRefreshServerFactory : IDisposable
         lock (_serversGuard)
         {
             hasExistingServer = _servers.TryGetValue(key, out server);
-            if (!hasExistingServer)
+            if (hasExistingServer && server != null && server.SupportsLaunchUrlBootstrap != appModel.UseLaunchUrlBootstrap)
+            {
+                serverToDispose = server;
+                server = appModel.TryCreateRefreshServer(projectNode);
+                _servers[key] = server;
+                hasExistingServer = false;
+            }
+            else if (!hasExistingServer)
             {
                 server = appModel.TryCreateRefreshServer(projectNode);
                 _servers.Add(key, server);
             }
         }
+
+        serverToDispose?.Dispose();
 
         if (server == null)
         {

--- a/src/Dotnet.Watch/Watch/Build/BuildNames.cs
+++ b/src/Dotnet.Watch/Watch/Build/BuildNames.cs
@@ -29,6 +29,8 @@ internal static class PropertyNames
     public const string PublishTrimmed = nameof(PublishTrimmed);
     public const string PublishAot = nameof(PublishAot);
     public const string EnableHotReloadInRuntimeConfigDevFile = nameof(EnableHotReloadInRuntimeConfigDevFile);
+    public const string WasmEnableHotReload = nameof(WasmEnableHotReload);
+    public const string Configuration = nameof(Configuration);
 }
 
 internal static class ItemNames

--- a/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
+++ b/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
@@ -78,12 +78,12 @@ internal sealed class ProjectLauncher(
                 (EnvironmentOptions.SuppressEmojis ? Emoji.Default : Emoji.Agent).GetLogMessagePrefix(EnvironmentOptions.LogMessagePrefix) + $"[{projectDisplayName}]";
         }
 
+        // Observes main project process output and launches browser when the URL is found in the output.
+        var outputObserver = context.BrowserLauncher.TryGetBrowserLaunchOutputObserver(projectNode, projectOptions, clients.BrowserRefreshServer, cancellationToken);
+
         clients.ConfigureLaunchEnvironment(environmentBuilder);
 
         processSpec.Arguments = GetProcessArguments(projectOptions, environmentBuilder);
-
-        // Observes main project process output and launches browser when the URL is found in the output.
-        var outputObserver = context.BrowserLauncher.TryGetBrowserLaunchOutputObserver(projectNode, projectOptions, clients.BrowserRefreshServer, cancellationToken);
 
         processSpec.RedirectOutput(outputObserver, context.ProcessOutputReporter, context.EnvironmentOptions, projectDisplayName);
 

--- a/src/Dotnet.Watch/dotnet-watch/Watch/DotNetWatcher.cs
+++ b/src/Dotnet.Watch/dotnet-watch/Watch/DotNetWatcher.cs
@@ -65,14 +65,14 @@ internal static class DotNetWatcher
                 ? await context.BrowserRefreshServerFactory.GetOrCreateBrowserRefreshServerAsync(projectRootNode, webAppModel, shutdownCancellationToken)
                 : null;
 
-            browserRefreshServer?.ConfigureLaunchEnvironment(environmentBuilder, enableHotReload: false);
-
             Action<OutputLine>? outputObserver = null;
             if (projectRootNode != null)
             {
                 Debug.Assert(context.MainProjectOptions != null);
                 outputObserver = context.BrowserLauncher.TryGetBrowserLaunchOutputObserver(projectRootNode, context.MainProjectOptions, browserRefreshServer, shutdownCancellationToken);
             }
+
+            browserRefreshServer?.ConfigureLaunchEnvironment(environmentBuilder, enableHotReload: false);
 
             processSpec.RedirectOutput(outputObserver, context.ProcessOutputReporter, context.EnvironmentOptions, projectRootNode?.GetDisplayName() ?? "");
 

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/EnvironmentUtilitiesTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/EnvironmentUtilitiesTests.cs
@@ -29,4 +29,20 @@ public class EnvironmentUtilitiesTests
 
         Assert.AreSequenceEqual([new KeyValuePair<string, string>("X", "b;a")], builder);
     }
+
+    [TestMethod]
+    public void RemoveValues()
+    {
+        var builder = new Dictionary<string, string>
+        {
+            ["X"] = "a;b;c"
+        };
+
+        builder.RemoveListItem("X", "b", separator: ';');
+        Assert.AreEqual("a;c", builder["X"]);
+
+        builder.RemoveListItem("X", "a", separator: ';');
+        builder.RemoveListItem("X", "c", separator: ';');
+        Assert.IsFalse(builder.ContainsKey("X"));
+    }
 }

--- a/test/dotnet-watch-test-browser/Program.cs
+++ b/test/dotnet-watch-test-browser/Program.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 if (args is not [var urlArg])
@@ -24,7 +25,21 @@ var encryptedSecret = GetEncryptedSecret(publicKey, secret);
 using var webSocket = await OpenWebSocket(webSocketUrls, encryptedSecret);
 var buffer = new byte[8 * 1024];
 
-while (await TryReceiveMessageAsync(webSocket, message => Log($"Received: {Encoding.UTF8.GetString(message)}")))
+while (await TryReceiveMessageAsync(webSocket, async message =>
+{
+    var messageText = Encoding.UTF8.GetString(message.Span);
+    Log($"Received: {messageText}");
+
+    using var payload = JsonDocument.Parse(message);
+    if (payload.RootElement.TryGetProperty("type", out var type) && type.GetString() == "ApplyManagedCodeUpdates")
+    {
+        await webSocket.SendAsync(
+            Encoding.UTF8.GetBytes("""{"success":true,"log":[]}"""),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None);
+    }
+}))
 {
 }
 
@@ -52,7 +67,7 @@ static async Task<WebSocket> OpenWebSocket(string[] urls, string encryptedSecret
     throw new InvalidOperationException("Unable to establish a connection.");
 }
 
-static async ValueTask<bool> TryReceiveMessageAsync(WebSocket socket, Action<ReadOnlySpan<byte>> receiver)
+static async ValueTask<bool> TryReceiveMessageAsync(WebSocket socket, Func<ReadOnlyMemory<byte>, Task> receiver)
 {
     var writer = new ArrayBufferWriter<byte>(initialCapacity: 1024);
 
@@ -82,12 +97,19 @@ static async ValueTask<bool> TryReceiveMessageAsync(WebSocket socket, Action<Rea
         }
     }
 
-    receiver(writer.WrittenSpan);
+    await receiver(writer.WrittenMemory);
     return true;
 }
 
 static async Task<(string[] url, string key)> GetWebSocketUrlsAndPublicKey(Uri baseUrl)
 {
+    if (TryGetLaunchUrlConfig(baseUrl) is { } launchUrlConfig)
+    {
+        Log($"WebSocket urls are '{string.Join(',', launchUrlConfig.urls)}'.");
+        Log($"Key is '{launchUrlConfig.key}'.");
+        return launchUrlConfig;
+    }
+
     var refreshScriptUrl = new Uri(baseUrl, "/_framework/aspnetcore-browser-refresh.js");
 
     Log($"Fetching: {refreshScriptUrl}");
@@ -103,6 +125,25 @@ static async Task<(string[] url, string key)> GetWebSocketUrlsAndPublicKey(Uri b
     Log($"Key is '{key}'.");
 
     return (webSocketUrl, key);
+}
+
+static (string[] urls, string key)? TryGetLaunchUrlConfig(Uri url)
+{
+    const string parameter = "__dotnet_watch=";
+    var configPart = url.Fragment
+        .TrimStart('#')
+        .Split('&')
+        .FirstOrDefault(part => part.StartsWith(parameter, StringComparison.Ordinal));
+
+    if (configPart == null)
+    {
+        return null;
+    }
+
+    using var config = JsonDocument.Parse(Uri.UnescapeDataString(configPart[parameter.Length..]));
+    return (
+        config.RootElement.GetProperty("webSocketUrls").GetString()!.Split(','),
+        config.RootElement.GetProperty("serverKey").GetString()!);
 }
 
 static string[] GetWebSocketUrls(string refreshScript)

--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Microsoft.DotNet.HotReload;
 using Microsoft.Extensions.Logging;
 
@@ -56,5 +57,55 @@ public class BrowserRefreshServerTests
         }
 
         AssertEx.SequenceEqual(expected.Order(), envBuilder.OrderBy(e => e.Key).Select(e => $"{e.Key}={e.Value}"));
+    }
+
+    [TestMethod]
+    public async Task LaunchUrlBootstrapDoesNotConfigureMiddleware()
+    {
+        var middlewarePath = Path.Combine(Path.GetTempPath(), "Microsoft.AspNetCore.Watch.BrowserRefresh.dll");
+        var server = new TestBrowserRefreshServer(middlewarePath, useLaunchUrlBootstrap: true)
+        {
+            CreateAndStartHostImpl = () => new WebServerHost(new TestListener(), ["ws://localhost:1234", "wss://localhost:5678"], virtualDirectory: "/")
+        };
+
+        await server.StartAsync(CancellationToken.None);
+
+        var environment = new Dictionary<string, string>
+        {
+            [MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSEndPoint] = "stale",
+            [MiddlewareEnvironmentVariables.AspNetCoreAutoReloadWSKey] = "stale",
+            [MiddlewareEnvironmentVariables.AspNetCoreAutoReloadVirtualDirectory] = "stale",
+            [MiddlewareEnvironmentVariables.LoggingLevel] = "stale",
+            [MiddlewareEnvironmentVariables.DotNetStartupHooks] = middlewarePath + Path.PathSeparator + "Other.StartupHook.dll",
+            [MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies] = "Microsoft.AspNetCore.Watch.BrowserRefresh;Other.HostingStartup",
+        };
+
+        server.ConfigureLaunchEnvironment(environment, enableHotReload: true);
+
+        AssertEx.SequenceEqual(
+            [
+                new KeyValuePair<string, string>(MiddlewareEnvironmentVariables.DotNetStartupHooks, "Other.StartupHook.dll"),
+                new KeyValuePair<string, string>(MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies, "Other.HostingStartup"),
+            ],
+            environment);
+
+        var launchUrl = server.AddLaunchUrlBootstrap("https://localhost/app#route");
+        var fragmentParts = new Uri(launchUrl).Fragment.TrimStart('#').Split('&');
+        Assert.AreEqual("route", fragmentParts[0]);
+
+        const string parameter = "__dotnet_watch=";
+        Assert.IsTrue(fragmentParts[1].StartsWith(parameter, StringComparison.Ordinal));
+
+        using var config = JsonDocument.Parse(Uri.UnescapeDataString(fragmentParts[1][parameter.Length..]));
+        Assert.AreEqual("ws://localhost:1234,wss://localhost:5678", config.RootElement.GetProperty("webSocketUrls").GetString());
+        Assert.IsFalse(string.IsNullOrEmpty(config.RootElement.GetProperty("serverKey").GetString()));
+
+        server.ConfigureLaunchUrlBootstrap(browserWillBeLaunched: false);
+        environment.Clear();
+        server.ConfigureLaunchEnvironment(environment, enableHotReload: true);
+
+        Assert.IsTrue(environment.ContainsKey(MiddlewareEnvironmentVariables.DotNetStartupHooks));
+        Assert.IsTrue(environment.ContainsKey(MiddlewareEnvironmentVariables.AspNetCoreHostingStartupAssemblies));
+        Assert.AreEqual("https://localhost/app", server.AddLaunchUrlBootstrap("https://localhost/app"));
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
@@ -16,10 +16,24 @@ public class RazorHotReloadTests : DotNetWatchTestBase
             targetFramework: tfm,
             packageVersionPropertySubstitutions: wasmVersion != null ? [("MicrosoftAspNetCoreAppRefPackageVersion", wasmVersion)] : null);
 
-        var port = TestOptions.GetTestPort();
-        App.Start(testAsset, ["--urls", "http://localhost:" + port], testFlags: TestFlags.MockBrowser);
+        var useLaunchUrlBootstrap = tfm == ToolsetInfo.CurrentTargetFramework;
+        if (useLaunchUrlBootstrap)
+        {
+            App.UseTestBrowser();
+        }
 
-        await App.WaitUntilOutputContains(MessageDescriptor.UsingBrowserRefreshMiddleware);
+        var port = TestOptions.GetTestPort();
+        App.Start(testAsset, ["--urls", "http://localhost:" + port], testFlags: useLaunchUrlBootstrap ? TestFlags.None : TestFlags.MockBrowser);
+
+        if (useLaunchUrlBootstrap)
+        {
+            await App.WaitUntilOutputContains("Using browser refresh launch URL bootstrap.");
+        }
+        else
+        {
+            await App.WaitUntilOutputContains(MessageDescriptor.UsingBrowserRefreshMiddleware);
+        }
+
         await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
 
         // AddExplicitInterfaceImplementation is an implicit capability that's always added for .NET targets:
@@ -35,19 +49,34 @@ public class RazorHotReloadTests : DotNetWatchTestBase
         // env variable passed when launching the server:
         await App.WaitUntilOutputContains($"HOTRELOAD_DELTA_CLIENT_LOG_MESSAGES=dotnet watch 🕵️ [blazorwasm ({tfm})]");
 
-        // Middleware should have been loaded to blazor-devserver before the browser is launched:
-        await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]");
-        await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]");
-        await App.WaitUntilOutputContains("Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js");
-        await App.WaitUntilOutputContains("Middleware loaded. Script /_framework/blazor-hotreload.js");
-        await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware");
-        await App.WaitUntilOutputContains("Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true");
+        if (useLaunchUrlBootstrap)
+        {
+            App.AssertOutputDoesNotContain("Microsoft.AspNetCore.Watch.BrowserRefresh");
+        }
+        else
+        {
+            // Middleware should have been loaded to blazor-devserver before the browser is launched:
+            await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BlazorWasmHotReloadMiddleware[0]");
+            await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserScriptMiddleware[0]");
+            await App.WaitUntilOutputContains("Middleware loaded. Script /_framework/aspnetcore-browser-refresh.js");
+            await App.WaitUntilOutputContains("Middleware loaded. Script /_framework/blazor-hotreload.js");
+            await App.WaitUntilOutputContains("dbug: Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware");
+            await App.WaitUntilOutputContains("Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES=debug, __ASPNETCORE_BROWSER_TOOLS=true");
+        }
 
         // shouldn't see any agent messages (agent is not loaded into blazor-devserver):
         App.AssertOutputDoesNotContain("Loaded into process");
 
         // Browser is launched based on blazor-devserver output "Now listening on: ...".
-        await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}"));
+        if (useLaunchUrlBootstrap)
+        {
+            await App.WaitUntilOutputContains($"http://localhost:{port}#__dotnet_watch=");
+            await App.WaitUntilOutputContains(MessageDescriptor.ConnectedToRefreshServer, "Browser #1");
+        }
+        else
+        {
+            await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}"));
+        }
 
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
         App.Process.ClearOutput();
@@ -98,12 +127,12 @@ public class RazorHotReloadTests : DotNetWatchTestBase
 
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
-        await App.WaitUntilOutputContains(MessageDescriptor.UsingBrowserRefreshMiddleware);
+        await App.WaitUntilOutputContains("Using browser refresh launch URL bootstrap.");
         await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
         await App.WaitUntilOutputContains(MessageDescriptor.PressCtrlRToRestart);
 
         // Browser is launched based on blazor-devserver output "Now listening on: ...".
-        await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}"));
+        await App.WaitUntilOutputContains($"http://localhost:{port}#__dotnet_watch=");
 
         App.SendControlR();
 

--- a/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
+++ b/test/dotnet-watch.Tests/TestUtilities/TestBrowserRefreshServer.cs
@@ -5,8 +5,8 @@ using Microsoft.DotNet.HotReload;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
-internal class TestBrowserRefreshServer(string middlewareAssemblyPath)
-    : AbstractBrowserRefreshServer(middlewareAssemblyPath, new TestLogger(), _ => new TestLogger(), _ => new TestLogger())
+internal class TestBrowserRefreshServer(string middlewareAssemblyPath, bool useLaunchUrlBootstrap = false)
+    : AbstractBrowserRefreshServer(middlewareAssemblyPath, new TestLogger(), _ => new TestLogger(), _ => new TestLogger(), useLaunchUrlBootstrap)
 {
     public Func<WebServerHost>? CreateAndStartHostImpl;
 


### PR DESCRIPTION
## Why

Modern standalone Blazor WebAssembly is served by the NativeAOT-compatible Gateway, which cannot dynamically load `Microsoft.AspNetCore.Watch.BrowserRefresh`. As a result, the hosting-startup middleware never injects the browser-refresh script and `dotnet watch` reports that no browser is connected.

This prototypes a .NET 11+ path that does not require Gateway middleware, HTML response rewriting, or dynamic assembly loading. It is an alternative and architectural follow-up to dotnet/aspnetcore#68900 and dotnet/aspnetcore#67611.

## Approach

- Add the browser-refresh WebSocket endpoints and public RSA key to the automatically launched URL fragment. Fragments are not sent to the application server, and the browser-generated shared secret never enters the URL.
- Consolidate Marek's dotnet/sdk#54142 WebSocket client into `Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js`, replacing the proposed middleware configuration endpoint.
- Restrict bootstrap WebSockets to the application host or loopback, remove the fragment before routing, and preserve browser history state.
- Apply managed deltas directly over the WebSocket and retain successful batches in watcher-scoped `sessionStorage` so manual and static-file reloads can replay them without `/_framework/blazor-hotreload`.
- Keep middleware behavior for older TFMs, hosted/non-WASM apps, initializer-disabled builds, and configurations where `dotnet watch` does not automatically launch the browser.

For the new path this removes dependencies on `DOTNET_STARTUP_HOOKS`, `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`, HTML script injection, `aspnetcore-browser-refresh.js`, `browser-refresh-config`, `blazor-hotreload`, and `clear-browser-cache`. The dotnet-watch WebSocket refresh server remains.

## Validation

- Full `./build.sh` build.
- Focused `dotnet-watch.Tests`: 18 passed.
- Focused `Microsoft.DotNet.HotReload.Client.Tests`: 3 passed.
- Reproduced the original failure before the change: a loaded Chromium page produced `No browser is connected` after a Razor edit.
- Exercised the rebuilt SDK with real headless Chromium and standalone Gateway: no middleware environment variables were supplied, the browser connected, a Razor delta changed the live `<h1>`, a manual page reload reconnected as a second browser, and the updated DOM was preserved by replay.

## Known limitations and follow-ups

- Updates produced while no browser is connected are not retained. Completing that requires watch/IDE-owned per-connection history along the direction of dotnet/sdk#49021 and dotnet/sdk#53485.
- VS and VS Code must emit the same bootstrap fragment before they can use this path.
- Manual browser-launch configurations intentionally retain middleware compatibility, so NativeAOT Gateway is not yet middleware-free in that mode.
- Arbitrary cross-host WebSocket endpoints are rejected until there is a bootstrap design with an external trust anchor.
- Direct stylesheet cache busting works, but nested `@import` and scoped CSS behavior needs more validation without `Clear-Site-Data`.
- The checked-in integration test uses the protocol test browser; the full Chromium DOM transition is currently a manual validation.